### PR TITLE
Fix: Text wrapping incorrectly after switching profile tabs

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6930,7 +6930,16 @@ void mudlet::activateProfile(Host* pHost)
 
     updateMultiViewControls();
 
-    mpCurrentActiveHost->updateDisplayDimensions();
+    // Deferred so the event loop processes pending show/visibility/resize
+    // events first and the upper pane's visibleRegion() reflects the final
+    // geometry. Otherwise mScreenWidth can snap to its qMax(40, ...) floor,
+    // sending a tiny NAWS to the server which then pre-wraps subsequent
+    // server-formatted output (broadcasts, prompts, room descriptions) far too
+    // narrowly until the next real resize.
+    // QTimer::singleShot with a receiver QObject* skips the call if the Host
+    // is destroyed before the timer fires - safe across profile teardown
+    // (do not refactor to a capturing lambda, which would lose this).
+    QTimer::singleShot(0, mpCurrentActiveHost.data(), &Host::updateDisplayDimensions);
 
     // Currently used to update the Discord Rich Presence
     emit signal_tabChanged(mpCurrentActiveHost->getName());

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6930,15 +6930,10 @@ void mudlet::activateProfile(Host* pHost)
 
     updateMultiViewControls();
 
-    // Deferred so the event loop processes pending show/visibility/resize
-    // events first and the upper pane's visibleRegion() reflects the final
-    // geometry. Otherwise mScreenWidth can snap to its qMax(40, ...) floor,
-    // sending a tiny NAWS to the server which then pre-wraps subsequent
-    // server-formatted output (broadcasts, prompts, room descriptions) far too
-    // narrowly until the next real resize.
-    // QTimer::singleShot with a receiver QObject* skips the call if the Host
-    // is destroyed before the timer fires - safe across profile teardown
-    // (do not refactor to a capturing lambda, which would lose this).
+    // Deferred so widget geometry is finalised before NAWS is recalculated;
+    // otherwise mScreenWidth hits its qMax(40, ...) floor and the server
+    // pre-wraps output too narrowly. Receiver-form singleShot is safe if the
+    // Host is destroyed first - do not change to a lambda.
     QTimer::singleShot(0, mpCurrentActiveHost.data(), &Host::updateDisplayDimensions);
 
     // Currently used to update the Discord Rich Presence


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes server-formatted text (broadcasts, prompts, room descriptions) appearing wrapped at an unnaturally narrow width when returning to a profile tab from another profile.

#### Motivation for adding to Mudlet

When switching tabs, Mudlet was telling the server how wide the window was before Qt had finished resizing it, so the server would format text for a tiny terminal until the next resize. Deferring that one notification by an event-loop tick lets Qt finish first, so the server gets the correct width and text wraps naturally on tab switch.

#### Other info (issues closed, discussion etc)

Same family of root cause as #8853 (using widget geometry before Qt finishes processing show events), but a different code path: NAWS was sent synchronously from `mudlet::activateProfile()` while `TTextEdit::mScreenWidth` was still snapped to its `qMax(40, ...)` floor due to an empty `visibleRegion()`.

---

Problem example

<img width="1725" height="938" alt="Screenshot 2026-04-25 at 9 05 00 AM" src="https://github.com/user-attachments/assets/7523b9fc-bd20-48ac-a25a-8e18b9f87971" />
