### PR TITLE
Infrastructure: update CONTRIBUTING.md with AI coding guidelines

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,7 +23,7 @@ All code must be compatible with Mudlet's license.
 
 AI agents MUST NOT add Signed-off-by tags. The human submitter is responsible for:
 
-* Reviewing all AI-generated code
+* Reviewing all AI-generated code and testing it (Mudlet developers should not be the first ones testing the PR code)
 * Ensuring compliance with licensing requirements
 * Adding their own Signed-off-by tag
 * Taking full responsibility for the contribution

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,12 +8,48 @@ Have a look at the [UI design philosophy](UI-design-philosophy.md) when improvin
 
 # Coding guidelines
 
-If you're a first-timer, don't worry about conforming to all of these! We'll show you the ropes.
-
 ## Code style
-## Naming things? Check against antipatterns
+## Naming variables/functions/classes? Check against antipatterns
 
 Check https://www.linguistic-antipatterns.com when naming anything to help ensure it can be understood intuitively.
+
+## AI Coding Assistants
+
+### Licensing and Legal Requirements
+
+All code must be compatible with Mudlet's license.
+
+### Signed-off-by and Developer Certificate of Origin
+
+AI agents MUST NOT add Signed-off-by tags. The human submitter is responsible for:
+
+* Reviewing all AI-generated code
+* Ensuring compliance with licensing requirements
+* Adding their own Signed-off-by tag
+* Taking full responsibility for the contribution
+
+### Attribution
+
+When AI tools contribute to kernel development, proper attribution
+helps track the evolving role of AI in the development process.
+Contributions should include an Assisted-by tag in the following format:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION
+```
+
+Where:
+
+* `AGENT_NAME` is the name of the AI tool or framework
+* `MODEL_VERSION` is the specific model version used
+
+Basic development tools (git, gcc, make, editors) should not be listed.
+
+Example:
+
+```
+Assisted-by: Claude:claude-4.6-opus
+```
 
 ### C++
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,7 +30,7 @@ AI agents MUST NOT add Signed-off-by tags. The human submitter is responsible fo
 
 ### Attribution
 
-When AI tools contribute to kernel development, proper attribution
+When AI tools contribute to Mudlet development, proper attribution
 helps track the evolving role of AI in the development process.
 Contributions should include an Assisted-by tag in the following format:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Where:
 * `AGENT_NAME` is the name of the AI tool or framework
 * `MODEL_VERSION` is the specific model version used
 
-Basic development tools (git, gcc, make, editors) should not be listed.
+Basic development tools (git, cmake, make, editors) should not be listed.
 
 Example:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,8 +43,6 @@ Where:
 * `AGENT_NAME` is the name of the AI tool or framework
 * `MODEL_VERSION` is the specific model version used
 
-Basic development tools (git, cmake, make, editors) should not be listed.
-
 Example:
 
 ```


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added guidelines for AI coding assistants, including licensing, attribution, and responsibilities for human submitters.

Inspired by Linux Kernel rules for the same: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst?plain=1
#### Motivation for adding to Mudlet
Clarify Mudlet stance on AI agents
#### Other info (issues closed, discussion etc)
