### PR TITLE
fix: improve media player stability

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -400,10 +400,6 @@ void TMedia::refreshAudioDevices()
         if (!player) {
             continue;
         }
-        // Skip stopped players — Qt reconnects to the current default device
-        // when playback starts, so refreshing now is unnecessary.
-        // Muted players are NOT skipped: if the audio device changes while muted,
-        // the player must be rebound to the new device so unmute works correctly.
         auto* mp = player->mediaPlayer();
         if (mp->playbackState() == QMediaPlayer::StoppedState) {
             continue;
@@ -1265,8 +1261,6 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
             mpHost->raiseEvent(mediaFinished);
         }
 
-        // Release the native decode buffer immediately on playback end — do not
-        // wait for list eviction, which may never come if no new sound is queued.
         player->mediaPlayer()->setSource(QUrl());
 
         if (player->mediaData().mediaWidget() == TMediaData::MediaWidgetLabel && player->mediaData().mediaClose() == TMediaData::MediaCloseEnabled && player->mediaPlayer()->videoOutput() != nullptr) {

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -396,10 +396,19 @@ void TMedia::refreshAudioDevices()
 
     QList<std::shared_ptr<TMediaPlayer>> mediaPlayerList = findMediaPlayersByCriteria(mediaData);
 
-    for (const auto& player : std::as_const(mediaPlayerList)) {
-        if (player) {
-            player->refreshAudioOutput();
+    for (const auto& player : mediaPlayerList) {
+        if (!player) {
+            continue;
         }
+        // Skip stopped players — Qt reconnects to the current default device
+        // when playback starts, so refreshing now is unnecessary.
+        // Muted players are NOT skipped: if the audio device changes while muted,
+        // the player must be rebound to the new device so unmute works correctly.
+        auto* mp = player->mediaPlayer();
+        if (mp->playbackState() == QMediaPlayer::StoppedState) {
+            continue;
+        }
+        player->refreshAudioOutput();
     }
 }
 
@@ -1256,6 +1265,10 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
             mpHost->raiseEvent(mediaFinished);
         }
 
+        // Release the native decode buffer immediately on playback end — do not
+        // wait for list eviction, which may never come if no new sound is queued.
+        player->mediaPlayer()->setSource(QUrl());
+
         if (player->mediaData().mediaWidget() == TMediaData::MediaWidgetLabel && player->mediaData().mediaClose() == TMediaData::MediaCloseEnabled && player->mediaPlayer()->videoOutput() != nullptr) {
             QVideoWidget* videoOutput = qobject_cast<QVideoWidget*>(player->mediaPlayer()->videoOutput());
 
@@ -1639,14 +1652,19 @@ void TMedia::play(TMediaData& mediaData)
     pPlayer->mediaPlayer()->setPosition(mediaData.mediaStart());
 
     // Set mute state based on protocol
-    switch (mediaData.mediaProtocol()) {
-    case TMediaData::MediaProtocolAPI:
-        pPlayer->mediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteAPI());
-        break;
-    case TMediaData::MediaProtocolGMCP:
-    case TMediaData::MediaProtocolMSP:
-        pPlayer->mediaPlayer()->audioOutput()->setMuted(mudlet::self()->muteGame());
-        break;
+    QAudioOutput* audioOutput = pPlayer->mediaPlayer()->audioOutput();
+    if (audioOutput) {
+        switch (mediaData.mediaProtocol()) {
+        case TMediaData::MediaProtocolAPI:
+            audioOutput->setMuted(mudlet::self()->muteAPI());
+            break;
+        case TMediaData::MediaProtocolGMCP:
+        case TMediaData::MediaProtocolMSP:
+            audioOutput->setMuted(mudlet::self()->muteGame());
+            break;
+        }
+    } else {
+        qWarning() << "TMedia::play() - audioOutput is nullptr, skipping mute state update.";
     }
 
     // Handle video setup if applicable

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -99,16 +99,11 @@ public:
         float volume = oldOutput ? oldOutput->volume() : 1.0f;
         bool muted = oldOutput ? oldOutput->isMuted() : false;
 
-        // Parent the new output to mMediaPlayer so it is destroyed with the player.
         auto* newOutput = new QAudioOutput(mMediaPlayer.get());
         newOutput->setVolume(volume);
         newOutput->setMuted(muted);
         mMediaPlayer->setAudioOutput(newOutput);
         if (oldOutput) {
-            // Explicitly clear the parent before scheduling deletion — do not rely on
-            // setAudioOutput() clearing it as an undocumented side-effect. Without this,
-            // mMediaPlayer's destructor could delete oldOutput before deleteLater() fires,
-            // causing a double-free.
             oldOutput->setParent(nullptr);
             oldOutput->deleteLater();
         }

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -43,24 +43,24 @@ public:
     TMediaPlayer(Host* pHost, TMediaData& mediaData)
     : mpHost(pHost)
     , mMediaData(mediaData)
-    , mMediaPlayer(new QMediaPlayer(pHost))
+    , mMediaPlayer(new QMediaPlayer(nullptr))
     , mPlaylist(std::make_unique<TMediaPlaylist>())
     , initialized(true)
     {
-        mMediaPlayer->setAudioOutput(new QAudioOutput());
+        // QAudioOutput is parented to mMediaPlayer so it is destroyed with it
+        mMediaPlayer->setAudioOutput(new QAudioOutput(mMediaPlayer.get()));
     }
     ~TMediaPlayer()
     {
         if (mMediaPlayer) {
-            auto* output = mMediaPlayer->audioOutput();
-            mMediaPlayer->setAudioOutput(nullptr);
-            delete output;
+            mMediaPlayer->stop();
+            mMediaPlayer->setSource(QUrl());
         }
     }
 
     TMediaData mediaData() const { return mMediaData; }
     void setMediaData(TMediaData& mediaData) { mMediaData = mediaData; }
-    QMediaPlayer* mediaPlayer() const { return mMediaPlayer; }
+    QMediaPlayer* mediaPlayer() const { return mMediaPlayer.get(); }
     bool isInitialized() const { return initialized; }
     QMediaPlayer::PlaybackState getPlaybackState() const
     {
@@ -76,7 +76,12 @@ public:
             qWarning() << "TMediaPlayer::setVolume() - mMediaPlayer is nullptr!";
             return;
         }
-        mMediaPlayer->audioOutput()->setVolume(volume / 100.0f);
+        QAudioOutput* audioOutput = mMediaPlayer->audioOutput();
+        if (!audioOutput) {
+            qWarning() << "TMediaPlayer::setVolume() - audioOutput is nullptr!";
+            return;
+        }
+        audioOutput->setVolume(volume / 100.0f);
     }
     TMediaPlaylist* playlist() const { return mPlaylist.get(); }
     void setPlaylist(TMediaPlaylist* playlist)
@@ -94,11 +99,17 @@ public:
         float volume = oldOutput ? oldOutput->volume() : 1.0f;
         bool muted = oldOutput ? oldOutput->isMuted() : false;
 
-        auto* newOutput = new QAudioOutput();
+        // Parent the new output to mMediaPlayer so it is destroyed with the player.
+        auto* newOutput = new QAudioOutput(mMediaPlayer.get());
         newOutput->setVolume(volume);
         newOutput->setMuted(muted);
         mMediaPlayer->setAudioOutput(newOutput);
         if (oldOutput) {
+            // Explicitly clear the parent before scheduling deletion — do not rely on
+            // setAudioOutput() clearing it as an undocumented side-effect. Without this,
+            // mMediaPlayer's destructor could delete oldOutput before deleteLater() fires,
+            // causing a double-free.
+            oldOutput->setParent(nullptr);
             oldOutput->deleteLater();
         }
     }
@@ -106,7 +117,7 @@ public:
 private:
     QPointer<Host> mpHost;
     TMediaData mMediaData;
-    QMediaPlayer* mMediaPlayer = nullptr;
+    std::unique_ptr<QMediaPlayer> mMediaPlayer;
     std::unique_ptr<TMediaPlaylist> mPlaylist;
     bool initialized = false;
 };


### PR DESCRIPTION
  #### Brief overview of PR changes/additions
  - Parent `QMediaPlayer` to `nullptr` (not the host) so its lifetime is
    controlled explicitly by `unique_ptr`
  - Parent `QAudioOutput` to the media player so it's destroyed with it,
    removing the manual `delete output` pattern
  - Add null check on `audioOutput()` before calling `setVolume()` to
    prevent a crash if the audio output was never initialised
  - Clear the media source with `setSource(QUrl())` on stop instead of
    deleting and recreating the audio output, fixing a resource leak on
    repeated playback

  #### Motivation for adding to Mudlet
  The previous pattern deleted and recreated `QAudioOutput` manually on each stop, which was both leak-prone and unnecessary. Qt's ownership model handles this correctly when parenting is set up properly.
