### PR TITLE
Fix: Clazy warnings part 4 - range-loop-reference

### DIFF
--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016, 2018, 2020, 2024, 2025 by Stephen Lyons           *
+ *   Copyright (C) 2016, 2018, 2020, 2024-2026 by Stephen Lyons            *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
@@ -134,7 +134,7 @@ void HostManager::changeAllHostColour(const Host* pHost)
         return;
     }
     //change all main and subconsoles color
-    for (QSharedPointer<Host> host : mHostPool.values()) {
+    for (const QSharedPointer<Host> &host : mHostPool.values()) {
         host->mpConsole->changeColors();
         // Mapper also needs a refresh of its colours
         auto mapper = host->mpMap->mpMapper;

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -586,7 +586,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         }
 
         // Remove all consoles from the stacked widget and reset their parents
-        for (auto console : std::as_const(mProfileConsoleMap)) {
+        for (const auto &console : std::as_const(mProfileConsoleMap)) {
             if (console) {
                 mpConsoleContainer->removeWidget(console);
                 console->setParent(nullptr);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3372,7 +3372,7 @@ void mudlet::restoreProfileFocus(const QString& profileName)
         auto detachedWindows = mudletInstance->mDetachedWindows;
         TDetachedWindow* detachedWindow = nullptr;
 
-        for (auto window : detachedWindows) {
+        for (const auto &window : detachedWindows) {
             if (window && window->getProfileNames().contains(profileName)) {
                 detachedWindow = window;
                 break;
@@ -4953,7 +4953,7 @@ void mudlet::slot_muteMedia()
 
 void mudlet::slot_audioOutputDeviceChanged()
 {
-    for (auto pHost : mHostManager) {
+    for (const auto &pHost : mHostManager) {
         if (pHost && pHost->mpMedia) {
             pHost->mpMedia->refreshAudioDevices();
         }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "Missing reference in range-for with non trivial type [clazy-range-loop-reference]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
A summary I found for this is:
> The warning occurs when using C++11 range-loops with non-trivial types by
value, which can cause unnecessary copy-constructor and destructor calls. To fix it, add a `const` reference to the range declaration, like `for (const auto &i : list) { ... }`.