### PR TITLE
improve: configurable auto-login timing

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -194,6 +194,10 @@ public:
     QString& getPass() { return mPass; }
     void setPass(const QString& password) { mPass = password; }
     bool hasAutoLoginCredentials() const { return !mLogin.isEmpty() && !mPass.isEmpty(); }
+    int getAutoLoginUsernameDelay() const { return mAutoLoginUsernameDelay; }
+    void setAutoLoginUsernameDelay(const int delay) { mAutoLoginUsernameDelay = delay; }
+    int getAutoLoginPasswordDelay() const { return mAutoLoginPasswordDelay; }
+    void setAutoLoginPasswordDelay(const int delay) { mAutoLoginPasswordDelay = delay; }
     int getRetries() { return mRetries; }
     void setRetries(const int retries) { mRetries = retries; }
     int getTimeout() { return mTimeout; }
@@ -923,6 +927,9 @@ private:
     QString mLine;
     QString mLogin;
     QString mPass;
+
+    int mAutoLoginUsernameDelay = 2000;
+    int mAutoLoginPasswordDelay = 1000;
 
     int mPort;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -491,6 +491,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mProxyAddress") = pHost->mProxyAddress.toUtf8().constData();
     host.append_attribute("mProxyPort") = QString::number(pHost->mProxyPort).toUtf8().constData();
     host.append_attribute("mProxyUsername") = pHost->mProxyUsername.toUtf8().constData();
+    host.append_attribute("mAutoLoginUsernameDelay") = QString::number(pHost->mAutoLoginUsernameDelay).toUtf8().constData();
+    host.append_attribute("mAutoLoginPasswordDelay") = QString::number(pHost->mAutoLoginPasswordDelay).toUtf8().constData();
 
     // Handle proxy password based on application version for backward compatibility
     // For version 4.20.0+, use secure storage and clear XML; for older versions, maintain plaintext in XML

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -807,6 +807,13 @@ void XMLimport::readHost(Host* pHost)
         pHost->mProxyPort = 0;
     }
 
+    if (attributes().hasAttribute(QLatin1String("mAutoLoginUsernameDelay"))) {
+        pHost->mAutoLoginUsernameDelay = attributes().value(qsl("mAutoLoginUsernameDelay")).toInt();
+    }
+    if (attributes().hasAttribute(QLatin1String("mAutoLoginPasswordDelay"))) {
+        pHost->mAutoLoginPasswordDelay = attributes().value(qsl("mAutoLoginPasswordDelay")).toInt();
+    }
+
     pHost->mProxyUsername = attributes().value(qsl("mProxyUsername")).toString();
 
     // Handle backward compatibility based on application version, not profile version

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -808,10 +808,10 @@ void XMLimport::readHost(Host* pHost)
     }
 
     if (attributes().hasAttribute(QLatin1String("mAutoLoginUsernameDelay"))) {
-        pHost->mAutoLoginUsernameDelay = attributes().value(qsl("mAutoLoginUsernameDelay")).toInt();
+        pHost->mAutoLoginUsernameDelay = qBound(0, attributes().value(qsl("mAutoLoginUsernameDelay")).toInt(), 60000);
     }
     if (attributes().hasAttribute(QLatin1String("mAutoLoginPasswordDelay"))) {
-        pHost->mAutoLoginPasswordDelay = attributes().value(qsl("mAutoLoginPasswordDelay")).toInt();
+        pHost->mAutoLoginPasswordDelay = qBound(0, attributes().value(qsl("mAutoLoginPasswordDelay")).toInt(), 60000);
     }
 
     pHost->mProxyUsername = attributes().value(qsl("mProxyUsername")).toString();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -588,7 +588,9 @@ void cTelnet::slot_send_login()
     if (!mpHost->getLogin().isEmpty()) {
         sendData(mpHost->getLogin());
     }
-    mTimerPass->start(std::chrono::milliseconds(mpHost->getAutoLoginPasswordDelay()));
+    if (mpHost->hasAutoLoginCredentials()) {
+        mTimerPass->start(std::chrono::milliseconds(mpHost->getAutoLoginPasswordDelay()));
+    }
 }
 
 void cTelnet::slot_send_pass()

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -588,6 +588,7 @@ void cTelnet::slot_send_login()
     if (!mpHost->getLogin().isEmpty()) {
         sendData(mpHost->getLogin());
     }
+    mTimerPass->start(std::chrono::milliseconds(mpHost->getAutoLoginPasswordDelay()));
 }
 
 void cTelnet::slot_send_pass()
@@ -676,8 +677,7 @@ void cTelnet::slot_socketConnected()
 #endif
     mpHost->mLuaInterpreter.call(qsl("onConnect"), QString());
     mConnectionTimer.start();
-    mTimerLogin->start(2s);
-    mTimerPass->start(3s);
+    mTimerLogin->start(std::chrono::milliseconds(mpHost->getAutoLoginUsernameDelay()));
 
     emit signal_connected(mpHost);
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1509,6 +1509,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             currentShortcuts[key] = defaultSequence;
         });
     }
+
+    spinBox_usernameDelay->setValue(pHost->getAutoLoginUsernameDelay());
+    spinBox_passwordDelay->setValue(pHost->getAutoLoginPasswordDelay());
 }
 
 void dlgProfilePreferences::disconnectHostRelatedControls()
@@ -3032,6 +3035,9 @@ void dlgProfilePreferences::slot_saveAndClose()
     mudlet* pMudlet = mudlet::self();
     Host* pHost = mpHost;
     if (pHost) {
+        pHost->setAutoLoginUsernameDelay(spinBox_usernameDelay->value());
+        pHost->setAutoLoginPasswordDelay(spinBox_passwordDelay->value());
+
         auto console = pHost->mpConsole;
         if (comboBox_dictionary->isEnabled() && comboBox_dictionary->currentIndex() >= 0) {
             pHost->setSpellDic(comboBox_dictionary->currentData().toString());

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4436,6 +4436,85 @@ you can use it but there could be issues with aligning columns of text</string>
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_autoLogin">
+         <property name="title">
+          <string>Auto-login</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_autoLogin">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_usernameDelay">
+            <property name="text">
+             <string>Delay before sending username:</string>
+            </property>
+            <property name="buddy">
+             <cstring>spinBox_usernameDelay</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="spinBox_usernameDelay">
+            <property name="toolTip">
+             <string>&lt;p&gt;Wait this long after connecting before sending the username.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Wait this long after connecting before sending the username.</string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> ms</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>60000</number>
+            </property>
+            <property name="singleStep">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>2000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_passwordDelay">
+            <property name="text">
+             <string>Delay before sending password:</string>
+            </property>
+            <property name="buddy">
+             <cstring>spinBox_passwordDelay</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="spinBox_passwordDelay">
+            <property name="toolTip">
+             <string>&lt;p&gt;Wait this long after sending the username before sending the password.&lt;/p&gt;</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Wait this long after sending the username before sending the password.</string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> ms</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>60000</number>
+            </property>
+            <property name="singleStep">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>1000</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_chat">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -5285,6 +5364,8 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>lineEdit_proxyPort</tabstop>
   <tabstop>lineEdit_proxyUsername</tabstop>
   <tabstop>lineEdit_proxyPassword</tabstop>
+  <tabstop>spinBox_usernameDelay</tabstop>
+  <tabstop>spinBox_passwordDelay</tabstop>
   <tabstop>toolButton_resetMainWindowShortcuts</tabstop>
   <tabstop>checkBox_announceIncomingText</tabstop>
   <tabstop>checkBox_advertiseScreenReader</tabstop>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes #9282.

#### Motivation for adding to Mudlet

Motivation detailed in the linked issue.

#### Other info (issues closed, discussion etc)

This technically changes auto-login behavior slightly. We no longer have two parallel timers and instead perform the login serially. This is an intentional change intended to make configuring these values more intuitive for users, preventing the possibility of sending password before username, etc.

But the default behavior should be identical.

#### Screenshot

<img width="1004" height="800" alt="config-delay" src="https://github.com/user-attachments/assets/21831694-fcf9-4ac3-a9d6-19cc01fb6934" />
