### PR TITLE
add: Lua memory introspection functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,10 @@ include_optional_module(ENVIRONMENT_VARIABLE WITH_SHADER_HOT_RELOAD
                         OPTION_VARIABLE USE_SHADER_HOT_RELOAD
                         READABLE_NAME "shader hot-reloading"
                         DEFAULT OFF)
+include_optional_module(ENVIRONMENT_VARIABLE WITH_MEMORY_TRACKING
+                        OPTION_VARIABLE USE_MEMORY_TRACKING
+                        READABLE_NAME "memory tracking"
+                        DEFAULT OFF)
 include_optional_module(ENVIRONMENT_VARIABLE WITH_VARIABLE_SPLASH_SCREEN
                         OPTION_VARIABLE USE_VARIABLE_SPLASH_SCREEN
                         READABLE_NAME "build-type splash screen")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -679,6 +679,11 @@ if(USE_SHADER_HOT_RELOAD AND USE_3DMAPPER)
   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC MUDLET_SHADER_HOT_RELOAD=1)
 endif()
 
+# Define memory tracking if enabled
+if(USE_MEMORY_TRACKING)
+  target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC MUDLET_MEMORY_TRACKING)
+endif()
+
 # Used to force an include of winsock2.h BEFORE Qt tries to include winsock.h
 # from windows.h - only needed on Windows builds but we cannot use Q_OS_WINDOWS
 # for an #ifdef because we need a symbol that is defined BEFORE we include

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5609,6 +5609,11 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "timeStampsEnabled", TLuaInterpreter::timeStampsEnabled);
     lua_register(pGlobalLua, "setActiveProfile", TLuaInterpreter::setActiveProfile);
     lua_register(pGlobalLua, "getKeyCode", TLuaInterpreter::getKeyCode);
+#ifdef MUDLET_MEMORY_TRACKING
+    lua_register(pGlobalLua, "getProcessMemoryUsage", TLuaInterpreter::getProcessMemoryUsage);
+    lua_register(pGlobalLua, "getSubsystemMemoryStats", TLuaInterpreter::getSubsystemMemoryStats);
+#endif
+
     // PLACEMARKER: End of main Lua interpreter functions registration
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -771,6 +771,11 @@ public:
     static int timeStampsEnabled(lua_State*);
     static int setActiveProfile(lua_State*);
     static int getKeyCode(lua_State*);
+#ifdef MUDLET_MEMORY_TRACKING
+    static int getProcessMemoryUsage(lua_State*);
+    static int getSubsystemMemoryStats(lua_State*);
+#endif
+
     // PLACEMARKER: End of Lua functions declarations
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -63,6 +63,23 @@
 #include <limits>
 #include <math.h>
 
+#ifdef MUDLET_MEMORY_TRACKING
+#if defined(Q_OS_LINUX)
+#include <fstream>
+#include <malloc.h>
+#elif defined(Q_OS_MACOS)
+#include <mach/mach.h>
+#include <malloc/malloc.h>
+#elif defined(Q_OS_WINDOWS)
+#include <windows.h>
+#include <psapi.h>
+#elif defined(Q_OS_BSD4)
+#include <sys/resource.h>
+#if defined(Q_OS_FREEBSD)
+#include <malloc.h>
+#endif
+#endif
+#endif // MUDLET_MEMORY_TRACKING
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
@@ -2857,3 +2874,249 @@ int TLuaInterpreter::closeProfile(lua_State* L)
     }
     return 0;
 }
+
+#ifdef MUDLET_MEMORY_TRACKING
+int TLuaInterpreter::getProcessMemoryUsage(lua_State* L)
+{
+    int64_t rssKb = 0;
+    bool success = false;
+
+#if defined(Q_OS_LINUX)
+    std::ifstream statusFile(qsl("/proc/self/status").toStdString());
+    std::string line;
+    while (std::getline(statusFile, line)) {
+        if (line.rfind("VmRSS:", 0) == 0) {
+            // Line format: "VmRSS:    12345 kB"
+            const char* p = line.c_str() + 6;
+            while (*p == ' ' || *p == '\t') {
+                ++p;
+            }
+            rssKb = static_cast<int64_t>(std::strtoll(p, nullptr, 10));
+            success = true;
+            break;
+        }
+    }
+#elif defined(Q_OS_MACOS)
+    mach_task_basic_info info;
+    mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &infoCount) == KERN_SUCCESS) {
+        rssKb = static_cast<int64_t>(info.resident_size / 1024);
+        success = true;
+    }
+#elif defined(Q_OS_WINDOWS)
+    PROCESS_MEMORY_COUNTERS pmc;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+        rssKb = static_cast<int64_t>(pmc.WorkingSetSize / 1024);
+        success = true;
+    }
+#elif defined(Q_OS_BSD4)
+    // ru_maxrss is in bytes on BSD (unlike Linux where it is kilobytes)
+    struct rusage ru = {};
+    if (getrusage(RUSAGE_SELF, &ru) == 0) {
+        rssKb = static_cast<int64_t>(ru.ru_maxrss / 1024);
+        success = true;
+    }
+#endif
+
+    if (success) {
+        lua_pushnumber(L, static_cast<lua_Number>(rssKb));
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+int TLuaInterpreter::getSubsystemMemoryStats(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+
+    lua_newtable(L);
+
+    // Lua heap via C API — immune to user scripts replacing collectgarbage global
+    const lua_Number heapKb = static_cast<lua_Number>(lua_gc(L, LUA_GCCOUNT, 0)) + static_cast<lua_Number>(lua_gc(L, LUA_GCCOUNTB, 0)) / 1024.0;
+    lua_pushstring(L, "lua_heap_kb");
+    lua_pushnumber(L, heapKb);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "lua_heap_mb");
+    lua_pushnumber(L, heapKb / 1024.0);
+    lua_settable(L, -3);
+
+    // Trigger counts (total, temp) via assembleReport()
+    {
+        const auto [_msg, total, _patterns, temp, _active, _activePatterns] = host.getTriggerUnit()->assembleReport();
+        lua_pushstring(L, "triggers_total");
+        lua_pushnumber(L, total);
+        lua_settable(L, -3);
+        lua_pushstring(L, "triggers_temp");
+        lua_pushnumber(L, temp);
+        lua_settable(L, -3);
+    }
+
+    // Timer counts
+    {
+        const auto [_msg, total, temp, _active] = host.getTimerUnit()->assembleReport();
+        lua_pushstring(L, "timers_total");
+        lua_pushnumber(L, total);
+        lua_settable(L, -3);
+        lua_pushstring(L, "timers_temp");
+        lua_pushnumber(L, temp);
+        lua_settable(L, -3);
+    }
+
+    // Alias counts
+    {
+        const auto [_msg, total, temp, _active] = host.getAliasUnit()->assembleReport();
+        lua_pushstring(L, "aliases_total");
+        lua_pushnumber(L, total);
+        lua_settable(L, -3);
+        lua_pushstring(L, "aliases_temp");
+        lua_pushnumber(L, temp);
+        lua_settable(L, -3);
+    }
+
+    // Event handler count (total registered handlers across all event names)
+    {
+        int handlerCount = 0;
+        for (const auto& handlerList : host.mEventHandlerMap) {
+            handlerCount += handlerList.size();
+        }
+        lua_pushstring(L, "event_handlers");
+        lua_pushnumber(L, handlerCount);
+        lua_settable(L, -3);
+    }
+
+    // Map room and area counts
+    if (host.mpMap && host.mpMap->mpRoomDB) {
+        lua_pushstring(L, "map_rooms");
+        lua_pushnumber(L, host.mpMap->mpRoomDB->size());
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "map_areas");
+        lua_pushnumber(L, host.mpMap->mpRoomDB->getAreaMap().size());
+        lua_settable(L, -3);
+    } else {
+        lua_pushstring(L, "map_rooms");
+        lua_pushnumber(L, 0);
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "map_areas");
+        lua_pushnumber(L, 0);
+        lua_settable(L, -3);
+    }
+
+    // Main console buffer line count
+    if (host.mpConsole) {
+        lua_pushstring(L, "console_buffer_lines");
+        lua_pushnumber(L, host.mpConsole->buffer.size());
+        lua_settable(L, -3);
+    }
+
+    // Media player counts: total live players per type and count of idle (stopped) players
+    if (host.mpMedia) {
+        int soundPlayers = 0;
+        int musicPlayers = 0;
+        int stoppedPlayers = 0;
+        host.mpMedia->getMediaPlayerCounts(soundPlayers, musicPlayers, stoppedPlayers);
+
+        lua_pushstring(L, "media_sound_players");
+        lua_pushnumber(L, soundPlayers);
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "media_music_players");
+        lua_pushnumber(L, musicPlayers);
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "media_stopped_players");
+        lua_pushnumber(L, stoppedPlayers);
+        lua_settable(L, -3);
+    }
+
+    // C heap statistics: bytes in use by live allocations vs total bytes obtained
+    // from the OS, summed across all malloc zones and broken out per zone.
+    // The gap between in_use and allocated is fragmented free space that has been
+    // freed but not yet returned to the OS.
+    {
+        bool heapStatsAvailable = false;
+        double heapInUseMb = 0.0;
+        double heapAllocatedMb = 0.0;
+        static constexpr double kBytesPerMb = 1024.0 * 1024.0;
+#if defined(Q_OS_MACOS)
+        heapStatsAvailable = true;
+        vm_address_t* zones = nullptr;
+        unsigned int zoneCount = 0;
+        // zones subtable: { [zone_name] = { in_use_mb = N, allocated_mb = N } }
+        lua_pushstring(L, "heap_zones");
+        lua_newtable(L);
+        if (malloc_get_all_zones(mach_task_self(), nullptr, &zones, &zoneCount) == KERN_SUCCESS) {
+            size_t totalInUse = 0;
+            size_t totalAllocated = 0;
+            for (unsigned int i = 0; i < zoneCount; ++i) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                auto* zone = reinterpret_cast<malloc_zone_t*>(zones[i]);
+                malloc_statistics_t zoneStats = {};
+                malloc_zone_statistics(zone, &zoneStats);
+                totalInUse += zoneStats.size_in_use;
+                totalAllocated += zoneStats.size_allocated;
+
+                const char* zoneName = zone->zone_name ? zone->zone_name : "unnamed";
+                lua_pushstring(L, zoneName);
+                lua_newtable(L);
+                lua_pushstring(L, "in_use_mb");
+                lua_pushnumber(L, static_cast<double>(zoneStats.size_in_use) / kBytesPerMb);
+                lua_settable(L, -3);
+                lua_pushstring(L, "allocated_mb");
+                lua_pushnumber(L, static_cast<double>(zoneStats.size_allocated) / kBytesPerMb);
+                lua_settable(L, -3);
+                lua_settable(L, -3);
+            }
+            heapInUseMb = static_cast<double>(totalInUse) / kBytesPerMb;
+            heapAllocatedMb = static_cast<double>(totalAllocated) / kBytesPerMb;
+        }
+        lua_settable(L, -3);
+#elif defined(Q_OS_LINUX)
+        heapStatsAvailable = true;
+        struct mallinfo2 mi = mallinfo2();
+        heapInUseMb = static_cast<double>(mi.uordblks) / kBytesPerMb;
+        heapAllocatedMb = (static_cast<double>(mi.arena) + static_cast<double>(mi.hblkhd)) / kBytesPerMb;
+#elif defined(Q_OS_WINDOWS)
+        heapStatsAvailable = true;
+        constexpr DWORD kMaxHeaps = 128;
+        HANDLE heapHandles[kMaxHeaps];
+        const DWORD heapCount = GetProcessHeaps(kMaxHeaps, heapHandles);
+        SIZE_T totalInUse = 0;
+        SIZE_T totalAllocated = 0;
+        for (DWORD i = 0; i < heapCount; ++i) {
+            PROCESS_HEAP_ENTRY entry = {};
+            HeapLock(heapHandles[i]);
+            while (HeapWalk(heapHandles[i], &entry)) {
+                if (entry.wFlags & PROCESS_HEAP_ENTRY_BUSY) {
+                    totalInUse += entry.cbData;
+                }
+                totalAllocated += entry.cbData + entry.cbOverhead;
+            }
+            HeapUnlock(heapHandles[i]);
+        }
+        heapInUseMb = static_cast<double>(totalInUse) / kBytesPerMb;
+        heapAllocatedMb = static_cast<double>(totalAllocated) / kBytesPerMb;
+#elif defined(Q_OS_FREEBSD)
+        heapStatsAvailable = true;
+        // FreeBSD/DragonFly: jemalloc provides a mallinfo() compatibility shim
+        struct mallinfo mi = mallinfo();
+        heapInUseMb = static_cast<double>(mi.uordblks) / kBytesPerMb;
+        heapAllocatedMb = (static_cast<double>(mi.arena) + static_cast<double>(mi.hblkhd)) / kBytesPerMb;
+#endif
+        if (heapStatsAvailable) {
+            lua_pushstring(L, "heap_in_use_mb");
+            lua_pushnumber(L, heapInUseMb);
+            lua_settable(L, -3);
+
+            lua_pushstring(L, "heap_allocated_mb");
+            lua_pushnumber(L, heapAllocatedMb);
+            lua_settable(L, -3);
+        }
+    }
+
+    return 1;
+}
+#endif // MUDLET_MEMORY_TRACKING

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1234,6 +1234,27 @@ int TMedia::getMaxAllowedVideoPlayers() const
     return std::max(2, 10 / hostCount);
 }
 
+#ifdef MUDLET_MEMORY_TRACKING
+void TMedia::getMediaPlayerCounts(int& soundPlayers, int& musicPlayers, int& stoppedPlayers) const
+{
+    soundPlayers = mAPISoundList.size() + mMSPSoundList.size() + mGMCPSoundList.size();
+    musicPlayers = mAPIMusicList.size() + mMSPMusicList.size() + mGMCPMusicList.size();
+
+    const auto countStopped = [](const QList<std::shared_ptr<TMediaPlayer>>& lst) {
+        int n = 0;
+        for (const auto& p : lst) {
+            if (p && p->getPlaybackState() == QMediaPlayer::StoppedState) {
+                ++n;
+            }
+        }
+        return n;
+    };
+
+    stoppedPlayers = countStopped(mAPISoundList) + countStopped(mMSPSoundList) + countStopped(mGMCPSoundList) + countStopped(mAPIMusicList) + countStopped(mMSPMusicList) + countStopped(mGMCPMusicList)
+                     + countStopped(mAPIVideoList) + countStopped(mGMCPVideoList);
+}
+#endif // MUDLET_MEMORY_TRACKING
+
 void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playbackState, const std::shared_ptr<TMediaPlayer>& player)
 {
     if (!player) {

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -130,6 +130,9 @@ public:
     int getMaxAllowedSoundPlayers() const;
     int getMaxAllowedMusicPlayers() const;
     int getMaxAllowedVideoPlayers() const;
+#ifdef MUDLET_MEMORY_TRACKING
+    void getMediaPlayerCounts(int& soundPlayers, int& musicPlayers, int& stoppedPlayers) const;
+#endif
 
     void playMedia(TMediaData& mediaData);
     QList<TMediaData> playingMedia(TMediaData& mediaData);


### PR DESCRIPTION
  #### Brief overview of PR changes/additions
  Adds two new Lua functions:
  - `getProcessMemoryUsage()` — returns current process RSS in Kb
    (Windows: `GetProcessMemoryInfo`, macOS: `task_info`, Linux: `/proc/self/status`)
  - `getSubsystemMemoryStats()` — returns a table with heap and Lua GC
    metrics, plus per-subsystem counts (map rooms/areas, active media
    players, loaded fonts, regex patterns)


  #### Motivation for adding to Mudlet
  There was no way for scripters or developers to observe Mudlet's memory
  usage from within Lua.

#### Other info (issues closed, discussion etc)

this would allow something like:

```lua
mem = mem or {}

mem.snapshot = function(label)
  local rss = getProcessMemoryUsage()
  local s = getSubsystemMemoryStats()
  
  local tag = label and ("[" .. label .. "] ") or ""

  local lines = {}

  lines[#lines + 1] = string.format(
      "%s<reset>RSS=<yellow>%.0f MB<reset>  lua=<green>%.1f MB<reset>  " ..
      "heap=<magenta>%.0f/%.0f MB<reset>  scrollback=<white>%d lines<reset>  " ..
      "triggers=<white>%d(%d temp)<reset>  timers=<white>%d(%d temp)<reset>  " ..
      "aliases=<white>%d(%d temp)<reset>  handlers=<white>%d<reset>  rooms=<white>%d<reset>",
      tag,
      rss / 1024,
      s.lua_heap_mb,
      s.heap_in_use_mb, s.heap_allocated_mb,
      s.console_buffer_lines or 0,
      s.triggers_total, s.triggers_temp,
      s.timers_total,   s.timers_temp,
      s.aliases_total,  s.aliases_temp,
      s.event_handlers,
      s.map_rooms
  )

  if s.heap_zones then
      local zones = {}
      for name, z in pairs(s.heap_zones) do
          zones[#zones + 1] = { name = name, in_use_mb = z.in_use_mb, allocated_mb = z.allocated_mb }
      end
      table.sort(zones, function(a, b) return a.allocated_mb > b.allocated_mb end)
      for _, z in ipairs(zones) do
          if z.allocated_mb >= 1 then
              lines[#lines + 1] = string.format(
                  "  <cyan>%-38s<reset> in_use=<yellow>%6.1f MB<reset>  allocated=<green>%6.1f MB<reset>",
                  z.name, z.in_use_mb, z.allocated_mb
              )
          end
      end
  end

  return table.concat(lines, "\n")
end


mem.logSnapshot = function(label)
  cecho('<yellow>' .. getTime(true, "hh:mm:ss") .. ': <white>' .. mem.snapshot(label) .. "\n")
end
```
to produce something like:
<img width="811" height="84" alt="image" src="https://github.com/user-attachments/assets/807fb03b-fa80-42e2-aea1-1bfdf7b301fb" />

to help track memory issues.