### PR TITLE
Fix: make --profile command-line argument case-insensitive

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4376,8 +4376,19 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     hostList.removeDuplicates();
     int loadedProfiles = 0;
 
-    for (auto& hostName : cliProfiles) {
-        if (hostList.contains(hostName)) {
+    for (const auto& requestedName : cliProfiles) {
+        // Resolve the requested name to the canonically-cased profile so that
+        // e.g. --profile="mY pRoFiLe" opens the "My Profile" directory. Matching
+        // against hostList (rather than getCanonicalProfileName) also covers the
+        // "Mudlet self-test" entry, which is not an on-disk or built-in profile.
+        QString hostName;
+        for (const auto& candidate : std::as_const(hostList)) {
+            if (candidate.compare(requestedName, Qt::CaseInsensitive) == 0) {
+                hostName = candidate;
+                break;
+            }
+        }
+        if (!hostName.isEmpty()) {
             QElapsedTimer timer;
             timer.start();
             doAutoLogin(hostName);


### PR DESCRIPTION
## Summary

Follow-up to #9283 (suggested by @ZookaOnGit). That PR made the Lua `loadProfile()` path case-insensitive; the `--profile` / `-p` launch argument goes through a different code path (`mudlet::startAutoLogin()`) and was still case-sensitive, so `./mudlet --profile="mY pRoFiLe"` silently failed to open the `My Profile` profile. The `MUDLET_PROFILES` environment variable feeds the same path and is fixed too.

`startAutoLogin` now resolves each requested name to the canonically-cased entry by comparing case-insensitively against the assembled host list before loading. Matching against that list, rather than reusing `getCanonicalProfileName`, also covers the `Mudlet self-test` entry, which is neither an on-disk nor a built-in profile — so launching it by exact name keeps working.

## Test plan

- [x] `--profile="mY pRoFiLe"` opens a user profile named `My Profile`
- [x] `--profile="My Profile"` (exact case) still opens it (no regression)
- [x] `--profile="blackmud"` opens the built-in BlackMUD
- [x] `--profile="Mudlet self-test"` (exact case) still launches the self-test (no regression)
- [x] `--profile="does-not-exist"` opens nothing / shows the connection dialog, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)