### PR TITLE
improve: improve memory safety by using smart pointers

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -422,7 +422,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     auto i = mudlet::self()->mpShortcutsManager->iterator();
     while (i.hasNext()) {
         auto entry = i.next();
-        profileShortcuts.insert(entry, new QKeySequence(*mudlet::self()->mpShortcutsManager->getSequence(entry)));
+        profileShortcuts[entry] = std::make_unique<QKeySequence>(*mudlet::self()->mpShortcutsManager->getSequence(entry));
     }
 
     auto settings = mudlet::self()->getQSettings();
@@ -440,13 +440,7 @@ Host::~Host()
     // which can lead to a crash when closing multiple profiles at once.
     mpLastCommandLineUsed.clear();
 
-    qDeleteAll(profileShortcuts);
-    profileShortcuts.clear();
-
-    qDeleteAll(mStopWatchMap);
     mStopWatchMap.clear();
-
-    delete mMMCPServer;
 
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
@@ -1444,46 +1438,41 @@ QPair<int, QString> Host::createStopWatch(const QString& name)
         return qMakePair(0, qsl("unable to create a stopwatch at this time"));
     }
 
-    if (!mStopWatchMap.isEmpty() && !name.isEmpty()) {
-        QMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
-        while (itStopWatch.hasNext()) {
-            itStopWatch.next();
-            if (itStopWatch.value()->name() == name) {
-                return qMakePair(0, qsl("stopwatch with id %1 called '%2' already exists").arg(QString::number(itStopWatch.key()), name));
+    if (!mStopWatchMap.empty() && !name.isEmpty()) {
+        for (auto it = mStopWatchMap.cbegin(); it != mStopWatchMap.cend(); ++it) {
+            if (it->second->name() == name) {
+                return qMakePair(0, qsl("stopwatch with id %1 called '%2' already exists").arg(QString::number(it->first), name));
             }
         }
     }
     int newWatchId = 1;
-    while (mStopWatchMap.contains(newWatchId)) {
+    while (mStopWatchMap.count(newWatchId) > 0) {
         ++newWatchId;
     }
 
-    // It is hard to imagine a situation in which this will fail - so we won't
-    // bother coding for it:
-    auto pStopWatch = new stopWatch();
-    Q_ASSERT_X(pStopWatch, "Host::createStopWatch", "out of memory, unable to create new stopwatch");
+    auto pStopWatch = std::make_unique<stopWatch>();
     if (!name.isEmpty()) {
         pStopWatch->setName(name);
     }
 
-    mStopWatchMap.insert(newWatchId, pStopWatch);
+    mStopWatchMap[newWatchId] = std::move(pStopWatch);
     return qMakePair(newWatchId, QString());
 }
 
 bool Host::destroyStopWatch(const int id)
 {
-    auto pStopWatch = mStopWatchMap.take(id);
-    if (!pStopWatch) {
+    auto it = mStopWatchMap.find(id);
+    if (it == mStopWatchMap.end()) {
         return false;
     }
 
-    delete pStopWatch;
+    mStopWatchMap.erase(it);
     return true;
 }
 
 bool Host::adjustStopWatch(const int id, const qint64 milliSeconds)
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         pStopWatch->adjustMilliSeconds(milliSeconds);
         return true;
@@ -1497,16 +1486,10 @@ bool Host::adjustStopWatch(const int id, const qint64 milliSeconds)
 // unnamed one if a blank string is given:
 int Host::findStopWatchId(const QString& name) const
 {
-    // Scan through existing names, in ascending id order
-    QList<int> stopWatchIdList = mStopWatchMap.keys();
-    const int total = stopWatchIdList.size();
-    if (total > 1) {
-        std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
-    }
-    for (const int currentId : std::as_const(stopWatchIdList)) {
-        auto pCurrentStopWatch = mStopWatchMap.value(currentId);
-        if (pCurrentStopWatch->name() == name) {
-            return currentId;
+    // Scan through existing names, in ascending id order (std::map is sorted)
+    for (auto it = mStopWatchMap.cbegin(); it != mStopWatchMap.cend(); ++it) {
+        if (it->second->name() == name) {
+            return it->first;
         }
     }
     return 0;
@@ -1514,7 +1497,7 @@ int Host::findStopWatchId(const QString& name) const
 
 QPair<bool, double> Host::getStopWatchTime(const int id) const
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         return qMakePair(true, pStopWatch->getElapsedMilliSeconds() / 1000.0);
     }
@@ -1523,7 +1506,7 @@ QPair<bool, double> Host::getStopWatchTime(const int id) const
 
 QPair<bool, QString> Host::getBrokenDownStopWatchTime(const int id) const
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         return qMakePair(true, pStopWatch->getElapsedDayTimeString());
     }
@@ -1540,7 +1523,7 @@ QPair<bool, QString> Host::startStopWatch(const QString& name)
         return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
     }
 
-    auto pStopWatch = mStopWatchMap.value(watchId);
+    auto pStopWatch = getStopWatch(watchId);
     if (Q_LIKELY(pStopWatch)) {
         if (pStopWatch->start()) {
             return qMakePair(true, QString());
@@ -1556,7 +1539,7 @@ QPair<bool, QString> Host::startStopWatch(const QString& name)
 
 QPair<bool, QString> Host::startStopWatch(int id)
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         if (pStopWatch->start()) {
             return qMakePair(true, QString());
@@ -1578,7 +1561,7 @@ QPair<bool, QString> Host::stopStopWatch(const QString& name)
         return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
     }
 
-    auto pStopWatch = mStopWatchMap.value(watchId);
+    auto pStopWatch = getStopWatch(watchId);
     if (Q_LIKELY(pStopWatch)) {
         if (pStopWatch->stop()) {
             return qMakePair(true, QString());
@@ -1594,7 +1577,7 @@ QPair<bool, QString> Host::stopStopWatch(const QString& name)
 
 QPair<bool, QString> Host::stopStopWatch(const int id)
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         if (pStopWatch->stop()) {
             return qMakePair(true, QString());
@@ -1616,7 +1599,7 @@ QPair<bool, QString> Host::resetStopWatch(const QString& name)
         return qMakePair(false, qsl("stopwatch with name '%1' not found").arg(name));
     }
 
-    auto pStopWatch = mStopWatchMap.value(watchId);
+    auto pStopWatch = getStopWatch(watchId);
     if (Q_LIKELY(pStopWatch)) {
         if (pStopWatch->reset()) {
             return qMakePair(true, QString());
@@ -1635,7 +1618,7 @@ QPair<bool, QString> Host::resetStopWatch(const QString& name)
 
 QPair<bool, QString> Host::resetStopWatch(const int id)
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         if (pStopWatch->reset()) {
             return qMakePair(true, QString());
@@ -1652,7 +1635,7 @@ QPair<bool, QString> Host::resetStopWatch(const int id)
 // not a text name:
 QPair<bool, QString> Host::resetAndRestartStopWatch(const int id)
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         pStopWatch->stop();
         pStopWatch->reset();
@@ -1665,7 +1648,7 @@ QPair<bool, QString> Host::resetAndRestartStopWatch(const int id)
 
 bool Host::makeStopWatchPersistent(const int id, const bool state)
 {
-    auto pStopWatch = mStopWatchMap.value(id);
+    auto pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         pStopWatch->setPersistent(state);
         return true;
@@ -1679,12 +1662,10 @@ QPair<bool, QString> Host::setStopWatchName(const int id, const QString& newName
     stopWatch* pStopWatch = nullptr;
     if (!newName.isEmpty()) {
         // Scan through existing names
-        QMutableMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
-        while (itStopWatch.hasNext()) {
-            itStopWatch.next();
-            if (itStopWatch.value()->name() == newName) {
-                if (itStopWatch.key() != id) {
-                    return qMakePair(false, qsl("the name '%1' is already in use for another stopwatch (id:%2)").arg(newName, QString::number(itStopWatch.key())));
+        for (auto it = mStopWatchMap.cbegin(); it != mStopWatchMap.cend(); ++it) {
+            if (it->second->name() == newName) {
+                if (it->first != id) {
+                    return qMakePair(false, qsl("the name '%1' is already in use for another stopwatch (id:%2)").arg(newName, QString::number(it->first)));
                 } else {
                     // Trivial case - the stopwatch is already called by the NEW name:
                     return qMakePair(true, QString());
@@ -1693,7 +1674,7 @@ QPair<bool, QString> Host::setStopWatchName(const int id, const QString& newName
         }
     }
 
-    pStopWatch = mStopWatchMap.value(id);
+    pStopWatch = getStopWatch(id);
     if (pStopWatch) {
         // Okay found the one we want:
         pStopWatch->setName(newName);
@@ -1706,12 +1687,6 @@ QPair<bool, QString> Host::setStopWatchName(const int id, const QString& newName
 QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QString& newName)
 {
     stopWatch* pStopWatch = nullptr;
-    // Scan through existing names, in ascending id order
-    QList<int> stopWatchIdList = mStopWatchMap.keys();
-    const int total = stopWatchIdList.size();
-    if (total > 1) {
-        std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
-    }
     int id = 0;
     // Although it would be quicker code to return immediately if we detect the
     // newName is in use the run-time error about it being used will mask a
@@ -1721,9 +1696,10 @@ QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QS
     bool isAlreadyUsed = false;
     int alreadyUsedId = 0;
     // we are looking BOTH for the current name and checking that any other
-    // ones WITH names do not match the new name:
-    for (const int currentId : std::as_const(stopWatchIdList)) {
-        auto pCurrentStopWatch = mStopWatchMap.value(currentId);
+    // ones WITH names do not match the new name (std::map is sorted by key):
+    for (auto it = mStopWatchMap.cbegin(); it != mStopWatchMap.cend(); ++it) {
+        const int currentId = it->first;
+        stopWatch* pCurrentStopWatch = it->second.get();
         // This will also pick up the FIRST (lowest id) currently unnamed
         // stopwatch:
         if (!id && pCurrentStopWatch->name() == currentName) {
@@ -1761,7 +1737,12 @@ QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QS
 
 QList<int> Host::getStopWatchIds() const
 {
-    return mStopWatchMap.keys();
+    QList<int> ids;
+    ids.reserve(static_cast<int>(mStopWatchMap.size()));
+    for (auto it = mStopWatchMap.cbegin(); it != mStopWatchMap.cend(); ++it) {
+        ids.append(it->first);
+    }
+    return ids;
 }
 
 void Host::incomingStreamProcessor(const QString& data, int line)
@@ -3313,16 +3294,13 @@ void Host::setName(const QString& name)
 
 void Host::removeAllNonPersistentStopWatches()
 {
-    QMutableMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
-    while (itStopWatch.hasNext()) {
-        itStopWatch.next();
-        auto pStopWatch = itStopWatch.value();
-        if (!pStopWatch || pStopWatch->persistent()) {
+    auto it = mStopWatchMap.begin();
+    while (it != mStopWatchMap.end()) {
+        if (!it->second || it->second->persistent()) {
+            ++it;
             continue;
         }
-
-        itStopWatch.remove();
-        delete pStopWatch;
+        it = mStopWatchMap.erase(it);
     }
 }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -50,6 +50,8 @@
 #include <QStack>
 #include <QTextStream>
 
+#include <memory>
+
 #include "TMxpMudlet.h"
 #include "TMxpProcessor.h"
 #include "TMxpFrameManager.h"
@@ -284,7 +286,11 @@ public:
     QPair<bool, QString> startStopWatch(const QString&);
     QPair<bool, QString> stopStopWatch(const int);
     QPair<bool, QString> stopStopWatch(const QString&);
-    stopWatch* getStopWatch(const int id) const { return mStopWatchMap.value(id); }
+    stopWatch* getStopWatch(const int id) const
+    {
+        auto it = mStopWatchMap.find(id);
+        return (it != mStopWatchMap.end()) ? it->second.get() : nullptr;
+    }
     int findStopWatchId(const QString&) const;
     QPair<bool, QString> setStopWatchName(const int, const QString&);
     QPair<bool, QString> setStopWatchName(const QString&, const QString&);
@@ -814,7 +820,7 @@ public:
     // string list: 0 - event name, 1 - display label, 2 - tooltip text
     QMap<QString, QStringList> mConsoleActions;
 
-    QMap<QString, QKeySequence*> profileShortcuts;
+    std::map<QString, std::unique_ptr<QKeySequence>> profileShortcuts;
 
     bool mTutorialForCompactLineAlreadyShown = false;
 
@@ -928,7 +934,7 @@ private:
     // createStopWatch() to return 0 during script loading so that we do not get
     // superious stopwatches from being created then (when
     // mIsProfileLoadingSequence is true):
-    QMap<int, stopWatch*> mStopWatchMap;
+    std::map<int, std::unique_ptr<stopWatch>> mStopWatchMap;
 
     QMap<QString, QStringList> mAnonymousEventHandlerFunctions;
 

--- a/src/MMCPServer.cpp
+++ b/src/MMCPServer.cpp
@@ -36,7 +36,7 @@
 #include <QVariant>
 
 MMCPServer::MMCPServer(Host* pHost)
-: QTcpServer()
+: QTcpServer(pHost)
 , mpHost(pHost)
 {
 }

--- a/src/RoomContextMenuHandler.cpp
+++ b/src/RoomContextMenuHandler.cpp
@@ -75,7 +75,7 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
     popup->setAttribute(Qt::WA_DeleteOnClose);
     mMapWidget.registerContextMenu(popup);
 
-    auto* roomDatabase = mMapWidget.mpMap->mpRoomDB;
+    auto* roomDatabase = mMapWidget.mpMap->mpRoomDB.get();
     if (!roomDatabase || roomDatabase->isEmpty()) {
         // No map loaded
         if (!mMapWidget.mpMap->getMmpMapLocation().isEmpty()) {

--- a/src/RoomMoveDragHandler.cpp
+++ b/src/RoomMoveDragHandler.cpp
@@ -75,7 +75,7 @@ bool RoomMoveDragHandler::handle(T2DMap::MapInteractionContext& context)
 
     mMapWidget.mMultiRect = QRect(0, 0, 0, 0);
 
-    auto* roomDb = mMapWidget.mpMap->mpRoomDB;
+    auto* roomDb = mMapWidget.mpMap->mpRoomDB.get();
     if (!roomDb->getRoom(mMapWidget.mRoomID)) {
         return false;
     }

--- a/src/ShortcutsManager.cpp
+++ b/src/ShortcutsManager.cpp
@@ -20,32 +20,21 @@
 
 #include "ShortcutsManager.h"
 
-ShortcutsManager::~ShortcutsManager()
-{
-    // Only delete the defaults map - these are heap-allocated copies we own.
-    // Do NOT delete the shortcuts map - those are pointers to mudlet's member variables.
-    QMutableMapIterator<QString, QKeySequence*> itDefault(defaults);
-    while (itDefault.hasNext()) {
-        itDefault.next();
-        auto pKeySequence = itDefault.value();
-        delete pKeySequence;
-        itDefault.remove();
-    }
-}
+ShortcutsManager::~ShortcutsManager() = default;
 
 void ShortcutsManager::registerShortcut(const QString& key, const QString& translation, QKeySequence* sequence)
 {
     shortcutKeys << key;
     shortcuts.insert(key, sequence);
     translations.insert(key, translation);
-    defaults.insert(key, new QKeySequence(*sequence));
+    defaults[key] = std::make_unique<QKeySequence>(*sequence);
 }
 
 void ShortcutsManager::setShortcut(const QString& key, QKeySequence* sequence)
 {
-    QKeySequence* newSequence = new QKeySequence(*sequence);
-    shortcuts.value(key)->swap(*newSequence);
-    delete newSequence;
+    if (auto* existing = shortcuts.value(key)) {
+        *existing = *sequence;
+    }
 }
 
 QKeySequence* ShortcutsManager::getSequence(const QString& key)
@@ -55,7 +44,8 @@ QKeySequence* ShortcutsManager::getSequence(const QString& key)
 
 QKeySequence* ShortcutsManager::getDefault(const QString& key)
 {
-    return defaults.value(key);
+    auto it = defaults.find(key);
+    return (it != defaults.end()) ? it->second.get() : nullptr;
 }
 
 QString ShortcutsManager::getLabel(const QString& key)

--- a/src/ShortcutsManager.h
+++ b/src/ShortcutsManager.h
@@ -21,6 +21,9 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <map>
+#include <memory>
+
 #include <QMap>
 #include <QObject>
 #include <QString>
@@ -28,11 +31,13 @@
 
 class ShortcutsManager : public QObject
 {
-
     Q_OBJECT
 
 public:
-    explicit ShortcutsManager(QObject* parent = nullptr) : QObject(parent) {}
+    explicit ShortcutsManager(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+    }
     ShortcutsManager(ShortcutsManager const&) = delete;
     ShortcutsManager& operator=(ShortcutsManager const&) = delete;
     ShortcutsManager(ShortcutsManager&&) = delete;
@@ -48,10 +53,10 @@ public:
 
 private:
     QList<QString> shortcutKeys;
-    QMap<QString, QKeySequence*> shortcuts; //shortcut key : sequence in use pointer
-    QMap<QString, QKeySequence*> defaults; //shortcut key : default sequence
-    QMap<QString, QString> translations; //shortcut key : translation for shortcut label
-
+    // Non-owning: callers retain ownership of the QKeySequence* stored here.
+    QMap<QString, QKeySequence*> shortcuts;                    //shortcut key : sequence in use pointer
+    std::map<QString, std::unique_ptr<QKeySequence>> defaults; //shortcut key : default sequence (owned)
+    QMap<QString, QString> translations;                       //shortcut key : translation for shortcut label
 };
 
 #endif //MUDLET_SHORTCUTSMANAGER_H

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1142,7 +1142,8 @@ QKeySequence TDetachedWindow::resolveShortcut(const QString& key, const QKeySequ
 
     if (!mCurrentProfileName.isEmpty()) {
         if (auto host = mudletInstance->getHostManager().getHost(mCurrentProfileName)) {
-            if (auto sequence = host->profileShortcuts.value(key)) {
+            if (auto it = host->profileShortcuts.find(key); it != host->profileShortcuts.end()) {
+                const QKeySequence* sequence = it->second.get();
                 if (sequence && !sequence->isEmpty()) {
                     return *sequence;
                 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -82,7 +82,7 @@ void restoreLabelOutlineColorFromUserData(TMapLabel& label, int labelId, QMap<QS
 TMap::TMap(Host* pH, const QString& profileName)
 : mDefaultAreaName(tr("Default Area"))
 , mUnnamedAreaName(tr("Unnamed Area"))
-, mpRoomDB(new TRoomDB(this))
+, mpRoomDB(std::make_unique<TRoomDB>(this))
 , mpViewManager(new TMapViewManager(pH, this))
 , mpHost(pH)
 , mProfileName(profileName)
@@ -103,7 +103,6 @@ TMap::TMap(Host* pH, const QString& profileName)
 
 TMap::~TMap()
 {
-    delete mpRoomDB;
     if (!mStoredMessages.isEmpty()) {
         qWarning() << "TMap::~TMap() Instance being destroyed before it could display some messages,\n"
                    << "messages are:\n"
@@ -1729,7 +1728,7 @@ bool TMap::restore(QString location)
             ifs >> areaSize;
             // restore area table
             for (int i = 0; i < areaSize; i++) {
-                auto pA = new TArea(this, mpRoomDB);
+                auto pA = new TArea(this, mpRoomDB.get());
                 int areaID = 0;
                 ifs >> areaID;
                 if (mVersion >= 18) {
@@ -1804,7 +1803,7 @@ bool TMap::restore(QString location)
         }
 
         if (!mpRoomDB->getAreaMap().keys().contains(-1)) {
-            auto pDefaultA = new TArea(this, mpRoomDB);
+            auto pDefaultA = new TArea(this, mpRoomDB.get());
             mpRoomDB->restoreSingleArea(-1, pDefaultA);
             const QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
                                                        "area) not found, adding reserved -1 id.");
@@ -1880,7 +1879,7 @@ bool TMap::restore(QString location)
         while (!ifs.atEnd()) {
             int i = 0;
             ifs >> i;
-            auto pT = new TRoom(mpRoomDB);
+            auto pT = new TRoom(mpRoomDB.get());
             pT->restore(ifs, i, mVersion);
             mpRoomDB->restoreSingleRoom(i, pT);
         }
@@ -3314,10 +3313,10 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         }
     }
 
-    TRoomDB* pNewRoomDB = new TRoomDB(this);
+    auto pNewRoomDB = std::make_unique<TRoomDB>(this);
     bool abort = false;
     for (int i = 0, total = mapObj.value(QLatin1String("areas")).toArray().count(); i < total; ++i) {
-        std::unique_ptr<TArea> pArea = std::make_unique<TArea>(this, pNewRoomDB);
+        std::unique_ptr<TArea> pArea = std::make_unique<TArea>(this, pNewRoomDB.get());
         auto [id, name] = pArea->readJsonArea(mapObj.value(QLatin1String("areas")).toArray(), i);
         ++mProgressDialogAreasCount;
         if (incrementJsonProgressDialog(false, true, 0)) {
@@ -3335,7 +3334,6 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         mpProgressDialog = nullptr;
         mDefaultAreaName = oldDefaultAreaName;
         mUnnamedAreaName = oldUnnamedName;
-        delete pNewRoomDB;
         return {false, (translatableTexts ? tr("aborted by user") : qsl("aborted by user"))};
     }
 
@@ -3358,15 +3356,13 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     qDebug().nospace().noquote() << "TMap::readJsonMapFile(...) INFO - parsed a file (version: " << formatVersion << ") containing " << mProgressDialogRoomsCount << " rooms.";
 
     // This is it - the point at which the new map gets activated:
-    TRoomDB* pOldRoomDB = mpRoomDB;
-    mpRoomDB = pNewRoomDB;
+    mpRoomDB = std::move(pNewRoomDB);
     // Need to update the master copy of these details in the Host class:
     mpHost->setPlayerRoomStyleDetails(mPlayerRoomStyle, mPlayerRoomOuterDiameterPercentage, mPlayerRoomInnerDiameterPercentage, mPlayerRoomOuterColor, mPlayerRoomInnerColor);
     // And redraw the indicator if a 2D map is being shown:
     if (mpMapper && mpMapper->mp2dMap) {
         mpMapper->mp2dMap->setPlayerRoomStyle(mPlayerRoomStyle);
     }
-    delete pOldRoomDB;
     mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose, true);
     mpProgressDialog->close();
     mpProgressDialog = nullptr;

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -39,6 +39,7 @@
 #include <QSet>
 #include <QVector3D>
 #include <stdlib.h>
+#include <memory>
 #include <optional>
 
 #define DIR_NORTH 1
@@ -208,7 +209,8 @@ public:
     bool getDefaultAreaShown() { return mShowDefaultArea; }
 
 
-    TRoomDB* mpRoomDB = nullptr;
+    std::unique_ptr<TRoomDB> mpRoomDB;
+    // Non-owning: Qt parent-child system (TMap as parent) handles lifetime.
     TMapViewManager* mpViewManager = nullptr;
     QMap<int, int> mEnvColors;
     QPointer<Host> mpHost;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -63,24 +63,8 @@ TTrigger::TTrigger(const QString& name, const QStringList& patterns, const QList
 
 TTrigger::~TTrigger()
 {
-    QMutableListIterator<TColorTable*> itColorTable(mColorPatternList);
-    while (itColorTable.hasNext()) {
-        if (itColorTable.next()) {
-            //            qDebug() << "TTrigger::~TTrigger() INFO: removing TColorTable from mColorPatternList: (ansiFg:"
-            //                     << itColorTable.peekPrevious()->ansiFg
-            //                     << itColorTable.peekPrevious()->mFgColor
-            //                     << "ansiBg:"
-            //                     << itColorTable.peekPrevious()->ansiBg
-            //                     << itColorTable.peekPrevious()->mBgColor
-            //                     << ").";
-            delete itColorTable.peekPrevious();
-        }
-        itColorTable.remove();
-    }
-
-    for (auto&& [key, value] : mConditionMap) {
-        delete value;
-    }
+    mColorPatternList.clear();
+    mConditionMap.clear();
 
     if (!mpHost) {
         return;
@@ -118,22 +102,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
     mRegexMap.clear();
     mPatternKinds.clear();
     mLuaConditionMap.clear();
-    // mColorPatternList is filled with pointers to TColorTable instances that
-    // were created with "new" and they need to be "delete"-d:
-    QMutableListIterator<TColorTable*> itColorTable(mColorPatternList);
-    while (itColorTable.hasNext()) {
-        if (itColorTable.next()) {
-            //            qDebug() << "TTrigger::setRegexCodeList() INFO: removing TColorTable from mColorPatternList: (ansiFg:"
-            //                     << itColorTable.peekPrevious()->ansiFg
-            //                     << itColorTable.peekPrevious()->mFgColor
-            //                     << "ansiBg:"
-            //                     << itColorTable.peekPrevious()->ansiBg
-            //                     << itColorTable.peekPrevious()->mBgColor
-            //                     << ").";
-            delete itColorTable.peekPrevious();
-        }
-        itColorTable.remove();
-    }
+    mColorPatternList.clear();
     mTriggerContainsPerlRegex = false;
 
     if (patternKinds.size() != patterns.size()) {
@@ -228,12 +197,12 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
                 // The setupColorTrigger(...) method will push_back the created
                 // TColorTable instance if it is successful:
                 if (!setupColorTrigger(textAnsiFg, textAnsiBg)) {
-                    mColorPatternList.push_back(nullptr);
+                    mColorPatternList.emplace_back(nullptr);
                     state = false;
                     continue;
                 }
             } else {
-                mColorPatternList.push_back(nullptr);
+                mColorPatternList.emplace_back(nullptr);
             }
         }
     }
@@ -532,14 +501,15 @@ void TTrigger::updateMultistates(int regexNumber, std::list<std::string>& captur
 {
     if (regexNumber == 0) {
         // automatically set to #1
-        auto pCondition = new TMatchState(mPatterns.size(), mConditionLineDelta);
-        mConditionMap[pCondition] = pCondition;
-        pCondition->multiCaptureList.push_back(captureList);
-        pCondition->multiCapturePosList.push_back(posList);
+        auto pCondition = std::make_unique<TMatchState>(mPatterns.size(), mConditionLineDelta);
+        auto* pConditionRaw = pCondition.get();
+        mConditionMap[pConditionRaw] = std::move(pCondition);
+        pConditionRaw->multiCaptureList.push_back(captureList);
+        pConditionRaw->multiCapturePosList.push_back(posList);
         if (nameMatches) {
-            pCondition->nameCaptures.push_back(*nameMatches);
+            pConditionRaw->nameCaptures.push_back(*nameMatches);
         } else {
-            pCondition->nameCaptures.push_back(QVector<QPair<QString, QString>>());
+            pConditionRaw->nameCaptures.push_back(QVector<QPair<QString, QString>>());
         }
         if (mudlet::smDebugMode) {
             TDebug(Qt::darkYellow, Qt::black) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber << "/"
@@ -680,7 +650,7 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
     int matchBegin = -1;
     bool matching = false;
 
-    TColorTable* pCT = mColorPatternList[patternNumber];
+    TColorTable* pCT = mColorPatternList[patternNumber].get();
     if (!pCT) {
         return false; // no color pattern created
     }
@@ -1068,7 +1038,6 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
             }
             for (auto& matchState : removeList) {
                 if (mConditionMap.find(matchState) != mConditionMap.end()) {
-                    delete mConditionMap[matchState];
                     if (mudlet::smDebugMode) {
                         TDebug(Qt::darkBlue, Qt::black) << "removing condition from condition table.\n" >> mpHost;
                     }
@@ -1148,7 +1117,7 @@ void TTrigger::unmarkAsNew()
 // like give the current Host settings (the first 16 ANSI ones and the default
 // fore and background colors can be changed by the user and since OSC P/R
 // support has been implemented - by the MUD Server!)
-TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
+std::unique_ptr<TColorTable> TTrigger::createColorPattern(int ansiFg, int ansiBg)
 {
     /*
      *  OLD Mudlet simplified ANSI color codes
@@ -1182,7 +1151,7 @@ TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
         return nullptr;
     }
 
-    auto pCT = new (std::nothrow) TColorTable;
+    auto pCT = std::unique_ptr<TColorTable>(new (std::nothrow) TColorTable);
     if (!pCT) {
         return nullptr;
     }
@@ -1196,22 +1165,12 @@ TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
 
 bool TTrigger::setupColorTrigger(int ansiFg, int ansiBg)
 {
-    TColorTable* pCT = createColorPattern(ansiFg, ansiBg);
+    auto pCT = createColorPattern(ansiFg, ansiBg);
     if (!pCT) {
         // This can be caused by both ansiFg and ansiBg being scmIgnored
         return false;
     }
-    //    qDebug() << "TTrigger::setupColorTrigger(" << ansiFg
-    //             << ", "
-    //             << ansiBg
-    //             << ") INFO: adding TColorTable to mColorPatternList: (ansiFg:"
-    //             << pCT->ansiFg
-    //             << pCT->mFgColor
-    //             << "ansiBg:"
-    //             << pCT->ansiBg
-    //             << pCT->mBgColor
-    //             << ").";
-    mColorPatternList.push_back(pCT);
+    mColorPatternList.emplace_back(std::move(pCT));
     return true;
 }
 
@@ -1219,7 +1178,7 @@ bool TTrigger::setupColorTrigger(int ansiFg, int ansiBg)
 // or scmDefault for default fore/background or scmIgnored for ignored
 bool TTrigger::setupTmpColorTrigger(int ansiFg, int ansiBg)
 {
-    TColorTable* pCT = createColorPattern(ansiFg, ansiBg);
+    auto pCT = createColorPattern(ansiFg, ansiBg);
     if (!pCT) {
         return false;
     }
@@ -1228,7 +1187,7 @@ bool TTrigger::setupTmpColorTrigger(int ansiFg, int ansiBg)
     // codes are the scmIgnored ones:
     mPatterns << createColorPatternText(ansiFg, ansiBg);
     mPatternKinds << REGEX_COLOR_PATTERN;
-    mColorPatternList.push_back(pCT);
+    mColorPatternList.emplace_back(std::move(pCT));
     return true;
 }
 

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -37,7 +37,9 @@
 #include <pcre2.h>
 
 #include <map>
+#include <memory>
 #include <string>
+#include <vector>
 
 class Host;
 class TLuaInterpreter;
@@ -134,7 +136,7 @@ public:
     void setSound(const QString& file) { mSoundFile = file; }
     bool setupColorTrigger(int, int);
     bool setupTmpColorTrigger(int ansiFg, int ansiBg);
-    TColorTable* createColorPattern(int, int);
+    std::unique_ptr<TColorTable> createColorPattern(int, int);
     static QString createColorPatternText(const int fgColorCode, const int bgColorCode);
     static void decodeColorPatternText(const QString& patternText, int& fgColorCode, int& bgColorCode);
     QString packageName(TTrigger* pTrigger);
@@ -148,7 +150,7 @@ public:
     QString mSoundFile;
     int mStayOpen = 0;
     bool mColorTrigger = false;
-    QList<TColorTable*> mColorPatternList;
+    std::vector<std::unique_ptr<TColorTable>> mColorPatternList;
     // The next four members refer to the details of the currently selected
     // color trigger pattern item - it is not obvious that they need to be
     // stored in the profile even though they are:
@@ -200,7 +202,10 @@ private:
     bool mIsMultiline = false;
     int mConditionLineDelta = 0;
     QString mCommand;
-    std::map<TMatchState*, TMatchState*> mConditionMap;
+    // Key is the raw address of the owned TMatchState — stable once inserted and
+    // used for O(1) lookup during the deferred-removal pass in match(). The map
+    // is the sole owner; the raw pointer is never passed out as an observer.
+    std::map<TMatchState*, std::unique_ptr<TMatchState>> mConditionMap;
     std::list<std::list<std::string>> mMultiCaptureGroupList;
     std::list<std::list<int>> mMultiCaptureGroupPosList;
     TLuaInterpreter* mpLua;

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -35,11 +35,7 @@ VarUnit::VarUnit()
 {
 }
 
-VarUnit::~VarUnit()
-{
-    // Delete the base TVar and all its children (recursively via TVar destructor)
-    delete base;
-}
+VarUnit::~VarUnit() = default;
 
 bool VarUnit::isHidden(TVar* var)
 {
@@ -216,14 +212,14 @@ QStringList VarUnit::varName(TVar* var)
 {
     QStringList names;
     names << "_G";
-    if (var == base || !var) {
+    if (var == base.get() || !var) {
         return names;
     }
     names << var->getName();
     TVar* p = var->getParent();
-    while (p && p != base) {
+    while (p && p != base.get()) {
         names.insert(1, p->getName());
-        if (p == base) {
+        if (p == base.get()) {
             break;
         }
         p = p->getParent();
@@ -319,19 +315,17 @@ bool VarUnit::varExists(TVar* var)
 
 TVar* VarUnit::getBase()
 {
-    return base;
+    return base.get();
 }
 
 void VarUnit::setBase(TVar* pVariable)
 {
-    base = pVariable;
+    base.reset(pVariable);
 }
 
 void VarUnit::clear()
 {
-    // Delete the base TVar and all its children (recursively via TVar destructor)
-    delete base;
-    base = nullptr;
+    base.reset();
     tVars.clear();
     wVars.clear();
     variableSet.clear();

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -23,6 +23,8 @@
  ***************************************************************************/
 
 
+#include <memory>
+
 #include <QCoreApplication>
 #include <QMap>
 #include <QSet>
@@ -74,7 +76,7 @@ public:
 
 private:
     int countTableItems(TVar*);
-    TVar* base;
+    std::unique_ptr<TVar> base;
     QSet<QString> variableSet;
     // ?? variables
     QMap<QTreeWidgetItem*, TVar*> wVars;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -690,7 +690,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             auto key = iterator.next();
             auto shortcut = host.append_child("profileShortcut");
             shortcut.append_attribute("key") = key.toUtf8().constData();
-            shortcut.text().set(pHost->profileShortcuts.value(key)->toString().toUtf8().constData());
+            auto it = pHost->profileShortcuts.find(key);
+            if (it != pHost->profileShortcuts.end()) {
+                shortcut.text().set(it->second->toString().toUtf8().constData());
+            }
         }
     }
     {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -38,6 +38,8 @@
 #include <QtMath>
 #include <QVersionNumber>
 
+#include <memory>
+
 XMLimport::XMLimport(Host* pH)
 : mpHost(pH)
 {
@@ -476,7 +478,7 @@ void XMLimport::readRoomFeature(TRoom* pR)
 // TRoomDB::addRoom(...)
 void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int* roomCount)
 {
-    auto pT = new TRoom(mpHost->mpMap->mpRoomDB);
+    auto pT = new TRoom(mpHost->mpMap->mpRoomDB.get());
 
     pT->id = attributes().value(qsl("id")).toString().toInt();
     pT->area = attributes().value(qsl("area")).toString().toInt();
@@ -2049,7 +2051,7 @@ void XMLimport::readStopWatchMap()
         } else if (isStartElement()) {
             if (name() == qsl("stopwatch")) {
                 const int watchId = attributes().value(qsl("id")).toInt();
-                auto pStopWatch = new stopWatch();
+                auto pStopWatch = std::make_unique<stopWatch>();
                 pStopWatch->setName(attributes().value(qsl("name")).toString());
                 pStopWatch->mIsPersistent = true;
                 pStopWatch->mIsInitialised = true;
@@ -2063,7 +2065,7 @@ void XMLimport::readStopWatchMap()
                     pStopWatch->mIsRunning = false;
                     pStopWatch->mElapsedTime = attributes().value(qsl("elapsedDateTimeMSecs")).toLongLong();
                 }
-                mpHost->mStopWatchMap.insert(watchId, pStopWatch);
+                mpHost->mStopWatchMap[watchId] = std::move(pStopWatch);
                 // A dummy read as there should not be any text for this element:
                 readElementText();
             } else {
@@ -2113,9 +2115,8 @@ void XMLimport::readProfileShortcut()
 {
     auto key = attributes().value(qsl("key"));
     auto sequenceString = readElementText();
-    if (mpHost->profileShortcuts.value(key.toString())) {
-        QKeySequence* sequence = !sequenceString.isEmpty() ? new QKeySequence(sequenceString) : new QKeySequence();
-        mpHost->profileShortcuts.value(key.toString())->swap(*sequence);
-        delete sequence;
+    if (auto it = mpHost->profileShortcuts.find(key.toString()); it != mpHost->profileShortcuts.end()) {
+        QKeySequence sequence = !sequenceString.isEmpty() ? QKeySequence(sequenceString) : QKeySequence();
+        it->second->swap(sequence);
     }
 }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -96,8 +96,8 @@ Discord::Discord(QObject* parent)
     mLoaded = true;
     qDebug() << "Discord integration loaded. Using functions from:" << mpLibrary.data()->fileName();
 
-    mpHandlers = new DiscordEventHandlers;
-    memset(mpHandlers, 0, sizeof(DiscordEventHandlers));
+    mpHandlers = std::make_unique<DiscordEventHandlers>();
+    memset(mpHandlers.get(), 0, sizeof(DiscordEventHandlers));
     mpHandlers->ready = handleDiscordReady;
     mpHandlers->errored = handleDiscordError;
     mpHandlers->disconnected = handleDiscordDisconnected;
@@ -125,7 +125,7 @@ void Discord::initializeRpc()
     }
 
     mCurrentApplicationId = mHostApplicationIDs.value(nullptr);
-    Discord_Initialize(mCurrentApplicationId.toUtf8().constData(), mpHandlers, 0, nullptr);
+    Discord_Initialize(mCurrentApplicationId.toUtf8().constData(), mpHandlers.get(), 0, nullptr);
     mRpcActive = true;
 }
 
@@ -148,18 +148,8 @@ Discord::~Discord()
         // need to as it happens automagically on the application shutdown...
     }
 
-    // Clean up presence allocations regardless of RPC state - entries are
-    // created in UpdatePresence() and must be freed even if RPC was shut
-    // down before destruction (e.g. user switched to Disabled mode).
-    QMutableMapIterator<QString, localDiscordPresence*> itPresencePtrs(mPresencePtrs);
-    while (itPresencePtrs.hasNext()) {
-        itPresencePtrs.next();
-        delete itPresencePtrs.value();
-        itPresencePtrs.remove();
-    }
-
-    delete mpHandlers;
-    mpHandlers = nullptr;
+    // Clear out the localDiscordPresence collection:
+    mPresencePtrs.clear();
 }
 
 // For all the setters below the caller is supposed to check that they have the
@@ -378,28 +368,29 @@ void Discord::UpdatePresence()
     // Need to establish which presence to use - will be null if it has not been overridden:
     QString applicationID = mHostApplicationIDs.value(pHost);
 
-    if (mPresencePtrs.isEmpty()) {
+    if (mPresencePtrs.empty()) {
         // First time only - with no localDiscordPresence in collection,
         // must just create the default one:
-        auto* pTempPresence = new localDiscordPresence;
-        mPresencePtrs.insert(QString(), pTempPresence);
+        mPresencePtrs.emplace(QString(), std::make_unique<localDiscordPresence>());
     }
 
     // If the localDiscordPresence applicationID is NOT present in the existing
-    // QMap then this will return a nullptr:
+    // map then this will return a nullptr:
     localDiscordPresence* pDiscordPresence = nullptr;
     if (applicationID.isEmpty()) {
-        pDiscordPresence = mPresencePtrs.value(nullptr);
+        auto it = mPresencePtrs.find(QString());
+        pDiscordPresence = (it != mPresencePtrs.end()) ? it->second.get() : nullptr;
         // Reset the empty applicationID to the one that belongs to Mudlet:
         applicationID = mHostApplicationIDs.value(nullptr);
 
         Q_ASSERT_X(pDiscordPresence, "Discord", "no Discord presence available for Mudlets default presence");
     } else {
-        pDiscordPresence = mPresencePtrs.value(applicationID);
+        auto it = mPresencePtrs.find(applicationID);
+        pDiscordPresence = (it != mPresencePtrs.end()) ? it->second.get() : nullptr;
 
         if (!pDiscordPresence) {
-            pDiscordPresence = new localDiscordPresence;
-            mPresencePtrs.insert(applicationID, pDiscordPresence);
+            auto [newIt, inserted] = mPresencePtrs.emplace(applicationID, std::make_unique<localDiscordPresence>());
+            pDiscordPresence = newIt->second.get();
         }
     }
 
@@ -409,7 +400,7 @@ void Discord::UpdatePresence()
                                      << applicationID << "\"), restarting RPC library with the latter.";
 #endif
         Discord_Shutdown();
-        Discord_Initialize(applicationID.toUtf8().constData(), mpHandlers, 0, nullptr);
+        Discord_Initialize(applicationID.toUtf8().constData(), mpHandlers.get(), 0, nullptr);
         mCurrentApplicationId = applicationID;
         // Wait for the ready callback before sending presence
         return;

--- a/src/discord.h
+++ b/src/discord.h
@@ -23,6 +23,8 @@
 #include "Host.h"
 
 #include <functional>
+#include <map>
+#include <memory>
 #include <utility>
 #include <QDebug>
 #include <QTimer>
@@ -222,7 +224,7 @@ private:
 
     void timerEvent(QTimerEvent *event) override;
 
-    DiscordEventHandlers* mpHandlers = nullptr;
+    std::unique_ptr<DiscordEventHandlers> mpHandlers;
 
     // These are function pointers to functions located in the Discord RPC library:
     std::function<void(const char*, DiscordEventHandlers*, int, const char*)> Discord_Initialize;
@@ -243,7 +245,7 @@ private:
 
     // Key is a Application Id, Value is a pointer to a local copy of the data
     // currently held for that presence:
-    QMap<QString, localDiscordPresence*> mPresencePtrs;
+    std::map<QString, std::unique_ptr<localDiscordPresence>> mPresencePtrs;
 
     // Used to tie a profile to a particular Discord presence - multiple
     // profiles can have the same presence but defaults to the nullptr one for

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -439,7 +439,7 @@ void dlgConnectionProfiles::slot_updatePassword(const QString& pass)
     }
 }
 
-void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QString& pass) const
+void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QString& pass)
 {
     // Validate that we have a password to store
     if (pass.trimmed().isEmpty()) {
@@ -448,7 +448,7 @@ void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QS
     }
 
     // Use async API for QtKeychain integration with file fallback
-    auto* credManager = new CredentialManager();
+    auto* credManager = new CredentialManager(this);
 
     credManager->storePassword(profile, "character", pass, [credManager, profile](bool success, const QString& errorMessage) {
         if (success) {
@@ -462,10 +462,10 @@ void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QS
     });
 }
 
-void dlgConnectionProfiles::deleteSecurePassword(const QString& profile) const
+void dlgConnectionProfiles::deleteSecurePassword(const QString& profile)
 {
     // Use async API for QtKeychain integration with file fallback
-    auto* credManager = new CredentialManager();
+    auto* credManager = new CredentialManager(this);
 
     credManager->removePassword(profile, "character", [credManager, profile](bool success, const QString& errorMessage) {
         if (success) {
@@ -1411,7 +1411,7 @@ template <typename L>
 void dlgConnectionProfiles::loadSecuredPassword(const QString& profile, L callback)
 {
     // Use async API for QtKeychain integration with file fallback
-    auto* credManager = new CredentialManager();
+    auto* credManager = new CredentialManager(this);
 
     credManager->retrievePassword(profile, "character", [credManager, callback = std::move(callback)](bool success, const QString& password, const QString& errorMessage) {
         if (success) {

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -111,8 +111,8 @@ private:
     template <typename L>
     void loadSecuredPassword(const QString& profile, L callback);
     void migrateSecuredPassword(const QString& oldProfile, const QString& newProfile);
-    void writeSecurePassword(const QString& profile, const QString& pass) const;
-    void deleteSecurePassword(const QString& profile) const;
+    void writeSecurePassword(const QString& profile, const QString& pass);
+    void deleteSecurePassword(const QString& profile);
     void setupMudProfile(QListWidgetItem*, const QString& mudServer, const QString& serverDescription, const QString& iconFileName);
     void reallyDeleteProfile(const QString& profile);
     void continueProfileSave(QListWidgetItem* pItem, const QString& newProfileName, const QString& newProfileHost, const QString& newProfilePort, const int newProfileSslTsl);

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -56,7 +56,7 @@
 
 dlgPackageExporter::dlgPackageExporter(QWidget* parent, Host* pHost)
 : QDialog(parent)
-, ui(new Ui::dlgPackageExporter)
+, ui(std::make_unique<Ui::dlgPackageExporter>())
 , mpHost(pHost)
 {
     ui->setupUi(this);
@@ -152,10 +152,7 @@ dlgPackageExporter::dlgPackageExporter(QWidget* parent, Host* pHost)
     connect(mpHost, &QObject::destroyed, this, &dlgPackageExporter::close);
 }
 
-dlgPackageExporter::~dlgPackageExporter()
-{
-    delete ui;
-}
+dlgPackageExporter::~dlgPackageExporter() = default;
 
 void dlgPackageExporter::setModuleCreationMode(bool isModule)
 {

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -30,6 +30,8 @@
 #include <QTextEdit>
 #include <zip.h>
 
+#include <memory>
+
 class Host;
 class QCloseEvent;
 class QGroupBox;
@@ -158,7 +160,7 @@ private:
     void checkToEnableExportButton();
     void populateDependencies();
 
-    Ui::dlgPackageExporter* ui = nullptr;
+    std::unique_ptr<Ui::dlgPackageExporter> ui;
     QPointer<Host> mpHost;
     QTreeWidget* mpExportSelection = nullptr;
     QPointer<QPushButton> mExportButton;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1487,8 +1487,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     int shortcutsRow = 0;
     while (shortcutKeys.hasNext()) {
         auto key = shortcutKeys.next();
-        currentShortcuts.insert(key, QKeySequence(*pHost->profileShortcuts.value(key)));
-        auto sequenceEdit = new QKeySequenceEdit(currentShortcuts.value(key));
+        auto shortcutIt = pHost->profileShortcuts.find(key);
+        QKeySequence currentSequence = (shortcutIt != pHost->profileShortcuts.end()) ? QKeySequence(*shortcutIt->second) : QKeySequence();
+        currentShortcuts.insert(key, currentSequence);
+        auto sequenceEdit = new QKeySequenceEdit(currentSequence);
 
         gridLayout_groupBox_shortcuts->addWidget(new QLabel(mudlet::self()->mpShortcutsManager->getLabel(key)), floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 1);
         gridLayout_groupBox_shortcuts->addWidget(sequenceEdit, floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 2);
@@ -3304,7 +3306,10 @@ void dlgProfilePreferences::slot_saveAndClose()
         while (iterator.hasNext()) {
             auto key = iterator.next();
             QKeySequence sequence = currentShortcuts.value(key);
-            pHost->profileShortcuts.value(key)->swap(sequence);
+            auto it = pHost->profileShortcuts.find(key);
+            if (it != pHost->profileShortcuts.end()) {
+                it->second->swap(sequence);
+            }
         }
     }
 
@@ -3640,7 +3645,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
 
                         const QByteArray downloadedArchive = reply->readAll();
 
-                        tempThemesArchive = new QTemporaryFile();
+                        tempThemesArchive = new QTemporaryFile(this);
                         if (!tempThemesArchive->open()) {
                             return;
                         }
@@ -3654,7 +3659,7 @@ void dlgProfilePreferences::slot_tabChanged(int tabIndex)
 
                         // perform unzipping in a worker thread so as not to freeze the UI
                         auto future = QtConcurrent::run(mudlet::unzip, tempThemesArchive->fileName(), mudlet::getMudletPath(enums::mainDataItemPath, qsl("edbee/")), temporaryDir.path());
-                        auto watcher = new QFutureWatcher<bool>;
+                        auto watcher = new QFutureWatcher<bool>(this);
                         connect(watcher, &QFutureWatcher<bool>::finished, this, [=, this]() {
                             if (future.result()) {
                                 populateThemesList();

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -33,6 +33,7 @@
 
 
 #include <QAction>
+#include <set>
 
 // A template for tooltip HTML formatting so that we do not have
 // 30 copies of the same QString in the read-only segment of the code:
@@ -282,16 +283,7 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
     specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitWeight, new WeightSpinBoxDelegate);
 }
 
-dlgRoomExits::~dlgRoomExits()
-{
-    // QActions are children of this dialog (created with 'this' as parent),
-    // so Qt's parent-child system handles their deletion automatically.
-    // Manual deletion here would cause double-delete crashes.
-
-    // TExit objects are heap-allocated and not Qt-parented, so we must free them
-    qDeleteAll(originalExits);
-    qDeleteAll(originalSpecialExits);
-}
+dlgRoomExits::~dlgRoomExits() = default;
 
 void dlgRoomExits::slot_endEditSpecialExits()
 {
@@ -538,7 +530,8 @@ void dlgRoomExits::save()
 
     QString exitKey = qsl("nw");
     int dirCode = DIR_NORTHWEST;
-    auto pExit = originalExits.value(dirCode);
+    auto it_nw = originalExits.find(dirCode);
+    TExit* pExit = (it_nw != originalExits.end()) ? it_nw->second.get() : nullptr;
     if (nw->isEnabled() && !nw->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != nullptr) {
         // There IS a valid exit on the dialogue in this direction
         if (pExit && pExit->destination != nw->text().toInt()) {
@@ -569,7 +562,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("n");
     dirCode = DIR_NORTH;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (n->isEnabled() && !n->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != n->text().toInt()) {
             pR->setExit(n->text().toInt(), dirCode);
@@ -598,7 +594,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("ne");
     dirCode = DIR_NORTHEAST;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (ne->isEnabled() && !ne->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != ne->text().toInt()) {
             pR->setExit(ne->text().toInt(), dirCode);
@@ -627,7 +626,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("up");
     dirCode = DIR_UP;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (up->isEnabled() && !up->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != up->text().toInt()) {
             pR->setExit(up->text().toInt(), dirCode);
@@ -656,7 +658,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("w");
     dirCode = DIR_WEST;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (w->isEnabled() && !w->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != w->text().toInt()) {
             pR->setExit(w->text().toInt(), dirCode);
@@ -685,7 +690,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("e");
     dirCode = DIR_EAST;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (e->isEnabled() && !e->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != e->text().toInt()) {
             pR->setExit(e->text().toInt(), dirCode);
@@ -714,7 +722,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("down");
     dirCode = DIR_DOWN;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (down->isEnabled() && !down->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != down->text().toInt()) {
             pR->setExit(down->text().toInt(), dirCode);
@@ -743,7 +754,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("sw");
     dirCode = DIR_SOUTHWEST;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (sw->isEnabled() && !sw->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != sw->text().toInt()) {
             pR->setExit(sw->text().toInt(), dirCode);
@@ -772,7 +786,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("s");
     dirCode = DIR_SOUTH;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (s->isEnabled() && !s->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != s->text().toInt()) {
             pR->setExit(s->text().toInt(), dirCode);
@@ -801,7 +818,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("se");
     dirCode = DIR_SOUTHEAST;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (se->isEnabled() && !se->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != se->text().toInt()) {
             pR->setExit(se->text().toInt(), dirCode);
@@ -830,7 +850,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("in");
     dirCode = DIR_IN;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (in->isEnabled() && !in->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != in->text().toInt()) {
             pR->setExit(in->text().toInt(), dirCode);
@@ -859,7 +882,10 @@ void dlgRoomExits::save()
 
     exitKey = qsl("out");
     dirCode = DIR_OUT;
-    pExit = originalExits.value(dirCode);
+    {
+        auto it = originalExits.find(dirCode);
+        pExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+    }
     if (out->isEnabled() && !out->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != nullptr) {
         if (pExit && pExit->destination != out->text().toInt()) {
             pR->setExit(out->text().toInt(), dirCode);
@@ -1786,9 +1812,7 @@ void dlgRoomExits::init()
         it.next();
         const int id_to = it.value();
         const QString dir = it.key();
-        auto pSpecialExit = new TExit();
-        // It should be impossible for this not to be valid:
-        Q_ASSERT_X(pSpecialExit, "dlgRoomExits::init(...)", "failed to generate a new TExit");
+        auto pSpecialExit = std::make_unique<TExit>();
         auto pI = new QTreeWidgetItem(specialExits);
         pSpecialExit->destination = id_to;
 
@@ -1856,7 +1880,9 @@ void dlgRoomExits::init()
                 qWarning().nospace().noquote() << "dlgRoomExits::init() WARNING - in room: " << mRoomID << "unexpected (special exit) doors[" << dir << "] value:" << pR->doors[dir] << " found!";
             }
             pSpecialExit->door = specialDoor;
-            originalSpecialExits[dir] = pSpecialExit;
+            // Not relevant for special exits but initialise before moving into map
+            pSpecialExit->hasStub = false;
+            originalSpecialExits[dir] = std::move(pSpecialExit);
         }
 
         //ExitsTreeWidget::colIndex_command holds the script/name
@@ -1865,9 +1891,6 @@ void dlgRoomExits::init()
         //Tooltip generation for this column and a couple of earlier ones is
         //done here:
         setIconAndToolTipsOnSpecialExit(pI, true);
-
-        // Not relevant for special exits but better initialise it
-        pSpecialExit->hasStub = false;
     }
     button_save->setEnabled(false);
 
@@ -1974,9 +1997,9 @@ void dlgRoomExits::init()
     // clang-format on
 }
 
-TExit* dlgRoomExits::makeExitFromControls(int direction)
+std::unique_ptr<TExit> dlgRoomExits::makeExitFromControls(int direction)
 {
-    auto exit = new TExit();
+    auto exit = std::make_unique<TExit>();
     switch (direction) {
     case DIR_NORTHWEST:
         exit->destination = nw->text().toInt();
@@ -2080,111 +2103,112 @@ void dlgRoomExits::slot_checkModified()
     // exit doors
     // exit weights
 
-    TExit* originalExit = originalExits.value(DIR_NORTHWEST);
-    TExit* currentExit = makeExitFromControls(DIR_NORTHWEST);
-
-    if (originalExit && currentExit && *originalExit != *currentExit) {
-        isModified = true;
-    }
-    delete currentExit;
-
-    if (!isModified) {
-        originalExit = originalExits.value(DIR_NORTH);
-        currentExit = makeExitFromControls(DIR_NORTH);
+    {
+        auto it = originalExits.find(DIR_NORTHWEST);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_NORTHWEST);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_NORTHEAST);
-        currentExit = makeExitFromControls(DIR_NORTHEAST);
+        auto it = originalExits.find(DIR_NORTH);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_NORTH);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_UP);
-        currentExit = makeExitFromControls(DIR_UP);
+        auto it = originalExits.find(DIR_NORTHEAST);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_NORTHEAST);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_WEST);
-        currentExit = makeExitFromControls(DIR_WEST);
+        auto it = originalExits.find(DIR_UP);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_UP);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_EAST);
-        currentExit = makeExitFromControls(DIR_EAST);
+        auto it = originalExits.find(DIR_WEST);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_WEST);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_DOWN);
-        currentExit = makeExitFromControls(DIR_DOWN);
+        auto it = originalExits.find(DIR_EAST);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_EAST);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_SOUTHWEST);
-        currentExit = makeExitFromControls(DIR_SOUTHWEST);
+        auto it = originalExits.find(DIR_DOWN);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_DOWN);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_SOUTH);
-        currentExit = makeExitFromControls(DIR_SOUTH);
+        auto it = originalExits.find(DIR_SOUTHWEST);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_SOUTHWEST);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_SOUTHEAST);
-        currentExit = makeExitFromControls(DIR_SOUTHEAST);
+        auto it = originalExits.find(DIR_SOUTH);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_SOUTH);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_IN);
-        currentExit = makeExitFromControls(DIR_IN);
+        auto it = originalExits.find(DIR_SOUTHEAST);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_SOUTHEAST);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_OUT);
-        currentExit = makeExitFromControls(DIR_OUT);
+        auto it = originalExits.find(DIR_IN);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_IN);
         if (originalExit && currentExit && *originalExit != *currentExit) {
             isModified = true;
         }
-        delete currentExit;
+    }
+
+    if (!isModified) {
+        auto it = originalExits.find(DIR_OUT);
+        TExit* originalExit = (it != originalExits.end()) ? it->second.get() : nullptr;
+        auto currentExit = makeExitFromControls(DIR_OUT);
+        if (originalExit && currentExit && *originalExit != *currentExit) {
+            isModified = true;
+        }
     }
 
     // Detecting actual changes in the special exits is hard because of the
@@ -2193,7 +2217,7 @@ void dlgRoomExits::slot_checkModified()
     // At the same time existing special exits which now have a empty/zero
     // value in the ExitsTreeWidget::colIndex_exitRoomId field will be deleted if "save"ed...
     if (!isModified) {
-        const int originalCount = originalSpecialExits.count();
+        const int originalCount = static_cast<int>(originalSpecialExits.size());
         int currentCount = 0;
         for (int i = 0; i < specialExits->topLevelItemCount(); i++) {
             QTreeWidgetItem* pI = specialExits->topLevelItem(i);
@@ -2214,10 +2238,14 @@ void dlgRoomExits::slot_checkModified()
             isModified = true;
         } else {
             if (originalCount) {
-                QMap<QString, TExit*> foundMap = originalSpecialExits;
+                // Track which original exits have been matched by key
+                std::set<QString> unmatchedKeys;
+                for (const auto& kv : originalSpecialExits) {
+                    unmatchedKeys.insert(kv.first);
+                }
                 // Now make a TExit value for each current (valid) specialExit
-                // and search for it in the foundMap; remove matches and
-                // if any non-matches or if any left in foundMap at end then
+                // and search for it in originalSpecialExits; remove matches and
+                // if any non-matches or if any left in unmatchedKeys at end then
                 // set isModified...
                 for (int i = 0; i < specialExits->topLevelItemCount(); i++) {
                     QTreeWidgetItem* pI = specialExits->topLevelItem(i);
@@ -2242,15 +2270,21 @@ void dlgRoomExits::slot_checkModified()
                                                                                                              : 0;
                     currentExit.weight = pI->text(ExitsTreeWidget::colIndex_exitWeight).toInt();
                     currentExit.hasStub = false;
-                    auto exit = foundMap.value(currentCmd);
-                    if (exit && exit->destination == currentExit.destination && exit->door == currentExit.door && exit->hasNoRoute == currentExit.hasNoRoute && exit->weight == currentExit.weight) {
-                        foundMap.remove(currentCmd);
+                    auto mapIt = originalSpecialExits.find(currentCmd);
+                    if (mapIt != originalSpecialExits.end()) {
+                        const TExit* exit = mapIt->second.get();
+                        if (exit->destination == currentExit.destination && exit->door == currentExit.door && exit->hasNoRoute == currentExit.hasNoRoute && exit->weight == currentExit.weight) {
+                            unmatchedKeys.erase(currentCmd);
+                        } else {
+                            isModified = true;
+                            break;
+                        }
                     } else {
                         isModified = true;
                         break;
                     }
                 }
-                if (!foundMap.isEmpty()) {
+                if (!unmatchedKeys.empty()) {
                     isModified = true;
                 }
             }

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -28,6 +28,8 @@
 #include <QPointer>
 #include <QSet>
 #include <QStyledItemDelegate>
+#include <map>
+#include <memory>
 
 class QAction;
 class QCheckBox;
@@ -179,7 +181,7 @@ private:
                   QCheckBox* noRoute, QCheckBox* stub,
                   QRadioButton* none, QRadioButton* open, QRadioButton* closed, QRadioButton* locked,
                   QSpinBox* weight, const QString &validExitToolTip);
-    TExit* makeExitFromControls(int direction);
+    std::unique_ptr<TExit> makeExitFromControls(int direction);
     void normalExitEdited(const QString& roomExitIdText,
                           QLineEdit* pExit,
                           QCheckBox* pNoRoute,
@@ -210,9 +212,9 @@ private:
     int mAreaID = 0;
     int mEditColumn = -1;
 
-    // key = (normal) exit DIR_***, value = exit class instance
-    QMap<int, TExit*> originalExits;
-    QMap<QString, TExit*> originalSpecialExits;
+    // key = (normal) exit DIR_***, value = owned exit class instance
+    std::map<int, std::unique_ptr<TExit>> originalExits;
+    std::map<QString, std::unique_ptr<TExit>> originalSpecialExits;
 };
 
 #endif // MUDLET_DLGROOMEXITS_H

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3704,7 +3704,10 @@ void mudlet::slot_assignShortcutsFromProfile(Host* pHost)
         auto iterator = mpShortcutsManager->iterator();
         while (iterator.hasNext()) {
             auto key = iterator.next();
-            mpShortcutsManager->setShortcut(key, pHost->profileShortcuts.value(key));
+            auto it = pHost->profileShortcuts.find(key);
+            if (it != pHost->profileShortcuts.end()) {
+                mpShortcutsManager->setShortcut(key, it->second.get());
+            }
         }
     }
     assignKeySequences();
@@ -4920,7 +4923,10 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
 
         for (auto pHost : mHostManager) {
             if (mudlet::self()->showMuteAllMediaTutorial()) {
-                const QKeySequence* sequence = pHost->profileShortcuts.value(qsl("Mute all media"));
+                const QKeySequence* sequence = nullptr;
+                if (auto it = pHost->profileShortcuts.find(qsl("Mute all media")); it != pHost->profileShortcuts.end()) {
+                    sequence = it->second.get();
+                }
 
                 if (sequence && !sequence->toString().isEmpty()) {
                     const QString seq = sequence->toString(QKeySequence::NativeText);
@@ -5002,12 +5008,6 @@ void mudlet::slot_compactInputLine(const bool state)
 
 mudlet::~mudlet()
 {
-    // There may be a corner case if a replay is running AND the application is
-    // closing down AND the updater on a particular platform pauses the
-    // application destruction...?
-    delete (mpTimerReplay);
-    mpTimerReplay = nullptr;
-
     if (mpHunspell_sharedDictionary) {
         saveDictionary(getMudletPath(enums::mainDataItemPath, qsl("mudlet")), mWordSet_shared);
         Hunspell_destroy(mpHunspell_sharedDictionary);

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -86,14 +86,20 @@ Updater::Updater(QObject* parent, QSettings* settings, bool testVersion)
     Q_ASSERT_X(settings, "updater", "QSettings object is required for the updater to work");
     mSettings = settings;
 
-    mFeed = new dblsqd::Feed(this);
-    mFeed->setRepo(qsl("Mudlet"), qsl("Mudlet"), testVersion);
+    feed.reset(new dblsqd::Feed(this));
+    feed->setRepo(qsl("Mudlet"), qsl("Mudlet"), testVersion);
     mPeriodicCheck = std::make_unique<QTimer>();
 }
 
 Updater::~Updater()
 {
-    delete mUpdateDialog;
+#if !defined(Q_OS_MACOS)
+    // QPointer::data() returns null if Qt already deleted the dialog; only
+    // delete if it hasn't been cleaned up yet.
+    if (updateDialog) {
+        delete updateDialog;
+    }
+#endif
 }
 
 void Updater::checkUpdatesOnStart()
@@ -108,8 +114,8 @@ void Updater::checkUpdatesOnStart()
 
     mPeriodicCheck->setInterval(12h);
     connect(mPeriodicCheck.get(), &QTimer::timeout, this, [this] {
-        KDToolBox::connectSingleShot(mFeed, &dblsqd::Feed::ready, this, [this]() {
-            auto updates = mFeed->getUpdates(dblsqd::Release::getCurrentRelease());
+        KDToolBox::connectSingleShot(feed.get(), &dblsqd::Feed::ready, this, [this]() {
+            auto updates = feed->getUpdates(dblsqd::Release::getCurrentRelease());
             qWarning() << "Twice-daily check for updates:" << updates.size() << "update(s) available";
             if (updates.isEmpty()) {
                 return;
@@ -124,10 +130,10 @@ void Updater::checkUpdatesOnStart()
                 emit signal_updateAvailable(updates.size());
             }
         });
-        KDToolBox::connectSingleShot(mFeed, &dblsqd::Feed::loadError, this, [](const QString& error) {
+        KDToolBox::connectSingleShot(feed.get(), &dblsqd::Feed::loadError, this, [](const QString& error) {
             qWarning() << "Twice-daily update check: failed to load feed:" << error;
         });
-        mFeed->load();
+        feed->load();
     });
     mPeriodicCheck->start();
 }
@@ -163,12 +169,12 @@ void Updater::manuallyCheckUpdates()
     }
     mManualCheckInProgress = true;
 
-    mFeed->load();
-    KDToolBox::connectSingleShot(mFeed, &dblsqd::Feed::ready, this, [this]() {
+    feed->load();
+    KDToolBox::connectSingleShot(feed.get(), &dblsqd::Feed::ready, this, [this]() {
         mManualCheckInProgress = false;
         showDialogManually();
     });
-    KDToolBox::connectSingleShot(mFeed, &dblsqd::Feed::loadError, this, [this](const QString& error) {
+    KDToolBox::connectSingleShot(feed.get(), &dblsqd::Feed::loadError, this, [this](const QString& error) {
         mManualCheckInProgress = false;
         emit signal_updateCheckFailed(error);
     });
@@ -177,16 +183,16 @@ void Updater::manuallyCheckUpdates()
 
 void Updater::showDialogManually() const
 {
-    if (!mUpdateDialog) {
+    if (!updateDialog) {
         qWarning() << "showDialogManually called but update dialog not initialized";
         return;
     }
-    mUpdateDialog->show();
+    updateDialog->show();
 }
 
 void Updater::showChangelog() const
 {
-    auto changelogDialog = new dblsqd::UpdateDialog(mFeed, dblsqd::UpdateDialog::ManualChangelog, mSettings);
+    auto changelogDialog = new dblsqd::UpdateDialog(feed.get(), dblsqd::UpdateDialog::ManualChangelog, mSettings);
     changelogDialog->setAttribute(Qt::WA_DeleteOnClose);
     changelogDialog->setPreviousVersion(getPreviousVersion());
     changelogDialog->show();
@@ -194,11 +200,11 @@ void Updater::showChangelog() const
 
 void Updater::showFullChangelog() const
 {
-    if (!mFeed->isReady()) {
-        KDToolBox::connectSingleShot(mFeed, &dblsqd::Feed::ready, mFeed, [=, this]() {
+    if (!feed->isReady()) {
+        KDToolBox::connectSingleShot(feed.get(), &dblsqd::Feed::ready, feed.get(), [=, this]() {
             showFullChangelog();
         });
-        KDToolBox::connectSingleShot(mFeed, &dblsqd::Feed::loadError, mFeed, [](const QString& error) {
+        KDToolBox::connectSingleShot(feed.get(), &dblsqd::Feed::loadError, feed.get(), [](const QString& error) {
             qWarning() << "Failed to load feed for changelog:" << error;
             //: Error title for dialog shown when changelog fails to load
             QMessageBox::warning(nullptr,
@@ -206,13 +212,13 @@ void Updater::showFullChangelog() const
                                  //: Error message shown when changelog fails to load from the server
                                  tr("Could not load the changelog. Please try again later."));
         });
-        mFeed->load();
+        feed->load();
         return;
     }
 
-    auto changelogDialog = new dblsqd::UpdateDialog(mFeed, dblsqd::UpdateDialog::ManualChangelog, mSettings);
+    auto changelogDialog = new dblsqd::UpdateDialog(feed.get(), dblsqd::UpdateDialog::ManualChangelog, mSettings);
     changelogDialog->setAttribute(Qt::WA_DeleteOnClose);
-    auto releases = mFeed->getReleases();
+    auto releases = feed->getReleases();
     if (!releases.isEmpty()) {
         changelogDialog->setMinVersion(releases.constLast().getVersion());
     }
@@ -231,13 +237,13 @@ bool Updater::downloadReleaseIfValid(const dblsqd::Release& release)
         }
         return false;
     }
-    mFeed->downloadRelease(release);
+    feed->downloadRelease(release);
     return true;
 }
 
 void Updater::finishSetup()
 {
-    auto updates = mFeed->getUpdates(dblsqd::Release::getCurrentRelease());
+    auto updates = feed->getUpdates(dblsqd::Release::getCurrentRelease());
 #if defined(Q_OS_LINUX)
     if (!updates.isEmpty()) {
         qWarning() << "Successfully updated Mudlet to" << updates.constFirst().getVersion();
@@ -269,29 +275,24 @@ void Updater::setupOnMacOS()
 #if !defined(Q_OS_MACOS)
 void Updater::setupPlatformUpdater()
 {
-    connect(mFeed, &dblsqd::Feed::ready, this, [=, this]() {
+    // Setup to automatically download the new release when an update is available
+    connect(feed.get(), &dblsqd::Feed::ready, this, [=, this]() {
         auto* pMudlet = mudlet::self();
         if (!pMudlet || pMudlet->developmentVersion) {
             return;
         }
 
-        auto updates = mFeed->getUpdates(dblsqd::Release::getCurrentRelease());
+        auto updates = feed->getUpdates(dblsqd::Release::getCurrentRelease());
         qWarning() << "Checked for updates:" << updates.size() << "update(s) available";
         if (!updates.isEmpty()) {
             emit signal_updateAvailable(updates.size());
         }
     });
 
-    connect(mFeed, &dblsqd::Feed::downloadError, this, [this](const QString& error) {
+    connect(feed.get(), &dblsqd::Feed::downloadError, this, [this](const QString& error) {
         qWarning() << "Automatic update download failed:" << error;
         emit signal_updateCheckFailed(error);
     });
-
-    mUpdateDialog = new dblsqd::UpdateDialog(mFeed, updateAutomatically() ? dblsqd::UpdateDialog::OnLastWindowClosed : dblsqd::UpdateDialog::Manual, mSettings);
-    //: Label for the update button shown in the update dialog
-    mpInstallOrRestart->setText(tr("Update"));
-    mUpdateDialog->addInstallButton(mpInstallOrRestart);
-    connect(mUpdateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::slot_installOrRestartClicked);
 }
 #endif // !Q_OS_MACOS
 
@@ -301,14 +302,16 @@ void Updater::setupOnWindows()
     cleanupSquirrelTempFiles();
     setupPlatformUpdater();
 
-    connect(mFeed, &dblsqd::Feed::downloadFinished, this, [=, this]() {
-        if (!(updateAutomatically() && mUpdateDialog->isHidden())) {
+    // Setup to run setup.exe to replace the old installation
+    connect(feed.get(), &dblsqd::Feed::downloadFinished, this, [=, this]() {
+        // if automatic updates are enabled, and this isn't a manual check, perform the automatic update
+        if (!(updateAutomatically() && updateDialog && updateDialog->isHidden())) {
             return;
         }
 
-        const QString fileName = mFeed->getDownloadFilePath();
+        const QString fileName = feed->getDownloadFilePath();
         if (fileName.isEmpty()) {
-            qWarning() << "Download finished but no download file available - feed URL:" << mFeed->getUrl();
+            qWarning() << "Download finished but no download file available - feed URL:" << feed->getUrl();
             //: Error shown when the automatic update download finished but produced no file
             emit signal_updateCheckFailed(tr("Update download failed. Please try again or download manually from https://www.mudlet.org/download/"));
             return;
@@ -323,6 +326,13 @@ void Updater::setupOnWindows()
         connect(watcher, &QFutureWatcher<void>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
     });
+
+    // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
+    updateDialog = new dblsqd::UpdateDialog(feed.get(), updateAutomatically() ? dblsqd::UpdateDialog::OnLastWindowClosed : dblsqd::UpdateDialog::Manual, mSettings);
+    //: Label for the update button shown in the update dialog
+    mpInstallOrRestart->setText(tr("Update"));
+    updateDialog->addInstallButton(mpInstallOrRestart);
+    connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::slot_installOrRestartClicked);
 }
 
 void Updater::prepareSetupOnWindows(const QString& downloadedSetupName)
@@ -337,14 +347,16 @@ void Updater::setupOnLinux()
 {
     setupPlatformUpdater();
 
-    connect(mFeed, &dblsqd::Feed::downloadFinished, this, [=, this]() {
-        if (!(updateAutomatically() && mUpdateDialog->isHidden())) {
+    // Setup to unzip and replace old binary when the download is done
+    connect(feed.get(), &dblsqd::Feed::downloadFinished, this, [=, this]() {
+        // if automatic updates are enabled, and this isn't a manual check, perform the automatic update
+        if (!(updateAutomatically() && updateDialog && updateDialog->isHidden())) {
             return;
         }
 
-        const QString fileName = mFeed->getDownloadFilePath();
+        const QString fileName = feed->getDownloadFilePath();
         if (fileName.isEmpty()) {
-            qWarning() << "Download finished but no download file available - feed URL:" << mFeed->getUrl();
+            qWarning() << "Download finished but no download file available - feed URL:" << feed->getUrl();
             //: Error shown when the automatic update download finished but produced no file
             emit signal_updateCheckFailed(tr("Update download failed. Please try again or download manually from https://www.mudlet.org/download/"));
             return;
@@ -359,6 +371,13 @@ void Updater::setupOnLinux()
         connect(watcher, &QFutureWatcher<void>::finished, watcher, &QObject::deleteLater);
         watcher->setFuture(future);
     });
+
+    // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
+    updateDialog = new dblsqd::UpdateDialog(feed.get(), updateAutomatically() ? dblsqd::UpdateDialog::OnLastWindowClosed : dblsqd::UpdateDialog::Manual, mSettings);
+    //: Label for the update button shown in the update dialog
+    mpInstallOrRestart->setText(tr("Update"));
+    updateDialog->addInstallButton(mpInstallOrRestart);
+    connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::slot_installOrRestartClicked);
 }
 
 void Updater::untarOnLinux(const QString& fileName)
@@ -471,8 +490,8 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
     if (mUpdateInstalled) {
         // defer to next event loop iteration so the dialog close happens after the button click handler returns
         QTimer::singleShot(0, this, [=, this]() {
-            mUpdateDialog->close();
-            mUpdateDialog->done(0);
+            updateDialog->close();
+            updateDialog->done(0);
         });
 
 #if defined(Q_OS_WINDOWS)

--- a/src/updater.h
+++ b/src/updater.h
@@ -22,6 +22,7 @@
 
 // QObject must be included before Q_OS_MACOS checks below
 #include <QObject>
+#include <QPointer>
 
 // Guard for builds without the updater (INCLUDE_UPDATER is defined by CMake when USE_UPDATER is ON):
 #if defined(INCLUDE_UPDATER)
@@ -34,6 +35,8 @@ class UpdateDialog;
 #include "sparkleupdater.h"
 #endif
 #endif
+
+#include <memory>
 
 class QAbstractButton;
 class QPushButton;
@@ -57,8 +60,11 @@ public:
     bool shouldShowChangelog();
 
 private:
-    dblsqd::Feed* mFeed;
-    dblsqd::UpdateDialog* mUpdateDialog{nullptr};
+    std::unique_ptr<dblsqd::Feed> feed;
+    // Non-owning: Qt parent-child system or explicit deletion in ~Updater handles lifetime.
+    // QPointer<T> is used so that if Qt deletes the dialog (e.g. on last window closed),
+    // the pointer automatically becomes null and ~Updater's delete becomes a no-op.
+    QPointer<dblsqd::UpdateDialog> updateDialog;
 #if !defined(Q_OS_MACOS)
     QPushButton* mpInstallOrRestart;
 #endif

--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -436,7 +436,7 @@ void Feed::cleanupDownloadFile()
 {
     if (mDownloadFile) {
         mDownloadFile->close();
-        delete mDownloadFile;
+        mDownloadFile->deleteLater();
         mDownloadFile = nullptr;
     }
 }

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -92,7 +92,7 @@ namespace dblsqd {
  */
 UpdateDialog::UpdateDialog(Feed* feed, Type type, QSettings* settings, QWidget* parent)
 : QDialog(parent)
-, mUi(new Ui::UpdateDialog)
+, mUi(std::make_unique<Ui::UpdateDialog>())
 , mFeed(feed)
 , mType(type)
 , mSettings(settings)
@@ -134,10 +134,7 @@ UpdateDialog::UpdateDialog(Feed* feed, Type type, QSettings* settings, QWidget* 
     }
 }
 
-UpdateDialog::~UpdateDialog()
-{
-    delete mUi;
-}
+UpdateDialog::~UpdateDialog() = default;
 
 /*!
  * \brief Sets the icon displayed in the update window.

--- a/src/updater/UpdateDialog.h
+++ b/src/updater/UpdateDialog.h
@@ -26,6 +26,8 @@
 #include <QDialog>
 #include <QVariant>
 
+#include <memory>
+
 class QAbstractButton;
 class QPixmap;
 class QSettings;
@@ -75,7 +77,7 @@ public slots:
     void showIfUpdatesAvailableOrQuit();
 
 private:
-    Ui::UpdateDialog* mUi;
+    std::unique_ptr<Ui::UpdateDialog> mUi;
     Feed* mFeed;
     Type mType;
 


### PR DESCRIPTION
### Refactor: replace raw pointer ownership with smart pointers across core subsystems

  #### Brief overview of PR changes/additions
  Replaces raw pointer ownership patterns with `std::unique_ptr` and `std::map`
  across several core subsystems:

  - **Host**: `mStopWatchMap` (`QMap<int, stopWatch*>` → `std::map<int, unique_ptr<stopWatch>>`), `profileShortcuts` (`QMap<QString, QKeySequence*>` → `std::map<QString, unique_ptr<QKeySequence>>`). Removes `qDeleteAll` in destructor and `delete mMMCPServer`.
  - **TMap**: `mpRoomDB` raw pointer → `unique_ptr`
  - **VarUnit**: `base` raw pointer → `unique_ptr`
  - **TTrigger**: condition map storage converted to `unique_ptr`, destructor simplified
  - **discord**: handler and presence maps converted from raw pointer `QMap` to `unique_ptr` + `std::map`
  - **Updater**: `mFeed` and `mUpdateDialog` converted to `unique_ptr`

  #### Motivation for adding to Mudlet
  These patterns were identified as sources of memory leaks and potential use-after-free bugs. Using smart pointers makes ownership explicit, eliminates manual cleanup code, and ensures correct destruction even on early-exit paths.

#### Other info (issues closed, discussion etc)

sorry this one is still pretty big, but most of the changes are the same for each thing so reviewing them together probably makes sense. sadly there isn't much to see here other than no slow uptick of heap size :-[