### PR TITLE
infrastructure: fix translation and 3rdparty update workflows

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -40,18 +40,6 @@ jobs:
               #### Motivation for adding to Mudlet
               So people don't get attacked with a "your mapping script is out of date!" notification as soon as they create a profile for a new IRE game.
 
-          - name: dblsqd
-            type: submodule
-            submodule_path: 3rdparty/dblsqd/
-            path: 3rdparty/dblsqd
-            branch: update-dblsqd
-            title: "Infrastructure: Update dblsqd to latest in our fork"
-            body: |
-              #### Brief overview of PR changes/additions
-              :crown: An automated PR to update dblsqd to its latest version in our fork.
-              #### Motivation for adding to Mudlet
-              Get new features, bugfixes, improvements! Stay modern.
-
           - name: lcf
             type: submodule-branch
             submodule_path: 3rdparty/lcf/
@@ -133,8 +121,8 @@ jobs:
         if: matrix.type == 'submodule-branch'
         run: |
           cd ${{ matrix.submodule_path }}
-          git checkout ${{ matrix.submodule_branch }}
-          git pull
+          git fetch origin ${{ matrix.submodule_branch }}
+          git checkout -B ${{ matrix.submodule_branch }} FETCH_HEAD
 
       - name: Check for changes
         id: getdiff

--- a/.github/workflows/update-en-us-plural.yml
+++ b/.github/workflows/update-en-us-plural.yml
@@ -21,7 +21,7 @@ jobs:
     - name: update plural american english file
       uses: Mudlet/lupdate-action@master
       with:
-        args: -locations absolute -pluralonly ./src ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ${{ env.PLURAL_TRANSLATIONS_FILE }}
+        args: -locations absolute -pluralonly ./src ./3rdparty/edbee-lib/edbee-lib -ts ${{ env.PLURAL_TRANSLATIONS_FILE }}
 
     - name: count the number of unfinished translations
       id: count_unfinished

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -24,7 +24,7 @@ jobs:
     - name: update text for translation
       uses: Mudlet/lupdate-action@master
       with:
-        args: -recursive ./src/ ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ./translations/mudlet.ts
+        args: -recursive ./src/ ./3rdparty/edbee-lib/edbee-lib -ts ./translations/mudlet.ts
 
     - name: check if any UI text was modified
       id: getdiff


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Drop stale `3rdparty/dblsqd/dblsqd` lupdate paths from the translation and en_US plural workflows (dblsqd is now vendored into `src/updater/`, scanned via `./src/`)
- Remove the dead `dblsqd` submodule entry from the `update-3rdparty` matrix
- `git fetch` the target branch before checkout in the `submodule-branch` step so the `lcf` update works from a detached submodule checkout

#### Motivation for adding to Mudlet
The weekly translation and 3rdparty update automations were failing because they still referenced dblsqd as a submodule; this unblocks them ahead of the 4.21.0 release.

#### Other info (issues closed, discussion etc)
Surfaced while running the release checklist for 4.21.0.

**Test case:** Trigger the "Update texts for translators", "Update plural american english translations", and "Update 3rdparty sources" workflows via workflow_dispatch on this branch - all jobs (including lcf) complete without the previous `3rdparty/dblsqd` / pathspec errors.