### PR TITLE
Fix: Clazy warnings part 1 - range-loop-detach

### DIFF
--- a/src/EditorDeleteItemCommand.cpp
+++ b/src/EditorDeleteItemCommand.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -598,7 +599,7 @@ void EditorDeleteItemCommand::redo()
     mLastOperationWasValid = false;
 
     // First pass: validate that items still exist and have the expected names
-    for (const auto& info : mDeletedItems) {
+    for (const auto& info : std::as_const(mDeletedItems)) {
         switch (mViewType) {
         case EditorViewType::cmTriggerView: {
             TTrigger* trigger = mpHost->getTriggerUnit()->getTrigger(info.itemID);
@@ -724,7 +725,7 @@ void EditorDeleteItemCommand::redo()
     // trying to unregister. Only delete items whose parent is not also being deleted
     // (parent deletion handles children), and only if they still match the recorded
     // name to avoid deleting unrelated items.
-    for (const auto& info : mDeletedItems) {
+    for (const auto& info : std::as_const(mDeletedItems)) {
         // Skip items whose parent is also in the deletion list
         // (they will be automatically deleted when the parent is deleted)
         if (info.parentID != -1) {

--- a/src/EditorUndoStack.cpp
+++ b/src/EditorUndoStack.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -80,7 +81,7 @@ void EditorUndoStack::emitChangesForCommand(const QUndoCommand* cmd)
         if (!itemIDs.isEmpty()) {
             // Double-check all IDs are valid before emitting
             bool allValid = true;
-            for (int id : itemIDs) {
+            for (const int id : itemIDs) {
                 if (id <= 0) {
                     allValid = false;
 #if defined(DEBUG_UNDO_REDO)
@@ -118,7 +119,7 @@ void EditorUndoStack::collectAffectedItems(const QUndoCommand* cmd, QMap<EditorV
         QList<int> itemIDs = mudletCmd->affectedItemIDs();
 
         // Add to the map, avoiding duplicates and invalid IDs
-        for (int id : itemIDs) {
+        for (int id : std::as_const(itemIDs)) {
             // Skip invalid IDs (0 or negative)
             if (id <= 0) {
                 continue;
@@ -207,7 +208,7 @@ void EditorUndoStack::undo()
 #if defined(DEBUG_UNDO_REDO)
             qDebug() << "EditorUndoStack::undo() - DeleteItemCommand restored items with ID changes:" << idChanges.size();
 #endif
-            for (const auto& change : idChanges) {
+            for (const auto& change : std::as_const(idChanges)) {
                 int oldID = change.first;
                 int newID = change.second;
 #if defined(DEBUG_UNDO_REDO)
@@ -264,7 +265,7 @@ void EditorUndoStack::redo()
 #if defined(DEBUG_UNDO_REDO)
                 qDebug() << "EditorUndoStack::redo() - AddItemCommand restored items with ID changes:" << idChanges.size();
 #endif
-                for (const auto& change : idChanges) {
+                for (const auto& change : std::as_const(idChanges)) {
                     int oldID = change.first;
                     int newID = change.second;
 #if defined(DEBUG_UNDO_REDO)

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2024 by Vadim Peretokin - vperetokin@gmail.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -46,7 +47,7 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
 
     if (jsonObj.contains("type")) {
         QJsonArray typesArray = jsonObj["type"].toArray();
-        for (const auto& type : typesArray) {
+        for (const auto& type : std::as_const(typesArray)) {
             mSupportedAuthTypes.append(type.toString());
         }
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2025 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2026 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *   Copyright (C) 2023-2025 by Lecker Kebap - Leris@mudlet.org            *
@@ -613,7 +613,7 @@ void Host::autoSaveMap()
 
 void Host::loadPackageInfo()
 {
-    for (const auto& package : mInstalledPackages) {
+    for (const auto& package : std::as_const(mInstalledPackages)) {
         const QDir dir(mudlet::self()->getMudletPath(enums::profilePackagePath, getName(), package));
         if (dir.exists(qsl("config.lua"))) {
             getPackageConfig(dir.absoluteFilePath(qsl("config.lua")));
@@ -1503,7 +1503,7 @@ int Host::findStopWatchId(const QString& name) const
     if (total > 1) {
         std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
     }
-    for (const int currentId : stopWatchIdList) {
+    for (const int currentId : std::as_const(stopWatchIdList)) {
         auto pCurrentStopWatch = mStopWatchMap.value(currentId);
         if (pCurrentStopWatch->name() == name) {
             return currentId;
@@ -1722,7 +1722,7 @@ QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QS
     int alreadyUsedId = 0;
     // we are looking BOTH for the current name and checking that any other
     // ones WITH names do not match the new name:
-    for (const int currentId : stopWatchIdList) {
+    for (const int currentId : std::as_const(stopWatchIdList)) {
         auto pCurrentStopWatch = mStopWatchMap.value(currentId);
         // This will also pick up the FIRST (lowest id) currently unnamed
         // stopwatch:

--- a/src/MudletInstanceCoordinator.cpp
+++ b/src/MudletInstanceCoordinator.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2023-2023 by Adam Robinson - seldon1951@hotmail.com     *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -78,7 +79,7 @@ bool MudletInstanceCoordinator::tryToStart()
 void MudletInstanceCoordinator::installPackagesToHost(Host* activeProfile)
 {
     mMutex.lock();
-    for (const QString& path : mQueuedPackagePaths) {
+    for (const QString& path : std::as_const(mQueuedPackagePaths)) {
         auto ret = activeProfile->installPackage(path, enums::PackageModuleType::Package);
     }
     mQueuedPackagePaths.clear();

--- a/src/SelectionRectangleHandler.cpp
+++ b/src/SelectionRectangleHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -211,7 +212,7 @@ bool SelectionRectangleHandler::handleMouseMove(T2DMap::MapInteractionContext& c
             mMapWidget.mMultiSelectionSet.unite(rectangleSelection);
         } else if (hasCtrl) {
             QSet<int> toggledSelection = mMapWidget.mMultiSelectionBaseSet;
-            for (int roomId : rectangleSelection) {
+            for (const int roomId : std::as_const(rectangleSelection)) {
                 if (toggledSelection.contains(roomId)) {
                     toggledSelection.remove(roomId);
                 } else {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2016, 2018-2025 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2016, 2018-2026 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2021-2022 by Piotr Wilczynski - delwing@gmail.com       *
@@ -4399,7 +4399,7 @@ void T2DMap::slot_setArea()
     std::sort(sortedAreaList.begin(), sortedAreaList.end(), sorter);
 
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
-    for (const QString& areaName : sortedAreaList) {
+    for (const QString& areaName : std::as_const(sortedAreaList)) {
         const int areaId = areaNamesMap.key(areaName);
         arealist_combobox->addItem(qsl("%1 (%2)").arg(areaName, QString::number(areaId)), QString::number(areaId));
     }
@@ -5264,8 +5264,8 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         QString basePath = fileInfo.absolutePath();
 
         // Export each Z level as a separate file
-        for (int currentZLevel : pArea->zLevels) {
             QString levelFileName = QString("%1/%2_level_%3.%4").arg(basePath).arg(baseFileName).arg(currentZLevel).arg(extension.isEmpty() ? "png" : extension);
+        for (const int currentZLevel : std::as_const(pArea->zLevels)) {
 
             // Recursively call this function for each Z level (without exportAllZLevels flag)
             auto [success, message] = exportAreaToImage(areaId, levelFileName, currentZLevel, zoom, false);
@@ -5421,7 +5421,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     QList<int> oneWayExits;
 
     // Build exit lists from rooms on current Z-level (like paintEvent does)
-    for (int roomId : pArea->rooms) {
+    for (const int roomId : std::as_const(pArea->rooms)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
         if (!pRoom || pRoom->z() != exportZLevel) {
             continue;
@@ -5435,7 +5435,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     int roomsSkipped = 0;
 
     // First pass: draw rooms on level below (like paintEvent shadow rooms)
-    for (int roomId : pArea->rooms) {
+    for (const int roomId : std::as_const(pArea->rooms)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
         if (!pRoom || pRoom->z() != exportZLevel - 1) {
             continue;
@@ -5470,7 +5470,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     }
 
     // Second pass: draw rooms on level above (like paintEvent upper level rooms)
-    for (int roomId : pArea->rooms) {
+    for (const int roomId : std::as_const(pArea->rooms)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
         if (!pRoom || pRoom->z() != exportZLevel + 1) {
             continue;
@@ -5880,7 +5880,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     }
 
     // Fourth pass: draw main rooms on current level using existing drawRoom method
-    for (int roomId : pArea->rooms) {
+    for (const int roomId : std::as_const(pArea->rooms)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
         if (!pRoom || pRoom->z() != exportZLevel) {
             roomsSkipped++;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5264,8 +5264,8 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         QString basePath = fileInfo.absolutePath();
 
         // Export each Z level as a separate file
-            QString levelFileName = QString("%1/%2_level_%3.%4").arg(basePath).arg(baseFileName).arg(currentZLevel).arg(extension.isEmpty() ? "png" : extension);
         for (const int currentZLevel : std::as_const(pArea->zLevels)) {
+            QString levelFileName = QString("%1/%2_level_%3.%4").arg(basePath).arg(baseFileName).arg(currentZLevel).arg(extension.isEmpty() ? "png" : extension);
 
             // Recursively call this function for each Z level (without exportAllZLevels flag)
             auto [success, message] = exportAreaToImage(areaId, levelFileName, currentZLevel, zoom, false);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018, 2020, 2022-2024 by Stephen Lyons             *
+ *   Copyright (C) 2014-2018, 2020, 2022-2024, 2026 by Stephen Lyons       *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -4753,7 +4753,7 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         }
         const QString qIndent(indent, QChar::Space);
         const QString qHangingIndent(hangingIndent, QChar::Space);
-        for (WrapInfo w : lineBreaks) {
+        for (const WrapInfo w : std::as_const(lineBreaks)) {
             // skip TChars as needed
             while (newBufferCharPosition < w.firstChar && !buffer[i].empty()) {
                 buffer[i].pop_front();
@@ -7077,7 +7077,7 @@ void TBuffer::applyPendingSelectionStyling()
 #if defined(DEBUG_OSC_PROCESSING)
         qDebug() << "[OSC] Processing pending selection styling for" << mPendingSelectionStyling.size() << "links";
 #endif
-        for (int linkId : mPendingSelectionStyling) {
+        for (const int linkId : std::as_const(mPendingSelectionStyling)) {
             updateLinkCharacters(linkId);
         }
         mPendingSelectionStyling.clear();

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -575,7 +576,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
 
         // Properly close each profile - this ensures proper cleanup and save prompts
         auto pMudlet = mudlet::self();
-        for (const QString& profileName : profilesToClose) {
+        for (const QString& profileName : std::as_const(profilesToClose)) {
 #if defined(DEBUG_WINDOW_HANDLING)
             qDebug() << "TDetachedWindow::closeEvent() - Properly closing profile:" << profileName;
 #endif
@@ -585,7 +586,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         }
 
         // Remove all consoles from the stacked widget and reset their parents
-        for (auto console : mProfileConsoleMap) {
+        for (auto console : std::as_const(mProfileConsoleMap)) {
             if (console) {
                 mpConsoleContainer->removeWidget(console);
                 console->setParent(nullptr);
@@ -595,7 +596,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         mProfileConsoleMap.clear();
 
         // Emit signal to notify main window for any remaining cleanup
-        for (const QString& profileName : profilesToClose) {
+        for (const QString& profileName : std::as_const(profilesToClose)) {
             emit windowClosed(profileName);
         }
     }
@@ -1723,7 +1724,7 @@ void TDetachedWindow::updateWindowMenu()
     }
 
     // Clean up existing window list actions
-    for (QAction* action : mWindowListActions) {
+    for (QAction* action : std::as_const(mWindowListActions)) {
         mpWindowMenu->removeAction(action);
         action->deleteLater();
     }
@@ -1794,7 +1795,7 @@ void TDetachedWindow::updateWindowMenu()
             // Get all profiles in this detached window
             QStringList profilesInWindow = detachedWindow->getProfileNames();
 
-            for (const QString& windowProfileName : profilesInWindow) {
+            for (const QString& windowProfileName : std::as_const(profilesInWindow)) {
                 //: This is an item in list of profiles in the "Window" menu of a detached Mudlet window. %1 is the name of the profile, and it is located not in Mudlet's main window, but in the detached window.
                 QString actionText = tr("%1 (Detached)").arg(windowProfileName);
                 QAction* profileAction = new QAction(actionText, this);
@@ -3174,7 +3175,7 @@ void TDetachedWindow::slot_closeAllProfiles()
     qDebug() << "TDetachedWindow::slot_closeAllProfiles() - Closing" << profilesToClose.size() << "profiles";
 
     auto pMudlet = mudlet::self();
-    for (const QString& profileName : profilesToClose) {
+    for (const QString& profileName : std::as_const(profilesToClose)) {
         qDebug() << "TDetachedWindow::slot_closeAllProfiles() - Closing profile:" << profileName;
         if (pMudlet) {
             pMudlet->slot_closeProfileByName(profileName);

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -156,7 +157,7 @@ void THyperlinkSelectionManager::setGroupExclusive(const QString& group, bool ex
         members.sort();
 
         bool foundFirst = false;
-        for (const QString& member : members) {
+        for (const QString& member : std::as_const(members)) {
             if (isSelected(group, member)) {
                 if (!foundFirst) {
                     foundFirst = true;

--- a/src/THyperlinkVisibilityManager.cpp
+++ b/src/THyperlinkVisibilityManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -239,7 +240,7 @@ void THyperlinkVisibilityManager::onDataReceived()
     quint32 minOutputDelay = 0;
     bool hasOutputLinks = false;
 
-    for (const auto& link : mTrackedLinks) {
+    for (const auto& link : std::as_const(mTrackedLinks)) {
         if (link.expireOnOutput) {
             hasOutputLinks = true;
             if (minOutputDelay == 0 || link.outputDelayMs < minOutputDelay) {
@@ -578,7 +579,7 @@ void THyperlinkVisibilityManager::stopTimerIfNotNeeded()
 {
     if (mpTimer && mpTimer->isActive()) {
         bool hasTimerLinks = false;
-        for (const auto& link : mTrackedLinks) {
+        for (const auto& link : std::as_const(mTrackedLinks)) {
             // Only skip zero-delay links if they don't require the timer
             // RevealThenConceal links in certain phases still need the timer even with zero delay
             if (link.delayMs == 0) {
@@ -685,7 +686,7 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
 
             // Stop timer if no more timer-based links exist
             bool hasTimers = false;
-            for (const auto& remainingLink : mTrackedLinks) {
+            for (const auto& remainingLink : std::as_const(mTrackedLinks)) {
                 if (remainingLink.delayMs > 0 || remainingLink.expireOnOutput) {
                     hasTimers = true;
                     break;

--- a/src/TLinkStore.cpp
+++ b/src/TLinkStore.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
- *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2023, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -99,7 +100,7 @@ void TLinkStore::expireLinks(const QString& expireName, Host* pH)
 
     QList<int> linkIds = mExpireToLinks.values(expireName);
 
-    for (int linkId : linkIds) {
+    for (const int linkId : std::as_const(linkIds)) {
         removeLinkById(linkId, pH);
     }
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
- *   Copyright (C) 2014-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2024, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -108,7 +109,7 @@ TMap::~TMap()
         qWarning() << "TMap::~TMap() Instance being destroyed before it could display some messages,\n"
                    << "messages are:\n"
                    << "------------";
-        for (const auto& message : mStoredMessages) {
+        for (const auto& message : std::as_const(mStoredMessages)) {
             qWarning() << message << "\n------------";
         }
     }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
- *   Copyright (C) 2014-2020, 2022-2025 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2020, 2022-2026 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
  *                                                                         *
@@ -146,7 +146,7 @@ QList<TMediaData> TMedia::playingMedia(TMediaData& mediaData)
         }
     }
 
-    for (const auto& pPlayer : mediaPlayerList) {
+    for (const auto& pPlayer : std::as_const(mediaPlayerList)) {
         if (!pPlayer) {
             continue;
         }
@@ -197,7 +197,7 @@ QList<TMediaData> TMedia::pausedMedia(TMediaData& mediaData)
         }
     }
 
-    for (const auto& pPlayer : mediaPlayerList) {
+    for (const auto& pPlayer : std::as_const(mediaPlayerList)) {
         if (!pPlayer) {
             continue;
         }
@@ -246,7 +246,7 @@ void TMedia::pauseMedia(TMediaData& mediaData)
         }
     }
 
-    for (const auto& pPlayer : mediaPlayerList) {
+    for (const auto& pPlayer : std::as_const(mediaPlayerList)) {
         if (!pPlayer) {
             continue;
         }
@@ -396,7 +396,7 @@ void TMedia::refreshAudioDevices()
 
     QList<std::shared_ptr<TMediaPlayer>> mediaPlayerList = findMediaPlayersByCriteria(mediaData);
 
-    for (const auto& player : mediaPlayerList) {
+    for (const auto& player : std::as_const(mediaPlayerList)) {
         if (player) {
             player->refreshAudioOutput();
         }
@@ -519,7 +519,7 @@ bool TMedia::resume(TMediaData mediaData)
         }
     }
 
-    for (const auto& pPlayer : mediaPlayerList) {
+    for (const auto& pPlayer : std::as_const(mediaPlayerList)) {
         if (!pPlayer) {
             continue;
         }
@@ -548,7 +548,7 @@ void TMedia::stopAllMediaPlayers()
 
     QList<std::shared_ptr<TMediaPlayer>> mediaPlayerList = findMediaPlayersByCriteria(mediaData);
 
-    for (const auto& pPlayer : mediaPlayerList) {
+    for (const auto& pPlayer : std::as_const(mediaPlayerList)) {
         if (!pPlayer) {
             continue;
         }
@@ -564,7 +564,7 @@ void TMedia::setMediaPlayersMuted(const TMediaData::MediaProtocol mediaProtocol,
 
     QList<std::shared_ptr<TMediaPlayer>> mediaPlayerList = findMediaPlayersByCriteria(mediaData);
 
-    for (const auto& player : mediaPlayerList) {
+    for (const auto& player : std::as_const(mediaPlayerList)) {
         if (!player) {
             continue;
         }
@@ -1354,7 +1354,7 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
 
     QList<std::shared_ptr<TMediaPlayer>> mediaPlayerList = TMedia::findMediaPlayersByCriteria(mediaData);
 
-    for (const auto& pTestPlayer : mediaPlayerList) {
+    for (const auto& pTestPlayer : std::as_const(mediaPlayerList)) {
         if (!pTestPlayer) {
             continue;
         }
@@ -1388,7 +1388,7 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
 {
     QList<std::shared_ptr<TMediaPlayer>> mediaPlayerList = TMedia::findMediaPlayersByCriteria(mediaData);
 
-    for (const auto& pTestPlayer : mediaPlayerList) {
+    for (const auto& pTestPlayer : std::as_const(mediaPlayerList)) {
         if (!pTestPlayer) {
             continue;
         }

--- a/src/TMxpCustomElementTagHandler.cpp
+++ b/src/TMxpCustomElementTagHandler.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
- *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2020, 2026 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,7 +37,7 @@ TMxpTagHandlerResult TMxpCustomElementTagHandler::handleStartTag(TMxpContext& ct
     }
 
     if (!el.definition.isEmpty()) {
-        for (const QSharedPointer<MxpNode>& ptr : el.parsedDefinition) {
+        for (const QSharedPointer<MxpNode>& ptr : std::as_const(el.parsedDefinition)) {
             if (!ptr->isTag()) {
                 ctx.handleContent(ptr->asText()->getContent());
             } else {

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2025 by Mike Conley - mike.conley@stickmud.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -44,7 +45,7 @@ TMxpFrame::~TMxpFrame()
     parentFrame = nullptr;
 
     // Orphan children - we do NOT delete them since TMxpFrameManager owns all frames
-    for (TMxpFrame* child : childFrames) {
+    for (TMxpFrame* child : std::as_const(childFrames)) {
         if (child && !child->mBeingDestroyed) {
             child->parentFrame = nullptr;
         }
@@ -252,7 +253,7 @@ void TMxpFrameManager::resetAllFrames()
     // Called on reconnect - MXP frames don't persist between sessions
     QStringList frameNames = mFrames.keys();
 
-    for (const QString& name : frameNames) {
+    for (const QString& name : std::as_const(frameNames)) {
         closeFrame(name);
     }
 
@@ -922,7 +923,7 @@ void TMxpFrameManager::removeFrameFromHierarchy(TMxpFrame* frame)
     frame->parentFrame = nullptr;
 
     // Orphan children (set their parentFrame to nullptr)
-    for (TMxpFrame* child : frame->childFrames) {
+    for (TMxpFrame* child : std::as_const(frame->childFrames)) {
         if (child && !child->mBeingDestroyed) {
             child->parentFrame = nullptr;
         }

--- a/src/TMxpTagProcessor.cpp
+++ b/src/TMxpTagProcessor.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018, 2026 by Stephen Lyons -                      *
+ *                                                 slysven@virginmedia.com *
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -70,7 +71,7 @@ TMxpTagHandlerResult TMxpTagProcessor::handleTag(TMxpContext& ctx, TMxpClient& c
         return MXP_TAG_NOT_HANDLED;
     }
 
-    for (const auto& handler : mRegisteredHandlers) {
+    for (const auto& handler : std::as_const(mRegisteredHandlers)) {
         TMxpTagHandlerResult result = handler->handleTag(ctx, client, tag);
 
         if (result != MXP_TAG_NOT_HANDLED) {
@@ -92,7 +93,7 @@ TMxpTagHandlerResult TMxpTagProcessor::handleTag(TMxpContext& ctx, TMxpClient& c
 
 void TMxpTagProcessor::handleContent(char ch)
 {
-    for (const auto& handler : mRegisteredHandlers) {
+    for (const auto& handler : std::as_const(mRegisteredHandlers)) {
         handler->handleContent(ch);
     }
 }

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2021 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2021, 2026 by Stephen Lyons - slysven@virginmedia.com   *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -46,7 +46,7 @@ TScript::~TScript()
     if (!mpHost) {
         return;
     }
-    for (const auto& handler : mEventHandlerList) {
+    for (const auto& handler : std::as_const(mEventHandlerList)) {
         mpHost->unregisterEventHandler(handler, this);
     }
     mpHost->getScriptUnit()->unregisterScript(this);
@@ -63,7 +63,7 @@ bool TScript::registerScript()
 
 void TScript::setEventHandlerList(QStringList handlerList)
 {
-    for (const QString& handler : mEventHandlerList) {
+    for (const QString& handler : std::as_const(mEventHandlerList)) {
         mpHost->unregisterEventHandler(handler, this);
     }
     mEventHandlerList.clear();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2023 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2016, 2018-2023, 2026 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
@@ -1800,13 +1800,13 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
                                 // For exclusive groups, update visual state of all other members that may have been deselected
                                 if (mgr->isGroupExclusive(group)) {
                                     QStringList groupMembers = mgr->getGroupMembers(group);
-                                    for (const QString& member : groupMembers) {
+                                    for (const QString& member : std::as_const(groupMembers)) {
                                         if (member != value) {
                                             // Get all link IDs with this group/value combination using the reverse index
                                             bool memberSelected = mgr->isSelected(group, member);
                                             QList<int> matchingLinkIds = mpBuffer->mLinkStore.getLinkIdsByGroupValue(group, member);
 
-                                            for (int otherLinkId : matchingLinkIds) {
+                                            for (const int otherLinkId : std::as_const(matchingLinkIds)) {
                                                 mpBuffer->setLinkSelected(otherLinkId, memberSelected);
                                                 mpBuffer->setLinkState(otherLinkId, memberSelected ? Mudlet::HyperlinkStyling::StateSelected : Mudlet::HyperlinkStyling::StateDefault);
                                                 mpBuffer->updateLinkCharacters(otherLinkId);
@@ -3666,7 +3666,7 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
                 mpBuffer->markLinkAsVisited(focusedLink);
 
                 // Execute the command(s)
-                for (const auto& cmd : commands) {
+                for (const auto& cmd : std::as_const(commands)) {
                     mpHost->send(cmd);
                 }
 

--- a/src/TriggerHighlighter.cpp
+++ b/src/TriggerHighlighter.cpp
@@ -1,4 +1,7 @@
 /***************************************************************************
+ *   Copyright (C) 2024 by Zooka                                           *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
@@ -39,7 +42,7 @@ void TriggerHighlighter::highlightBlock(const QString& text)
         return;
     }
 
-    for (const HighlightingRule& rule : highlightingRules) {
+    for (const HighlightingRule& rule : std::as_const(highlightingRules)) {
         QRegularExpressionMatchIterator matchIterator = rule.pattern.globalMatch(text);
         while (matchIterator.hasNext()) {
             QRegularExpressionMatch match = matchIterator.next();

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,7 +2,8 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2017-2023 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2023, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -559,7 +560,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
 
         auto mInstalledPackages = host.append_child("mInstalledPackages");
 
-        for (const auto& package : pHost->mInstalledPackages) {
+        for (const auto& package : std::as_const(pHost->mInstalledPackages)) {
             mInstalledPackages.append_child("string").text().set(package.toUtf8().constData());
         }
 
@@ -726,7 +727,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     {
         QStringList allExperiments = pHost->getAllExperiments();
         if (!allExperiments.isEmpty()) {
-            for (const auto& experimentKey : allExperiments) {
+            for (const auto& experimentKey : std::as_const(allExperiments)) {
                 auto experiment = host.append_child("experiment");
                 experiment.append_attribute("key") = experimentKey.toUtf8().constData();
                 experiment.append_attribute("enabled") = "yes";
@@ -1228,7 +1229,7 @@ void XMLexport::writeScript(TScript* pT, pugi::xml_node xmlParent)
             writeScriptElement(pT->mScript, scriptContents);
 
             auto eventHandlerList = scriptContents.append_child("eventHandlerList");
-            for (const auto& handler : pT->mEventHandlerList) {
+            for (const auto& handler : std::as_const(pT->mEventHandlerList)) {
                 eventHandlerList.append_child("string").text().set(handler.toUtf8().constData());
             }
         }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -222,7 +222,7 @@ cTelnet::~cTelnet()
 #else
         qWarning("cTelnet::~cTelnet() Instance being destroyed before it could display some messages,\nmessages are:\n------------");
 #endif
-        for (const auto& message : messageStack) {
+        for (const auto& message : std::as_const(messageStack)) {
 #if defined(Q_OS_WINDOWS)
             qWarning("%s", qPrintable(message));
             qWarning("------------");
@@ -753,7 +753,7 @@ void cTelnet::slot_socketDisconnected()
                 // so do not auto-reconnect:
                 mDontReconnect = true;
 
-                for (const auto& error : sslErrors) {
+                for (const auto& error : std::as_const(sslErrors)) {
                     reasons.append(error.errorString());
                 }
             }
@@ -962,13 +962,13 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 
     // Report found IP addresses:
     QStringList addressesToReport;
-    for (const auto& address : addressList_ipV6) {
+    for (const auto& address : std::as_const(addressList_ipV6)) {
         /*: Used to add an IPv6 address line to the list displayed during
  connecting to a Host. Some, e.g. Far Eastern locales may require a
  different text here if they do not use spaces, or need "wide" '(' ')'s*/
         addressesToReport << tr("%1 (IPv6)").arg(address);
     }
-    for (const auto& address : addressList_ipV4) {
+    for (const auto& address : std::as_const(addressList_ipV4)) {
         /*: Used to add an IPv4 address line to the list displayed during
  connecting to a Host. Some, e.g. Far Eastern locales may require a
  different text here if they do not use spaces, or "wide" '('...')'*/
@@ -1269,7 +1269,7 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
             }
         } else {
             // Plain, raw ASCII, we hope!
-            for (const auto c : data) {
+            for (const auto c : std::as_const(data)) {
                 if ((!mEncodingWarningIssued) && (c.row() || c.cell() > 127)) {
                     QString errorMsg = tr(errorMsgTemplate, "%1 is the command that was sent to the game.").arg(data);
                     postMessage(errorMsg);
@@ -3346,7 +3346,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 QByteArray acceptedCharacterSet;
 
                 if (!characterSetList.isEmpty()) {
-                    for (QByteArray characterSet : characterSetList) {
+                    for (QByteArray characterSet : std::as_const(characterSetList)) {
                         characterSet = characterSet.toUpper();
 
                         if (mAcceptableEncodings.contains(characterSet) || mAcceptableEncodings.contains(("M_" + characterSet))

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2018, 2020-2023, 2025 by Stephen Lyons             *
+ *   Copyright (C) 2016-2018, 2020-2023, 2025-2026 by Stephen Lyons        *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
@@ -124,7 +124,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
     auto objectList = mpCopyProfile->associatedObjects();
     QList<QWidget*> widgetList;
-    for (auto pObjectItem : objectList) {
+    for (const auto pObjectItem : std::as_const(objectList)) {
         auto pWidgetItem = qobject_cast<QWidget*>(pObjectItem);
         if (pWidgetItem) {
             widgetList << pWidgetItem;
@@ -137,7 +137,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
     objectList = copyProfileSettings->associatedObjects();
     widgetList.clear();
-    for (auto pObjectItem : objectList) {
+    for (const auto pObjectItem : std::as_const(objectList)) {
         auto pWidgetItem = qobject_cast<QWidget*>(pObjectItem);
         if (pWidgetItem) {
             widgetList << pWidgetItem;
@@ -1999,14 +1999,14 @@ bool dlgConnectionProfiles::copyFolder(const QString& sourceFolder, const QStrin
         destDir.mkdir(destFolder);
     }
     QStringList files = sourceDir.entryList(QDir::Files);
-    for (const QString& file : files) {
+    for (const QString& file : std::as_const(files)) {
         const QString srcName = sourceFolder + QDir::separator() + file;
         const QString destName = destFolder + QDir::separator() + file;
         QFile::copy(srcName, destName);
     }
     files.clear();
     files = sourceDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
-    for (const QString& file : files) {
+    for (const QString& file : std::as_const(files)) {
         const QString srcName = sourceFolder + QDir::separator() + file;
         const QString destName = destFolder + QDir::separator() + file;
         copyFolder(srcName, destName);

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2011 by Heiko Koehn - KoehnHeiko@googlemail.com         *
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
- *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2022, 2026 by Stephen Lyons - slysven@virginmedia.com   *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -205,7 +205,7 @@ void dlgPackageManager::populatePackagesWithUpdates()
 {
     mPackagesWithUpdates.clear();
 
-    for (const QString& packageName : mpHost->mInstalledPackages) {
+    for (const QString& packageName : std::as_const(mpHost->mInstalledPackages)) {
         if (!packageLookup.contains(packageName)) {
             continue;
         }
@@ -248,7 +248,7 @@ bool dlgPackageManager::readPackageRepositoryFile()
 
     repositoryPackages = obj[qsl("packages")].toArray();
     packageLookup.clear();
-    for (const QJsonValue& val : repositoryPackages) {
+    for (const QJsonValue& val : std::as_const(repositoryPackages)) {
         QJsonObject pkg = val.toObject();
         packageLookup.insert(pkg["mpackage"].toString(), pkg);
     }
@@ -619,7 +619,7 @@ void dlgPackageManager::slot_removePackages()
         removePackages << item->text();
     }
 
-    for (const QString& package : removePackages) {
+    for (const QString& package : std::as_const(removePackages)) {
         mpHost->uninstallPackage(package, enums::PackageModuleType::Package);
     }
 
@@ -632,7 +632,7 @@ void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
     packageList->clear();
 
     if (mCurrentView == NavigationView::Installed) {
-        for (const auto& value : mpHost->mPackageInfo) {
+        for (const auto& value : std::as_const(mpHost->mPackageInfo)) {
             const QString name = value.value(qsl("mpackage"));
             const QString title = value.value(qsl("title"));
             const QString description = value.value(qsl("description"));
@@ -657,7 +657,7 @@ void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
             }
         }
     } else if (mCurrentView == NavigationView::Explore) {
-        for (const QJsonValue& value : repositoryPackages) {
+        for (const QJsonValue& value : std::as_const(repositoryPackages)) {
             const QJsonObject pkg = value.toObject();
             const QString name = pkg[qsl("mpackage")].toString();
             const QString title = pkg[qsl("title")].toString();
@@ -678,7 +678,7 @@ void dlgPackageManager::slot_searchTextChanged(const QString& searchText)
             }
         }
     } else if (mCurrentView == NavigationView::Updates) {
-        for (const QString& packageName : mPackagesWithUpdates) {
+        for (const QString& packageName : std::as_const(mPackagesWithUpdates)) {
             const auto packageInfo = mpHost->mPackageInfo.value(packageName);
             const QString title = packageInfo.value(qsl("title"));
             const QString description = packageInfo.value(qsl("description"));
@@ -743,7 +743,7 @@ void dlgPackageManager::slot_setPackageList()
         if (!readPackageRepositoryFile()) {
             return;
         }
-        for (const QJsonValue& packageVal : repositoryPackages) {
+        for (const QJsonValue& packageVal : std::as_const(repositoryPackages)) {
             auto item = new QListWidgetItem();
             const QJsonObject packageObj = packageVal.toObject();
             const QString packageName = packageObj.value("mpackage").toString();
@@ -762,7 +762,7 @@ void dlgPackageManager::slot_setPackageList()
             packageDescription->setPlainText(tr("All packages are up to date."));
         }
 
-        for (const QString& packageName : mPackagesWithUpdates) {
+        for (const QString& packageName : std::as_const(mPackagesWithUpdates)) {
             auto item = new QListWidgetItem();
             item->setText(packageName);
             const auto packageInfo{mpHost->mPackageInfo.value(packageName)};

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2021 by Piotr Wilczynski - delwing@gmail.com            *
- *   Copyright (C) 2022-2023, 2025 by Stephen Lyons                        *
+ *   Copyright (C) 2022-2023, 2025-2026 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2022-2025 by Lecker Kebap - Leris@mudlet.org            *
  *                                                                         *
@@ -77,7 +77,7 @@ void dlgRoomProperties::init(QHash<QString, int> usedNames,
     mpRooms = pRooms;
 
     // Store original border values for live preview restoration on cancel
-    for (TRoom* room : mpRooms) {
+    for (TRoom* room : std::as_const(mpRooms)) {
         mOriginalBorderColors[room] = room->mBorderColor;
         mOriginalBorderThicknesses[room] = room->mBorderThickness;
     }
@@ -743,7 +743,7 @@ void dlgRoomProperties::slot_borderThicknessChanged(int value)
 void dlgRoomProperties::emitBorderPreview()
 {
     // Apply current border settings directly to rooms for live preview
-    for (TRoom* room : mpRooms) {
+    for (TRoom* room : std::as_const(mpRooms)) {
         if (mBorderColorWasChanged) {
             room->mBorderColor = selectedBorderColor;
         }
@@ -756,7 +756,7 @@ void dlgRoomProperties::emitBorderPreview()
 
 void dlgRoomProperties::restoreOriginalBorders()
 {
-    for (TRoom* room : mpRooms) {
+    for (TRoom* room : std::as_const(mpRooms)) {
         room->mBorderColor = mOriginalBorderColors.value(room);
         room->mBorderThickness = mOriginalBorderThicknesses.value(room);
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2024, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Owen Davison - odavison@cs.dal.ca               *
  *   Copyright (C) 2016-2020 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Tom Scheper - scheper@gmail.com                 *
@@ -1408,7 +1409,7 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
-    for (auto* patternEdit : mTriggerPatternEdit) {
+    for (auto* patternEdit : std::as_const(mTriggerPatternEdit)) {
         applyPatternWidgetStyle(patternEdit);
     }
 }
@@ -1729,7 +1730,7 @@ void dlgTriggerEditor::setupPatternNavigationShortcuts()
         mLastPatternShortcut = nullptr;
     }
 
-    for (auto* shortcut : mPatternNavigationShortcuts) {
+    for (auto* shortcut : std::as_const(mPatternNavigationShortcuts)) {
         if (shortcut) {
             shortcut->deleteLater();
         }
@@ -2855,7 +2856,7 @@ void dlgTriggerEditor::delete_alias()
     QStringList itemNames;
     QList<TAlias*> aliasesToDelete;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TAlias* pT = mpHost->getAliasUnit()->getAlias(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -2933,7 +2934,7 @@ void dlgTriggerEditor::delete_alias()
     };
 
     // Capture each selected alias and all its descendants
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TAlias* pT = mpHost->getAliasUnit()->getAlias(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             int parentID = -1;
@@ -2971,7 +2972,7 @@ void dlgTriggerEditor::delete_alias()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         const int itemId = pItem->data(0, Qt::UserRole).toInt();
         TAlias* pT = mpHost->getAliasUnit()->getAlias(itemId);
@@ -3025,7 +3026,7 @@ void dlgTriggerEditor::delete_action()
     QStringList itemNames;
     QList<TAction*> actionsToDelete;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TAction* pT = mpHost->getActionUnit()->getAction(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -3081,7 +3082,7 @@ void dlgTriggerEditor::delete_action()
     };
 
     // Capture each selected action and all its descendants
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TAction* pT = mpHost->getActionUnit()->getAction(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             // Determine parent ID and position
@@ -3113,7 +3114,7 @@ void dlgTriggerEditor::delete_action()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         const int itemId = pItem->data(0, Qt::UserRole).toInt();
         TAction* pT = mpHost->getActionUnit()->getAction(itemId);
@@ -3176,7 +3177,7 @@ void dlgTriggerEditor::delete_variable()
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TVar* var = vu->getWVar(pItem);
         if (var) {
             itemNames << var->getName();
@@ -3207,7 +3208,7 @@ void dlgTriggerEditor::delete_variable()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         TVar* var = vu->getWVar(pItem);
 
@@ -3250,7 +3251,7 @@ void dlgTriggerEditor::delete_script()
     QStringList itemNames;
     QList<TScript*> scriptsToDelete;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TScript* pT = mpHost->getScriptUnit()->getScript(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -3306,7 +3307,7 @@ void dlgTriggerEditor::delete_script()
     };
 
     // Capture each selected script and all its descendants
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TScript* pT = mpHost->getScriptUnit()->getScript(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             // Determine parent ID and position
@@ -3338,7 +3339,7 @@ void dlgTriggerEditor::delete_script()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         const int itemId = pItem->data(0, Qt::UserRole).toInt();
         TScript* pT = mpHost->getScriptUnit()->getScript(itemId);
@@ -3392,7 +3393,7 @@ void dlgTriggerEditor::delete_key()
     QStringList itemNames;
     QList<TKey*> keysToDelete;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TKey* pT = mpHost->getKeyUnit()->getKey(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -3448,7 +3449,7 @@ void dlgTriggerEditor::delete_key()
     };
 
     // Capture each selected key and all its descendants
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TKey* pT = mpHost->getKeyUnit()->getKey(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             // Determine parent ID and position
@@ -3480,7 +3481,7 @@ void dlgTriggerEditor::delete_key()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         const int itemId = pItem->data(0, Qt::UserRole).toInt();
         TKey* pT = mpHost->getKeyUnit()->getKey(itemId);
@@ -3534,7 +3535,7 @@ void dlgTriggerEditor::delete_trigger()
     QStringList itemNames;
     QList<TTrigger*> triggersToDelete;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -3590,7 +3591,7 @@ void dlgTriggerEditor::delete_trigger()
     };
 
     // Capture each selected trigger and all its descendants
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             // Determine parent ID and position
@@ -3627,7 +3628,7 @@ void dlgTriggerEditor::delete_trigger()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         const int itemId = pItem->data(0, Qt::UserRole).toInt();
         TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(itemId);
@@ -3681,7 +3682,7 @@ void dlgTriggerEditor::delete_timer()
     QStringList itemNames;
     QList<TTimer*> timersToDelete;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TTimer* pT = mpHost->getTimerUnit()->getTimer(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -3737,7 +3738,7 @@ void dlgTriggerEditor::delete_timer()
     };
 
     // Capture each selected timer and all its descendants
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TTimer* pT = mpHost->getTimerUnit()->getTimer(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             // Determine parent ID and position
@@ -3769,7 +3770,7 @@ void dlgTriggerEditor::delete_timer()
     std::reverse(selectedItems.begin(), selectedItems.end());
 
     QTreeWidgetItem* newSelection = nullptr;
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         QTreeWidgetItem* pParentItem = pItem->parent();
         const int itemId = pItem->data(0, Qt::UserRole).toInt();
         TTimer* pT = mpHost->getTimerUnit()->getTimer(itemId);
@@ -5740,7 +5741,7 @@ void dlgTriggerEditor::saveTrigger()
     QStringList patterns;
     QList<int> patternKinds;
     int validItems = 0;
-    for (auto* patternEdit : mTriggerPatternEdit) {
+    for (const auto* patternEdit : std::as_const(mTriggerPatternEdit)) {
         QString pattern = patternEdit->singleLineTextEdit_pattern->toPlainText();
 
         // Spaces in the pattern may be marked with middle dots, convert them back
@@ -8290,7 +8291,7 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
     if (pT) {
         const QString name = pT->getName();
         QStringList eventHandlerList = pT->getEventHandlerList();
-        for (const QString& handler : eventHandlerList) {
+        for (const QString& handler : std::as_const(eventHandlerList)) {
             auto pItem = new QListWidgetItem(mpScriptsMainArea->listWidget_script_registered_event_handlers);
             pItem->setText(handler);
             mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
@@ -9669,7 +9670,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     if (mFirstPatternShortcut) {
         mFirstPatternShortcut->setEnabled(enablePatternShortcuts);
     }
-    for (auto* shortcut : mPatternNavigationShortcuts) {
+    for (auto* shortcut : std::as_const(mPatternNavigationShortcuts)) {
         if (shortcut) {
             shortcut->setEnabled(enablePatternShortcuts);
         }
@@ -10030,7 +10031,7 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
 
     introTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
     QString introTextOptions;
-    for (const auto& [name, headline, contents] : introAddCurrentItem.options) {
+    for (const auto& [name, headline, contents] : std::as_const(introAddCurrentItem.options)) {
         introTextOptions.append((name != desiredOption) ? qsl("<li><a href='%1' style='color: inherit; text-decoration: underline;'>%2</a></li>").arg(name, headline)
                                                         : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
@@ -10965,7 +10966,7 @@ void dlgTriggerEditor::exportTriggerToClipboard()
     QStringList triggerNames;
     QList<TTrigger*> triggersToExport;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         const int triggerID = pItem->data(0, Qt::UserRole).toInt();
         TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
         if (pT) {
@@ -11029,7 +11030,7 @@ void dlgTriggerEditor::exportTimerToClipboard()
     QStringList timerNames;
     QList<TTimer*> timersToExport;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         const int timerID = pItem->data(0, Qt::UserRole).toInt();
         TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
         if (pT) {
@@ -11085,7 +11086,7 @@ void dlgTriggerEditor::exportAliasToClipboard()
     QStringList aliasNames;
     QList<TAlias*> aliasesToExport;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         const int aliasID = pItem->data(0, Qt::UserRole).toInt();
         TAlias* pT = mpHost->getAliasUnit()->getAlias(aliasID);
         if (pT) {
@@ -11141,7 +11142,7 @@ void dlgTriggerEditor::exportActionToClipboard()
     QStringList actionNames;
     QList<TAction*> actionsToExport;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         const int actionID = pItem->data(0, Qt::UserRole).toInt();
         TAction* pT = mpHost->getActionUnit()->getAction(actionID);
         if (pT) {
@@ -11197,7 +11198,7 @@ void dlgTriggerEditor::exportScriptToClipboard()
     QStringList scriptNames;
     QList<TScript*> scriptsToExport;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         const int scriptID = pItem->data(0, Qt::UserRole).toInt();
         TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
         if (pT) {
@@ -11253,7 +11254,7 @@ void dlgTriggerEditor::exportKeyToClipboard()
     QStringList keyNames;
     QList<TKey*> keysToExport;
 
-    for (QTreeWidgetItem* pItem : selectedItems) {
+    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         const int keyID = pItem->data(0, Qt::UserRole).toInt();
         TKey* pT = mpHost->getKeyUnit()->getKey(keyID);
         if (pT) {
@@ -11483,7 +11484,7 @@ void dlgTriggerEditor::slot_pasteXml()
 
         QString originalClipboard = QApplication::clipboard()->text();
 
-        for (const QString& xmlItem : xmlPackages) {
+        for (const QString& xmlItem : std::as_const(xmlPackages)) {
             QString xmlItemTrimmed = xmlItem.trimmed();
             if (xmlItemTrimmed.isEmpty()) {
                 continue; // Skip empty items
@@ -11527,7 +11528,7 @@ void dlgTriggerEditor::slot_pasteXml()
 
                     bool isGroup = (targetItem && targetItem->childCount() > 0) || (targetTrigger && targetTrigger->isFolder());
 
-                    for (int itemID : importedIDs) {
+                    for (const int itemID : std::as_const(importedIDs)) {
                         if (isGroup) {
                             mpHost->getTriggerUnit()->reParentTrigger(itemID, 0, targetId, -1, -1);
                         } else {
@@ -11912,7 +11913,7 @@ void dlgTriggerEditor::slot_pasteXml()
         if (xmlPackages.size() > 1) {
             // Multiple items were pasted
             if (!importedIDs.isEmpty()) {
-                for (int itemID : importedIDs) {
+                for (const int itemID : std::as_const(importedIDs)) {
                     registerUndoCommand(importedItemType, itemID);
                 }
             }
@@ -13247,7 +13248,7 @@ void dlgTriggerEditor::slot_restoreEditorItemsToolbar()
 void dlgTriggerEditor::clearTriggerForm()
 {
     // Clear pattern fields
-    for (auto* patternEdit : mTriggerPatternEdit) {
+    for (auto* patternEdit : std::as_const(mTriggerPatternEdit)) {
         patternEdit->singleLineTextEdit_pattern->clear();
         if (patternEdit->singleLineTextEdit_pattern->isHidden()) {
             patternEdit->singleLineTextEdit_pattern->show();
@@ -13623,7 +13624,7 @@ void dlgTriggerEditor::slot_itemsChanged(EditorViewType viewType, QList<int> aff
                 }
             }
         } else {
-            for (auto* patternEdit : mTriggerPatternEdit) {
+            for (auto* patternEdit : std::as_const(mTriggerPatternEdit)) {
                 patternEdit->singleLineTextEdit_pattern->clear();
                 if (patternEdit->singleLineTextEdit_pattern->isHidden()) {
                     patternEdit->singleLineTextEdit_pattern->show();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2025 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2026 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
@@ -1791,7 +1791,7 @@ void mudlet::slot_newMapWindow()
 void mudlet::updateWindowMenu()
 {
     // Clean up existing window list actions
-    for (QAction* action : mWindowListActions) {
+    for (QAction* action : std::as_const(mWindowListActions)) {
         menuWindow->removeAction(action);
         action->deleteLater();
     }
@@ -1848,7 +1848,7 @@ void mudlet::updateWindowMenu()
         // Collect unique detached windows to avoid duplicates
         QSet<TDetachedWindow*> uniqueDetachedWindows;
 
-        for (const auto& detachedWindow : mDetachedWindows) {
+        for (const auto& detachedWindow : std::as_const(mDetachedWindows)) {
             if (detachedWindow) {
                 uniqueDetachedWindows.insert(detachedWindow);
             }
@@ -1859,7 +1859,7 @@ void mudlet::updateWindowMenu()
             // Get all profiles in this detached window
             QStringList profilesInWindow = detachedWindow->getProfileNames();
 
-            for (const QString& windowProfileName : profilesInWindow) {
+            for (const QString& windowProfileName : std::as_const(profilesInWindow)) {
                 QString actionText = tr("%1 (Detached)").arg(windowProfileName);
                 QAction* profileAction = new QAction(actionText, this);
                 profileAction->setCheckable(true);
@@ -1873,7 +1873,7 @@ void mudlet::updateWindowMenu()
     }
 
     // Also update window menus on all detached windows
-    for (const auto& detachedWindow : mDetachedWindows) {
+    for (const auto& detachedWindow : std::as_const(mDetachedWindows)) {
         if (detachedWindow) {
             detachedWindow->updateWindowMenu();
         }
@@ -1956,7 +1956,7 @@ void mudlet::slot_activateDetachedWindowProfile()
     QString profileName = action->data().toString();
 
     // Find which detached window contains this profile
-    for (const auto& detachedWindow : mDetachedWindows) {
+    for (const auto& detachedWindow : std::as_const(mDetachedWindows)) {
         if (detachedWindow && detachedWindow->getProfileNames().contains(profileName)) {
             // Activate the detached window
             detachedWindow->raise();
@@ -2748,7 +2748,7 @@ void mudlet::closeEvent(QCloseEvent* event)
 
     // Snapshot detached windows before closeHost() mutates mDetachedWindows
     QSet<TDetachedWindow*> uniqueDetachedWindows;
-    for (const auto& window : mDetachedWindows) {
+    for (const auto& window : std::as_const(mDetachedWindows)) {
         if (window) {
             uniqueDetachedWindows.insert(window.data());
         }
@@ -4551,7 +4551,7 @@ QString mudlet::findMatchingProfile(const QString& host, int port)
     QString matchedProfile;
     QDateTime latestTime;
 
-    for (const auto& profileName : profileNames) {
+    for (const auto& profileName : std::as_const(profileNames)) {
         QString profileHost = readProfileData(profileName, qsl("url"));
         QString profilePort = readProfileData(profileName, qsl("port"));
 
@@ -4725,7 +4725,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     }
 
     // install default packages
-    for (const auto& package : mPackagesToInstallList) {
+    for (const auto& package : std::as_const(mPackagesToInstallList)) {
         pHost->installPackage(package, enums::PackageModuleType::Package);
     }
 
@@ -7044,7 +7044,7 @@ void mudlet::refreshTabBar()
     }
 
     // Also refresh all detached windows to ensure they show CDC identifiers
-    for (const auto& detachedWindow : mDetachedWindows) {
+    for (const auto& detachedWindow : std::as_const(mDetachedWindows)) {
         if (detachedWindow) {
             detachedWindow->refreshTabBar();
         }
@@ -7231,7 +7231,7 @@ bool mudlet::experiencedMudletPlayer()
     QFileInfoList entries = profilesDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
     QDateTime sixMonthsAgo = QDateTime::currentDateTime().addMonths(-6);
 
-    for (const QFileInfo& entry : entries) {
+    for (const QFileInfo& entry : std::as_const(entries)) {
         if (entry.lastModified() < sixMonthsAgo) {
             cachedResult = true;
             return true;
@@ -7300,7 +7300,7 @@ bool mudlet::profileExists(const QString& profileName)
 
 void mudlet::saveDetachedWindowsGeometry()
 {
-    for (const auto& detachedWindow : mDetachedWindows) {
+    for (const auto& detachedWindow : std::as_const(mDetachedWindows)) {
         if (detachedWindow) {
             detachedWindow->saveWindowGeometry();
         }
@@ -7718,7 +7718,7 @@ void mudlet::addConsoleToSplitter(TMainConsole* console, int index)
     bool needsResize = false;
 
     // Check if any widget has zero or very small size
-    for (int size : sizes) {
+    for (const int size : std::as_const(sizes)) {
         if (size < 10) { // Less than 10 pixels is effectively invisible
             needsResize = true;
             break;
@@ -8814,7 +8814,7 @@ void mudlet::reattachOrphanedProfiles()
     qWarning() << "reattachOrphanedProfiles: Reattaching" << orphanedProfiles.size() << "orphaned profiles:" << orphanedProfiles;
 
     // Reattach each orphaned profile to the main window
-    for (const QString& profileName : orphanedProfiles) {
+    for (const QString& profileName : std::as_const(orphanedProfiles)) {
         Host* pHost = mHostManager.getHost(profileName);
 
         if (!pHost || !pHost->mpConsole) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "C+11 range-loop might detach Qt container [clazy-range-loop-detach]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
There was over 100 of this particular item - some of them also could have `const` applied to the iterator.