### PR TITLE
Fix: Clazy warnings part 8 - sanitize-inline-keyword

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1128,19 +1128,19 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
 // player's room if it is visible. This is so it is drawn LAST (and any effects,
 // or extra markings for it do not get overwritten by the drawing of the other
 // rooms)...
-/* inline */ void T2DMap::drawRoom(QPainter& painter,
-                                   QFont& roomVNumFont,
-                                   QFont& mapNameFont,
-                                   QPen& pen,
-                                   TRoom* pRoom,
-                                   const bool isGridMode,
-                                   const bool areRoomIdsLegible,
-                                   const bool showRoomName,
-                                   const int speedWalkStartRoomId,
-                                   const float rx,
-                                   const float ry,
-                                   const QMap<int, QPointF>& areaExitsMap,
-                                   const bool showRoomCollision)
+void T2DMap::drawRoom(QPainter& painter,
+                      QFont& roomVNumFont,
+                      QFont& mapNameFont,
+                      QPen& pen,
+                      TRoom* pRoom,
+                      const bool isGridMode,
+                      const bool areRoomIdsLegible,
+                      const bool showRoomName,
+                      const int speedWalkStartRoomId,
+                      const float rx,
+                      const float ry,
+                      const QMap<int, QPointF>& areaExitsMap,
+                      const bool showRoomCollision)
 {
     const int currentRoomId = pRoom->getId();
     if (pRoom->isHidden()) {

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -205,9 +205,9 @@ public:
 
 
     // default 2D zoom level
-    inline static const qreal csmDefaultXYZoom = 20.0;
+    static inline const qreal csmDefaultXYZoom = 20.0;
     // minimum 2D zoom level
-    inline static const qreal csmMinXYZoom = 3.0;
+    static inline const qreal csmMinXYZoom = 3.0;
 
 
     TMap* mpMap = nullptr;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4531,7 +4531,7 @@ int TBuffer::calculateWrapPosition(int lineNumber, int begin, int end)
     return lineSize;
 }
 
-inline int TBuffer::skipSpacesAtBeginOfLine(const int row, const int column)
+int TBuffer::skipSpacesAtBeginOfLine(const int row, const int column)
 {
     int offset = 0;
     int position = column;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2017-2018, 2020, 2022-2023 by Stephen Lyons       *
+ *   Copyright (C) 2015, 2017-2018, 2020, 2022-2023, 2026 by Stephen Lyons *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -284,12 +284,12 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
 
 class TBuffer
 {
-    inline static const TEncodingTable& csmEncodingTable = TEncodingTable::csmDefaultInstance;
+    static inline const TEncodingTable& csmEncodingTable = TEncodingTable::csmDefaultInstance;
 
-    inline static const int TCHAR_IN_BYTES = sizeof(TChar);
+    static inline const int TCHAR_IN_BYTES = sizeof(TChar);
 
     // limit on how many characters a single echo can accept for performance reasons
-    inline static const int MAX_CHARACTERS_PER_ECHO = 1000000;
+    static inline const int MAX_CHARACTERS_PER_ECHO = 1000000;
 
 public:
     explicit TBuffer(Host* pH, TConsole* pConsole = nullptr);
@@ -301,7 +301,7 @@ public:
     void expandLine(int y, int count, TChar&);
     int wrapLine(int startLine, int maxWidth, int indentSize, int hangingIndentSize);
     void log(int, int);
-    int skipSpacesAtBeginOfLine(const int row, const int column);
+    inline int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, const TChar& format, const QVector<int>& luaReference = QVector<int>());
     QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0, int spacePadding = 0);
     int size() { return static_cast<int>(buffer.size()); }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -504,7 +504,7 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
     }
 }
 
-/* inline */ void TTextEdit::replaceControlCharacterWith_Picture(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
+void TTextEdit::replaceControlCharacterWith_Picture(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
 {
     switch (unicode) {
     case 0:
@@ -647,7 +647,7 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
     }
 }
 
-/* inline */ void TTextEdit::replaceControlCharacterWith_OEMFont(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
+void TTextEdit::replaceControlCharacterWith_OEMFont(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
 {
     Q_UNUSED(column)
     switch (unicode) {
@@ -2645,7 +2645,7 @@ int TTextEdit::getRowCount() const
     return qRound(height() / QFontMetricsF(font()).lineSpacing());
 }
 
-inline QString TTextEdit::htmlCenter(const QString& text)
+QString TTextEdit::htmlCenter(const QString& text)
 {
     return qsl("<center>%1</center>").arg(text);
 }
@@ -2654,7 +2654,7 @@ inline QString TTextEdit::htmlCenter(const QString& text)
 // that some entries do not work like this and we cannot just display a short
 // bit of text to indicate them in the analysis of the on-screen content- the
 // language directional controls may be like that:
-inline QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QChar& second)
+QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QChar& second)
 {
     // clang-format off
     if (second.isNull()) {
@@ -2856,7 +2856,7 @@ inline QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QC
     // clang-format on
 }
 
-inline QString TTextEdit::byteToLuaCodeOrChar(const char* byte)
+QString TTextEdit::byteToLuaCodeOrChar(const char* byte)
 {
     if (!byte) {
         return QString();

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2018, 2020 by Stephen Lyons                       *
+ *   Copyright (C) 2015, 2018, 2020, 2026 by Stephen Lyons                 *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
@@ -176,7 +176,7 @@ private slots:
 
 private:
     QString getSelectedText(const QChar& newlineChar = QChar::LineFeed, const bool showTimestamps = false);
-    static QString htmlCenter(const QString&);
+    inline static QString htmlCenter(const QString&);
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
- *   Copyright (C) 2017-2018, 2021 by Stephen Lyons                        *
+ *   Copyright (C) 2017-2018, 2021, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -528,7 +528,7 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
     }
 }
 
-inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches)
+void TTrigger::updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches)
 {
     if (regexNumber == 0) {
         // automatically set to #1
@@ -569,7 +569,7 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
     }
 }
 
-inline void TTrigger::filter(std::string& capture, int& posOffset)
+void TTrigger::filter(std::string& capture, int& posOffset)
 {
     if (capture.empty()) {
         return;

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -174,8 +174,8 @@ public:
 private:
     TTrigger() = default;
 
-    void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
-    void filter(std::string&, int&);
+    inline void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
+    inline void filter(std::string&, int&);
     void processExactMatch(const QString& line, int patternNumber, int posOffset);
     void processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
                            const QSharedPointer<pcre2_code>& re, int haystackCLength, pcre2_match_data* match_data, int rc);

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -66,7 +66,7 @@ public:
     bool ancestorsActive() const;
     QString& getError();
     void setError(QString);
-    bool state() const;
+    inline bool state() const;
 /* No longer used - most cases were accessing the member directly
     QString getPackageName() const { return mPackageName; }
     void setPackageName(const QString& n) { mPackageName = n; }
@@ -92,7 +92,7 @@ public:
 // Not used:    QString mModuleName;
 
 protected:
-    virtual bool canBeActivated() const;
+    inline virtual bool canBeActivated() const;
 
     bool mOK_init;
     bool mOK_code;
@@ -205,13 +205,13 @@ bool Tree<T>::setIsActive(bool b)
 }
 
 template <class T>
-inline bool Tree<T>::state() const
+bool Tree<T>::state() const
 {
     return (mOK_init && mOK_code);
 }
 
 template <class T>
-inline bool Tree<T>::canBeActivated() const
+bool Tree<T>::canBeActivated() const
 {
     return (shouldBeActive() && state());
 }

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -107,7 +107,7 @@ private:
     void writeScriptPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeKeyPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeVariablePackage(Host* pHost, pugi::xml_node& mMudletPackage);
-    static void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
+    static inline void replaceAll(std::string& source, const std::string& from, const std::string& to);
     bool saveXmlFile(QSaveFile& file);
     bool saveXml(const QString&);
     static bool saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
One of a series of PRs, each addressing a type of issue reported by Clazy.

This is the: "the 'inline' keyword is specified on the definition, but not the declaration. This could lead to hard-to-suppress warnings with some compilers (e.g. MinGW). The 'inline' keyword should be used for the declaration only. [clazy-sanitize-inline-keyword]" one.

#### Motivation for adding to Mudlet
Remove warnings detected by the Clazy tool - either when explicitly run on the Mudlet code-base or detected by the background scanner/analyser that Qt Creator offers.

#### Other info (issues closed, discussion etc)
A summary I found for this is:
> This can lead to compiler warnings, and the recommended fix is to add the inline keyword to the declaration in-class.

In some cases we had `static inline` and others `inline static` and the inconsistency made it hard to spot all of them. This PR converts latter to the former.

Also add a missing `inline` to `(void) TTrigger::filter(std::string&, int&)` in the declaration in the header file after it was removed from the definition in the class file.