### PR TITLE
Improve: read tooltips aloud without HTML tags in profile preferences

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -195,6 +195,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;Can you help translate Mudlet?&lt;/p&gt;&lt;p&gt;If so, please visit: &lt;b&gt;https://www.mudlet.org/translate&lt;/b&gt;.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Can you help translate Mudlet? If so, please visit: https://www.mudlet.org/translate.</string>
+            </property>
            </widget>
           </item>
           <item row="0" column="2">
@@ -211,6 +214,9 @@
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;If you are playing a non-English game and seeing � instead of text, or special letters like &lt;span style=&quot; font-weight:600;&quot;&gt;ñ&lt;/span&gt; aren't showing right - try changing the encoding to UTF-8 or to one suggested by your game.&lt;/p&gt;&lt;p&gt;For some encodings on some Operating Systems Mudlet itself has to provide the codec needed; if that is the case for this Mudlet then there will be a &lt;tt&gt;m &lt;/tt&gt; prefixed applied to those encoding names (so if they have errors the blame can be applied correctly!)&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Choose the character encoding for this game. If you see replacement characters or special letters are wrong, try UTF-8 or whichever encoding your game suggests. Encoding names prefixed with the letter m are provided by Mudlet itself rather than the operating system.</string>
             </property>
            </widget>
           </item>
@@ -276,6 +282,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;Show a toolbar notification if Mudlet is minimized and new data arrives.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Show a toolbar notification if Mudlet is minimized and new data arrives.</string>
+            </property>
             <property name="text">
              <string>Notify on new data</string>
             </property>
@@ -288,6 +297,9 @@
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;If checked, Mudlet will be registered as the default handler for telnet:// and telnets:// (secure) links in your system.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>If checked, Mudlet will be registered as the default handler for telnet:// and telnets:// (secure) links in your system.</string>
             </property>
            </widget>
           </item>
@@ -343,6 +355,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;This also needs GMCP to be enabled in the protocols.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>This also needs GMCP to be enabled in the protocols.</string>
+            </property>
             <property name="text">
              <string>Allow server to download and play media</string>
             </property>
@@ -361,6 +376,9 @@
            <widget class="QCheckBox" name="mIsToLogInHtml">
             <property name="toolTip">
              <string>&lt;p&gt;When checked will cause the date-stamp named log file to be HTML (file extension '.html') which can convey color, font and other formatting information rather than a plain text (file extension '.txt') format.  If changed while logging is already in progress it is necessary to stop and restart logging for this setting to take effect in a new log file.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>When checked, log files are saved as HTML so colors and fonts are preserved; otherwise they are saved as plain text. If logging is already running, stop and restart it for this to take effect.</string>
             </property>
             <property name="text">
              <string>Save log files in HTML format instead of plain text</string>
@@ -497,6 +515,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;Use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly.</string>
+            </property>
             <property name="text">
              <string>Strict UNIX line endings</string>
             </property>
@@ -526,6 +547,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;Highlights your input line text when scrolling through your history for easy cancellation.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Highlights your input line text when scrolling through your history for easy cancellation.</string>
+            </property>
             <property name="text">
              <string>Highlight history</string>
             </property>
@@ -542,6 +566,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;Check all Key-bindings against key-presses.&lt;/p&gt;&lt;p&gt;&lt;i&gt;Versions of Mudlet prior to &lt;b&gt;3.9.0&lt;/b&gt; would stop checking after the first matching combination of&lt;/i&gt; KeyCode &lt;i&gt;and&lt;/i&gt; KeyModifier &lt;i&gt;was found and then send the command and/or run the script of that Key-binding only.  This&lt;/i&gt; per-profile &lt;i&gt;option tells Mudlet to check and run the remaining matches; but, to retain compatibility with previous versions, defaults to the &lt;b&gt;un&lt;/b&gt;-checked state.&lt;/i&gt;&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When checked, every key-binding that matches a key-press is run, not only the first match. Off by default for compatibility with older Mudlet behaviour.</string>
+            </property>
             <property name="text">
              <string>React to all keybindings on the same key</string>
             </property>
@@ -557,6 +584,9 @@
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;Disable password masking when servers request hidden input.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is not recommended for security reasons as passwords will be visible in plain text.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Disable password masking when servers request hidden input. Warning: This is not recommended for security reasons as passwords will be visible in plain text.</string>
             </property>
             <property name="text">
              <string>Disable password masking</string>
@@ -602,6 +632,9 @@
 &lt;li&gt;&lt;b&gt;Always&lt;/b&gt;: Commands are always shown regardless of script settings&lt;/li&gt;
 &lt;/ul&gt;
 &lt;p&gt;&lt;i&gt;This can be disabled by the game server if it negotiates to use the telnet ECHO option.&lt;/i&gt;&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Controls how sent commands are echoed in the display. Never means commands are never shown; Script controlled lets scripts decide via the second argument to send(); Always shows commands regardless of script settings. The game server can override this by negotiating the telnet ECHO option.</string>
             </property>
             <item>
              <property name="text">
@@ -686,6 +719,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;This option controls spell-checking on the command line in the main console for this profile.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>This option controls spell-checking on the command line in the main console for this profile.</string>
+            </property>
             <property name="text">
              <string>System/Mudlet dictionary:</string>
             </property>
@@ -719,6 +755,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;A user dictionary specific to this profile will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>A user dictionary specific to this profile will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.</string>
+            </property>
             <property name="text">
              <string>Profile</string>
             </property>
@@ -728,6 +767,9 @@
            <widget class="QRadioButton" name="radioButton_userDictionary_common">
             <property name="toolTip">
              <string>&lt;p&gt;A user dictionary that is shared between all profiles (which have this option selected) will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>A user dictionary that is shared between all profiles (which have this option selected) will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.</string>
             </property>
             <property name="text">
              <string>Shared</string>
@@ -848,6 +890,9 @@
             <property name="toolTip">
              <string>&lt;p&gt;Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Use anti aliasing on fonts. Smooths fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry.</string>
+            </property>
             <property name="text">
              <string>Enable anti-aliasing</string>
             </property>
@@ -929,6 +974,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Extra space to have before text on top - can be set to negative to move text up beyond the screen.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Extra space to have before text on top - can be set to negative to move text up beyond the screen.</string>
+            </property>
             <property name="minimum">
              <number>-1000000</number>
             </property>
@@ -975,6 +1023,9 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;Extra space to have before text on the left - can be set to negative to move text left beyond the screen.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Extra space to have before text on the left - can be set to negative to move text left beyond the screen.</string>
             </property>
             <property name="minimum">
              <number>-1000000</number>
@@ -1023,6 +1074,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Extra space to have before text on the bottom - can be set to negative to allow text to go down beyond the screen.</string>
+            </property>
             <property name="minimum">
              <number>-1000000</number>
             </property>
@@ -1069,6 +1123,9 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;Extra space to have before text on the right - can be set to negative to move text right beyond the screen.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Extra space to have before text on the right - can be set to negative to move text right beyond the screen.</string>
             </property>
             <property name="minimum">
              <number>-1000000</number>
@@ -1230,6 +1287,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string>&lt;p&gt;Subsequent wrapped lines will be indented by this amount.&lt;/p&gt;</string>
                </property>
+               <property name="accessibleDescription">
+                <string>Subsequent wrapped lines will be indented by this amount.</string>
+               </property>
                <property name="text">
                 <string>Indent hanging wrapped lines by:</string>
                </property>
@@ -1296,6 +1356,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string>&lt;p&gt;Maximum number of lines to keep in the console buffer. When exceeded, older lines are removed in batches.&lt;/p&gt;</string>
                </property>
+               <property name="accessibleDescription">
+                <string>Maximum number of lines to keep in the console buffer. When exceeded, older lines are removed in batches.</string>
+               </property>
                <property name="text">
                 <string>Main display size:</string>
                </property>
@@ -1308,6 +1371,9 @@ you can use it but there could be issues with aligning columns of text</string>
               <widget class="QSpinBox" name="console_buffer_size_spinBox">
                <property name="toolTip">
                 <string>&lt;p&gt;Maximum number of lines to keep in the console buffer. Minimum is 100 lines.&lt;/p&gt;</string>
+               </property>
+               <property name="accessibleDescription">
+                <string>Maximum number of lines to keep in the console buffer. Minimum is 100 lines.</string>
                </property>
                <property name="minimum">
                 <number>100</number>
@@ -1338,6 +1404,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Use the maximum buffer size your system can handle. This will be calculated based on available memory.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Use the maximum buffer size your system can handle. This will be calculated based on available memory.</string>
+            </property>
             <property name="text">
              <string>Use maximum lines possible</string>
             </property>
@@ -1366,6 +1435,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLineEdit" name="doubleclick_ignore_lineedit">
             <property name="toolTip">
              <string>&lt;p&gt;Enter the characters you'd like double-clicking to stop selecting text on here. If you don't enter any, double-clicking on a word will only stop at a space, and will include characters like a double or a single quote. For example, double-clicking on the word &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; in the following will select &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;quot;&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you set the characters in the field to &lt;span style=&quot; font-weight:600;&quot;&gt;'&amp;quot;! &lt;/span&gt;which will mean it should stop selecting on ' &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; &amp;quot; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; ! then double-clicking on &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; will just select &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &amp;quot;&lt;span style=&quot; font-weight:600;&quot;&gt;Hello&lt;/span&gt;!&amp;quot;&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Characters that double-click selection should stop on. Without this, only spaces end a selection, so quotes and punctuation get included with the word. For example, entering an apostrophe, double quote and exclamation mark would make double-clicking select just the word Hello rather than "Hello!".</string>
             </property>
             <property name="text">
              <string>'&quot;</string>
@@ -1409,6 +1481,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Some games (notably all IRE MUDs) suffer from a bug where they don't properly communicate with the client on where a newline should be. Enable this to fix text from getting appended to the previous prompt line.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Some games (notably all IRE MUDs) suffer from a bug where they don't properly communicate with the client on where a newline should be. Enable this to fix text from getting appended to the previous prompt line.</string>
+            </property>
             <property name="text">
              <string>Fix unnecessary linebreaks on GA servers</string>
             </property>
@@ -1425,6 +1500,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_echoLuaErrors">
             <property name="toolTip">
              <string>&lt;p&gt;Prints Lua errors to the main console in addition to the error tab in the editor.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Prints Lua errors to the main console in addition to the error tab in the editor.</string>
             </property>
             <property name="text">
              <string>Echo Lua errors to the main console</string>
@@ -1594,6 +1672,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show tabs and spaces with visible marks instead of whitespace.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When displaying Lua contents in the main text editor area of the Editor show tabs and spaces with visible marks instead of whitespace.</string>
+            </property>
             <property name="text">
              <string>Show Spaces/Tabs</string>
             </property>
@@ -1603,6 +1684,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_showLineFeedsAndParagraphs">
             <property name="toolTip">
              <string>&lt;body&gt;&lt;p&gt;When displaying Lua contents in the main text editor area of the Editor show  line and paragraphs ends with visible marks as well as whitespace.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>When displaying Lua contents in the main text editor area of the Editor show line and paragraph ends with visible marks as well as whitespace.</string>
             </property>
             <property name="text">
              <string>Show Line/Paragraphs</string>
@@ -1614,6 +1698,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Shows bidirection Unicode characters which can be used to change the meaning of source code while remaining invisible to the eye.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Shows bidirectional Unicode characters which can be used to change the meaning of source code while remaining invisible to the eye.</string>
+            </property>
             <property name="text">
              <string>Show invisible Unicode control characters</string>
             </property>
@@ -1623,6 +1710,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_showIdNumbers">
             <property name="toolTip">
              <string>&lt;p&gt;Shows the &lt;b&gt;unique&lt;/b&gt; ID number that Mudlet uses internally to identify each instance of an item this is the same number that the Lua API functions that create aliases, key-binding, etc. return on success. This may be useful to know when there are multiple items of the same type with the same name and will be incorporated in the names of the related items' Lua scripts in the Central Debug Console output.&lt;/p&gt;&lt;p&gt;Note that although the number assigned to an item is constant during a session of the profile it may be different the next time the profile is loaded if other items are added or removed.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Shows Mudlet's internal ID number for each item. This is the same ID returned by Lua functions that create aliases, triggers, timers and so on, and is helpful when several items share the same name. The ID is stable during a session but may change the next time the profile is loaded.</string>
             </property>
             <property name="text">
              <string>Show Items' ID number</string>
@@ -1673,6 +1763,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;The foreground color used by default for the main console (unless changed by a lua command or the game server).&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>The foreground color used by default for the main console (unless changed by a lua command or the game server).</string>
+            </property>
             <property name="autoFillBackground">
              <bool>true</bool>
             </property>
@@ -1699,6 +1792,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;The background color used by default for the main console (unless changed by a lua command or the game server).&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>The background color used by default for the main console (unless changed by a lua command or the game server).</string>
+            </property>
             <property name="autoFillBackground">
              <bool>true</bool>
             </property>
@@ -1722,6 +1818,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;The foreground color used for the main input area.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>The foreground color used for the main input area.</string>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -1742,6 +1841,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;The background color used for the main input area.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>The background color used for the main input area.</string>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -1761,6 +1863,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QPushButton" name="pushButton_command_foreground_color">
             <property name="toolTip">
              <string>&lt;p&gt;The foreground color used for text sent to the game server.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>The foreground color used for text sent to the game server.</string>
             </property>
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -1784,6 +1889,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QPushButton" name="pushButton_command_background_color">
             <property name="toolTip">
              <string>&lt;p&gt;The background color used for text sent to the game server.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>The background color used for text sent to the game server.</string>
             </property>
             <property name="autoFillBackground">
              <bool>true</bool>
@@ -2189,6 +2297,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;If this option is checked the Mud Server may send codes to change the above 16 colors or to reset them to their defaults by using standard ANSI &lt;tt&gt;OSC&lt;/tt&gt; Escape codes.&lt;/p&gt;&lt;p&gt;Specifically &lt;tt&gt;&amp;lt;OSC&amp;gt;Pirrggbb&amp;lt;ST&amp;gt;&lt;/tt&gt; will set the color with index &lt;i&gt;i&lt;/i&gt; to have the color with the given &lt;i&gt;rr&lt;/i&gt; red, &lt;i&gt;gg&lt;/i&gt; green and &lt;i&gt;bb&lt;/i&gt;  blue components where i is a single hex-digit ('0' to '9' or 'a' to 'f' or 'A' to 'F' to give a number between 0 an d15) and rr, gg and bb are two digit hex-digits numbers (between 0 to 255); &amp;lt;OSC&amp;gt; is &lt;i&gt;Operating System Command&lt;/i&gt; which is normally encoded as the ASCII &amp;lt;ESC&amp;gt; character followed by &lt;tt&gt;[&lt;/tt&gt; and &amp;lt;ST&amp;gt; is the &lt;i&gt;String Terminator&lt;/i&gt; which is normally encoded as the ASCII &amp;lt;ESC&amp;gt; character followed by &lt;tt&gt;\&lt;tt&gt;.&lt;/p&gt;&lt;p&gt;Conversely &lt;tt&gt;&amp;lt;OSC&amp;gt;R&amp;lt;ST&amp;gt;&lt;/tt&gt; will reset the colors to the defaults like the button to the right does.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When checked, the game server may change the 16 ANSI colors above using standard OSC P escape sequences, or reset them to their defaults using OSC R, the same as the reset button beside this option.</string>
+            </property>
             <property name="text">
              <string>Server allowed to redefine these colors</string>
             </property>
@@ -2251,6 +2362,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_reportMapIssuesOnScreen">
             <property name="toolTip">
              <string>&lt;p&gt;Mudlet now does some sanity checking and repairing to clean up issues that may have arisen in previous version due to faulty code or badly documented commands. However if significant problems are found the report can be quite extensive, in particular for larger maps.&lt;/p&gt;&lt;p&gt;Unless this option is set, Mudlet will reduce the amount of on-screen messages by hiding many texts and showing a suggestion to review the report file instead.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>When checked, show the full map sanity-check and repair report on screen. Otherwise Mudlet hides most messages and points you at the report file instead, which is helpful for large maps.</string>
             </property>
             <property name="text">
              <string>report map issues on screen</string>
@@ -2343,6 +2457,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Select profiles that you want to copy map to, then press the Copy button to the right.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Select profiles that you want to copy map to, then press the Copy button to the right.</string>
+            </property>
             <property name="text">
              <string comment="text on button to select other profiles to receive the map from this profile, this is used when no profiles have been selected">pick destinations...</string>
             </property>
@@ -2355,6 +2472,9 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;Copy map into the selected profiles on the left.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Copy map into the selected profiles on the left.</string>
             </property>
             <property name="text">
              <string notr="true" comment="text will be placed on this button by the C++ code"/>
@@ -2387,6 +2507,9 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
             <property name="toolTip">
              <string>&lt;p&gt;Change this to a lower version if you need to save your map in a format that can be read by older versions of Mudlet. Doing so will lose the extra data available in the current map format.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Change this to a lower version if you need to save your map in a format that can be read by older versions of Mudlet. Doing so will lose the extra data available in the current map format.</string>
             </property>
             <property name="editable">
              <bool>false</bool>
@@ -2427,6 +2550,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>On games that provide maps for download, you can press this button to get the latest map. Note that this will overwrite any changes you've done to your map, and will use the new map only.</string>
+            </property>
             <property name="text">
              <string>Download latest map provided by your game:</string>
             </property>
@@ -2439,6 +2565,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QPushButton" name="buttonDownloadMap">
             <property name="toolTip">
              <string>&lt;p&gt;On games that provide maps for download, you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>On games that provide maps for download, you can press this button to get the latest map. Note that this will overwrite any changes you've done to your map, and will use the new map only.</string>
             </property>
             <property name="text">
              <string>Download</string>
@@ -2518,6 +2647,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;When enabled, rooms on floors above and below the current level will be drawn with a lighter color to show the map layout context.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When enabled, rooms on floors above and below the current level will be drawn with a lighter color to show the map layout context.</string>
+            </property>
             <property name="text">
              <string>Draw rooms on upper and lower levels</string>
             </property>
@@ -2530,6 +2662,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_invertMapZoom">
             <property name="toolTip">
              <string>&lt;p&gt;If checked, scrolling up zooms out and scrolling down zooms in. If unchecked, scrolling up zooms in and scrolling down zooms out.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>If checked, scrolling up zooms out and scrolling down zooms in. If unchecked, scrolling up zooms in and scrolling down zooms out.</string>
             </property>
             <property name="text">
              <string>Invert zoom direction</string>
@@ -2560,6 +2695,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;The default area (area id -1) is used by some mapper scripts as a temporary 'holding area' for rooms before they're placed in the correct area.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>The default area (area id -1) is used by some mapper scripts as a temporary 'holding area' for rooms before they're placed in the correct area.</string>
+            </property>
             <property name="text">
              <string>Show the default area in map area selection</string>
             </property>
@@ -2573,6 +2711,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;This enables borders around room. Color can be set in Mapper colors tab.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>This enables borders around room. Color can be set in Mapper colors tab.</string>
+            </property>
             <property name="text">
              <string>Show room borders</string>
             </property>
@@ -2585,6 +2726,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="mMapperUseAntiAlias">
             <property name="toolTip">
              <string>&lt;p&gt;This enables anti-aliasing (AA) for the 2D map view, making it look smoother and nicer. Disable this if you're on a very slow computer.&lt;/p&gt;&lt;p&gt;3D map view always has anti-aliasing enabled.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>This enables anti-aliasing (AA) for the 2D map view, making it look smoother and nicer. Disable this if you're on a very slow computer. 3D map view always has anti-aliasing enabled.</string>
             </property>
             <property name="text">
              <string>Use high quality graphics in 2D view</string>
@@ -2659,6 +2803,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string>&lt;p&gt;Percentage ratio (&lt;i&gt;the default is 120%&lt;/i&gt;) of the marker symbol to the space available for the room.&lt;/p&gt;</string>
                </property>
+               <property name="accessibleDescription">
+                <string>Percentage ratio (the default is 120%) of the marker symbol to the space available for the room.</string>
+               </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
@@ -2686,6 +2833,9 @@ you can use it but there could be issues with aligning columns of text</string>
                </property>
                <property name="toolTip">
                 <string>&lt;p&gt;Percentage ratio of the inner diameter of the marker symbol to the outer one (&lt;i&gt;the default is 70%&lt;/i&gt;).&lt;/p&gt;</string>
+               </property>
+               <property name="accessibleDescription">
+                <string>Percentage ratio of the inner diameter of the marker symbol to the outer one (the default is 70%).</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -3525,6 +3675,9 @@ you can use it but there could be issues with aligning columns of text</string>
               <property name="toolTip">
                <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to. Discord usernames are always lowercase.&lt;/p&gt;</string>
               </property>
+              <property name="accessibleDescription">
+               <string>Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to. Discord usernames are always lowercase.</string>
+              </property>
               <property name="placeholderText">
                <string>Discord username</string>
               </property>
@@ -3677,6 +3830,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_mmcpSnoopInMainConsole">
             <property name="toolTip">
              <string>&lt;p&gt;Show Snoop data in main console window.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Show Snoop data in main console window.</string>
             </property>
             <property name="text">
              <string>Show snoop data in main console</string>
@@ -4182,6 +4338,9 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="toolTip">
           <string>&lt;p&gt;To encourage enhanced data transfer protection and privacy, be prompted for a choice to switch to an encrypted port when advertised via Mud Server Status Protocol (MSSP).&lt;/p&gt;</string>
          </property>
+         <property name="accessibleDescription">
+          <string>To encourage enhanced data transfer protection and privacy, be prompted for a choice to switch to an encrypted port when advertised via Mud Server Status Protocol (MSSP).</string>
+         </property>
          <property name="text">
           <string>Allow secure connection reminder</string>
          </property>
@@ -4243,6 +4402,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Username for logging into the proxy if required.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Username for logging into the proxy if required.</string>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -4258,6 +4420,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLineEdit" name="lineEdit_proxyPassword">
             <property name="toolTip">
              <string>&lt;p&gt;Password for logging into the proxy if required.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Password for logging into the proxy if required.</string>
             </property>
             <property name="echoMode">
              <enum>QLineEdit::EchoMode::Password</enum>
@@ -4374,6 +4539,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When checked, Mudlet announces incoming game text through the system screen reader. On some platforms such as macOS the system screen reader may skip text; if that happens, uncheck this and use a custom TTS solution instead.</string>
+            </property>
             <property name="text">
              <string>Announce incoming text in screen reader</string>
             </property>
@@ -4467,6 +4635,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Enable F3 and Shift+F3 shortcuts for searching up and down in the buffer.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Enable F3 and Shift+F3 shortcuts for searching up and down in the buffer.</string>
+            </property>
             <property name="text">
              <string>Enable F3 search shortcuts</string>
             </property>
@@ -4476,6 +4647,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_enableBlinkText">
             <property name="toolTip">
              <string>&lt;p&gt;When enabled, text with the blinking attribute (SGR codes 5 and 6) is displayed with a smooth pulsing effect. When disabled, blinking text is shown in italics instead.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>When enabled, text with the blinking attribute (SGR codes 5 and 6) is displayed with a smooth pulsing effect. When disabled, blinking text is shown in italics instead.</string>
             </property>
             <property name="text">
              <string>Enable blinking text</string>
@@ -4527,6 +4701,9 @@ you can use it but there could be issues with aligning columns of text</string>
              <string>&lt;p&gt;This option adds a line line break &lt;LF&gt; or &quot;
 &quot; to your command input on empty commands. This option will rarely be necessary.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>This option adds a line break (LF, or new-line) to your command input on empty commands. This option will rarely be necessary.</string>
+            </property>
             <property name="text">
              <string>Force new line on empty commands</string>
             </property>
@@ -4544,6 +4721,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Some servers use KaVir’s protocol snippet, which expects the client to provide both its name and a decimal version number during Telnet TTYPE negotiation. However, including a version number is not in accordance with the relevant RFCs as the period character is not permitted therein; so since 2024 Mudlet has stopped sending it by default. As a result, servers that rely on this information may assume Mudlet is version 1.0 or earlier, and consequently restrict color support to 16 colors instead of enabling 256-color mode.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When checked, send Mudlet's version number alongside its name during Telnet TTYPE negotiation. Some servers using KaVir's protocol snippet need this to enable 256-color mode; Mudlet stopped sending it by default in 2024 because the period character it contains is not allowed by the relevant RFCs.</string>
+            </property>
             <property name="text">
              <string>Send Mudlet version in terminal type</string>
             </property>
@@ -4553,6 +4733,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QCheckBox" name="checkBox_mForceMXPProcessorOn">
             <property name="toolTip">
              <string>&lt;p&gt;Some servers do not negotiate Mud eXtension Protocol (MXP). When checked, this preference forces the MXP processor to be enabled. Note: To disable MXP entirely, leave this unchecked and also uncheck MXP in Choose protocols section of the General tab in Settings.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>When checked, force the MXP processor on for servers that do not negotiate it. To disable MXP entirely, leave this unchecked and also uncheck MXP under Choose protocols on the General tab.</string>
             </property>
             <property name="text">
              <string>Force MXP processing on</string>
@@ -4597,6 +4780,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Media files used with Mudlet's Lua API, Mud Client Media Protocol (MCMP), and Mud Sound Protocol (MSP) are cached with the game profile. You can press this button to clear the media cache. For many games the media will get downloaded again upon demand.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>Media files used with Mudlet's Lua API, Mud Client Media Protocol (MCMP), and Mud Sound Protocol (MSP) are cached with the game profile. You can press this button to clear the media cache. For many games the media will get downloaded again upon demand.</string>
+            </property>
             <property name="text">
              <string>Purge stored media files for the current profile:</string>
             </property>
@@ -4609,6 +4795,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QPushButton" name="buttonPurgeMediaCache">
             <property name="toolTip">
              <string>&lt;p&gt;Media files used with Mudlet's Lua API, Mud Client Media Protocol (MCMP), and Mud Sound Protocol (MSP) are cached with the game profile. You can press this button to clear the media cache. For many games the media will get downloaded again upon demand.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Media files used with Mudlet's Lua API, Mud Client Media Protocol (MCMP), and Mud Sound Protocol (MSP) are cached with the game profile. You can press this button to clear the media cache. For many games the media will get downloaded again upon demand.</string>
             </property>
             <property name="text">
              <string>Clear</string>
@@ -4699,6 +4888,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Some MUDs use a flawed interpretation of the ANSI Set Graphics Rendition (&lt;b&gt;SGR&lt;/b&gt;) code sequences for 16M color mode which only uses semi-colons and not colons to separate parameter elements i.e. instead of using a code in the form: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38:2:&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Unused&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance&amp;gt;&lt;tt&gt;:&lt;/tt&gt;&amp;lt;Tolerance Color Space (0=CIELUV; 1=CIELAB)&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;where the &lt;i&gt;Color Space Id&lt;/i&gt; is expected to be an empty string to specify the usual (default) case and all of the &lt;i&gt;Parameter Elements&lt;/i&gt; (the &quot;2&quot; and the values in the &lt;tt&gt;&amp;lt;...&amp;gt;&lt;/tt&gt;s) may, technically, be omitted; they use: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt;&lt;br&gt;or: &lt;br&gt;&lt;tt&gt;\e[&lt;/tt&gt;...&lt;tt&gt;38;2;&lt;/tt&gt;&amp;lt;Color Space Id&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Red&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Green&amp;gt;&lt;tt&gt;;&lt;/tt&gt;&amp;lt;Blue&amp;gt;&lt;tt&gt;;&lt;/tt&gt;...&lt;tt&gt;m&lt;/tt&gt; .&lt;/p&gt;&lt;p&gt;It is not possible to reliably detect the difference between these two so checking this option causes Mudlet to expect the last one with the additional (but empty!) parameter.&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When checked, interpret 16-million-color SGR sequences using the non-standard semi-colon form some MUDs send, which includes an extra empty parameter for the color space identifier. Enable this if true-color text from your game shows the wrong colors.</string>
+            </property>
             <property name="text">
              <string>Expect Color Space Id in SGR...(3|4)8;2;...m codes</string>
             </property>
@@ -4766,6 +4958,9 @@ you can use it but there could be issues with aligning columns of text</string>
                <property name="toolTip">
                 <string comment="The term in '...' refer to a Mudlet specific thing and ought to match the corresponding translation elsewhere.">&lt;p&gt;Show 'LUA OK' messages for Timers with the specified minimum interval (h:mm:ss.zzz), the minimum value (the default) shows all such messages but can render the &lt;i&gt;Central Debug Console&lt;/i&gt; useless if there is a very small interval timer running.&lt;/p&gt;</string>
                </property>
+               <property name="accessibleDescription">
+                <string>Show 'LUA OK' messages for Timers with the specified minimum interval (h:mm:ss.zzz), the minimum value (the default) shows all such messages but can render the Central Debug Console useless if there is a very small interval timer running.</string>
+               </property>
                <property name="text">
                 <string>Show debug messages for timers not smaller than:</string>
                </property>
@@ -4813,6 +5008,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;If checked this will cause all problem Unicode codepoints to be reported in the debug output as they occur; if cleared then each different one will only be reported once and summarized in as a table when the console in which they occurred is finally destroyed (when the profile is closed).&lt;/p&gt;</string>
             </property>
+            <property name="accessibleDescription">
+             <string>When checked, every problem Unicode codepoint is reported in the debug output as it occurs. When unchecked, each distinct codepoint is reported only once and a summary table is shown when the console closes.</string>
+            </property>
             <property name="text">
              <string>Report all Codepoint problems immediately</string>
             </property>
@@ -4832,6 +5030,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QDoubleSpinBox" name="doubleSpinBox_networkPacketTimeout">
             <property name="toolTip">
              <string>&lt;p&gt;&lt;i&gt;Go-Ahead&lt;/i&gt; (&lt;tt&gt;GA&lt;/tt&gt;) and &lt;i&gt;End-of-record&lt;/i&gt; (&lt;tt&gt;EOR&lt;/tt&gt;) signalling tells Mudlet when the game server is done sending text. On games that do not provide &lt;tt&gt;GA&lt;/tt&gt; or &lt;tt&gt;EOR&lt;/tt&gt;, this option controls how long Mudlet will wait for more text to arrive. Greater values will help reduce the risk that Mudlet will split a large piece of text (with unintended line-breaks in the middle) which can stop some triggers from working. Lesser values increases the risk of text getting broken up, but may make the game feel more responsive.&lt;/p&gt;&lt;p&gt;&lt;i&gt;The default value, which was what Mudlet used before this control was added, is 0.300 Seconds.&lt;/i&gt;&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>How long Mudlet waits for more text on games that do not send Go-Ahead or End-of-record signals. Larger values reduce the chance that long output is split mid-sentence and breaks triggers; smaller values feel more responsive. Default is 0.300 seconds.</string>
             </property>
             <property name="suffix">
              <string extracomment="For most locales a space should be included so that the text is separated from the number!"> seconds</string>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds plain-text accessible descriptions to widgets in the profile preferences dialog so that screen readers no longer announce the HTML markup that is used to style their tooltips. The tooltips themselves are unchanged.

#### Motivation for adding to Mudlet

Without these, screen reader users currently hear things like "less than p greater than search buffer less than slash p greater than" instead of the actual help text, which is confusing and an accessibility barrier.

#### Other info (issues closed, discussion etc)

Towards #8547. Builds on the caret-mode accessible description added in #9206.