### PR TITLE
Infrastructure: rename local variables to reflect their type in `TAction` class

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2021-2023 by Stephen Lyons                        *
+ *   Copyright (C) 2017, 2021-2023, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -87,8 +87,8 @@ void TAction::compileAll()
         }
         mOK_code = false;
     }
-    for (auto action : *mpMyChildrenList) {
-        action->compileAll();
+    for (auto pTAction : *mpMyChildrenList) {
+        pTAction->compileAll();
     }
 }
 
@@ -102,8 +102,8 @@ void TAction::compile()
             mOK_code = false;
         }
     }
-    for (auto action : *mpMyChildrenList) {
-        action->compile();
+    for (auto pTAction : *mpMyChildrenList) {
+        pTAction->compile();
     }
 }
 
@@ -170,84 +170,84 @@ void TAction::execute()
 
 void TAction::expandToolbar(TToolBar* pT)
 {
-    for (auto action : *mpMyChildrenList) {
-        if (!action->isActive()) {
+    for (auto pTAction : *mpMyChildrenList) {
+        if (!pTAction->isActive()) {
             // This test and conditional loop abort was missing from this method
             // but is needed so that disabled buttons do not appear on
             // floating toolbars - possible future scope here to have "disabled"
             // buttons show in a "greyed-out" state... - Slysven
             continue;
         }
-        const QIcon icon(action->mIcon);
-        const QString name = action->getName();
-        auto button = new TFlipButton(action, mpHost);
-        button->setIcon(icon);
-        button->setText(name);
-        button->setCheckable(action->mIsPushDownButton);
+        const QIcon icon(pTAction->mIcon);
+        const QString name = pTAction->getName();
+        auto pTFlipButton = new TFlipButton(pTAction, mpHost);
+        pTFlipButton->setIcon(icon);
+        pTFlipButton->setText(name);
+        pTFlipButton->setCheckable(pTAction->mIsPushDownButton);
 
-        if (action->mIsPushDownButton) {
-            button->setChecked(action->mButtonState);
+        if (pTAction->mIsPushDownButton) {
+            pTFlipButton->setChecked(pTAction->mButtonState);
         } else {
             // The following was added to ensure a non-Pushdown button is never
             // left in a checked state - Slysven
-            button->setChecked(false);
+            pTFlipButton->setChecked(false);
         }
 
-        button->setFlat(mButtonFlat);
+        pTFlipButton->setFlat(mButtonFlat);
         // This applies the CSS for THIS TAction to a CHILD's representation on the Toolbar
-        button->setStyleSheet(css);
+        pTFlipButton->setStyleSheet(css);
 
-        if (action->isFolder()) {
-            auto newMenu = new QMenu(pT);
+        if (pTAction->isFolder()) {
+            auto pNewMenu = new QMenu(pT);
             // This applies the CSS for THIS TAction to a CHILD's own menu - is this right
-            newMenu->setStyleSheet(css);
+            pNewMenu->setStyleSheet(css);
             // CHECK: Use the Child's CSS instead for a menu on it? - Slysven:
-            // newMenu->setStyleSheet( action->css );
-            action->insertActions(pT, newMenu);
+            // pNewMenu->setStyleSheet( pTAction->css );
+            pTAction->insertActions(pT, pNewMenu);
             // This has been move until AFTER the child's menu has been
-            // populated, it was being done straight after newMenu was created,
+            // populated, it was being done straight after pNewMenu was created,
             // but I think we ought to insert the items into the menu before
             // applying the menu to the button - Slysven
-            button->setMenu(newMenu);
+            pTFlipButton->setMenu(pNewMenu);
         }
 
-        if (action->mpFButton) {
-            action->mpFButton->deleteLater();
+        if (pTAction->mpFButton) {
+            pTAction->mpFButton->deleteLater();
         }
-        action->mpFButton = button;
+        pTAction->mpFButton = pTFlipButton;
 
-        // Moved to be AFTER the action->mIsFolder test as I think we ought to
+        // Moved to be AFTER the pTAction->mIsFolder test as I think we ought to
         // add the button to the toolbar AFTER any menu (children) items have
         // been put on the button - Slysven
-        pT->addButton(button);
+        pT->addButton(pTFlipButton);
     }
 }
 
 // This seems to be the TToolBar version of TAction::fillMenu(TEasyButtonBar *, QMenu *)
 // Unlike the other this one seems to introduce an "intermediate" single menu
 // item to which the sub-menu is added.
-void TAction::insertActions(TToolBar* pT, QMenu* menu)
+void TAction::insertActions(TToolBar* pT, QMenu* pMenu)
 {
     mpToolBar = pT;
-    auto action = new EAction(mpHost, QIcon(mIcon), mName, mID);
-    action->setCheckable(mIsPushDownButton);
-    action->setStatusTip(mName);
-    if (mpEButton) {
-        mpEButton->deleteLater();
+    auto pEAction = new EAction(mpHost, QIcon(mIcon), mName, mID);
+    pEAction->setCheckable(mIsPushDownButton);
+    pEAction->setStatusTip(mName);
+    if (mpEAction) {
+        mpEAction->deleteLater();
     }
-    mpEButton = action;
-    menu->addAction(action);
+    mpEAction = pEAction;
+    pMenu->addAction(pEAction);
 
     if (isFolder()) {
         // The use of mudlet::self() here meant that the QMenu was not destroyed
         // until the mudlet instance is at the end of the application!
         // Changed to use pT, the toolbar
-        auto newMenu = new QMenu(pT);
-        newMenu->setStyleSheet(css);
-        action->setMenu(newMenu);
+        auto pNewMenu = new QMenu(pT);
+        pNewMenu->setStyleSheet(css);
+        pEAction->setMenu(pNewMenu);
 
         for (auto childAction : *mpMyChildrenList) {
-            childAction->insertActions(pT, newMenu);
+            childAction->insertActions(pT, pNewMenu);
         }
     }
 }
@@ -255,129 +255,129 @@ void TAction::insertActions(TToolBar* pT, QMenu* menu)
 
 void TAction::expandToolbar(TEasyButtonBar* pT)
 {
-    for (auto action : *mpMyChildrenList) {
-        if (!action->isActive()) {
+    for (auto pTAction : *mpMyChildrenList) {
+        if (!pTAction->isActive()) {
             continue;
         }
-        const QIcon icon(action->mIcon);
-        const QString name = action->getName();
-        auto button = new TFlipButton(action, mpHost);
-        button->setIcon(icon);
-        button->setText(name);
-        button->setCheckable(action->mIsPushDownButton);
+        const QIcon icon(pTAction->mIcon);
+        const QString name = pTAction->getName();
+        auto pTFlipButton = new TFlipButton(pTAction, mpHost);
+        pTFlipButton->setIcon(icon);
+        pTFlipButton->setText(name);
+        pTFlipButton->setCheckable(pTAction->mIsPushDownButton);
 
-        if (action->mIsPushDownButton) {
-            button->setChecked(action->mButtonState);
+        if (pTAction->mIsPushDownButton) {
+            pTFlipButton->setChecked(pTAction->mButtonState);
         } else {
             // The following was added to ensure a non-Pushdown button is never
             // left in a checked state - Slysven
-            button->setChecked(false);
+            pTFlipButton->setChecked(false);
         }
 
-        button->setFlat(mButtonFlat);
+        pTFlipButton->setFlat(mButtonFlat);
         // This applies the CSS for THIS TAction to a CHILD's representation on the Toolbar
-        button->setStyleSheet(css);
+        pTFlipButton->setStyleSheet(css);
 
         //FIXME: Heiko April 2012: only run checkbox button scripts, but run them even if unchecked
-        if (action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
-            qDebug() << "expandToolBar() name=" << action->mName << " executing script";
-            action->execute();
+        if (pTAction->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
+            qDebug() << "expandToolBar() name=" << pTAction->mName << " executing script";
+            pTAction->execute();
         }
 
 
-        if (action->isFolder()) {
-            // This applied the CSS for THIS TAction to a CHILD's own menu - is this right
-            auto newMenu = new QMenu(button);
+        if (pTAction->isFolder()) {
+            auto pNewMenu = new QMenu(pTFlipButton);
 
+            // This applied the CSS for THIS TAction to a CHILD's own menu - is this right
             // CHECK: consider using the Child's CSS instead for a menu on it
             // - Slysven:
-            // newMenu->setStyleSheet( action->css );
-            newMenu->setStyleSheet(css);
+            // pNewMenu->setStyleSheet( pTAction->css );
+            pNewMenu->setStyleSheet(css);
+
+            pTAction->fillMenu(pT, pNewMenu);
 
             // This has been moved until AFTER the child's menu has been
-            // populated, it was being done straight after newMenu was created,
+            // populated, it was being done straight after pNewMenu was created,
             // but I think we ought to insert the items into the menu before
             // applying the menu to the button - Slysven
-            action->fillMenu(pT, newMenu);
-
-            button->setMenu(newMenu);
+            pTFlipButton->setMenu(pNewMenu);
         }
 
-        if (action->mpFButton) {
-            action->mpFButton->deleteLater();
+        if (pTAction->mpFButton) {
+            pTAction->mpFButton->deleteLater();
         }
-        action->mpFButton = button;
+        pTAction->mpFButton = pTFlipButton;
 
-        // Moved to be AFTER the action->mIsFolder test as I think we ought to
+        // Moved to be AFTER the pTAction->mIsFolder test as I think we ought to
         // add the button to the toolbar AFTER any menu (children) items have
         // been put on the button - Slysven
-        pT->addButton(button);
+        pT->addButton(pTFlipButton);
     }
 }
 
 // This seems to be the second half of TEasyButtonBar version of:
 //   TAction::insertActions( TToolBar *, QMenu * )
 // the need for the split is not yet clear to me! - Slysven
-void TAction::fillMenu(TEasyButtonBar* pT, QMenu* menu)
+void TAction::fillMenu(TEasyButtonBar* pT, QMenu* pMenu)
 {
-    for (auto action : *mpMyChildrenList) {
-        if (!action->isActive()) {
+    for (auto pTAction : *mpMyChildrenList) {
+        if (!pTAction->isActive()) {
             continue;
         }
         mpEasyButtonBar = pT;
-        auto newAction = new EAction(mpHost, QIcon(mIcon), action->mName, action->mID);
-        newAction->setStatusTip(action->mName);
-        newAction->setCheckable(action->mIsPushDownButton);
-        if (action->mIsPushDownButton) {
-            newAction->setChecked(action->mButtonState);
+        auto pEAction = new EAction(mpHost, QIcon(mIcon), pTAction->mName, pTAction->mID);
+        pEAction->setStatusTip(pTAction->mName);
+        pEAction->setCheckable(pTAction->mIsPushDownButton);
+        if (pTAction->mIsPushDownButton) {
+            pEAction->setChecked(pTAction->mButtonState);
         } else {
-            newAction->setChecked(false);
+            pEAction->setChecked(false);
         }
 
-        if (action->mpEButton) {
-            action->mpEButton->deleteLater();
+        if (pTAction->mpEAction) {
+            pTAction->mpEAction->deleteLater();
         }
-        action->mpEButton = newAction;
+        pTAction->mpEAction = pEAction;
 
         //FIXME: Heiko April 2012 -> expandToolBar()
-        if (action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
-            action->execute();
+        if (pTAction->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
+            pTAction->execute();
         }
 
-        if (action->isFolder()) {
+        if (pTAction->isFolder()) {
             // Adding a QWidget derived pointer to new QMenu() means the menu
             // will be destroyed when the pointed to item is, we just need to
             // find the item that it is attached to - ah ha, try the toolbar...
-            auto newMenu = new QMenu(pT);
-            newAction->setMenu(newMenu);
+            auto pNewMenu = new QMenu(pT);
+            pEAction->setMenu(pNewMenu);
 
             // CHECK: consider using the Child's CSS instead for a menu on it
             // - Slysven:
-            // newMenu->setStyleSheet( action->css );
-            newMenu->setStyleSheet(css);
+            // pNewMenu->setStyleSheet( pTAction->css );
+            pNewMenu->setStyleSheet(css);
 
-            action->fillMenu(pT, newMenu);
+            pTAction->fillMenu(pT, pNewMenu);
         }
 
-        // Menu is PARENT'S menu newAction, this line moved to be AFTER child builds its own menu if it is a folder
-        menu->addAction(newAction);
+        // Menu is PARENT'S menu pEAction, this line moved to be AFTER child builds its own menu if it is a folder
+        pMenu->addAction(pEAction);
     }
 }
 
 // This only has code corresponding to the first part of:
-//   TAction::insertActions( TToolBar * pT, QMenu * menu )
-void TAction::insertActions(TEasyButtonBar* pT, QMenu* menu)
+//   TAction::insertActions( TToolBar * pT, QMenu * pMenu )
+void TAction::insertActions(TEasyButtonBar* pT, QMenu* pMenu)
 {
     mpEasyButtonBar = pT;
-    auto action = new EAction(mpHost, QIcon(mIcon), mName, mID);
-    action->setCheckable(mIsPushDownButton);
-    action->setStatusTip(mName);
-    if (mpEButton) {
-        mpEButton->deleteLater();
+    auto pEAction = new EAction(mpHost, QIcon(mIcon), mName, mID);
+    pEAction->setCheckable(mIsPushDownButton);
+    pEAction->setStatusTip(mName);
+    if (mpEAction) {
+        mpEAction->deleteLater();
     }
-    mpEButton = action;
-    Q_ASSERT_X(menu, "TAction::insertActions(TEasyButtonBar*, QMenu*)", "method called with a NULL QMenu pointer!");
-    menu->addAction(action);
+    mpEAction = pEAction;
+    Q_ASSERT_X(pMenu, "TAction::insertActions(TEasyButtonBar*, QMenu*)", "method called with a NULL QMenu pointer!");
+    pMenu->addAction(pEAction);
 }
 
 void TAction::setName(const QString& name)
@@ -393,35 +393,35 @@ void TAction::setName(const QString& name)
     }
 }
 
-QString TAction::packageName(TAction* pAction) const
+QString TAction::packageName(TAction* pTAction) const
 {
-    if (!pAction) {
+    if (!pTAction) {
         return QString();
     }
 
-    if (!pAction->mPackageName.isEmpty()) {
-        return !mpHost->mInstalledModules.contains(pAction->mPackageName) ? pAction->mPackageName : QString();
+    if (!pTAction->mPackageName.isEmpty()) {
+        return !mpHost->mInstalledModules.contains(pTAction->mPackageName) ? pTAction->mPackageName : QString();
     }
 
-    if (pAction->getParent()) {
-        return packageName(pAction->getParent());
+    if (pTAction->getParent()) {
+        return packageName(pTAction->getParent());
     }
 
     return QString();
 }
 
-QString TAction::moduleName(TAction* pAction) const
+QString TAction::moduleName(TAction* pTAction) const
 {
-    if (!pAction) {
+    if (!pTAction) {
         return QString();
     }
 
-    if (!pAction->mPackageName.isEmpty()) {
-        return mpHost->mInstalledModules.contains(pAction->mPackageName) ? pAction->mPackageName : QString();
+    if (!pTAction->mPackageName.isEmpty()) {
+        return mpHost->mInstalledModules.contains(pTAction->mPackageName) ? pTAction->mPackageName : QString();
     }
 
-    if (pAction->getParent()) {
-        return moduleName(pAction->getParent());
+    if (pTAction->getParent()) {
+        return moduleName(pTAction->getParent());
     }
 
     return QString();

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -98,7 +98,7 @@ public:
 
     QPointer<TToolBar> mpToolBar;
     QPointer<TEasyButtonBar> mpEasyButtonBar;
-    QPointer<EAction> mpEButton;
+    QPointer<EAction> mpEAction;
     QPointer<TFlipButton> mpFButton;
     // The following was an int but there was confusion over:
     // EITHER: "1" = released/unclicked/up & "2" = pressed/clicked/down

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2022, 2024 by Stephen Lyons                        *
+ *   Copyright (C) 2013-2022, 2024, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
@@ -1587,8 +1587,8 @@ int TLuaInterpreter::setButtonState(lua_State* L)
 
     if (pItem->mButtonState != checked) {
         pItem->mButtonState = checked;
-        if (pItem->mpEButton) {
-            pItem->mpEButton->setChecked(checked);
+        if (pItem->mpEAction) {
+            pItem->mpEAction->setChecked(checked);
         }
         if (pItem->mpFButton) {
             pItem->mpFButton->setChecked(checked);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Make the names of local objects in the `TAction` class reflect their type to, for instance clarify whether we are working on a `QAction`, a `TAction` or an `EAction` - also prepending a `p` for pointers.

#### Motivation for adding to Mudlet
This is to make it a bit clearer as I try to untangle the :spaghetti: code in the `TAction` class - i.e. the "base" class for Buttons/Menus/Toolbars.

There are some issues within that type of Mudlet object, including memory leaks (objects not been deleted after use) and functional oddities, such as menus on the `TToolBar` type object having two menu objects for a single Mudlet instance with the upper one displaying just the lower one and that lower one actually containing the buttons within that group.

#### Other info (issues closed, discussion etc)
This should NOT produce any functional changes as it is entirely to do with the names of variables (and one miss-named class member) - and the relocation of a couple of comments that were out of place.