### PR TITLE
infrastructure: release builds no longer show a -dev version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,9 +137,18 @@ endif()
 # Set APP_VERSION
 set(APP_VERSION 4.20.1)
 
-# Set APP_BUILD based on environment variable MUDLET_VERSION_BUILD or default
-if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD} STREQUAL "")
-    set(BUILD_VALUE "$ENV{MUDLET_VERSION_BUILD}-${GIT_SHA1}")
+# Set APP_BUILD based on environment variable MUDLET_VERSION_BUILD. An explicitly
+# empty value must be distinguished from an unset one so release builds (CI exports
+# MUDLET_VERSION_BUILD="") get a clean version with no "-dev-<sha>" suffix:
+#   unset (local dev build)         -> "-dev-<sha>"
+#   defined but empty (release)     -> "" (no suffix)
+#   defined with a value (ptb/test) -> "<value>-<sha>"
+if(DEFINED ENV{MUDLET_VERSION_BUILD})
+    if("$ENV{MUDLET_VERSION_BUILD}" STREQUAL "")
+        set(BUILD_VALUE "")
+    else()
+        set(BUILD_VALUE "$ENV{MUDLET_VERSION_BUILD}-${GIT_SHA1}")
+    endif()
 else()
     set(BUILD_VALUE "-dev-${GIT_SHA1}")
 endif()
@@ -150,11 +159,6 @@ message(STATUS "Value written to app-build.txt file: ${BUILD_VALUE}")
 set(APP_BUILD ${BUILD_VALUE} CACHE STRING "Auto-set during CMake run. Do not alter manually." FORCE)
 
 set(LIB_MUDLET_TARGET "mudlet_core")
-
-# For release builds, comment out the above and uncomment below:
-# file(WRITE ${CMAKE_SOURCE_DIR}/src/app-build.txt " ")
-# message(STATUS "Value written to app-build.txt file: {nothing}")
-# set(APP_BUILD "" CACHE STRING "Auto-set during CMake run. Do not alter manually." FORCE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Distinguish an explicitly empty `MUDLET_VERSION_BUILD` (set by release CI) from an unset one, so tagged releases get a clean version with no `-dev-<sha>` suffix.
- Quote the `STREQUAL` comparison so an empty value doesn't error out at configure time.
- Remove the obsolete manual comment/uncomment release block in `CMakeLists.txt`.

#### Motivation for adding to Mudlet
Release builds (e.g. 4.21.0) were showing `4.21.0-dev-<sha>` in the title bar and reporting `CLIENT_VERSION` as `4/21/0-DEV-<SHA>`, so games keying off NEW-ENVIRON `CLIENT_VERSION` saw every release as a dev build.

#### Other info (issues closed, discussion etc)
Fixes #9328

The release CI (`CI/set-build-info.sh`) already exports `MUDLET_VERSION_BUILD=""` on tag builds, so releases are now clean automatically. This makes two manual steps in the wiki Release Checklist obsolete ("strip out BUILD to be empty" / "reset BUILD to be -dev").

**Test case:**
- Release: `MUDLET_VERSION_BUILD="" cmake . && cmake --build .` then `./src/mudlet --version` -> `mudlet <version>` (no suffix).
- Local dev: unset `MUDLET_VERSION_BUILD`, reconfigure/build -> `mudlet <version>-dev-<sha>`.
- ptb/testing: `MUDLET_VERSION_BUILD=-ptb` -> `<version>-ptb-<sha>` (unchanged).