### PR TITLE
Fix: prevent crashes on removing multiple buttons/menus/toolbars in editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3080,18 +3080,6 @@ void dlgTriggerEditor::delete_alias()
     }
 }
 
-/*static*/ void dlgTriggerEditor::findAllDescendants(QSet<QTreeWidgetItem*>& set, QTreeWidgetItem* pItem)
-{
-    if (!pItem) {
-        return;
-    }
-    set.insert(pItem);
-    for (int i = 0, count = pItem->childCount(); i < count; ++i) {
-        // Recursively call the function for each child
-        findAllDescendants(set, pItem->child(i));
-    }
-}
-
 void dlgTriggerEditor::delete_action()
 {
     QList<QTreeWidgetItem*> initiallySelectedItems = treeWidget_actions->selectedItems();
@@ -3101,12 +3089,14 @@ void dlgTriggerEditor::delete_action()
 
     // Capture each selected action and all its descendants
     // and put them into here:
-    QSet<QTreeWidgetItem*> selectedItemsSet;
-    for (const auto& item : initiallySelectedItems) {
-        findAllDescendants(selectedItemsSet, item);
+    QList<QTreeWidgetItem*> selectedItems;
+    for (const auto& item : std::as_const(initiallySelectedItems)) {
+        treeWidget_actions->getAllChildren(item, selectedItems);
     }
 
-    QList<QTreeWidgetItem*> selectedItems{selectedItemsSet.begin(), selectedItemsSet.end()};
+    // Remove any duplicates by converting to a set and back to a list:
+    QSet<QTreeWidgetItem*> selectedItemsSet{selectedItems.cbegin(), selectedItems.cend()};
+    selectedItems = QList<QTreeWidgetItem*>{selectedItemsSet.cbegin(), selectedItemsSet.cend()};
 
     QStringList itemNames;
     QList<TAction*> actionsToDelete;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3080,17 +3080,37 @@ void dlgTriggerEditor::delete_alias()
     }
 }
 
+/*static*/ void dlgTriggerEditor::findAllDescendants(QSet<QTreeWidgetItem*>& set, QTreeWidgetItem* pItem)
+{
+    if (!pItem) {
+        return;
+    }
+    set.insert(pItem);
+    for (int i = 0, count = pItem->childCount(); i < count; ++i) {
+        // Recursively call the function for each child
+        findAllDescendants(set, pItem->child(i));
+    }
+}
+
 void dlgTriggerEditor::delete_action()
 {
-    QList<QTreeWidgetItem*> selectedItems = treeWidget_actions->selectedItems();
-    if (selectedItems.isEmpty()) {
+    QList<QTreeWidgetItem*> initiallySelectedItems = treeWidget_actions->selectedItems();
+    if (initiallySelectedItems.isEmpty()) {
         return;
     }
 
+    // Capture each selected action and all its descendants
+    // and put them into here:
+    QSet<QTreeWidgetItem*> selectedItemsSet;
+    for (const auto& item : initiallySelectedItems) {
+        findAllDescendants(selectedItemsSet, item);
+    }
+
+    QList<QTreeWidgetItem*> selectedItems{selectedItemsSet.begin(), selectedItemsSet.end()};
+
     QStringList itemNames;
     QList<TAction*> actionsToDelete;
-
-    for (const QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
+    for (const QTreeWidgetItem* pItem : std::as_const(initiallySelectedItems)) {
         TAction* pT = mpHost->getActionUnit()->getAction(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
             itemNames << pT->getName();
@@ -3104,10 +3124,14 @@ void dlgTriggerEditor::delete_action()
 
     // Show confirmation dialog for multiple items
     QString message;
-    if (actionsToDelete.size() == 1) {
-        message = tr("Do you really want to delete button \"%1\"?").arg(itemNames.first());
+    if (selectedItems.size() == 1) {
+        message = tr("Do you really want to delete button/menu/toolbar \"%1\"?").arg(itemNames.first());
     } else {
-        message = tr("Do you really want to delete %1 buttons?\n\nItems to be deleted:\n%2").arg(actionsToDelete.size()).arg(itemNames.join(", "));
+        //: This needs further work to properly in all locales as currently %1 is a ', ' spaced "quoted" list of items
+        message = tr("Do you really want to delete %n item(s) of type button, menu or toolbar?<br><br>Items to be deleted:<br>\"%1\".",
+                     nullptr,
+                     actionsToDelete.size())
+                .arg(itemNames.join(qsl("\", \"")));
     }
 
     // Capture state of all items BEFORE deletion for undo
@@ -3145,7 +3169,6 @@ void dlgTriggerEditor::delete_action()
         }
     };
 
-    // Capture each selected action and all its descendants
     for (QTreeWidgetItem* pItem : std::as_const(selectedItems)) {
         TAction* pT = mpHost->getActionUnit()->getAction(pItem->data(0, Qt::UserRole).toInt());
         if (pT) {
@@ -3173,18 +3196,6 @@ void dlgTriggerEditor::delete_action()
         QModelIndex indexB = treeWidget_actions->indexFromItem(b);
         return indexA.row() < indexB.row();
     });
-
-    /* Note that selectedItems only contains the actually selected items and
-     * not necessarily their children - so it cannot be used to identify that
-     * multiple items were scheduled to be removed.*/
-    if (deletedItems.count() > 1) {
-        showWarning(tr("Sorry your selection will require the deletion of %n item(s) and due to a current limitation within Mudlet it is not possible to delete more than one button, or a menu or toolbar that contains any buttons or menus, at a time.<br><br>"
-                       "Please remove each individual button, one at a time, before any parent menu or toolbar.",
-                       nullptr,
-                       deletedItems.count()),
-                    true);
-        return;
-    }
 
     // Delete in reverse order to maintain valid indices
     std::reverse(selectedItems.begin(), selectedItems.end());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3174,6 +3174,18 @@ void dlgTriggerEditor::delete_action()
         return indexA.row() < indexB.row();
     });
 
+    /* Note that selectedItems only contains the actually selected items and
+     * not necessarily their children - so it cannot be used to identify that
+     * multiple items were scheduled to be removed.*/
+    if (deletedItems.count() > 1) {
+        showWarning(tr("Sorry your selection will require the deletion of %n item(s) and due to a current limitation within Mudlet it is not possible to delete more than one button, or a menu or toolbar that contains any buttons or menus, at a time.<br><br>"
+                       "Please remove each individual button, one at a time, before any parent menu or toolbar.",
+                       nullptr,
+                       deletedItems.count()),
+                    true);
+        return;
+    }
+
     // Delete in reverse order to maintain valid indices
     std::reverse(selectedItems.begin(), selectedItems.end());
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -590,6 +590,9 @@ private:
                                                              {tr("Statistics"), qsl("Ctrl+9")},
                                                              {tr("Debug"), qsl("Ctrl+0")}};
 
+    static void findAllDescendants(QSet<QTreeWidgetItem*>&, QTreeWidgetItem*);
+
+
     std::unordered_map<SingleLineTextEdit*, bool> lineEditShouldMarkSpaces;
 
     QToolBar* toolBar = nullptr;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -590,9 +590,6 @@ private:
                                                              {tr("Statistics"), qsl("Ctrl+9")},
                                                              {tr("Debug"), qsl("Ctrl+0")}};
 
-    static void findAllDescendants(QSet<QTreeWidgetItem*>&, QTreeWidgetItem*);
-
-
     std::unordered_map<SingleLineTextEdit*, bool> lineEditShouldMarkSpaces;
 
     QToolBar* toolBar = nullptr;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Prevents fatal segmentation faults when trying to delete more than one button, menu or toolbar in the editor. This seems to be a regression that was introduced by the undo/redo system (#8469) into that editor. I suspect this is because that code `delete`s `TAction` instances directly but in the process that causes the regeneration of all the toolbars which retain pointers to the deleted `TActions` with fatal results.

~~This is not a fix for the underlying cause but a preventative step that aborts with a warning message should the end user try to delete, say, a populated toolbar or menu, or multiple buttons at once.~~

#### Motivation for adding to Mudlet
Prevent fatal crashes of whole client.

#### Other info (issues closed, discussion etc)
~~An actual fix for this issue is not immediately obviously but since this defect is already present in the latest release AND PTBs this PR at least needs to go in ASAP.~~
This now constitutes an actual fix - in the deletion process for `Actions` (buttons/menus/toolbars) the item selected for deletion are examined to gather all the other (children) that also need to be deleted and the whole set is converted into a `QList` similar (but all inclusive) to the supplied list. When this revised list is sorted so that the ordering is suitable for deletion (with the lowest leaf node first) then deletion can proceed without a problem - unlike before.