### PR TITLE
Fix: plain Copy after Copy HTML no longer leaves HTML on the clipboard

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2023,8 +2023,10 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     // The last two of these tags were missing and meant the HTML was not terminated properly
     QClipboard* clipboard = QApplication::clipboard();
     clipboard->setText(text);
-    mSelectedRegion = QRegion(0, 0, 0, 0);
-    forceUpdate();
+    // Deliberately leave mSelectedRegion intact (unlike the now-removed clear
+    // here) so a follow-up plain Copy still sees the selection - otherwise
+    // establishSelectedText() bails and the HTML is left on the clipboard. This
+    // matches slot_copySelectionToClipboard(), which also keeps the selection.
 }
 
 bool TTextEdit::establishSelectedText()


### PR DESCRIPTION
## Summary

`slot_copySelectionToClipboardHTML()` cleared `mSelectedRegion` after copying, while `slot_copySelectionToClipboard()` leaves the selection intact. Because `establishSelectedText()` returns early when the region is empty, a plain Copy performed right after a Copy HTML (without re-selecting) did nothing, so the clipboard kept the previously-copied HTML.

The HTML slot now leaves the selection in place, matching the plain Copy slot, so either copy action can follow the other on the same selection.

Fixes #9291

> ⚠️ Draft: opened for the maintainers' early visibility. `Signed-off-by` will be added once the change has been manually tested.

## Test plan

- [ ] Select terminal text → Copy HTML → paste elsewhere = HTML
- [ ] Without re-selecting, Copy → paste = plain text (previously stayed HTML)
- [ ] Copy → Copy HTML on the same selection still works in that order too
- [ ] Selection highlight remains visible after Copy HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)