### PR TITLE
infrastructure: speed up compilation with precompiled headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -651,6 +651,37 @@ set_target_properties(${LIB_MUDLET_TARGET} PROPERTIES
   AUTOMOC ON AUTORCC ON POSITION_INDEPENDENT_CODE ON
   AUTOGEN_ORIGIN_DEPENDS OFF)
 
+# Precompiled headers: parse the most-included, stable Qt and standard-library
+# headers once for the whole library instead of in every translation unit. This
+# cuts a clean build's compile time noticeably. Only headers that are ubiquitous
+# and rarely change are listed - never Mudlet's own headers, which would make the
+# PCH invalidate on most edits. Gated behind an option (default ON) so it can be
+# turned off on memory-constrained machines (e.g. small single-board computers)
+# with -DUSE_PCH=OFF.
+option(USE_PCH "Use precompiled headers to speed up compilation" ON)
+if(USE_PCH)
+  target_precompile_headers(${LIB_MUDLET_TARGET} PRIVATE
+    <memory>
+    <string>
+    <functional>
+    <QtGlobal>
+    <QString>
+    <QStringList>
+    <QByteArray>
+    <QList>
+    <QVector>
+    <QMap>
+    <QHash>
+    <QSet>
+    <QPointer>
+    <QObject>
+    <QDebug>
+  )
+  # sparkleupdater.mm (macOS) is Objective-C++; the C++ precompiled header is
+  # built with Objective-C disabled and cannot be applied to it, so exclude it.
+  set_source_files_properties(sparkleupdater.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+endif()
+
 if(USE_FONTS)
   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC INCLUDE_FONTS)
 endif()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Add an optional precompiled header (PCH) for the `mudlet_core` library, covering the most-included, stable Qt and standard-library headers (`QString`, `QObject`, `QPointer`, the container types, `<memory>`, etc.).
- Gated behind a `USE_PCH` CMake option (default `ON`); can be disabled on memory-constrained machines with `-DUSE_PCH=OFF`.
- Excludes the macOS Objective-C++ source (`sparkleupdater.mm`) from the PCH via `SKIP_PRECOMPILE_HEADERS`.

#### Motivation for adding to Mudlet
Cuts a clean `mudlet_core` compile by ~42% (649s -> 374s; benchmarked ccache-off, RelWithDebInfo, 8-core Apple Silicon) with no behavioural change to the produced binary.

#### Other info (issues closed, discussion etc)
Part of #6765. A lighter, safer alternative to unity builds (#5724): PCH does not carry the same memory-pressure problems, and the `USE_PCH` opt-out addresses the "keep it under developer control" concern raised there. Also verified that ccache caches PCH-using compiles correctly (100% hits) with the default config, so no ccache changes are needed - PCH and ccache stack (clean rebuild with warm cache measured 393s -> 251s).

**Test case:** `cmake .. && ninja` builds successfully with PCH on by default (and noticeably faster on a clean build); a clean build configured with `-DUSE_PCH=OFF` also still builds successfully.