### PR TITLE
Fix: Clazy warnings part 7 - isempty-vs-count

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4340,7 +4340,7 @@ void T2DMap::slot_undoCustomLineLastPoint()
     if (mCustomLinesRoomFrom > 0) {
         TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
         if (room) {
-            if (room->customLines.value(mCustomLinesRoomExit).count() > 0) {
+            if (!room->customLines.value(mCustomLinesRoomExit).isEmpty()) {
                 room->customLines[mCustomLinesRoomExit].pop_back();
             }
             room->calcRoomDimensions();

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -399,7 +399,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
             }
             lua_pop(L, 1);
         }
-        if (!i || !x.count()) {
+        if (!i || x.isEmpty()) {
             // If there is only an empty sub-table inside the table then i is
             // one but there is nothing in any of the QLists and things will
             // still blow up as per Issue #5272 - so also check for at least one

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1357,7 +1357,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             ofs << pR->mSymbol;
         } else {
             qint8 oldCharacterCode = 0;
-            if (pR->mSymbol.length()) {
+            if (!pR->mSymbol.isEmpty()) {
                 // There is something for a symbol
                 const QChar firstChar = pR->mSymbol.at(0);
                 if (pR->mSymbol.length() == 1 && firstChar.row() == 0 && firstChar.cell() > 32) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -89,7 +89,7 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
     // to set up the initial encoder
     encodingChanged("UTF-8");
     termType = qsl("Mudlet " APP_VERSION);
-    if (mudlet::self()->mAppBuild.trimmed().length()) {
+    if (!mudlet::self()->mAppBuild.trimmed().isEmpty()) {
         termType.append(mudlet::self()->mAppBuild);
     }
 
@@ -758,7 +758,7 @@ void cTelnet::slot_socketDisconnected()
                 }
             }
 
-            if (reasons.count()) {
+            if (!reasons.isEmpty()) {
                 /*: This message is used when we have been trying to connect or
  we were connected securely, but the connection has been lost.
  It is possible with a secure connection that there is MORE
@@ -1770,7 +1770,7 @@ QString cTelnet::getNewEnvironClientVersion()
     static const auto allInvalidCharacters = QRegularExpression(qsl("[^A-Z,0-9,-,\\/]"));
     static const auto multipleHyphens = QRegularExpression(qsl("-{2,}"));
 
-    if (auto build = mudlet::self()->mAppBuild; build.trimmed().length()) {
+    if (auto build = mudlet::self()->mAppBuild; !build.trimmed().isEmpty()) {
         clientVersion.append(build);
     }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -384,7 +384,7 @@ void dlgConnectionProfiles::slot_updateDescription()
 
 void dlgConnectionProfiles::indicatePackagesInstallOnConnect(QStringList packages)
 {
-    if (!packages.length()) {
+    if (packages.isEmpty()) {
         return;
     }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1249,7 +1249,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             ssl_expires_label->setStyleSheet(QString());
 
             const QList<QSslError> sslErrors = pHost->mTelnet.getSslErrors();
-            if (sslErrors.count()) {
+            if (!sslErrors.isEmpty()) {
                 // handle ssl errors
                 notificationAreaIconLabelWarning->show();
                 frame_notificationArea->show();

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -302,7 +302,7 @@ void dlgRoomExits::slot_endEditSpecialExits()
     if (mpEditItem != nullptr && mEditColumn >= 0) {
         specialExits->closePersistentEditor(mpEditItem, mEditColumn);
         // Restore placeholder text for the exitRoomID field
-        if (mEditColumn == ExitsTreeWidget::colIndex_exitRoomId && !mpEditItem->text(ExitsTreeWidget::colIndex_exitRoomId).trimmed().length()) {
+        if (mEditColumn == ExitsTreeWidget::colIndex_exitRoomId && mpEditItem->text(ExitsTreeWidget::colIndex_exitRoomId).trimmed().isEmpty()) {
             mpEditItem->setText(ExitsTreeWidget::colIndex_exitRoomId, mSpecialExitRoomIdPlaceholder);
         }
         mpEditItem = nullptr;
@@ -369,7 +369,7 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
             break;
 
         case ExitsTreeWidget::colIndex_command:
-            if (!mpEditItem->text(ExitsTreeWidget::colIndex_command).trimmed().length()) {
+            if (mpEditItem->text(ExitsTreeWidget::colIndex_command).trimmed().isEmpty()) {
                 // Restore the placeholder text if there is nothing but spaces in the entry:
                 mpEditItem->setText(ExitsTreeWidget::colIndex_command, mSpecialExitCommandPlaceholder);
             }
@@ -1050,7 +1050,7 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
 
 /* static */ QString dlgRoomExits::generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool exitRoomLocked, const bool outOfAreaExit, const int exitRoomWeight)
 {
-    if (exitRoomName.trimmed().length()) {
+    if (!exitRoomName.trimmed().isEmpty()) {
         if (exitRoomLocked) {
             if (outOfAreaExit) {
                 return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".").arg(exitRoomName.toHtmlEscaped(), exitAreaName.toHtmlEscaped()),
@@ -1626,7 +1626,7 @@ void dlgRoomExits::init()
     mAreaID = pR->getArea();
     roomWeight->setText(QString::number(pR->getWeight()));
     QString titleText;
-    if (pR->name.trimmed().length()) {
+    if (!pR->name.trimmed().isEmpty()) {
         titleText = tr(R"(Exits for room: "%1" [*])").arg(pR->name);
     } else {
         titleText = tr("Exits for room Id: %1 [*]").arg(mRoomID);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "Use isEmpty() instead [-Wclazy-isempty-vs-count]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
A summary I found for this is:
> Using isEmpty() is preferred over comparing count to zero because it is more efficient and improves code readability. This is especially important for collections that do not implement `RandomAccessCollection`, as counting elements can be costly.

However a conflicting alternative merely suggests that only the semantics are better reflect by the use of `isEmpty` - there is no difference in performance - and the first bit is certainly the basis of our (Mudlet Core Devs) existing preference for it.