### PR TITLE
improve: configurable auto-login timing via Mudlet.ini

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -687,7 +687,9 @@ void cTelnet::slot_socketConnected()
     mpHost->mLuaInterpreter.call(qsl("onConnect"), QString());
     mConnectionTimer.start();
     QSettings& settings = *mudlet::getQSettings();
-    const auto usernameDelay = qBound(0, settings.value(qsl("autoLoginUsernameDelay"), AUTO_LOGIN_USERNAME_DELAY_MS).toInt(), AUTO_LOGIN_MAX_DELAY_MS);
+    bool usernameDelayOk = false;
+    const int usernameDelayRaw = settings.value(qsl("autoLoginUsernameDelay"), AUTO_LOGIN_USERNAME_DELAY_MS).toInt(&usernameDelayOk);
+    const auto usernameDelay = qBound(0, usernameDelayOk ? usernameDelayRaw : AUTO_LOGIN_USERNAME_DELAY_MS, AUTO_LOGIN_MAX_DELAY_MS);
     mTimerLogin->start(std::chrono::milliseconds(usernameDelay));
 
     emit signal_connected(mpHost);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -57,11 +57,16 @@
 #include <QMessageBox>
 #include <QNetworkProxy>
 #include <QProgressDialog>
+#include <QSettings>
 #include <QSignalBlocker>
 #include <QSslError>
+#include <QtGlobal>
 
 using namespace std::chrono_literals;
 
+constexpr int AUTO_LOGIN_USERNAME_DELAY_MS = 2000;
+constexpr int AUTO_LOGIN_PASSWORD_DELAY_MS = 1000;
+constexpr int AUTO_LOGIN_MAX_DELAY_MS = 60000;
 
 constexpr size_t BUFFER_SIZE = 100000L;
 // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (1 of 7) - investigate switching from using `char[]` to `std::array<char>`
@@ -588,6 +593,11 @@ void cTelnet::slot_send_login()
     if (!mpHost->getLogin().isEmpty()) {
         sendData(mpHost->getLogin());
     }
+    if (mpHost->hasAutoLoginCredentials()) {
+        QSettings& settings = *mudlet::getQSettings();
+        const auto passwordDelay = qBound(0, settings.value(qsl("autoLoginPasswordDelay"), AUTO_LOGIN_PASSWORD_DELAY_MS).toInt(), AUTO_LOGIN_MAX_DELAY_MS);
+        mTimerPass->start(std::chrono::milliseconds(passwordDelay));
+    }
 }
 
 void cTelnet::slot_send_pass()
@@ -676,8 +686,9 @@ void cTelnet::slot_socketConnected()
 #endif
     mpHost->mLuaInterpreter.call(qsl("onConnect"), QString());
     mConnectionTimer.start();
-    mTimerLogin->start(2s);
-    mTimerPass->start(3s);
+    QSettings& settings = *mudlet::getQSettings();
+    const auto usernameDelay = qBound(0, settings.value(qsl("autoLoginUsernameDelay"), AUTO_LOGIN_USERNAME_DELAY_MS).toInt(), AUTO_LOGIN_MAX_DELAY_MS);
+    mTimerLogin->start(std::chrono::milliseconds(usernameDelay));
 
     emit signal_connected(mpHost);
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -595,7 +595,9 @@ void cTelnet::slot_send_login()
     }
     if (mpHost->hasAutoLoginCredentials()) {
         QSettings& settings = *mudlet::getQSettings();
-        const auto passwordDelay = qBound(0, settings.value(qsl("autoLoginPasswordDelay"), AUTO_LOGIN_PASSWORD_DELAY_MS).toInt(), AUTO_LOGIN_MAX_DELAY_MS);
+        bool passwordDelayOk = false;
+        const int passwordDelayRaw = settings.value(qsl("autoLoginPasswordDelay"), AUTO_LOGIN_PASSWORD_DELAY_MS).toInt(&passwordDelayOk);
+        const auto passwordDelay = qBound(0, passwordDelayOk ? passwordDelayRaw : AUTO_LOGIN_PASSWORD_DELAY_MS, AUTO_LOGIN_MAX_DELAY_MS);
         mTimerPass->start(std::chrono::milliseconds(passwordDelay));
     }
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fixes #9282.

Alternative to #9290, adding `autoLoginPasswordDelay` and `autoLoginUsernameDelay` to `Mudlet.ini` instead of new controls in the GUI.

See https://github.com/Mudlet/Mudlet/pull/9290#pullrequestreview-4350427985 where this approach was suggested as an alternative. This isn't my favorite solution, but it's very unobtrusive and seems like a clear improvement over leaving arbitrary delays hardcoded to me.

Naming wasn't totally clear. `autosaveIntervalMinutes` has a unit postfix, but `themesUpdatePeriod` does not (and seems to be a millisecond value), so for consistency I left off the postfix.

#### Motivation for adding to Mudlet

Motivation detailed in the linked issue.

#### Other info (issues closed, discussion etc)

This technically changes auto-login behavior slightly. We no longer have two parallel timers and instead perform the login serially. This is an intentional change intended to make configuring these values more intuitive for users, preventing the possibility of sending password before username, etc.

But the default behavior should be identical.

Tested with values present and each set to zero, values present 5/10 seconds, values not present.