### PR TITLE
fix: restore "Show room names" toggle to the mapper menu

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -883,6 +883,14 @@ void dlgMapper::slot_setupMapperMenu()
     connect(showRoomIdsAction, &QAction::toggled, this, &dlgMapper::slot_toggleShowRoomIDsFromMenu);
     menu->addAction(showRoomIdsAction);
 
+    auto* showRoomNamesAction = new QAction(tr("Show room names"), this);
+    showRoomNamesAction->setCheckable(true);
+    showRoomNamesAction->setChecked(mpMap->getRoomNamesShown());
+    showRoomNamesAction->setToolTip(tr("When enabled, room names will be displayed on the map."));
+
+    connect(showRoomNamesAction, &QAction::toggled, this, &dlgMapper::slot_toggleShowRoomNamesFromMenu);
+    menu->addAction(showRoomNamesAction);
+
     auto* showMapGrid = new QAction(tr("Show map grid"), this);
     showMapGrid->setCheckable(true);
     showMapGrid->setChecked(mpHost->mMapperShowGrid);
@@ -926,6 +934,12 @@ void dlgMapper::slot_toggleShowRoomIDsFromMenu(bool enabled)
 {
     mp2dMap->mShowRoomID = enabled;
     mp2dMap->mpHost->mShowRoomID = enabled;
+    mp2dMap->update();
+}
+
+void dlgMapper::slot_toggleShowRoomNamesFromMenu(bool enabled)
+{
+    mpMap->setRoomNamesShown(enabled);
     mp2dMap->update();
 }
 

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -89,6 +89,7 @@ public slots:
     void slot_setupMapperMenu();
     void slot_toggleUpperLowerLevels(bool enabled);
     void slot_toggleShowRoomIDsFromMenu(bool enabled);
+    void slot_toggleShowRoomNamesFromMenu(bool enabled);
     void updateInfoMenu();
     void slot_showSaveWarningMenu();
     void slot_saveErrorChanged(bool hasError);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Re-add a checkable **Show room names** action to the mapper menu, next to **Show room IDs** (it was dropped when the menu was rebuilt in `slot_setupMapperMenu()`).
- The action's checked state reflects the persisted map flag (`TMap::getRoomNamesShown()`); toggling it calls `setRoomNamesShown()` and repaints the 2D map.

#### Motivation for adding to Mudlet
Restores the only UI control for showing room names on the map — the backing state and 2D renderer support were still present, but the menu entry had gone missing.

#### Other info (issues closed, discussion etc)
Fixes #9297

A dedicated `bool` slot (`slot_toggleShowRoomNamesFromMenu`) is used rather than the pre-existing `slot_toggleShowRoomNames(int)`, because `QAction::toggled` emits a `bool` while the int slot compares against `Qt::Checked` (`== 2`) and would never match a bool-derived `1`. This mirrors how `Show room IDs` is wired.

**Test case:**
1. Open a profile with a map and show the mapper.
2. Click the mapper menu (☰) → toggle **Show room names** on → room names appear on the 2D map.
3. Toggle it off → room names disappear.
4. Reopen the menu → the checkbox reflects the current (persisted) state.

---
⚠️ Draft: not yet manually tested or signed off.