### PR TITLE
Fix: low-contrast input fields in dark mode on macOS

### DIFF
--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -37,9 +37,6 @@ void DarkTheme::polish(QPalette& palette)
     // modify palette to dark
     palette.setColor(QPalette::Window, QColor(53, 53, 53));
     palette.setColor(QPalette::WindowText, Qt::white);
-    // Base must be noticeably darker than Window so input widgets stand out
-    // from the dialog background; AlternateBase is offset to keep list/tree
-    // row striping visible. Issue #9214.
     palette.setColor(QPalette::Base, QColor(25, 25, 25));
     palette.setColor(QPalette::AlternateBase, QColor(40, 40, 40));
     palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -37,8 +37,12 @@ void DarkTheme::polish(QPalette& palette)
     // modify palette to dark
     palette.setColor(QPalette::Window, QColor(53, 53, 53));
     palette.setColor(QPalette::WindowText, Qt::white);
-    palette.setColor(QPalette::Base, QColor(42, 42, 42));
-    palette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
+    // Base is noticeably darker than Window so input fields (QLineEdit,
+    // QPlainTextEdit, QListWidget, ...) are clearly distinguishable from the
+    // surrounding dialog background, and Mid (45,45,45) reads as a visible
+    // border between them. See issue #9214.
+    palette.setColor(QPalette::Base, QColor(25, 25, 25));
+    palette.setColor(QPalette::AlternateBase, QColor(35, 35, 35));
     palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
     palette.setColor(QPalette::ToolTipText, Qt::white);
     palette.setColor(QPalette::Text, Qt::white);

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -40,9 +40,10 @@ void DarkTheme::polish(QPalette& palette)
     // Base is noticeably darker than Window so input fields (QLineEdit,
     // QPlainTextEdit, QListWidget, ...) are clearly distinguishable from the
     // surrounding dialog background, and Mid (45,45,45) reads as a visible
-    // border between them. See issue #9214.
+    // border between them. AlternateBase is offset 15 units from Base so list
+    // and tree row striping stays visible. See issue #9214.
     palette.setColor(QPalette::Base, QColor(25, 25, 25));
-    palette.setColor(QPalette::AlternateBase, QColor(35, 35, 35));
+    palette.setColor(QPalette::AlternateBase, QColor(40, 40, 40));
     palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
     palette.setColor(QPalette::ToolTipText, Qt::white);
     palette.setColor(QPalette::Text, Qt::white);

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -37,11 +37,9 @@ void DarkTheme::polish(QPalette& palette)
     // modify palette to dark
     palette.setColor(QPalette::Window, QColor(53, 53, 53));
     palette.setColor(QPalette::WindowText, Qt::white);
-    // Base is noticeably darker than Window so input fields (QLineEdit,
-    // QPlainTextEdit, QListWidget, ...) are clearly distinguishable from the
-    // surrounding dialog background, and Mid (45,45,45) reads as a visible
-    // border between them. AlternateBase is offset 15 units from Base so list
-    // and tree row striping stays visible. See issue #9214.
+    // Base must be noticeably darker than Window so input widgets stand out
+    // from the dialog background; AlternateBase is offset to keep list/tree
+    // row striping visible. Issue #9214.
     palette.setColor(QPalette::Base, QColor(25, 25, 25));
     palette.setColor(QPalette::AlternateBase, QColor(40, 40, 40));
     palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Darkens `QPalette::Base` (and `AlternateBase`) in the custom Fusion-based dark theme so input fields like `QLineEdit`, `QPlainTextEdit`, and `QListWidget` are clearly distinguishable from the surrounding dialog (`QPalette::Window`) background. `QPalette::Mid` (45,45,45) now reads as a visible border between the two.

Before #8847, macOS used the native dark style which already provided this contrast. The switch to the Fusion-based `DarkTheme` exposed the existing `Base` colour (42,42,42), which is too close to `Window` (53,53,53). The effect is most visible on dialogs that don't wrap inputs in a lighter container, such as the Scripts and Timers main areas.

#### Motivation for adding to Mudlet

Restores readable input fields in dark mode on macOS Tahoe, matching the contrast users had in 4.20.1 and earlier.

#### Other info (issues closed, discussion etc)

Closes #9214.

---

**Before**

<img width="1728" height="1020" alt="Screenshot 2026-04-25 at 4 06 50 PM" src="https://github.com/user-attachments/assets/697b04be-b9e5-412a-8287-57bfe842cfea" />

---

**After**

<img width="1728" height="1034" alt="Screenshot 2026-04-25 at 4 10 58 PM" src="https://github.com/user-attachments/assets/26cad5e0-830a-4d8e-87a4-6dc9842385b4" />
