### PR TITLE
Fix: line-initial underscores no longer clipped at certain font sizes (regression of #7866)

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -871,7 +871,18 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter,
     if (caretIsHere) {
         bgColor = mCaretColor;
     }
-    if (!textRect.isNull() && (mpConsole->getType() == TConsole::MainConsole) || bgColor != mpConsole->getConsoleBgColor()) {
+    // Fill the cell background when:
+    //  - the text bg differs from the console bg (e.g. coloured text), or
+    //  - the main console has a background image to paint the text bg over (#8885), or
+    //  - the main console bg is partially transparent and would otherwise let
+    //    the underlying surface bleed through.
+    // Skipping the fill when the bg matches an opaque console bg lets glyph
+    // descenders that extend slightly past mFontHeight (e.g. underscores at
+    // certain font sizes) survive the next line's drawing (#9070).
+    const bool fillNeeded = bgColor != mpConsole->getConsoleBgColor()
+                            || (mpConsole->getType() == TConsole::MainConsole
+                                && (mpConsole->mBgImageMode > 0 || bgColor.alpha() < 255));
+    if (!textRect.isNull() && fillNeeded) {
         painter.fillRect(textRect, bgColor);
     }
     return charWidth;


### PR DESCRIPTION
## Summary

Underscores at the bottom edge of glyphs in ASCII-art logos (e.g. the `____` top of a `D`) disappear in the main console at certain font sizes (notably Bitstream Vera Sans Mono at 14 and 17). Working fix from #7866 had landed in 4.19.1 via #7840.

Root cause: #8887 changed `TTextEdit::drawGraphemeBackground()` so the main console fills every character cell with the bg colour unconditionally, instead of only when the text bg differs from the console bg. When the font's actual rendered glyph height slightly exceeds `mFontHeight` (a known quirk for certain monospace fonts at certain sizes), descenders drawn by `painter.drawText(textRect, Qt::AlignCenter | Qt::TextDontClip | ...)` overflow into the next cell. The next line's unconditional bg fill then erases those overflow pixels — wiping out the underscore at the bottom of `____` and similar glyphs.

This change narrows the unconditional fill back to the case #8887 actually targeted (`mpConsole->mBgImageMode > 0`, i.e. there is a background image we need to paint the text bg over for opacity) plus the case where the user has explicit alpha on the bg colour (`bgColor.alpha() < 255`). For default text on an opaque console bg with no image, the fill is skipped — matching 4.19.1 behaviour and letting descender overflow survive into the next cell.

While here, the previous condition also had an operator-precedence bug (`A && B || C` parsed as `(A && B) || C`); the new condition expresses the intent with explicit parentheses.

Fixes #9070
Re-tests #8885 (background image opacity)

## Test plan

- [ ] Connect to `dev.cryosphere.org 6766 TLS` with Bitstream Vera Sans Mono at size 17 and confirm the ASCII-art logo renders with all underscores intact
- [ ] Confirm the regression no longer occurs at size 14 either
- [ ] Set a background image on the main console with `setBackgroundImage()` and confirm text backgrounds remain opaque over the image (the #8885 case #8887 was trying to fix)
- [ ] Set `mBgColor` with `alpha < 255` via the colour picker added by #8887 and confirm text bg still respects the alpha
- [ ] Confirm coloured text (`cecho` with a non-default bg, trigger colorisers, search highlights) still paints its bg correctly in the main console and miniconsoles
- [ ] Confirm subconsoles/miniconsoles still behave as before this PR (no behavioural change for non-main-console types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)