### PR TITLE
Fix: prevent use-after-free in TRoom::setArea dirty-area tracking

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -348,7 +348,11 @@ void TRoom::setId(const int roomId)
 // alternative means to do them as a fault recovery
 bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
 {
-    static QSet<TArea*> dirtyAreas;
+    // Track dirty areas by ID rather than TArea* across calls: a TArea* held
+    // through a deferred window can dangle if the map is cleared in between
+    // (e.g. clearMapDB(), profile close, bulk map reload). Looking up the
+    // pointer freshly at flush time safely skips areas that no longer exist.
+    static QSet<int> dirtyAreaIds;
     TArea* pA = mpRoomDB->getArea(areaID);
     if (!pA) {
         // There is no TArea instance with that _areaID
@@ -373,7 +377,7 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
         // areas are still "out of area exits" UNLESS the room moves to the SAME
         // area that the other exits are in.
         // Add to local store of dirty areas
-        dirtyAreas.insert(pA2);
+        dirtyAreaIds.insert(area);
         // Flag the area itself in case something goes
         // wrong on last room in a series
         pA2->mIsDirty = true;
@@ -386,16 +390,20 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
     area = areaID;
     pA->addRoom(id);
 
-    dirtyAreas.insert(pA);
+    dirtyAreaIds.insert(areaID);
     pA->mIsDirty = true;
 
     if (!deferAreaRecalculations) {
-        QSetIterator<TArea*> itpArea = dirtyAreas;
-        while (itpArea.hasNext()) {
-            TArea* pArea = itpArea.next();
-            pArea->clean();
+        // Swap out the set before iterating so that reentrant calls into
+        // setArea() from within clean()/determineAreaExits() (e.g. via Lua
+        // event handlers) don't mutate the container we're walking.
+        QSet<int> toClean;
+        toClean.swap(dirtyAreaIds);
+        for (const int aid : toClean) {
+            if (TArea* pArea = mpRoomDB->getArea(aid)) {
+                pArea->clean();
+            }
         }
-        dirtyAreas.clear();
     }
 
     mpRoomDB->mpMap->setUnsaved(__func__);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes a use-after-free in `TRoom::setArea` (`src/TRoom.cpp`).

The function held a file-local `static QSet<TArea*> dirtyAreas` that accumulated raw area pointers across calls when `deferAreaRecalculations=true` and flushed them via `pArea->clean()` on the next non-deferred call. If a `TArea` got freed in between (`TRoomDB::clearMapDB()` → `deleteMap()`, profile close, map reload) the pointers dangled and the next flush crashed in `TArea::determineAreaExits()` while iterating the freed area's `rooms` `QSet<int>`.

The fix switches the static set to `QSet<int> dirtyAreaIds`, re-resolves each `TArea*` via `mpRoomDB->getArea(aid)` right before `clean()` (silently skipping IDs that no longer exist), and swaps the set out before iterating so reentrant `setArea` calls from inside `clean()`/`determineAreaExits()` (e.g. via Lua event handlers) don't mutate the container being walked.

#### Motivation for adding to Mudlet

Real-world crash on Mudlet 4.20.1 (macOS arm64, Qt 6.9):

```
EXC_BAD_ACCESS (SIGSEGV)  KERN_INVALID_ADDRESS at 0x7080000008f50019
Thread 0 Crashed (com.apple.main-thread):
  QHashPrivate::Span<Node<int, QHashDummyValue>>::hasNode
  QSet<int>::constBegin
  TArea::determineAreaExits            (+48)
  TArea::clean                         (+44)
  TRoom::setArea(int, bool)            (+924)
  TMap::setRoomArea(int, int, bool)
  TLuaInterpreter::setRoomArea
  TLuaInterpreter::callEventHandler
  Host::raiseEvent
  TLuaInterpreter::parseJSON
  cTelnet::setGMCPVariables
  …
```

##### Deterministic reproduction

Paste into the Lua input line of any Mudlet profile (no MUD connection required). Prefix with `lua ` if running directly from the input line.

```lua
-- Mudlet 4.20.1 setRoomArea use-after-free repro.
-- Before patch: process crashes in the final setRoomArea (TArea::determineAreaExits).
-- After patch:  prints "repro finished without crash".

local function banner(s) echo("\n=== " .. s .. " ===\n") end

banner("Step 1: seed static dirtyAreas with TArea* for areas that will be freed")
-- Lua addRoom() calls TMap::setRoomArea(..., defer=true) with no matching flush,
-- so each call stashes a TArea* in the file-local static in TRoom::setArea.
local seedID = addAreaName("repro_Seed")
for i = 19001, 19010 do addRoom(i, seedID) end

banner("Step 2: deleteMap() - frees every TArea, static set now holds dangling pointers")
deleteMap()

banner("Step 3: create a fresh area + rooms (more entries accumulate in the static set)")
local freshID = addAreaName("repro_Fresh")
for i = 20001, 20005 do addRoom(i, freshID) end

banner("Step 4: single-room setRoomArea triggers defer=false flush -> iterates stale pointers")
local otherID = addAreaName("repro_Other")
setRoomArea(20001, otherID)  -- boom on buggy builds

banner("repro finished without crash")
```

#### Other info (issues closed, discussion etc)

- The Lua `addRoom` binding (`TLuaInterpreterMapper.cpp:585`) always calls `setRoomArea(..., defer=true)` with no matching flush, which is what seeds the static set for later crashes. This PR only fixes the UAF — the deferred-entries-leak-across-calls issue is a separate architectural concern (the static also leaks between `TMap` instances in multi-profile setups). Natural follow-up: move the dirty set onto `TRoomDB` as a member with an explicit `flushDirtyAreas()` method, call it from `TRoomDB::clearMapDB()` and from Lua bindings that batch edits, and share the implementation with `T2DMap.cpp` / `RoomMoveDragHandler.cpp` which already use the ID-based pattern locally.
- No behaviour change for healthy call sequences: IDs resolve to the same `TArea*` they would have been.
