### PR TITLE
Fix: Clazy warnings part 1A (more) - range-loop-detach

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1957,7 +1957,7 @@ void T2DMap::drawGridModeRooms(QPainter& painter,
             // QLinearGradient (Qt::blue at alpha ~180 gives an equivalent look
             // over the env base colour that was already written into lodImage).
             const QColor selectionTint(0, 0, 255, 180);
-            for (const int selId : mMultiSelectionSet) {
+            for (const int selId : std::as_const(mMultiSelectionSet)) {
                 TRoom* room = mpMap->mpRoomDB->getRoom(selId);
                 if (!room || room->z() != zLevel) {
                     continue;

--- a/test/TMxpSendTagHandlerTest.cpp
+++ b/test/TMxpSendTagHandlerTest.cpp
@@ -43,7 +43,7 @@ private slots:
 
     auto nodes = TMxpTagParser::parseToMxpNodeList(input, false);
     QCOMPARE(nodes.size(), 3);
-    for (const auto &node : nodes) {
+    for (const auto &node : std::as_const(nodes)) {
       processor.handleNode(processor, stub, node.get());
     }
 
@@ -130,7 +130,7 @@ private slots:
     TMxpStubClient stub;
 
     auto nodes = TMxpTagParser::parseToMxpNodeList(input, false);
-    for (const auto &node : nodes) {
+    for (const auto &node : std::as_const(nodes)) {
       processor.handleNode(processor, stub, node.get());
     }
 

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -564,7 +564,7 @@ private slots:
       QList<QTreeWidgetItem *> items;
       items << folder << child1 << child2;
       itemType.treeWidget()->clearSelection();
-      for (auto *item : items) {
+      for (auto *item : std::as_const(items)) {
         item->setSelected(true);
       }
       itemType.treeWidget()->setCurrentItem(folder);
@@ -603,7 +603,7 @@ private slots:
       QList<QTreeWidgetItem *> items;
       items << folder << folder->child(0);
       itemType.treeWidget()->clearSelection();
-      for (auto *item : items) {
+      for (auto *item : std::as_const(items)) {
         item->setSelected(true);
       }
       itemType.treeWidget()->setCurrentItem(folder);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is some further: "C+11 range-loop might detach Qt container [clazy-range-loop-detach]" type ones.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
This is a supplement to PR #9195.