### PR TITLE
Improve: Make screen reader descriptions plain text

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4141,6 +4141,7 @@ void T2DMap::slot_customLineProperties()
                 qWarning("T2DMap::slot_customLineProperties() ERROR: failed to create the dialog!");
                 return;
             }
+            utils::setAccessibleDescriptionsFromToolTips(dialog);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->setWindowIcon(QIcon(qsl(":/icons/mudlet_custom_exit_properties.png")));
             auto* le_toId = dialog->findChild<QLineEdit*>(qsl("toId"));
@@ -5477,6 +5478,7 @@ void T2DMap::slot_setCustomLine()
     if (!dialog) {
         return;
     }
+    utils::setAccessibleDescriptionsFromToolTips(dialog);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowIcon(QIcon(qsl(":/icons/mudlet_custom_exit.png")));
     mCustomLinesRoomFrom = mMultiSelectionHighlightRoomId;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -513,6 +513,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     mpBufferSearchDown->setIcon(QIcon(qsl(":/icons/import.png")));
     connect(mpBufferSearchDown, &QAbstractButton::clicked, this, &TConsole::slot_searchBufferDown);
 
+    // Screen readers fall back to reading the tooltip - including its raw HTML
+    // markup - for widgets without an accessible description:
+    const QList<QWidget*> toolTippedWidgets = {mpBufferSearchBox, mpBufferSearchUp, mpBufferSearchDown, timeStampButton, replayButton, logButton, emergencyStop, mpLineEdit_networkLatency};
+    for (auto* pToolTippedWidget : toolTippedWidgets) {
+        utils::setAccessibleDescriptionFromToolTip(pToolTippedWidget);
+    }
+
     if (mType == MainConsole) {
         setF3SearchEnabled(mpHost->getF3SearchEnabled());
     }
@@ -980,6 +987,7 @@ void TConsole::slot_toggleReplayRecording()
         printSystemMessage(tr("Replay recording has started. File: %1").arg(mReplayFile.fileName()) % QChar::LineFeed);
         //: Button tooltip for the replay recording toggle button
         replayButton->setToolTip(utils::richText(tr("Stop recording of replay")));
+        utils::setAccessibleDescriptionFromToolTip(replayButton);
     } else {
         if (!mReplayFile.commit()) {
             qDebug() << "TConsole::slot_toggleReplayRecording: error saving replay: " << mReplayFile.errorString();
@@ -991,6 +999,7 @@ void TConsole::slot_toggleReplayRecording()
         }
         //: Button tooltip for the replay recording toggle button
         replayButton->setToolTip(utils::richText(tr("Start recording of replay")));
+        utils::setAccessibleDescriptionFromToolTip(replayButton);
     }
 }
 

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1072,6 +1072,14 @@ void TDetachedWindow::createToolBar()
     mpActionFullScreenView->setObjectName(qsl("fullscreen_action"));
     mpToolBar->addAction(mpActionFullScreenView);
 
+    // The buttons that the toolbar creates for the actions otherwise report
+    // the action's tooltip - with its raw HTML markup - as their accessible
+    // description, which screen readers read aloud verbatim:
+    const auto toolBarButtons = mpToolBar->findChildren<QToolButton*>();
+    for (auto* pToolButton : toolBarButtons) {
+        utils::setAccessibleDescriptionFromToolTip(pToolButton);
+    }
+
     // Setup context menu for the toolbar
     mpToolBar->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mpToolBar, &QToolBar::customContextMenuRequested, this, &TDetachedWindow::slot_showDetachedToolBarContextMenu);

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -340,6 +340,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
                                .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
         }
         logButton->setToolTip(utils::richText(tr("Stop logging game output to log file.")));
+        utils::setAccessibleDescriptionFromToolTip(logButton);
     } else {
         // Logging is being turned off
         buffer.logRemainingOutput();
@@ -356,6 +357,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         mLogFile.flush();
         mLogFile.close();
         logButton->setToolTip(utils::richText(tr("Start logging game output to log file.")));
+        utils::setAccessibleDescriptionFromToolTip(logButton);
     }
 }
 

--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -29,6 +29,7 @@
 #include "TTextEdit.h"
 #include "TTrigger.h"
 #include "mudlet.h"
+#include "utils.h"
 
 
 dlgColorTrigger::dlgColorTrigger(QWidget* pParentWidget, TTrigger* pT, const bool isBackGround, const QString& title)
@@ -194,6 +195,8 @@ dlgColorTrigger::dlgColorTrigger(QWidget* pParentWidget, TTrigger* pT, const boo
     } else if ((mIsBackground && mpTrigger->mColorTriggerBgAnsi == TTrigger::scmIgnored) || (!mIsBackground && mpTrigger->mColorTriggerFgAnsi == TTrigger::scmIgnored)) {
         buttonBox->button(QDialogButtonBox::Ignore)->setFocus();
     }
+
+    utils::setAccessibleDescriptionsFromToolTips(this);
 }
 
 void dlgColorTrigger::setupBasicButton(QPushButton* pButton, const int ansiColor, const QColor& color, const QString& colorText)
@@ -360,6 +363,7 @@ void dlgColorTrigger::slot_moreColorsClicked()
     buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 
     buttonBox->button(QDialogButtonBox::Apply)->setToolTip(utils::richText(tr("All color options are showing.")));
+    utils::setAccessibleDescriptionFromToolTip(buttonBox->button(QDialogButtonBox::Apply));
 
     if (groupBox_rgbScale->isHidden()) {
         groupBox_rgbScale->show();

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -29,6 +29,7 @@
 #include "TEncodingHelper.h"
 #include "TMainConsole.h"
 #include "mudlet.h"
+#include "utils.h"
 
 #include <QKeyEvent>
 #include <QMenu>
@@ -40,6 +41,8 @@ dlgComposer::dlgComposer(Host* pH)
 : mpHost(pH)
 {
     setupUi(this);
+    utils::setAccessibleDescriptionsFromToolTips(this);
+
     const QFont font = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);
     edit->setFont(font);
     connect(saveButton, &QAbstractButton::clicked, this, &dlgComposer::slot_save);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -212,6 +212,9 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
     } else {
         character_password_entry->setToolTip(utils::richText(tr("Characters password. Note that the password is not encrypted in storage")));
     }
+    // Screen readers fall back to reading the tooltip - including its raw HTML
+    // markup - for a widget without an accessible description:
+    utils::setAccessibleDescriptionFromToolTip(character_password_entry);
 
     connect(mpAction_revealPassword, &QAction::triggered, this, &dlgConnectionProfiles::slot_togglePasswordVisibility);
     connect(offline_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_load);
@@ -1173,6 +1176,10 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
     if (mudlet::self()->getHostManager().getHost(profile_name)) {
         remove_profile_button->setEnabled(false);
         remove_profile_button->setToolTip(utils::richText(tr("A profile that is in use cannot be removed")));
+        // Screen readers fall back to reading the tooltip - including its raw
+        // HTML markup - for a widget without an accessible description, and the
+        // tooltip here changes as the selection changes so refresh it each time:
+        utils::setAccessibleDescriptionFromToolTip(remove_profile_button);
         connect_button->setEnabled(false);
         offline_button->setEnabled(false);
 
@@ -1212,6 +1219,7 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
         }
         remove_profile_button->setEnabled(true);
         remove_profile_button->setToolTip(QString());
+        utils::setAccessibleDescriptionFromToolTip(remove_profile_button);
     }
 }
 
@@ -1278,6 +1286,9 @@ void dlgConnectionProfiles::fillout_form()
             description = getDescription(qsl("mudlet.org"));
             if (!description.isEmpty()) {
                 pItem->setToolTip(utils::richText(description));
+                // Item views fall back to the tooltip - with its raw HTML - for
+                // an item's accessible description unless this is set:
+                pItem->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pItem->toolTip()));
             }
         }
 #endif
@@ -1383,6 +1394,9 @@ void dlgConnectionProfiles::loadCustomProfile(const QString& profileName) const
     auto description = getDescription(profileName);
     if (!description.isEmpty()) {
         pItem->setToolTip(utils::richText(description));
+        // Item views fall back to the tooltip - with its raw HTML - for an
+        // item's accessible description unless this is set:
+        pItem->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pItem->toolTip()));
     }
     listWidget_profiles->addItem(pItem);
 }
@@ -1903,6 +1917,9 @@ bool dlgConnectionProfiles::validateProfile()
 #if defined(QT_NO_SSL)
         port_ssl_tsl->setEnabled(false);
         port_ssl_tsl->setToolTip(utils::richText(tr("Mudlet is not configured for secure connections.")));
+        // Screen readers fall back to reading the tooltip - including its raw
+        // HTML markup - for a widget without an accessible description:
+        utils::setAccessibleDescriptionFromToolTip(port_ssl_tsl);
         if (port_ssl_tsl->isChecked()) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(qsl("%1\n%2\n\n").arg(notificationAreaMessageBox->text(), tr("Mudlet is not configured for secure connections.")));
@@ -1921,6 +1938,7 @@ bool dlgConnectionProfiles::validateProfile()
         } else {
             port_ssl_tsl->setEnabled(true);
             port_ssl_tsl->setToolTip(QString());
+            utils::setAccessibleDescriptionFromToolTip(port_ssl_tsl);
         }
 #endif
 
@@ -2112,6 +2130,9 @@ void dlgConnectionProfiles::setupMudProfile(QListWidgetItem* pItem, const QStrin
     }
     if (!serverDescription.isEmpty()) {
         pItem->setToolTip(utils::richText(serverDescription));
+        // Item views fall back to the tooltip - with its raw HTML - for an
+        // item's accessible description unless this is set:
+        pItem->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pItem->toolTip()));
     }
 }
 

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -32,6 +32,7 @@ dlgMapLabel::dlgMapLabel(QWidget* pParentWidget)
 : QDialog(pParentWidget)
 {
     setupUi(this);
+    utils::setAccessibleDescriptionFromToolTip(checkBox_scaling);
 
     setAttribute(Qt::WA_DeleteOnClose);
     //: Create label dialog title

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -24,6 +24,7 @@
 #include "dlgModuleManager.h"
 
 #include "mudlet.h"
+#include "utils.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -102,6 +103,7 @@ void dlgModuleManager::layoutModules()
             masterModule->setText(QString());
             //: Tooltip for master module checkbox
             masterModule->setToolTip(utils::richText(tr("Master module: saved and resynchronized across all sessions on Save Profile or session end.")));
+            masterModule->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(masterModule->toolTip()));
 
             // Although there is now no text used here this may help to make the
             // checkbox more central in the column
@@ -112,6 +114,7 @@ void dlgModuleManager::layoutModules()
             itemEntry->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
             itemLocation->setText(moduleInfo[0]);
             itemLocation->setToolTip(utils::richText(moduleInfo[0]));         // show the full path in a tooltip, in case it doesn't fit in the table
+            itemLocation->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(itemLocation->toolTip()));
             itemLocation->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled); // disallow editing of module path, because that is not saved
             itemPriority->setData(Qt::EditRole, mpHost->mModulePriorities[moduleName]);
             moduleTable->setItem(row, 0, itemEntry);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -62,6 +62,7 @@
 #include <QStandardPaths>
 #include <QString>
 #include <QTableWidget>
+#include <QTextDocument>
 #include <QTemporaryDir>
 #include <QTemporaryFile>
 #include <QToolBar>
@@ -3958,6 +3959,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
     anyFont.setStyleStrategy(static_cast<QFont::StyleStrategy>(mpHost->mpMap->mMapSymbolFont.styleStrategy() & ~(QFont::NoFontMerging)));
 
     int row = -1;
+    QTextDocument accessibleTextDocument;
     QHashIterator<QString, QSet<int>> itUsedSymbol(roomSymbolsHash);
     while (itUsedSymbol.hasNext()) {
         itUsedSymbol.next();
@@ -3969,13 +3971,13 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         auto* pSymbolInFont = new QTableWidgetItem();
         pSymbolInFont->setTextAlignment(Qt::AlignCenter);
         pSymbolInFont->setToolTip(utils::richText(tr("The room symbol will appear like this if only symbols (glyphs) from the specific font are used.")));
-        pSymbolInFont->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pSymbolInFont->toolTip()));
+        pSymbolInFont->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(accessibleTextDocument, pSymbolInFont->toolTip()));
         pSymbolInFont->setFont(selectedFont);
 
         auto* pSymbolAnyFont = new QTableWidgetItem();
         pSymbolAnyFont->setTextAlignment(Qt::AlignCenter);
         pSymbolAnyFont->setToolTip(utils::richText(tr("The room symbol will appear like this if symbols (glyphs) from any font can be used.")));
-        pSymbolAnyFont->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pSymbolAnyFont->toolTip()));
+        pSymbolAnyFont->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(accessibleTextDocument, pSymbolAnyFont->toolTip()));
         pSymbolAnyFont->setFont(anyFont);
 
         const QFontMetrics SymbolInFontMetrics(selectedFont);
@@ -4011,13 +4013,13 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
                                          "on many Unix type operating systems will also use these numbers which cover "
                                          "everything from U+0020 {Space} to U+10FFFD the last usable number in the <i>Private Use "
                                          "Plane 16</i> via most of the written marks that humanity has ever made.</p>"));
-        pCodePointDisplay->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pCodePointDisplay->toolTip()));
+        pCodePointDisplay->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(accessibleTextDocument, pCodePointDisplay->toolTip()));
 
         // Need to pad the numbers with spaces so that sorting works correctly:
         QTableWidgetItem* pUsageCount = new QTableWidgetItem(qsl("%1").arg(roomsWithSymbol.count(), 5, 10, QChar(' ')));
         pUsageCount->setTextAlignment(Qt::AlignCenter);
         pUsageCount->setToolTip(utils::richText(tr("How many rooms in the whole map have this symbol.")));
-        pUsageCount->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pUsageCount->toolTip()));
+        pUsageCount->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(accessibleTextDocument, pUsageCount->toolTip()));
 
         QStringList roomNumberStringList;
         QListIterator<int> itRoom(roomsWithSymbol);
@@ -4037,7 +4039,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         QTableWidgetItem* pRoomNumbers = new QTableWidgetItem(roomNumberStringList.join(qsl(", ")));
         pRoomNumbers->setToolTip(utils::richText(tr("The rooms with this symbol, up to a maximum of thirty-two, if there are more "
                                                     "than this, it is indicated but they are not shown.")));
-        pRoomNumbers->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pRoomNumbers->toolTip()));
+        pRoomNumbers->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(accessibleTextDocument, pRoomNumbers->toolTip()));
 
         auto* pDummyButton = new QToolButton();
         if (isSingleFontUsable) {
@@ -4071,7 +4073,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
                                                             "<i>getRoomChar</i> and <i>setRoomChar</i> functions.")));
             }
         }
-        utils::setAccessibleDescriptionFromToolTip(pDummyButton);
+        pDummyButton->setAccessibleDescription(utils::stripHtmlTags(accessibleTextDocument, pDummyButton->toolTip()));
         pTableWidget->setCellWidget(++row, 0, pDummyButton);
 
         pTableWidget->setItem(row, 1, pSymbolInFont);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -767,9 +767,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
             comboBox_dictionary->addItem(displayText, entries.at(i));
             comboBox_dictionary->setItemData(comboBox_dictionary->count() - 1, toolTip, Qt::ToolTipRole);
-            // Item views fall back to the tooltip - with its raw HTML - for an
-            // item's accessible description unless this is set:
-            comboBox_dictionary->setItemData(comboBox_dictionary->count() - 1, utils::stripHtmlTags(toolTip), Qt::AccessibleDescriptionRole);
+            // Keep the tooltip for sighted mouse users, but do not announce the
+            // dictionary file path as extra screen-reader text for every item:
+            comboBox_dictionary->setItemData(comboBox_dictionary->count() - 1, QString(), Qt::AccessibleDescriptionRole);
 
             if (entries.at(i) == currentDictionary) {
                 currentIndex = comboBox_dictionary->count() - 1;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -198,6 +198,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         checkbox_noAutomaticUpdates->setChecked(true);
         checkbox_noAutomaticUpdates->setDisabled(true);
         checkbox_noAutomaticUpdates->setToolTip(utils::richText(tr("Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet.")));
+        utils::setAccessibleDescriptionFromToolTip(checkbox_noAutomaticUpdates);
     } else {
         checkbox_noAutomaticUpdates->setChecked(!pMudlet->pUpdater->updateAutomatically());
         // This is the extra connect(...) relating to settings' changes saved by
@@ -240,6 +241,24 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     //: Tooltip for show icons on menus option
     checkBox_showIconsOnMenus->setToolTip(tr("<p>Control menu icon display: on, off, or auto (system default). "
                                              "May require restart.</p>"));
+
+    // Screen readers fall back to reading the tooltip - including its raw HTML
+    // markup - for widgets without an accessible description:
+    const QList<QWidget*> toolTippedWidgets = {lineEdit_logFileFolder,
+                                               pushButton_whereToLog,
+                                               pushButton_resetLogDir,
+                                               comboBox_logFileNameFormat,
+                                               lineEdit_logFileName,
+                                               widget_timerDebugOutputMinimumInterval,
+                                               pushButton_showGlyphUsage,
+                                               fontComboBox_mapSymbols,
+                                               checkBox_isOnlyMapSymbolFontToBeUsed,
+                                               checkBox_useWideAmbiguousEastAsianGlyphs,
+                                               checkBox_enableTextAnalyzer,
+                                               checkBox_showIconsOnMenus};
+    for (auto* pToolTippedWidget : toolTippedWidgets) {
+        utils::setAccessibleDescriptionFromToolTip(pToolTippedWidget);
+    }
     lineEdit_mmcpPort->setPlaceholderText(QString::number(csDefaultMMCPHostPort));
     lineEdit_mmcpChatName->setPlaceholderText(csDefaultMMCPChatName);
     connect(lineEdit_mmcpChatName, &QLineEdit::editingFinished, this, &dlgProfilePreferences::slot_mmcpChatNameChanged);
@@ -748,6 +767,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
             comboBox_dictionary->addItem(displayText, entries.at(i));
             comboBox_dictionary->setItemData(comboBox_dictionary->count() - 1, toolTip, Qt::ToolTipRole);
+            // Item views fall back to the tooltip - with its raw HTML - for an
+            // item's accessible description unless this is set:
+            comboBox_dictionary->setItemData(comboBox_dictionary->count() - 1, utils::stripHtmlTags(toolTip), Qt::AccessibleDescriptionRole);
 
             if (entries.at(i) == currentDictionary) {
                 currentIndex = comboBox_dictionary->count() - 1;
@@ -760,6 +782,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     } else {
         comboBox_dictionary->setEnabled(false);
         comboBox_dictionary->setToolTip(utils::richText(tr("No Hunspell dictionary files found, spell-checking will not be available.")));
+        utils::setAccessibleDescriptionFromToolTip(comboBox_dictionary);
     }
     comboBox_dictionary->blockSignals(false);
 
@@ -3946,11 +3969,13 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         auto* pSymbolInFont = new QTableWidgetItem();
         pSymbolInFont->setTextAlignment(Qt::AlignCenter);
         pSymbolInFont->setToolTip(utils::richText(tr("The room symbol will appear like this if only symbols (glyphs) from the specific font are used.")));
+        pSymbolInFont->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pSymbolInFont->toolTip()));
         pSymbolInFont->setFont(selectedFont);
 
         auto* pSymbolAnyFont = new QTableWidgetItem();
         pSymbolAnyFont->setTextAlignment(Qt::AlignCenter);
         pSymbolAnyFont->setToolTip(utils::richText(tr("The room symbol will appear like this if symbols (glyphs) from any font can be used.")));
+        pSymbolAnyFont->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pSymbolAnyFont->toolTip()));
         pSymbolAnyFont->setFont(anyFont);
 
         const QFontMetrics SymbolInFontMetrics(selectedFont);
@@ -3986,11 +4011,13 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
                                          "on many Unix type operating systems will also use these numbers which cover "
                                          "everything from U+0020 {Space} to U+10FFFD the last usable number in the <i>Private Use "
                                          "Plane 16</i> via most of the written marks that humanity has ever made.</p>"));
+        pCodePointDisplay->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pCodePointDisplay->toolTip()));
 
         // Need to pad the numbers with spaces so that sorting works correctly:
         QTableWidgetItem* pUsageCount = new QTableWidgetItem(qsl("%1").arg(roomsWithSymbol.count(), 5, 10, QChar(' ')));
         pUsageCount->setTextAlignment(Qt::AlignCenter);
         pUsageCount->setToolTip(utils::richText(tr("How many rooms in the whole map have this symbol.")));
+        pUsageCount->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pUsageCount->toolTip()));
 
         QStringList roomNumberStringList;
         QListIterator<int> itRoom(roomsWithSymbol);
@@ -4010,6 +4037,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
         QTableWidgetItem* pRoomNumbers = new QTableWidgetItem(roomNumberStringList.join(qsl(", ")));
         pRoomNumbers->setToolTip(utils::richText(tr("The rooms with this symbol, up to a maximum of thirty-two, if there are more "
                                                     "than this, it is indicated but they are not shown.")));
+        pRoomNumbers->setData(Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pRoomNumbers->toolTip()));
 
         auto* pDummyButton = new QToolButton();
         if (isSingleFontUsable) {
@@ -4043,6 +4071,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
                                                             "<i>getRoomChar</i> and <i>setRoomChar</i> functions.")));
             }
         }
+        utils::setAccessibleDescriptionFromToolTip(pDummyButton);
         pTableWidget->setCellWidget(++row, 0, pDummyButton);
 
         pTableWidget->setItem(row, 1, pSymbolInFont);
@@ -4143,6 +4172,7 @@ void dlgProfilePreferences::generateDiscordTooltips()
                                         //: Discord Rich Presence time until or time elapsed
                                         .arg(tr("Time"));
         widget->setToolTip(tooltip);
+        utils::setAccessibleDescriptionFromToolTip(widget);
     };
 
     setToolTip(checkBox_discordServerAccessToDetail, qsl("detail"));

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -157,9 +157,11 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
         }
         // Set the tooltip for the QLineEdit:
         mpEditor->setToolTip(roomIdToolTipText);
+        utils::setAccessibleDescriptionFromToolTip(mpEditor);
         if (mpItem) {
             // And duplicate it in the status:
             mpItem->setToolTip(ExitsTreeWidget::colIndex_exitStatus, roomIdToolTipText);
+            mpDlgRoomExits->setItemAccessibleDescriptionFromToolTip(mpItem, ExitsTreeWidget::colIndex_exitStatus);
         }
     }
 
@@ -234,8 +236,10 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
                                                "If left like this, this exit will be deleted when <tt>save</tt> is clicked."));
     }
     mpEditor->setToolTip(roomIdToolTipText);
+    utils::setAccessibleDescriptionFromToolTip(mpEditor);
 
     mpItem->setToolTip(ExitsTreeWidget::colIndex_exitStatus, roomIdToolTipText);
+    mpDlgRoomExits->setItemAccessibleDescriptionFromToolTip(mpItem, ExitsTreeWidget::colIndex_exitStatus);
 }
 
 dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
@@ -244,6 +248,7 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
 , mRoomID(roomNumber)
 {
     setupUi(this);
+    utils::setAccessibleDescriptionsFromToolTips(this);
 
     mIcon_invalidExit.addFile(qsl(":/icons/dialog-error.png"), QSize(24, 24));
     mIcon_inAreaExit.addFile(qsl(":/icons/dialog-ok-apply.png"), QSize(24, 24));
@@ -284,6 +289,38 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
 }
 
 dlgRoomExits::~dlgRoomExits() = default;
+
+void dlgRoomExits::setItemAccessibleDescriptionFromToolTip(QTreeWidgetItem* pItem, const int column) const
+{
+    if (!pItem) {
+        return;
+    }
+
+    pItem->setData(column, Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pItem->toolTip(column)));
+}
+
+void dlgRoomExits::setItemAccessibleDescriptionsFromToolTips(QTreeWidgetItem* pItem) const
+{
+    if (!pItem) {
+        return;
+    }
+
+    QTextDocument document;
+    const int columns[] = {ExitsTreeWidget::colIndex_exitRoomId,
+                           ExitsTreeWidget::colIndex_exitStatus,
+                           ExitsTreeWidget::colIndex_lockExit,
+                           ExitsTreeWidget::colIndex_exitWeight,
+                           ExitsTreeWidget::colIndex_doorNone,
+                           ExitsTreeWidget::colIndex_doorOpen,
+                           ExitsTreeWidget::colIndex_doorClosed,
+                           ExitsTreeWidget::colIndex_doorLocked,
+                           ExitsTreeWidget::colIndex_command};
+    for (const int column : columns) {
+        if (!pItem->toolTip(column).isEmpty()) {
+            pItem->setData(column, Qt::AccessibleDescriptionRole, utils::stripHtmlTags(document, pItem->toolTip(column)));
+        }
+    }
+}
 
 void dlgRoomExits::slot_endEditSpecialExits()
 {
@@ -472,6 +509,7 @@ void dlgRoomExits::slot_addSpecialExit()
     specialExits->addTopLevelItem(pI);
 
     setIconAndToolTipsOnSpecialExit(pI, true);
+    setItemAccessibleDescriptionsFromToolTips(pI);
 }
 
 void dlgRoomExits::save()
@@ -1036,6 +1074,8 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     } else {
         pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_command, utils::richText(tr("Some mapper scripts may require prefixing the keyword \"script:\").")));
     }
+
+    setItemAccessibleDescriptionsFromToolTips(pSpecialExit);
 }
 
 void dlgRoomExits::setActionOnExit(QLineEdit* pExitLineEdit, QAction* pWantedAction) const
@@ -1173,6 +1213,8 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText,
         pDoorType_locked->setEnabled(false);
         pStub->setEnabled(true);
     }
+
+    utils::setAccessibleDescriptionFromToolTip(pExit);
 }
 
 void dlgRoomExits::normalStubExitChanged(const int state,
@@ -1217,6 +1259,8 @@ void dlgRoomExits::normalStubExitChanged(const int state,
         pWeight->setEnabled(false);
         pWeight->setValue(0); // Prevent a weight to be set/changed on a also
     }
+
+    utils::setAccessibleDescriptionFromToolTip(pExit);
 }
 
 // These slots are called as the text for the exitID is edited
@@ -1629,6 +1673,7 @@ void dlgRoomExits::initExit(int direction,
             none->setChecked(true);
         }
     }
+    utils::setAccessibleDescriptionFromToolTip(exitLineEdit);
     originalExits[direction] = makeExitFromControls(direction);
 }
 
@@ -1644,6 +1689,7 @@ void dlgRoomExits::init()
         // Revise the tool tip:
         //: This text is a revision to the default tooltip text set for this widget in the 'room_exits.ui' file. Bold HTML tags are used to emphasis that this room's locked status overrides any weight or lock ("No route") setting of any exit that comes to it.
         roomID->setToolTip(utils::richText(tr("This is the Room ID number for this room; this <b>room is locked</b> so it will not be used for speed-walks at all.")));
+        utils::setAccessibleDescriptionFromToolTip(roomID);
     } else {
         // Hide the padlock icon to the right of the room number display to
         // show the unlocked status of the room:

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -176,6 +176,8 @@ private slots:
 
 private:
     static QString generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool exitRoomLocked, const bool outOfAreaExit, const int exitRoomWeight);
+    void setItemAccessibleDescriptionFromToolTip(QTreeWidgetItem*, int column) const;
+    void setItemAccessibleDescriptionsFromToolTips(QTreeWidgetItem*) const;
     void init();
     void initExit(int direction, int exitId, QLineEdit* exitLineEdit,
                   QCheckBox* noRoute, QCheckBox* stub,

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -25,6 +25,7 @@
 #include "Host.h"
 #include "TMap.h"
 #include "TRoomDB.h"
+#include "utils.h"
 
 #include <QColorDialog>
 #include <QMenu>
@@ -37,6 +38,7 @@ dlgRoomProperties::dlgRoomProperties(Host* pHost, QWidget* pParentWidget)
 {
     // init generated dialog
     setupUi(this);
+    utils::setAccessibleDescriptionsFromToolTips(this);
 
     connect(lineEdit_roomSymbol, &QLineEdit::textChanged, this, &dlgRoomProperties::slot_updatePreview);
     connect(comboBox_roomSymbol, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgRoomProperties::slot_symbolComboBoxItemChanged);
@@ -220,6 +222,7 @@ void dlgRoomProperties::initHiddenInstructions(const int hiddenRoomCount)
  state of being hidden when the selection includes multiple rooms and they
  are not all in the same state.*/
         checkBox_hidden->setToolTip(utils::richText(tr("Leave as partially checked to not change the state of the selected rooms.")));
+        utils::setAccessibleDescriptionFromToolTip(checkBox_hidden);
         return;
     }
 
@@ -230,6 +233,7 @@ void dlgRoomProperties::initHiddenInstructions(const int hiddenRoomCount)
                                 nullptr,
                                 mpRooms.size()));
     checkBox_hidden->setToolTip(QString());
+    utils::setAccessibleDescriptionFromToolTip(checkBox_hidden);
 }
 
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1055,15 +1055,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     QMainWindow::addToolBar(Qt::TopToolBarArea, toolBar);
     QMainWindow::addToolBar(Qt::LeftToolBarArea, toolBar2);
 
-    // The buttons that the toolbars create for the actions otherwise report
-    // the action's tooltip - with its raw HTML markup - as their accessible
-    // description, which screen readers read aloud verbatim:
-    for (auto* pToolBar : {toolBar, toolBar2}) {
-        const auto toolButtons = pToolBar->findChildren<QToolButton*>();
-        for (auto* pToolButton : toolButtons) {
-            utils::setAccessibleDescriptionFromToolTip(pToolButton);
-        }
-    }
+    updateToolbarButtonAccessibleTexts();
 
     // (Top) "Actions" toolbar:
     //: This will restore that toolbar in the editor window, after a user has hidden it or moved it to another docking location or floated it elsewhere.
@@ -1599,8 +1591,58 @@ void dlgTriggerEditor::updateUndoRedoAccessibleDescriptions()
     if (!toolBar) {
         return;
     }
-    utils::setAccessibleDescriptionFromToolTip(toolBar->widgetForAction(mpUndoAction));
-    utils::setAccessibleDescriptionFromToolTip(toolBar->widgetForAction(mpRedoAction));
+    updateToolButtonAccessibleText(qobject_cast<QToolButton*>(toolBar->widgetForAction(mpUndoAction)));
+    updateToolButtonAccessibleText(qobject_cast<QToolButton*>(toolBar->widgetForAction(mpRedoAction)));
+}
+
+void dlgTriggerEditor::updateToolbarButtonAccessibleTexts()
+{
+    for (auto* pToolBar : {toolBar, toolBar2}) {
+        if (!pToolBar) {
+            continue;
+        }
+        const auto toolButtons = pToolBar->findChildren<QToolButton*>();
+        for (auto* pToolButton : toolButtons) {
+            updateToolButtonAccessibleText(pToolButton);
+        }
+    }
+}
+
+void dlgTriggerEditor::updateToolButtonAccessibleText(QToolButton* pToolButton)
+{
+    if (!pToolButton) {
+        return;
+    }
+
+    utils::setAccessibleDescriptionFromToolTip(pToolButton);
+
+    const auto* pAction = pToolButton->defaultAction();
+    if (!pAction) {
+        return;
+    }
+
+    QString accessibleName = pAction->text();
+    if (accessibleName.isEmpty()) {
+        accessibleName = pAction->iconText();
+    }
+
+    QString shortcut = pAction->shortcut().toString(QKeySequence::NativeText);
+    if (shortcut.isEmpty()) {
+        if (auto it = mButtonShortcuts.find(accessibleName); it != mButtonShortcuts.end()) {
+            shortcut = QKeySequence(it->second).toString(QKeySequence::NativeText);
+        }
+    }
+
+    if (!accessibleName.isEmpty() && !shortcut.isEmpty()) {
+        //: Accessible name for an editor toolbar button. %1 is the button label, %2 is a keyboard shortcut.
+        accessibleName = tr("%1 (%2)").arg(accessibleName, shortcut);
+    } else if (accessibleName.isEmpty()) {
+        accessibleName = utils::stripHtmlTags(pToolButton->toolTip());
+    }
+
+    if (!accessibleName.isEmpty()) {
+        pToolButton->setAccessibleName(accessibleName);
+    }
 }
 
 void dlgTriggerEditor::applyPatternWidgetStyle(dlgTriggerPatternEdit* patternWidget)
@@ -12340,6 +12382,7 @@ void dlgTriggerEditor::setShortcuts(const bool active)
 {
     setShortcuts(toolBar->actions(), active);
     setShortcuts(toolBar2->actions(), active);
+    updateToolbarButtonAccessibleTexts();
 }
 
 void dlgTriggerEditor::setShortcuts(QList<QAction*> actionList, const bool active)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -483,6 +483,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
             mpUndoAction->setToolTip(utils::richText(undoText));
             mpUndoAction->setStatusTip(undoText);
         }
+        updateUndoRedoAccessibleDescriptions();
     });
     connect(mpUndoStack, &QUndoStack::redoTextChanged, this, [this](const QString& text) {
         QString shortcut = mpRedoAction->shortcut().toString(QKeySequence::NativeText);
@@ -497,6 +498,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
             mpRedoAction->setToolTip(utils::richText(redoText));
             mpRedoAction->setStatusTip(redoText);
         }
+        updateUndoRedoAccessibleDescriptions();
     });
 
     // Store guarded pointer to text editor's undo stack for safe signal connections
@@ -1053,6 +1055,16 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     QMainWindow::addToolBar(Qt::TopToolBarArea, toolBar);
     QMainWindow::addToolBar(Qt::LeftToolBarArea, toolBar2);
 
+    // The buttons that the toolbars create for the actions otherwise report
+    // the action's tooltip - with its raw HTML markup - as their accessible
+    // description, which screen readers read aloud verbatim:
+    for (auto* pToolBar : {toolBar, toolBar2}) {
+        const auto toolButtons = pToolBar->findChildren<QToolButton*>();
+        for (auto* pToolButton : toolButtons) {
+            utils::setAccessibleDescriptionFromToolTip(pToolButton);
+        }
+    }
+
     // (Top) "Actions" toolbar:
     //: This will restore that toolbar in the editor window, after a user has hidden it or moved it to another docking location or floated it elsewhere.
     mpAction_restoreEditorActionsToolbar = new QAction(tr("Restore Actions toolbar"), this);
@@ -1573,6 +1585,18 @@ void dlgTriggerEditor::slot_updateUndoRedoButtonStates()
         mpRedoAction->setToolTip(utils::richText(redoText));
         mpRedoAction->setStatusTip(redoText);
     }
+    updateUndoRedoAccessibleDescriptions();
+}
+
+// The undo/redo tooltips change at runtime so the plain text mirrored into the
+// toolbar buttons' accessible descriptions has to be refreshed alongside them:
+void dlgTriggerEditor::updateUndoRedoAccessibleDescriptions()
+{
+    if (!toolBar) {
+        return;
+    }
+    utils::setAccessibleDescriptionFromToolTip(toolBar->widgetForAction(mpUndoAction));
+    utils::setAccessibleDescriptionFromToolTip(toolBar->widgetForAction(mpRedoAction));
 }
 
 void dlgTriggerEditor::applyPatternWidgetStyle(dlgTriggerPatternEdit* patternWidget)
@@ -6874,6 +6898,9 @@ void dlgTriggerEditor::saveVar()
     } else if (varUnit->isSaved(variable)) {
         pItem->setCheckState(0, Qt::Checked);
     }
+    // Item views fall back to the tooltip - with its raw HTML - for an item's
+    // accessible description unless this is set:
+    pItem->setData(0, Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pItem->toolTip(0)));
     pItem->setData(0, Qt::UserRole, variable->getValueType());
     QIcon icon;
     switch (variable->getValueType()) {
@@ -7099,6 +7126,7 @@ void dlgTriggerEditor::setupPatternControls(const int type, dlgTriggerPatternEdi
             pItem->label_prompt->setToolTip(utils::richText(tr("A Go-Ahead (GA) signal from the game is required to make this feature work")));
             pItem->label_prompt->setEnabled(false);
         }
+        utils::setAccessibleDescriptionFromToolTip(pItem->label_prompt);
         pItem->label_prompt->show();
         pItem->spinBox_lineSpacer->hide();
         break;
@@ -8078,6 +8106,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     } else if (vu->isSaved(var)) {
         pItem->setCheckState(0, Qt::Checked);
     }
+    pItem->setData(0, Qt::AccessibleDescriptionRole, utils::stripHtmlTags(pItem->toolTip(0)));
     pItem->setData(0, Qt::UserRole, var->getValueType());
     pItem->setIcon(0, icon);
     mChangingVar = false;
@@ -13120,6 +13149,7 @@ void dlgTriggerEditor::slot_clearSoundFile()
     mpTriggersMainArea->lineEdit_soundFile->clear();
     mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(false);
     mpTriggersMainArea->lineEdit_soundFile->setToolTip(utils::richText(tr("Sound file to play when the trigger fires.")));
+    utils::setAccessibleDescriptionFromToolTip(mpTriggersMainArea->lineEdit_soundFile);
 }
 
 void dlgTriggerEditor::slot_showAllTriggerControls(const bool isShown)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -483,7 +483,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
             mpUndoAction->setToolTip(utils::richText(undoText));
             mpUndoAction->setStatusTip(undoText);
         }
-        updateUndoRedoAccessibleDescriptions();
+        updateUndoRedoAccessibleTexts();
     });
     connect(mpUndoStack, &QUndoStack::redoTextChanged, this, [this](const QString& text) {
         QString shortcut = mpRedoAction->shortcut().toString(QKeySequence::NativeText);
@@ -498,7 +498,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
             mpRedoAction->setToolTip(utils::richText(redoText));
             mpRedoAction->setStatusTip(redoText);
         }
-        updateUndoRedoAccessibleDescriptions();
+        updateUndoRedoAccessibleTexts();
     });
 
     // Store guarded pointer to text editor's undo stack for safe signal connections
@@ -1209,10 +1209,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpActionsMainArea->comboBox_action_button_rotation, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_saveProperty_ActionButtonRotation);
     connect(mpActionsMainArea->plainTextEdit_action_css, &QPlainTextEdit::textChanged, this, &dlgTriggerEditor::slot_saveProperty_ActionCSS);
 
-    // The search combobox's tooltip comes from the .ui file with HTML markup
-    // that screen readers would otherwise read aloud verbatim:
-    utils::setAccessibleDescriptionFromToolTip(comboBox_searchTerms);
-
     comboBox_searchTerms->lineEdit()->setClearButtonEnabled(true);
     auto pLineEdit_searchTerm = comboBox_searchTerms->lineEdit();
 
@@ -1267,6 +1263,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpAction_searchOptions->setMenu(pMenu_searchOptions);
 
     pLineEdit_searchTerm->addAction(mpAction_searchOptions, QLineEdit::LeadingPosition);
+
+    utils::setAccessibleDescriptionsFromToolTips(this);
 
     connect(mpScriptsMainArea->toolButton_script_add_event_handler, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_scriptMainAreaAddHandler);
     connect(mpScriptsMainArea->toolButton_script_remove_event_handler, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_scriptMainAreaDeleteHandler);
@@ -1581,12 +1579,12 @@ void dlgTriggerEditor::slot_updateUndoRedoButtonStates()
         mpRedoAction->setToolTip(utils::richText(redoText));
         mpRedoAction->setStatusTip(redoText);
     }
-    updateUndoRedoAccessibleDescriptions();
+    updateUndoRedoAccessibleTexts();
 }
 
-// The undo/redo tooltips change at runtime so the plain text mirrored into the
-// toolbar buttons' accessible descriptions has to be refreshed alongside them:
-void dlgTriggerEditor::updateUndoRedoAccessibleDescriptions()
+// The undo/redo tooltips change at runtime so their accessible text has to be
+// refreshed alongside them:
+void dlgTriggerEditor::updateUndoRedoAccessibleTexts()
 {
     if (!toolBar) {
         return;
@@ -1614,10 +1612,9 @@ void dlgTriggerEditor::updateToolButtonAccessibleText(QToolButton* pToolButton)
         return;
     }
 
-    utils::setAccessibleDescriptionFromToolTip(pToolButton);
-
     const auto* pAction = pToolButton->defaultAction();
     if (!pAction) {
+        utils::setAccessibleDescriptionFromToolTip(pToolButton);
         return;
     }
 
@@ -1638,10 +1635,15 @@ void dlgTriggerEditor::updateToolButtonAccessibleText(QToolButton* pToolButton)
         accessibleName = tr("%1 (%2)").arg(accessibleName, shortcut);
     } else if (accessibleName.isEmpty()) {
         accessibleName = utils::stripHtmlTags(pToolButton->toolTip());
+        const auto firstSentenceEnd = accessibleName.indexOf(QRegularExpression(qsl(R"([.!?]\s)")));
+        if (firstSentenceEnd > 0) {
+            accessibleName = accessibleName.left(firstSentenceEnd + 1).trimmed();
+        }
     }
 
     if (!accessibleName.isEmpty()) {
         pToolButton->setAccessibleName(accessibleName);
+        pToolButton->setAccessibleDescription(QString());
     }
 }
 
@@ -9862,6 +9864,8 @@ void dlgTriggerEditor::changeView(EditorViewType view)
         qDebug() << "ERROR: dlgTriggerEditor::changeView() undefined view";
     }
 
+    updateToolbarButtonAccessibleTexts();
+
     // Update undo/redo button states when changing views
     slot_updateUndoRedoButtonStates();
 
@@ -10065,6 +10069,7 @@ void dlgTriggerEditor::showError(const QString& text)
     mpSystemMessageArea->notificationAreaIconLabelError->show();
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
     mpSystemMessageArea->notificationAreaMessageBox->setText(text);
+    const QString plainText = utils::setPlainAccessibleText(mpSystemMessageArea->notificationAreaMessageBox, text);
     mpSystemMessageArea->show();
     mCurrentBannerKey.clear();
 
@@ -10073,7 +10078,7 @@ void dlgTriggerEditor::showError(const QString& text)
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
 
     if (!mpHost->mIsProfileLoadingSequence) {
-        mudlet::self()->announce(text);
+        mudlet::self()->announce(plainText);
     }
 }
 
@@ -10083,6 +10088,7 @@ void dlgTriggerEditor::showWarning(const QString& text, bool announce)
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
     mpSystemMessageArea->notificationAreaIconLabelWarning->show();
     mpSystemMessageArea->notificationAreaMessageBox->setText(text);
+    const QString plainText = utils::setPlainAccessibleText(mpSystemMessageArea->notificationAreaMessageBox, text);
     mpSystemMessageArea->show();
     mCurrentBannerKey.clear();
 
@@ -10091,7 +10097,7 @@ void dlgTriggerEditor::showWarning(const QString& text, bool announce)
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
 
     if (!mpHost->mIsProfileLoadingSequence && announce) {
-        mudlet::self()->announce(text);
+        mudlet::self()->announce(plainText);
     }
 }
 
@@ -10101,10 +10107,11 @@ void dlgTriggerEditor::showInfo(const QString& text)
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
     mpSystemMessageArea->notificationAreaIconLabelInformation->show();
     mpSystemMessageArea->notificationAreaMessageBox->setText(text);
+    const QString plainText = utils::setPlainAccessibleText(mpSystemMessageArea->notificationAreaMessageBox, text);
     mpSystemMessageArea->show();
     mCurrentBannerKey.clear();
     if (!mpHost->mIsProfileLoadingSequence) {
-        mudlet::self()->announce(text);
+        mudlet::self()->announce(plainText);
     }
 }
 
@@ -14151,6 +14158,7 @@ void dlgTriggerEditor::showBannerUndoToast()
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
     mpSystemMessageArea->notificationAreaIconLabelInformation->show();
     mpSystemMessageArea->notificationAreaMessageBox->setText(toastMessage);
+    utils::setPlainAccessibleText(mpSystemMessageArea->notificationAreaMessageBox, toastMessage);
     mpSystemMessageArea->show();
 
     connect(mpBannerUndoTimer, &QTimer::timeout, this, &dlgTriggerEditor::hideSystemMessageArea);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1217,6 +1217,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpActionsMainArea->comboBox_action_button_rotation, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_saveProperty_ActionButtonRotation);
     connect(mpActionsMainArea->plainTextEdit_action_css, &QPlainTextEdit::textChanged, this, &dlgTriggerEditor::slot_saveProperty_ActionCSS);
 
+    // The search combobox's tooltip comes from the .ui file with HTML markup
+    // that screen readers would otherwise read aloud verbatim:
+    utils::setAccessibleDescriptionFromToolTip(comboBox_searchTerms);
+
     comboBox_searchTerms->lineEdit()->setClearButtonEnabled(true);
     auto pLineEdit_searchTerm = comboBox_searchTerms->lineEdit();
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -554,7 +554,7 @@ private:
     void showOrHideRestoreEditorItemsToolbarAction();
     void updateToolbarButtonAccessibleTexts();
     void updateToolButtonAccessibleText(QToolButton* pToolButton);
-    void updateUndoRedoAccessibleDescriptions();
+    void updateUndoRedoAccessibleTexts();
     void checkForMoreThanOneTriggerItem();
     TTrigger* getTriggerFromTreeItem(QTreeWidgetItem* item);
     TAlias* getAliasFromTreeItem(QTreeWidgetItem* item);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -88,6 +88,7 @@ class dlgTriggersMainArea;
 class dlgActionMainArea;
 class dlgSearchArea;
 class dlgAliasMainArea;
+class QToolButton;
 class dlgScriptsMainArea;
 class dlgKeysMainArea;
 class dlgTriggerPatternEdit;
@@ -551,6 +552,8 @@ private:
 
     void showOrHideRestoreEditorActionsToolbarAction();
     void showOrHideRestoreEditorItemsToolbarAction();
+    void updateToolbarButtonAccessibleTexts();
+    void updateToolButtonAccessibleText(QToolButton* pToolButton);
     void updateUndoRedoAccessibleDescriptions();
     void checkForMoreThanOneTriggerItem();
     TTrigger* getTriggerFromTreeItem(QTreeWidgetItem* item);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -551,6 +551,7 @@ private:
 
     void showOrHideRestoreEditorActionsToolbarAction();
     void showOrHideRestoreEditorItemsToolbarAction();
+    void updateUndoRedoAccessibleDescriptions();
     void checkForMoreThanOneTriggerItem();
     TTrigger* getTriggerFromTreeItem(QTreeWidgetItem* item);
     TAlias* getAliasFromTreeItem(QTreeWidgetItem* item);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -534,6 +534,14 @@ void mudlet::init()
     mpMainToolBar->addAction(mpActionFullScreenView);
     mpMainToolBar->widgetForAction(mpActionFullScreenView)->setObjectName(mpActionFullScreenView->objectName());
 
+    // The buttons that the toolbar creates for the actions otherwise report
+    // the action's tooltip - with its raw HTML markup - as their accessible
+    // description, which screen readers read aloud verbatim:
+    const auto mainToolBarButtons = mpMainToolBar->findChildren<QToolButton*>();
+    for (auto* pToolButton : mainToolBarButtons) {
+        utils::setAccessibleDescriptionFromToolTip(pToolButton);
+    }
+
     const QFont mainFont = QFont(qsl("Bitstream Vera Sans Mono"), 8, QFont::Normal);
     mpWidget_profileContainer->setFont(mainFont);
     mpWidget_profileContainer->show();
@@ -2305,6 +2313,7 @@ void mudlet::disableToolbarButtons()
     // more texts to show {the default is to repeat the menu text which is not
     // useful} with a call to menuEditor->setToolTipsVisible(true);
     dactionReplay->setToolTip(mpActionReplay->toolTip());
+    utils::setAccessibleDescriptionFromToolTip(mpMainToolBar->widgetForAction(mpActionReplay));
     dactionReplay->setEnabled(false);
 
     mpActionReconnect->setEnabled(false);
@@ -2390,6 +2399,7 @@ void mudlet::updateMainWindowToolbarState()
                                       "<p><i>Disabled until a profile is loaded.</i></p>"));
         dactionReplay->setToolTip(mpActionReplay->toolTip());
     }
+    utils::setAccessibleDescriptionFromToolTip(mpMainToolBar->widgetForAction(mpActionReplay));
 
     mpActionMudletDiscord->setEnabled(true);
     dactionDiscord->setEnabled(true);
@@ -2495,6 +2505,7 @@ void mudlet::enableToolbarButtons()
         // more texts to show {the default is to repeat the menu text which is not
         // useful} with a call to menuEditor->setToolTipsVisible(true);
         dactionReplay->setToolTip(mpActionReplay->toolTip());
+        utils::setAccessibleDescriptionFromToolTip(mpMainToolBar->widgetForAction(mpActionReplay));
     }
 
     mpActionReconnect->setEnabled(true);
@@ -5172,6 +5183,7 @@ bool mudlet::replayStart()
     dactionReplay->setEnabled(false);
     mpActionReplay->setToolTip(utils::richText(tr("Cannot load a replay as one is already in progress in this or another profile.")));
     dactionReplay->setToolTip(mpActionReplay->toolTip());
+    utils::setAccessibleDescriptionFromToolTip(mpMainToolBar->widgetForAction(mpActionReplay));
 
     mpToolBarReplay = new QToolBar(this);
     mpToolBarReplay->setIconSize(QSize(8 * mToolbarIconSize, 8 * mToolbarIconSize));
@@ -5192,12 +5204,14 @@ bool mudlet::replayStart()
     mpActionReplaySpeedUp->setToolTip(utils::richText(tr("Replay each step with a shorter time interval between steps.")));
     mpToolBarReplay->addAction(mpActionReplaySpeedUp);
     mpToolBarReplay->widgetForAction(mpActionReplaySpeedUp)->setObjectName(mpActionReplaySpeedUp->objectName());
+    utils::setAccessibleDescriptionFromToolTip(mpToolBarReplay->widgetForAction(mpActionReplaySpeedUp));
 
     mpActionReplaySpeedDown = new QAction(QIcon(qsl(":/icons/import.png")), tr("Slower"), this);
     mpActionReplaySpeedDown->setObjectName(qsl("replay_speed_down_action"));
     mpActionReplaySpeedDown->setToolTip(utils::richText(tr("Replay each step with a longer time interval between steps.")));
     mpToolBarReplay->addAction(mpActionReplaySpeedDown);
     mpToolBarReplay->widgetForAction(mpActionReplaySpeedDown)->setObjectName(mpActionReplaySpeedDown->objectName());
+    utils::setAccessibleDescriptionFromToolTip(mpToolBarReplay->widgetForAction(mpActionReplaySpeedDown));
 
     mpLabelReplaySpeedDisplay = new QLabel(this);
     mpActionSpeedDisplay = mpToolBarReplay->addWidget(mpLabelReplaySpeedDisplay);
@@ -5267,6 +5281,7 @@ void mudlet::replayOver()
     dactionReplay->setEnabled(true);
     mpActionReplay->setToolTip(utils::richText(tr("Load a Mudlet replay.")));
     dactionReplay->setToolTip(mpActionReplay->toolTip());
+    utils::setAccessibleDescriptionFromToolTip(mpMainToolBar->widgetForAction(mpActionReplay));
 }
 
 void mudlet::slot_replaySpeedUp()
@@ -5740,6 +5755,7 @@ void mudlet::slot_updateAvailable(const int updateCount)
                                  // Intentional comment
                                  nullptr,
                                  updateCount));
+    utils::setAccessibleDescriptionFromToolTip(mpButtonAbout);
     mpButtonAbout->setText(tr("About"));
     mpButtonAbout->setPopupMode(QToolButton::InstantPopup);
     // Now insert our new button after the current QAction/QToolButton

--- a/src/ui/map_label.ui
+++ b/src/ui/map_label.ui
@@ -214,9 +214,6 @@
         <property name="toolTip">
          <string>&lt;p&gt;If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.&lt;/p&gt;</string>
         </property>
-        <property name="accessibleDescription">
-         <string>If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.</string>
-        </property>
         <property name="text">
          <string>Scale with zoom</string>
         </property>

--- a/src/ui/map_label.ui
+++ b/src/ui/map_label.ui
@@ -214,6 +214,9 @@
         <property name="toolTip">
          <string>&lt;p&gt;If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.&lt;/p&gt;</string>
         </property>
+        <property name="accessibleDescription">
+         <string>If deselected the label will have the same size when you zoom in and out in the mapper. If it is selected the label will scale when you zoom the mapper.</string>
+        </property>
         <property name="text">
          <string>Scale with zoom</string>
         </property>

--- a/src/utils.h
+++ b/src/utils.h
@@ -72,18 +72,23 @@ public:
     // richText()) to plain text suitable for the accessibility APIs - screen
     // readers would otherwise read the markup aloud, see:
     // https://github.com/Mudlet/Mudlet/issues/8547
-    static QString stripHtmlTags(const QString& text)
+    static QString stripHtmlTags(QTextDocument& document, const QString& text)
     {
         if (text.isEmpty()) {
             return text;
         }
-        QTextDocument document;
         document.setHtml(text);
         QString plainText = document.toPlainText();
         // Block elements come out as separate lines but a single space between
         // them reads better as a screen reader announcement:
         plainText.replace(scmWhitespaceRun, qsl(" "));
         return plainText.trimmed();
+    }
+
+    static QString stripHtmlTags(const QString& text)
+    {
+        QTextDocument document;
+        return stripHtmlTags(document, text);
     }
 
     // Mirrors a widget's tooltip into its accessible description with the HTML
@@ -96,6 +101,37 @@ public:
             return;
         }
         pWidget->setAccessibleDescription(stripHtmlTags(pWidget->toolTip()));
+    }
+
+    static void setAccessibleDescriptionsFromToolTips(QWidget* pWidget)
+    {
+        if (!pWidget) {
+            return;
+        }
+
+        QTextDocument document;
+        const auto setAccessibleDescription = [&document](QWidget* pChildWidget) {
+            if (!pChildWidget || pChildWidget->toolTip().isEmpty()) {
+                return;
+            }
+            pChildWidget->setAccessibleDescription(stripHtmlTags(document, pChildWidget->toolTip()));
+        };
+
+        setAccessibleDescription(pWidget);
+        const auto childWidgets = pWidget->findChildren<QWidget*>();
+        for (auto* pChildWidget : childWidgets) {
+            setAccessibleDescription(pChildWidget);
+        }
+    }
+
+    static QString setPlainAccessibleText(QWidget* pWidget, const QString& text)
+    {
+        const QString plainText = stripHtmlTags(text);
+        if (pWidget) {
+            pWidget->setAccessibleName(plainText);
+            pWidget->setAccessibleDescription(plainText);
+        }
+        return plainText;
     }
 
     // Qt 6.9 deprecated QDateTime::setOffsetFromUtc(int) and made it hard to

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,6 +28,7 @@
 #include <QRegularExpression>
 #include <QString>
 #include <QScreen>
+#include <QTextDocument>
 #include <QWidget>
 
 #include <cstring>
@@ -65,6 +66,37 @@ public:
     // defining a static function/method here we can save using the same
     // qsl all over the place:
     static QString richText(const QString& text) { return qsl("<p>%1</p>").arg(text); }
+
+    inline static const auto scmWhitespaceRun = QRegularExpression(qsl(R"(\s+)"));
+    // Reduces text that may contain HTML markup (e.g. tooltips styled with
+    // richText()) to plain text suitable for the accessibility APIs - screen
+    // readers would otherwise read the markup aloud, see:
+    // https://github.com/Mudlet/Mudlet/issues/8547
+    static QString stripHtmlTags(const QString& text)
+    {
+        if (text.isEmpty()) {
+            return text;
+        }
+        QTextDocument document;
+        document.setHtml(text);
+        QString plainText = document.toPlainText();
+        // Block elements come out as separate lines but a single space between
+        // them reads better as a screen reader announcement:
+        plainText.replace(scmWhitespaceRun, qsl(" "));
+        return plainText.trimmed();
+    }
+
+    // Mirrors a widget's tooltip into its accessible description with the HTML
+    // stripped, for use where the tooltip is the only documentation a widget
+    // has - without this screen readers fall back to reading the tooltip with
+    // its raw markup:
+    static void setAccessibleDescriptionFromToolTip(QWidget* pWidget)
+    {
+        if (!pWidget) {
+            return;
+        }
+        pWidget->setAccessibleDescription(stripHtmlTags(pWidget->toolTip()));
+    }
 
     // Qt 6.9 deprecated QDateTime::setOffsetFromUtc(int) and made it hard to
     // replicate the exact strings that we had before:

--- a/test/functional_tests/AccessibleTooltipsTest.cpp
+++ b/test/functional_tests/AccessibleTooltipsTest.cpp
@@ -1,0 +1,51 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "dlgComposer.h"
+#include "utils.h"
+
+#include <QRegularExpression>
+
+
+class AccessibleTooltipsTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void composerSaveButtonAccessibleDescriptionStripsRichTooltip()
+    {
+        dlgComposer composer(nullptr);
+
+        QVERIFY(containsHtmlTag(composer.saveButton->toolTip()));
+        QCOMPARE(composer.saveButton->accessibleDescription(), utils::stripHtmlTags(composer.saveButton->toolTip()));
+        QVERIFY(!containsHtmlTag(composer.saveButton->accessibleDescription()));
+    }
+
+private:
+    static bool containsHtmlTag(const QString& text)
+    {
+        static const QRegularExpression htmlTag(qsl(R"(<[/A-Za-z][^>]*>)"));
+        return text.contains(htmlTag);
+    }
+};
+
+QTEST_MAIN(AccessibleTooltipsTest)
+#include "AccessibleTooltipsTest.moc"

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ if(NOT WIN32)
 endif()
 
 set(FUNCTIONAL_TEST_SOURCES
+    AccessibleTooltipsTest.cpp
     TelnetTextDisplayedTest.cpp
     TelnetBenchmark.cpp
     ResetProfileTest.cpp

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -37,6 +37,7 @@
 #include "mudlet.h"
 #include "utils.h"
 
+#include <QKeySequence>
 #include <QRegularExpression>
 #include <QToolBar>
 #include <QToolButton>
@@ -1880,7 +1881,8 @@ private slots:
         qobject_cast<QToolButton *>(mpEditor->toolBar->widgetForAction(mpEditor->mAddItem));
     QVERIFY(addTriggerButton);
 
-    QCOMPARE(addTriggerButton->accessibleName(), qsl("Add Trigger (Ctrl+N)"));
+    const QString addShortcut = mpEditor->mAddItem->shortcut().toString(QKeySequence::NativeText);
+    QCOMPARE(addTriggerButton->accessibleName(), qsl("Add Trigger (%1)").arg(addShortcut));
     QVERIFY2(addTriggerButton->accessibleDescription().isEmpty(),
              qPrintable(qsl("Toolbar button exposes redundant accessible "
                             "description: %1")

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -35,6 +35,11 @@
 #include "dlgTriggerPatternEdit.h"
 #include "dlgTriggersMainArea.h"
 #include "mudlet.h"
+#include "utils.h"
+
+#include <QRegularExpression>
+#include <QToolBar>
+#include <QToolButton>
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -54,6 +59,16 @@ static void initializeQRCResources() {
 #endif
   qInitResources_mudlet();
   qInitResources_qm();
+}
+
+static bool containsHtmlTag(const QString &text) {
+  static const QRegularExpression htmlTag(qsl(R"(<[/A-Za-z][^>]*>)"));
+  return text.contains(htmlTag);
+}
+
+static bool toolbarActionButton(const QWidget *widget) {
+  const auto *toolButton = qobject_cast<const QToolButton *>(widget);
+  return toolButton && toolButton->defaultAction();
 }
 
 class dlgTriggerEditorUndoRedoTest : public QObject {
@@ -1828,6 +1843,65 @@ private slots:
 
     QVERIFY2(!canUndoBefore || countAfterUndo == initialCount,
              "No items should disappear when undo clicked without changes");
+  }
+
+  void testAccessibleDescriptionsStripRichTextTooltips() {
+    int checkedWidgets = 0;
+    const auto childWidgets = mpEditor->findChildren<QWidget *>();
+    for (const auto *widget : childWidgets) {
+      const QString tooltip = widget->toolTip();
+      if (!containsHtmlTag(tooltip)) {
+        continue;
+      }
+      if (toolbarActionButton(widget)) {
+        continue;
+      }
+
+      ++checkedWidgets;
+      QVERIFY2(!widget->accessibleDescription().isEmpty(),
+               qPrintable(qsl("%1 has a rich text tooltip but no accessible "
+                              "description")
+                              .arg(widget->objectName())));
+      QVERIFY2(!containsHtmlTag(widget->accessibleDescription()),
+               qPrintable(qsl("%1 exposes HTML markup in its accessible "
+                              "description: %2")
+                              .arg(widget->objectName(),
+                                   widget->accessibleDescription())));
+    }
+
+    QVERIFY2(checkedWidgets > 20,
+             "Expected to cover the trigger editor's rich text tooltips");
+  }
+
+  void testToolbarButtonAccessibleTextDoesNotDuplicateTooltip() {
+    mpEditor->slot_showTriggers();
+
+    auto *addTriggerButton =
+        qobject_cast<QToolButton *>(mpEditor->toolBar->widgetForAction(mpEditor->mAddItem));
+    QVERIFY(addTriggerButton);
+
+    QCOMPARE(addTriggerButton->accessibleName(), qsl("Add Trigger (Ctrl+N)"));
+    QVERIFY2(addTriggerButton->accessibleDescription().isEmpty(),
+             qPrintable(qsl("Toolbar button exposes redundant accessible "
+                            "description: %1")
+                            .arg(addTriggerButton->accessibleDescription())));
+  }
+
+  void testSystemMessageAccessibleTextStripsRichText() {
+    const QString richText = qsl("<p><b>Unable to activate trigger.</b></p>"
+                                 "<p><i>Fix the pattern and try again.</i></p>");
+
+    mpEditor->showInfo(richText);
+
+    auto *messageBox = mpEditor->mpSystemMessageArea->notificationAreaMessageBox;
+    QVERIFY(messageBox);
+    QVERIFY(containsHtmlTag(messageBox->text()));
+
+    const QString plainText = utils::stripHtmlTags(richText);
+    QCOMPARE(messageBox->accessibleName(), plainText);
+    QCOMPARE(messageBox->accessibleDescription(), plainText);
+    QVERIFY(!containsHtmlTag(messageBox->accessibleName()));
+    QVERIFY(!containsHtmlTag(messageBox->accessibleDescription()));
   }
 
   void testTriggerNameWiped() {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Mudlet now gives screen readers plain text descriptions for controls that previously exposed raw HTML markup. This covers profile, editor, toolbar, console, mapper, module, room, composer, color trigger, and connection-profile surfaces, including controls whose tooltip text changes at runtime.

#### Motivation for adding to Mudlet

Screen reader users should hear clear control descriptions instead of HTML tags, file paths, or stale tooltip text. Reusing the translated tooltip text as the source keeps the accessible alternative in sync without duplicating translation work.

#### Other info (issues closed, discussion etc)

Closes #8547.

Built locally on Windows with CLANG64 Release. Manually confirmed the HTML-stripping behavior works nicely with NVDA on Windows.