### PR TITLE
Fix: Let screen reader users reach the menu bar with Alt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,6 @@ endif()
 set(mudlet_SRCS
     ActionUnit.cpp
     AliasUnit.cpp
-    AltFocusMenuBarDisable.cpp
     ctelnet.cpp
     DarkTheme.cpp
     discord.cpp
@@ -90,6 +89,7 @@ set(mudlet_SRCS
     MMCPServer.cpp
     mudlet.cpp
     MudletInstanceCoordinator.cpp
+    MudletProxyStyle.cpp
     EditorUndoStack.cpp
     MxpTag.cpp
     EditorAddItemCommand.cpp
@@ -265,7 +265,6 @@ set(mudlet_HDRS
     ../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h
     ActionUnit.h
     AliasUnit.h
-    AltFocusMenuBarDisable.h
     ctelnet.h
     CredentialManager.h
     DarkTheme.h
@@ -315,6 +314,7 @@ set(mudlet_HDRS
     mudlet.h
     EditorCommand.h
     MudletInstanceCoordinator.h
+    MudletProxyStyle.h
     EditorUndoStack.h
     MxpTag.h
     EditorAddItemCommand.h

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -19,11 +19,11 @@
  ***************************************************************************/
 
 #include "DarkTheme.h"
-#include "AltFocusMenuBarDisable.h"
+#include "MudletProxyStyle.h"
 
 //DarkTheme only works with Fusion style
 DarkTheme::DarkTheme()
-: DarkTheme(new AltFocusMenuBarDisable(qsl("Fusion")))
+: DarkTheme(new MudletProxyStyle(qsl("Fusion")))
 {
 }
 

--- a/src/MudletProxyStyle.cpp
+++ b/src/MudletProxyStyle.cpp
@@ -18,22 +18,28 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "AltFocusMenuBarDisable.h"
+#include "MudletProxyStyle.h"
 
-AltFocusMenuBarDisable::AltFocusMenuBarDisable()
+#include <QStyleFactory>
+
+MudletProxyStyle::MudletProxyStyle()
 {
     setObjectName(baseStyle()->objectName());
 }
 
-AltFocusMenuBarDisable::AltFocusMenuBarDisable(const QString& style)
+MudletProxyStyle::MudletProxyStyle(const QString& style)
 : QProxyStyle(QStyleFactory::create(style))
 {
 }
 
-int AltFocusMenuBarDisable::styleHint(StyleHint styleHint, const QStyleOption* opt, const QWidget* widget, QStyleHintReturn* returnData) const
+int MudletProxyStyle::styleHint(StyleHint styleHint, const QStyleOption* opt, const QWidget* widget, QStyleHintReturn* returnData) const
 {
     if (styleHint == QStyle::SH_MenuBar_AltKeyNavigation) {
-        return 0;
+        // Force-enable on every base style (Fusion defaults to off) so that a
+        // lone Alt press focuses the menu bar, as screen reader users expect;
+        // Qt only activates the menu bar when Alt is released without another
+        // key being pressed, so Alt+key keybindings still work (Mudlet/Mudlet#6145)
+        return 1;
     }
     if (styleHint == QStyle::SH_ItemView_ActivateItemOnSingleClick) {
         return 0;

--- a/src/MudletProxyStyle.cpp
+++ b/src/MudletProxyStyle.cpp
@@ -20,6 +20,7 @@
 
 #include "MudletProxyStyle.h"
 
+#include <QAccessible>
 #include <QStyleFactory>
 
 MudletProxyStyle::MudletProxyStyle()
@@ -35,11 +36,13 @@ MudletProxyStyle::MudletProxyStyle(const QString& style)
 int MudletProxyStyle::styleHint(StyleHint styleHint, const QStyleOption* opt, const QWidget* widget, QStyleHintReturn* returnData) const
 {
     if (styleHint == QStyle::SH_MenuBar_AltKeyNavigation) {
-        // Force-enable on every base style (Fusion defaults to off) so that a
-        // lone Alt press focuses the menu bar, as screen reader users expect;
-        // Qt only activates the menu bar when Alt is released without another
-        // key being pressed, so Alt+key keybindings still work (Mudlet/Mudlet#6145)
-        return 1;
+        // Screen reader users expect a lone Alt tap to focus the menu bar
+        // (Mudlet/Mudlet#6145), but for everyone else an accidental Alt tap
+        // stealing focus from the command line is a nuisance when using
+        // Alt-based keybindings (Mudlet/Mudlet#4280), so only enable the hint
+        // while assistive technology is in use. QMenuBar re-reads this hint on
+        // every Alt key event, so the gate applies live, on each keypress
+        return QAccessible::isActive() ? 1 : 0;
     }
     if (styleHint == QStyle::SH_ItemView_ActivateItemOnSingleClick) {
         return 0;

--- a/src/MudletProxyStyle.h
+++ b/src/MudletProxyStyle.h
@@ -24,7 +24,8 @@
 
 // Applies Mudlet's application-wide style hint adjustments on top of whichever
 // base style is in use; previously named AltFocusMenuBarDisable when it
-// suppressed the Alt key menu bar navigation that it now ensures is enabled
+// unconditionally suppressed the Alt key menu bar navigation that it now
+// enables for screen reader users only
 class MudletProxyStyle : public QProxyStyle
 {
     Q_OBJECT

--- a/src/MudletProxyStyle.h
+++ b/src/MudletProxyStyle.h
@@ -17,20 +17,22 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef MUDLET_ALTFOCUSMENUBARDISABLE_H
-#define MUDLET_ALTFOCUSMENUBARDISABLE_H
+#ifndef MUDLET_MUDLETPROXYSTYLE_H
+#define MUDLET_MUDLETPROXYSTYLE_H
 
 #include <QProxyStyle>
-#include <QStyleFactory>
 
-class AltFocusMenuBarDisable : public QProxyStyle
+// Applies Mudlet's application-wide style hint adjustments on top of whichever
+// base style is in use; previously named AltFocusMenuBarDisable when it
+// suppressed the Alt key menu bar navigation that it now ensures is enabled
+class MudletProxyStyle : public QProxyStyle
 {
     Q_OBJECT
 
 public:
-    AltFocusMenuBarDisable();
-    explicit AltFocusMenuBarDisable(const QString &style);
-    int styleHint(StyleHint styleHint, const QStyleOption *opt, const QWidget *widget, QStyleHintReturn *returnData) const;
+    MudletProxyStyle();
+    explicit MudletProxyStyle(const QString& style);
+    int styleHint(StyleHint styleHint, const QStyleOption* opt, const QWidget* widget, QStyleHintReturn* returnData) const override;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,6 @@
 #include <QSplashScreen>
 #include <QStringList>
 #include <QTranslator>
-#include "AltFocusMenuBarDisable.h"
 #include "TAccessibleConsole.h"
 #include "TAccessibleTextEdit.h"
 #include "FileOpenHandler.h"

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -28,12 +28,12 @@
 
 #include "mudlet.h"
 
-#include "AltFocusMenuBarDisable.h"
 #include "CredentialManager.h"
 #include "DarkTheme.h"
 #include "LuaInterface.h"
 #include "TDebug.h"
 #include "MudletInstanceCoordinator.h"
+#include "MudletProxyStyle.h"
 #include "TDetachedWindow.h"
 #include "TDockWidget.h"
 #include "TEvent.h"
@@ -6260,11 +6260,11 @@ void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
             qApp->setStyle(new DarkTheme);
         } else {
             // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-            qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
+            qApp->setStyle(new MudletProxyStyle(mDefaultStyle));
         }
     } else {
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-        qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
+        qApp->setStyle(new MudletProxyStyle(mDefaultStyle));
     }
 
     getHostManager().changeAllHostColour(getActiveHost());


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Screen reader users can reach Mudlet's menu bar by pressing Alt again. The existing behavior for Alt-based keybindings is preserved for users who are not running assistive technology.

#### Motivation for adding to Mudlet

Alt-to-menu-bar navigation is a standard desktop accessibility expectation, and it makes Mudlet's menus easier to reach with a screen reader.

#### Other info (issues closed, discussion etc)

Addresses #6145. Built locally on Windows with CLANG64 Release; manually confirmed the menu bar behavior works with a screen reader.
I have not tested this on mac; "alt" or command may not be ideal on that platform for focusing the menu bar.