### PR TITLE
add lpeg parsing library

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -325,6 +325,7 @@ jobs:
 
         $LUAROCKS LuaFileSystem
         $LUAROCKS luautf8
+        $LUAROCKS lpeg
 
         if [ "$RUNNER_OS" = "macOS" ]; then
           $LUAROCKS lua-zip ZIP_DIR=${HOMEBREW_PREFIX}/opt/libzip

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -331,6 +331,7 @@ jobs:
 
         $LUAROCKS LuaFileSystem
         $LUAROCKS luautf8
+        $LUAROCKS lpeg
 
         if [ "$RUNNER_OS" = "macOS" ]; then
           $LUAROCKS lua-zip ZIP_DIR=${HOMEBREW_PREFIX}/opt/libzip

--- a/CI/org.mudlet.mudlet.yml
+++ b/CI/org.mudlet.mudlet.yml
@@ -162,6 +162,7 @@ modules:
       - luarocks install --tree="/app" lua-yajl YAJL_INCDIR="/app/include" YAJL_LIBDIR="/app/lib" LUA_INCDIR="/app/include"
       - luarocks install --tree="/app" luautf8
       - luarocks install --tree="/app" LuaFileSystem
+      - luarocks install --tree="/app" lpeg LUA_INCDIR="/app/include"
       - luarocks install --tree="/app" lua-zip ZIP_INCDIR="/app/include" ZIP_LIBDIR="/app/lib" LUA_INCDIR="/app/include"
       - luarocks install --tree="/app" LuaSQL-SQLite3 SQLITE_INCDIR="/app/include"
       - luarocks install --tree="/app" lrexlib-pcre PCRE_INCDIR="/app/include" PCRE_LIBDIR="/app/lib"

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5766,6 +5766,11 @@ void TLuaInterpreter::initLuaGlobals()
         mpHost->postMessage(modLoadMessageQueue.dequeue());
     }
 
+    loadLuaModule(modLoadMessageQueue, QLatin1String("lpeg"), tr("lpeg.* Lua functions won't be available."), QString(), QLatin1String("lpeg"));
+    while (!modLoadMessageQueue.isEmpty()) {
+        mpHost->postMessage(modLoadMessageQueue.dequeue());
+    }
+
     QString tn = "atcp";
     QStringList args;
     set_lua_table(tn, args);


### PR DESCRIPTION
Completes the addition of the [lpeg](https://www.inf.puc-rio.br/~roberto/lpeg/) parsing library to mudlet on all targets.

It had previously been [partially added](https://github.com/Mudlet/Mudlet/blob/ea57a6dc1c86aa12fdb87947e99da289c2de9db9/src/mudlet-lua/lua/LuaGlobal.lua#L6), and may be available in windows builds already.

Muds involve a lot of text processing, but are not necessarily regular languages and so cannot be fully handled by regular expressions alone. LPEG is an extremely sophisticated parsing tool; it is small, performant, influential, and still represents the state of the art in parsing expression grammars.

LPEG is as close as anything gets to being in the standard library of lua. It was written by the same author as lua, is hosted and maintained by PUC RIO, its official docs are right there alongside the main lua docs. It is a blessed lib and can be considered extremely stable.

This PR to mudlet depends on [this PR](https://github.com/Mudlet/installers/pull/142) to the installers repo, to ship the binary for linux and macos. As far as I can tell it is already included for windows.
