### PR TITLE
infrastructure: bump next milestone to 4.22.0

### DIFF
--- a/.github/repo-metadata.yml
+++ b/.github/repo-metadata.yml
@@ -2,4 +2,4 @@
 
 milestones:
   # assign new PRs to this milestone
-  next-milestone: 4.21.0
+  next-milestone: 4.22.0


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Point `next-milestone` at 4.22.0 now that 4.21.0 has been branched/tagged

#### Motivation for adding to Mudlet
New PRs should be auto-assigned to the upcoming 4.22.0 milestone.

#### Other info (issues closed, discussion etc)
Part of the 4.21.0 release process.

**Test case:** Open a new PR after merge - the labeler assigns it to the 4.22.0 milestone.