### PR TITLE
Fix: Clazy warnings part 3 - qstring-arg

### DIFF
--- a/src/MMCPClient.cpp
+++ b/src/MMCPClient.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
- *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2024, 2026 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -111,7 +111,10 @@ void MMCPClient::slot_connected()
     mPeerAddress = convertToIPv4(mTcpSocket.peerAddress());
     mPeerPort = mTcpSocket.peerPort();
 
-    QString str = qsl("CHAT:%1\n%2%3").arg(mpMMCPServer->getChatName()).arg(mPeerAddress).arg(mPeerPort, -5);
+    QString str = qsl("CHAT:%1\n%2%3")
+                          .arg(mpMMCPServer->getChatName(),
+                               mPeerAddress)
+                          .arg(mPeerPort, -5);
 
     mTcpSocket.write(str.toLatin1());
 
@@ -444,9 +447,7 @@ void MMCPClient::slot_displayError(QAbstractSocket::SocketError socketError)
 void MMCPClient::sendMessage(const QString& msg)
 {
     writeData(qsl("%1%2%3")
-                      .arg(static_cast<char>(Message))
-                      .arg(msg)
-                      .arg(static_cast<char>(End)));
+                      .arg(static_cast<char>(Message), msg, static_cast<char>(End)));
 }
 
 
@@ -500,9 +501,7 @@ void MMCPClient::sendRequestConnections()
 void MMCPClient::sendVersion()
 {
     writeData(qsl("%1%2%4")
-                      .arg(static_cast<char>(Version))
-                      .arg(mudlet::self()->scmVersion)
-                      .arg(static_cast<char>(End)));
+                      .arg(static_cast<char>(Version), mudlet::self()->scmVersion, static_cast<char>(End)));
 }
 
 /**
@@ -763,14 +762,14 @@ void MMCPClient::handleIncomingChatGroup(const QString& msg)
 
     using namespace AnsiColors;
 
-    //: Incoming group message
+    //: Incoming group message, %1, %2 and %4 are ANSI Escape codes
     const QString groupMsg = tr("%1%2%3%4(%5)%1%2%6%1")
-                                     .arg(RST)
-                                     .arg(FBLDRED)
-                                     .arg(mpHost->getMMCPChatPrefix())
-                                     .arg(FBLDCYN)
-                                     .arg(groupStr)
-                                     .arg(trimmedMsg);
+                                     .arg(RST,
+                                          FBLDRED,
+                                          mpHost->getMMCPChatPrefix(),
+                                          FBLDCYN,
+                                          groupStr,
+                                          trimmedMsg);
 
     mpMMCPServer->clientMessage(this, groupMsg);
 }
@@ -780,7 +779,7 @@ void MMCPClient::handleIncomingChatGroup(const QString& msg)
  */
 void MMCPClient::handleIncomingNameChange(const QString& newName)
 {
-    const QString infoMsg = tr("[ CHAT ]  - %1 is now known as %2.").arg(mPeerName).arg(newName);
+    const QString infoMsg = tr("[ CHAT ]  - %1 is now known as %2.").arg(mPeerName, newName);
     mpHost->postMessage(infoMsg);
     mPeerName = newName;
 }
@@ -857,9 +856,7 @@ void MMCPClient::handleIncomingPeekList(const QString& list)
 void MMCPClient::handleIncomingPingRequest(const QString& msg)
 {
     writeData(qsl("%1%2%3")
-                      .arg(static_cast<char>(PingResponse))
-                      .arg(msg)
-                      .arg(static_cast<char>(End)));
+                      .arg(static_cast<char>(PingResponse), msg, static_cast<char>(End)));
 }
 
 /**
@@ -874,7 +871,7 @@ void MMCPClient::handleIncomingPingResponse(const QString& data)
         const QString infoMsg = tr("[ CHAT ]  - Ping returned from %1: %2 ms").arg(mPeerName).arg(QDateTime::currentMSecsSinceEpoch() - returnTime);
         mpHost->postMessage(infoMsg);
     } else {
-        const QString infoMsg = tr("[ CHAT ]  - Bad Ping response from %1: %2").arg(mPeerName).arg(data);
+        const QString infoMsg = tr("[ CHAT ]  - Bad Ping response from %1: %2").arg(mPeerName, data);
         mpHost->postMessage(infoMsg);
     }
 }

--- a/src/MMCPServer.cpp
+++ b/src/MMCPServer.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2024 by John McKisson - john.mckisson@gmail.com         *
- *   Copyright (C) 2024 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2024, 2026 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -232,9 +232,7 @@ QPair<bool, QString> MMCPServer::chatTo(const QVariant& target, const QString& m
 
     if (pClient) {
         const QString outMsg = qsl("%1%2 chats to you, '%3'\n%4")
-                                       .arg(static_cast<char>(TextPersonal))
-                                       .arg(getChatName(), msg)
-                                       .arg(static_cast<char>(End));
+                                       .arg(static_cast<char>(TextPersonal), getChatName(), msg, static_cast<char>(End));
         pClient->writeData(outMsg);
 
         using namespace AnsiColors;
@@ -264,10 +262,7 @@ QPair<bool, QString> MMCPServer::chatAll(const QString& msg)
     }
 
     const QString outMsg = qsl("%1\n%2 chats to everybody, '%3'%4")
-                                   .arg(static_cast<char>(TextEveryone))
-                                   .arg(getChatName())
-                                   .arg(msg)
-                                   .arg(static_cast<char>(End));
+                                   .arg(static_cast<char>(TextEveryone), getChatName(), msg, static_cast<char>(End));
 
     QListIterator<QPointer<MMCPClient>> it(mPeersList);
     while (it.hasNext()) {
@@ -466,9 +461,7 @@ QPair<bool, QString> MMCPServer::chatName(const QString& name)
 
     if (!mPeersList.isEmpty()) {
         const QString outMsg = qsl("%1%2%3")
-                                       .arg(static_cast<char>(NameChange))
-                                       .arg(name)
-                                       .arg(static_cast<char>(End));
+                                       .arg(static_cast<char>(NameChange), name, static_cast<char>(End));
 
         QListIterator<QPointer<MMCPClient>> it(mPeersList);
         while (it.hasNext()) {
@@ -495,9 +488,7 @@ QPair<bool, QString> MMCPServer::sendSideChannel(const QString& channel, const Q
     }
 
     const QString outMsg = qsl("%1%2,%3%4")
-                                   .arg(static_cast<char>(SideChannel))
-                                   .arg(channel, msg)
-                                   .arg(static_cast<char>(End));
+                                   .arg(static_cast<char>(SideChannel), channel, msg, static_cast<char>(End));
     QListIterator<QPointer<MMCPClient>> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
@@ -578,9 +569,7 @@ QPair<bool, QString> MMCPServer::emoteAll(const QString& msg)
     }
 
     const QString outMsg = qsl("%1%2 %3\n%4")
-                                   .arg(static_cast<char>(TextEveryone))
-                                   .arg(getChatName(), msg)
-                                   .arg(static_cast<char>(End));
+                                   .arg(static_cast<char>(TextEveryone), getChatName(), msg, static_cast<char>(End));
     QListIterator<QPointer<MMCPClient>> it(mPeersList);
     while (it.hasNext()) {
         MMCPClient* cl = it.next();
@@ -1078,9 +1067,7 @@ void MMCPServer::sendPublicPeek(MMCPClient* pClient)
 void MMCPServer::sendServedMessage(MMCPClient* pClient, const QString& msg, bool onlyToServed)
 {
     const QString cmdStr = qsl("%1%2%3")
-                                   .arg(static_cast<char>(TextEveryone))
-                                   .arg(msg)
-                                   .arg(static_cast<char>(End));
+                                   .arg(static_cast<char>(TextEveryone), msg, static_cast<char>(End));
 
     QListIterator<QPointer<MMCPClient>> it(mPeersList);
     while (it.hasNext()) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5265,7 +5265,7 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
 
         // Export each Z level as a separate file
         for (const int currentZLevel : std::as_const(pArea->zLevels)) {
-            QString levelFileName = QString("%1/%2_level_%3.%4").arg(basePath).arg(baseFileName).arg(currentZLevel).arg(extension.isEmpty() ? "png" : extension);
+            QString levelFileName = qsl("%1/%2_level_%3.%4").arg(basePath, baseFileName, QString::number(currentZLevel), extension.isEmpty() ? "png" : extension);
 
             // Recursively call this function for each Z level (without exportAllZLevels flag)
             auto [success, message] = exportAreaToImage(areaId, levelFileName, currentZLevel, zoom, false);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2024, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2021 by Vadim Peretokin - vperetokin@gmail.com          *
@@ -1473,15 +1474,14 @@ bool TConsole::setConsoleBackgroundImage(const QString& imgPath, int mode)
     }
 
     if (mode == 1) {
-        styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); border-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
+        styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); border-image: url(%2);}").arg(getColorCode(bgColor), imgPath);
     } else if (mode == 2) {
         styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); background-image: url(%2); background-repeat: no-repeat; background-position: center; background-origin: margin;}")
-                             .arg(getColorCode(bgColor))
-                             .arg(imgPath);
+                             .arg(getColorCode(bgColor), imgPath);
     } else if (mode == 3) {
-        styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); background-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
+        styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); background-image: url(%2);}").arg(getColorCode(bgColor), imgPath);
     } else if (mode == 4) {
-        styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); %2}").arg(getColorCode(bgColor)).arg(imgPath);
+        styleSheet = qsl("QWidget#MainDisplay{background-color: rgba(%1); %2}").arg(getColorCode(bgColor), imgPath);
     } else {
         return false;
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2983,31 +2983,30 @@ void TTextEdit::slot_analyseSelection()
             quint8 columnsToUse = qMax(size_t{2}, utf8Width);
 
             if (includeThisCodePoint) {
-                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>").arg(QString::number(columnsToUse), QString::number(index + 1), QString::number(index + 2)));
+                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>")
+                                            .arg(QString::number(columnsToUse),
+                                                 QString::number(index + 1),
+                                                 QString::number(index + 2)));
 
                 // The use of one qsl inside another is because it is
                 // impossible to force an upper-case alphabet to Hex digits otherwise
                 // just for that number (and not the rest of the resultant String):
-                // &#8232; is the Unicode Line Separator
-                utf16Vals.append(
-                        qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
-                                .arg(QString::number(columnsToUse))
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-                                .arg(qsl("%1")
-                                             .arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))), 4, 16, zero)
-                                             .toUpper())
-                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
-                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
-#else
-                                .arg(qsl("%1").arg(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1)), 4, 16, zero).toUpper())
-                                .arg(mpBuffer->lineBuffer.at(line).at(index).unicode(), 4, 16, zero)
-                                .arg(mpBuffer->lineBuffer.at(line).at(index + 1).unicode(), 4, 16, zero));
-#endif
+                // &#8232; is the Unicode Line Separator.
+                // The static casts are only needed since Qt 6.9.0 but they
+                // shouldn't do any harm prior to that:
+                utf16Vals.append(qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
+                                         .arg(QString::number(columnsToUse),
+                                              qsl("%1").arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
+                                                                                                         mpBuffer->lineBuffer.at(line).at(index + 1))),
+                                                            4, 16, zero).toUpper())
+                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
+                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
 
                 // Note the addition to the index here to jump over the low-surrogate:
                 graphemes.append(qsl("<td colspan=\"%1\">%2</td>")
-                                         .arg(QString::number(columnsToUse))
-                                         .arg(convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))));
+                                         .arg(QString::number(columnsToUse),
+                                              convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index),
+                                                                        mpBuffer->lineBuffer.at(line).at(index + 1))));
             }
 
             switch (utf8Width) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "Use multi-arg instead [clazy-qstring-arg]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
A summary I found for this is:
>Using multi-arg methods is recommended for better performance and reduced
memory usage in `QString` operations. This approach is encouraged to optimise code efficiency.
