### PR TITLE
Fix: connection status indicators causing tab padding issues on macOS

### DIFF
--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1379,7 +1379,8 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     }
 
     if (tabIndex < 0 || tabIndex >= mpTabBar->count()) {
-        qWarning() << "TDetachedWindow::updateTabIndicator: invalid tab index" << tabIndex << "(tab count" << mpTabBar->count() << ")";
+        // Stale index can occur during tab-removal races; not an error.
+        qDebug() << "TDetachedWindow::updateTabIndicator: invalid tab index" << tabIndex << "(tab count" << mpTabBar->count() << ")";
         return;
     }
 

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -586,7 +586,7 @@ void TDetachedWindow::closeEvent(QCloseEvent* event)
         }
 
         // Remove all consoles from the stacked widget and reset their parents
-        for (const auto &console : std::as_const(mProfileConsoleMap)) {
+        for (const auto& console : std::as_const(mProfileConsoleMap)) {
             if (console) {
                 mpConsoleContainer->removeWidget(console);
                 console->setParent(nullptr);
@@ -1379,6 +1379,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     }
 
     if (tabIndex < 0 || tabIndex >= mpTabBar->count()) {
+        qWarning() << "TDetachedWindow::updateTabIndicator: invalid tab index" << tabIndex << "(tab count" << mpTabBar->count() << ")";
         return;
     }
 
@@ -1395,23 +1396,29 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
 
     // Get the host and determine connection status
     Host* pHost = pMudlet->getHostManager().getHost(profileName);
-    QIcon tabIcon;
+    TabConnectionIndicator state = TabConnectionIndicator::None;
 
     // Only show connection indicators if the global setting is enabled
     if (pMudlet->showTabConnectionIndicators()) {
         if (pHost) {
-            bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
-            bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-            tabIcon = mudlet::createConnectionStatusIcon(isConnected, isConnecting, false);
+            switch (pHost->mTelnet.getConnectionState()) {
+            case QAbstractSocket::ConnectedState:
+                state = TabConnectionIndicator::Connected;
+                break;
+            case QAbstractSocket::ConnectingState:
+            case QAbstractSocket::HostLookupState:
+                state = TabConnectionIndicator::Connecting;
+                break;
+            default:
+                state = TabConnectionIndicator::Disconnected;
+                break;
+            }
         } else {
-            tabIcon = mudlet::createConnectionStatusIcon(false, false, true);
+            state = TabConnectionIndicator::Error;
         }
-    } else {
-        // No icon when indicators are disabled
-        tabIcon = QIcon();
     }
 
-    // Set the tab text and icon, accounting for CDC identifiers
+    // Set the tab text and indicator, accounting for CDC identifiers
     QString displayText = profileName;
 
     // Apply CDC identifier prefix if debug mode is active (like main window does)
@@ -1424,7 +1431,7 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
     }
 
     mpTabBar->setTabText(tabIndex, displayText);
-    mpTabBar->setTabIcon(tabIndex, tabIcon);
+    mpTabBar->setTabConnectionIndicator(tabIndex, state);
 }
 
 void TDetachedWindow::updateAllTabIndicators()

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1380,7 +1380,9 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
 
     if (tabIndex < 0 || tabIndex >= mpTabBar->count()) {
         // Stale index can occur during tab-removal races; not an error.
+#if defined(DEBUG_WINDOW_HANDLING)
         qDebug() << "TDetachedWindow::updateTabIndicator: invalid tab index" << tabIndex << "(tab count" << mpTabBar->count() << ")";
+#endif
         return;
     }
 

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1418,7 +1418,6 @@ void TDetachedWindow::updateTabIndicator(int tabIndex)
         }
     }
 
-    // Set the tab text and indicator, accounting for CDC identifiers
     QString displayText = profileName;
 
     // Apply CDC identifier prefix if debug mode is active (like main window does)

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -53,10 +53,10 @@ void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPa
     auto* appStyle = qApp->style();
 
     const auto* tabOption = (element == QStyle::CE_TabBarTab) ? qstyleoption_cast<const QStyleOptionTab*>(option) : nullptr;
-    const int tabIndex = tabOption ? mpTabBar->tabAt(tabOption->rect.center()) : -1;
+    const int tabIndex = (tabOption && mpTabBar) ? mpTabBar->tabAt(tabOption->rect.center()) : -1;
 
     if (element == QStyle::CE_TabBarTab && widget) {
-        QString tabName = mpTabBar->tabData(tabIndex).toString();
+        QString tabName = mpTabBar ? mpTabBar->tabData(tabIndex).toString() : QString();
         QFont font = widget->font();
         bool isStyleChanged = false;
         if (mBoldTabsSet.contains(tabName) || mItalicTabsSet.contains(tabName) || mUnderlineTabsSet.contains(tabName)) {
@@ -106,7 +106,7 @@ QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, con
                 rect.setLeft(qMax(rect.left(), reservationStart) + sIndicatorReservedWidth);
                 // Mirror the reservation on the trailing edge so Qt's centering
                 // lands on the tab's true center rather than being offset toward
-                // the close button - see PR #9231 review feedback.
+                // the close button.
                 rect.setRight(rect.right() - sIndicatorReservedWidth);
             }
         }
@@ -118,8 +118,8 @@ QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, con
 void TStyle::paintConnectionIndicator(QPainter* painter, const QStyleOptionTab* tabOption, TabConnectionIndicator state) const
 {
     constexpr int diameter = 8;
-    // Leaves a ~4 px gap between the dot and the tab text, given
-    // sIndicatorReservedWidth (20) - leftMargin (8) - diameter (8) = 4.
+    // Provides a comfortable gap from the close button on the leading
+    // edge and the tab text on the trailing edge.
     constexpr int leftMargin = 8;
     const QRect& tabRect = tabOption->rect;
     // Sit just past the close button (which is on the leading edge on macOS)

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -75,12 +75,10 @@ void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPa
         appStyle->drawControl(element, option, painter, widget);
     }
 
-    // Paint the connection-status indicator on top of the rendered tab.
-    // We hook CE_TabBarTab (rather than CE_TabBarTabLabel) because the macOS
-    // native style draws the whole tab in CE_TabBarTab without sub-dispatching
-    // to CE_TabBarTabLabel - see issue #9213.
-    // tabAt() may return -1 (e.g. style previewing); tabConnectionIndicator()
-    // guards that case and returns None, which is then a no-op.
+    // Hook CE_TabBarTab (not CE_TabBarTabLabel) - the macOS native style
+    // draws the whole tab in CE_TabBarTab and never sub-dispatches to
+    // CE_TabBarTabLabel. tabAt() may return -1; tabConnectionIndicator()
+    // treats that as None.
     if (element == QStyle::CE_TabBarTab) {
         const auto* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
         if (tabOption) {
@@ -96,15 +94,13 @@ QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, con
 {
     QRect rect = QProxyStyle::subElementRect(element, option, widget);
 
-    // Reserve space at the leading edge of the tab for the connection
-    // indicator so that long tab text is not painted underneath it.
-    // tabAt() may return -1; tabConnectionIndicator() guards that case.
+    // Reserve space at the leading edge of the tab so long tab text is not
+    // painted underneath the indicator.
     if (element == SE_TabBarTabText) {
         const auto* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
         if (tabOption && mpTabBar) {
             const TabConnectionIndicator state = tabConnectionIndicator(mpTabBar->tabAt(tabOption->rect.center()));
             if (state != TabConnectionIndicator::None) {
-                // Place reserved space after the leading close button (if any).
                 const QRect leftBtn = QProxyStyle::subElementRect(SE_TabBarTabLeftButton, option, widget);
                 const int reservationStart = leftBtn.isValid() ? leftBtn.right() + 1 : rect.left();
                 rect.setLeft(qMax(rect.left(), reservationStart) + sIndicatorReservedWidth);
@@ -120,10 +116,9 @@ void TStyle::paintConnectionIndicator(QPainter* painter, const QStyleOptionTab* 
     constexpr int diameter = 8;
     constexpr int leftMargin = 6;
     const QRect& tabRect = tabOption->rect;
-    // On macOS the close button sits at the leading edge of the tab; place the
-    // indicator just to the right of it so they do not overlap. On platforms
-    // without a leading close button the indicator falls back to the tab's
-    // leading edge.
+    // Sit just past the close button (which is on the leading edge on macOS)
+    // so the two do not overlap; fall back to the tab's leading edge when
+    // there is no close button.
     const QRect leftBtn = QProxyStyle::subElementRect(SE_TabBarTabLeftButton, tabOption, mpTabBar);
     const int startX = leftBtn.isValid() ? leftBtn.right() + 1 : tabRect.left();
     const int x = startX + leftMargin;
@@ -169,9 +164,9 @@ bool TStyle::setTabConnectionIndicator(const QString& tabName, TabConnectionIndi
     if (tabName.isEmpty()) {
         return false;
     }
-    // Removing a stale indicator must always be allowed (e.g. from removeTab),
-    // even if the tab no longer exists. For inserts, verify the tab name
-    // corresponds to a real tab to avoid leaking phantom entries.
+    // Removing a stale indicator is always safe (the tab may already be gone,
+    // e.g. from removeTab); for inserts, refuse unknown names so we don't
+    // accumulate phantom entries.
     if (state == TabConnectionIndicator::None) {
         return mConnectionIndicators.remove(tabName) > 0;
     }
@@ -300,9 +295,8 @@ QSize TTabBar::tabSizeHint(int index) const
         s.setWidth(s.width() - w + bw);
     }
 
-    // Reserve space at the trailing edge for our manually-painted connection
-    // indicator (issue #9213). We paint it ourselves rather than via
-    // setTabIcon() so the native macOS tab style does not add its own padding.
+    // Reserve room for the connection indicator we paint ourselves
+    // (see TabConnectionIndicator declaration for why).
     if (mStyle.tabConnectionIndicator(index) != TabConnectionIndicator::None) {
         s.setWidth(s.width() + TStyle::sIndicatorReservedWidth);
     }

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -52,8 +52,11 @@ void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPa
     // dark palette colors on Windows 10
     auto* appStyle = qApp->style();
 
+    const auto* tabOption = (element == QStyle::CE_TabBarTab) ? qstyleoption_cast<const QStyleOptionTab*>(option) : nullptr;
+    const int tabIndex = tabOption ? mpTabBar->tabAt(tabOption->rect.center()) : -1;
+
     if (element == QStyle::CE_TabBarTab && widget) {
-        QString tabName = mpTabBar->tabData(mpTabBar->tabAt(option->rect.center())).toString();
+        QString tabName = mpTabBar->tabData(tabIndex).toString();
         QFont font = widget->font();
         bool isStyleChanged = false;
         if (mBoldTabsSet.contains(tabName) || mItalicTabsSet.contains(tabName) || mUnderlineTabsSet.contains(tabName)) {
@@ -79,13 +82,10 @@ void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPa
     // draws the whole tab in CE_TabBarTab and never sub-dispatches to
     // CE_TabBarTabLabel. tabAt() may return -1; tabConnectionIndicator()
     // treats that as None.
-    if (element == QStyle::CE_TabBarTab) {
-        const auto* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
-        if (tabOption) {
-            const TabConnectionIndicator state = tabConnectionIndicator(mpTabBar->tabAt(tabOption->rect.center()));
-            if (state != TabConnectionIndicator::None) {
-                paintConnectionIndicator(painter, tabOption, state);
-            }
+    if (tabOption) {
+        const TabConnectionIndicator state = tabConnectionIndicator(tabIndex);
+        if (state != TabConnectionIndicator::None) {
+            paintConnectionIndicator(painter, tabOption, state);
         }
     }
 }

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -104,6 +104,10 @@ QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, con
                 const QRect leftBtn = QProxyStyle::subElementRect(SE_TabBarTabLeftButton, option, widget);
                 const int reservationStart = leftBtn.isValid() ? leftBtn.right() + 1 : rect.left();
                 rect.setLeft(qMax(rect.left(), reservationStart) + sIndicatorReservedWidth);
+                // Mirror the reservation on the trailing edge so Qt's centering
+                // lands on the tab's true center rather than being offset toward
+                // the close button - see PR #9231 review feedback.
+                rect.setRight(rect.right() - sIndicatorReservedWidth);
             }
         }
     }
@@ -114,7 +118,9 @@ QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, con
 void TStyle::paintConnectionIndicator(QPainter* painter, const QStyleOptionTab* tabOption, TabConnectionIndicator state) const
 {
     constexpr int diameter = 8;
-    constexpr int leftMargin = 6;
+    // Leaves a ~4 px gap between the dot and the tab text, given
+    // sIndicatorReservedWidth (20) - leftMargin (8) - diameter (8) = 4.
+    constexpr int leftMargin = 8;
     const QRect& tabRect = tabOption->rect;
     // Sit just past the close button (which is on the leading edge on macOS)
     // so the two do not overlap; fall back to the tab's leading edge when

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -196,7 +196,7 @@ bool TStyle::setTabConnectionIndicator(const QString& tabName, TabConnectionIndi
 
 bool TStyle::setTabConnectionIndicator(int index, TabConnectionIndicator state)
 {
-    if (index < 0 || index >= mpTabBar->count()) {
+    if (!mpTabBar || index < 0 || index >= mpTabBar->count()) {
         return false;
     }
     return setTabConnectionIndicator(mpTabBar->tabData(index).toString(), state);
@@ -212,7 +212,7 @@ TabConnectionIndicator TStyle::tabConnectionIndicator(const QString& tabName) co
 
 TabConnectionIndicator TStyle::tabConnectionIndicator(int index) const
 {
-    if (index < 0 || index >= mpTabBar->count()) {
+    if (!mpTabBar || index < 0 || index >= mpTabBar->count()) {
         return TabConnectionIndicator::None;
     }
     return tabConnectionIndicator(mpTabBar->tabData(index).toString());

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -30,6 +30,7 @@
 
 #include <QApplication>
 #include <QStyleOption>
+#include <QStyleOptionTab>
 #include <QPainter>
 #include <QVariant>
 #include <QMouseEvent>
@@ -51,7 +52,7 @@ void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPa
     // dark palette colors on Windows 10
     auto* appStyle = qApp->style();
 
-    if (element == QStyle::CE_TabBarTab) {
+    if (element == QStyle::CE_TabBarTab && widget) {
         QString tabName = mpTabBar->tabData(mpTabBar->tabAt(option->rect.center())).toString();
         QFont font = widget->font();
         bool isStyleChanged = false;
@@ -73,6 +74,147 @@ void TStyle::drawControl(ControlElement element, const QStyleOption* option, QPa
     } else {
         appStyle->drawControl(element, option, painter, widget);
     }
+
+    // Paint the connection-status indicator on top of the rendered tab.
+    // We hook CE_TabBarTab (rather than CE_TabBarTabLabel) because the macOS
+    // native style draws the whole tab in CE_TabBarTab without sub-dispatching
+    // to CE_TabBarTabLabel - see issue #9213.
+    // tabAt() may return -1 (e.g. style previewing); tabConnectionIndicator()
+    // guards that case and returns None, which is then a no-op.
+    if (element == QStyle::CE_TabBarTab) {
+        const auto* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
+        if (tabOption) {
+            const TabConnectionIndicator state = tabConnectionIndicator(mpTabBar->tabAt(tabOption->rect.center()));
+            if (state != TabConnectionIndicator::None) {
+                paintConnectionIndicator(painter, tabOption, state);
+            }
+        }
+    }
+}
+
+QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, const QWidget* widget) const
+{
+    QRect rect = QProxyStyle::subElementRect(element, option, widget);
+
+    // Reserve space at the leading edge of the tab for the connection
+    // indicator so that long tab text is not painted underneath it.
+    // tabAt() may return -1; tabConnectionIndicator() guards that case.
+    if (element == SE_TabBarTabText) {
+        const auto* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
+        if (tabOption && mpTabBar) {
+            const TabConnectionIndicator state = tabConnectionIndicator(mpTabBar->tabAt(tabOption->rect.center()));
+            if (state != TabConnectionIndicator::None) {
+                // Place reserved space after the leading close button (if any).
+                const QRect leftBtn = QProxyStyle::subElementRect(SE_TabBarTabLeftButton, option, widget);
+                const int reservationStart = leftBtn.isValid() ? leftBtn.right() + 1 : rect.left();
+                rect.setLeft(qMax(rect.left(), reservationStart) + sIndicatorReservedWidth);
+            }
+        }
+    }
+
+    return rect;
+}
+
+void TStyle::paintConnectionIndicator(QPainter* painter, const QStyleOptionTab* tabOption, TabConnectionIndicator state) const
+{
+    constexpr int diameter = 8;
+    constexpr int leftMargin = 6;
+    const QRect& tabRect = tabOption->rect;
+    // On macOS the close button sits at the leading edge of the tab; place the
+    // indicator just to the right of it so they do not overlap. On platforms
+    // without a leading close button the indicator falls back to the tab's
+    // leading edge.
+    const QRect leftBtn = QProxyStyle::subElementRect(SE_TabBarTabLeftButton, tabOption, mpTabBar);
+    const int startX = leftBtn.isValid() ? leftBtn.right() + 1 : tabRect.left();
+    const int x = startX + leftMargin;
+    const int y = tabRect.center().y() - diameter / 2 + 1;
+    const QRect dotRect(x, y, diameter, diameter);
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    switch (state) {
+    case TabConnectionIndicator::Connected:
+        painter->setBrush(QColor(50, 180, 50));
+        painter->setPen(QPen(QColor(40, 150, 40), 1));
+        painter->drawEllipse(dotRect);
+        break;
+    case TabConnectionIndicator::Connecting:
+        painter->setBrush(QColor(220, 180, 50));
+        painter->setPen(QPen(QColor(180, 150, 40), 1));
+        painter->drawEllipse(dotRect);
+        break;
+    case TabConnectionIndicator::Error: {
+        painter->setBrush(QColor(220, 50, 50));
+        painter->setPen(QPen(QColor(180, 40, 40), 1));
+        QPolygon triangle;
+        triangle << QPoint(dotRect.center().x(), dotRect.top()) << QPoint(dotRect.left(), dotRect.bottom()) << QPoint(dotRect.right(), dotRect.bottom());
+        painter->drawPolygon(triangle);
+        break;
+    }
+    case TabConnectionIndicator::Disconnected:
+        painter->setBrush(Qt::transparent);
+        painter->setPen(QPen(QColor(120, 120, 120), 2));
+        painter->drawEllipse(dotRect);
+        break;
+    case TabConnectionIndicator::None:
+        break;
+    }
+
+    painter->restore();
+}
+
+bool TStyle::setTabConnectionIndicator(const QString& tabName, TabConnectionIndicator state)
+{
+    if (tabName.isEmpty()) {
+        return false;
+    }
+    // Removing a stale indicator must always be allowed (e.g. from removeTab),
+    // even if the tab no longer exists. For inserts, verify the tab name
+    // corresponds to a real tab to avoid leaking phantom entries.
+    if (state == TabConnectionIndicator::None) {
+        return mConnectionIndicators.remove(tabName) > 0;
+    }
+    bool textIsInATab = false;
+    for (int i = 0, total = mpTabBar->count(); i < total; ++i) {
+        if (mpTabBar->tabData(i).toString() == tabName) {
+            textIsInATab = true;
+            break;
+        }
+    }
+    if (!textIsInATab) {
+        return false;
+    }
+    const auto it = mConnectionIndicators.constFind(tabName);
+    if (it != mConnectionIndicators.cend() && it.value() == state) {
+        return false;
+    }
+    mConnectionIndicators.insert(tabName, state);
+    return true;
+}
+
+bool TStyle::setTabConnectionIndicator(int index, TabConnectionIndicator state)
+{
+    if (index < 0 || index >= mpTabBar->count()) {
+        return false;
+    }
+    return setTabConnectionIndicator(mpTabBar->tabData(index).toString(), state);
+}
+
+TabConnectionIndicator TStyle::tabConnectionIndicator(const QString& tabName) const
+{
+    if (tabName.isEmpty()) {
+        return TabConnectionIndicator::None;
+    }
+    return mConnectionIndicators.value(tabName, TabConnectionIndicator::None);
+}
+
+TabConnectionIndicator TStyle::tabConnectionIndicator(int index) const
+{
+    if (index < 0 || index >= mpTabBar->count()) {
+        return TabConnectionIndicator::None;
+    }
+    return tabConnectionIndicator(mpTabBar->tabData(index).toString());
 }
 
 void TStyle::setNamedTabState(const QString& tabName, const bool state, QSet<QString>& effect)
@@ -137,8 +279,9 @@ bool TStyle::indexedTabState(const int index, const QSet<QString>& effect) const
 
 QSize TTabBar::tabSizeHint(int index) const
 {
+    QSize s = QTabBar::tabSizeHint(index);
+
     if (mStyle.tabBold(index) || mStyle.tabItalic(index) || mStyle.tabUnderline(index)) {
-        const QSize s = QTabBar::tabSizeHint(index);
         const QFontMetrics fm(font());
         // Note that this method must use (because it is associated with sizing
         // the text to show) the (possibly Qt modified to include an
@@ -154,9 +297,17 @@ QSize TTabBar::tabSizeHint(int index) const
 
         const int bw = bfm.horizontalAdvance(tabText(index));
 
-        return {s.width() - w + bw, s.height()};
+        s.setWidth(s.width() - w + bw);
     }
-    return QTabBar::tabSizeHint(index);
+
+    // Reserve space at the trailing edge for our manually-painted connection
+    // indicator (issue #9213). We paint it ourselves rather than via
+    // setTabIcon() so the native macOS tab style does not add its own padding.
+    if (mStyle.tabConnectionIndicator(index) != TabConnectionIndicator::None) {
+        s.setWidth(s.width() + TStyle::sIndicatorReservedWidth);
+    }
+
+    return s;
 }
 
 QString TTabBar::tabName(const int index) const
@@ -186,6 +337,7 @@ void TTabBar::removeTab(int index)
         setTabBold(index, false);
         setTabItalic(index, false);
         setTabUnderline(index, false);
+        setTabConnectionIndicator(index, TabConnectionIndicator::None);
         QTabBar::removeTab(index);
     }
 }
@@ -197,6 +349,7 @@ void TTabBar::removeTab(const QString& tabName)
         setTabBold(index, false);
         setTabItalic(index, false);
         setTabUnderline(index, false);
+        setTabConnectionIndicator(index, TabConnectionIndicator::None);
         QTabBar::removeTab(index);
     }
 }

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -125,16 +125,27 @@ public:
     {
         if (mStyle.setTabConnectionIndicator(tabName, state)) {
             // updateGeometry() invalidates the cached tab sizes so tabSizeHint()
-            // is consulted again; update() then triggers the repaint.
+            // is consulted again. For the brief Connecting stage we paint
+            // synchronously so a fast follow-up Connected transition cannot
+            // coalesce the pending paint and skip the yellow dot entirely;
+            // other transitions can take the cheaper deferred update().
             updateGeometry();
-            update();
+            if (state == TabConnectionIndicator::Connecting) {
+                repaint();
+            } else {
+                update();
+            }
         }
     }
     void setTabConnectionIndicator(const int index, TabConnectionIndicator state)
     {
         if (mStyle.setTabConnectionIndicator(index, state)) {
             updateGeometry();
-            update();
+            if (state == TabConnectionIndicator::Connecting) {
+                repaint();
+            } else {
+                update();
+            }
         }
     }
     TabConnectionIndicator tabConnectionIndicator(const QString& tabName) const { return mStyle.tabConnectionIndicator(tabName); }

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -27,10 +27,9 @@
 #include <QString>
 #include <QTabBar>
 
-// Connection status indicator drawn at the right edge of a tab. Drawn by
-// TStyle directly (rather than using QTabBar::setTabIcon), to avoid native
-// style icon padding inflating tab width and miscentering on macOS - see
-// issue #9213.
+// Connection status indicator drawn next to the tab text by TStyle. We paint
+// it ourselves rather than via QTabBar::setTabIcon() because the macOS native
+// style adds substantial padding around any tab icon - see issue #9213.
 enum class TabConnectionIndicator {
     None,
     Connected,
@@ -42,8 +41,7 @@ enum class TabConnectionIndicator {
 class TStyle : public QProxyStyle
 {
 public:
-    // Reserved horizontal space (in logical pixels) added to the tab when an
-    // indicator is shown: indicator diameter + left margin + right margin.
+    // Indicator diameter + left margin + right margin, in logical pixels.
     static constexpr int sIndicatorReservedWidth = 14;
 
     explicit TStyle(QTabBar* bar)
@@ -67,8 +65,8 @@ public:
     bool tabItalic(const int index) const { return indexedTabState(index, mItalicTabsSet); }
     bool tabUnderline(const QString& tabName) const { return namedTabState(tabName, mUnderlineTabsSet); }
     bool tabUnderline(const int index) const { return indexedTabState(index, mUnderlineTabsSet); }
-    // Returns true if the stored state changed (caller can use this to
-    // avoid unnecessary repaints).
+    // Returns true only if the stored state actually changed, so callers
+    // can skip unnecessary repaints.
     bool setTabConnectionIndicator(const QString& tabName, TabConnectionIndicator state);
     bool setTabConnectionIndicator(int index, TabConnectionIndicator state);
     TabConnectionIndicator tabConnectionIndicator(const QString& tabName) const;

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -99,7 +99,7 @@ class TTabBar : public QTabBar
 public:
     explicit TTabBar(QWidget* parent)
     : QTabBar(parent)
-    , mStyle(qobject_cast<QTabBar*>(this))
+    , mStyle(this)
     {
         setStyle(&mStyle);
         setAcceptDrops(true);

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -42,7 +42,9 @@ class TStyle : public QProxyStyle
 {
 public:
     // Indicator diameter + left margin + right margin, in logical pixels.
-    static constexpr int sIndicatorReservedWidth = 14;
+    // Tuned so the dot is not crammed against the close button or the tab
+    // text - see PR #9231 review feedback.
+    static constexpr int sIndicatorReservedWidth = 20;
 
     explicit TStyle(QTabBar* bar)
     : mpTabBar(bar)

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -42,8 +42,8 @@ class TStyle : public QProxyStyle
 {
 public:
     // Indicator diameter + left margin + right margin, in logical pixels.
-    // Tuned so the dot is not crammed against the close button or the tab
-    // text - see PR #9231 review feedback.
+    // Tuned so the dot is not crammed against the close button or the
+    // tab text.
     static constexpr int sIndicatorReservedWidth = 20;
 
     explicit TStyle(QTabBar* bar)

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -21,26 +21,45 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QHash>
 #include <QProxyStyle>
 #include <QSet>
 #include <QString>
 #include <QTabBar>
 
+// Connection status indicator drawn at the right edge of a tab. Drawn by
+// TStyle directly (rather than using QTabBar::setTabIcon), to avoid native
+// style icon padding inflating tab width and miscentering on macOS - see
+// issue #9213.
+enum class TabConnectionIndicator {
+    None,
+    Connected,
+    Connecting,
+    Disconnected,
+    Error,
+};
+
 class TStyle : public QProxyStyle
 {
 public:
+    // Reserved horizontal space (in logical pixels) added to the tab when an
+    // indicator is shown: indicator diameter + left margin + right margin.
+    static constexpr int sIndicatorReservedWidth = 14;
+
     explicit TStyle(QTabBar* bar)
     : mpTabBar(bar)
-    {}
+    {
+    }
 
     ~TStyle() = default;
 
-    void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const;
+    void drawControl(ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget = nullptr) const override;
+    QRect subElementRect(SubElement element, const QStyleOption* option, const QWidget* widget = nullptr) const override;
     void setTabBold(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mBoldTabsSet); }
     void setTabBold(const int index, const bool state) { setIndexedTabState(index, state, mBoldTabsSet); }
     void setTabItalic(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mItalicTabsSet); }
     void setTabItalic(const int index, const bool state) { setIndexedTabState(index, state, mItalicTabsSet); }
-    void setTabUnderline(const QString& tabName, const bool state) {setNamedTabState(tabName, state, mUnderlineTabsSet); }
+    void setTabUnderline(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mUnderlineTabsSet); }
     void setTabUnderline(const int index, const bool state) { setIndexedTabState(index, state, mUnderlineTabsSet); }
     bool tabBold(const QString& tabName) const { return namedTabState(tabName, mBoldTabsSet); }
     bool tabBold(const int index) const { return indexedTabState(index, mBoldTabsSet); }
@@ -48,14 +67,21 @@ public:
     bool tabItalic(const int index) const { return indexedTabState(index, mItalicTabsSet); }
     bool tabUnderline(const QString& tabName) const { return namedTabState(tabName, mUnderlineTabsSet); }
     bool tabUnderline(const int index) const { return indexedTabState(index, mUnderlineTabsSet); }
+    // Returns true if the stored state changed (caller can use this to
+    // avoid unnecessary repaints).
+    bool setTabConnectionIndicator(const QString& tabName, TabConnectionIndicator state);
+    bool setTabConnectionIndicator(int index, TabConnectionIndicator state);
+    TabConnectionIndicator tabConnectionIndicator(const QString& tabName) const;
+    TabConnectionIndicator tabConnectionIndicator(int index) const;
 
 private:
     bool indexedTabState(int index, const QSet<QString>& effect) const;
     bool namedTabState(const QString& tabName, const QSet<QString>& effect) const;
     void setNamedTabState(const QString& tabName, bool state, QSet<QString>& effect);
     void setIndexedTabState(int index, bool state, QSet<QString>& effect);
+    void paintConnectionIndicator(QPainter* painter, const QStyleOptionTab* tabOption, TabConnectionIndicator state) const;
 
-    QTabBar * mpTabBar;
+    QTabBar* mpTabBar;
     // The sets that hold the tab names that have the particular effect, we
     // use the text rather than the indexes because the tabs could be capable of
     // being reordered, but the names are expected to be constant (or if the
@@ -64,6 +90,8 @@ private:
     QSet<QString> mBoldTabsSet;
     QSet<QString> mItalicTabsSet;
     QSet<QString> mUnderlineTabsSet;
+    // Keyed by tab name (not index) for the same reorder-tolerance reason.
+    QHash<QString, TabConnectionIndicator> mConnectionIndicators;
 };
 
 class TTabBar : public QTabBar
@@ -83,18 +111,32 @@ public:
     QSize tabSizeHint(int index) const override;
     void applyPrefixToDisplayedText(const int index, const QString& prefix = QString());
     void applyPrefixToDisplayedText(const QString& tabName, const QString& prefix = QString());
-    void setTabBold(const QString& tabName, const bool state) {mStyle.setTabBold(tabName, state); }
-    void setTabBold(const int index, const bool state) {mStyle.setTabBold(index, state); }
-    void setTabItalic(const QString& tabName, const bool state) {mStyle.setTabItalic(tabName, state); }
-    void setTabItalic(const int index, const bool state) {mStyle.setTabItalic(index, state); }
-    void setTabUnderline(const QString& tabName, const bool state) {mStyle.setTabUnderline(tabName, state); }
-    void setTabUnderline(const int index, const bool state) {mStyle.setTabUnderline(index, state); }
-    bool tabBold(const QString& tabName) const {return mStyle.tabBold(tabName);}
-    bool tabBold(const int index) const {return mStyle.tabBold(index);}
-    bool tabItalic(const QString& tabName) const {return mStyle.tabItalic(tabName);}
-    bool tabItalic(const int index) const {return mStyle.tabItalic(index);}
-    bool tabUnderline(const QString& tabName) const {return mStyle.tabUnderline(tabName);}
-    bool tabUnderline(const int index) const {return mStyle.tabUnderline(index);}
+    void setTabBold(const QString& tabName, const bool state) { mStyle.setTabBold(tabName, state); }
+    void setTabBold(const int index, const bool state) { mStyle.setTabBold(index, state); }
+    void setTabItalic(const QString& tabName, const bool state) { mStyle.setTabItalic(tabName, state); }
+    void setTabItalic(const int index, const bool state) { mStyle.setTabItalic(index, state); }
+    void setTabUnderline(const QString& tabName, const bool state) { mStyle.setTabUnderline(tabName, state); }
+    void setTabUnderline(const int index, const bool state) { mStyle.setTabUnderline(index, state); }
+    bool tabBold(const QString& tabName) const { return mStyle.tabBold(tabName); }
+    bool tabBold(const int index) const { return mStyle.tabBold(index); }
+    bool tabItalic(const QString& tabName) const { return mStyle.tabItalic(tabName); }
+    bool tabItalic(const int index) const { return mStyle.tabItalic(index); }
+    bool tabUnderline(const QString& tabName) const { return mStyle.tabUnderline(tabName); }
+    bool tabUnderline(const int index) const { return mStyle.tabUnderline(index); }
+    void setTabConnectionIndicator(const QString& tabName, TabConnectionIndicator state)
+    {
+        if (mStyle.setTabConnectionIndicator(tabName, state)) {
+            update();
+        }
+    }
+    void setTabConnectionIndicator(const int index, TabConnectionIndicator state)
+    {
+        if (mStyle.setTabConnectionIndicator(index, state)) {
+            update();
+        }
+    }
+    TabConnectionIndicator tabConnectionIndicator(const QString& tabName) const { return mStyle.tabConnectionIndicator(tabName); }
+    TabConnectionIndicator tabConnectionIndicator(const int index) const { return mStyle.tabConnectionIndicator(index); }
     QString tabName(const int index) const;
     int tabIndex(const QString& tabName) const;
     void removeTab(const QString& tabName);

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -124,12 +124,16 @@ public:
     void setTabConnectionIndicator(const QString& tabName, TabConnectionIndicator state)
     {
         if (mStyle.setTabConnectionIndicator(tabName, state)) {
+            // updateGeometry() invalidates the cached tab sizes so tabSizeHint()
+            // is consulted again; update() then triggers the repaint.
+            updateGeometry();
             update();
         }
     }
     void setTabConnectionIndicator(const int index, TabConnectionIndicator state)
     {
         if (mStyle.setTabConnectionIndicator(index, state)) {
+            updateGeometry();
             update();
         }
     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -450,7 +450,7 @@ void cTelnet::connectIt(const QString& address, int port)
     // Set early - before the recursion-on-busy-socket block below - so the
     // qApp->processEvents() call there cannot leave the indicator briefly
     // showing Disconnected during a reconnect.
-    mIsLookingUpHost = true;
+    mLookingUpHost = true;
 
     if (mpHost) {
         mUSE_IRE_DRIVER_BUGFIX = mpHost->mUSE_IRE_DRIVER_BUGFIX;
@@ -535,7 +535,7 @@ void cTelnet::reconnect()
 void cTelnet::disconnectIt()
 {
     mDontReconnect = true;
-    mIsLookingUpHost = false;
+    mLookingUpHost = false;
     if (mpSocket) {
         // This will write out any pending data before it disconnects...
         mpSocket->disconnectFromHost();
@@ -685,7 +685,7 @@ void cTelnet::slot_socketDisconnected()
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
     qDebug().noquote() << "cTelnet::slot_socketDisconnected() INFO - called.";
 #endif
-    mIsLookingUpHost = false;
+    mLookingUpHost = false;
     TEvent event{};
 #if !defined(QT_NO_SSL)
     bool sslerr = false;
@@ -909,7 +909,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
     qDebug().noquote() << "cTelnet::slot_socketHostFound(QHostInfo) INFO - called.";
 #endif
-    mIsLookingUpHost = false;
+    mLookingUpHost = false;
     QStringList addressList_ipV4;
     QStringList addressList_ipV6;
     for (const QHostAddress& address : hostInfo.addresses()) {
@@ -1192,7 +1192,6 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 }
 
                 mSocket_ipV6.connectToHost(connectToText, mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv6Protocol);
-
             }
             if (hasIPv4_address) {
                 connect(&mSocket_ipV4, &QAbstractSocket::connected, this, &cTelnet::slot_socketConnected, Qt::UniqueConnection);
@@ -1213,8 +1212,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 } else {
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
  is the port number for the connection.*/
-                    TDebug(QColorConstants::Blue, QColorConstants::White)
-                                    << tr("Trying open (IPv4) connection to %1:%2 ...").arg(displayAddress, QString::number(mHostPort)).append(QChar::LineFeed)
+                    TDebug(QColorConstants::Blue, QColorConstants::White) << tr("Trying open (IPv4) connection to %1:%2 ...").arg(displayAddress, QString::number(mHostPort)).append(QChar::LineFeed)
                             >> mpHost;
                     /*: %1 is the URL or IPv4 address for the Game Server and %2
  is the port number for the connection.*/
@@ -1222,7 +1220,6 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
                 }
 
                 mSocket_ipV4.connectToHost(connectToText, mHostPort, QIODevice::ReadWrite, QAbstractSocket::IPv4Protocol);
-
             }
         }
 #if !defined(QT_NO_SSL)
@@ -5340,7 +5337,7 @@ QAbstractSocket::SocketState cTelnet::getConnectionState() const
     }
     // connectIt() has been called but QHostInfo::lookupHost has not yet
     // returned, so neither socket has been told to connect.
-    if (mIsLookingUpHost) {
+    if (mLookingUpHost) {
         return QAbstractSocket::HostLookupState;
     }
     if (mSocket_ipV4.state() == QAbstractSocket::ClosingState || mSocket_ipV6.state() == QAbstractSocket::ClosingState) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -449,6 +449,11 @@ void cTelnet::sendGMCPSupportsRemove(const QString& package)
 
 void cTelnet::connectIt(const QString& address, int port)
 {
+    // Set early - before the recursion-on-busy-socket block below - so the
+    // qApp->processEvents() call there cannot leave the indicator briefly
+    // showing Disconnected during a reconnect.
+    mIsLookingUpHost = true;
+
     if (mpHost) {
         mUSE_IRE_DRIVER_BUGFIX = mpHost->mUSE_IRE_DRIVER_BUGFIX;
         mFORCE_GA_OFF = mpHost->mFORCE_GA_OFF;
@@ -532,6 +537,7 @@ void cTelnet::reconnect()
 void cTelnet::disconnectIt()
 {
     mDontReconnect = true;
+    mIsLookingUpHost = false;
     if (mpSocket) {
         // This will write out any pending data before it disconnects...
         mpSocket->disconnectFromHost();
@@ -681,6 +687,7 @@ void cTelnet::slot_socketDisconnected()
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
     qDebug().noquote() << "cTelnet::slot_socketDisconnected() INFO - called.";
 #endif
+    mIsLookingUpHost = false;
     TEvent event{};
 #if !defined(QT_NO_SSL)
     bool sslerr = false;
@@ -904,6 +911,7 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
     qDebug().noquote() << "cTelnet::slot_socketHostFound(QHostInfo) INFO - called.";
 #endif
+    mIsLookingUpHost = false;
     QStringList addressList_ipV4;
     QStringList addressList_ipV6;
     for (const QHostAddress& address : hostInfo.addresses()) {
@@ -5310,7 +5318,9 @@ QAbstractSocket::SocketState cTelnet::getConnectionState() const
     if (mSocket_ipV4.state() == QAbstractSocket::HostLookupState || mSocket_ipV6.state() == QAbstractSocket::HostLookupState) {
         return QAbstractSocket::HostLookupState;
     }
-    if (mSocket_ipV4.state() == QAbstractSocket::HostLookupState || mSocket_ipV6.state() == QAbstractSocket::HostLookupState) {
+    // connectIt() has been called but QHostInfo::lookupHost has not yet
+    // returned, so neither socket has been told to connect.
+    if (mIsLookingUpHost) {
         return QAbstractSocket::HostLookupState;
     }
     if (mSocket_ipV4.state() == QAbstractSocket::ClosingState || mSocket_ipV6.state() == QAbstractSocket::ClosingState) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -500,6 +500,8 @@ void cTelnet::connectIt(const QString& address, int port)
         return;
     }
 
+    // mpHost is a QPointer and can in principle be cleared if the Host is
+    // destroyed mid-connect; slot authors must null-check before dereferencing.
     emit signal_connecting(mpHost);
 
     mHostUrl = address;
@@ -545,6 +547,10 @@ void cTelnet::disconnectIt()
 // Only called from terminateConnection() for a "secure" connection:
 void cTelnet::abortConnection()
 {
+    // Clear the DNS-lookup flag here as well as in slot_socketDisconnected so
+    // the tab's "Connecting" indicator is dropped immediately rather than
+    // lingering until the (asynchronous) disconnect signal arrives.
+    mLookingUpHost = false;
     mDontReconnect = true;
     if (mpSocket) {
         // One socket is probably active - and has signals connected - but will

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -400,7 +400,7 @@ private:
     bool mWaitingForResponse = false;
     // True between connectIt() and slot_socketHostFound, so
     // getConnectionState() reports HostLookupState during DNS lookup.
-    bool mIsLookingUpHost = false;
+    bool mLookingUpHost = false;
     std::queue<int> mCommandQueue;
 
     z_stream mZstream = {};

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -396,6 +396,9 @@ private:
     QString mHostUrl;
     int mHostPort = 0;
     bool mWaitingForResponse = false;
+    // True between connectIt() and slot_socketHostFound, so
+    // getConnectionState() reports HostLookupState during DNS lookup.
+    bool mIsLookingUpHost = false;
     std::queue<int> mCommandQueue;
 
     z_stream mZstream = {};

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7581,6 +7581,10 @@ void mudlet::reattachTab(const QString& profileName, int insertIndex)
     const int newTabIndex = mpTabBar->insertTab(insertIndex, safeProfileName);
     mpTabBar->setTabData(newTabIndex, safeProfileName);
 
+    // Seed the connection indicator immediately so the re-attached tab does
+    // not render without one until slot_tabChanged() runs further down.
+    updateMainWindowTabIndicators();
+
     // Check for duplicate tabs
     int tabCount = 0;
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2159,6 +2159,15 @@ void mudlet::addConsoleForNewHost(Host* pH)
      */
     mpTabBar->setTabData(newTabID, tabName);
 
+    // Caller blocks the event loop next (loadGlobal, installModulesList,
+    // loadMap, ...), so a deferred update() would leave the tab blank until
+    // that finishes. Paint synchronously instead. Seeded as Connecting; the
+    // offline branch of slot_connectionDialogueFinished resets it.
+    if (mShowTabConnectionIndicators) {
+        mpTabBar->setTabConnectionIndicator(newTabID, TabConnectionIndicator::Connecting);
+    }
+    mpTabBar->repaint();
+
     // update the window title for the currently selected profile
     updateMainWindowTitle();
 
@@ -4767,6 +4776,9 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     } else {
         const QString infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
         pHost->postMessage(infoMsg);
+
+        // Reconcile the Connecting placeholder seeded in addConsoleForNewHost.
+        updateMainWindowTabIndicators();
 
         // Bring main window to focus when new profile loads offline
         show();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2090,6 +2090,15 @@ void mudlet::slot_refreshTabIndicatorsDelayed()
     updateDetachedWindowToolbars();
 }
 
+void mudlet::slot_telnetConnectionStateChanged()
+{
+    // Without this the tab connection indicators only refresh on tab change,
+    // toolbar updates, or the 3 s post-load timer, so users typically miss
+    // the brief "Connecting" (yellow) state.
+    updateMainWindowTabIndicators();
+    updateDetachedWindowTabIndicators();
+}
+
 void mudlet::addConsoleForNewHost(Host* pH)
 {
     if (pH->mpConsole) {
@@ -2102,6 +2111,11 @@ void mudlet::addConsoleForNewHost(Host* pH)
     pH->mpConsole = pConsole;
     pConsole->setWindowTitle(pH->getName());
     pConsole->setObjectName(pH->getName());
+
+    // Refresh tab connection indicators on each socket state change.
+    connect(&pH->mTelnet, &cTelnet::signal_connecting, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
+    connect(&pH->mTelnet, &cTelnet::signal_connected, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
+    connect(&pH->mTelnet, &cTelnet::signal_disconnected, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
 
     // Apply Host's console buffer size settings to the newly created console
     int bufferSize = pH->getConsoleBufferSize();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -82,8 +82,6 @@
 #include <QMediaDevices>
 #include <QMediaPlayer>
 #include <QMessageBox>
-#include <QPainter>
-#include <QPixmap>
 #include <QPoint>
 #include <QScreen>
 #include <QScrollBar>
@@ -3372,7 +3370,7 @@ void mudlet::restoreProfileFocus(const QString& profileName)
         auto detachedWindows = mudletInstance->mDetachedWindows;
         TDetachedWindow* detachedWindow = nullptr;
 
-        for (const auto &window : detachedWindows) {
+        for (const auto& window : detachedWindows) {
             if (window && window->getProfileNames().contains(profileName)) {
                 detachedWindow = window;
                 break;
@@ -4953,7 +4951,7 @@ void mudlet::slot_muteMedia()
 
 void mudlet::slot_audioOutputDeviceChanged()
 {
-    for (const auto &pHost : mHostManager) {
+    for (const auto& pHost : mHostManager) {
         if (pHost && pHost->mpMedia) {
             pHost->mpMedia->refreshAudioDevices();
         }
@@ -7765,47 +7763,6 @@ void mudlet::updateDetachedWindowToolbars()
     }
 }
 
-QIcon mudlet::createConnectionStatusIcon(bool isConnected, bool isConnecting, bool hasError)
-{
-    // Create a 16x16 pixmap for the icon
-    QPixmap pixmap(16, 16);
-    pixmap.fill(Qt::transparent);
-
-    QPainter painter(&pixmap);
-    painter.setRenderHint(QPainter::Antialiasing, true);
-
-    // Set up the dot properties
-    const int centerX = 8;
-    const int centerY = 8;
-    const int radius = 4;
-
-    if (hasError) {
-        // Red filled triangle for error
-        painter.setBrush(QColor(220, 50, 50));
-        painter.setPen(QPen(QColor(180, 40, 40), 1));
-        QPolygon triangle;
-        triangle << QPoint(centerX, centerY - 4) << QPoint(centerX - 4, centerY + 3) << QPoint(centerX + 4, centerY + 3);
-        painter.drawPolygon(triangle);
-    } else if (isConnected) {
-        // Green filled circle for connected
-        painter.setBrush(QColor(50, 180, 50));
-        painter.setPen(QPen(QColor(40, 150, 40), 1));
-        painter.drawEllipse(centerX - radius, centerY - radius, radius * 2, radius * 2);
-    } else if (isConnecting) {
-        // Yellow filled circle for connecting
-        painter.setBrush(QColor(220, 180, 50));
-        painter.setPen(QPen(QColor(180, 150, 40), 1));
-        painter.drawEllipse(centerX - radius, centerY - radius, radius * 2, radius * 2);
-    } else {
-        // Empty circle (just outline) for disconnected
-        painter.setBrush(Qt::transparent);
-        painter.setPen(QPen(QColor(120, 120, 120), 2));
-        painter.drawEllipse(centerX - radius, centerY - radius, radius * 2, radius * 2);
-    }
-
-    return QIcon(pixmap);
-}
-
 void mudlet::updateMainWindowTabIndicators()
 {
     if (!mpTabBar) {
@@ -7820,22 +7777,29 @@ void mudlet::updateMainWindowTabIndicators()
         }
 
         Host* pHost = mHostManager.getHost(profileName);
-        QIcon tabIcon;
+        TabConnectionIndicator state = TabConnectionIndicator::None;
 
         // Only show connection indicators if the setting is enabled
-        if (mShowTabConnectionIndicators && pHost) {
-            bool isConnected = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectedState);
-            bool isConnecting = (pHost->mTelnet.getConnectionState() == QAbstractSocket::ConnectingState);
-            tabIcon = createConnectionStatusIcon(isConnected, isConnecting, false);
-        } else if (mShowTabConnectionIndicators && !pHost) {
-            tabIcon = createConnectionStatusIcon(false, false, true);
-        } else {
-            // No icon when indicators are disabled
-            tabIcon = QIcon();
+        if (mShowTabConnectionIndicators) {
+            if (pHost) {
+                switch (pHost->mTelnet.getConnectionState()) {
+                case QAbstractSocket::ConnectedState:
+                    state = TabConnectionIndicator::Connected;
+                    break;
+                case QAbstractSocket::ConnectingState:
+                case QAbstractSocket::HostLookupState:
+                    state = TabConnectionIndicator::Connecting;
+                    break;
+                default:
+                    state = TabConnectionIndicator::Disconnected;
+                    break;
+                }
+            } else {
+                state = TabConnectionIndicator::Error;
+            }
         }
 
-        // Only set the tab icon, keep the original tab text as just the profile name
-        mpTabBar->setTabIcon(i, tabIcon);
+        mpTabBar->setTabConnectionIndicator(i, state);
     }
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -475,7 +475,6 @@ public slots:
     void slot_detachedWindowClosed(const QString& profileName);
     void slot_profileDetachToWindow(const QString& profileName, TDetachedWindow* targetWindow);
     void updateDetachedWindowToolbars();
-    static QIcon createConnectionStatusIcon(bool isConnected, bool isConnecting, bool hasError);
     void updateMainWindowTabIndicators();
     void updateMainWindowTabBarAutoHide();
     void updateTabIndicators();               // Update all tab indicators (main window)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -552,6 +552,7 @@ private slots:
     void slot_updateShortcuts();
     void slot_windowStateChanged(const Qt::WindowStates);
     void slot_refreshTabIndicatorsDelayed();
+    void slot_telnetConnectionStateChanged();
 
 
 private:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Replaces the QIcon-based tab connection indicators with a custom-painted dot drawn directly by the tab style. On macOS the previous implementation triggered the native style's large icon padding, which ellipsized tab text and added unwanted right-side margin. The new approach reserves a small fixed amount of space next to the tab's leading close button and paints the dot/triangle there, so tab labels get the room they need on every platform.

The indicators also now refresh as soon as the underlying socket changes state, so the brief yellow "Connecting" stage is actually visible instead of being missed between the previous sparse refresh points.

#### Motivation for adding to Mudlet

Restores readable tab titles on macOS when "Show connection status on tabs" is enabled, while keeping the same colour-coded connection indicators users are familiar with - and making the "Connecting" state usefully visible.

#### Other info (issues closed, discussion etc)

Closes #9213.