### PR TITLE
Fix: heap-use-after-free in TriggerUnit::processDataStream

### DIFF
--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -300,7 +300,13 @@ void TriggerUnit::processDataStream(const QString& data, int line)
 
     mProcessingDepth++;
 
-    for (auto trigger : mTriggerRootNodeList) {
+    // Iterate a snapshot of the root list: a trigger's Lua script can call
+    // uninstallPackage()/installPackage() and mutate mTriggerRootNodeList
+    // mid-iteration (the underlying std::list::remove frees the iterator's
+    // current node → use-after-free on the next ++). AliasUnit dodges the
+    // same hazard for the same reason — see Mudlet issue #4297.
+    auto copyOfNodeList = mTriggerRootNodeList;
+    for (auto trigger : copyOfNodeList) {
         trigger->match(subject, data, line);
     }
     free(subject);


### PR DESCRIPTION
## Summary

A trigger's Lua script can call `uninstallPackage("<self>")` (a pattern used by hot-reload tooling and remote-eval companions). When it does, Mudlet aborts with a heap-use-after-free inside `TriggerUnit::processDataStream`'s outer iteration over `mTriggerRootNodeList`.

Sequence:

```
processDataStream
  for (auto trigger : mTriggerRootNodeList)        ← iteration
    trigger->match(...)
      → execute() → Lua callback
      → uninstallPackage("<self>")
      → Host::uninstallPackage
      → TriggerUnit::uninstall
      → removeTriggerRootNode
      → mTriggerRootNodeList.remove(pT)            ← frees the list node
  }                                                ← iterator++ reads the freed node → UAF
```

`AliasUnit::processDataStream` already iterates a snapshot of its root list with the comment _"Using copy fixes #4297"_. TriggerUnit was missed by that fix — same hazard, same one-line remediation.

## Reproducer

A package with one trigger whose script body is `uninstallPackage("<self>")`. Fire the trigger via `feedTriggers("CRASH_REPRO_TRIGGER\n")` from a Lua script. Without this patch:

```
==ERROR: AddressSanitizer: heap-use-after-free
   in TriggerUnit::processDataStream
freed by:
   std::list::remove
   TriggerUnit::removeTriggerRootNode
   TriggerUnit::uninstall
   Host::uninstallPackage
   TLuaInterpreter::uninstallPackage    ← Lua callback running inside
   TTrigger::execute                     ← the for-loop body
   TTrigger::match
   TriggerUnit::processDataStream
SIGABRT
```

With this patch: clean run, no ASan errors.

Verified on `release-4.20` (where the user-visible crash was originally reported) and on `development` (where it manifests identically).

## Test plan

- [x] ASan build of `development` with the reproducer above — UAF gone
- [x] ASan build of unpatched `development` — UAF reproduces consistently
- [x] Diff inspected: 1 file, +7 / -1, matches AliasUnit's existing pattern verbatim
- [ ] CI Linux/macOS/Windows builds + existing test suite (let CI handle)