### PR TITLE
Fix: Prevent stray Go-Ahead bytes from breaking text into one-letter-per-line

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -5057,10 +5057,15 @@ Some data loss is likely - please mention this problem to the game admins.)",
                     }
                 }
 
-                cleandata.push_back('\xff');
                 recvdGA = false;
-                gotPrompt(cleandata);
-                cleandata = "";
+                // Skip empty GA-only prompts: some servers emit stray GAs
+                // (issue #9223) which would otherwise produce one empty
+                // prompt line per GA.
+                if (!cleandata.empty()) {
+                    cleandata.push_back('\xff');
+                    gotPrompt(cleandata);
+                    cleandata = "";
+                }
             } else {
                 cleandata.push_back('\n');
             }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4814,10 +4814,13 @@ void cTelnet::slot_processReplayChunk()
                 }
             }
 
-            cleandata.push_back('\n');
             recvdGA = false;
-            gotPrompt(cleandata);
-            cleandata = "";
+            // Skip empty GA-only prompts: see processSocketData() for issue #9223.
+            if (!cleandata.empty()) {
+                cleandata.push_back('\n');
+                gotPrompt(cleandata);
+                cleandata = "";
+            }
         }
     } //for
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes a display problem where text from the game would arrive split letter-by-letter onto separate lines when the server was under load. Mudlet now ignores Go-Ahead signals from the server that have no actual text attached to them, so they no longer create empty prompts that fragment the output.

#### Motivation for adding to Mudlet

Players on The Inquisition: Legacy reported that bursts of incoming text became unreadable, with each character on its own line. This change keeps the display intact when the server emits stray Go-Ahead bytes during slow output.

#### Other info (issues closed, discussion etc)

Closes #9223
