### PR TITLE
Fix: prevent focus being forced away from Editor when Toolbar activated

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -480,9 +480,6 @@ void ActionUnit::showToolBar(const QString& name)
         }
     }
     mudlet::self()->processEventLoopHack();
-    // If a toolbar is clicked on for a profile that is not the "current"
-    // one, this will switch the focus to THAT profile:
-    mudlet::self()->activateProfile(mpHost);
 }
 
 void ActionUnit::hideToolBar(const QString& name)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When a toolbar is "Activated" the application focus is forcible reverted to the main window and one has to click on that before one can return to the editor. This PR removes that redundant and annoying misstep.

#### Motivation for adding to Mudlet
Improve the User Experience in the editor.

#### Other info (issues closed, discussion etc)
TBH the comment does not make sense given the situation that was manifesting itself - I ran into this issue whilst working on/testing #9332 and it was a real PITA...!

