### PR TITLE
infrastructure: harden release deploy scripts

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -383,17 +383,32 @@ else
     powershell.exe <<EOF
 \$installerExePath = "${INSTALLER_EXE_WINPATHFILE}"
 \$DEPLOY_PATH = "${DEPLOY_PATH}"
-scp.exe -i temp_key_file -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$installerExePath mudmachine@mudlet.org:\${DEPLOY_PATH}
+scp.exe -i temp_key_file -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$installerExePath mudmachine@make.mudlet.org:\${DEPLOY_PATH}
+if (\$LASTEXITCODE -ne 0) { exit \$LASTEXITCODE }
 EOF
+    installer_scp_rc=$?
 
     shred -u temp_key_file
 
-    DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-64-installer.exe"
-
-    if ! curl --output /dev/null --silent --head --fail "${DEPLOY_URL}"; then
-      echo "Error: release not found as expected at ${DEPLOY_URL}"
+    if [ "$installer_scp_rc" -ne 0 ]; then
+      echo "::error::failed to upload Windows installer to make.mudlet.org (scp exit ${installer_scp_rc})"
       exit 1
     fi
+
+    DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-64-installer.exe"
+
+    # Retry to tolerate the delay between scp landing the file and it being served
+    # at www.mudlet.org - the publish step is not instantaneous.
+    verify_attempt=0
+    until curl --output /dev/null --silent --head --fail "${DEPLOY_URL}"; do
+      verify_attempt=$((verify_attempt + 1))
+      if [ "$verify_attempt" -ge 18 ]; then
+        echo "::warning::installer uploaded to make.mudlet.org but not yet downloadable at ${DEPLOY_URL} after $verify_attempt attempts (CloudFlare/publish lag); the scp above is the authoritative upload check"
+        break
+      fi
+      echo "Release not yet available at ${DEPLOY_URL}, retrying in 10s (attempt $verify_attempt/18)..."
+      sleep 10
+    done
 
     SHA256SUM=$(shasum -a 256 "${INSTALLER_EXE_PATHFILE}" | awk '{print $1}')
 
@@ -411,7 +426,7 @@ EOF
     current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
     read -r day month year hour minute second <<< "${current_timestamp}"
 
-    curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+    curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
     -H "x-wp-download-token: ${X_WP_DOWNLOAD_TOKEN}" \
     -F "file_type=2" \
     -F "file_remote=${DEPLOY_URL}" \
@@ -448,19 +463,32 @@ EOF
 \$portableZipPath = "${PORTABLE_ZIP_WINPATH}"
 \$DEPLOY_PATH = "${DEPLOY_PATH}"
 \$remoteFileName = "${PORTABLE_REMOTE_NAME}"
-scp.exe -i temp_key_file_portable -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$portableZipPath mudmachine@mudlet.org:\${DEPLOY_PATH}/\$remoteFileName
+scp.exe -i temp_key_file_portable -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$portableZipPath mudmachine@make.mudlet.org:\${DEPLOY_PATH}/\$remoteFileName
+if (\$LASTEXITCODE -ne 0) { exit \$LASTEXITCODE }
 EOF
+      portable_scp_rc=$?
 
       shred -u temp_key_file_portable
+
+      if [ "$portable_scp_rc" -ne 0 ]; then
+        echo "::error::failed to upload Windows portable ZIP to make.mudlet.org (scp exit ${portable_scp_rc})"
+        exit 1
+      fi
 
       # Define portable ZIP URL - should match the naming convention
       PORTABLE_DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-windows-64-portable.zip"
 
-      # Verify portable ZIP was uploaded
-      if ! curl --output /dev/null --silent --head --fail "${PORTABLE_DEPLOY_URL}"; then
-        echo "Error: portable ZIP not found as expected at ${PORTABLE_DEPLOY_URL}"
-        exit 1
-      fi
+      # Verify portable ZIP was uploaded (retry to tolerate publish propagation delay)
+      verify_attempt=0
+      until curl --output /dev/null --silent --head --fail "${PORTABLE_DEPLOY_URL}"; do
+        verify_attempt=$((verify_attempt + 1))
+        if [ "$verify_attempt" -ge 18 ]; then
+          echo "::warning::portable ZIP uploaded to make.mudlet.org but not yet downloadable at ${PORTABLE_DEPLOY_URL} after $verify_attempt attempts (CloudFlare/publish lag)"
+          break
+        fi
+        echo "Portable ZIP not yet available at ${PORTABLE_DEPLOY_URL}, retrying in 10s (attempt $verify_attempt/18)..."
+        sleep 10
+      done
 
       # Calculate SHA256 for portable ZIP
       PORTABLE_SHA256SUM=$(shasum -a 256 "${PORTABLE_ZIP_PATH}" | awk '{print $1}')
@@ -469,7 +497,7 @@ EOF
       echo "sha256 of portable ZIP: ${PORTABLE_SHA256SUM}"
 
       # Register portable ZIP with download manager
-      curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+      curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
       -H "x-wp-download-token: ${X_WP_DOWNLOAD_TOKEN}" \
       -F "file_type=2" \
       -F "file_remote=${PORTABLE_DEPLOY_URL}" \
@@ -536,7 +564,8 @@ EOF
   if [[ "${DBLSQD_CHANNEL}" == "release" ]]; then
     echo "=== Registering release with Dblsqd ==="
     echo "dblsqd push -a mudlet -c \"${DBLSQD_CHANNEL}\" -r \"${DBLSQD_VERSION_STRING}\" -s mudlet --type 'standalone' --attach win:x86_64 \"${DEPLOY_URL}\""
-    dblsqd push -a mudlet -c "${DBLSQD_CHANNEL}" -r "${DBLSQD_VERSION_STRING}" -s mudlet --type 'standalone' --attach win:x86_64 "${DEPLOY_URL}"
+    # Non-fatal: dblsqd is legacy (GitHub releases are the primary distribution now).
+    dblsqd push -a mudlet -c "${DBLSQD_CHANNEL}" -r "${DBLSQD_VERSION_STRING}" -s mudlet --type 'standalone' --attach win:x86_64 "${DEPLOY_URL}" || echo "::warning::dblsqd push failed for win:x86_64 - continuing (GitHub release is the primary distribution)"
   fi
 
 fi

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -154,23 +154,37 @@ then
       } >> "$GITHUB_ENV"
 
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}-linux-x64.AppImage.tar" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
-
-      DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
-      if ! curl --output /dev/null --silent --head --fail "$DEPLOY_URL"; then
-        echo "Error: release not found as expected at $DEPLOY_URL"
+      if ! scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}-linux-x64.AppImage.tar" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"; then
+        echo "::error::failed to upload Mudlet-${VERSION}-linux-x64.AppImage.tar to make.mudlet.org"
         exit 1
       fi
 
+      DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
+      # Retry to tolerate the delay between scp landing on make.mudlet.org and the
+      # file being served at www.mudlet.org - the publish step is not instantaneous.
+      verify_attempt=0
+      until curl --output /dev/null --silent --head --fail "$DEPLOY_URL"; do
+        verify_attempt=$((verify_attempt + 1))
+        if [ "$verify_attempt" -ge 18 ]; then
+          echo "::warning::release uploaded to make.mudlet.org but not yet downloadable at $DEPLOY_URL after $verify_attempt attempts (CloudFlare/publish lag); the scp above is the authoritative upload check"
+          break
+        fi
+        echo "Release not yet available at $DEPLOY_URL, retrying in 10s (attempt $verify_attempt/18)..."
+        sleep 10
+      done
+
       # upload an unzipped, unversioned release for appimage.github.io
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet.AppImage" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
+      if ! scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet.AppImage" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"; then
+        echo "::error::failed to upload Mudlet.AppImage to make.mudlet.org"
+        exit 1
+      fi
       DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
 
       SHA256SUM=$(shasum -a 256 "Mudlet-${VERSION}-linux-x64.AppImage.tar" | awk '{print $1}')
       current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
       read -r day month year hour minute second <<< "$current_timestamp"
 
-      curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+      curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
       -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
       -F "file_type=2" \
       -F "file_remote=$DEPLOY_URL" \
@@ -189,17 +203,26 @@ then
 
       echo "=== Uploading portable version ==="
       PORTABLE_NAME="Mudlet-${VERSION}-linux-x64-portable"
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${PORTABLE_NAME}.tar.gz" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
-      PORTABLE_DEPLOY_URL="https://www.mudlet.org/wp-content/files/${PORTABLE_NAME}.tar.gz"
-
-      if ! curl --output /dev/null --silent --head --fail "$PORTABLE_DEPLOY_URL"; then
-        echo "Error: portable release not found as expected at $PORTABLE_DEPLOY_URL"
+      if ! scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${PORTABLE_NAME}.tar.gz" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"; then
+        echo "::error::failed to upload ${PORTABLE_NAME}.tar.gz to make.mudlet.org"
         exit 1
       fi
+      PORTABLE_DEPLOY_URL="https://www.mudlet.org/wp-content/files/${PORTABLE_NAME}.tar.gz"
+
+      verify_attempt=0
+      until curl --output /dev/null --silent --head --fail "$PORTABLE_DEPLOY_URL"; do
+        verify_attempt=$((verify_attempt + 1))
+        if [ "$verify_attempt" -ge 18 ]; then
+          echo "::warning::portable uploaded to make.mudlet.org but not yet downloadable at $PORTABLE_DEPLOY_URL after $verify_attempt attempts (CloudFlare/publish lag)"
+          break
+        fi
+        echo "Portable release not yet available at $PORTABLE_DEPLOY_URL, retrying in 10s (attempt $verify_attempt/18)..."
+        sleep 10
+      done
 
       PORTABLE_SHA256SUM=$(shasum -a 256 "${PORTABLE_NAME}.tar.gz" | awk '{print $1}')
 
-      curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+      curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
       -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
       -F "file_type=2" \
       -F "file_remote=$PORTABLE_DEPLOY_URL" \
@@ -235,7 +258,9 @@ then
       # release registration and uploading will be manual for the time being
     else
       echo "=== Registering release with Dblsqd ==="
-      dblsqd push -a mudlet -c release -r "${VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${DEPLOY_URL}"
+      # Non-fatal: dblsqd is legacy (GitHub releases are the primary distribution now),
+      # and the dblsqd release may not be pre-created. Do not let it block the build.
+      dblsqd push -a mudlet -c release -r "${VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${DEPLOY_URL}" || echo "::warning::dblsqd push failed for linux:x86_64 - continuing (GitHub release is the primary distribution)"
     fi
 
     if [ "${public_test_build}" != "true" ]; then
@@ -255,7 +280,7 @@ then
       current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")
       read -r day month year hour minute second <<< "$current_timestamp"
 
-      curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+      curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
       -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
       -F "file_type=2" \
       -F "file_remote=$FILE_URL" \

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -274,7 +274,10 @@ then
       chmod +x "${HOME}/git-archive-all.sh"
       "${HOME}/git-archive-all.sh" "Mudlet-${VERSION}.tar"
       xz "Mudlet-${VERSION}.tar"
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}.tar.xz" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
+      if ! scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}.tar.xz" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"; then
+        echo "::error::failed to upload Mudlet-${VERSION}.tar.xz to make.mudlet.org"
+        exit 1
+      fi
       FILE_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}.tar.xz"
       SHA256SUM=$(shasum -a 256 "Mudlet-${VERSION}.tar.xz" | awk '{print $1}')
       current_timestamp=$(date "+%-d %-m %Y %-H %-M %-S")

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -20,20 +20,36 @@ sign_app_bundle () {
 
   local appBundle="$1"
   echo "Signing app bundle: ${appBundle}"
-  codesign -s "$IDENTITY" -o runtime --timestamp "${appBundle}"
+  # -f forces a re-sign: the portable flow adds portable.txt to the bundle, which
+  # invalidates the signature applied during the main dmg flow. Return non-zero on
+  # failure so callers can skip the portable rather than ship a broken bundle.
+  if ! codesign -f -s "$IDENTITY" -o runtime --timestamp "${appBundle}"; then
+    echo "::warning::failed to codesign ${appBundle}"
+    return 1
+  fi
   echo "Successfully signed app bundle"
 
   echo "Notarizing app bundle"
+  # notarytool needs an archive (zip/dmg/pkg), not a bare .app bundle.
+  local notarizeZip="${appBundle}.notarize.zip"
+  ditto -c -k --keepParent "${appBundle}" "${notarizeZip}"
+  local notarized="false"
   for i in {1..3}; do
     echo "Trying to notarize app bundle (attempt ${i})"
-    if xcrun notarytool submit "${appBundle}" --apple-id "$APPLE_USERNAME" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait; then
+    if xcrun notarytool submit "${notarizeZip}" --apple-id "$APPLE_USERNAME" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait; then
       echo "Successfully notarized app bundle"
+      notarized="true"
       break
     fi
   done
+  rm -f "${notarizeZip}"
 
-  echo "Stapling notarization ticket to app bundle"
-  xcrun stapler staple "${appBundle}"
+  if [ "${notarized}" = "true" ]; then
+    echo "Stapling notarization ticket to app bundle"
+    xcrun stapler staple "${appBundle}" || echo "::warning::failed to staple notarization ticket to ${appBundle}"
+  else
+    echo "::warning::could not notarize ${appBundle}; shipping a signed but un-notarized portable app bundle"
+  fi
 }
 
 BUILD_DIR="${BUILD_FOLDER}"
@@ -179,13 +195,24 @@ if [ "${DEPLOY}" = "deploy" ]; then
       } >> "$GITHUB_ENV"
 
       echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/Mudlet-${VERSION}-${ARCH}.dmg" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
-      DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-${ARCH}.dmg"
-
-      if ! curl --output /dev/null --silent --head --fail "$DEPLOY_URL"; then
-        echo "Error: release not found as expected at $DEPLOY_URL"
+      if ! scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/Mudlet-${VERSION}-${ARCH}.dmg" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"; then
+        echo "::error::failed to upload Mudlet-${VERSION}-${ARCH}.dmg to make.mudlet.org"
         exit 1
       fi
+      DEPLOY_URL="https://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-${ARCH}.dmg"
+
+      # Retry to tolerate the delay between scp landing on make.mudlet.org and the
+      # file being served at www.mudlet.org - the publish step is not instantaneous.
+      verify_attempt=0
+      until curl --output /dev/null --silent --head --fail "$DEPLOY_URL"; do
+        verify_attempt=$((verify_attempt + 1))
+        if [ "$verify_attempt" -ge 18 ]; then
+          echo "::warning::release uploaded to make.mudlet.org but not yet downloadable at $DEPLOY_URL after $verify_attempt attempts (CloudFlare/publish lag); the scp above is the authoritative upload check"
+          break
+        fi
+        echo "Release not yet available at $DEPLOY_URL, retrying in 10s (attempt $verify_attempt/18)..."
+        sleep 10
+      done
 
       SHA256SUM=$(shasum -a 256 "${HOME}/Desktop/Mudlet-${VERSION}-${ARCH}.dmg" | awk '{print $1}')
 
@@ -208,28 +235,50 @@ if [ "${DEPLOY}" = "deploy" ]; then
           exit 1
         fi
 
-        # Sign the app bundle specifically for portable version
+        # Sign the app bundle for the portable version. portable.txt currently
+        # lives in Contents/MacOS/, which breaks codesign; until the marker is
+        # moved to a codesign-safe location (to be fixed on the development
+        # branch), the macOS portable is best-effort: skip it on signing failure
+        # rather than fail the whole release build.
+        PORTABLE_READY="true"
         if [ -n "$MACOS_SIGNING_PASS" ]; then
           echo "Signing app bundle for portable version"
-          sign_app_bundle "$APP_PATH"
+          if ! sign_app_bundle "$APP_PATH"; then
+            echo "::warning::macOS portable signing failed; skipping the macOS portable for this build"
+            PORTABLE_READY="false"
+          fi
         fi
 
-        tar -czf "${PORTABLE_NAME}.tar.gz" -C "$APP_DIR" "mudlet.app"
+        if [ "${PORTABLE_READY}" = "true" ]; then
+          tar -czf "${PORTABLE_NAME}.tar.gz" -C "$APP_DIR" "mudlet.app"
+        fi
       else
         echo "Error: Could not find mudlet.app anywhere in ${BUILD_DIR}"
         echo "Directory contents:"
         find "${BUILD_DIR}" -name "*.app" -type d
         exit 1
       fi
-      PORTABLE_SHA256SUM=$(shasum -a 256 "${HOME}/Desktop/${PORTABLE_NAME}.tar.gz" | awk '{print $1}')
 
-      echo "=== Uploading portable version ==="
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/${PORTABLE_NAME}.tar.gz" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"
-      PORTABLE_DEPLOY_URL="https://www.mudlet.org/wp-content/files/${PORTABLE_NAME}.tar.gz"
+      if [ "${PORTABLE_READY}" = "true" ]; then
+        PORTABLE_SHA256SUM=$(shasum -a 256 "${HOME}/Desktop/${PORTABLE_NAME}.tar.gz" | awk '{print $1}')
 
-      if ! curl --output /dev/null --silent --head --fail "$PORTABLE_DEPLOY_URL"; then
-        echo "Error: portable release not found as expected at $PORTABLE_DEPLOY_URL"
-        exit 1
+        echo "=== Uploading portable version ==="
+        if ! scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/${PORTABLE_NAME}.tar.gz" "mudmachine@make.mudlet.org:${DEPLOY_PATH}"; then
+          echo "::error::failed to upload ${PORTABLE_NAME}.tar.gz to make.mudlet.org"
+          exit 1
+        fi
+        PORTABLE_DEPLOY_URL="https://www.mudlet.org/wp-content/files/${PORTABLE_NAME}.tar.gz"
+
+        verify_attempt=0
+        until curl --output /dev/null --silent --head --fail "$PORTABLE_DEPLOY_URL"; do
+          verify_attempt=$((verify_attempt + 1))
+          if [ "$verify_attempt" -ge 18 ]; then
+            echo "::warning::portable uploaded to make.mudlet.org but not yet downloadable at $PORTABLE_DEPLOY_URL after $verify_attempt attempts (CloudFlare/publish lag)"
+            break
+          fi
+          echo "Portable release not yet available at $PORTABLE_DEPLOY_URL, retrying in 10s (attempt $verify_attempt/18)..."
+          sleep 10
+        done
       fi
 
       if [ "${ARCH}" = "arm64" ]; then
@@ -243,7 +292,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
       read -r day month year hour minute second <<< "$current_timestamp"
 
       # Upload regular DMG version
-      curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+      curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
       -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
       -F "file_type=2" \
       -F "file_remote=$DEPLOY_URL" \
@@ -260,8 +309,9 @@ if [ "${DEPLOY}" = "deploy" ]; then
       -F "output=json" \
       -F "do=Add File"
 
-      # Upload portable version
-      curl --retry 5 -X POST 'https://www.mudlet.org/download-add.php' \
+      # Upload portable version (only when the portable was successfully built)
+      if [ "${PORTABLE_READY}" = "true" ]; then
+      curl --retry 5 -X POST 'https://make.mudlet.org/download-add.php' \
       -H "x-wp-download-token: $X_WP_DOWNLOAD_TOKEN" \
       -F "file_type=2" \
       -F "file_remote=$PORTABLE_DEPLOY_URL" \
@@ -277,6 +327,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
       -F "file_timestamp_second=$second" \
       -F "output=json" \
       -F "do=Add File"
+      fi
 
     fi
 
@@ -298,7 +349,9 @@ if [ "${DEPLOY}" = "deploy" ]; then
       # release registration and uploading will be manual for the time being
     else
       echo "=== Registering release with Dblsqd ==="
-      dblsqd push -a mudlet -c release -r "${VERSION}" -s mudlet --type "standalone" --attach mac:${ARCH_DBLSQD} "${DEPLOY_URL}"
+      # Non-fatal: dblsqd is legacy (GitHub releases are the primary distribution now),
+      # and the dblsqd release may not be pre-created. Do not let it block the build.
+      dblsqd push -a mudlet -c release -r "${VERSION}" -s mudlet --type "standalone" --attach mac:${ARCH_DBLSQD} "${DEPLOY_URL}" || echo "::warning::dblsqd push failed for mac:${ARCH_DBLSQD} - continuing (GitHub release is the primary distribution)"
     fi
   fi
 


### PR DESCRIPTION
Releasing 4.21.0 surfaced several breakages in the release deploy scripts. The fixes below were validated end-to-end by the successful 4.21.0 release build (mac, linux, windows all green and signed) on the `release-4.21` branch; this PR brings them to `development` so future releases and PTBs benefit, plus one additional fix found while verifying the release.

What changed

All three deploy scripts (`CI/osx.after_success.sh`, `CI/linux.after_success.sh`, `CI/deploy-mudlet-for-windows.sh`):

- Upload via `make.mudlet.org` instead of `mudlet.org` for SCP - CloudFlare blocks port 22 on `mudlet.org` ("Network is unreachable"), `make.mudlet.org` is the direct host. *(validated in 4.21.0)*
- Retry the publish-check (`curl --head`) and treat publish lag as a non-fatal `::warning::` - the file landing via scp is the authoritative upload check; the www URL can lag behind due to CloudFlare/publish propagation. *(validated)*
- macOS: `codesign -f` so re-signing works, notarize via a `ditto`-created zip archive (notarytool needs an archive, not a bare `.app`), and make the portable best-effort so a portable signing failure can no longer fail the whole job and block the release. *(validated)*
- `dblsqd push` non-fatal - GitHub Releases are the primary channel now. *(validated)*
- Route the `download-add.php` POST through `make.mudlet.org` *(new fix, not yet exercised by a release)* - `www.mudlet.org` is behind CloudFlare, which returns a "Just a moment..." challenge page to the registration POST, so the download-page entry was silently never registered (the script even printed "registered successfully" regardless). `make.mudlet.org` reaches the same WordPress backend directly (`server: Apache`, no challenge). `file_remote` still points at the public `www.mudlet.org/wp-content/files/...` URL, which serves fine.

Follow-ups (not in this PR)

- The macOS portable still can't be code-signed because `portable.txt` is written into `Contents/MacOS/`, which breaks `codesign`. Proper fix = move the portable marker to a codesign-safe location (e.g. `Contents/Resources/`) and update `main.cpp` / `mudlet.cpp` / `CredentialManager.cpp` + the macOS deploy. Tracked separately as it is an app-behavior change needing manual testing.
- Optionally make `download-add.php` parse its JSON response and warn on a non-success body, instead of the unconditional success echo.