### PR TITLE
Fix: Clazy warnings part 2 - detaching-temporary

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1720,7 +1720,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     // try and set the player to a room if we don't have a known location
     if (!pPlayerRoom && !mpMap->mpRoomDB->isEmpty()) {
-        int randomRoom = mpMap->mpRoomDB->getRoomIDList().first();
+        int randomRoom = mpMap->mpRoomDB->getRoomIDList().constFirst();
         pPlayerRoom = mpMap->mpRoomDB->getRoom(randomRoom);
         playerRoomId = pPlayerRoom->getId();
     }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018-2020, 2022-2025 by Stephen Lyons                   *
+ *   Copyright (C) 2018-2020, 2022-2026 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2023-2025 by Lecker Kebap - Leris@mudlet.org            *
  *                                                                         *
@@ -916,7 +916,7 @@ void TCommandLine::fillSpellCheckList(QMouseEvent* event, QMenu* popup)
     * only) argument given.
     */
 
-    auto separator_aboveStandardMenu = popup->insertSeparator(popup->actions().first());
+    auto separator_aboveStandardMenu = popup->insertSeparator(popup->actions().constFirst());
     if (handle_profile) {
         popup->insertAction(separator_aboveStandardMenu, action_removeWord);
         popup->insertAction(action_removeWord, action_addWord);

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2010 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016, 2022 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2016, 2022, 2026 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -410,7 +411,7 @@ void dlgComposer::fillSpellCheckList(QMouseEvent* event, QMenu* popup)
     * only) argument given.
     */
 
-    auto separator_aboveStandardMenu = popup->insertSeparator(popup->actions().first());
+    auto separator_aboveStandardMenu = popup->insertSeparator(popup->actions().constFirst());
     if (handle_profile) {
         popup->insertAction(separator_aboveStandardMenu, action_removeWord);
         popup->insertAction(action_removeWord, action_addWord);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014, 2016-2018, 2020-2023, 2025 by Stephen Lyons       *
+ *   Copyright (C) 2014, 2016-2018, 2020-2023, 2025-2026 by Stephen Lyons  *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
@@ -2676,7 +2676,7 @@ void dlgProfilePreferences::slot_saveMap()
             return;
         }
 
-        auto fileName = dialog->selectedFiles().first();
+        auto fileName = dialog->selectedFiles().constFirst();
 
         QSettings& settings = *mudlet::getQSettings();
         QString lastDir = QFileInfo(fileName).absolutePath();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "Don't call QList::first() on temporary [clazy-detaching-temporary]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
A summary I found for this is:
> Clazy-detaching-temporary is a warning in the Clazy tool that indicates a
potential issue when calling certain methods, like `QList::first()`, on temporary objects, which may lead to unnecessary copies. This warning is meant to help developers avoid performance pitfalls in Qt applications.
