### PR TITLE
fix: keep Lua autocomplete from taking editor focus

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -56,6 +56,7 @@
 #include "mudlet.h"
 #include "utils.h"
 #include "edbee/models/textdocumentscopes.h"
+#include "edbee/views/components/texteditorautocompletecomponent.h"
 
 #include <QCheckBox>
 #include <QAbstractButton>
@@ -393,6 +394,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpSourceEditorEdbee = mpSourceEditorArea->edbeeEditorWidget;
     mpSourceEditorEdbee->setAutoScrollMargin(20);
     mpSourceEditorEdbee->setPlaceholderText(tr("-- add your Lua code here"));
+    configureSourceEditorAutocompleteFocus();
     mpSourceEditorEdbeeDocument = mpSourceEditorEdbee->textDocument();
 
     // Update the status bar on changes
@@ -12198,6 +12200,13 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
 
 bool dlgTriggerEditor::eventFilter(QObject* watched, QEvent* event)
 {
+    if (watched == mpSourceEditorAutocompleteList && event->type() == QEvent::FocusIn) {
+        if (mpSourceEditorEdbee && mpSourceEditorEdbee->textEditorComponent()) {
+            mpSourceEditorEdbee->textEditorComponent()->setFocus(Qt::OtherFocusReason);
+        }
+        return true;
+    }
+
     if (mIsGrabKey) {
         if (event->type() == QEvent::KeyPress) {
             auto* keyEvent = static_cast<QKeyEvent*>(event);
@@ -12237,6 +12246,34 @@ bool dlgTriggerEditor::eventFilter(QObject* watched, QEvent* event)
     }
 
     return QMainWindow::eventFilter(watched, event);
+}
+
+void dlgTriggerEditor::configureSourceEditorAutocompleteFocus()
+{
+    if (!mpSourceEditorEdbee || !mpSourceEditorEdbee->autoCompleteComponent()) {
+        return;
+    }
+
+    auto* autocompleteList = mpSourceEditorEdbee->autoCompleteComponent()->listWidget();
+    if (!autocompleteList) {
+        return;
+    }
+
+    autocompleteList->setFocusPolicy(Qt::NoFocus);
+    autocompleteList->setAttribute(Qt::WA_ShowWithoutActivating);
+
+    if (auto* popupMenu = autocompleteList->parentWidget()) {
+        popupMenu->setFocusPolicy(Qt::NoFocus);
+        popupMenu->setAttribute(Qt::WA_ShowWithoutActivating);
+    }
+
+    if (mpSourceEditorAutocompleteList != autocompleteList) {
+        if (mpSourceEditorAutocompleteList) {
+            mpSourceEditorAutocompleteList->removeEventFilter(this);
+        }
+        mpSourceEditorAutocompleteList = autocompleteList;
+        mpSourceEditorAutocompleteList->installEventFilter(this);
+    }
 }
 
 bool dlgTriggerEditor::event(QEvent* event)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -67,10 +67,12 @@
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QIcon>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QMessageBox>
 #include <QMetaEnum>
 #include <QPalette>
+#include <QScopedValueRollback>
 #include <QScrollBar>
 #include <QSettings>
 #include <QShortcut>
@@ -12200,11 +12202,36 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
 
 bool dlgTriggerEditor::eventFilter(QObject* watched, QEvent* event)
 {
+    if (!mForwardingSourceEditorAutocompleteKey && mpSourceEditorEdbee
+        && watched == mpSourceEditorEdbee->textEditorComponent()
+        && event->type() == QEvent::KeyPress && mpSourceEditorAutocompleteList
+        && mpSourceEditorAutocompleteList->isVisible()) {
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
+        switch (keyEvent->key()) {
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+        case Qt::Key_PageUp:
+        case Qt::Key_PageDown:
+        case Qt::Key_Enter:
+        case Qt::Key_Return:
+        case Qt::Key_Tab:
+        case Qt::Key_Escape: {
+            QKeyEvent forwardedEvent(keyEvent->type(), keyEvent->key(), keyEvent->modifiers(), keyEvent->text(),
+                                     keyEvent->isAutoRepeat(), keyEvent->count());
+            QScopedValueRollback<bool> forwardingGuard(mForwardingSourceEditorAutocompleteKey, true);
+            QCoreApplication::sendEvent(mpSourceEditorAutocompleteList, &forwardedEvent);
+            return true;
+        }
+        default:
+            break;
+        }
+    }
+
     if (watched == mpSourceEditorAutocompleteList && event->type() == QEvent::FocusIn) {
         if (mpSourceEditorEdbee && mpSourceEditorEdbee->textEditorComponent()) {
             mpSourceEditorEdbee->textEditorComponent()->setFocus(Qt::OtherFocusReason);
+            return true;
         }
-        return true;
     }
 
     if (mIsGrabKey) {
@@ -12265,6 +12292,10 @@ void dlgTriggerEditor::configureSourceEditorAutocompleteFocus()
     if (auto* popupMenu = autocompleteList->parentWidget()) {
         popupMenu->setFocusPolicy(Qt::NoFocus);
         popupMenu->setAttribute(Qt::WA_ShowWithoutActivating);
+    }
+
+    if (auto* textEditorComponent = mpSourceEditorEdbee->textEditorComponent()) {
+        textEditorComponent->installEventFilter(this);
     }
 
     if (mpSourceEditorAutocompleteList != autocompleteList) {

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -649,6 +649,7 @@ private:
     edbee::TextEditorWidget* mpSourceEditorEdbee = nullptr;
     edbee::TextDocument* mpSourceEditorEdbeeDocument = nullptr;
     edbee::TextSearcher* mpSourceEditorSearcher = nullptr;
+    QPointer<QWidget> mpSourceEditorAutocompleteList;
 
     inline static const QRegularExpression csmSimplifyStatusBarRegex{qsl(R"(^(?:\[\*\] )?(.+?) \|)")};
 
@@ -738,6 +739,7 @@ private:
 
     QMap<EditorViewType, QMap<int, EditorState>> mEditorStates;
 
+    void configureSourceEditorAutocompleteFocus();
     void saveEditorState(EditorViewType viewType, int itemId);
     void restoreEditorState(EditorViewType viewType, int itemId);
     void clearEditorState(EditorViewType viewType, int itemId);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -650,6 +650,7 @@ private:
     edbee::TextDocument* mpSourceEditorEdbeeDocument = nullptr;
     edbee::TextSearcher* mpSourceEditorSearcher = nullptr;
     QPointer<QWidget> mpSourceEditorAutocompleteList;
+    bool mForwardingSourceEditorAutocompleteKey = false;
 
     inline static const QRegularExpression csmSimplifyStatusBarRegex{qsl(R"(^(?:\[\*\] )?(.+?) \|)")};
 

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -263,10 +263,22 @@ private slots:
     editorComponent->setFocus();
     QTRY_VERIFY(editorComponent->hasFocus());
 
+    autocompleteList->addItems({qsl("alpha"), qsl("beta")});
+    autocompleteList->setCurrentRow(0);
+    popupMenu->show();
+    autocompleteList->show();
+
+    QKeyEvent downEvent(QEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
+    QCoreApplication::sendEvent(editorComponent, &downEvent);
+    QCOMPARE(autocompleteList->currentRow(), 1);
+    QTRY_VERIFY(editorComponent->hasFocus());
+
+    autocompleteList->setFocusPolicy(Qt::StrongFocus);
     autocompleteList->setFocus();
     QCoreApplication::processEvents();
     QTRY_VERIFY(editorComponent->hasFocus());
     QVERIFY(!autocompleteList->hasFocus());
+    autocompleteList->setFocusPolicy(Qt::NoFocus);
   }
 
   void testCoreOperations_data() {

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -34,6 +34,7 @@
 #include "dlgTriggerEditor.h"
 #include "dlgTriggerPatternEdit.h"
 #include "dlgTriggersMainArea.h"
+#include "edbee/views/components/texteditorautocompletecomponent.h"
 #include "mudlet.h"
 
 extern void qInitResources_mudlet();
@@ -237,6 +238,37 @@ private slots:
   // ========================================================================
   // CATEGORY 1: Core Operations - Single Items
   // ========================================================================
+  void testSourceEditorAutocompleteDoesNotKeepFocus() {
+    QVERIFY2(mpEditor->mpSourceEditorEdbee,
+             "Source editor should be available");
+
+    auto *autocomplete =
+        mpEditor->mpSourceEditorEdbee->autoCompleteComponent();
+    QVERIFY2(autocomplete, "Autocomplete component should be available");
+
+    auto *autocompleteList = autocomplete->listWidget();
+    QVERIFY2(autocompleteList, "Autocomplete list should be available");
+    QCOMPARE(autocompleteList->focusPolicy(), Qt::NoFocus);
+    QVERIFY(autocompleteList->testAttribute(Qt::WA_ShowWithoutActivating));
+
+    auto *popupMenu = autocompleteList->parentWidget();
+    QVERIFY2(popupMenu, "Autocomplete popup should be available");
+    QCOMPARE(popupMenu->focusPolicy(), Qt::NoFocus);
+    QVERIFY(popupMenu->testAttribute(Qt::WA_ShowWithoutActivating));
+
+    auto *editorComponent =
+        mpEditor->mpSourceEditorEdbee->textEditorComponent();
+    QVERIFY2(editorComponent, "Source editor text component should exist");
+
+    editorComponent->setFocus();
+    QTRY_VERIFY(editorComponent->hasFocus());
+
+    autocompleteList->setFocus();
+    QCoreApplication::processEvents();
+    QTRY_VERIFY(editorComponent->hasFocus());
+    QVERIFY(!autocompleteList->hasFocus());
+  }
+
   void testCoreOperations_data() {
     QTest::addColumn<int>("itemTypeIndex");
     QTest::addColumn<QString>("itemTypeName");


### PR DESCRIPTION
/claim #5310

## Summary
- Prevent the trigger editor's Lua autocomplete popup from accepting or retaining keyboard focus.
- Mark the autocomplete list and popup menu as no-focus/non-activating widgets when Mudlet configures the source editor.
- Add a focus-event fallback that returns focus to the edbee text editor component if the autocomplete list receives focus anyway.
- Add regression coverage for the autocomplete popup focus behavior.

## Tests
- Added `dlgTriggerEditorUndoRedoTest::testSourceEditorAutocompleteDoesNotKeepFocus`.