### PR TITLE
Fix: stop re-prompting to set Mudlet as the telnet:// link handler after declining

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -829,39 +829,23 @@ int main(int argc, char* argv[])
 
     bool forceAsk = false;
 #if defined(Q_OS_MACOS)
+    // Detect whether the current scheme handler still points at *this* Mudlet
+    // bundle. We compare bundle identifiers via LSCopyDefaultHandlerForURLScheme
+    // because that reflects the user's chosen default. LSCopyDefaultApplicationURLForURL
+    // resolves a full URL to *some* app that can open it, which always returns
+    // Mudlet itself when our Info.plist declares the telnet/telnets schemes —
+    // even when the user has set a different default.
     if (!headlessMode) {
-        CFURLRef testUrl = CFURLCreateWithString(kCFAllocatorDefault, CFSTR("telnet://test"), nullptr);
-        if (testUrl) {
-            CFURLRef appUrl = LSCopyDefaultApplicationURLForURL(testUrl, kLSRolesAll, nullptr);
-            if (appUrl) {
-                char pathBuffer[4096];
-                if (CFURLGetFileSystemRepresentation(appUrl, true, reinterpret_cast<UInt8*>(pathBuffer), sizeof(pathBuffer))) {
-                    QString handlerPath = QString::fromUtf8(pathBuffer);
-                    QString myPath = QCoreApplication::applicationFilePath();
-                    QFileInfo myInfo(myPath);
-                    QDir myBundleDir = myInfo.absoluteDir();
-                    if (myBundleDir.dirName() == qsl("MacOS")) {
-                        myBundleDir.cdUp();
-                    }
-                    if (myBundleDir.dirName() == qsl("Contents")) {
-                        myBundleDir.cdUp();
-                    }
-                    QString myBundlePath = myBundleDir.absolutePath();
-
-                    if (QFileInfo(handlerPath).canonicalFilePath() != QFileInfo(myBundlePath).canonicalFilePath()) {
-                        qDebug() << "main: macOS telnet handler path mismatch. Registered:" << handlerPath << "Current:" << myBundlePath;
-                        forceAsk = true;
-                    }
-                } else {
-                    forceAsk = true;
-                }
-                CFRelease(appUrl);
-            } else {
+        CFStringRef registeredHandler = LSCopyDefaultHandlerForURLScheme(CFSTR("telnet"));
+        if (registeredHandler) {
+            QString registeredBundleId = QString::fromCFString(registeredHandler).toLower();
+            CFStringRef myBundleId = CFBundleGetIdentifier(CFBundleGetMainBundle());
+            QString myBundleIdStr = myBundleId ? QString::fromCFString(myBundleId).toLower() : QString();
+            if (!myBundleIdStr.isEmpty() && registeredBundleId != myBundleIdStr) {
+                qDebug() << "main: macOS telnet handler bundle id mismatch. Registered:" << registeredBundleId << "Current:" << myBundleIdStr;
                 forceAsk = true;
             }
-            CFRelease(testUrl);
-        } else {
-            qWarning() << "main: CFURLCreateWithString returned null for telnet://test";
+            CFRelease(registeredHandler);
         }
     }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -894,9 +894,7 @@ int main(int argc, char* argv[])
             QString existingHandler = checkSettings.value(".").toString();
             existingHandlerFound = !existingHandler.isEmpty() && !existingHandler.toLower().contains("mudlet");
             qDebug() << "main: Windows telnet handler check:" << (existingHandlerFound ? "found existing" : "none/mudlet");
-#endif
-
-#if defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX)
             // Check Linux xdg-mime for existing handler
             QProcess xdgQuery;
             xdgQuery.start(qsl("xdg-mime"), QStringList() << qsl("query") << qsl("default") << qsl("x-scheme-handler/telnet"));
@@ -909,9 +907,7 @@ int main(int argc, char* argv[])
                 existingHandlerFound = !existingHandler.isEmpty() && !existingHandler.toLower().contains("mudlet");
                 qDebug() << "main: Linux telnet handler check:" << existingHandler << (existingHandlerFound ? "(existing)" : "(none/mudlet)");
             }
-#endif
-
-#if defined(Q_OS_MACOS)
+#elif defined(Q_OS_MACOS)
             if (forceAsk) {
                 existingHandlerFound = true;
             } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include "mudlet.h"
 #include "MudletInstanceCoordinator.h"
 #include <chrono>
+#include <QCheckBox>
 #include <QCommandLineParser>
 #include <QDir>
 #include <QMessageBox>
@@ -868,81 +869,101 @@ int main(int argc, char* argv[])
     if (headlessMode) {
         shouldRegisterTelnet = appSettings->value("telnetHandlerEnabled", false).toBool();
         qDebug() << "main: Headless mode detected, skipping telnet handler registration";
-    } else if (!forceAsk && appSettings->contains("telnetHandlerAsked")) {
-        shouldRegisterTelnet = appSettings->value("telnetHandlerEnabled", false).toBool();
     } else {
-        // First time - check if there's an existing handler
-        bool existingHandlerFound = false;
+        const bool asked = appSettings->contains("telnetHandlerAsked");
+        const bool storedEnabled = appSettings->value("telnetHandlerEnabled", false).toBool();
+        const bool dontAsk = appSettings->value("telnetHandlerDontAsk", false).toBool();
+
+        // forceAsk indicates the platform-level handler no longer points at this
+        // Mudlet bundle. We only want to re-prompt in that recovery case if the
+        // user previously accepted (so their original intent was to be the
+        // handler) and they have not opted out of prompts via "Don't ask again".
+        // When dontAsk is set we still silently re-apply storedEnabled below,
+        // which will re-register Mudlet as the handler if that was their choice.
+        const bool needRecoveryPrompt = forceAsk && storedEnabled && !dontAsk;
+
+        if (asked && !needRecoveryPrompt) {
+            shouldRegisterTelnet = storedEnabled;
+        } else {
+            // First time - check if there's an existing handler
+            bool existingHandlerFound = false;
 
 #if defined(Q_OS_WIN)
-        // Check Windows registry for existing telnet handler
-        QSettings checkSettings("HKEY_CLASSES_ROOT\\telnet\\shell\\open\\command", QSettings::NativeFormat);
-        QString existingHandler = checkSettings.value(".").toString();
-        existingHandlerFound = !existingHandler.isEmpty() && !existingHandler.toLower().contains("mudlet");
-        qDebug() << "main: Windows telnet handler check:" << (existingHandlerFound ? "found existing" : "none/mudlet");
+            // Check Windows registry for existing telnet handler
+            QSettings checkSettings("HKEY_CLASSES_ROOT\\telnet\\shell\\open\\command", QSettings::NativeFormat);
+            QString existingHandler = checkSettings.value(".").toString();
+            existingHandlerFound = !existingHandler.isEmpty() && !existingHandler.toLower().contains("mudlet");
+            qDebug() << "main: Windows telnet handler check:" << (existingHandlerFound ? "found existing" : "none/mudlet");
 #endif
 
 #if defined(Q_OS_LINUX)
-        // Check Linux xdg-mime for existing handler
-        QProcess xdgQuery;
-        xdgQuery.start(qsl("xdg-mime"), QStringList() << qsl("query") << qsl("default") << qsl("x-scheme-handler/telnet"));
-        xdgQuery.waitForFinished(3000);
-        if (xdgQuery.error() == QProcess::FailedToStart) {
-            existingHandlerFound = true;
-            qDebug() << "main: Linux telnet handler check: xdg-mime not found (assuming existing handler to ask user)";
-        } else {
-            QString existingHandler = QString::fromUtf8(xdgQuery.readAllStandardOutput()).trimmed();
-            existingHandlerFound = !existingHandler.isEmpty() && !existingHandler.toLower().contains("mudlet");
-            qDebug() << "main: Linux telnet handler check:" << existingHandler << (existingHandlerFound ? "(existing)" : "(none/mudlet)");
-        }
+            // Check Linux xdg-mime for existing handler
+            QProcess xdgQuery;
+            xdgQuery.start(qsl("xdg-mime"), QStringList() << qsl("query") << qsl("default") << qsl("x-scheme-handler/telnet"));
+            xdgQuery.waitForFinished(3000);
+            if (xdgQuery.error() == QProcess::FailedToStart) {
+                existingHandlerFound = true;
+                qDebug() << "main: Linux telnet handler check: xdg-mime not found (assuming existing handler to ask user)";
+            } else {
+                QString existingHandler = QString::fromUtf8(xdgQuery.readAllStandardOutput()).trimmed();
+                existingHandlerFound = !existingHandler.isEmpty() && !existingHandler.toLower().contains("mudlet");
+                qDebug() << "main: Linux telnet handler check:" << existingHandler << (existingHandlerFound ? "(existing)" : "(none/mudlet)");
+            }
 #endif
 
 #if defined(Q_OS_MACOS)
-        if (forceAsk) {
-            existingHandlerFound = true;
-        } else {
-            CFStringRef telnetScheme = CFSTR("telnet");
-            CFStringRef existingHandler = LSCopyDefaultHandlerForURLScheme(telnetScheme);
-            if (existingHandler) {
-                QString handlerStr = QString::fromCFString(existingHandler);
-                existingHandlerFound = !handlerStr.isEmpty() && !handlerStr.toLower().contains("mudlet");
-                CFRelease(existingHandler);
+            if (forceAsk) {
+                existingHandlerFound = true;
+            } else {
+                CFStringRef telnetScheme = CFSTR("telnet");
+                CFStringRef existingHandler = LSCopyDefaultHandlerForURLScheme(telnetScheme);
+                if (existingHandler) {
+                    QString handlerStr = QString::fromCFString(existingHandler);
+                    existingHandlerFound = !handlerStr.isEmpty() && !handlerStr.toLower().contains("mudlet");
+                    CFRelease(existingHandler);
+                }
             }
-        }
 #endif
 
-        if (existingHandlerFound) {
-            QMessageBox msgBox;
-            //: Title for the dialog asking if Mudlet should handle telnet:// and telnets:// links
-            msgBox.setWindowTitle(QObject::tr("Telnet Protocol Handler"));
-            //: Text shown when another application is already handling telnet:// and telnets:// links
-            msgBox.setText(QObject::tr("Another application is set to handle telnet:// and telnets:// links."));
-            //: Detailed explanation for telnet handler override prompt
-            msgBox.setInformativeText(QObject::tr("Would you like Mudlet to handle telnet:// and telnets:// links instead?\n\n"
-                                                  "This will allow you to click on telnet:// and telnets:// links in your browser "
-                                                  "to automatically open them in Mudlet.\n\n"
-                                                  "You can change this later in Settings > General."));
-            msgBox.setIcon(QMessageBox::Question);
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::No);
+            if (existingHandlerFound) {
+                QMessageBox msgBox;
+                //: Title for the dialog asking if Mudlet should handle telnet:// and telnets:// links
+                msgBox.setWindowTitle(QObject::tr("Telnet Protocol Handler"));
+                //: Text shown when another application is already handling telnet:// and telnets:// links
+                msgBox.setText(QObject::tr("Another application is set to handle telnet:// and telnets:// links."));
+                //: Detailed explanation for telnet handler override prompt
+                msgBox.setInformativeText(QObject::tr("Would you like Mudlet to handle telnet:// and telnets:// links instead?\n\n"
+                                                      "This will allow you to click on telnet:// and telnets:// links in your browser "
+                                                      "to automatically open them in Mudlet.\n\n"
+                                                      "You can change this later in Settings > General."));
+                msgBox.setIcon(QMessageBox::Question);
+                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                msgBox.setDefaultButton(QMessageBox::No);
 
-            int result = msgBox.exec();
-            bool userChoice = (result == QMessageBox::Yes);
+                //: Checkbox on the telnet handler prompt that suppresses future prompts
+                auto* dontAskCheckBox = new QCheckBox(QObject::tr("Don't ask again"));
+                msgBox.setCheckBox(dontAskCheckBox);
 
-            appSettings->setValue("telnetHandlerAsked", true);
-            appSettings->setValue("telnetHandlerEnabled", userChoice);
-            appSettings->sync();
+                int result = msgBox.exec();
+                bool userChoice = (result == QMessageBox::Yes);
+                bool dontAskAgain = dontAskCheckBox->isChecked();
 
-            shouldRegisterTelnet = userChoice;
-            qDebug() << "main: User" << (userChoice ? "accepted" : "declined") << "telnet handler override";
-        } else {
-            // No existing handler - register silently
-            appSettings->setValue("telnetHandlerAsked", true);
-            appSettings->setValue("telnetHandlerEnabled", true);
-            appSettings->sync();
+                appSettings->setValue("telnetHandlerAsked", true);
+                appSettings->setValue("telnetHandlerEnabled", userChoice);
+                appSettings->setValue("telnetHandlerDontAsk", dontAskAgain);
+                appSettings->sync();
 
-            shouldRegisterTelnet = true;
-            qDebug() << "main: No existing telnet handler, registering Mudlet silently";
+                shouldRegisterTelnet = userChoice;
+                qDebug() << "main: User" << (userChoice ? "accepted" : "declined") << "telnet handler override" << (dontAskAgain ? "(don't ask again)" : "");
+            } else {
+                // No existing handler - register silently
+                appSettings->setValue("telnetHandlerAsked", true);
+                appSettings->setValue("telnetHandlerEnabled", true);
+                appSettings->sync();
+
+                shouldRegisterTelnet = true;
+                qDebug() << "main: No existing telnet handler, registering Mudlet silently";
+            }
         }
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes the "Should Mudlet handle telnet:// links?" dialog reappearing on every macOS launch after the user clicked No, and adds a "Don't ask again" checkbox so users can permanently dismiss the prompt.

#### Motivation for adding to Mudlet

Users who don't want Mudlet to be the default telnet:// handler shouldn't be nagged at every startup. The dialog now respects a previous "No" the same way it does on Windows and Linux, and gives everyone an explicit opt-out.

#### Other info (issues closed, discussion etc)

Closes #9215.

---

https://github.com/user-attachments/assets/74a40bdb-acba-4262-a42b-49ea3dd1b6b7
