### PR TITLE
improve: 2D mapper rendering speed on single-Z-level areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ qrc_*.cpp
 mudlet
 app-build.txt
 src/crash_reporter/build/
+/package*
+/portable*
+/Mudlet*
 
 
 # Qt creator's clangd cache

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -574,9 +574,6 @@ add_library(${LIB_MUDLET_TARGET} STATIC
     ${mudlet_UIS}
 )
 
-# Enable Lua 5.1 compatibility layer for LUA_GLOBALSINDEX and other legacy constants
-target_compile_definitions(${LIB_MUDLET_TARGET} PRIVATE LUA_COMPAT_5_1)
-
 ########################### Debugging code inclusions ##########################
 # Controls the include/selection of extra code to aide developers debug various
 # features of Mudlet, generally speaking they will not be '#define'd in

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,8 @@ set(mudlet_SRCS
     TAction.cpp
     TAlias.cpp
     TArea.cpp
+    TAreaGridIndex.cpp
+    TAreaZLevelIndex.cpp
     TBuffer.cpp
     TCommandLine.cpp
     TConsole.cpp
@@ -341,6 +343,8 @@ set(mudlet_HDRS
     TAction.h
     TAlias.h
     TArea.h
+    TAreaGridIndex.h
+    TAreaZLevelIndex.h
     TAstar.h
     TBuffer.h
     TCommandLine.h
@@ -569,6 +573,9 @@ add_library(${LIB_MUDLET_TARGET} STATIC
     ${mudlet_HDRS}
     ${mudlet_UIS}
 )
+
+# Enable Lua 5.1 compatibility layer for LUA_GLOBALSINDEX and other legacy constants
+target_compile_definitions(${LIB_MUDLET_TARGET} PRIVATE LUA_COMPAT_5_1)
 
 ########################### Debugging code inclusions ##########################
 # Controls the include/selection of extra code to aide developers debug various

--- a/src/PanInteractionHandler.cpp
+++ b/src/PanInteractionHandler.cpp
@@ -130,7 +130,7 @@ bool PanInteractionHandler::handleMouseMove(T2DMap::MapInteractionContext& conte
 
     map->m2DPanStart = panNewPosition;
     mMapWidget.mShiftMode = true;
-    mMapWidget.update();
+    mMapWidget.scheduleRender();
 
     return true;
 }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -61,10 +61,12 @@
 #include <QMapIterator>
 #include <QMenu>
 #include <QStandardPaths>
+#include <QTimer>
 #include <QtEvents>
 #include <QtUiTools>
 #include <QWidget>
 
+#include <climits>
 #include <cmath>
 
 #include <algorithm>
@@ -118,7 +120,26 @@ std::optional<int> T2DMap::roomIdAtWidgetPosition(const QPoint& widgetPosition, 
     const int my = widgetPosition.y();
     const int mz = mMapCenterZ;
 
-    QSetIterator<int> roomIterator(area->getAreaRooms());
+    if (area->gridMode) {
+        // Grid mode: snap the click to the nearest grid-cell centre and look
+        // it up directly.  The pixel-distance check below breaks at extreme
+        // zoom-out where rooms are sub-pixel in size, whereas this works at
+        // all zoom levels.
+        const int worldX = qRound(static_cast<double>(mx - fx) / mRoomWidth);
+        const int worldY = qRound(static_cast<double>(fy - my) / mRoomHeight);
+        const QSet<int>& cellRooms = area->getGridIndex().roomsAt(mz, worldX, worldY);
+        if (!cellRooms.isEmpty()) {
+            return *cellRooms.constBegin();
+        }
+        return std::nullopt;
+    }
+
+    // Non-grid mode: use pixel-distance hit test with a minimum 1-pixel radius
+    // so that clicks remain functional even when rooms are very small on screen.
+    const int halfW = qMax(1, qRound(mRoomWidth * rSize / 2.0));
+    const int halfH = qMax(1, qRound(mRoomHeight * rSize / 2.0));
+
+    QSetIterator<int> roomIterator(area->getRoomsForZ(mz));
     while (roomIterator.hasNext()) {
         const int roomId = roomIterator.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
@@ -128,9 +149,8 @@ std::optional<int> T2DMap::roomIdAtWidgetPosition(const QPoint& widgetPosition, 
 
         const int rx = room->x() * mRoomWidth + fx;
         const int ry = room->y() * -1 * mRoomHeight + fy;
-        const int rz = room->z();
 
-        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
+        if (qAbs(mx - rx) < halfW && qAbs(my - ry) < halfH) {
             return roomId;
         }
     }
@@ -153,7 +173,18 @@ QSet<int> T2DMap::roomIdsAtWidgetPosition(const QPoint& widgetPosition, const TA
     const int my = widgetPosition.y();
     const int mz = mMapCenterZ;
 
-    QSetIterator<int> roomIterator(area->getAreaRooms());
+    if (area->gridMode) {
+        // Grid mode: look up the exact cell under the cursor.
+        const int worldX = qRound(static_cast<double>(mx - fx) / mRoomWidth);
+        const int worldY = qRound(static_cast<double>(fy - my) / mRoomHeight);
+        const QSet<int>& cellRooms = area->getGridIndex().roomsAt(mz, worldX, worldY);
+        return cellRooms;
+    }
+
+    const int halfW = qMax(1, qRound(mRoomWidth * rSize / 2.0));
+    const int halfH = qMax(1, qRound(mRoomHeight * rSize / 2.0));
+
+    QSetIterator<int> roomIterator(area->getRoomsForZ(mz));
     while (roomIterator.hasNext()) {
         const int roomId = roomIterator.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
@@ -163,9 +194,8 @@ QSet<int> T2DMap::roomIdsAtWidgetPosition(const QPoint& widgetPosition, const TA
 
         const int rx = room->x() * mRoomWidth + fx;
         const int ry = room->y() * -1 * mRoomHeight + fy;
-        const int rz = room->z();
 
-        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
+        if (qAbs(mx - rx) < halfW && qAbs(my - ry) < halfH) {
             result.insert(roomId);
         }
     }
@@ -200,40 +230,56 @@ void T2DMap::prepareSingleClickSelection(MapInteractionContext& context)
     const float fx = ((xspan / 2.0f) - mMapCenterX) * mRoomWidth;
     const float fy = ((yspan / 2.0f) - mMapCenterY) * mRoomHeight;
 
-    QSetIterator<int> roomIterator(area->getAreaRooms());
-    while (roomIterator.hasNext()) {
-        const int roomId = roomIterator.next();
-        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
-        if (!room) {
-            continue;
+    const int mx = context.widgetPosition.x();
+    const int my = context.widgetPosition.y();
+    const int mz = mMapCenterZ;
+
+    // Build the list of rooms under the cursor.  Grid mode uses the spatial
+    // index for an exact cell lookup (works at all zoom levels including
+    // extreme zoom-out where rooms are sub-pixel sized).  Non-grid mode uses
+    // a pixel-distance test with a minimum 1-pixel radius.
+    QList<int> hitRooms;
+    if (area->gridMode) {
+        const int worldX = qRound(static_cast<double>(mx - fx) / mRoomWidth);
+        const int worldY = qRound(static_cast<double>(fy - my) / mRoomHeight);
+        for (const int roomId : area->getGridIndex().roomsAt(mz, worldX, worldY)) {
+            hitRooms.append(roomId);
         }
+    } else {
+        const int halfW = qMax(1, qRound(mRoomWidth * rSize / 2.0));
+        const int halfH = qMax(1, qRound(mRoomHeight * rSize / 2.0));
+        QSetIterator<int> roomIterator(area->getRoomsForZ(mz));
+        while (roomIterator.hasNext()) {
+            const int roomId = roomIterator.next();
+            TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+            if (!room) {
+                continue;
+            }
+            const int rx = room->x() * mRoomWidth + fx;
+            const int ry = room->y() * -1 * mRoomHeight + fy;
+            if (qAbs(mx - rx) < halfW && qAbs(my - ry) < halfH) {
+                hitRooms.append(roomId);
+            }
+        }
+    }
 
-        const int rx = room->x() * mRoomWidth + fx;
-        const int ry = room->y() * -1 * mRoomHeight + fy;
-        const int rz = room->z();
+    for (const int roomId : hitRooms) {
+        const bool hasShift = context.modifiers.testFlag(Qt::ShiftModifier);
+        const bool hasCtrl = context.modifiers.testFlag(Qt::ControlModifier);
+        const bool isAlreadySelected = mMultiSelectionSet.contains(roomId);
 
-        const int mx = context.widgetPosition.x();
-        const int my = context.widgetPosition.y();
-        const int mz = mMapCenterZ;
-
-        if ((qAbs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (qAbs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
-            const bool hasShift = context.modifiers.testFlag(Qt::ShiftModifier);
-            const bool hasCtrl = context.modifiers.testFlag(Qt::ControlModifier);
-            const bool isAlreadySelected = mMultiSelectionSet.contains(roomId);
-
-            if (hasCtrl) {
-                if (isAlreadySelected && !hasShift) {
-                    mMultiSelectionSet.remove(roomId);
-                } else {
-                    mMultiSelectionSet.insert(roomId);
-                }
+        if (hasCtrl) {
+            if (isAlreadySelected && !hasShift) {
+                mMultiSelectionSet.remove(roomId);
             } else {
                 mMultiSelectionSet.insert(roomId);
             }
+        } else {
+            mMultiSelectionSet.insert(roomId);
+        }
 
-            if (!mMultiSelectionSet.empty()) {
-                mMultiSelection = false;
-            }
+        if (!mMultiSelectionSet.empty()) {
+            mMultiSelection = false;
         }
     }
 
@@ -391,6 +437,10 @@ T2DMap::T2DMap(QWidget* parent)
         app->installEventFilter(this);
     }
 
+    mpRenderThrottleTimer = new QTimer(this);
+    mpRenderThrottleTimer->setSingleShot(true);
+    connect(mpRenderThrottleTimer, &QTimer::timeout, this, qOverload<>(&T2DMap::update));
+
     mMultiSelectionListWidget.setParent(this);
     mMultiSelectionListWidget.setColumnCount(2);
     mMultiSelectionListWidget.hideColumn(1);
@@ -485,6 +535,13 @@ void T2DMap::init()
     flushSymbolPixmapCache();
     flushTextLabelPixmapCache();
     mLargeAreaExitArrows = mpHost->getLargeAreaExitArrows();
+}
+
+void T2DMap::scheduleRender()
+{
+    if (!mpRenderThrottleTimer->isActive()) {
+        mpRenderThrottleTimer->start(csmRenderThrottleMs);
+    }
 }
 
 void T2DMap::slot_shiftDown()
@@ -649,15 +706,14 @@ void T2DMap::switchArea(const QString& newAreaName)
                     // We now have lowest level with the highest number of rooms
                     // Now find the geometry center of the rooms on THAT level
                     // In a similar manner to the getCenterSelection() method
-                    itRoom.toFront();
                     float mean_x = 0.0;
                     float mean_y = 0.0;
                     uint processedRoomCount = 0;
                     QSet<TRoom*> roomsToConsider; // Hold on to relevant rooms for
                                                   // following step
-                    while (itRoom.hasNext()) {
-                        TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
-                        if (!room || room->z() != minLevelWithMaxRoomCount) {
+                    for (const int roomId : area->getRoomsForZ(minLevelWithMaxRoomCount)) {
+                        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+                        if (!room) {
                             continue;
                         }
 
@@ -717,10 +773,9 @@ void T2DMap::switchArea(const QString& newAreaName)
                 uint processedRoomCount = 0;
                 QSet<TRoom*> roomsToConsider; // Hold on to relevant rooms for
                                               // following step
-                QSetIterator<int> itRoom(area->getAreaRooms());
-                while (itRoom.hasNext()) {
-                    TRoom* room = mpMap->mpRoomDB->getRoom(itRoom.next());
-                    if (!room || room->z() != mMapCenterZ) {
+                for (const int roomId : area->getRoomsForZ(mMapCenterZ)) {
+                    TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+                    if (!room) {
                         continue;
                     }
 
@@ -1653,6 +1708,615 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
     }
 }
 
+// Grid mode rendering driven by the spatial grid index.
+// Only rooms inside the current viewport rectangle are fetched from the index,
+// reducing the collect phase from O(Z-level rooms) to O(visible cells).
+void T2DMap::drawGridModeRooms(QPainter& painter,
+                               const TArea* pDrawnArea,
+                               const int zLevel,
+                               const int playerRoomId,
+                               const float mRX,
+                               const float mRY,
+                               const float mRoomWidth,
+                               const float mRoomHeight,
+                               const float widgetWidth,
+                               const float widgetHeight,
+                               QFont& roomVNumFont,
+                               bool& isPlayerRoomVisible,
+                               QPointF& playerRoomOnWidgetCoordinates,
+                               bool areRoomIdsLegible,
+                               QString* profileOutput)
+{
+    QElapsedTimer timer;
+    timer.start();
+
+    // Compute viewport bounds in integer map coordinates.
+    // The forward transform is:  rx = room->x() * mRoomWidth + mRX
+    //                            ry = room->y() * -1 * mRoomHeight + mRY
+    // Inverting gives the integer range of rooms that can appear on screen.
+    // A 1-cell margin is added so rooms whose rect straddles the widget edge
+    // are not clipped.
+    const int minX = static_cast<int>(std::floor(static_cast<double>(-mRX) / mRoomWidth)) - 1;
+    const int maxX = static_cast<int>(std::ceil(static_cast<double>(widgetWidth - mRX) / mRoomWidth)) + 1;
+    const int minY = static_cast<int>(std::floor(static_cast<double>(mRY - widgetHeight) / mRoomHeight)) - 1;
+    const int maxY = static_cast<int>(std::ceil(static_cast<double>(mRY) / mRoomHeight)) + 1;
+
+    const qreal timeIndex = timer.nsecsElapsed() / 1000000.0;
+    timer.start();
+
+    // Helper: convert environment ID to QColor (mirrors drawRoom logic).
+    auto envToColor = [this](int env) -> QColor {
+        if (mpMap->mEnvColors.contains(env)) {
+            env = mpMap->mEnvColors[env];
+        } else if (!mpMap->mCustomEnvColors.contains(env)) {
+            env = 1;
+        }
+        switch (env) {
+        case 1:
+            return mpHost->mRed_2;
+        case 2:
+            return mpHost->mGreen_2;
+        case 3:
+            return mpHost->mYellow_2;
+        case 4:
+            return mpHost->mBlue_2;
+        case 5:
+            return mpHost->mMagenta_2;
+        case 6:
+            return mpHost->mCyan_2;
+        case 7:
+            return mpHost->mWhite_2;
+        case 8:
+            return mpHost->mBlack_2;
+        case 9:
+            return mpHost->mLightRed_2;
+        case 10:
+            return mpHost->mLightGreen_2;
+        case 11:
+            return mpHost->mLightYellow_2;
+        case 12:
+            return mpHost->mLightBlue_2;
+        case 13:
+            return mpHost->mLightMagenta_2;
+        case 14:
+            return mpHost->mLightCyan_2;
+        case 15:
+            return mpHost->mLightWhite_2;
+        case 16:
+            return mpHost->mLightBlack_2;
+        default:
+            if (mpMap->mCustomEnvColors.contains(env)) {
+                return mpMap->mCustomEnvColors[env];
+            }
+            if (env > 16 && env < 232) {
+                quint8 const base = env - 16;
+                quint8 r = base / 36;
+                quint8 g = (base - (r * 36)) / 6;
+                quint8 b = (base - (r * 36)) - (g * 6);
+                r = r == 0 ? 0 : (r - 1) * 40 + 95;
+                g = g == 0 ? 0 : (g - 1) * 40 + 95;
+                b = b == 0 ? 0 : (b - 1) * 40 + 95;
+                return QColor(r, g, b, 255);
+            }
+            if (env > 231 && env < 256) {
+                quint8 const k = ((env - 232) * 10) + 8;
+                return QColor(k, k, k, 255);
+            }
+            return mpHost->mBgColor_2;
+        }
+    };
+
+    const TAreaGridIndex& gridIndex = pDrawnArea->getGridIndex();
+    int roomCount = 0;
+
+    // LOD fast path: when rooms are smaller than this pixel threshold their
+    // individual details (collision borders, symbols, vnums) are invisible.
+    // QPainterPath::addRect() costs ~3.6 us per room regardless of room size,
+    // making the normal path unusable at high zoom-out with thousands of rooms.
+    // Writing directly to a QImage scanline is ~10x faster overall.
+    constexpr float cLodPixelThreshold = 4.0f;
+    if (mRoomWidth < cLodPixelThreshold) {
+        const int imgW = static_cast<int>(std::ceil(static_cast<double>(widgetWidth)));
+        const int imgH = static_cast<int>(std::ceil(static_cast<double>(widgetHeight)));
+        QImage lodImage(imgW, imgH, QImage::Format_ARGB32_Premultiplied);
+        lodImage.fill(0); // transparent: background was already rendered beneath us
+
+        // Cache env -> QRgb so envToColor() is called at most once per env ID.
+        QHash<int, QRgb> envColorCache;
+
+        if (mRoomWidth < 1.0f) {
+            // Sub-pixel LOD: each output pixel may cover multiple rooms.
+            // Iterate output pixels and look up the representative room per unique
+            // world cell. Run-length optimizations skip redundant lookups:
+            //   - Row runs: when the same worldY repeats across consecutive output
+            //     rows (common at extreme zoom-out where 1 room spans ~5.8 rows at
+            //     roomSizePx=0.171), duplicate the previous scanline with memcpy.
+            //   - Column runs: when the same worldX repeats across consecutive pixels
+            //     in a row, reuse the previously computed color.
+            // Combined, these reduce unique lookups from ~5.36M to ~4,600 at the
+            // reported zoom level, yielding a ~700x speedup in this branch.
+            int lastWorldY = INT_MIN;
+            for (int py = 0; py < imgH; ++py) {
+                QRgb* line = reinterpret_cast<QRgb*>(lodImage.scanLine(py));
+                const int worldY = static_cast<int>(std::floor(static_cast<double>(mRY - py) / mRoomHeight));
+
+                if (worldY == lastWorldY && py > 0) {
+                    // Same world row as the previous scanline: just copy it.
+                    const QRgb* prevLine = reinterpret_cast<const QRgb*>(lodImage.constScanLine(py - 1));
+                    std::copy_n(prevLine, imgW, line);
+                    continue;
+                }
+                lastWorldY = worldY;
+
+                int lastWorldX = INT_MIN;
+                QRgb currentColor = 0;
+
+                for (int px = 0; px < imgW; ++px) {
+                    const int worldX = static_cast<int>(std::floor(static_cast<double>(px - mRX) / mRoomWidth));
+
+                    if (worldX != lastWorldX) {
+                        lastWorldX = worldX;
+                        currentColor = 0;
+
+                        const QSet<int>& rooms = gridIndex.roomsAt(zLevel, worldX, worldY);
+                        // Iterate to find the first non-hidden room at this cell.
+                        for (const int roomId : rooms) {
+                            TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+                            if (!room || room->isHidden()) {
+                                continue;
+                            }
+                            ++roomCount;
+                            if (roomId == playerRoomId) {
+                                isPlayerRoomVisible = true;
+                                playerRoomOnWidgetCoordinates = QPointF(static_cast<qreal>(worldX * mRoomWidth + mRX), static_cast<qreal>(worldY * -1.0f * mRoomHeight + mRY));
+                                // Player room drawn by paintEvent; leave pixel transparent.
+                            } else {
+                                const auto colorIt = envColorCache.constFind(room->environment);
+                                if (colorIt != envColorCache.constEnd()) {
+                                    currentColor = *colorIt;
+                                } else {
+                                    currentColor = envToColor(room->environment).rgba();
+                                    envColorCache.insert(room->environment, currentColor);
+                                }
+                            }
+                            break; // Use only the first non-hidden room at this cell.
+                        }
+                    }
+
+                    line[px] = currentColor;
+                }
+            }
+        } else {
+            // Room-driven LOD path for 1.0 <= mRoomWidth < cLodPixelThreshold.
+            // Each room spans >= 1 output pixel; iterate rooms from the grid index.
+            for (const int roomId : gridIndex.roomsInViewport(zLevel, minX, maxX, minY, maxY)) {
+                TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+                if (!room || room->isHidden()) {
+                    continue;
+                }
+
+                ++roomCount;
+
+                const float rx = room->x() * mRoomWidth + mRX;
+                const float ry = room->y() * -1.0f * mRoomHeight + mRY;
+
+                if (playerRoomId == roomId) {
+                    isPlayerRoomVisible = true;
+                    playerRoomOnWidgetCoordinates = QPointF(static_cast<qreal>(rx), static_cast<qreal>(ry));
+                    continue;
+                }
+
+                // Map the room center to a pixel rect, clamped to image bounds.
+                const int px = static_cast<int>(rx - mRoomWidth * 0.5f);
+                const int py = static_cast<int>(ry - mRoomHeight * 0.5f);
+                const int pw = qMax(1, static_cast<int>(std::ceil(static_cast<double>(mRoomWidth))));
+                const int ph = qMax(1, static_cast<int>(std::ceil(static_cast<double>(mRoomHeight))));
+                const int xStart = qBound(0, px, imgW);
+                const int xEnd = qBound(0, px + pw, imgW);
+                const int yStart = qBound(0, py, imgH);
+                const int yEnd = qBound(0, py + ph, imgH);
+                if (xStart >= xEnd || yStart >= yEnd) {
+                    continue;
+                }
+
+                QRgb colorRgb;
+                const auto colorIt = envColorCache.constFind(room->environment);
+                if (colorIt != envColorCache.constEnd()) {
+                    colorRgb = *colorIt;
+                } else {
+                    colorRgb = envToColor(room->environment).rgba();
+                    envColorCache.insert(room->environment, colorRgb);
+                }
+
+                // Direct scanline writes bypass QPainterPath construction.
+                for (int dy = yStart; dy < yEnd; ++dy) {
+                    QRgb* scanLine = reinterpret_cast<QRgb*>(lodImage.scanLine(dy));
+                    for (int dx = xStart; dx < xEnd; ++dx) {
+                        scanLine[dx] = colorRgb;
+                    }
+                }
+            }
+        }
+
+        const qreal timeCollect = timer.nsecsElapsed() / 1000000.0;
+        timer.start();
+
+        painter.drawImage(0, 0, lodImage);
+
+        // Overlay selected rooms with a blue tint so the selection highlight
+        // is preserved in both LOD paths.  At LOD scales (rooms are < 4px wide)
+        // a real gradient is imperceptible, so we paint a semi-transparent blue
+        // rect over the env-colored pixel(s) to produce the same "env + blue"
+        // appearance as the full-detail selection gradient.
+        if (!mMultiSelectionSet.isEmpty()) {
+            painter.save();
+            painter.setPen(Qt::NoPen);
+            const int roomW = qMax(1, qRound(static_cast<double>(mRoomWidth)));
+            const int roomH = qMax(1, qRound(static_cast<double>(mRoomHeight)));
+            // Semi-transparent blue matches the blue endpoint of the full-detail
+            // QLinearGradient (Qt::blue at alpha ~180 gives an equivalent look
+            // over the env base colour that was already written into lodImage).
+            const QColor selectionTint(0, 0, 255, 180);
+            for (const int selId : mMultiSelectionSet) {
+                TRoom* room = mpMap->mpRoomDB->getRoom(selId);
+                if (!room || room->z() != zLevel) {
+                    continue;
+                }
+                const int rx = qRound(room->x() * mRoomWidth + mRX);
+                const int ry = qRound(room->y() * -1.0 * mRoomHeight + mRY);
+                const QRect selRect(rx - roomW / 2, ry - roomH / 2, roomW, roomH);
+                if (selRect.intersects(QRect(0, 0, static_cast<int>(widgetWidth), static_cast<int>(widgetHeight)))) {
+                    painter.fillRect(selRect, selectionTint);
+                }
+            }
+            painter.restore();
+        }
+
+        const qreal timeBlit = timer.nsecsElapsed() / 1000000.0;
+
+        if (qEnvironmentVariableIsSet("MUDLET_PROFILE_MAP") && profileOutput) {
+            // Build the profiling string and return it to paintEvent so it can
+            // be printed AFTER phase6Time is captured.  Calling qDebug() here
+            // would inflate phase6 time by 100-200 ms on Windows debug builds.
+            const char* lodPathName = (mRoomWidth < 1.0f) ? "LOD sub-pixel" : "LOD pixel";
+            QDebug dbg(profileOutput);
+            dbg.noquote().nospace() << "drawGridModeRooms (" << lodPathName << ") timing (ms):"
+                                    << " total:" << (timeIndex + timeCollect + timeBlit) << " indexSetup:" << timeIndex << " collect+pixelWrite:" << timeCollect << " imageBlit:" << timeBlit
+                                    << " visibleRooms:" << roomCount << " viewportCells:" << static_cast<qint64>(maxX - minX + 1) * (maxY - minY + 1) << " viewportBounds: x[" << minX << "," << maxX
+                                    << "] y[" << minY << "," << maxY << "]"
+                                    << " roomSizePx:" << mRoomWidth << " gridIndexRooms:" << gridIndex.size() << " gridIndexBytes:" << gridIndex.memoryEstimateBytes();
+        }
+
+        // Handle double-click speedwalk via grid-cell lookup.  The pixel-level
+        // hit test inside drawRoom() is never reached in the LOD path, so we
+        // must resolve the clicked cell here before returning.
+        if (mPick) {
+            const int clickWorldX = qRound(static_cast<double>(mPHighlight.x() - mRX) / mRoomWidth);
+            const int clickWorldY = qRound(static_cast<double>(mRY - mPHighlight.y()) / mRoomHeight);
+            const QSet<int>& clickedRooms = gridIndex.roomsAt(zLevel, clickWorldX, clickWorldY);
+            if (!clickedRooms.isEmpty()) {
+                const int clickedRoomId = *clickedRooms.constBegin();
+                mPick = false;
+                if (mStartSpeedWalk) {
+                    mStartSpeedWalk = false;
+                    initiateSpeedWalk(playerRoomId, clickedRoomId);
+                }
+            } else {
+                mPick = false;
+            }
+        }
+        return;
+    }
+
+    // Full detail path (mRoomWidth >= cLodPixelThreshold): collect rooms grouped
+    // by environment color, then batch-draw using QPainterPath per color group.
+    QHash<int, QList<QRectF>> roomsByEnvironment;
+    QHash<int, QList<QRectF>> collisionRoomsByEnvironment;
+    QList<QPair<TRoom*, QRectF>> decorationRooms;
+    QList<QPair<TRoom*, QRectF>> selectedRooms;
+    QList<QPair<TRoom*, QRectF>> highlightedRooms;
+    QList<QPair<TRoom*, QPointF>> verticalExitRooms;
+
+    const bool showVnums = mShowRoomID && areRoomIdsLegible && mMaxRoomIdDigits > 0;
+
+    for (const auto& [roomId, roomCollision] : gridIndex.roomsInViewportWithCollisions(zLevel, minX, maxX, minY, maxY)) {
+        TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
+        if (!room || room->isHidden()) {
+            continue;
+        }
+
+        const float rx = room->x() * mRoomWidth + mRX;
+        const float ry = room->y() * -1 * mRoomHeight + mRY;
+
+        // Belt-and-suspenders: the viewport bounds above should make this pass
+        // always, but guard against floating-point edge cases at the margin.
+        if (rx < -mRoomWidth || ry < -mRoomHeight || rx > widgetWidth + mRoomWidth || ry > widgetHeight + mRoomHeight) {
+            continue;
+        }
+
+        ++roomCount;
+
+        if (playerRoomId == roomId) {
+            isPlayerRoomVisible = true;
+            playerRoomOnWidgetCoordinates = QPointF(static_cast<qreal>(rx), static_cast<qreal>(ry));
+            continue;
+        }
+
+        const QRectF roomRect(rx - mRoomWidth / 2.0, ry - mRoomHeight / 2.0, mRoomWidth, mRoomHeight);
+
+        if (mMultiSelectionSet.contains(roomId)) {
+            selectedRooms.append({room, roomRect});
+        } else if (roomCollision) {
+            collisionRoomsByEnvironment[room->environment].append(roomRect);
+        } else {
+            roomsByEnvironment[room->environment].append(roomRect);
+        }
+
+        if (room->highlight) {
+            highlightedRooms.append({room, roomRect});
+        }
+
+        if (showVnums || !room->mSymbol.isEmpty()) {
+            decorationRooms.append({room, roomRect});
+        }
+
+        if (room->getUp() > 0 || room->exitStubs.contains(DIR_UP) || room->getDown() > 0 || room->exitStubs.contains(DIR_DOWN) || room->getIn() > 0 || room->exitStubs.contains(DIR_IN)
+            || room->getOut() > 0 || room->exitStubs.contains(DIR_OUT)) {
+            verticalExitRooms.append({room, QPointF(rx, ry)});
+        }
+    }
+
+    const qreal timeCollect = timer.nsecsElapsed() / 1000000.0;
+    timer.start();
+
+    // Batch draw normal rooms by environment color.
+    painter.setPen(Qt::NoPen);
+    for (auto it = roomsByEnvironment.constBegin(); it != roomsByEnvironment.constEnd(); ++it) {
+        QPainterPath path;
+        for (const auto& rect : it.value()) {
+            if (mBubbleMode) {
+                path.addEllipse(rect);
+            } else {
+                path.addRect(rect);
+            }
+        }
+        painter.fillPath(path, envToColor(it.key()));
+    }
+
+    const qreal timeBatchDraw = timer.nsecsElapsed() / 1000000.0;
+    timer.start();
+
+    // Batch draw collision rooms with a colored border.
+    const int collisionBorderWidth = qMax(1, static_cast<int>(mRoomWidth / 50.0));
+    for (auto it = collisionRoomsByEnvironment.constBegin(); it != collisionRoomsByEnvironment.constEnd(); ++it) {
+        const QColor color = envToColor(it.key());
+        QPainterPath fillPath;
+        for (const auto& rect : it.value()) {
+            if (mBubbleMode) {
+                fillPath.addEllipse(rect);
+            } else {
+                fillPath.addRect(rect);
+            }
+        }
+        painter.fillPath(fillPath, color);
+
+        QPen collisionPen(mpHost->mRoomCollisionBorderColor, collisionBorderWidth);
+        painter.setPen(collisionPen);
+        for (const auto& rect : it.value()) {
+            if (mBubbleMode) {
+                painter.drawEllipse(rect);
+            } else {
+                painter.drawRect(rect);
+            }
+        }
+    }
+
+    // Draw selected rooms with a gradient fill so they stand out in editing mode.
+    // This mirrors the selection highlight in drawRoom() which is never called for
+    // grid mode rooms.
+    painter.setPen(Qt::NoPen);
+    for (const auto& [room, roomRect] : selectedRooms) {
+        const QColor roomColor = envToColor(room->environment);
+        QLinearGradient selectionBg(roomRect.topLeft(), roomRect.bottomRight());
+        selectionBg.setColorAt(0.2, roomColor);
+        selectionBg.setColorAt(1, Qt::blue);
+        painter.setBrush(selectionBg);
+        if (mBubbleMode) {
+            painter.drawEllipse(roomRect);
+        } else {
+            painter.drawRect(roomRect);
+        }
+    }
+
+    // Draw custom per-room radial highlights (pRoom->highlight flag).
+    for (const auto& [room, roomRect] : highlightedRooms) {
+        const float roomRadius = (room->highlightRadius * mRoomWidth) / 2.0f;
+        const QPointF roomCenter = roomRect.center();
+        QRadialGradient gradient(roomCenter, roomRadius);
+        gradient.setColorAt(0.85f, room->highlightColor);
+        gradient.setColorAt(0.0f, room->highlightColor2);
+        const QPen transparentPen(Qt::transparent);
+        QPainterPath diameterPath;
+        painter.setBrush(gradient);
+        painter.setPen(transparentPen);
+        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+        painter.drawPath(diameterPath);
+    }
+
+    // Draw vertical exits (up/down/in/out) for grid mode rooms, mirroring drawRoom().
+    if (!verticalExitRooms.isEmpty()) {
+        constexpr float allInsideTipOffsetFactor = 1 / 20.0f;
+        constexpr float upDownXOrYFactor = 1 / 3.1f;
+        constexpr float inOuterXFactor = 1 / 4.5f;
+        constexpr float inUpDownYFactor = 1 / 7.0f;
+        constexpr float outOuterXFactor = 1 / 2.2f;
+        constexpr float outUpDownYFactor = 1 / 5.5f;
+        constexpr float outInterXFactor = 1 / 3.5f;
+        painter.save();
+        for (const auto& [room, center] : verticalExitRooms) {
+            const float rx = center.x();
+            const float ry = center.y();
+            const QColor roomColor = envToColor(room->environment);
+            const QColor lc = (roomColor.lightness() > 127) ? QColorConstants::Black : QColorConstants::White;
+            QPen exitPen;
+            exitPen.setColor(lc);
+            exitPen.setCosmetic(mMapperUseAntiAlias);
+            exitPen.setCapStyle(Qt::RoundCap);
+            exitPen.setJoinStyle(Qt::RoundJoin);
+            QPen innerPen = exitPen;
+            QBrush innerBrush = painter.brush();
+            innerBrush.setStyle(Qt::NoBrush);
+            // Draws one or two polygons with door colouring, matching drawRoom().
+            auto drawExitPoly = [&](const QList<QPolygonF>& polys, int doorVal, bool hasExit) {
+                bool isDoor = true;
+                QBrush brush;
+                switch (doorVal) {
+                case 1:
+                    brush.setColor(mOpenDoorColor);
+                    innerPen.setColor(mOpenDoorColor);
+                    break;
+                case 2:
+                    brush.setColor(mClosedDoorColor);
+                    innerPen.setColor(mClosedDoorColor);
+                    break;
+                case 3:
+                    brush.setColor(mLockedDoorColor);
+                    innerPen.setColor(mLockedDoorColor);
+                    break;
+                default:
+                    brush.setColor(lc);
+                    isDoor = false;
+                    break;
+                }
+                if (hasExit) {
+                    exitPen.setWidthF(mRoomWidth * rSize * 0.050f);
+                    innerPen.setWidthF(mRoomWidth * rSize * 0.025f);
+                    brush.setStyle(Qt::Dense4Pattern);
+                } else {
+                    exitPen.setWidthF(mRoomWidth * rSize * 0.025f);
+                    innerPen.setWidthF(mRoomWidth * rSize * 0.0125f);
+                    brush.setStyle(Qt::DiagCrossPattern);
+                }
+                painter.setPen(exitPen);
+                painter.setBrush(brush);
+                for (const auto& poly : polys) {
+                    painter.drawPolygon(poly);
+                }
+                if (isDoor) {
+                    painter.setPen(innerPen);
+                    painter.setBrush(innerBrush);
+                    for (const auto& poly : polys) {
+                        painter.drawPolygon(poly);
+                    }
+                }
+            };
+
+            if (room->getUp() > 0 || room->exitStubs.contains(DIR_UP)) {
+                QPolygonF poly;
+                poly << QPointF(rx, ry + (mRoomHeight * rSize * allInsideTipOffsetFactor)) << QPointF(rx - (mRoomWidth * rSize * upDownXOrYFactor), ry + (mRoomHeight * rSize * upDownXOrYFactor))
+                     << QPointF(rx + (mRoomWidth * rSize * upDownXOrYFactor), ry + (mRoomHeight * rSize * upDownXOrYFactor));
+                drawExitPoly({poly}, room->doors.value(key_up), room->getUp() > 0);
+            }
+            if (room->getDown() > 0 || room->exitStubs.contains(DIR_DOWN)) {
+                QPolygonF poly;
+                poly << QPointF(rx, ry - (mRoomHeight * rSize * allInsideTipOffsetFactor)) << QPointF(rx - (mRoomWidth * rSize * upDownXOrYFactor), ry - (mRoomHeight * rSize * upDownXOrYFactor))
+                     << QPointF(rx + (mRoomWidth * rSize * upDownXOrYFactor), ry - (mRoomHeight * rSize * upDownXOrYFactor));
+                drawExitPoly({poly}, room->doors.value(key_down), room->getDown() > 0);
+            }
+            if (room->getIn() > 0 || room->exitStubs.contains(DIR_IN)) {
+                QPolygonF left, right;
+                left << QPointF(rx - (mRoomWidth * rSize * allInsideTipOffsetFactor), ry) << QPointF(rx - (mRoomWidth * rSize * inOuterXFactor), ry + (mRoomHeight * rSize * inUpDownYFactor))
+                     << QPointF(rx - (mRoomWidth * rSize * inOuterXFactor), ry - (mRoomHeight * rSize * inUpDownYFactor));
+                right << QPointF(rx + (mRoomWidth * rSize * allInsideTipOffsetFactor), ry) << QPointF(rx + (mRoomWidth * rSize * inOuterXFactor), ry + (mRoomHeight * rSize * inUpDownYFactor))
+                      << QPointF(rx + (mRoomWidth * rSize * inOuterXFactor), ry - (mRoomHeight * rSize * inUpDownYFactor));
+                drawExitPoly({left, right}, room->doors.value(key_in), room->getIn() > 0);
+            }
+            if (room->getOut() > 0 || room->exitStubs.contains(DIR_OUT)) {
+                QPolygonF left, right;
+                left << QPointF(rx - (mRoomWidth * rSize * outOuterXFactor), ry) << QPointF(rx - (mRoomWidth * rSize * outInterXFactor), ry + (mRoomHeight * rSize * outUpDownYFactor))
+                     << QPointF(rx - (mRoomWidth * rSize * outInterXFactor), ry - (mRoomHeight * rSize * outUpDownYFactor));
+                right << QPointF(rx + (mRoomWidth * rSize * outOuterXFactor), ry) << QPointF(rx + (mRoomWidth * rSize * outInterXFactor), ry + (mRoomHeight * rSize * outUpDownYFactor))
+                      << QPointF(rx + (mRoomWidth * rSize * outInterXFactor), ry - (mRoomHeight * rSize * outUpDownYFactor));
+                drawExitPoly({left, right}, room->doors.value(key_out), room->getOut() > 0);
+            }
+        }
+        painter.restore();
+    }
+
+    const qreal timeCollision = timer.nsecsElapsed() / 1000000.0;
+    timer.start();
+    // Decoration pass: symbols and V-numbers for rooms that need them.
+    // Runs over the pre-filtered decoration list built during the collect pass,
+    // so no second viewport scan is needed.
+    for (const auto& entry : decorationRooms) {
+        TRoom* room = entry.first;
+        const QRectF& roomRect = entry.second;
+
+        if (!showVnums && !room->mSymbol.isEmpty()) {
+            const QColor roomColor = envToColor(room->environment);
+            QColor symbolColor;
+            if (room->mSymbolColor.isValid()) {
+                symbolColor = room->mSymbolColor;
+            } else {
+                symbolColor = (roomColor.lightness() > 127) ? Qt::black : Qt::white;
+            }
+            const QString pixmapKey = qsl("%1_%2").arg(symbolColor.name(), room->mSymbol);
+            if (!mSymbolPixmapCache.contains(pixmapKey)) {
+                addSymbolToPixmapCache(pixmapKey, room->mSymbol, symbolColor, true);
+            }
+            if (const QPixmap* pix = mSymbolPixmapCache.object(pixmapKey); pix && !pix->isNull()) {
+                painter.save();
+                painter.setBackgroundMode(Qt::TransparentMode);
+                painter.drawPixmap(QPoint(qRound(roomRect.left() + (roomRect.width() - pix->width()) / 2.0), qRound(roomRect.top() + (roomRect.height() - pix->height()) / 2.0)), *pix);
+                painter.restore();
+            }
+        }
+
+        if (showVnums) {
+            const QColor roomColor = envToColor(room->environment);
+            const QColor textColor = (roomColor.lightness() > 127) ? QColor(Qt::black) : QColor(Qt::white);
+            painter.save();
+            painter.setPen(QPen(textColor));
+            painter.setFont(roomVNumFont);
+            painter.drawText(roomRect, Qt::AlignCenter, QString::number(room->getId()));
+            painter.restore();
+        }
+    }
+
+    const qreal timeDecor = timer.nsecsElapsed() / 1000000.0;
+
+    // Handle mPick (double-click speedwalk) for grid mode (full-detail path).
+    // Use rounding to snap the click to the nearest room centre — floor() would
+    // miss rooms clicked in the left or bottom half of their cell.
+    if (mPick) {
+        const int clickWorldX = qRound(static_cast<double>(mPHighlight.x() - mRX) / mRoomWidth);
+        const int clickWorldY = qRound(static_cast<double>(mRY - mPHighlight.y()) / mRoomHeight);
+        const QSet<int>& clickedRooms = gridIndex.roomsAt(zLevel, clickWorldX, clickWorldY);
+        if (!clickedRooms.isEmpty()) {
+            const int clickedRoomId = *clickedRooms.constBegin();
+            mPick = false;
+            if (mStartSpeedWalk) {
+                mStartSpeedWalk = false;
+                initiateSpeedWalk(playerRoomId, clickedRoomId);
+            }
+        } else {
+            mPick = false;
+        }
+    }
+
+    if (qEnvironmentVariableIsSet("MUDLET_PROFILE_MAP") && profileOutput) {
+        // Build the profiling string and return it to paintEvent so it can
+        // be printed AFTER phase6Time is captured.  Calling qDebug() here
+        // would inflate phase6 time by 100-200 ms on Windows debug builds.
+        QDebug dbg(profileOutput);
+        dbg.noquote().nospace() << "drawGridModeRooms timing (ms):"
+                                << " total:" << (timeIndex + timeCollect + timeBatchDraw + timeCollision + timeDecor) << " indexSetup:" << timeIndex << " collect(gridIndex):" << timeCollect
+                                << " batchDraw:" << timeBatchDraw << " collision:" << timeCollision << " decor:" << timeDecor << " visibleRooms:" << roomCount
+                                << " viewportCells:" << static_cast<qint64>(maxX - minX + 1) * (maxY - minY + 1) << " viewportBounds: x[" << minX << "," << maxX << "] y[" << minY << "," << maxY << "]"
+                                << " gridIndexRooms:" << gridIndex.size() << " gridIndexBytes:" << gridIndex.memoryEstimateBytes();
+    }
+}
+
 // Revised to use a QCache to hold QPixmap * to generated images for room symbols
 void T2DMap::paintEvent(QPaintEvent* e)
 {
@@ -1662,6 +2326,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
     }
     QElapsedTimer renderTimer;
     renderTimer.start();
+
+    // Single phase timer restarted at each phase boundary.
+    QElapsedTimer phaseTimer;
+    phaseTimer.start();
+    qreal phase1Time = 0, phase2Time = 0, phase3Time = 0, phase4Time = 0, phase5Time = 0, phase6Time = 0, phase7Time = 0;
 
     QPainter painter(this);
     if (!painter.isActive()) {
@@ -1745,6 +2414,10 @@ void T2DMap::paintEvent(QPaintEvent* e)
         painter.restore();
         return;
     }
+
+    phase1Time = phaseTimer.nsecsElapsed() / 1000000.0;
+    phaseTimer.restart();
+
     // This is only a safety check to avoid a probably impossible condition, we
     // have already established that pPlayerRoom is valid so for it to NOT be
     // in a valid area is unlikely:
@@ -1794,6 +2467,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
     if (!pDrawnArea) {
         return;
     }
+
+    phase2Time = phaseTimer.nsecsElapsed() / 1000000.0;
+    phaseTimer.restart();
 
     xyzoom = pDrawnArea->get2DMapZoom();
     if (widgetWidth > widgetHeight) {
@@ -1932,6 +2608,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
         painter.restore();
     }
 
+    phase3Time = phaseTimer.nsecsElapsed() / 1000000.0;
+    phaseTimer.restart();
+
     // Draw label sizing or group selection box
     if (mSizeLabel) {
         painter.fillRect(mMultiRect, QColor(250, 190, 0, 190));
@@ -1943,69 +2622,62 @@ void T2DMap::paintEvent(QPaintEvent* e)
     bool isPlayerRoomVisible = false;
     // QPoint doesn't work here as the key as it can't be hashed...!
     QSet<QPair<int, int>> usedRoomPositions;
-    // Draw the rooms:
-    QSetIterator<int> itRoom(pDrawnArea->getAreaRooms());
 
     if (mudlet::self()->mDrawUpperLowerLevels) {
-        // draw room on lower z-levels
-        while (itRoom.hasNext()) {
-            const int currentAreaRoom = itRoom.next();
+        // draw rooms on lower z-level - iterate only the rooms actually on that
+        // level instead of scanning every room in the area
+        const QSet<int>& lowerLevelRooms = pDrawnArea->getRoomsForZ(zLevel - 1);
+        for (const int currentAreaRoom : lowerLevelRooms) {
             TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
             if (!room) {
                 continue;
             }
 
-            if (room->z() == zLevel - 1) {
-                const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
-                const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
-                if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
-                    painter.save();
-                    painter.setPen(Qt::NoPen);
-                    painter.setBrush(mpHost->mLowerLevelColor);
-                    if (mBubbleMode) {
-                        const float roomRadius = 0.5 * rSize * mRoomWidth;
-                        const QPointF roomCenter = QPointF(rx - (roomRadius * rSize * 0.5), ry + (roomRadius * rSize * 0.5));
-                        QPainterPath diameterPath;
-                        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
-                        painter.drawPath(diameterPath);
-                    } else {
-                        painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
-                    }
-                    painter.restore();
+            const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+            const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+            if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
+                painter.save();
+                painter.setPen(Qt::NoPen);
+                painter.setBrush(mpHost->mLowerLevelColor);
+                if (mBubbleMode) {
+                    const float roomRadius = 0.5 * rSize * mRoomWidth;
+                    const QPointF roomCenter = QPointF(rx - (roomRadius * rSize * 0.5), ry + (roomRadius * rSize * 0.5));
+                    QPainterPath diameterPath;
+                    diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+                    painter.drawPath(diameterPath);
+                } else {
+                    painter.drawRect(rx - (mRoomWidth * rSize * 0.8), ry - (mRoomHeight * rSize * 0.2), mRoomWidth * rSize, mRoomHeight * rSize);
                 }
+                painter.restore();
             }
         }
-        itRoom.toFront();
 
-        // draw rooms on upper z-levels
-        while (itRoom.hasNext()) {
-            const int currentAreaRoom = itRoom.next();
+        // draw rooms on upper z-level
+        const QSet<int>& upperLevelRooms = pDrawnArea->getRoomsForZ(zLevel + 1);
+        for (const int currentAreaRoom : upperLevelRooms) {
             TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
             if (!room) {
                 continue;
             }
 
-            if (room->z() == zLevel + 1) {
-                const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
-                const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
-                if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
-                    painter.save();
-                    painter.setPen(QPen(mpHost->mUpperLevelColor, 1));
-                    painter.setBrush(Qt::transparent);
-                    if (mBubbleMode) {
-                        const float roomRadius = 0.5 * rSize * mRoomWidth;
-                        const QPointF roomCenter = QPointF(rx + (roomRadius * rSize * 0.5), ry - (roomRadius * rSize * 0.5));
-                        QPainterPath diameterPath;
-                        diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
-                        painter.drawPath(diameterPath);
-                    } else {
-                        painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
-                    }
-                    painter.restore();
+            const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+            const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+            if (rx >= 0 && ry >= 0 && rx <= widgetWidth && ry <= widgetHeight) {
+                painter.save();
+                painter.setPen(QPen(mpHost->mUpperLevelColor, 1));
+                painter.setBrush(Qt::transparent);
+                if (mBubbleMode) {
+                    const float roomRadius = 0.5 * rSize * mRoomWidth;
+                    const QPointF roomCenter = QPointF(rx + (roomRadius * rSize * 0.5), ry - (roomRadius * rSize * 0.5));
+                    QPainterPath diameterPath;
+                    diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
+                    painter.drawPath(diameterPath);
+                } else {
+                    painter.drawRect(rx - (mRoomWidth * rSize * 0.2), ry - (mRoomHeight * rSize * 0.8), mRoomWidth * rSize, mRoomHeight * rSize);
                 }
+                painter.restore();
             }
         }
-        itRoom.toFront();
     }
 
     // Draw the ("background") labels that are on the bottom of the map:
@@ -2047,45 +2719,85 @@ void T2DMap::paintEvent(QPaintEvent* e)
         }
     }
 
+    phase4Time = phaseTimer.nsecsElapsed() / 1000000.0;
+    phaseTimer.restart();
+
     // draw room exits
     if (!pDrawnArea->gridMode) {
         paintRoomExits(painter, pen, exitList, oneWayExits, pDrawnArea, zLevel, exitWidth, areaExitsMap);
     }
 
-    // now draw rooms on selected z-level
-    while (itRoom.hasNext()) {
-        const int currentAreaRoom = itRoom.next();
-        TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-        if (!room) {
-            continue;
-        }
+    phase5Time = phaseTimer.nsecsElapsed() / 1000000.0;
+    phaseTimer.restart();
 
-        if (room->z() != zLevel) {
-            continue;
-        }
+    // Draw rooms on selected z-level - use batch rendering for grid mode
+    QElapsedTimer getRoomsTimer;
+    getRoomsTimer.start();
+    const QSet<int>& currentLevelRooms = pDrawnArea->getRoomsForZ(zLevel);
+    qreal timeGetRoomsForZ = getRoomsTimer.nsecsElapsed() / 1000000.0;
+    // getRoomsForZ print is deferred to the final profiling block below
+    // to avoid inflating phase6Time with qDebug() overhead on Windows.
+    QString gridModeProfileOutput;
+    QElapsedTimer phase6Sub;
+    phase6Sub.start();
+    painter.save(); // prevent room-drawing state from leaking into labels/info box
+    if (pDrawnArea->gridMode) {
+        // Grid mode: use spatial grid index for O(visible cells) rendering
+        drawGridModeRooms(painter,
+                          pDrawnArea,
+                          zLevel,
+                          playerRoomId,
+                          mRX,
+                          mRY,
+                          mRoomWidth,
+                          mRoomHeight,
+                          widgetWidth,
+                          widgetHeight,
+                          roomVNumFont,
+                          isPlayerRoomVisible,
+                          playerRoomOnWidgetCoordinates,
+                          isFontBigEnoughToShowRoomVnum,
+                          &gridModeProfileOutput);
+    } else {
+        // Non-grid mode: use full-featured per-room rendering
+        for (const int currentAreaRoom : currentLevelRooms) {
+            TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+            if (!room) {
+                continue;
+            }
 
-        const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
-        const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
-        if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
-            continue;
-        }
+            const float rx = room->x() * mRoomWidth + static_cast<float>(mRX);
+            const float ry = room->y() * -1 * mRoomHeight + static_cast<float>(mRY);
+            if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
+                continue;
+            }
 
-        if (playerRoomId == currentAreaRoom) {
-            // We defer drawing THIS (the player's room) until the end
-            isPlayerRoomVisible = true;
-            playerRoomOnWidgetCoordinates = QPointF(static_cast<qreal>(rx), static_cast<qreal>(ry));
-        } else {
-            // Not the player's room
-            const QPair<int, int> roomPos{room->x(), room->y()};
-            const bool roomCollision = usedRoomPositions.contains(roomPos);
-            usedRoomPositions.insert(roomPos);
-            drawRoom(painter, roomVNumFont, mapNameFont, pen, room, pDrawnArea->gridMode, isFontBigEnoughToShowRoomVnum, showRoomNames, playerRoomId, rx, ry, areaExitsMap, roomCollision);
+            if (playerRoomId == currentAreaRoom) {
+                // We defer drawing THIS (the player's room) until the end
+                isPlayerRoomVisible = true;
+                playerRoomOnWidgetCoordinates = QPointF(static_cast<qreal>(rx), static_cast<qreal>(ry));
+            } else {
+                // Not the player's room
+                const QPair<int, int> roomPos{room->x(), room->y()};
+                const bool roomCollision = usedRoomPositions.contains(roomPos);
+                usedRoomPositions.insert(roomPos);
+                drawRoom(painter, roomVNumFont, mapNameFont, pen, room, pDrawnArea->gridMode, isFontBigEnoughToShowRoomVnum, showRoomNames, playerRoomId, rx, ry, areaExitsMap, roomCollision);
+            }
         }
     }
+    painter.restore(); // end of room-drawing save
 
+    const qreal timePhase6RoomsDraw = phase6Sub.nsecsElapsed() / 1000000.0;
+    phase6Sub.restart();
+
+    qreal timePhase6DrawRoom = 0.0;
+    qreal timePhase6Gradient = 0.0;
+    painter.save(); // prevent player-room drawing state from leaking into labels/info box
     if (isPlayerRoomVisible) {
-        const QPair<int, int> roomPos{pPlayerRoom->x(), pPlayerRoom->y()};
-        const bool roomCollision = usedRoomPositions.contains(roomPos);
+        // In grid mode use the spatial index (detects collisions even with off-screen rooms).
+        // In non-grid mode the usedRoomPositions set was populated during the room loop above.
+        const bool roomCollision =
+                pDrawnArea->gridMode ? pDrawnArea->getGridIndex().roomsAt(zLevel, pPlayerRoom->x(), pPlayerRoom->y()).size() > 1 : usedRoomPositions.contains({pPlayerRoom->x(), pPlayerRoom->y()});
         drawRoom(painter,
                  roomVNumFont,
                  mapNameFont,
@@ -2099,6 +2811,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
                  static_cast<float>(playerRoomOnWidgetCoordinates.y()),
                  areaExitsMap,
                  roomCollision);
+        timePhase6DrawRoom = phase6Sub.nsecsElapsed() / 1000000.0;
+        phase6Sub.restart();
+
         painter.save();
         const QPen transparentPen(Qt::transparent);
         QPainterPath myPath;
@@ -2133,7 +2848,12 @@ void T2DMap::paintEvent(QPaintEvent* e)
         }
         painter.drawPath(myPath);
         painter.restore();
+        timePhase6Gradient = phase6Sub.nsecsElapsed() / 1000000.0;
     }
+    painter.restore(); // end of player-room save
+
+    phase6Time = phaseTimer.nsecsElapsed() / 1000000.0;
+    phaseTimer.restart();
 
     // Draw the ("foreground") labels that are on the top of the map:
     itMapLabel.toFront();
@@ -2217,16 +2937,46 @@ void T2DMap::paintEvent(QPaintEvent* e)
         infoColor = QColor(Qt::white);
     }
 
-    int roomID = mRoomID;
-    if (!isCenterViewCall && !mMultiSelectionSet.empty()) {
-        if (mpMap->mpRoomDB->getRoom(*(mMultiSelectionSet.constBegin()))) {
-            roomID = mMultiSelectionHighlightRoomId;
-        }
+    // The info box always shows the player room unless rooms are explicitly
+    // selected.  playerRoomId is fresh each frame; mRoomID is only updated when
+    // centeringOnPlayer fires and can be stale or zero before first centering.
+    int roomID = playerRoomId;
+    if (!mMultiSelectionSet.empty() && mMultiSelectionHighlightRoomId > 0 && mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId)) {
+        roomID = mMultiSelectionHighlightRoomId;
     }
 
     int xOffset = 10;
     if (mMultiSelectionListWidget.isVisible()) {
         xOffset += mMultiSelectionListWidget.x() + mMultiSelectionListWidget.rect().width();
+    }
+
+    phase7Time = phaseTimer.nsecsElapsed() / 1000000.0;
+
+    if (qEnvironmentVariableIsSet("MUDLET_PROFILE_MAP")) {
+        // Accumulate all profiling text into ONE string then emit a single
+        // qDebug() call.  On Windows each qDebug() call invokes OutputDebugString
+        // which can take 5-30 ms when a debugger is attached; batching to one
+        // call reduces that to a fixed per-frame cost of one call.
+        QString profileOut;
+        QDebug pdbg(&profileOut);
+        pdbg.nospace().noquote() << "getRoomsForZ: " << timeGetRoomsForZ << "ms\n";
+        if (!gridModeProfileOutput.isEmpty()) {
+            pdbg << gridModeProfileOutput << "\n";
+        }
+        pdbg << "phase6 subs: roomsDraw=" << timePhase6RoomsDraw << " playerRoom=" << timePhase6DrawRoom << " gradient=" << timePhase6Gradient << " playerVisible=" << isPlayerRoomVisible << "\n";
+        // Comprehensive infoBox diagnostic: shows every condition paintMapInfo
+        // checks so we can see exactly why it produces blank output.
+        auto* mgr = mpMap->mMapInfoContributorManager;
+        const bool roomIDValid = mpMap->mpRoomDB->getRoom(roomID) != nullptr;
+        const bool contribOk = mgr != nullptr && mpHost->mMapInfoContributors.intersects(QSet<QString>(mgr->getContributorKeys().constBegin(), mgr->getContributorKeys().constEnd()));
+        pdbg << "infoBox: roomID=" << roomID << " player=" << playerRoomId << " mRoomID=" << mRoomID << " areaID=" << mAreaID << " selectionSize=" << static_cast<int>(mMultiSelectionSet.size())
+             << " xOffset=" << xOffset << " listWidgetVisible=" << mMultiSelectionListWidget.isVisible() << " listWidgetGeom=" << mMultiSelectionListWidget.x() << "+"
+             << mMultiSelectionListWidget.rect().width() << " widgetWidth=" << width() << " shift=" << mShiftMode << " centerView=" << isCenterViewCall << " playerVisible=" << isPlayerRoomVisible
+             << " roomValid=" << roomIDValid << " contribOk=" << contribOk << " painterHasClip=" << painter.hasClipping() << " painterClipRect=" << painter.clipRegion().boundingRect()
+             << " fontHeight=" << mFontHeight << "\n"
+             << "paintEvent: total=" << renderTimer.elapsed() << " p1=" << phase1Time << " p2=" << phase2Time << " p3=" << phase3Time << " p4=" << phase4Time << " p5=" << phase5Time
+             << " p6=" << phase6Time << " p7=" << phase7Time;
+        qDebug().noquote() << profileOut;
     }
 
     dlgMapper::paintMapInfo(renderTimer, painter, mpHost, mpMap, roomID, mAreaID, mMultiSelectionSet.size(), infoColor, xOffset, 20, width(), mFontHeight);
@@ -2392,7 +3142,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             }
         }
     }
-    QSetIterator<int> itRoom2(pArea->getAreaRooms());
+    QSetIterator<int> itRoom2(pArea->getRoomsForZ(zLevel));
     while (itRoom2.hasNext()) {
         const int _id = itRoom2.next();
         TRoom* room = mpMap->mpRoomDB->getRoom(_id);
@@ -2404,11 +3154,6 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
         }
         const float rx = room->x() * mRoomWidth + mRX;
         const float ry = room->y() * -1 * mRoomHeight + mRY;
-        const int rz = room->z();
-
-        if (rz != zLevel) {
-            continue;
-        }
 
         if (room->customLines.empty()) {
             if (rx < 0 || ry < 0 || rx > widgetWidth || ry > widgetHeight) {
@@ -2788,6 +3533,7 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             const int ez = pE->z();
 
             const QVector3D p1(ex, ey, ez);
+            const int rz = mMapCenterZ;
             const QVector3D p2(rx, ry, rz);
             // This was a QLine (so used integer coordinates), but lets
             // try with a QLineF as we are using floating point numbers:
@@ -4603,7 +5349,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
 
             flushSymbolPixmapCache();
             flushTextLabelPixmapCache();
-            update();
+            scheduleRender();
         }
         e->accept();
         return;
@@ -5419,9 +6165,9 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     QList<int> oneWayExits;
 
     // Build exit lists from rooms on current Z-level (like paintEvent does)
-    for (const int roomId : std::as_const(pArea->rooms)) {
+    for (const int roomId : pArea->getRoomsForZ(exportZLevel)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
-        if (!pRoom || pRoom->z() != exportZLevel) {
+        if (!pRoom) {
             continue;
         }
         exitList << roomId;
@@ -5433,9 +6179,9 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     int roomsSkipped = 0;
 
     // First pass: draw rooms on level below (like paintEvent shadow rooms)
-    for (const int roomId : std::as_const(pArea->rooms)) {
+    for (const int roomId : pArea->getRoomsForZ(exportZLevel - 1)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
-        if (!pRoom || pRoom->z() != exportZLevel - 1) {
+        if (!pRoom) {
             continue;
         }
 
@@ -5468,9 +6214,9 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     }
 
     // Second pass: draw rooms on level above (like paintEvent upper level rooms)
-    for (const int roomId : std::as_const(pArea->rooms)) {
+    for (const int roomId : pArea->getRoomsForZ(exportZLevel + 1)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
-        if (!pRoom || pRoom->z() != exportZLevel + 1) {
+        if (!pRoom) {
             continue;
         }
 
@@ -5506,11 +6252,11 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
         // Since we can't easily override those methods, we'll create a custom export-specific exit drawing
 
         // Draw exits using similar logic to paintRoomExits but with export-specific coordinates
-        QSetIterator<int> itRoom2(pArea->getAreaRooms());
+        QSetIterator<int> itRoom2(pArea->getRoomsForZ(exportZLevel));
         while (itRoom2.hasNext()) {
             const int roomId = itRoom2.next();
             TRoom* room = mpMap->mpRoomDB->getRoom(roomId);
-            if (!room || room->z() != exportZLevel) {
+            if (!room) {
                 continue;
             }
 
@@ -5878,9 +6624,9 @@ std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& fi
     }
 
     // Fourth pass: draw main rooms on current level using existing drawRoom method
-    for (const int roomId : std::as_const(pArea->rooms)) {
+    for (const int roomId : pArea->getRoomsForZ(exportZLevel)) {
         TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
-        if (!pRoom || pRoom->z() != exportZLevel) {
+        if (!pRoom) {
             roomsSkipped++;
             continue;
         }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -65,6 +65,7 @@ class QComboBox;
 class QElapsedTimer;
 class QListWidgetItem;
 class QPushButton;
+class QTimer;
 class QTreeWidgetItem;
 class QMouseEvent;
 class QMenu;
@@ -180,6 +181,13 @@ public:
     void switchArea(const QString& newAreaName);
     void switchArea(int areaId);
     void clearSelection();
+
+    // Schedules a repaint through a single-shot timer, coalescing multiple
+    // rapid requests (e.g. during mouse wheel zoom or pan drag) into at most
+    // one repaint per csmRenderThrottleMs.  Use this instead of update() for
+    // continuously-firing input events; call update() directly for discrete
+    // user actions where an immediate repaint is expected.
+    void scheduleRender();
 
     // Secondary view support (for multiple map views feature)
     void setSecondaryView(bool isSecondary) { mIsSecondaryView = isSecondary; }
@@ -428,6 +436,22 @@ private:
                          const float,
                          const QMap<int, QPointF>&,
                          const bool showRoomCollision);
+    // Batch rendering for large grid mode areas - draws rooms grouped by color
+    void drawGridModeRooms(QPainter&,
+                           const TArea* pDrawnArea,
+                           const int zLevel,
+                           const int playerRoomId,
+                           const float mRX,
+                           const float mRY,
+                           const float mRoomWidth,
+                           const float mRoomHeight,
+                           const float widgetWidth,
+                           const float widgetHeight,
+                           QFont& roomVNumFont,
+                           bool& isPlayerRoomVisible,
+                           QPointF& playerRoomOnWidgetCoordinates,
+                           bool areRoomIdsLegible,
+                           QString* profileOutput = nullptr);
     void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
@@ -440,6 +464,12 @@ private:
         int x;
         int y;
     } mContextMenuClickPosition;
+
+    // Throttle repaint requests from continuous mouse events (pan drag, scroll
+    // wheel zoom) to avoid saturating the main thread at high event rates.
+    // Maximum of one repaint per csmRenderThrottleMs is allowed via scheduleRender().
+    static constexpr int csmRenderThrottleMs = 16; // ~60 fps cap
+    QTimer* mpRenderThrottleTimer = nullptr;
 
     // This holds the ID of the room highlighted in yellow when multiple
     // rooms are selected. It is either the first selected room, or the

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -361,6 +361,8 @@ void TArea::addRoom(int id)
     if (pR) {
         if (!rooms.contains(id)) {
             rooms.insert(id);
+            mZLevelIndex.addRoom(id, pR->z());
+            mGridIndex.addRoom(id, pR->z(), pR->x(), pR->y());
         } else {
             qDebug() << "TArea::addRoom(" << id << ") No creation! room already exists";
         }
@@ -378,6 +380,13 @@ void TArea::calcSpan()
     ymaxForZ.clear();
     zLevels.clear();
 
+    // Collect the room-to-Z mapping in a single pass so mZLevelIndex can be
+    // rebuilt without a second iteration. Also collect the full z/x/y data
+    // so the grid index can be rebuilt at the same time.
+    QHash<int, int> roomIdToZ;
+    roomIdToZ.reserve(rooms.size());
+    QHash<int, QHash<int, QPair<int, int>>> zToRoomXY;
+
     bool isFirstDone = false;
     QSetIterator<int> itRoom(rooms);
     while (itRoom.hasNext()) {
@@ -386,6 +395,9 @@ void TArea::calcSpan()
         if (!pR) {
             continue;
         }
+
+        roomIdToZ.insert(id, pR->z());
+        zToRoomXY[pR->z()].insert(id, {pR->x(), pR->y()});
 
         if (!isFirstDone) {
             // Only do this initialization for the first valid room
@@ -464,6 +476,10 @@ void TArea::calcSpan()
         // The {x|y}{min|max}ForZ are, by definition!
         std::sort(zLevels.begin(), zLevels.end());
     }
+
+    // Rebuild the Z-level room index from the authoritative room set.
+    mZLevelIndex.rebuild(roomIdToZ);
+    mGridIndex.rebuild(zToRoomXY);
 }
 
 // Added a second argument to cut-out extremes recalculation if not required
@@ -480,11 +496,20 @@ void TArea::removeRoom(int room, bool deferAreaRecalculations)
 
     // Will use to flag whether some things have to be recalculated.
     bool isOnExtreme = false;
-    if (rooms.contains(room) && !deferAreaRecalculations) {
-        // just a check, if the area DOESN'T have the room then it is not wise
-        // to behave as if it did
-        TRoom* pR = mpRoomDB->getRoom(room);
-        if (pR) {
+    TRoom* pR = mpRoomDB->getRoom(room);
+    if (pR) {
+        // Always keep the Z-level index consistent regardless of whether area
+        // recalculations are deferred.  The incremental removal is O(1) and
+        // ensures getRoomsForZ() returns correct results until calcSpan() next
+        // runs (which rebuilds the index authoritatively).
+        if (rooms.contains(room)) {
+            mZLevelIndex.removeRoom(room, pR->z());
+            mGridIndex.removeRoom(room, pR->z(), pR->x(), pR->y());
+        }
+
+        if (rooms.contains(room) && !deferAreaRecalculations) {
+            // just a check, if the area DOESN'T have the room then it is not wise
+            // to behave as if it did
             // Now see if the room is on an extreme - if it the only room on a
             // particular z-coordinate it will be on all four
             if (xminForZ.contains(pR->z()) && xminForZ.value(pR->z()) >= pR->x()) {

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -24,6 +24,8 @@
  ***************************************************************************/
 
 
+#include "TAreaGridIndex.h"
+#include "TAreaZLevelIndex.h"
 #include "TMap.h"
 
 #include "TMapLabel.h"
@@ -51,6 +53,20 @@ public:
     const QSet<int>& getAreaRooms() const { return rooms; }
     const QList<int> getAreaExitRoomIds() const { return mAreaExits.uniqueKeys(); }
     const QMultiMap<int, QPair<QString, int>> getAreaExitRoomData() const;
+    // Atomically updates both the Z-level index and the grid index when a room
+    // moves to a new position.  All callers should use this instead of calling
+    // moveRoomZ and moveRoomInGridIndex separately.
+    void moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY)
+    {
+        mZLevelIndex.moveRoom(id, fromZ, toZ);
+        mGridIndex.moveRoom(id, fromZ, fromX, fromY, toZ, toX, toY);
+    }
+    // Returns the set of room IDs on the given Z level.  The returned reference
+    // is stable for the lifetime of the index (an internal empty set is used
+    // for Z levels with no rooms), so it can be safely iterated immediately.
+    const QSet<int>& getRoomsForZ(int z) const { return mZLevelIndex.roomsForZ(z); }
+    // Returns a const reference to the grid index for read-only access by the renderer.
+    const TAreaGridIndex& getGridIndex() const { return mGridIndex; }
     void calcSpan();
     void fast_calcSpan(int);
     void determineAreaExits();
@@ -133,6 +149,13 @@ private:
     // key=in_area room id, pair.first=out_of_area room id pair.second=direction
     // Made private as we may change implementation detail
     QMultiMap<int, QPair<int, int>> mAreaExits;
+
+    // Per-Z-level room index. Maintained incrementally alongside TArea::rooms.
+    // Allows paintEvent to iterate only the rooms on a given Z level, avoiding
+    // an O(N-total) scan just to find which rooms match the current Z.
+    TAreaZLevelIndex mZLevelIndex;
+    // Per-(z,x,y) grid index for efficient viewport queries in grid mode.
+    TAreaGridIndex mGridIndex;
 
     // In use this has a minimum of 3.0 and a default of 20.0, the latter will
     // be applied in the constructor initialisation list:

--- a/src/TAreaGridIndex.cpp
+++ b/src/TAreaGridIndex.cpp
@@ -131,15 +131,15 @@ QList<int> TAreaGridIndex::roomsInViewport(int z, int minX, int maxX, int minY, 
         return result;
     }
     const auto& xyMap = *zIt;
-    for (int x = minX; x <= maxX; ++x) {
-        const auto xIt = xyMap.constFind(x);
-        if (xIt == xyMap.constEnd()) {
+    for (auto xIt = xyMap.constBegin(); xIt != xyMap.constEnd(); ++xIt) {
+        const int x = xIt.key();
+        if (x < minX || x > maxX) {
             continue;
         }
         const auto& yMap = *xIt;
-        for (int y = minY; y <= maxY; ++y) {
-            const auto yIt = yMap.constFind(y);
-            if (yIt == yMap.constEnd()) {
+        for (auto yIt = yMap.constBegin(); yIt != yMap.constEnd(); ++yIt) {
+            const int y = yIt.key();
+            if (y < minY || y > maxY) {
                 continue;
             }
             for (const int roomId : *yIt) {
@@ -158,15 +158,15 @@ QList<QPair<int, bool>> TAreaGridIndex::roomsInViewportWithCollisions(int z, int
         return result;
     }
     const auto& xyMap = *zIt;
-    for (int x = minX; x <= maxX; ++x) {
-        const auto xIt = xyMap.constFind(x);
-        if (xIt == xyMap.constEnd()) {
+    for (auto xIt = xyMap.constBegin(); xIt != xyMap.constEnd(); ++xIt) {
+        const int x = xIt.key();
+        if (x < minX || x > maxX) {
             continue;
         }
         const auto& yMap = *xIt;
-        for (int y = minY; y <= maxY; ++y) {
-            const auto yIt = yMap.constFind(y);
-            if (yIt == yMap.constEnd()) {
+        for (auto yIt = yMap.constBegin(); yIt != yMap.constEnd(); ++yIt) {
+            const int y = yIt.key();
+            if (y < minY || y > maxY) {
                 continue;
             }
             const bool collision = yIt->size() > 1;

--- a/src/TAreaGridIndex.cpp
+++ b/src/TAreaGridIndex.cpp
@@ -1,0 +1,204 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TAreaGridIndex.h"
+
+const QSet<int> TAreaGridIndex::csmEmptySet;
+
+void TAreaGridIndex::addRoom(int id, int z, int x, int y)
+{
+    auto& cell = mIndex[z][x][y];
+    if (!cell.contains(id)) {
+        cell.insert(id);
+        ++mCachedSize;
+    }
+}
+
+void TAreaGridIndex::removeRoom(int id, int z, int x, int y)
+{
+    auto zIt = mIndex.find(z);
+    if (zIt == mIndex.end()) {
+        return;
+    }
+    auto xIt = zIt->find(x);
+    if (xIt == zIt->end()) {
+        return;
+    }
+    auto yIt = xIt->find(y);
+    if (yIt == xIt->end()) {
+        return;
+    }
+    if (yIt->remove(id)) {
+        --mCachedSize;
+    }
+    if (yIt->isEmpty()) {
+        xIt->erase(yIt);
+    }
+    if (xIt->isEmpty()) {
+        zIt->erase(xIt);
+    }
+    if (zIt->isEmpty()) {
+        mIndex.erase(zIt);
+    }
+}
+
+void TAreaGridIndex::moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY)
+{
+    if (fromZ == toZ && fromX == toX && fromY == toY) {
+        return;
+    }
+    removeRoom(id, fromZ, fromX, fromY);
+    addRoom(id, toZ, toX, toY);
+}
+
+void TAreaGridIndex::rebuild(int z, const QHash<int, QPair<int, int>>& roomIdToXY)
+{
+    // Subtract the room count for the Z level being replaced.
+    const auto zIt = mIndex.constFind(z);
+    if (zIt != mIndex.constEnd()) {
+        for (const auto& xMap : *zIt) {
+            for (const auto& cell : xMap) {
+                mCachedSize -= cell.size();
+            }
+        }
+    }
+    mIndex.remove(z);
+
+    // Insert the new rooms.  Each key in roomIdToXY is a unique room ID.
+    mCachedSize += roomIdToXY.size();
+    QHashIterator<int, QPair<int, int>> it(roomIdToXY);
+    while (it.hasNext()) {
+        it.next();
+        mIndex[z][it.value().first][it.value().second].insert(it.key());
+    }
+    mCachedMemoryEstimate = computeMemoryEstimate();
+}
+
+void TAreaGridIndex::rebuild(const QHash<int, QHash<int, QPair<int, int>>>& zToRoomXY)
+{
+    // Full rebuild: bypass the per-Z path so computeMemoryEstimate() is called
+    // only once rather than once per Z level.
+    mIndex.clear();
+    mCachedSize = 0;
+    for (auto itZ = zToRoomXY.constBegin(); itZ != zToRoomXY.constEnd(); ++itZ) {
+        const int z = itZ.key();
+        for (auto it = itZ.value().constBegin(); it != itZ.value().constEnd(); ++it) {
+            mIndex[z][it.value().first][it.value().second].insert(it.key());
+        }
+        mCachedSize += itZ.value().size();
+    }
+    mCachedMemoryEstimate = computeMemoryEstimate();
+}
+
+const QSet<int>& TAreaGridIndex::roomsAt(int z, int x, int y) const
+{
+    const auto zIt = mIndex.constFind(z);
+    if (zIt == mIndex.constEnd()) {
+        return csmEmptySet;
+    }
+    const auto xIt = zIt->constFind(x);
+    if (xIt == zIt->constEnd()) {
+        return csmEmptySet;
+    }
+    const auto yIt = xIt->constFind(y);
+    if (yIt == xIt->constEnd()) {
+        return csmEmptySet;
+    }
+    return *yIt;
+}
+
+QList<int> TAreaGridIndex::roomsInViewport(int z, int minX, int maxX, int minY, int maxY) const
+{
+    QList<int> result;
+    const auto zIt = mIndex.constFind(z);
+    if (zIt == mIndex.constEnd()) {
+        return result;
+    }
+    const auto& xyMap = *zIt;
+    for (int x = minX; x <= maxX; ++x) {
+        const auto xIt = xyMap.constFind(x);
+        if (xIt == xyMap.constEnd()) {
+            continue;
+        }
+        const auto& yMap = *xIt;
+        for (int y = minY; y <= maxY; ++y) {
+            const auto yIt = yMap.constFind(y);
+            if (yIt == yMap.constEnd()) {
+                continue;
+            }
+            for (const int roomId : *yIt) {
+                result.append(roomId);
+            }
+        }
+    }
+    return result;
+}
+
+QList<QPair<int, bool>> TAreaGridIndex::roomsInViewportWithCollisions(int z, int minX, int maxX, int minY, int maxY) const
+{
+    QList<QPair<int, bool>> result;
+    const auto zIt = mIndex.constFind(z);
+    if (zIt == mIndex.constEnd()) {
+        return result;
+    }
+    const auto& xyMap = *zIt;
+    for (int x = minX; x <= maxX; ++x) {
+        const auto xIt = xyMap.constFind(x);
+        if (xIt == xyMap.constEnd()) {
+            continue;
+        }
+        const auto& yMap = *xIt;
+        for (int y = minY; y <= maxY; ++y) {
+            const auto yIt = yMap.constFind(y);
+            if (yIt == yMap.constEnd()) {
+                continue;
+            }
+            const bool collision = yIt->size() > 1;
+            for (const int roomId : *yIt) {
+                result.append({roomId, collision});
+            }
+        }
+    }
+    return result;
+}
+
+int TAreaGridIndex::computeMemoryEstimate() const
+{
+    // Count the number of containers at each nesting level to give a
+    // better-than-nothing estimate.  Qt QHash internals allocate roughly
+    // 48 bytes of base overhead plus ~16 bytes per stored entry at a typical
+    // load factor.  These constants are intentionally conservative.
+    constexpr int kHashBase = 48;
+    constexpr int kHashEntry = 16;
+
+    int zCount = mIndex.size();
+    int xCount = 0;
+    int yCount = 0;
+    int roomCount = 0;
+    for (auto zIt = mIndex.constBegin(); zIt != mIndex.constEnd(); ++zIt) {
+        xCount += zIt->size();
+        for (auto xIt = zIt->constBegin(); xIt != zIt->constEnd(); ++xIt) {
+            yCount += xIt->size();
+            for (auto yIt = xIt->constBegin(); yIt != xIt->constEnd(); ++yIt) {
+                roomCount += yIt->size();
+            }
+        }
+    }
+    return zCount * (kHashBase + kHashEntry) + xCount * (kHashBase + kHashEntry) + yCount * (kHashBase + kHashEntry) + roomCount * static_cast<int>(sizeof(int));
+}

--- a/src/TAreaGridIndex.h
+++ b/src/TAreaGridIndex.h
@@ -1,0 +1,81 @@
+#ifndef MUDLET_TAREA_GRID_INDEX_H
+#define MUDLET_TAREA_GRID_INDEX_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QHash>
+#include <QList>
+#include <QPair>
+#include <QSet>
+
+// Three-level spatial index: Z → X → Y → set of room IDs.
+// Used by the 2D map renderer to retrieve only the rooms visible in the
+// current viewport rather than scanning every room in the area.
+class TAreaGridIndex
+{
+public:
+    void addRoom(int id, int z, int x, int y);
+    void removeRoom(int id, int z, int x, int y);
+    void moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY);
+
+    // Replaces all rooms on the given Z level from a roomId → (x,y) mapping.
+    void rebuild(int z, const QHash<int, QPair<int, int>>& roomIdToXY);
+
+    // Replaces the entire index from a pre-bucketed z → (roomId → (x,y)) mapping.
+    void rebuild(const QHash<int, QHash<int, QPair<int, int>>>& zToRoomXY);
+
+    // Returns all room IDs at the exact grid cell (z, x, y).
+    // Returns a reference to a stable empty set when the cell is unoccupied.
+    const QSet<int>& roomsAt(int z, int x, int y) const;
+
+    // Returns all room IDs whose grid cell lies within the inclusive rectangle
+    // [minX..maxX] × [minY..maxY] on the given Z level.
+    QList<int> roomsInViewport(int z, int minX, int maxX, int minY, int maxY) const;
+
+    // Like roomsInViewport but also sets the collision flag (true when two or
+    // more rooms share the same cell). Avoids a secondary roomsAt() lookup per
+    // room in the rendering collect pass.
+    QList<QPair<int, bool>> roomsInViewportWithCollisions(int z, int minX, int maxX, int minY, int maxY) const;
+
+    bool isEmpty() const { return mIndex.isEmpty(); }
+    void clear()
+    {
+        mIndex.clear();
+        mCachedSize = 0;
+        mCachedMemoryEstimate = 0;
+    }
+
+    // O(1) — counts are maintained incrementally by add/remove/rebuild.
+    int size() const { return mCachedSize; }
+
+    // O(1) — computed once at rebuild time and updated incrementally.
+    // Rough memory usage estimate in bytes, for profiling/diagnostics.
+    int memoryEstimateBytes() const { return mCachedMemoryEstimate; }
+
+private:
+    int computeMemoryEstimate() const;
+
+    QHash<int, QHash<int, QHash<int, QSet<int>>>> mIndex;
+    int mCachedSize = 0;
+    int mCachedMemoryEstimate = 0;
+    static const QSet<int> csmEmptySet;
+};
+
+#endif // MUDLET_TAREA_GRID_INDEX_H

--- a/src/TAreaGridIndex.h
+++ b/src/TAreaGridIndex.h
@@ -65,8 +65,9 @@ public:
     // O(1) — counts are maintained incrementally by add/remove/rebuild.
     int size() const { return mCachedSize; }
 
-    // O(1) — computed once at rebuild time and updated incrementally.
-    // Rough memory usage estimate in bytes, for profiling/diagnostics.
+    // O(1) — rough memory usage estimate in bytes, for profiling/diagnostics.
+    // Refreshed by rebuild() and reset by clear(); may be stale after
+    // incremental add/remove/move updates until the next rebuild().
     int memoryEstimateBytes() const { return mCachedMemoryEstimate; }
 
 private:

--- a/src/TAreaZLevelIndex.cpp
+++ b/src/TAreaZLevelIndex.cpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TAreaZLevelIndex.h"
+
+const QSet<int> TAreaZLevelIndex::csmEmptySet;
+
+void TAreaZLevelIndex::addRoom(int id, int z)
+{
+    mIndex[z].insert(id);
+}
+
+void TAreaZLevelIndex::removeRoom(int id, int z)
+{
+    auto it = mIndex.find(z);
+    if (it == mIndex.end()) {
+        return;
+    }
+    it->remove(id);
+    if (it->isEmpty()) {
+        mIndex.erase(it);
+    }
+}
+
+void TAreaZLevelIndex::moveRoom(int id, int fromZ, int toZ)
+{
+    if (fromZ == toZ) {
+        return;
+    }
+    removeRoom(id, fromZ);
+    addRoom(id, toZ);
+}
+
+void TAreaZLevelIndex::rebuild(const QHash<int, int>& roomIdToZ)
+{
+    mIndex.clear();
+    QHashIterator<int, int> it(roomIdToZ);
+    while (it.hasNext()) {
+        it.next();
+        mIndex[it.value()].insert(it.key());
+    }
+}
+
+const QSet<int>& TAreaZLevelIndex::roomsForZ(int z) const
+{
+    const auto it = mIndex.constFind(z);
+    if (it == mIndex.constEnd()) {
+        return csmEmptySet;
+    }
+    return *it;
+}

--- a/src/TAreaZLevelIndex.h
+++ b/src/TAreaZLevelIndex.h
@@ -1,0 +1,52 @@
+#ifndef MUDLET_TAREA_ZLEVEL_INDEX_H
+#define MUDLET_TAREA_ZLEVEL_INDEX_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QHash>
+#include <QSet>
+
+/*
+ * Maintains an incrementally-updated reverse index of room IDs by Z level.
+ * Allows roomsForZ() to return only the rooms on a given level without
+ * scanning the full area room set.
+ */
+class TAreaZLevelIndex
+{
+public:
+    void addRoom(int id, int z);
+    void removeRoom(int id, int z);
+    void moveRoom(int id, int fromZ, int toZ);
+
+    // Replaces the entire index from a roomId → Z mapping.
+    void rebuild(const QHash<int, int>& roomIdToZ);
+
+    // Returns all room IDs on the given Z level, or a stable empty set.
+    const QSet<int>& roomsForZ(int z) const;
+
+    bool isEmpty() const { return mIndex.isEmpty(); }
+    void clear() { mIndex.clear(); }
+
+private:
+    QHash<int, QSet<int>> mIndex;
+    static const QSet<int> csmEmptySet;
+};
+
+#endif // MUDLET_TAREA_ZLEVEL_INDEX_H

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -231,6 +231,18 @@ bool TMap::setRoomCoordinates(int id, int x, int y, int z)
         return false;
     }
 
+    const int oldX = pR->x();
+    const int oldY = pR->y();
+    const int oldZ = pR->z();
+
+    if (oldX != x || oldY != y || oldZ != z) {
+        TArea* pA = mpRoomDB->getArea(pR->getArea());
+        if (pA) {
+            // Atomically update both indices for any coordinate change.
+            pA->moveRoom(id, oldZ, oldX, oldY, z, x, y);
+        }
+    }
+
     pR->setCoordinates(x, y, z);
 
     setUnsaved(__func__);

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -291,16 +291,19 @@ bool TRoomDB::__removeRoom(int id)
             }
             ++i;
         }
+        const int areaID = pR->getArea();
+        TArea* pA = getArea(areaID);
+        if (pA) {
+            // removeRoom needs the TRoom to be present in the DB so it can look
+            // up coordinates for index maintenance; call it before removing the
+            // room from the rooms hash.
+            pA->removeRoom(id);
+        }
         rooms.remove(id);
         if (roomIDToHash.contains(id)) {
             const QString hash = roomIDToHash[id];
             roomIDToHash.remove(id);
             hashToRoomID.remove(hash);
-        }
-        const int areaID = pR->getArea();
-        TArea* pA = getArea(areaID);
-        if (pA) {
-            pA->removeRoom(id);
         }
         if ((!mpTempRoomDeletionSet) || mpTempRoomDeletionSet->size() == 1) { // if NOT deleting multiple rooms
             entranceMap.remove(id);                                           // Only removes matching keys

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -530,6 +530,10 @@ int dlgMapper::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffs
     font.setBold(properties.isBold);
     font.setItalic(properties.isItalic);
     painter.setFont(font);
+    // Set the pen before calling boundingRect: Qt6's drawTextItem early-returns
+    // when pen().style() == Qt::NoPen, which causes boundingRect to return
+    // height=0 and makes drawText render nothing (grey box with no text).
+    painter.setPen(properties.color);
     const int infoHeight = fontHeight;
     QRect testRect;
     QRect mapInfoRect = QRect(xOffset, yOffset, widgetWidth - 10 - xOffset, infoHeight);
@@ -541,7 +545,6 @@ int dlgMapper::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffs
                                     infoText);
     mapInfoRect.setHeight(testRect.height() + 10);
     painter.fillRect(mapInfoRect, bgColor);
-    painter.setPen(properties.color);
     painter.drawText(mapInfoRect.left() + 10,
                      mapInfoRect.top(),
                      mapInfoRect.width() - 20,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,8 @@ set(UNIT_TESTS
     SecureStringUtilsTest
     CredentialManagerTest
     DiscordTest
+    TAreaZLevelIndexTest
+    TAreaGridIndexTest
 )
 
 foreach(test_name ${UNIT_TESTS})

--- a/test/TAreaGridIndexTest.cpp
+++ b/test/TAreaGridIndexTest.cpp
@@ -1,0 +1,523 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <TAreaGridIndex.h>
+
+#include <QtTest/QtTest>
+
+/*
+ * Unit tests for TAreaGridIndex.
+ *
+ * The class is pure data (no GUI / Host / TMap dependencies), so these tests
+ * run without needing the full Mudlet application stack.
+ *
+ * Coverage goals
+ * - addRoom: single cell, multiple rooms at same cell, different cells, duplicate, cross-Z
+ * - removeRoom: normal, last-room-at-cell prunes bucket, non-existent id/z (no
+ *   crash), wrong coords leaves correct cell intact
+ * - moveRoom: same-coords no-op, different XY same Z, different Z, pruning of empty cell
+ * - rebuild (per-Z): populates, overwrites prior Z level, does not affect other Z levels
+ * - rebuild (full): populates all Z levels, overwrites previous state, empty map -> isEmpty
+ * - roomsAt: existing cell, non-existent cell (no crash), stable empty reference
+ * - roomsInViewport: all in, some out, empty Z, multiple rooms per cell, inclusive edges
+ * - roomsInViewportWithCollisions: solo rooms, colliding rooms, out-of-viewport exclusion, empty Z
+ * - isEmpty / clear / size
+ * - Integration: add + full rebuild + remove + move
+ */
+class TAreaGridIndexTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    // -------------------------------------------------------------------------
+    // addRoom
+    // -------------------------------------------------------------------------
+
+    void addRoom_singleCell_idAppearsAtThatCell()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(42, 0, 3, 5);
+        QVERIFY(idx.roomsAt(0, 3, 5).contains(42));
+    }
+
+    void addRoom_multipleRoomsAtSameCell_allPresent()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 2, 2);
+        idx.addRoom(2, 0, 2, 2);
+        const QSet<int>& cell = idx.roomsAt(0, 2, 2);
+        QVERIFY(cell.contains(1));
+        QVERIFY(cell.contains(2));
+        QCOMPARE(cell.size(), 2);
+    }
+
+    void addRoom_roomsAtDifferentCells_segregated()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(10, 0, 1, 2);
+        idx.addRoom(20, 0, 3, 4);
+        QVERIFY(idx.roomsAt(0, 1, 2).contains(10));
+        QVERIFY(!idx.roomsAt(0, 1, 2).contains(20));
+        QVERIFY(idx.roomsAt(0, 3, 4).contains(20));
+        QVERIFY(!idx.roomsAt(0, 3, 4).contains(10));
+    }
+
+    void addRoom_duplicate_noDoubleEntry()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(7, 0, 1, 1);
+        idx.addRoom(7, 0, 1, 1); // duplicate
+        QCOMPARE(idx.roomsAt(0, 1, 1).size(), 1);
+        QVERIFY(idx.roomsAt(0, 1, 1).contains(7));
+    }
+
+    void addRoom_acrossZLevels_segregated()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(100, 0, 5, 5);
+        idx.addRoom(200, 1, 5, 5);
+        QVERIFY(idx.roomsAt(0, 5, 5).contains(100));
+        QVERIFY(!idx.roomsAt(0, 5, 5).contains(200));
+        QVERIFY(idx.roomsAt(1, 5, 5).contains(200));
+        QVERIFY(!idx.roomsAt(1, 5, 5).contains(100));
+    }
+
+    // -------------------------------------------------------------------------
+    // removeRoom
+    // -------------------------------------------------------------------------
+
+    void removeRoom_idNoLongerAtCell()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 3, 3);
+        idx.addRoom(2, 0, 3, 3);
+        idx.removeRoom(1, 0, 3, 3);
+        QVERIFY(!idx.roomsAt(0, 3, 3).contains(1));
+        QVERIFY(idx.roomsAt(0, 3, 3).contains(2));
+    }
+
+    void removeRoom_lastRoomAtCell_cellPruned()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(42, 0, 7, 8);
+        idx.removeRoom(42, 0, 7, 8);
+        QVERIFY(idx.roomsAt(0, 7, 8).isEmpty());
+        QVERIFY(idx.isEmpty());
+    }
+
+    void removeRoom_nonExistentId_nocrash()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        // Should not crash
+        idx.removeRoom(999, 0, 0, 0);
+        QVERIFY(idx.roomsAt(0, 0, 0).contains(1));
+    }
+
+    void removeRoom_nonExistentZ_nocrash()
+    {
+        TAreaGridIndex idx;
+        // Should not crash when Z level has no rooms
+        idx.removeRoom(1, 99, 0, 0);
+        QVERIFY(idx.isEmpty());
+    }
+
+    void removeRoom_wrongCoords_idRemainsAtCorrectCell()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(5, 0, 2, 3);
+        idx.removeRoom(5, 0, 9, 9); // wrong x/y
+        QVERIFY(idx.roomsAt(0, 2, 3).contains(5));
+    }
+
+    // -------------------------------------------------------------------------
+    // moveRoom
+    // -------------------------------------------------------------------------
+
+    void moveRoom_sameCoords_isNoOp()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(10, 0, 4, 4);
+        idx.moveRoom(10, 0, 4, 4, 0, 4, 4); // no-op
+        QVERIFY(idx.roomsAt(0, 4, 4).contains(10));
+    }
+
+    void moveRoom_differentXY_sameZ_appearsAtNewCell()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(10, 0, 1, 1);
+        idx.moveRoom(10, 0, 1, 1, 0, 5, 6);
+        QVERIFY(!idx.roomsAt(0, 1, 1).contains(10));
+        QVERIFY(idx.roomsAt(0, 5, 6).contains(10));
+    }
+
+    void moveRoom_differentZ_appearsAtNewCellOnly()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(10, 0, 2, 2);
+        idx.moveRoom(10, 0, 2, 2, 3, 2, 2);
+        QVERIFY(!idx.roomsAt(0, 2, 2).contains(10));
+        QVERIFY(idx.roomsAt(3, 2, 2).contains(10));
+    }
+
+    void moveRoom_partialMove_oldCellPrunedWhenEmpty()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(10, 0, 0, 0); // only room at (z=0,x=0,y=0)
+        idx.moveRoom(10, 0, 0, 0, 1, 0, 0);
+        QVERIFY(idx.roomsAt(0, 0, 0).isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // rebuild (per-Z)
+    // -------------------------------------------------------------------------
+
+    void rebuildPerZ_populatesFromMapping()
+    {
+        TAreaGridIndex idx;
+        const QHash<int, QPair<int, int>> mapping = {{1, {2, 3}}, {4, {5, 6}}};
+        idx.rebuild(0, mapping);
+        QVERIFY(idx.roomsAt(0, 2, 3).contains(1));
+        QVERIFY(idx.roomsAt(0, 5, 6).contains(4));
+    }
+
+    void rebuildPerZ_overwritesPriorZLevel()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(99, 0, 9, 9); // stale data on Z=0
+
+        const QHash<int, QPair<int, int>> mapping = {{1, {0, 0}}};
+        idx.rebuild(0, mapping);
+
+        QVERIFY(!idx.roomsAt(0, 9, 9).contains(99)); // stale gone
+        QVERIFY(idx.roomsAt(0, 0, 0).contains(1));
+    }
+
+    void rebuildPerZ_doesNotAffectOtherZLevels()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(55, 1, 3, 3); // on Z=1
+
+        const QHash<int, QPair<int, int>> mapping = {{1, {0, 0}}};
+        idx.rebuild(0, mapping); // rebuild only Z=0
+
+        QVERIFY(idx.roomsAt(1, 3, 3).contains(55)); // Z=1 still intact
+        QVERIFY(idx.roomsAt(0, 0, 0).contains(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // rebuild (full -- all Z levels at once)
+    // -------------------------------------------------------------------------
+
+    void rebuildFull_populatesAllZLevels()
+    {
+        TAreaGridIndex idx;
+        const QHash<int, QHash<int, QPair<int, int>>> zToRoomXY = {{0, {{1, {2, 3}}, {2, {4, 5}}}}, {1, {{3, {0, 0}}}}};
+        idx.rebuild(zToRoomXY);
+        QVERIFY(idx.roomsAt(0, 2, 3).contains(1));
+        QVERIFY(idx.roomsAt(0, 4, 5).contains(2));
+        QVERIFY(idx.roomsAt(1, 0, 0).contains(3));
+    }
+
+    void rebuildFull_overwritesPreviousState()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(99, 5, 9, 9); // stale data
+
+        const QHash<int, QHash<int, QPair<int, int>>> zToRoomXY = {{0, {{1, {0, 0}}}}};
+        idx.rebuild(zToRoomXY);
+
+        QVERIFY(!idx.roomsAt(5, 9, 9).contains(99)); // stale gone
+        QVERIFY(idx.roomsAt(0, 0, 0).contains(1));
+    }
+
+    void rebuildFull_emptyMapping_indexIsEmpty()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        idx.rebuild(QHash<int, QHash<int, QPair<int, int>>>{});
+        QVERIFY(idx.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // roomsAt
+    // -------------------------------------------------------------------------
+
+    void roomsAt_existingCell_returnsCorrectSet()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(7, 2, 10, 20);
+        idx.addRoom(8, 2, 10, 20);
+        const QSet<int> expected = {7, 8};
+        QCOMPARE(idx.roomsAt(2, 10, 20), expected);
+    }
+
+    void roomsAt_nonExistentCell_returnsEmptySet()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        // (0, 99, 99) was never populated
+        QVERIFY(idx.roomsAt(0, 99, 99).isEmpty());
+    }
+
+    void roomsAt_returnsStableReferenceForEmptyCell()
+    {
+        TAreaGridIndex idx;
+        // Two calls to a non-existent cell must return references to the same
+        // static empty set (no dangling references).
+        const QSet<int>& ref1 = idx.roomsAt(77, 1, 2);
+        const QSet<int>& ref2 = idx.roomsAt(77, 1, 2);
+        QVERIFY(&ref1 == &ref2);
+        QVERIFY(ref1.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // roomsInViewport
+    // -------------------------------------------------------------------------
+
+    void roomsInViewport_allRoomsInViewport_allReturned()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        idx.addRoom(2, 0, 1, 1);
+        idx.addRoom(3, 0, 2, 2);
+
+        const QList<int> result = idx.roomsInViewport(0, 0, 2, 0, 2);
+        const QSet<int> visited(result.constBegin(), result.constEnd());
+
+        QCOMPARE(visited, QSet<int>({1, 2, 3}));
+    }
+
+    void roomsInViewport_someRoomsOutsideViewport_onlyInsideReturned()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0); // inside [0..2] x [0..2]
+        idx.addRoom(2, 0, 5, 5); // outside
+        idx.addRoom(3, 0, 2, 2); // inside
+
+        const QList<int> result = idx.roomsInViewport(0, 0, 2, 0, 2);
+        const QSet<int> visited(result.constBegin(), result.constEnd());
+
+        QVERIFY(visited.contains(1));
+        QVERIFY(visited.contains(3));
+        QVERIFY(!visited.contains(2));
+    }
+
+    void roomsInViewport_emptyZ_returnsEmpty()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0); // on Z=0
+
+        const QList<int> result = idx.roomsInViewport(99, 0, 10, 0, 10);
+
+        QCOMPARE(result.size(), 0);
+    }
+
+    void roomsInViewport_multipleRoomsPerCell_allReturned()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 3, 3);
+        idx.addRoom(2, 0, 3, 3); // same cell as room 1
+
+        const QList<int> result = idx.roomsInViewport(0, 0, 5, 0, 5);
+        const QSet<int> visited(result.constBegin(), result.constEnd());
+
+        QVERIFY(visited.contains(1));
+        QVERIFY(visited.contains(2));
+        QCOMPARE(visited.size(), 2);
+    }
+
+    void roomsInViewport_exactBounds_inclusiveEdges()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);   // at minX, minY
+        idx.addRoom(2, 0, 10, 0);  // at maxX, minY
+        idx.addRoom(3, 0, 0, 10);  // at minX, maxY
+        idx.addRoom(4, 0, 10, 10); // at maxX, maxY
+        idx.addRoom(5, 0, 11, 5);  // just outside (x > maxX)
+
+        const QList<int> result = idx.roomsInViewport(0, 0, 10, 0, 10);
+        const QSet<int> visited(result.constBegin(), result.constEnd());
+
+        QVERIFY(visited.contains(1));
+        QVERIFY(visited.contains(2));
+        QVERIFY(visited.contains(3));
+        QVERIFY(visited.contains(4));
+        QVERIFY(!visited.contains(5));
+        QCOMPARE(visited.size(), 4);
+    }
+
+    // -------------------------------------------------------------------------
+    // roomsInViewportWithCollisions
+    // -------------------------------------------------------------------------
+
+    void roomsInViewportWithCollisions_soloRooms_collisionFalse()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        idx.addRoom(2, 0, 1, 0);
+        idx.addRoom(3, 0, 2, 0);
+
+        const auto result = idx.roomsInViewportWithCollisions(0, 0, 2, 0, 0);
+        QCOMPARE(result.size(), 3);
+        for (const auto& [id, collision] : result) {
+            QVERIFY(!collision); // each room is alone in its cell
+        }
+    }
+
+    void roomsInViewportWithCollisions_sharedCell_collisionTrue()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 5, 5);
+        idx.addRoom(2, 0, 5, 5); // same cell as room 1 → collision
+
+        const auto result = idx.roomsInViewportWithCollisions(0, 5, 5, 5, 5);
+        QCOMPARE(result.size(), 2);
+        QSet<int> ids;
+        for (const auto& [id, collision] : result) {
+            ids.insert(id);
+            QVERIFY(collision);
+        }
+        QVERIFY(ids.contains(1));
+        QVERIFY(ids.contains(2));
+    }
+
+    void roomsInViewportWithCollisions_mixedCells_flagPerCell()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0); // solo
+        idx.addRoom(2, 0, 1, 0); // shared
+        idx.addRoom(3, 0, 1, 0); // shares cell with 2
+
+        const auto result = idx.roomsInViewportWithCollisions(0, 0, 1, 0, 0);
+        QCOMPARE(result.size(), 3);
+        QMap<int, bool> idToCollision;
+        for (const auto& [id, collision] : result) {
+            idToCollision[id] = collision;
+        }
+        QVERIFY(!idToCollision[1]); // solo cell
+        QVERIFY(idToCollision[2]);  // shared cell
+        QVERIFY(idToCollision[3]);  // shared cell
+    }
+
+    void roomsInViewportWithCollisions_outOfViewport_excluded()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 5, 5);  // inside viewport
+        idx.addRoom(2, 0, 20, 5); // outside viewport
+
+        const auto result = idx.roomsInViewportWithCollisions(0, 0, 10, 0, 10);
+        QCOMPARE(result.size(), 1);
+        QCOMPARE(result.first().first, 1);
+    }
+
+    void roomsInViewportWithCollisions_emptyZ_returnsEmpty()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 5, 5);
+
+        const auto result = idx.roomsInViewportWithCollisions(99, 0, 10, 0, 10);
+        QVERIFY(result.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // isEmpty / clear / size
+    // -------------------------------------------------------------------------
+
+    void isEmpty_newIndex_isTrue()
+    {
+        TAreaGridIndex idx;
+        QVERIFY(idx.isEmpty());
+    }
+
+    void isEmpty_afterAddRoom_isFalse()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        QVERIFY(!idx.isEmpty());
+    }
+
+    void clear_removesAllData()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, 0, 0);
+        idx.addRoom(2, 1, 5, 5);
+        idx.clear();
+        QVERIFY(idx.isEmpty());
+        QVERIFY(idx.roomsAt(0, 0, 0).isEmpty());
+        QVERIFY(idx.roomsAt(1, 5, 5).isEmpty());
+    }
+
+    void size_reflectsRoomCount()
+    {
+        TAreaGridIndex idx;
+        QCOMPARE(idx.size(), 0);
+        idx.addRoom(1, 0, 0, 0);
+        QCOMPARE(idx.size(), 1);
+        idx.addRoom(2, 0, 0, 0); // same cell, different id
+        QCOMPARE(idx.size(), 2);
+        idx.addRoom(3, 1, 5, 5); // different Z
+        QCOMPARE(idx.size(), 3);
+        idx.removeRoom(2, 0, 0, 0);
+        QCOMPARE(idx.size(), 2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration
+    // -------------------------------------------------------------------------
+
+    void integration_addRebuildRemoveMove()
+    {
+        TAreaGridIndex idx;
+
+        // Start by adding a few rooms manually
+        idx.addRoom(1, 0, 0, 0);
+        idx.addRoom(2, 0, 1, 0);
+
+        // Full rebuild replaces everything
+        const QHash<int, QHash<int, QPair<int, int>>> zToRoomXY = {{0, {{1, {0, 0}}, {2, {1, 0}}, {3, {2, 0}}}}, {1, {{4, {0, 0}}}}};
+        idx.rebuild(zToRoomXY);
+
+        // Verify rebuild state
+        QVERIFY(idx.roomsAt(0, 0, 0).contains(1));
+        QVERIFY(idx.roomsAt(0, 1, 0).contains(2));
+        QVERIFY(idx.roomsAt(0, 2, 0).contains(3));
+        QVERIFY(idx.roomsAt(1, 0, 0).contains(4));
+
+        // Remove room 3
+        idx.removeRoom(3, 0, 2, 0);
+        QVERIFY(!idx.roomsAt(0, 2, 0).contains(3));
+
+        // Move room 4 from z=1 to z=0 at (3, 0)
+        idx.moveRoom(4, 1, 0, 0, 0, 3, 0);
+        QVERIFY(!idx.roomsAt(1, 0, 0).contains(4));
+        QVERIFY(idx.roomsAt(0, 3, 0).contains(4));
+
+        // Z=1 should be empty now (all rooms moved out)
+        QVERIFY(idx.roomsAt(1, 0, 0).isEmpty());
+
+        // Final size: rooms 1, 2, 4 remain
+        QCOMPARE(idx.size(), 3);
+    }
+};
+
+QTEST_GUILESS_MAIN(TAreaGridIndexTest)
+
+#include "TAreaGridIndexTest.moc"

--- a/test/TAreaZLevelIndexTest.cpp
+++ b/test/TAreaZLevelIndexTest.cpp
@@ -1,0 +1,339 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <TAreaZLevelIndex.h>
+
+#include <QtTest/QtTest>
+
+/*
+ * Unit tests for TAreaZLevelIndex.
+ *
+ * The class is pure data (no GUI / Host / TMap dependencies), so these tests
+ * run without needing the full Mudlet application stack.
+ *
+ * Coverage goals
+ * - addRoom: single-Z, multi-Z, duplicate (no-op)
+ * - removeRoom: normal, last-room-on-Z prunes bucket, non-existent ID/Z (no
+ * crash)
+ * - moveRoom: same-Z no-op, cross-Z move
+ * - rebuild: from scratch overwrites any prior state
+ * - roomsForZ: existing Z, non-existent Z returns stable empty ref
+ * - isEmpty / clear
+ * - Room IDs are NOT necessarily sequential or in ascending order
+ */
+class TAreaZLevelIndexTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    // -------------------------------------------------------------------------
+    // addRoom
+    // -------------------------------------------------------------------------
+
+    void addRoom_singleZ_idAppearsOnThatLevel()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(42, 0);
+        QVERIFY(idx.roomsForZ(0).contains(42));
+    }
+
+    void addRoom_multipleRoomsOnSameZ()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 5);
+        idx.addRoom(2, 5);
+        idx.addRoom(3, 5);
+        const QSet<int> expected = {1, 2, 3};
+        QCOMPARE(idx.roomsForZ(5), expected);
+    }
+
+    void addRoom_roomsOnDifferentZLevels()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(10, -1);
+        idx.addRoom(20, 0);
+        idx.addRoom(30, 1);
+
+        QCOMPARE(idx.roomsForZ(-1), QSet<int>{10});
+        QCOMPARE(idx.roomsForZ(0), QSet<int>{20});
+        QCOMPARE(idx.roomsForZ(1), QSet<int>{30});
+    }
+
+    void addRoom_nonSequentialIds_allStoredCorrectly()
+    {
+        // Room IDs are not necessarily in ascending order (per problem statement)
+        TAreaZLevelIndex idx;
+        idx.addRoom(9999, 0);
+        idx.addRoom(1, 0);
+        idx.addRoom(500, 0);
+        const QSet<int> expected = {1, 500, 9999};
+        QCOMPARE(idx.roomsForZ(0), expected);
+    }
+
+    void addRoom_duplicate_noDoubleEntry()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(7, 3);
+        idx.addRoom(7, 3); // duplicate
+        QCOMPARE(idx.roomsForZ(3).size(), 1);
+        QVERIFY(idx.roomsForZ(3).contains(7));
+    }
+
+    // -------------------------------------------------------------------------
+    // removeRoom
+    // -------------------------------------------------------------------------
+
+    void removeRoom_idNoLongerInLevel()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        idx.addRoom(2, 0);
+        idx.removeRoom(1, 0);
+        QVERIFY(!idx.roomsForZ(0).contains(1));
+        QVERIFY(idx.roomsForZ(0).contains(2));
+    }
+
+    void removeRoom_lastRoomOnZ_zLevelBucketPruned()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(42, 7);
+        idx.removeRoom(42, 7);
+        // The Z=7 bucket should be gone; roomsForZ should return an empty set
+        QVERIFY(idx.roomsForZ(7).isEmpty());
+        // And the index itself should be empty
+        QVERIFY(idx.isEmpty());
+    }
+
+    void removeRoom_nonExistentId_nocrash()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        // Removing an ID that was never added should not crash
+        idx.removeRoom(999, 0);
+        QCOMPARE(idx.roomsForZ(0), QSet<int>{1});
+    }
+
+    void removeRoom_nonExistentZ_nocrash()
+    {
+        TAreaZLevelIndex idx;
+        // Removing from a Z level that has no rooms should not crash
+        idx.removeRoom(1, 99);
+        QVERIFY(idx.isEmpty());
+    }
+
+    void removeRoom_wrongZ_idRemainsAtCorrectZ()
+    {
+        // Removing a room from the wrong Z level should not remove it from the
+        // correct Z level where it actually lives.
+        TAreaZLevelIndex idx;
+        idx.addRoom(5, 2);
+        idx.removeRoom(5, 3); // wrong Z
+        QVERIFY(idx.roomsForZ(2).contains(5));
+    }
+
+    // -------------------------------------------------------------------------
+    // moveRoom
+    // -------------------------------------------------------------------------
+
+    void moveRoom_sameZ_isNoOp()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(10, 0);
+        idx.moveRoom(10, 0, 0); // no-op
+        QVERIFY(idx.roomsForZ(0).contains(10));
+    }
+
+    void moveRoom_crossZ_appearsOnNewLevelOnly()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(10, 0);
+        idx.moveRoom(10, 0, 5);
+        QVERIFY(!idx.roomsForZ(0).contains(10));
+        QVERIFY(idx.roomsForZ(5).contains(10));
+    }
+
+    void moveRoom_crossZ_oldBucketPrunedWhenEmpty()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(10, 0); // only room on Z=0
+        idx.moveRoom(10, 0, 1);
+        QVERIFY(idx.roomsForZ(0).isEmpty());
+    }
+
+    void moveRoom_crossZ_otherRoomsOnOldLevelUnaffected()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        idx.addRoom(2, 0);
+        idx.moveRoom(1, 0, 1);
+        QVERIFY(!idx.roomsForZ(0).contains(1));
+        QVERIFY(idx.roomsForZ(0).contains(2)); // room 2 stays
+        QVERIFY(idx.roomsForZ(1).contains(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // rebuild
+    // -------------------------------------------------------------------------
+
+    void rebuild_populatesIndexFromMapping()
+    {
+        TAreaZLevelIndex idx;
+        const QHash<int, int> mapping = {{1, 0}, {2, 0}, {3, 1}, {4, -1}};
+        idx.rebuild(mapping);
+
+        const QSet<int> z0Expected = {1, 2};
+        QCOMPARE(idx.roomsForZ(0), z0Expected);
+        QCOMPARE(idx.roomsForZ(1), QSet<int>{3});
+        QCOMPARE(idx.roomsForZ(-1), QSet<int>{4});
+    }
+
+    void rebuild_overwritesPreviousState()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(99, 99); // stale data
+
+        const QHash<int, int> mapping = {{1, 0}};
+        idx.rebuild(mapping);
+
+        QVERIFY(!idx.roomsForZ(99).contains(99)); // stale data gone
+        QVERIFY(idx.roomsForZ(0).contains(1));
+    }
+
+    void rebuild_emptyMapping_indexIsEmpty()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        idx.rebuild({});
+        QVERIFY(idx.isEmpty());
+    }
+
+    void rebuild_nonSequentialIds()
+    {
+        // Room IDs are not necessarily in ascending order
+        TAreaZLevelIndex idx;
+        const QHash<int, int> mapping = {{9999, 0}, {1, 0}, {500, 0}};
+        idx.rebuild(mapping);
+        const QSet<int> expected = {1, 500, 9999};
+        QCOMPARE(idx.roomsForZ(0), expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // roomsForZ
+    // -------------------------------------------------------------------------
+
+    void roomsForZ_nonExistentZ_returnsEmptySet()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        // Z=99 has no rooms
+        const QSet<int>& result = idx.roomsForZ(99);
+        QVERIFY(result.isEmpty());
+    }
+
+    void roomsForZ_returnsStableReferenceForEmptyZ()
+    {
+        TAreaZLevelIndex idx;
+        // Two calls to a non-existent Z should return references to the same
+        // static empty set (not dangling references).
+        const QSet<int>& ref1 = idx.roomsForZ(77);
+        const QSet<int>& ref2 = idx.roomsForZ(77);
+        QVERIFY(&ref1 == &ref2);
+        QVERIFY(ref1.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // isEmpty / clear
+    // -------------------------------------------------------------------------
+
+    void isEmpty_newIndex_isTrue()
+    {
+        TAreaZLevelIndex idx;
+        QVERIFY(idx.isEmpty());
+    }
+
+    void isEmpty_afterAddRoom_isFalse()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        QVERIFY(!idx.isEmpty());
+    }
+
+    void isEmpty_afterRemoveLastRoom_isTrue()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        idx.removeRoom(1, 0);
+        QVERIFY(idx.isEmpty());
+    }
+
+    void clear_removesAllRooms()
+    {
+        TAreaZLevelIndex idx;
+        idx.addRoom(1, 0);
+        idx.addRoom(2, 1);
+        idx.clear();
+        QVERIFY(idx.isEmpty());
+        QVERIFY(idx.roomsForZ(0).isEmpty());
+        QVERIFY(idx.roomsForZ(1).isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge / integration
+    // -------------------------------------------------------------------------
+
+    void integration_addRebuildRemove()
+    {
+        // Simulate a complete lifecycle: add rooms, rebuild, remove one, verify.
+        TAreaZLevelIndex idx;
+
+        const QHash<int, int> mapping = {{1, 0}, {2, 0}, {3, 1}};
+        idx.rebuild(mapping);
+
+        idx.removeRoom(1, 0);
+        QVERIFY(!idx.roomsForZ(0).contains(1));
+        QVERIFY(idx.roomsForZ(0).contains(2));
+
+        idx.addRoom(4, 0);
+        QVERIFY(idx.roomsForZ(0).contains(4));
+
+        idx.moveRoom(3, 1, 0);
+        QVERIFY(idx.roomsForZ(0).contains(3));
+        QVERIFY(idx.roomsForZ(1).isEmpty());
+    }
+
+    void singleZArea_allRoomsOnSameLevel()
+    {
+        // The primary use case: a large area where every room is on Z=0.
+        // Verifies that the index correctly reflects all rooms on Z=0 and
+        // that other Z levels return empty sets.
+        TAreaZLevelIndex idx;
+        constexpr int N = 1000;
+        for (int i = 1; i <= N; ++i) {
+            idx.addRoom(i, 0);
+        }
+        QCOMPARE(idx.roomsForZ(0).size(), N);
+        QVERIFY(idx.roomsForZ(-1).isEmpty());
+        QVERIFY(idx.roomsForZ(1).isEmpty());
+    }
+};
+
+QTEST_GUILESS_MAIN(TAreaZLevelIndexTest)
+
+#include "TAreaZLevelIndexTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add TAreaZLevelIndex and TAreaGridIndex - spatial indices maintained alongside TArea::rooms that allow the renderer to query only rooms on the current Z level or within the visible viewport rectangle, instead of iterating all rooms in the area on every paint event.

Key changes:
- TAreaZLevelIndex: Z -> set<roomId> index, O(1) getRoomsForZ()
- TAreaGridIndex: Z -> X -> Y -> set<roomId> viewport index for grid mode
- T2DMap::drawGridModeRooms: new batch renderer for grid mode using the spatial index; includes LOD fast-path for sub-pixel zoom levels that writes directly to QImage scanlines (~700x speedup vs QPainterPath)
- T2DMap::scheduleRender: throttled repaint via QTimer (~60fps cap) for continuous input events (pan drag, scroll-wheel zoom)
- paintEvent: uses getRoomsForZ() for upper/lower level shadows and exits, eliminating per-frame O(N-total) scans
- dlgMapper: fix setPen before boundingRect to prevent invisible info box
- TMap::setRoomCoordinates: keeps both indices consistent on room moves

#### Motivation for adding to Mudlet
As grid mode maps scale, interacting with the map (specifically zooming and panning) becomes sluggish to unusable in the extreme. 

#### Other info (issues closed, discussion etc)
