### PR TITLE
infrastructure: fix PTB's from being built again when no new commits happened

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -406,6 +406,8 @@ jobs:
         APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
         WITH_SENTRY: "ON"
         GITHUB_FORCE_BUILD: ${{ github.event.inputs.scheduled == 'true' }}
+        # needed so CI/*.after_success.sh can query existing releases to skip duplicate PTBs
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload packaged Mudlet
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -231,6 +231,8 @@ jobs:
         GITHUB_FORCE_BUILD: ${{ github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # needed so deploy-mudlet-for-windows.sh can query existing releases to skip duplicate PTBs
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: $GITHUB_WORKSPACE/CI/deploy-mudlet-for-windows.sh
 
     - name: (Windows) Upload unsigned installer for signing

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -237,6 +237,8 @@ jobs:
         GITHUB_FORCE_BUILD: ${{ github.event.inputs.scheduled == 'true' }}
         GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         GITHUB_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # needed so deploy-mudlet-for-windows.sh can query existing releases to skip duplicate PTBs
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: $GITHUB_WORKSPACE/CI/deploy-mudlet-for-windows.sh
 
     - name: (Windows) Upload unsigned installer for signing

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -412,6 +412,8 @@ jobs:
         APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
         WITH_SENTRY: "ON"
         GITHUB_FORCE_BUILD: ${{ github.event.inputs.scheduled == 'true' }}
+        # needed so CI/*.after_success.sh can query existing releases to skip duplicate PTBs
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload packaged Mudlet
       uses: actions/upload-artifact@v7

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -184,10 +184,27 @@ else
     # Skip duplicate check if this is a manually forced build
     if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
       echo "=== Forced build requested, skipping duplicate PTB check ==="
-    elif gh release list --repo "${GITHUB_REPOSITORY}" --limit 20 --json tagName \
-            --jq '.[].tagName' 2>/dev/null | grep -qF -- "${BUILD_COMMIT}"; then
-      echo "=== PTB already exists for commit ${BUILD_COMMIT}, aborting public test build generation ==="
-      exit 0
+    else
+      # gh needs GH_TOKEN in the environment - if the query fails (missing
+      # token or API error) we must not silently build a duplicate, so warn
+      # and carry on rather than swallowing the error and falling through.
+      if existing_ptb_tags=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
+            --json tagName --jq '.[].tagName | select(contains("-ptb-"))'); then
+        while IFS= read -r existing_tag; do
+          [[ -n "${existing_tag}" ]] || continue
+          # the short commit hash is the trailing field of the release tag;
+          # compare on prefix as git can vary the abbreviated length per run
+          existing_commit="${existing_tag##*-}"
+          if [[ -n "${BUILD_COMMIT}" ]] \
+              && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \
+                || [[ "${existing_commit}" == "${BUILD_COMMIT}"* ]]; }; then
+            echo "=== PTB already exists for commit ${BUILD_COMMIT} (${existing_tag}), aborting public test build generation ==="
+            exit 0
+          fi
+        done <<< "${existing_ptb_tags}"
+      else
+        echo "::warning::Could not list releases to check for duplicate PTB (is GH_TOKEN set?) - proceeding with build"
+      fi
     fi
 
     # Squirrel uses the name of the binary for the Start menu, so need to rename

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -185,15 +185,13 @@ else
     if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
       echo "=== Forced build requested, skipping duplicate PTB check ==="
     else
-      # gh needs GH_TOKEN in the environment - if the query fails (missing
-      # token or API error) we must not silently build a duplicate, so warn
-      # and carry on rather than swallowing the error and falling through.
+      # don't swallow a gh failure (e.g. missing GH_TOKEN) - warning and
+      # building beats silently shipping a duplicate PTB
       if existing_ptb_tags=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
             --json tagName --jq '.[].tagName | select(contains("-ptb-"))'); then
         while IFS= read -r existing_tag; do
           [[ -n "${existing_tag}" ]] || continue
-          # the short commit hash is the trailing field of the release tag;
-          # compare on prefix as git can vary the abbreviated length per run
+          # prefix-compare as git can vary the abbreviated hash length per run
           existing_commit="${existing_tag##*-}"
           if [[ -n "${BUILD_COMMIT}" ]] \
               && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -74,10 +74,27 @@ then
       # Skip duplicate check if this is a manually forced build
       if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
         echo "== Forced build requested, skipping duplicate PTB check =="
-      elif gh release list --repo "${GITHUB_REPOSITORY}" --limit 20 --json tagName \
-              --jq '.[].tagName' 2>/dev/null | grep -qF -- "${BUILD_COMMIT}"; then
-        echo "== PTB already exists for commit ${BUILD_COMMIT}, aborting public test build generation =="
-        exit 0
+      else
+        # gh needs GH_TOKEN in the environment - if the query fails (missing
+        # token or API error) we must not silently build a duplicate, so warn
+        # and carry on rather than swallowing the error and falling through.
+        if existing_ptb_tags=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
+              --json tagName --jq '.[].tagName | select(contains("-ptb-"))'); then
+          while IFS= read -r existing_tag; do
+            [[ -n "${existing_tag}" ]] || continue
+            # the short commit hash is the trailing field of the release tag;
+            # compare on prefix as git can vary the abbreviated length per run
+            existing_commit="${existing_tag##*-}"
+            if [[ -n "${BUILD_COMMIT}" ]] \
+                && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \
+                  || [[ "${existing_commit}" == "${BUILD_COMMIT}"* ]]; }; then
+              echo "== PTB already exists for commit ${BUILD_COMMIT} (${existing_tag}), aborting public test build generation =="
+              exit 0
+            fi
+          done <<< "${existing_ptb_tags}"
+        else
+          echo "::warning::Could not list releases to check for duplicate PTB (is GH_TOKEN set?) - proceeding with build"
+        fi
       fi
 
       echo "== Creating a public test build =="

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -75,15 +75,13 @@ then
       if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
         echo "== Forced build requested, skipping duplicate PTB check =="
       else
-        # gh needs GH_TOKEN in the environment - if the query fails (missing
-        # token or API error) we must not silently build a duplicate, so warn
-        # and carry on rather than swallowing the error and falling through.
+        # don't swallow a gh failure (e.g. missing GH_TOKEN) - warning and
+        # building beats silently shipping a duplicate PTB
         if existing_ptb_tags=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
               --json tagName --jq '.[].tagName | select(contains("-ptb-"))'); then
           while IFS= read -r existing_tag; do
             [[ -n "${existing_tag}" ]] || continue
-            # the short commit hash is the trailing field of the release tag;
-            # compare on prefix as git can vary the abbreviated length per run
+            # prefix-compare as git can vary the abbreviated hash length per run
             existing_commit="${existing_tag##*-}"
             if [[ -n "${BUILD_COMMIT}" ]] \
                 && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -95,10 +95,27 @@ if [ "${DEPLOY}" = "deploy" ]; then
       # Skip duplicate check if this is a manually forced build
       if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
         echo "== Forced build requested, skipping duplicate PTB check =="
-      elif gh release list --repo "${GITHUB_REPOSITORY}" --limit 20 --json tagName \
-              --jq '.[].tagName' 2>/dev/null | grep -qF -- "${BUILD_COMMIT}"; then
-        echo "== PTB already exists for commit ${BUILD_COMMIT}, aborting public test build generation =="
-        exit 0
+      else
+        # gh needs GH_TOKEN in the environment - if the query fails (missing
+        # token or API error) we must not silently build a duplicate, so warn
+        # and carry on rather than swallowing the error and falling through.
+        if existing_ptb_tags=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
+              --json tagName --jq '.[].tagName | select(contains("-ptb-"))'); then
+          while IFS= read -r existing_tag; do
+            [[ -n "${existing_tag}" ]] || continue
+            # the short commit hash is the trailing field of the release tag;
+            # compare on prefix as git can vary the abbreviated length per run
+            existing_commit="${existing_tag##*-}"
+            if [[ -n "${BUILD_COMMIT}" ]] \
+                && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \
+                  || [[ "${existing_commit}" == "${BUILD_COMMIT}"* ]]; }; then
+              echo "== PTB already exists for commit ${BUILD_COMMIT} (${existing_tag}), aborting public test build generation =="
+              exit 0
+            fi
+          done <<< "${existing_ptb_tags}"
+        else
+          echo "::warning::Could not list releases to check for duplicate PTB (is GH_TOKEN set?) - proceeding with build"
+        fi
       fi
 
       echo "== Creating a public test build =="

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -96,15 +96,13 @@ if [ "${DEPLOY}" = "deploy" ]; then
       if [[ "${GITHUB_FORCE_BUILD}" == "true" ]]; then
         echo "== Forced build requested, skipping duplicate PTB check =="
       else
-        # gh needs GH_TOKEN in the environment - if the query fails (missing
-        # token or API error) we must not silently build a duplicate, so warn
-        # and carry on rather than swallowing the error and falling through.
+        # don't swallow a gh failure (e.g. missing GH_TOKEN) - warning and
+        # building beats silently shipping a duplicate PTB
         if existing_ptb_tags=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
               --json tagName --jq '.[].tagName | select(contains("-ptb-"))'); then
           while IFS= read -r existing_tag; do
             [[ -n "${existing_tag}" ]] || continue
-            # the short commit hash is the trailing field of the release tag;
-            # compare on prefix as git can vary the abbreviated length per run
+            # prefix-compare as git can vary the abbreviated hash length per run
             existing_commit="${existing_tag##*-}"
             if [[ -n "${BUILD_COMMIT}" ]] \
                 && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The duplicate-PTB check ran 'gh release list' with no GH_TOKEN and swallowed the auth error via 2>/dev/null, so it always fell through and built a duplicate PTB even when no new commits had landed.
#### Motivation for adding to Mudlet
Don't rebuild PTBs when no new commits hav elanded.
#### Other info (issues closed, discussion etc)
