### PR TITLE
Fix: correct use of forward declared type items in headers

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2021, 2023-2024 by Stephen Lyons                  *
+ *   Copyright (C) 2017, 2021, 2023-2024, 2026 by Stephen Lyons            *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -31,6 +31,14 @@
 #include "mudlet.h"
 
 #include <functional>
+
+/* We need an explict constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any deferencing
+ * of it there:*/
+ActionUnit::ActionUnit(Host* pHost)
+: mpHost(pHost)
+{
+}
 
 ActionUnit::~ActionUnit()
 {

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -32,8 +32,8 @@
 
 #include <functional>
 
-/* We need an explict constructor in this file as the Host class is forward
- * declared in the header file and it is problematic to define any deferencing
+/* We need an explicit constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any dereferencing
  * of it there:*/
 ActionUnit::ActionUnit(Host* pHost)
 : mpHost(pHost)

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2022-2023 by Stephen Lyons                        *
+ *   Copyright (C) 2017, 2022-2023, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -43,9 +43,7 @@ class ActionUnit
     friend class XMLimport;
 
 public:
-    explicit ActionUnit(Host* pHost)
-    : mpHost(pHost)
-    {}
+    explicit ActionUnit(Host*);
     ~ActionUnit();
 
     std::list<TAction*> getActionRootNodeList()

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -28,8 +28,8 @@
 
 #include <functional>
 
-/* We need an explict constructor in this file as the Host class is forward
- * declared in the header file and it is problematic to define any deferencing
+/* We need an explicit constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any dereferencing
  * of it there:*/
 AliasUnit::AliasUnit(Host* pHost)
 : mpHost(pHost)

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2024, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,6 +27,14 @@
 #include "TAlias.h"
 
 #include <functional>
+
+/* We need an explict constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any deferencing
+ * of it there:*/
+AliasUnit::AliasUnit(Host* pHost)
+: mpHost(pHost)
+{
+}
 
 AliasUnit::~AliasUnit()
 {

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2023, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -41,10 +42,7 @@ class AliasUnit
     friend class XMLimport;
 
 public:
-    explicit AliasUnit(Host* pHost)
-    : mpHost(pHost)
-    {
-    }
+    explicit AliasUnit(Host*);
     ~AliasUnit();
 
     std::list<TAlias*> getAliasRootNodeList() { return mAliasRootNodeList; }

--- a/src/GifTracker.cpp
+++ b/src/GifTracker.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2023-2023 by Adam Robinson - seldon1951@hotmail.com     *
+ *   Copyright (C) 2023 by Adam Robinson - seldon1951@hotmail.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +23,13 @@
 
 #include "Host.h"
 
+/* We need an explict constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any deferencing
+ * of it there:*/
+GifTracker::GifTracker(Host* pHost)
+: mpHost(pHost)
+{
+}
 
 bool GifTracker::registerGif(QMovie* pT)
 {

--- a/src/GifTracker.cpp
+++ b/src/GifTracker.cpp
@@ -23,8 +23,8 @@
 
 #include "Host.h"
 
-/* We need an explict constructor in this file as the Host class is forward
- * declared in the header file and it is problematic to define any deferencing
+/* We need an explicit constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any dereferencing
  * of it there:*/
 GifTracker::GifTracker(Host* pHost)
 : mpHost(pHost)

--- a/src/GifTracker.h
+++ b/src/GifTracker.h
@@ -2,7 +2,8 @@
 #define MUDLET_GIFUNIT_H
 
 /***************************************************************************
- *   Copyright (C) 2023-2023 by Adam Robinson - seldon1951@hotmail.com     *
+ *   Copyright (C) 2023 by Adam Robinson - seldon1951@hotmail.com          *
+ *   Copyright (C) 2026 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,9 +37,7 @@ class GifTracker
 
 public:
     GifTracker() = default;
-    explicit GifTracker(Host* pHost)
-    : mpHost(pHost)
-    {}
+    explicit GifTracker(Host* pHost);
 
     bool registerGif(QMovie* pT);
     void unregisterGif(QMovie* pT);
@@ -46,7 +45,6 @@ public:
 
 
 private:
-    //GifTracker() = default;
     QPointer<Host> mpHost;
     std::list<QMovie*> mMovieList;
 };

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2024, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,6 +28,14 @@
 #include "TScript.h"
 
 #include <functional>
+
+/* We need an explict constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any deferencing
+ * of it there:*/
+ScriptUnit::ScriptUnit(Host* pHost)
+: mpHost(pHost)
+{
+}
 
 ScriptUnit::~ScriptUnit()
 {

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -29,8 +29,8 @@
 
 #include <functional>
 
-/* We need an explict constructor in this file as the Host class is forward
- * declared in the header file and it is problematic to define any deferencing
+/* We need an explicit constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any dereferencing
  * of it there:*/
 ScriptUnit::ScriptUnit(Host* pHost)
 : mpHost(pHost)

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2023, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -40,9 +41,7 @@ class ScriptUnit
     friend class XMLimport;
 
 public:
-    explicit ScriptUnit(Host* pHost)
-    : mpHost(pHost)
-    {}
+    explicit ScriptUnit(Host*);
     ~ScriptUnit();
 
     std::list<TScript*> getScriptRootNodeList()

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017-2022 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2022, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +25,7 @@
 
 
 #include "Tree.h"
+#include "utils.h" // For NameGroupMatches
 
 #include <QDebug>
 #include <QPointer>
@@ -34,7 +36,6 @@
 
 class Host;
 
-using NameGroupMatches = QVector<QPair<QString, QString>>;
 
 class TAlias : public Tree<TAlias>
 {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1888,7 +1888,7 @@ void TCommandLine::resizeEvent(QResizeEvent* event)
 
 /* We need to have this method defined in this file as the TConsole class is
  * forward declared in the header file and it is problematic to define any
- * deferencing of it there:*/
+ * dereferencing of it there:*/
 TConsole* TCommandLine::console() const
 {
     return mpConsole;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1885,3 +1885,11 @@ void TCommandLine::resizeEvent(QResizeEvent* event)
         positionPasswordToggleButton();
     }
 }
+
+/* We need to have this method defined in this file as the TConsole class is
+ * forward declared in the header file and it is problematic to define any
+ * deferencing of it there:*/
+TConsole* TCommandLine::console() const
+{
+    return mpConsole;
+}

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018-2019, 2022-2023 by Stephen Lyons                   *
+ *   Copyright (C) 2018-2019, 2022-2023, 2026 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
@@ -76,7 +76,7 @@ public:
     void removeBlacklist(const QString&);
     void clearBlacklist();
     void adjustHeight();
-    TConsole* console() const { return mpConsole; }
+    TConsole* console() const;
     void setEchoSuppression(bool suppress);
 
     int mActionFunction = 0;

--- a/src/TDockWidget.cpp
+++ b/src/TDockWidget.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
- *   Copyright (C) 2019-2020, 2022-2023 by Stephen Lyons                   *
+ *   Copyright (C) 2019-2020, 2022-2023, 2026 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -92,4 +92,12 @@ void TDockWidget::setVisible(bool visible)
     } else {
         QWidget::setVisible(false);
     }
+}
+
+/* We need to have this method defined in this file as the TConsole class is
+ * forward declared in the header file and it is problematic to define any
+ * deferencing of it there:*/
+TConsole* TDockWidget::getConsole()
+{
+    return mpConsole;
 }

--- a/src/TDockWidget.cpp
+++ b/src/TDockWidget.cpp
@@ -96,7 +96,7 @@ void TDockWidget::setVisible(bool visible)
 
 /* We need to have this method defined in this file as the TConsole class is
  * forward declared in the header file and it is problematic to define any
- * deferencing of it there:*/
+ * dereferencing of it there:*/
 TConsole* TDockWidget::getConsole()
 {
     return mpConsole;

--- a/src/TDockWidget.h
+++ b/src/TDockWidget.h
@@ -2,7 +2,7 @@
 #define MUDLET_TDOCKWIDGET_H
 /***************************************************************************
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
- *   Copyright (C) 2019, 2022-2023 by Stephen Lyons                        *
+ *   Copyright (C) 2019, 2022-2023, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -35,7 +35,7 @@ class TDockWidget : public QDockWidget {
 public:
     TDockWidget(Host *, const QString &);
     void setTConsole(TConsole*);
-    TConsole* getConsole() {return mpConsole;}
+    TConsole* getConsole();
     void setVisible(bool) override;
 
 

--- a/src/TMatchState.h
+++ b/src/TMatchState.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2010 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2022, 2026 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,6 +21,15 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
+#include <list>
+#include <string>
+
+#include <QString>
+#include <QPair>
+#include <QVector>
+
+using NameGroupMatches = QVector<QPair<QString, QString>>;
 
 class TMatchState
 {

--- a/src/TMatchState.h
+++ b/src/TMatchState.h
@@ -22,6 +22,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "utils.h" // For NameGroupMatches
+
 #include <list>
 #include <string>
 
@@ -29,7 +31,6 @@
 #include <QPair>
 #include <QVector>
 
-using NameGroupMatches = QVector<QPair<QString, QString>>;
 
 class TMatchState
 {

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2018, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +25,7 @@
 
 
 #include "Tree.h"
+#include "utils.h" // For NameGroupMatches
 
 #include <QColor>
 #include <QDebug>
@@ -50,8 +52,6 @@ class TMatchState;
 #define REGEX_LINE_SPACER 5
 #define REGEX_COLOR_PATTERN 6
 #define REGEX_PROMPT 7
-
-using NameGroupMatches = QVector<QPair<QString, QString>>;
 
 struct TColorTable
 {

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2019, 2022-2024 by Stephen Lyons                        *
+ *   Copyright (C) 2019, 2022-2024, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -28,6 +28,14 @@
 #include "TTimer.h"
 
 #include <functional>
+
+/* We need an explict constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any deferencing
+ * of it there:*/
+TimerUnit::TimerUnit(Host* pHost)
+: mpHost(pHost)
+{
+}
 
 TimerUnit::~TimerUnit()
 {

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -29,8 +29,8 @@
 
 #include <functional>
 
-/* We need an explict constructor in this file as the Host class is forward
- * declared in the header file and it is problematic to define any deferencing
+/* We need an explicit constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any dereferencing
  * of it there:*/
 TimerUnit::TimerUnit(Host* pHost)
 : mpHost(pHost)

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2019, 2022-2023 by Stephen Lyons                        *
+ *   Copyright (C) 2019, 2022-2023, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -47,10 +47,7 @@ class TimerUnit
     friend class XMLimport;
 
 public:
-    explicit TimerUnit(Host* pHost)
-    : mpHost(pHost)
-    {
-    }
+    explicit TimerUnit(Host*);
     ~TimerUnit();
 
     void resetStats();

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -30,8 +30,8 @@
 
 #include <functional>
 
-/* We need an explict constructor in this file as the Host class is forward
- * declared in the header file and it is problematic to define any deferencing
+/* We need an explicit constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any dereferencing
  * of it there:*/
 TriggerUnit::TriggerUnit(Host* pHost)
 : mpHost(pHost)

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022-2024 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2024, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,6 +29,16 @@
 #include "TTrigger.h"
 
 #include <functional>
+
+/* We need an explict constructor in this file as the Host class is forward
+ * declared in the header file and it is problematic to define any deferencing
+ * of it there:*/
+TriggerUnit::TriggerUnit(Host* pHost)
+: mpHost(pHost)
+, mMaxID(0)
+, mModuleMember()
+{
+}
 
 TriggerUnit::~TriggerUnit()
 {

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2022-2023, 2026 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -41,12 +42,7 @@ class TriggerUnit
     friend class XMLimport;
 
 public:
-    explicit TriggerUnit(Host* pHost)
-    : mpHost(pHost)
-    , mMaxID(0)
-    , mModuleMember()
-    {
-    }
+    explicit TriggerUnit(Host*);
     ~TriggerUnit();
 
     std::list<TTrigger*> getTriggerRootNodeList() { return mTriggerRootNodeList; }

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,8 @@
 
 using TEnterEvent = QEnterEvent;
 
+using NameGroupMatches = QVector<QPair<QString, QString>>;
+
 // Common enum for specifying insertion mode for tree items
 // Used across all editor item types (triggers, aliases, timers, scripts, actions, keys)
 enum class TreeItemInsertMode {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A number of fixes to remove errors reported during Clazy analysis of the Mudlet files - such errors prevent getting warnings from such files for things that are addressed by #9195 and #9196. Generally this required the movement of method definitions from a header file to the corresponding class file so that forward declared types/classes were not used/returned by definitions in the header files.

#### Motivation for adding to Mudlet
Preparing the code-base to allow further investigation of warnings that Clang-Tidy reports when it can review ALL the files in the Mudlet sources.

#### Other info (issues closed, discussion etc)
I suspect this will reveal some more warnings of the types in those other mentioned PRs - in the files that could not be analysed before because of the errors fixed here.
