### PR TITLE
Fix: trigger multi-line attribute resets when adding a sibling trigger

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5400,6 +5400,12 @@ void dlgTriggerEditor::addAction(bool isFolder)
     }
 
     // Reset UI
+    // Block property-save slots so the widget changes below don't fire write-backs
+    // into the previously selected action (mpCurrentActionItem still points at it).
+    // Unchecking checkBox_action_button_isPushDown otherwise calls
+    // slot_saveProperty_ActionIsPushDown on the old action. slot_actionSelected()
+    // clears the flag once the new item is loaded.
+    mBlockPropertySave = true;
     mpActionsMainArea->lineEdit_action_icon->clear();
     mpActionsMainArea->checkBox_action_button_isPushDown->setChecked(false);
     clearDocument(mpSourceEditorEdbee); // New Action

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4957,6 +4957,10 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
     }
 
     // Reset UI
+    // Block property-save slots so the widget changes below don't fire write-backs
+    // into the previously selected trigger (mpCurrentTriggerItem still points at
+    // it). slot_triggerSelected() clears the flag once the new item is loaded.
+    mBlockPropertySave = true;
     mpTriggersMainArea->lineEdit_trigger_name->clear();
     mpTriggersMainArea->label_idNumber->clear();
     mpTriggersMainArea->checkBox_perlSlashGOption->setChecked(false);

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -1674,6 +1674,56 @@ private slots:
     cleanupAll(mItemTypes[0]);
   }
 
+  void testAddTriggerDoesNotClearSelectedMultilineState() {
+    mpEditor->slot_showTriggers();
+    cleanupAll(mItemTypes[0]);
+
+    mpEditor->addTrigger(false);
+    QVERIFY(mpEditor->mpTriggerBaseItem->childCount() > 0);
+
+    QTreeWidgetItem *firstTriggerItem = mpEditor->mpTriggerBaseItem->child(0);
+    QVERIFY(firstTriggerItem != nullptr);
+
+    const int firstTriggerID = firstTriggerItem->data(0, Qt::UserRole).toInt();
+    TTrigger *firstTrigger =
+        mpHost->getTriggerUnit()->getTrigger(firstTriggerID);
+    QVERIFY(firstTrigger != nullptr);
+
+    mpEditor->treeWidget_triggers->setCurrentItem(firstTriggerItem);
+    mpEditor->slot_triggerSelected(firstTriggerItem);
+    mpEditor->mpUndoStack->clear();
+
+    mpEditor->showPatternItems(2);
+    QVERIFY(mpEditor->mTriggerPatternEdit.size() >= 2);
+    mpEditor->mTriggerPatternEdit[0]->singleLineTextEdit_pattern->setPlainText(
+        qsl("first line"));
+    mpEditor->mTriggerPatternEdit[1]->singleLineTextEdit_pattern->setPlainText(
+        qsl("second line"));
+    mpEditor->mpTriggersMainArea->spinBox_lineMargin->setValue(2);
+    QCoreApplication::processEvents();
+    mpEditor->saveTrigger();
+
+    QVERIFY(firstTrigger->isMultiline());
+    QCOMPARE(firstTrigger->getConditionLineDelta(), 2);
+    QCOMPARE(firstTrigger->getPatternsList().size(), 2);
+
+    mpEditor->addTrigger(false);
+    QCoreApplication::processEvents();
+
+    QCOMPARE(mpEditor->mpTriggerBaseItem->childCount(), 2);
+    QVERIFY2(firstTrigger->isMultiline(),
+             "Adding a sibling trigger should not clear the previously "
+             "selected trigger's multi-line state");
+    QCOMPARE(firstTrigger->getConditionLineDelta(), 2);
+
+    mpEditor->treeWidget_triggers->setCurrentItem(firstTriggerItem);
+    mpEditor->slot_triggerSelected(firstTriggerItem);
+
+    QCOMPARE(mpEditor->mpTriggersMainArea->spinBox_lineMargin->value(), 2);
+
+    cleanupAll(mItemTypes[0]);
+  }
+
   void testTriggerHighlightingColor() {
     mpEditor->slot_showTriggers();
     cleanupAll(mItemTypes[0]);
@@ -1759,6 +1809,51 @@ private slots:
     QCOMPARE(mpEditor->mpActionsMainArea->comboBox_action_button_rotation
                  ->currentIndex(),
              newRotationIndex);
+
+    cleanupAll(mItemTypes[5]);
+  }
+
+  void testAddActionDoesNotClearSelectedPushDownButton() {
+    mpEditor->slot_showActions();
+    cleanupAll(mItemTypes[5]);
+
+    mpEditor->addAction(false);
+    QVERIFY(mpEditor->mpActionBaseItem->childCount() > 0);
+
+    QTreeWidgetItem *firstActionItem = mpEditor->mpActionBaseItem->child(0);
+    QVERIFY(firstActionItem != nullptr);
+
+    const int firstActionID = firstActionItem->data(0, Qt::UserRole).toInt();
+    TAction *firstAction = mpHost->getActionUnit()->getAction(firstActionID);
+    QVERIFY(firstAction != nullptr);
+
+    mpEditor->treeWidget_actions->setCurrentItem(firstActionItem);
+    mpEditor->slot_actionSelected(firstActionItem);
+    mpEditor->mpUndoStack->clear();
+
+    mpEditor->mpActionsMainArea->checkBox_action_button_isPushDown->setChecked(
+        true);
+    QCoreApplication::processEvents();
+
+    QVERIFY(firstAction->isPushDownButton());
+    QVERIFY(
+        mpEditor->mpActionsMainArea->checkBox_action_button_isPushDown
+            ->isChecked());
+
+    mpEditor->addAction(false);
+    QCoreApplication::processEvents();
+
+    QCOMPARE(mpEditor->mpActionBaseItem->childCount(), 2);
+    QVERIFY2(firstAction->isPushDownButton(),
+             "Adding a sibling action should not clear the previously "
+             "selected action's push-down state");
+
+    mpEditor->treeWidget_actions->setCurrentItem(firstActionItem);
+    mpEditor->slot_actionSelected(firstActionItem);
+
+    QVERIFY(
+        mpEditor->mpActionsMainArea->checkBox_action_button_isPushDown
+            ->isChecked());
 
     cleanupAll(mItemTypes[5]);
   }


### PR DESCRIPTION
## Summary

When a multi-line trigger is selected and the user clicks "Add new trigger", `dlgTriggerEditor::addTrigger()` runs its "Reset UI" block to clear the form for the new entry. That block calls `spinBox_lineMargin->setValue(-1)`, `checkBox_perlSlashGOption->setChecked(false)`, `checkBox_filterTrigger->setChecked(false)`, `spinBox_stayOpen->setValue(0)`, and `groupBox_triggerColorizer->setChecked(false)`.

Each of those widget changes fires the matching `slot_saveProperty_Trigger*` slot synchronously. `mpCurrentTriggerItem` is not updated to the new item until later in `addTrigger()`, so the slots write the reset values into the *previously selected* trigger — flipping `isMultiline` to false, clearing colorizer settings, etc. Re-selecting the original trigger shows it as plain `OR / Multi-item`.

The fix sets `mBlockPropertySave = true` immediately before the UI reset block. `slot_triggerSelected()` clears the flag once the new item is loaded, restoring normal behaviour.

Fixes #9216

## Test plan

- [ ] Reproduce the original bug on a build without this patch (multi-line trigger reverts to OR/Multi-item after adding a sibling)
- [ ] On a build with this patch, perform the same steps and confirm the multi-line trigger keeps its `AND / Multi-line (within: N lines)` setting
- [ ] Confirm the other trigger properties (perl /g, filter, stay open, colorizer) are also not clobbered on the previous trigger when adding a sibling
- [ ] Confirm property edits on the *new* trigger still produce undo entries as before (the flag is cleared by `slot_triggerSelected`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)