### PR TITLE
Fix: Keep blinking text updating reliably

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1136,6 +1136,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
 void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
 {
     mHasBlinkingContent = false;
+    bool reusedCachedScreenContent = false;
 
     qreal dpr = devicePixelRatioF();
     QPixmap screenPixmap;
@@ -1173,6 +1174,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     }
     if ((r.height() < rect().height()) && (lineOffset > 0)) {
         p.drawPixmap(0, 0, mScreenMap);
+        reusedCachedScreenContent = true;
         from = y_top;
         noScroll = true;
         if (!mForceUpdate && !mMouseTracking) {
@@ -1187,6 +1189,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
             && (mScreenHeight - mScrollVector) * mFontHeight <= mScreenMap.height()) {
             screenPixmap = mScreenMap.copy(0, mScrollVector * mFontHeight * dpr, mScreenWidth * mFontWidth * dpr, (mScreenHeight - mScrollVector) * mFontHeight * dpr);
             p.drawPixmap(0, 0, screenPixmap);
+            reusedCachedScreenContent = true;
             from = mScreenHeight - mScrollVector - 1;
         }
     } else if ((!noScroll) && (mScrollVector < 0 && mScrollVector >= ((-1) * mScreenHeight)) && (!mForceUpdate)) {
@@ -1194,6 +1197,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
             && (mScreenHeight - abs(mScrollVector)) * mFontHeight <= mScreenMap.height()) {
             screenPixmap = mScreenMap.copy(0, 0, mScreenWidth * mFontWidth * dpr, (mScreenHeight - abs(mScrollVector)) * mFontHeight * dpr);
             p.drawPixmap(0, abs(mScrollVector) * mFontHeight, screenPixmap);
+            reusedCachedScreenContent = true;
             from = 0;
             y_bottom = abs(mScrollVector);
         }
@@ -1227,7 +1231,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     mLastRenderedOffset = lineOffset;
     mForceUpdate = false;
 
-    const bool shouldBeRegistered = mEnableBlinkText && mHasBlinkingContent;
+    const bool shouldBeRegistered = shouldRegisterBlinkClient(mEnableBlinkText, mHasBlinkingContent, mIsBlinkClientRegistered, reusedCachedScreenContent);
     if (auto* pMudlet = mudlet::self()) {
         if (shouldBeRegistered && !mIsBlinkClientRegistered) {
             pMudlet->registerBlinkClient();
@@ -1237,6 +1241,22 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
             mIsBlinkClientRegistered = false;
         }
     }
+}
+
+bool TTextEdit::shouldRegisterBlinkClient(const bool enableBlinkText, const bool hasBlinkingContentInRedrawnRegion, const bool isBlinkClientRegistered, const bool reusedCachedScreenContent)
+{
+    if (!enableBlinkText) {
+        return false;
+    }
+
+    if (hasBlinkingContentInRedrawnRegion) {
+        return true;
+    }
+
+    // Incremental paints can copy existing blinking rows from the cached screen map
+    // without redrawing them. Keep the timer alive until a full repaint can
+    // definitively determine that no blinking content remains visible.
+    return isBlinkClientRegistered && reusedCachedScreenContent;
 }
 
 void TTextEdit::paintEvent(QPaintEvent* e)
@@ -2953,10 +2973,7 @@ void TTextEdit::slot_analyseSelection()
             quint8 columnsToUse = qMax(size_t{2}, utf8Width);
 
             if (includeThisCodePoint) {
-                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>")
-                                            .arg(QString::number(columnsToUse),
-                                                 QString::number(index + 1),
-                                                 QString::number(index + 2)));
+                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>").arg(QString::number(columnsToUse), QString::number(index + 1), QString::number(index + 2)));
 
                 // The use of one qsl inside another is because it is
                 // impossible to force an upper-case alphabet to Hex digits otherwise
@@ -2964,19 +2981,18 @@ void TTextEdit::slot_analyseSelection()
                 // &#8232; is the Unicode Line Separator.
                 // The static casts are only needed since Qt 6.9.0 but they
                 // shouldn't do any harm prior to that:
-                utf16Vals.append(qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
-                                         .arg(QString::number(columnsToUse),
-                                              qsl("%1").arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
-                                                                                                         mpBuffer->lineBuffer.at(line).at(index + 1))),
-                                                            4, 16, zero).toUpper())
-                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
-                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
+                utf16Vals.append(
+                        qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
+                                .arg(QString::number(columnsToUse),
+                                     qsl("%1")
+                                             .arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))), 4, 16, zero)
+                                             .toUpper())
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
 
                 // Note the addition to the index here to jump over the low-surrogate:
                 graphemes.append(qsl("<td colspan=\"%1\">%2</td>")
-                                         .arg(QString::number(columnsToUse),
-                                              convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index),
-                                                                        mpBuffer->lineBuffer.at(line).at(index + 1))));
+                                         .arg(QString::number(columnsToUse), convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))));
             }
 
             switch (utf8Width) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1253,9 +1253,12 @@ bool TTextEdit::shouldRegisterBlinkClient(const bool enableBlinkText, const bool
         return true;
     }
 
-    // Incremental paints can copy existing blinking rows from the cached screen map
-    // without redrawing them. Keep the timer alive until a full repaint can
-    // definitively determine that no blinking content remains visible.
+    // When content is rendered by copying rows from mScreenMap (scroll or
+    // partial-height repaint), those rows are not re-scanned for blinking
+    // characters, so mHasBlinkingContent will be false even if blinking content
+    // is still visible. Preserve the blink timer in that case; the next full
+    // repaint will reset mHasBlinkingContent from scratch and unregister the
+    // timer if nothing blinking remains.
     return isBlinkClientRegistered && reusedCachedScreenContent;
 }
 
@@ -2973,7 +2976,10 @@ void TTextEdit::slot_analyseSelection()
             quint8 columnsToUse = qMax(size_t{2}, utf8Width);
 
             if (includeThisCodePoint) {
-                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>").arg(QString::number(columnsToUse), QString::number(index + 1), QString::number(index + 2)));
+                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>")
+                                            .arg(QString::number(columnsToUse),
+                                                 QString::number(index + 1),
+                                                 QString::number(index + 2)));
 
                 // The use of one qsl inside another is because it is
                 // impossible to force an upper-case alphabet to Hex digits otherwise
@@ -2981,18 +2987,19 @@ void TTextEdit::slot_analyseSelection()
                 // &#8232; is the Unicode Line Separator.
                 // The static casts are only needed since Qt 6.9.0 but they
                 // shouldn't do any harm prior to that:
-                utf16Vals.append(
-                        qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
-                                .arg(QString::number(columnsToUse),
-                                     qsl("%1")
-                                             .arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))), 4, 16, zero)
-                                             .toUpper())
-                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
-                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
+                utf16Vals.append(qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
+                                         .arg(QString::number(columnsToUse),
+                                              qsl("%1").arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
+                                                                                                         mpBuffer->lineBuffer.at(line).at(index + 1))),
+                                                            4, 16, zero).toUpper())
+                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
+                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
 
                 // Note the addition to the index here to jump over the low-surrogate:
                 graphemes.append(qsl("<td colspan=\"%1\">%2</td>")
-                                         .arg(QString::number(columnsToUse), convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))));
+                                         .arg(QString::number(columnsToUse),
+                                              convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index),
+                                                                        mpBuffer->lineBuffer.at(line).at(index + 1))));
             }
 
             switch (utf8Width) {

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -100,6 +100,7 @@ public:
     int getColumnCount() const;
     int getRowCount() const;
     void toggleTimeStamps(const bool);
+    static bool shouldRegisterBlinkClient(bool enableBlinkText, bool hasBlinkingContentInRedrawnRegion, bool isBlinkClientRegistered, bool reusedCachedScreenContent);
 
 #if defined(DEBUG_CODEPOINT_PROBLEMS)
     void reportCodepointErrors();

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -100,7 +100,6 @@ public:
     int getColumnCount() const;
     int getRowCount() const;
     void toggleTimeStamps(const bool);
-    static bool shouldRegisterBlinkClient(bool enableBlinkText, bool hasBlinkingContentInRedrawnRegion, bool isBlinkClientRegistered, bool reusedCachedScreenContent);
 
 #if defined(DEBUG_CODEPOINT_PROBLEMS)
     void reportCodepointErrors();
@@ -125,6 +124,9 @@ public:
     // previous column value so that we can return to it if the next line is
     // long enough again.
     int mOldCaretColumn = 0;
+
+    friend class TTextEditBlinkTest;
+    static bool shouldRegisterBlinkClient(bool enableBlinkText, bool hasBlinkingContentInRedrawnRegion, bool isBlinkClientRegistered, bool reusedCachedScreenContent);
 
     QColor mFgColor;
     bool mIsCommandPopup = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(UNIT_TESTS
     SecureStringUtilsTest
     CredentialManagerTest
     DiscordTest
+    TTextEditBlinkTest
     TAreaZLevelIndexTest
     TAreaGridIndexTest
 )

--- a/test/TTextEditBlinkTest.cpp
+++ b/test/TTextEditBlinkTest.cpp
@@ -1,0 +1,22 @@
+#include "TTextEdit.h"
+
+#include <QTest>
+
+class TTextEditBlinkTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void keepsRegistrationWhenCachedBlinkingContentMayStillBeVisible() { QVERIFY(TTextEdit::shouldRegisterBlinkClient(true, false, true, true)); }
+
+    void unregistersWhenBlinkingIsDisabled() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(false, true, true, true)); }
+
+    void registersWhenCurrentPaintFindsBlinkingContent() { QVERIFY(TTextEdit::shouldRegisterBlinkClient(true, true, false, false)); }
+
+    void unregistersWhenNoBlinkingContentRemainsAfterFullScan() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, true, false)); }
+
+    void staysUnregisteredWithoutCurrentOrCachedBlinkingContent() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, false, true)); }
+};
+
+QTEST_GUILESS_MAIN(TTextEditBlinkTest)
+#include "TTextEditBlinkTest.moc"

--- a/test/TTextEditBlinkTest.cpp
+++ b/test/TTextEditBlinkTest.cpp
@@ -1,3 +1,22 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
 #include "TTextEdit.h"
 
 #include <QTest>
@@ -7,17 +26,32 @@ class TTextEditBlinkTest : public QObject
     Q_OBJECT
 
 private slots:
-    void keepsRegistrationWhenCachedBlinkingContentMayStillBeVisible() { QVERIFY(TTextEdit::shouldRegisterBlinkClient(true, false, true, true)); }
+    void shouldRegisterBlinkClient_data()
+    {
+        QTest::addColumn<bool>("enableBlinkText");
+        QTest::addColumn<bool>("hasBlinkingContentInRedrawnRegion");
+        QTest::addColumn<bool>("isBlinkClientRegistered");
+        QTest::addColumn<bool>("reusedCachedScreenContent");
+        QTest::addColumn<bool>("expected");
 
-    void unregistersWhenBlinkingIsDisabled() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(false, true, true, true)); }
+        QTest::newRow("keeps registration when cached blinking content may still be visible") << true << false << true << true << true;
+        QTest::newRow("unregisters when blinking is disabled") << false << true << true << true << false;
+        QTest::newRow("unregisters when blinking is disabled regardless of other flags") << false << false << false << false << false;
+        QTest::newRow("registers when current paint finds blinking content") << true << true << false << false << true;
+        QTest::newRow("unregisters when paint did not reuse cache") << true << false << true << false << false;
+        QTest::newRow("unregisters when client was not registered even with cached content") << true << false << false << true << false;
+    }
 
-    void unregistersWhenBlinkingIsDisabledRegardlessOfOtherFlags() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(false, false, false, false)); }
+    void shouldRegisterBlinkClient()
+    {
+        QFETCH(bool, enableBlinkText);
+        QFETCH(bool, hasBlinkingContentInRedrawnRegion);
+        QFETCH(bool, isBlinkClientRegistered);
+        QFETCH(bool, reusedCachedScreenContent);
+        QFETCH(bool, expected);
 
-    void registersWhenCurrentPaintFindsBlinkingContent() { QVERIFY(TTextEdit::shouldRegisterBlinkClient(true, true, false, false)); }
-
-    void unregistersWhenPaintDidNotReuseCache() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, true, false)); }
-
-    void unregistersWhenClientWasNotRegisteredEvenWithCachedContent() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, false, true)); }
+        QCOMPARE(TTextEdit::shouldRegisterBlinkClient(enableBlinkText, hasBlinkingContentInRedrawnRegion, isBlinkClientRegistered, reusedCachedScreenContent), expected);
+    }
 };
 
 QTEST_GUILESS_MAIN(TTextEditBlinkTest)

--- a/test/TTextEditBlinkTest.cpp
+++ b/test/TTextEditBlinkTest.cpp
@@ -11,11 +11,13 @@ private slots:
 
     void unregistersWhenBlinkingIsDisabled() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(false, true, true, true)); }
 
+    void unregistersWhenBlinkingIsDisabledRegardlessOfOtherFlags() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(false, false, false, false)); }
+
     void registersWhenCurrentPaintFindsBlinkingContent() { QVERIFY(TTextEdit::shouldRegisterBlinkClient(true, true, false, false)); }
 
-    void unregistersWhenNoBlinkingContentRemainsAfterFullScan() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, true, false)); }
+    void unregistersWhenPaintDidNotReuseCache() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, true, false)); }
 
-    void staysUnregisteredWithoutCurrentOrCachedBlinkingContent() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, false, true)); }
+    void unregistersWhenClientWasNotRegisteredEvenWithCachedContent() { QVERIFY(!TTextEdit::shouldRegisterBlinkClient(true, false, false, true)); }
 };
 
 QTEST_GUILESS_MAIN(TTextEditBlinkTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Keeps blinking text updating reliably so it does not appear stuck.

#### Motivation for adding to Mudlet
Makes everyday play feel consistent and avoids needing a reconnect.

#### Other info (issues closed, discussion etc)
Closes #9318