### PR TITLE
Fix: sysWindowResize fires for half-screen transitions on tiling WMs

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2105,10 +2105,16 @@ QSize TConsole::getMainWindowSize() const
         return mOldSize;
     }
 
-    // Reject suspicious shrinkage (more than 50% reduction) - geometry may not have settled yet
+    // Reject very dramatic shrinkage as a secondary safety net for profile-switch
+    // transitions where geometry may not have settled. The original threshold of 0.5
+    // also rejected legitimate fullscreen->half-screen transitions on tiling WMs
+    // (e.g. hyprland, sway, i3), suppressing sysWindowResize events. The 0.2 value
+    // still catches the near-zero transient sizes the original fix targets while
+    // letting half-screen resizes through. The primary defence is the minValidWidth
+    // check above.
     if (mOldSize.width() > 0) {
         const double shrinkageRatio = static_cast<double>(mainWindowSize.width()) / mOldSize.width();
-        if (shrinkageRatio < 0.5) {
+        if (shrinkageRatio < 0.2) {
             return mOldSize;
         }
     }


### PR DESCRIPTION
## Summary

On tiling window managers (hyprland, sway, i3, etc.), going from fullscreen to half-screen never fired `sysWindowResize`. Geyser containers anchored to the right edge of the main window were left at their old offsets and ended up off-screen.

Root cause: #8853 added a "suspicious shrinkage" guard in `TConsole::getMainWindowSize()` that returns the *previous* size whenever the new width is less than 50% of the old one. The intent was to ignore transient invalid sizes during profile-switch transitions. A typical half-screen resize on a wide tiling-WM monitor produces a ratio of around 0.45, which trips the guard. `resizeEvent` then reads `getMainWindowSize()` twice in a row, gets the same old value back both times, and concludes "no change" — so the Lua `sysWindowResize` event is not raised.

This change lowers the threshold from `0.5` to `0.2`. The primary safety net for profile-switch transients is still the `minValidWidth=50` check immediately above; the shrinkage check is a secondary heuristic and `0.2` is plenty to catch the dramatic near-zero transient sizes the original PR targeted while letting real half-screen resizes through.

The reporter independently verified that `0.2` resolves their case ([comment](https://github.com/Mudlet/Mudlet/issues/9262#issuecomment-4411257823)).

The matching guard in `TMainConsole::getUserWindowSize()` is left untouched because the reporter confirms `sysUserWindowResize` events still fire correctly for user windows; only the main system window was affected.

Fixes #9262

## Test plan

- [ ] Verify the original profile-switch miniconsole fix from #8853 still works: switch between profiles and confirm miniconsole text is not cut off
- [ ] On a tiling window manager, transition Mudlet between fullscreen and half-screen and confirm `sysWindowResize` fires (e.g. via `registerAnonymousEventHandler("sysWindowResize", ...)`)
- [ ] Confirm Adjustable.Containers anchored to negative left offsets reposition correctly when the window shrinks
- [ ] Confirm wrap width updates correctly after the half-screen transition
- [ ] Confirm a window resize on a floating window manager (no tiling) still produces correct sysWindowResize events

🤖 Generated with [Claude Code](https://claude.com/claude-code)