### PR TITLE
Fix: variable editor keeps new variables nested in their parent table

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6752,7 +6752,14 @@ void dlgTriggerEditor::saveVar()
             varUnit->addVariable(variable);
             varUnit->addTreeItem(pItem, variable);
             varUnit->removeTempVar(pItem);
-            varUnit->getBase()->addChild(variable);
+            // Attach to its real parent TVar (set in addVar) so the XML writer,
+            // which iterates from the base, nests it inside the parent table
+            // rather than at root level.
+            TVar* parentVar = variable->getParent();
+            if (!parentVar) {
+                parentVar = varUnit->getBase();
+            }
+            parentVar->addChild(variable);
             pItem->setText(0, newName);
             mpCurrentVarItem = nullptr;
         } else if (variable) {


### PR DESCRIPTION
## Summary

When a user added a new variable inside an existing saved table via the Variables editor, the variable was stored at root level in the profile XML rather than inside the table. After saving and reloading the profile, the variable appeared outside its parent table.

Root cause: `dlgTriggerEditor::saveVar()`'s "new variable" path (varRecast == 2) called `varUnit->getBase()->addChild(variable)`. That unconditionally attaches the new TVar to the root of the in-memory tree, even though `addVar()` had already set the TVar's parent pointer to the enclosing table. `XMLexport::writeVariablePackage()` iterates the tree from the base and recurses into table children, so the variable ended up at the top level in XML instead of nested inside its table.

The fix attaches the new TVar to its actual parent (set in `addVar()`), with the base as a fallback for the root-level case.

Fixes #9266

## Test plan

- [ ] Reproduce the bug on a build without this patch: open variable editor, create a variable inside an existing saved table, save profile, reload — variable appears at root level
- [ ] On a patched build, repeat the same steps and confirm the variable remains nested inside its parent table after profile reload
- [ ] Create a top-level (not inside any table) variable and confirm it is still saved and restored correctly
- [ ] Create a new table inside an existing table and confirm the nested table is preserved across save/reload
- [ ] Confirm existing saved variables are unaffected (no spurious duplicates or migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)