### PR TITLE
fix: set main connection to be low latency

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -649,6 +649,7 @@ void cTelnet::slot_socketConnected()
 #endif
     }
 
+    mpSocket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
     reset();
     setKeepAlive(mpSocket->socketDescriptor());
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Disables Nagle's algorithm on the main socket (mmcp socket was already doing this). 

#### Motivation for adding to Mudlet

reduce latency when sending commands to the mud (can add additional round trip before a command is sent).

#### Other info (issues closed, discussion etc)

Nagle's algorithm batches small TCP writes — it holds outgoing data until the previous send has been acknowledged by the remote end. This is good for throughput but bad for interactive use: when a user hits
  Enter, the command can sit in the kernel's send buffer waiting for an ACK from the server before being transmitted, adding up to one full round-trip of latency before the server even sees the command.