### PR TITLE
Fix: make loadProfile case-insensitive for built-in and user profiles

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6906,19 +6906,19 @@ int TLuaInterpreter::getProfileInformation(lua_State* L)
         break;
     }
     default: {
-        QString profileName = getVerifiedString(L, __func__, 1, "profile name");
-        if (profileName.isEmpty()) {
+        const QString requestedName = getVerifiedString(L, __func__, 1, "profile name");
+        if (requestedName.isEmpty()) {
             lua_pushnil(L);
             lua_pushstring(L, "getProfileInformation: profile name cannot be empty");
             return 2;
         }
-        if (!mudlet::self()->profileExists(profileName)) {
+        const QString profileName = mudlet::self()->getCanonicalProfileName(requestedName);
+        if (profileName.isEmpty()) {
             lua_pushnil(L);
-            lua_pushfstring(L, "getProfileInformation: profile '%s' does not exist", profileName.toUtf8().constData());
+            lua_pushfstring(L, "getProfileInformation: profile '%s' does not exist", requestedName.toUtf8().constData());
             return 2;
-        } else {
-            info = mudlet::self()->readProfileData(profileName, qsl("description"));
         }
+        info = mudlet::self()->readProfileData(profileName, qsl("description"));
         break;
     }
     }

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2802,22 +2802,23 @@ int TLuaInterpreter::getProfiles(lua_State* L)
 int TLuaInterpreter::loadProfile(lua_State* L)
 {
     auto& hostManager = mudlet::self()->getHostManager();
-    const QString profileName = getVerifiedString(L, __func__, 1, "profile name");
+    const QString requestedName = getVerifiedString(L, __func__, 1, "profile name");
     bool offline = false;
 
     if (lua_gettop(L) > 1) {
         offline = getVerifiedBool(L, __func__, 2, "offline mode", true);
     }
 
-    if (profileName.isEmpty()) {
+    if (requestedName.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L, "loadProfile: profile name cannot be empty");
         return 2;
     }
 
-    if (!mudlet::self()->profileExists(profileName)) {
+    const QString profileName = mudlet::self()->getCanonicalProfileName(requestedName);
+    if (profileName.isEmpty()) {
         lua_pushnil(L);
-        lua_pushfstring(L, "loadProfile: profile '%s' does not exist", profileName.toUtf8().constData());
+        lua_pushfstring(L, "loadProfile: profile '%s' does not exist", requestedName.toUtf8().constData());
         return 2;
     }
 
@@ -2845,18 +2846,19 @@ int TLuaInterpreter::loadProfile(lua_State* L)
 int TLuaInterpreter::closeProfile(lua_State* L)
 {
     auto& hostManager = mudlet::self()->getHostManager();
-    QString profileName;
+    QString requestedName;
 
     if (lua_gettop(L) == 0) {
         Host& host = getHostFromLua(L);
-        profileName = host.getName();
+        requestedName = host.getName();
     } else {
-        profileName = getVerifiedString(L, __func__, 1, "profile name");
+        requestedName = getVerifiedString(L, __func__, 1, "profile name");
     }
 
-    if (!mudlet::self()->profileExists(profileName)) {
+    const QString profileName = mudlet::self()->getCanonicalProfileName(requestedName);
+    if (profileName.isEmpty()) {
         lua_pushnil(L);
-        lua_pushfstring(L, "closeProfile: profile '%s' does not exist", profileName.toUtf8().constData());
+        lua_pushfstring(L, "closeProfile: profile '%s' does not exist", requestedName.toUtf8().constData());
         return 2;
     }
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2406,17 +2406,18 @@ int TLuaInterpreter::selectString(lua_State* L)
 int TLuaInterpreter::setActiveProfile(lua_State* L)
 {
     auto& hostManager = mudlet::self()->getHostManager();
-    const QString profileName = getVerifiedString(L, __func__, 1, "profile name");
+    const QString requestedName = getVerifiedString(L, __func__, 1, "profile name");
 
-    if (profileName.isEmpty()) {
+    if (requestedName.isEmpty()) {
         lua_pushboolean(L, false);
         lua_pushstring(L, "setActiveProfile: profile name cannot be empty");
         return 2;
     }
 
-    if (!mudlet::self()->profileExists(profileName)) {
+    const QString profileName = mudlet::self()->getCanonicalProfileName(requestedName);
+    if (profileName.isEmpty()) {
         lua_pushboolean(L, false);
-        lua_pushfstring(L, "setActiveProfile: profile '%s' does not exist", profileName.toUtf8().constData());
+        lua_pushfstring(L, "setActiveProfile: profile '%s' does not exist", requestedName.toUtf8().constData());
         return 2;
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7309,14 +7309,28 @@ void mudlet::changeEvent(QEvent* event)
 
 bool mudlet::profileExists(const QString& profileName)
 {
-    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    return !getCanonicalProfileName(profileName).isEmpty();
+}
 
-    if (profiles.contains(profileName, Qt::CaseInsensitive)) {
-        return true;
+QString mudlet::getCanonicalProfileName(const QString& profileName)
+{
+    if (profileName.isEmpty()) {
+        return QString();
     }
 
-    auto it = TGameDetails::findGame(profileName);
-    return it != TGameDetails::scmDefaultGames.end();
+    const QStringList profiles = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    for (const auto& profile : profiles) {
+        if (profile.compare(profileName, Qt::CaseInsensitive) == 0) {
+            return profile;
+        }
+    }
+
+    const auto it = TGameDetails::findGame(profileName, Qt::CaseInsensitive);
+    if (it != TGameDetails::scmDefaultGames.constEnd()) {
+        return it->name;
+    }
+
+    return QString();
 }
 
 void mudlet::saveDetachedWindowsGeometry()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -317,6 +317,7 @@ public:
     bool mediaMuted() const { return mMuteAPI && mMuteGame; }
     bool mediaUnmuted() const { return !mMuteAPI && !mMuteGame; }
     bool profileExists(const QString& profileName);
+    QString getCanonicalProfileName(const QString& profileName);
     bool showSplitscreenTutorial();
     void showedSplitscreenTutorial();
     bool showMuteAllMediaTutorial();


### PR DESCRIPTION
## Summary

`loadProfile('BLACKMUD')` opened a tab but failed to connect, because `TGameDetails::findGame` defaults to case-sensitive lookup so no URL or port was set on the new host. And `loadProfile('SoMe MuD')` for a user profile named `Some MUD` loaded with the wrong-case tab title because the user-supplied name was used verbatim downstream.

Adds `mudlet::getCanonicalProfileName()` to resolve a user-supplied name to its canonical form via case-insensitive lookup against on-disk profiles first, then built-ins. `profileExists()` is now a thin wrapper around the helper. `TLuaInterpreter::loadProfile` canonicalizes the requested name before all downstream calls, so the URL lookup, the `hostLoaded` check, and the resulting tab title all use the canonical casing.

Fixes #9269

## Test plan

- [ ] `loadProfile('BLACKMUD')` connects to BlackMUD with the correct tab title
- [ ] `loadProfile('SoMe MuD')` for a user profile named `Some MUD` loads with the tab titled `Some MUD`
- [ ] `loadProfile('BlackMUD')` (correct case) still works
- [ ] `loadProfile('does-not-exist')` still errors with "profile does not exist"
- [ ] `loadProfile('BlackMUD')` called twice in a row still errors with "already loaded" on the second call

🤖 Generated with [Claude Code](https://claude.com/claude-code)