### PR TITLE
infrastructure: bump development to 4.22.0-dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ else()
 endif()
 
 # Set APP_VERSION
-set(APP_VERSION 4.20.1)
+set(APP_VERSION 4.22.0)
 
 # Set APP_BUILD based on environment variable MUDLET_VERSION_BUILD or default
 if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD} STREQUAL "")


### PR DESCRIPTION
4.21.0 is released, so development should track the next version.

Bumps `APP_VERSION` from 4.20.1 to 4.22.0; combined with the automatic `-dev-<sha>` build suffix, development builds now report `4.22.0-dev-<sha>`.

Signed off by me.