### PR TITLE
Fix: Make sure every source file is included in the build list

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,9 +157,6 @@ set(mudlet_SRCS
     TMapViewManager.cpp
     TMedia.cpp
     TMediaPlaylist.cpp
-    TMxpElementDefinitionHandler.cpp
-    TMxpElementRegistry.cpp
-    TMxpFormattingTagsHandler.cpp
     TMxpBRTagHandler.cpp
     TMxpHRTagHandler.cpp
     TMxpColorTagHandler.cpp
@@ -333,8 +330,10 @@ set(mudlet_HDRS
     CustomLineEditHandler.h
     CustomLineSession.h
     LabelInteractionHandler.h
+    MiddleMousePanHandler.h
     PackageItemDelegate.h
     PanInteractionHandler.h
+    RoomContextMenuHandler.h
     RoomMoveActivationHandler.h
     RoomMoveDragHandler.h
     SelectionRectangleHandler.h
@@ -377,6 +376,7 @@ set(mudlet_HDRS
     TMapViewManager.h
     TMatchState.h
     TMedia.h
+    TMediaData.h
     TMediaPlaylist.h
     TMxpBRTagHandler.h
     TMxpHRTagHandler.h
@@ -388,6 +388,7 @@ set(mudlet_HDRS
     TMxpElementDefinitionHandler.h
     TMxpElementRegistry.h
     TMxpEntityTagHandler.h
+    TMxpEvent.h
     TMxpExpireTagHandler.h
     TMxpFontTagHandler.h
     TMxpFormattingTagsHandler.h
@@ -404,6 +405,7 @@ set(mudlet_HDRS
     TMxpStatTagHandler.h
     TMxpSupportTagHandler.h
     TMxpTagHandler.h
+    TMxpTagHandlerResult.h
     TMxpTagParser.h
     TMxpTagProcessor.h
     TMxpVarTagHandler.h
@@ -424,6 +426,7 @@ set(mudlet_HDRS
     TTextCodec.h
     TTextBox.h
     TTextEdit.h
+    TTextProperties.h
     TTimer.h
     TToolBar.h
     TTreeWidget.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,11 +39,18 @@ if(USE_FONTS)
   endif()
 endif()
 
+# Add every .cpp source file here, kept in alphabetical order (case-insensitive).
 set(mudlet_SRCS
     ActionUnit.cpp
     AliasUnit.cpp
     AltFocusMenuBarDisable.cpp
+    CredentialManager.cpp
     ctelnet.cpp
+    CustomLineDrawContextMenuHandler.cpp
+    CustomLineDrawHandler.cpp
+    CustomLineEditContextMenuHandler.cpp
+    CustomLineEditHandler.cpp
+    CustomLineSession.cpp
     DarkTheme.cpp
     discord.cpp
     dlgAboutDialog.cpp
@@ -72,8 +79,14 @@ set(mudlet_SRCS
     dlgTriggerPatternEdit.cpp
     dlgTriggersMainArea.cpp
     dlgVarsMainArea.cpp
-    EditorItemXMLHelpers.cpp
     EAction.cpp
+    EditorAddItemCommand.cpp
+    EditorDeleteItemCommand.cpp
+    EditorItemXMLHelpers.cpp
+    EditorModifyPropertyCommand.cpp
+    EditorMoveItemCommand.cpp
+    EditorToggleActiveCommand.cpp
+    EditorUndoStack.cpp
     exitstreewidget.cpp
     FileOpenHandler.cpp
     FontManager.cpp
@@ -83,40 +96,28 @@ set(mudlet_SRCS
     HostManager.cpp
     ircmessageformatter.cpp
     KeyUnit.cpp
+    LabelInteractionHandler.cpp
     LuaInterface.cpp
     main.cpp
     mapInfoContributorManager.cpp
+    MiddleMousePanHandler.cpp
     MMCPClient.cpp
     MMCPServer.cpp
     mudlet.cpp
     MudletInstanceCoordinator.cpp
-    EditorUndoStack.cpp
     MxpTag.cpp
-    EditorAddItemCommand.cpp
-    EditorDeleteItemCommand.cpp
-    EditorModifyPropertyCommand.cpp
-    EditorMoveItemCommand.cpp
-    EditorToggleActiveCommand.cpp
-    CredentialManager.cpp
-    ScriptUnit.cpp
-    SecureStringUtils.cpp
-    SentryWrapper.cpp
-    ShortcutsManager.cpp
-    SingleLineTextEdit.cpp
-    T2DMap.cpp
-    CustomLineDrawContextMenuHandler.cpp
-    CustomLineDrawHandler.cpp
-    CustomLineEditContextMenuHandler.cpp
-    CustomLineEditHandler.cpp
-    CustomLineSession.cpp
-    LabelInteractionHandler.cpp
-    MiddleMousePanHandler.cpp
     PackageItemDelegate.cpp
     PanInteractionHandler.cpp
     RoomContextMenuHandler.cpp
     RoomMoveActivationHandler.cpp
     RoomMoveDragHandler.cpp
+    ScriptUnit.cpp
+    SecureStringUtils.cpp
     SelectionRectangleHandler.cpp
+    SentryWrapper.cpp
+    ShortcutsManager.cpp
+    SingleLineTextEdit.cpp
+    T2DMap.cpp
     TAccessibleTextEdit.cpp
     TAction.cpp
     TAlias.cpp
@@ -127,8 +128,10 @@ set(mudlet_SRCS
     TCommandLine.cpp
     TConsole.cpp
     TDebug.cpp
+    TDetachedWindow.cpp
     TDockWidget.cpp
     TEasyButtonBar.cpp
+    TEncodingHelper.cpp
     TEncodingTable.cpp
     TEntityHandler.cpp
     TEntityResolver.cpp
@@ -145,11 +148,11 @@ set(mudlet_SRCS
     TLuaInterpreterDiscord.cpp
     TLuaInterpreterMapper.cpp
     TLuaInterpreterMedia.cpp
+    TLuaInterpreterMMCP.cpp
     TLuaInterpreterMudletObjects.cpp
     TLuaInterpreterNetworking.cpp
     TLuaInterpreterTextToSpeech.cpp
     TLuaInterpreterUI.cpp
-    TLuaInterpreterMMCP.cpp
     TMainConsole.cpp
     TMap.cpp
     TMapLabel.cpp
@@ -158,9 +161,9 @@ set(mudlet_SRCS
     TMedia.cpp
     TMediaPlaylist.cpp
     TMxpBRTagHandler.cpp
-    TMxpHRTagHandler.cpp
     TMxpColorTagHandler.cpp
     TMxpCustomElementTagHandler.cpp
+    TMxpDestTagHandler.cpp
     TMxpElementDefinitionHandler.cpp
     TMxpElementRegistry.cpp
     TMxpEntityTagHandler.cpp
@@ -169,7 +172,7 @@ set(mudlet_SRCS
     TMxpFormattingTagsHandler.cpp
     TMxpFrameManager.cpp
     TMxpFrameTagHandler.cpp
-    TMxpDestTagHandler.cpp
+    TMxpHRTagHandler.cpp
     TMxpImageTagHandler.cpp
     TMxpLinkTagHandler.cpp
     TMxpMudlet.cpp
@@ -196,10 +199,8 @@ set(mudlet_SRCS
     TSplitterHandle.cpp
     TStringUtils.cpp
     TTabBar.cpp
-    TDetachedWindow.cpp
-    TTextCodec.cpp
-    TEncodingHelper.cpp
     TTextBox.cpp
+    TTextCodec.cpp
     TTextEdit.cpp
     TTimer.cpp
     TToolBar.cpp
@@ -227,6 +228,7 @@ if(APPLE)
 endif()
 
 # This is for compiled UI files, not those used at runtime
+# Add every .ui file here, kept in alphabetical order (case-insensitive).
 set(mudlet_UIS
     ui/about_dialog.ui
     ui/actions_main_area.ui
@@ -238,9 +240,9 @@ set(mudlet_UIS
     ui/irc.ui
     ui/keybindings_main_area.ui
     ui/main_window.ui
-    ui/module_manager.ui
     ui/map_label.ui
     ui/mapper.ui
+    ui/module_manager.ui
     ui/notes_editor.ui
     ui/package_manager.ui
     ui/profile_preferences.ui
@@ -251,11 +253,12 @@ set(mudlet_UIS
     ui/source_editor_find_area.ui
     ui/system_message_area.ui
     ui/timers_main_area.ui
-    ui/triggers_main_area.ui
     ui/trigger_editor.ui
     ui/trigger_pattern_edit.ui
+    ui/triggers_main_area.ui
     ui/vars_main_area.ui)
 
+# Add every .h header file here, kept in alphabetical order (case-insensitive).
 set(mudlet_HDRS
     ../3rdparty/discord/rpc/include/discord_register.h
     ../3rdparty/discord/rpc/include/discord_rpc.h
@@ -263,8 +266,13 @@ set(mudlet_HDRS
     ActionUnit.h
     AliasUnit.h
     AltFocusMenuBarDisable.h
-    ctelnet.h
     CredentialManager.h
+    ctelnet.h
+    CustomLineDrawContextMenuHandler.h
+    CustomLineDrawHandler.h
+    CustomLineEditContextMenuHandler.h
+    CustomLineEditHandler.h
+    CustomLineSession.h
     DarkTheme.h
     discord.h
     dlgAboutDialog.h
@@ -293,8 +301,16 @@ set(mudlet_HDRS
     dlgTriggerPatternEdit.h
     dlgTriggersMainArea.h
     dlgVarsMainArea.h
-    EditorItemXMLHelpers.h
     EAction.h
+    EditorAddItemCommand.h
+    EditorCommand.h
+    EditorDeleteItemCommand.h
+    EditorItemXMLHelpers.h
+    EditorModifyPropertyCommand.h
+    EditorMoveItemCommand.h
+    EditorToggleActiveCommand.h
+    EditorUndoStack.h
+    enums.h
     exitstreewidget.h
     FileOpenHandler.h
     FontManager.h
@@ -304,40 +320,28 @@ set(mudlet_HDRS
     HostManager.h
     ircmessageformatter.h
     KeyUnit.h
+    LabelInteractionHandler.h
     LuaInterface.h
     mapInfoContributorManager.h
+    MiddleMousePanHandler.h
     MMCP.h
     MMCPClient.h
     MMCPServer.h
     mudlet.h
-    EditorCommand.h
     MudletInstanceCoordinator.h
-    EditorUndoStack.h
     MxpTag.h
-    EditorAddItemCommand.h
-    EditorDeleteItemCommand.h
-    EditorModifyPropertyCommand.h
-    EditorMoveItemCommand.h
-    EditorToggleActiveCommand.h
-    ScriptUnit.h
-    SecureStringUtils.h
-    ShortcutsManager.h
-    SingleLineTextEdit.h
-    T2DMap.h
-    CustomLineDrawContextMenuHandler.h
-    CustomLineDrawHandler.h
-    CustomLineEditContextMenuHandler.h
-    CustomLineEditHandler.h
-    CustomLineSession.h
-    LabelInteractionHandler.h
-    MiddleMousePanHandler.h
     PackageItemDelegate.h
     PanInteractionHandler.h
     RoomContextMenuHandler.h
     RoomMoveActivationHandler.h
     RoomMoveDragHandler.h
+    ScriptUnit.h
+    SecureStringUtils.h
     SelectionRectangleHandler.h
     SentryWrapper.h
+    ShortcutsManager.h
+    SingleLineTextEdit.h
+    T2DMap.h
     TAccessibleConsole.h
     TAccessibleTextEdit.h
     TAction.h
@@ -350,6 +354,7 @@ set(mudlet_HDRS
     TCommandLine.h
     TConsole.h
     TDebug.h
+    TDetachedWindow.h
     TDockWidget.h
     TEasyButtonBar.h
     TEncodingHelper.h
@@ -360,13 +365,13 @@ set(mudlet_HDRS
     TFlipButton.h
     TForkedProcess.h
     TGameDetails.h
-    TimerUnit.h
-    TKey.h
-    TLabel.h
     THyperlinkCompactManager.h
     THyperlinkSelectionManager.h
     THyperlinkStyling.h
     THyperlinkVisibilityManager.h
+    TimerUnit.h
+    TKey.h
+    TLabel.h
     TLinkStore.h
     TLuaInterpreter.h
     TMainConsole.h
@@ -379,7 +384,6 @@ set(mudlet_HDRS
     TMediaData.h
     TMediaPlaylist.h
     TMxpBRTagHandler.h
-    TMxpHRTagHandler.h
     TMxpClient.h
     TMxpColorTagHandler.h
     TMxpContext.h
@@ -394,6 +398,7 @@ set(mudlet_HDRS
     TMxpFormattingTagsHandler.h
     TMxpFrameManager.h
     TMxpFrameTagHandler.h
+    TMxpHRTagHandler.h
     TMxpImageTagHandler.h
     TMxpLinkTagHandler.h
     TMxpMudlet.h
@@ -422,9 +427,8 @@ set(mudlet_HDRS
     TSplitterHandle.h
     TStringUtils.h
     TTabBar.h
-    TDetachedWindow.h
-    TTextCodec.h
     TTextBox.h
+    TTextCodec.h
     TTextEdit.h
     TTextProperties.h
     TTimer.h
@@ -437,8 +441,7 @@ set(mudlet_HDRS
     widechar_width.h
     WideComboBox.h
     XMLexport.h
-    XMLimport.h
-    enums.h)
+    XMLimport.h)
 
 
 if(USE_UPDATER)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -353,6 +353,7 @@ set(mudlet_HDRS
     TDebug.h
     TDockWidget.h
     TEasyButtonBar.h
+    TEncodingHelper.h
     TEncodingTable.h
     TEntityHandler.h
     TEntityResolver.h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,4 +48,14 @@ add_dependencies(PasswordMigrationTest ${LIB_MUDLET_TARGET})
 target_link_libraries(PasswordMigrationTest PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
 add_test(NAME PasswordMigrationTest COMMAND $<TARGET_FILE:PasswordMigrationTest>)
 
+# Build-file consistency check. Independent of the Mudlet library: it only reads
+# src/CMakeLists.txt and the src/ directory, so it does not link LIB_MUDLET_TARGET.
+add_executable(CMakeListsConsistencyTest CMakeListsConsistencyTest.cpp)
+target_link_libraries(CMakeListsConsistencyTest PRIVATE Qt6::Test)
+target_compile_definitions(CMakeListsConsistencyTest PRIVATE MUDLET_SRC_DIR="${CMAKE_SOURCE_DIR}/src")
+add_test(NAME CMakeListsConsistencyTest COMMAND $<TARGET_FILE:CMakeListsConsistencyTest>)
+set_tests_properties(CMakeListsConsistencyTest PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
+)
+
 add_subdirectory(functional_tests)

--- a/test/CMakeListsConsistencyTest.cpp
+++ b/test/CMakeListsConsistencyTest.cpp
@@ -1,0 +1,161 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include <QDir>
+#include <QFile>
+#include <QMap>
+#include <QRegularExpression>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+/*
+ * Build-file consistency check for src/CMakeLists.txt.
+ *
+ * The project lists its sources and headers explicitly (rather than globbing),
+ * which is the recommended CMake practice but makes it easy to forget to add a
+ * new file - or to paste one in twice. That is exactly what happened in #9344,
+ * where TEncodingHelper.h (and, it turned out, several other headers) were left
+ * out of mudlet_HDRS, and a few sources were listed twice.
+ *
+ * This test walks the top-level files in src/ and the text of src/CMakeLists.txt
+ * and fails if any .cpp / .h is missing from the build file, or is listed more
+ * than once. The src/ path is provided at configure time via MUDLET_SRC_DIR.
+ *
+ * Scope note: only top-level .cpp and .h files directly in src/ are checked.
+ * Files in subdirectories (updater/, etc.) are listed with a path prefix and are
+ * left for a future extension if needed.
+ */
+class CMakeListsConsistencyTest : public QObject
+{
+    Q_OBJECT
+
+    static QString srcDir() { return QStringLiteral(MUDLET_SRC_DIR); }
+
+    static QString readCMakeLists()
+    {
+        QFile file(srcDir() + QStringLiteral("/CMakeLists.txt"));
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return QString();
+        }
+        // Drop comments so a filename mentioned in a comment cannot be mistaken
+        // for a build-list entry.
+        QString content;
+        const QString raw = QString::fromUtf8(file.readAll());
+        const auto lines = raw.split(QLatin1Char('\n'));
+        for (const QString& line : lines) {
+            const qsizetype hash = line.indexOf(QLatin1Char('#'));
+            content.append(hash >= 0 ? line.left(hash) : line);
+            content.append(QLatin1Char('\n'));
+        }
+        return content;
+    }
+
+    // All *.cpp / *.h base names referenced anywhere in the (comment-stripped)
+    // CMakeLists text. Used for the "is it listed at all?" check, so a file added
+    // only through a conditional list(APPEND ...) still counts as listed.
+    static QSet<QString> referencedNames(const QString& content)
+    {
+        QSet<QString> names;
+        static const QRegularExpression re(QStringLiteral("([A-Za-z0-9_]+\\.(?:cpp|h))\\b"));
+        auto it = re.globalMatch(content);
+        while (it.hasNext()) {
+            names.insert(it.next().captured(1));
+        }
+        return names;
+    }
+
+    // Counts only "bare" list entries - a filename alone on its line, the form
+    // used inside the set(mudlet_SRCS ...) / set(mudlet_HDRS ...) lists. This is
+    // where accidental duplicates appear. Conditional list(APPEND ...) lines and
+    // OTHER_FILES references are deliberately excluded, since the same file may be
+    // appended under several mutually-exclusive platform branches.
+    static QMap<QString, int> bareEntryCounts(const QString& content)
+    {
+        QMap<QString, int> counts;
+        static const QRegularExpression re(QStringLiteral("^[ \\t]*([A-Za-z0-9_./]+\\.(?:cpp|h))[ \\t]*$"));
+        const auto lines = content.split(QLatin1Char('\n'));
+        for (const QString& line : lines) {
+            const auto match = re.match(line);
+            if (!match.hasMatch()) {
+                continue;
+            }
+            QString name = match.captured(1);
+            const qsizetype slash = name.lastIndexOf(QLatin1Char('/'));
+            if (slash >= 0) {
+                name = name.mid(slash + 1);
+            }
+            counts[name] += 1;
+        }
+        return counts;
+    }
+
+    static QStringList topLevelSources()
+    {
+        QDir dir(srcDir());
+        return dir.entryList({QStringLiteral("*.cpp"), QStringLiteral("*.h")}, QDir::Files);
+    }
+
+private slots:
+
+    void sourceDirectory_isReadable()
+    {
+        QVERIFY2(QDir(srcDir()).exists(), qPrintable(QStringLiteral("src dir not found: %1").arg(srcDir())));
+        QVERIFY2(!readCMakeLists().isEmpty(), "src/CMakeLists.txt could not be read");
+        QVERIFY2(!topLevelSources().isEmpty(), "no source files found in src/");
+    }
+
+    void everySourceAndHeader_isListed()
+    {
+        const QSet<QString> refs = referencedNames(readCMakeLists());
+
+        QStringList missing;
+        for (const QString& file : topLevelSources()) {
+            if (!refs.contains(file)) {
+                missing << file;
+            }
+        }
+        missing.sort();
+
+        QVERIFY2(missing.isEmpty(), qPrintable(QStringLiteral("Files present in src/ but not listed in src/CMakeLists.txt: %1").arg(missing.join(QStringLiteral(", ")))));
+    }
+
+    void noSourceOrHeader_isListedTwice()
+    {
+        const QMap<QString, int> refs = bareEntryCounts(readCMakeLists());
+        const QStringList files = topLevelSources();
+        const QSet<QString> present(files.cbegin(), files.cend());
+
+        QStringList duplicates;
+        for (auto it = refs.cbegin(); it != refs.cend(); ++it) {
+            if (it.value() > 1 && present.contains(it.key())) {
+                duplicates << QStringLiteral("%1 (x%2)").arg(it.key()).arg(it.value());
+            }
+        }
+        duplicates.sort();
+
+        QVERIFY2(duplicates.isEmpty(), qPrintable(QStringLiteral("Files listed more than once in src/CMakeLists.txt: %1").arg(duplicates.join(QStringLiteral(", ")))));
+    }
+};
+
+QTEST_GUILESS_MAIN(CMakeListsConsistencyTest)
+
+#include "CMakeListsConsistencyTest.moc"

--- a/test/CMakeListsConsistencyTest.cpp
+++ b/test/CMakeListsConsistencyTest.cpp
@@ -61,11 +61,11 @@ class CMakeListsConsistencyTest : public QObject
         // for a build-list entry.
         QString content;
         const QString raw = QString::fromUtf8(file.readAll());
-        const auto lines = raw.split(QLatin1Char('\n'));
+        const auto lines = raw.split(QChar::LineFeed);
         for (const QString& line : lines) {
             const qsizetype hash = line.indexOf(QLatin1Char('#'));
             content.append(hash >= 0 ? line.left(hash) : line);
-            content.append(QLatin1Char('\n'));
+            content.append(QChar::LineFeed);
         }
         return content;
     }
@@ -100,7 +100,7 @@ class CMakeListsConsistencyTest : public QObject
     {
         QMap<QString, int> counts;
         static const QRegularExpression re(QStringLiteral("^([A-Za-z0-9_-]+\\.(?:cpp|h|mm))$"));
-        const auto lines = content.split(QLatin1Char('\n'));
+        const auto lines = content.split(QChar::LineFeed);
         for (const QString& line : lines) {
             // Trim first so a CRLF checkout (trailing '\r') still matches.
             const auto match = re.match(line.trimmed());

--- a/test/CMakeListsConsistencyTest.cpp
+++ b/test/CMakeListsConsistencyTest.cpp
@@ -40,9 +40,10 @@
  * and fails if any .cpp / .h is missing from the build file, or is listed more
  * than once. The src/ path is provided at configure time via MUDLET_SRC_DIR.
  *
- * Scope note: only top-level .cpp and .h files directly in src/ are checked.
- * Files in subdirectories (updater/, etc.) are listed with a path prefix and are
- * left for a future extension if needed.
+ * Scope note: only top-level .cpp, .h and .mm files directly in src/ are checked.
+ * Files in subdirectories (updater/, etc.) and any path-prefixed entries are
+ * excluded from both the presence and the duplicate checks, and are left for a
+ * future extension if needed.
  */
 class CMakeListsConsistencyTest : public QObject
 {
@@ -69,13 +70,19 @@ class CMakeListsConsistencyTest : public QObject
         return content;
     }
 
-    // All *.cpp / *.h base names referenced anywhere in the (comment-stripped)
-    // CMakeLists text. Used for the "is it listed at all?" check, so a file added
-    // only through a conditional list(APPEND ...) still counts as listed.
+    // Un-prefixed *.cpp / *.h / *.mm base names referenced in the (comment-stripped)
+    // CMakeLists text. The leading negative lookbehind requires the name to start a
+    // fresh token (not preceded by a path separator or another name character), so a
+    // path-prefixed mention such as "src/sparkleupdater.h" in set_source_files_properties
+    // is NOT counted - only its bare list entry "sparkleupdater.h" is. That way a file
+    // removed from mudlet_SRCS/mudlet_HDRS is still reported missing even when it is
+    // referenced elsewhere by full path. Bare list entries (including the last one,
+    // which carries the trailing set() ")"), conditional list(APPEND ...) entries, and
+    // the add_executable() source all match.
     static QSet<QString> referencedNames(const QString& content)
     {
         QSet<QString> names;
-        static const QRegularExpression re(QStringLiteral("([A-Za-z0-9_]+\\.(?:cpp|h))\\b"));
+        static const QRegularExpression re(QStringLiteral("(?<![/A-Za-z0-9_-])([A-Za-z0-9_-]+\\.(?:cpp|h|mm))\\b"));
         auto it = re.globalMatch(content);
         while (it.hasNext()) {
             names.insert(it.next().captured(1));
@@ -83,27 +90,24 @@ class CMakeListsConsistencyTest : public QObject
         return names;
     }
 
-    // Counts only "bare" list entries - a filename alone on its line, the form
-    // used inside the set(mudlet_SRCS ...) / set(mudlet_HDRS ...) lists. This is
-    // where accidental duplicates appear. Conditional list(APPEND ...) lines and
-    // OTHER_FILES references are deliberately excluded, since the same file may be
+    // Counts "bare" top-level list entries - a filename with no path, alone on its
+    // line, the form used inside the set(mudlet_SRCS ...) / set(mudlet_HDRS ...)
+    // lists. This is the form the duplicates removed in this PR took. Path-prefixed
+    // bare entries and conditional list(APPEND ...) lines are deliberately excluded:
+    // the former are outside the top-level scope this test checks, and a file may be
     // appended under several mutually-exclusive platform branches.
     static QMap<QString, int> bareEntryCounts(const QString& content)
     {
         QMap<QString, int> counts;
-        static const QRegularExpression re(QStringLiteral("^[ \\t]*([A-Za-z0-9_./]+\\.(?:cpp|h))[ \\t]*$"));
+        static const QRegularExpression re(QStringLiteral("^([A-Za-z0-9_-]+\\.(?:cpp|h|mm))$"));
         const auto lines = content.split(QLatin1Char('\n'));
         for (const QString& line : lines) {
-            const auto match = re.match(line);
+            // Trim first so a CRLF checkout (trailing '\r') still matches.
+            const auto match = re.match(line.trimmed());
             if (!match.hasMatch()) {
                 continue;
             }
-            QString name = match.captured(1);
-            const qsizetype slash = name.lastIndexOf(QLatin1Char('/'));
-            if (slash >= 0) {
-                name = name.mid(slash + 1);
-            }
-            counts[name] += 1;
+            counts[match.captured(1)] += 1;
         }
         return counts;
     }
@@ -111,7 +115,7 @@ class CMakeListsConsistencyTest : public QObject
     static QStringList topLevelSources()
     {
         QDir dir(srcDir());
-        return dir.entryList({QStringLiteral("*.cpp"), QStringLiteral("*.h")}, QDir::Files);
+        return dir.entryList({QStringLiteral("*.cpp"), QStringLiteral("*.h"), QStringLiteral("*.mm")}, QDir::Files);
     }
 
 private slots:
@@ -143,6 +147,22 @@ private slots:
         const QMap<QString, int> refs = bareEntryCounts(readCMakeLists());
         const QStringList files = topLevelSources();
         const QSet<QString> present(files.cbegin(), files.cend());
+
+        // Sanity floor: if the bare-entry parser recognised hardly any of the known
+        // files, the CMakeLists format has likely changed and an empty duplicate
+        // result would be meaningless. Fail loudly rather than silently stopping
+        // guarding.
+        int matched = 0;
+        for (auto it = refs.cbegin(); it != refs.cend(); ++it) {
+            if (present.contains(it.key())) {
+                ++matched;
+            }
+        }
+        QVERIFY2(matched > present.size() / 2,
+                 qPrintable(QStringLiteral("bare-entry parser matched only %1 of %2 src files - "
+                                           "src/CMakeLists.txt format likely changed; the duplicate check cannot be trusted")
+                                    .arg(matched)
+                                    .arg(present.size())));
 
         QStringList duplicates;
         for (auto it = refs.cbegin(); it != refs.cend(); ++it) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

A few of Mudlet's files had been accidentally left out of the build list, and a couple were listed twice. This adds the missing ones, removes the duplicates, and adds an automatic check that catches this kind of slip-up from now on.

#### Motivation for adding to Mudlet

When a file is missing from the build list it can quietly cause trouble for the people working on Mudlet, and in one recent case it contributed to a feature breaking. The new check makes the problem impossible to miss, so it gets noticed and fixed before it reaches anyone.

See Also: [Discord chat](https://discord.com/channels/283581582550237184/283582439002210305/1517465119700029440)

#### Other info (issues closed, discussion etc)

Builds and runs cleanly on macOS; the new check passes and was confirmed to flag the original missing and duplicated files.