### PR TITLE
fix: password masking could be silently disabled on new profiles

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -523,7 +523,7 @@ public:
     QPointer<dlgModuleManager> mpModuleManager;
     TLuaInterpreter mLuaInterpreter;
 
-    bool mDisablePasswordMasking;
+    bool mDisablePasswordMasking = false;
     int commandLineMinimumHeight = 30;
     bool mAlertOnNewData = true;
     bool mAllowToSendCommand = true;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Give `Host::mDisablePasswordMasking` a default initializer of `false`.

#### Motivation for adding to Mudlet
The member was uninitialized in the constructor, so a new profile read an indeterminate value that could persist to disk and silently turn off command-line password masking.

#### Other info (issues closed, discussion etc)
Follow-up to #8213, which introduced the setting. The import default (`setBoolAttributeWithDefault(..., false)`) only protects profiles where the attribute is absent (pre-#8213 profiles); profiles created/saved after #8213 could persist a stray `disablePasswordMasking="yes"` from uninitialized memory, after which the default no longer applies.

**Test case:** Build, create a fresh profile, open Settings and confirm "Disable password masking" is unchecked by default, and that password entry on the command line is masked.