### PR TITLE
infrastructure: disable Sentry on PTB builds to test update-stall hypothesis

### DIFF
--- a/src/SentryWrapper.cpp
+++ b/src/SentryWrapper.cpp
@@ -40,6 +40,10 @@
 #include <cstdlib>
 #include <algorithm>
 
+#ifdef WITH_SENTRY
+static bool s_sentryInitialized = false;
+#endif
+
 // Initializes Sentry options for crash/error reporting.
 // Crashes are first stored in a local cache folder, then automatically sent.
 //
@@ -50,6 +54,18 @@
 void initSentry()
 {
 #ifdef WITH_SENTRY
+    QString appBuild;
+    QFile gitShaFile(qsl(":/app-build.txt"));
+    if (gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        appBuild = QString::fromUtf8(gitShaFile.readAll()).trimmed();
+    }
+
+    // Skip Sentry on PTB builds: sentry_close() blocks on shutdown which can
+    // prevent Mudlet from quitting cleanly and stall Sparkle/Squirrel updates.
+    if (appBuild.startsWith(qsl("-ptb"))) {
+        return;
+    }
+
     sentry_options_t* options = sentry_options_new();
     std::string runtimeAppDir = getExeDir();
     QString path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/mudlet/sentry";
@@ -58,11 +74,6 @@ void initSentry()
         return;
     }
 
-    QString appBuild;
-    QFile gitShaFile(qsl(":/app-build.txt"));
-    if (gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        appBuild = QString::fromUtf8(gitShaFile.readAll()).trimmed();
-    }
     const std::string release = qsl("mudlet@%1%2").arg(APP_VERSION, appBuild).toStdString();
 
     sentry_options_set_database_path(options, path.toUtf8().constData());
@@ -71,6 +82,17 @@ void initSentry()
     sentry_options_set_external_crash_reporter_path(options, makeExecutablePath(runtimeAppDir, "MudletCrashReporter").c_str());
 
     sentry_init(options);
+    s_sentryInitialized = true;
+#endif
+}
+
+void closeSentry()
+{
+#ifdef WITH_SENTRY
+    if (s_sentryInitialized) {
+        sentry_close();
+        s_sentryInitialized = false;
+    }
 #endif
 }
 

--- a/src/SentryWrapper.h
+++ b/src/SentryWrapper.h
@@ -27,9 +27,10 @@
 
 #include <string>
 
-void        initSentry();
+void initSentry();
+void closeSentry();
 std::string makeExecutablePath(const std::string& dir, const std::string& name);
 std::string getExeDir();
-void        crashIfRequested();
+void crashIfRequested();
 
 #endif // SENTRY_WRAPPER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,7 +292,7 @@ int main(int argc, char* argv[])
 #ifdef WITH_SENTRY
     initSentry();
     auto sentryClose = qScopeGuard([] {
-        sentry_close();
+        closeSentry();
     });
 #endif
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Skip `sentry_init()` and `sentry_close()` on PTB builds. Detection is done at runtime by checking the `:/app-build.txt` resource for a `-ptb` prefix. Release, dev and test builds are unchanged.

#### Motivation for adding to Mudlet
Testing the hypothesis from Discord (https://discord.com/channels/283581582550237184/427919962561052673/1502238266701647922) that Sentry is blocking Mudlet's exit between PTB updates - `sentry_close()` is documented to block the calling thread until its background worker finishes.

#### Other info (issues closed, discussion etc)