### PR TITLE
Fix: Windows updater hanging on close and spawning duplicate processes

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5774,8 +5774,13 @@ void mudlet::slot_updateInstalled()
 
     // rejig to restart Mudlet instead
     connect(dactionUpdate, &QAction::triggered, this, [=, this]() {
+#if defined(Q_OS_WINDOWS)
+        // On Windows the binary isn't swapped in place yet - the installer still has to run.
+        pUpdater->slot_installOrRestartClicked(nullptr, QString());
+#else
         forceClose();
         QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+#endif
     });
     dactionUpdate->setText(tr("Update installed - restart to apply"));
 #endif // !Q_OS_MACOS

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -287,7 +287,9 @@ void Updater::setupPlatformUpdater()
         emit signal_updateCheckFailed(error);
     });
 
-    mUpdateDialog = new dblsqd::UpdateDialog(mFeed, updateAutomatically() ? dblsqd::UpdateDialog::OnLastWindowClosed : dblsqd::UpdateDialog::Manual, mSettings);
+    // OnLastWindowClosed flips setQuitOnLastWindowClosed(false) and re-shows the dialog on close,
+    // so Mudlet won't exit via the X button while an update is pending. Drive the dialog manually instead.
+    mUpdateDialog = new dblsqd::UpdateDialog(mFeed, dblsqd::UpdateDialog::Manual, mSettings);
     //: Label for the update button shown in the update dialog
     mpInstallOrRestart->setText(tr("Update"));
     mUpdateDialog->addInstallButton(mpInstallOrRestart);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
About-menu "Update installed - restart to apply" now routes through the installer batch on Windows instead of relaunching the un-swapped exe.

Always construct the update dialog in Manual mode - OnLastWindowClosed disables quitOnLastWindowClosed and re-shows the dialog when the main window closes, preventing Mudlet from exiting via the X button.
#### Motivation for adding to Mudlet
Addressing Windows PTB not updating properly.
#### Other info (issues closed, discussion etc)
This is a bit hard to test - requires merging first then having 2 PTB builds.