### PR TITLE
Fix: Clazy warnings part 5 - fully-qualified-moc-types

### DIFF
--- a/src/EditorUndoStack.h
+++ b/src/EditorUndoStack.h
@@ -73,7 +73,7 @@ public:
 
 signals:
     // Emitted when items are modified by undo/redo (allows targeted UI updates instead of full refresh)
-    void itemsChanged(EditorViewType viewType, QList<int> affectedItemIDs);
+    void itemsChanged(EditorViewTypes::EditorViewType viewType, QList<int> affectedItemIDs);
 
 protected:
     // Expose protected command() method for accessing commands on the stack

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -333,7 +333,7 @@ private slots:
     void slot_clickedMessageBox(const QString&);
     void slot_addPattern();
     void slot_bannerDismissClicked();
-    void slot_itemsChanged(::EditorViewType viewType, QList<int> affectedItemIDs);
+    void slot_itemsChanged(EditorViewTypes::EditorViewType viewType, QList<int> affectedItemIDs);
 
     // Per-property immediate save slots for triggers (create individual undo entries)
     void slot_saveProperty_TriggerName();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "slot arguments need to be fully-qualified [clazy-fully-qualified-moc-types]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
A summary I found for this is:
>The warning "slot arguments need to be fully-qualified" occurs when a signal, slot, or invocable declaration in Qt does not use fully-qualified type names, which can cause issues with old-style connects and QML interaction. To fix this, ensure that the type names in your signal or slot declarations include their full namespace or class scope. For example, if you have a type `MyType` in `namespace MyNameSpace`, you should declare your signal as `void mySignal(MyNameSpace::MyType)` instead of `void mySignal(MyType)`.

There is a further example of this issue in: `./3rdparty/communi/include/IrcUtil/irccompleter.h` at line 69 column 52, but since that is not part of Mudlet's own code it isn't addressable here.