### PR TITLE
Infrastructure: rename ActionUnit::UpdateToolbar() to  ActionUnit::UpdateAllToolbars()

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -269,7 +269,7 @@ void ActionUnit::unregisterAction(TAction* pT)
     }
     if (pT->getParent() && pT->getParent()->mPackageName.isEmpty()) {
         removeAction(pT);
-        updateToolbar();
+        updateAllToolbars();
         return;
     } else {
         if (pT->mpEasyButtonBar && pT->mPackageName.isEmpty()) {
@@ -322,7 +322,6 @@ void ActionUnit::removeAction(TAction* pT)
 
     mActionMap.remove(pT->getID());
 }
-
 
 int ActionUnit::getNewID()
 {
@@ -476,7 +475,7 @@ void ActionUnit::showToolBar(const QString& name)
     for (auto& easyButtonBar : mEasyButtonBarList) {
         if (easyButtonBar->mpTAction->getName() == name) {
             easyButtonBar->mpTAction->setIsActive(true);
-            updateToolbar();
+            updateAllToolbars();
         }
     }
     mudlet::self()->processEventLoopHack();
@@ -629,7 +628,7 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 }
 
 
-void ActionUnit::updateToolbar()
+void ActionUnit::updateAllToolbars()
 {
     regenerateToolBars();
     regenerateEasyButtonBars();

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -295,7 +295,7 @@ void ActionUnit::unregisterAction(TAction* pT)
         } else {
             removeAction(pT);
         }
-        updateToolbar();
+        updateAllToolbars();
         return;
     }
 }
@@ -489,7 +489,7 @@ void ActionUnit::hideToolBar(const QString& name)
     for (auto& easyButtonBar : mEasyButtonBarList) {
         if (easyButtonBar->mpTAction->getName() == name) {
             easyButtonBar->mpTAction->setIsActive(false);
-            updateToolbar();
+            updateAllToolbars();
         }
     }
     mudlet::self()->processEventLoopHack();

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -67,7 +67,7 @@ public:
     int getNewID();
     void uninstall(const QString&);
     void _uninstall(TAction* pChild, const QString& packageName);
-    void updateToolbar();
+    void updateAllToolbars();
     std::list<QPointer<TToolBar>> getToolBarList() { return mToolBarList; }
     TAction* getHeadAction(TToolBar*);
     TAction* getHeadAction(TEasyButtonBar*);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2376,7 +2376,7 @@ bool Host::uninstallPackage(const QString& packageName, enums::PackageModuleType
         mpEditorDialog->doCleanReset();
     }
 
-    getActionUnit()->updateToolbar();
+    getActionUnit()->updateAllToolbars();
 
     const QString dest = mudlet::getMudletPath(enums::profilePackagePath, getName(), packageName);
     removeDir(dest, dest);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -2106,7 +2106,7 @@ int TLuaInterpreter::tempButton(lua_State* L)
 
     pT->registerAction();
     // N/U:     int childID = pT->getID();
-    host.getActionUnit()->updateToolbar();
+    host.getActionUnit()->updateAllToolbars();
     return 1;
 }
 
@@ -2152,7 +2152,7 @@ int TLuaInterpreter::tempButtonToolbar(lua_State* L)
     pT->setIsActive(true);
     pT->registerAction();
     // N/U:     int childID = pT->getID();
-    host.getActionUnit()->updateToolbar();
+    host.getActionUnit()->updateAllToolbars();
 
 
     return 1;

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2762,7 +2762,7 @@ int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
         }
         action->css = css;
     }
-    host.getActionUnit()->updateToolbar();
+    host.getActionUnit()->updateAllToolbars();
     lua_pushboolean(L, 1);
     return 1;
 }

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -331,7 +331,7 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
                 break;
             case TreeType::Action:
                 mpHost->getActionUnit()->reParentAction(childID, moveInfo.oldParentID, newParentID, parentPosition, childPosition);
-                mpHost->getActionUnit()->updateToolbar();
+                mpHost->getActionUnit()->updateAllToolbars();
                 break;
             case TreeType::Var:
             case TreeType::None:

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -202,7 +202,7 @@ std::pair<bool, QString> XMLimport::importPackage(QFile* pfile, QString packName
         }
 
         if (gotAction) {
-            mpHost->getActionUnit()->updateToolbar();
+            mpHost->getActionUnit()->updateAllToolbars();
         } else {
             mpHost->getActionUnit()->unregisterAction(mpAction);
             delete mpAction;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3219,7 +3219,7 @@ void dlgTriggerEditor::delete_action()
         clearActionForm();
     }
 
-    mpHost->getActionUnit()->updateToolbar();
+    mpHost->getActionUnit()->updateAllToolbars();
 }
 
 void dlgTriggerEditor::delete_variable()
@@ -4656,7 +4656,7 @@ void dlgTriggerEditor::activeToggle_action()
     pItem->setText(0, pT->getName());
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
 
-    mpHost->getActionUnit()->updateToolbar();
+    mpHost->getActionUnit()->updateAllToolbars();
     if (pItem->childCount() > 0) {
         children_icon_action(pItem);
     }
@@ -5413,7 +5413,7 @@ void dlgTriggerEditor::addAction(bool isFolder)
     // After the action is saved it may trigger the rebuild.
     pNewAction->setDataSaved();
 
-    mpHost->getActionUnit()->updateToolbar();
+    mpHost->getActionUnit()->updateAllToolbars();
 
     // Finalize selection
     mpCurrentActionItem = pNewItem;
@@ -6449,7 +6449,7 @@ void dlgTriggerEditor::saveAction()
         }
     }
 
-    mpHost->getActionUnit()->updateToolbar();
+    mpHost->getActionUnit()->updateAllToolbars();
     mudlet::self()->processEventLoopHack();
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2184,7 +2184,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     connect(pH, &Host::profileSaveFinished, pH->mpEditorDialog, &dlgTriggerEditor::slot_profileSaveFinished);
     pEditor->fillout_form();
 
-    pH->getActionUnit()->updateToolbar();
+    pH->getActionUnit()->updateAllToolbars();
 
     pH->mpConsole->show();
     pH->mpConsole->repaint();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A rename to more accurately reflect that the method works on ALL toolBars/ easyButtonBars and not just a single one.

#### Motivation for adding to Mudlet
To improve nomenclature.

#### Other info (issues closed, discussion etc)
There should be no functional changes with this item.