### PR TITLE
Fix layout of new profile list items

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -779,6 +779,9 @@ void dlgConnectionProfiles::continueProfileSave(QListWidgetItem* pItem, const QS
     } else {
         setItemName(pItem, newProfileName);
         pItem->setIcon(customIcon(newProfileName, std::nullopt));
+        // If this was a brand new profile, it did not previously have an icon. Setting an icon
+        // does not seem to cause the list widget to re-layout, so we'll do that manually.
+        QMetaObject::invokeMethod(listWidget_profiles, &QAbstractItemView::doItemsLayout, Qt::QueuedConnection);
     }
 }
 
@@ -1340,7 +1343,6 @@ void dlgConnectionProfiles::fillout_form()
     if (toselectRow != -1) {
         listWidget_profiles->setCurrentRow(toselectRow);
     }
-
 }
 
 void dlgConnectionProfiles::setProfileIcon() const


### PR DESCRIPTION
#### Brief overview of PR changes/additions

"Manually" cause a re-layout of `listWidget_profiles` when a profile is saved.

#### Motivation for adding to Mudlet

Fixes #9258

#### Other info (issues closed, discussion etc)

This is the most surgical fix I could think of for the issue, but the issue is revealing some (imo) pretty strange behavior in the process of creating a new profile. At the moment, we are adding new iconless items to `listWidget_profiles`, which seemingly have no width and therefor are "fit" on the last line of the list. When the item is later updated to set an icon, it stays where it was.

I was working on another branch that stores "new profile" data in memory and only creates a list item when saved, but this was spiraling into a pretty massive changeset, so I'm offering up this little fix for now.