### PR TITLE
Fix: resize command line box for appendCmdLine/printCmdLine/clearCmdLine

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -239,6 +239,7 @@ int TLuaInterpreter::appendCmdLine(lua_State* L)
     cur.clearSelection();
     cur.movePosition(QTextCursor::EndOfLine);
     pN->setTextCursor(cur);
+    pN->adjustHeight();
     return 0;
 }
 
@@ -252,6 +253,7 @@ int TLuaInterpreter::clearCmdLine(lua_State* L)
     }
     auto pN = COMMANDLINE(L, name);
     pN->clear();
+    pN->adjustHeight();
     return 0;
 }
 
@@ -1376,6 +1378,7 @@ int TLuaInterpreter::printCmdLine(lua_State* L)
     cur.clearSelection();
     cur.movePosition(QTextCursor::EndOfLine);
     pN->setTextCursor(cur);
+    pN->adjustHeight();
     return 0;
 }
 


### PR DESCRIPTION
## Summary

`appendCmdLine`, `printCmdLine` and `clearCmdLine` changed the command line text but never recalculated the input box height, so it stayed at whatever size the user's last typing produced — e.g. a tall box left tall after `clearCmdLine()`, or a single-line box failing to grow for multi-line text pushed in by a script.

Each now calls the existing `TCommandLine::adjustHeight()` after changing the text, the same way interactive editing already does.

**Scope:** this fixes the **main** command line, which is what #5597 reports. Named command lines created with `createCommandLine()` are `SubCommandLine`s, which `adjustHeight()` intentionally does not autoresize (a deliberate workaround for a text-cursor visibility issue — see `TCommandLine::adjustHeight()`). The new calls are harmless there (they only run the existing scroll-to-top workaround), so this PR does not change named-command-line behaviour.

Fixes #5597

## Test plan

- [ ] `printCmdLine("a\nb\nc")` grows the main input box to fit
- [ ] `clearCmdLine()` shrinks the main input box back to one line
- [ ] `appendCmdLine(...)` with multi-line text grows the main input box
- [ ] A named command line (`createCommandLine`) is unaffected — it does not autoresize, by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)
