### PR TITLE
Improve: Make spacing between widgets in the connection dialog more consistent

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -26,19 +26,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="leftMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="topMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <item>
     <widget class="QWidget" name="widget_top" native="true">
@@ -56,7 +56,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="spacing">
-       <number>0</number>
+       <number>12</number>
       </property>
       <property name="leftMargin">
        <number>0</number>
@@ -86,9 +86,15 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <property name="spacing">
+          <number>12</number>
+         </property>
+         <property name="leftMargin">
           <number>0</number>
          </property>
          <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
           <number>0</number>
          </property>
          <property name="bottomMargin">
@@ -326,7 +332,7 @@
            <property name="minimumSize">
             <size>
              <width>0</width>
-             <height>50</height>
+             <height>25</height>
             </size>
            </property>
            <property name="maximumSize">
@@ -336,6 +342,21 @@
             </size>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
             <item>
              <spacer name="horizontalSpacer_4">
               <property name="orientation">
@@ -381,6 +402,11 @@
                 <width>0</width>
                 <height>25</height>
                </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>13</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Copy</string>
@@ -428,7 +454,7 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>340</width>
+          <width>328</width>
           <height>0</height>
          </size>
         </property>
@@ -439,6 +465,21 @@
          </size>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="spacing">
+          <number>12</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
           <widget class="QTextBrowser" name="welcome_message">
            <property name="enabled">
@@ -860,6 +901,21 @@
    <item>
     <widget class="QWidget" name="widget_bottom" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="spacing">
+       <number>12</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Refer to the annotated screenshot below.

1. I adjusted the top margin of the left half of the dialog to match the right side.
2. The gap between the left and right containers is twice as large as the insets from the edge of the dialog. I removed the margins and used spacing in the horizontal horizontal layout instead.
3. Removed the extra padding on the right side of the profile management buttons.
4. This gap was made consistent with the other gaps.
5. ~~The "copy" button was using a default value for the font size. I added a font size that matches the other buttons.~~

<img width="760" height="721" alt="annotated" src="https://github.com/user-attachments/assets/40fc6e0f-08af-4b70-824f-ce03d0a4b778" />

##### Before and After

|Before|After|
|-|-|
| <img width="760" height="721" alt="before" src="https://github.com/user-attachments/assets/98db9d83-e770-4de2-bd39-af93ebb1c90a" /> | <img width="760" height="724" alt="after" src="https://github.com/user-attachments/assets/072952a8-8352-43c7-903e-281239201a92" /> |
| <img width="760" height="725" alt="before2" src="https://github.com/user-attachments/assets/b208475e-4f07-4531-a185-7f07fe3d30df" /> | <img width="760" height="729" alt="after2" src="https://github.com/user-attachments/assets/ec54aca4-daf6-4e5f-bcfe-1d255136ad86" /> |





#### Motivation for adding to Mudlet

I'm familiarizing myself with the codebase and QT in general, and the minor inconsistencies in this dialog seemed like a good target.

#### Other info (issues closed, discussion etc)

The gap between the "dialog buttons" in the bottom right cluster, and the between buttons in the "profile management" cluster are slightly different. The dialog buttons seem to have platform-dependent behavior 