### PR TITLE
improve: make small area centering opt-in via Mudlet.ini

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -429,6 +429,8 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     auto settings = mudlet::self()->getQSettings();
     const auto interval = settings->value("autosaveIntervalMinutes", 2).toInt();
     startMapAutosave(interval);
+
+    mMapperCenterSmallAreas = settings->value("mapCenterSmallAreas", false).toBool();
 }
 
 Host::~Host()

--- a/src/Host.h
+++ b/src/Host.h
@@ -795,6 +795,10 @@ public:
     bool mMapperUseAntiAlias = true;
     bool mMapperShowRoomBorders = true;
     bool mMapperShowGrid = false;
+    // Center the map on an area as a whole when it fits entirely in the
+    // viewport, instead of following the player room. Off by default;
+    // configurable via the mapCenterSmallAreas key in Mudlet.ini.
+    bool mMapperCenterSmallAreas = false;
     bool mVersionInTTYPE = false;
     QSet<QChar> mDoubleClickIgnore;
     QPointer<QDockWidget> mpDockableMapWidget;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2493,8 +2493,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
     }
 
     // Center map on area when it fits entirely in viewport, but only when
-    // following player movement - not during manual panning or editing
-    if (centeringOnPlayer && !mRoomBeingMoved && !mMultiSelection) {
+    // following player movement - not during manual panning or editing.
+    // Off by default; opt in via the mapCenterSmallAreas key in Mudlet.ini.
+    if (mpHost->mMapperCenterSmallAreas && centeringOnPlayer && !mRoomBeingMoved && !mMultiSelection) {
         const int zLevel = mMapCenterZ;
 
         // Get area bounds for current Z level (use overall bounds as fallback)


### PR DESCRIPTION

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The area auto-centering feature (#8766) - which centers the map on a whole area when it fits entirely in the viewport - did not work well for most users, who would rather have it off. Make it opt-in instead: it is now disabled by default and enabled via the mapCenterSmallAreas key in Mudlet.ini, following the autosaveIntervalMinutes pattern.

See also #8982.
#### Motivation for adding to Mudlet
Better player experience
#### Other info (issues closed, discussion etc)
