### PR TITLE
infrastructure: bump next-milestone to 4.22.0

### DIFF
--- a/.github/repo-metadata.yml
+++ b/.github/repo-metadata.yml
@@ -2,4 +2,4 @@
 
 milestones:
   # assign new PRs to this milestone
-  next-milestone: 4.21.0
+  next-milestone: 4.22.0


### PR DESCRIPTION
4.21.0 is released, so new PRs should be assigned to the 4.22.0 milestone.

Routine post-release metadata bump.

Assisted-by: Claude:claude-opus-4-8