### PR TITLE
fix: disable "never" for one toolbar when other is "never" (#7079)

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -60,6 +60,7 @@
 #include <QPainter>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QStandardItemModel>
 #include <QString>
 #include <QTableWidget>
 #include <QTemporaryDir>
@@ -155,6 +156,10 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     default:
         comboBox_toolBarVisibility->setCurrentIndex(2);
     }
+
+    // Sync "Never" item deactivation so the dialog opens with consistent state
+    // if either visibility was already "Never" on previous save (issue #7079).
+    slot_syncMenuToolBarNeverItem();
 
     checkBox_showTabConnectionIndicators->setChecked(pMudlet->mShowTabConnectionIndicators);
     connect(checkBox_showTabConnectionIndicators, &QCheckBox::toggled, this, [=](bool checked) {
@@ -4239,6 +4244,10 @@ void dlgProfilePreferences::slot_setMapSymbolFont(const QFont& font)
 // of access to the setting/controls completely - once there is a profile loaded
 // access to the settings/controls can be overridden by a context menu action on
 // any TConsole instance:
+//
+// Additionally the "Never" entry in the other toolbar-visibility comboBox is
+// greyed out (deactivated) while this control is set to "Never", so the user
+// cannot even temporarily select "Never" for both - see issue #7079.
 void dlgProfilePreferences::slot_changeShowMenuBar(int newIndex)
 {
     if (!newIndex && !comboBox_toolBarVisibility->currentIndex()) {
@@ -4246,6 +4255,7 @@ void dlgProfilePreferences::slot_changeShowMenuBar(int newIndex)
         // control - so force it back to the "Only if no profile one
         comboBox_menuBarVisibility->setCurrentIndex(1);
     }
+    slot_syncMenuToolBarNeverItem();
 }
 
 void dlgProfilePreferences::slot_changeShowToolBar(int newIndex)
@@ -4254,6 +4264,30 @@ void dlgProfilePreferences::slot_changeShowToolBar(int newIndex)
         // This control has been set to the "Never" setting but so is the other
         // control - so force it back to the "Only if no profile one
         comboBox_toolBarVisibility->setCurrentIndex(1);
+    }
+    slot_syncMenuToolBarNeverItem();
+}
+
+// Deactivate (grey out) the "Never" item of comboBox_toolBarVisibility when
+// the menu bar is set to "Never", and vice versa. This makes the existing
+// mutual-exclusion visible to the user instead of silently snapping the
+// selected value back (issue #7079).
+void dlgProfilePreferences::slot_syncMenuToolBarNeverItem()
+{
+    const int menuIndex = comboBox_menuBarVisibility->currentIndex();
+    const int toolIndex = comboBox_toolBarVisibility->currentIndex();
+    const bool menuIsNever = (menuIndex == 0);
+    const bool toolIsNever = (toolIndex == 0);
+
+    if (auto* toolModel = qobject_cast<QStandardItemModel*>(comboBox_toolBarVisibility->model())) {
+        if (QStandardItem* item = toolModel->item(0)) {
+            item->setEnabled(!menuIsNever);
+        }
+    }
+    if (auto* menuModel = qobject_cast<QStandardItemModel*>(comboBox_menuBarVisibility->model())) {
+        if (QStandardItem* item = menuModel->item(0)) {
+            item->setEnabled(!toolIsNever);
+        }
     }
 }
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -154,6 +154,9 @@ private slots:
     void slot_setTreeWidgetIconSize(const int);
     void slot_changeMenuBarVisibility(const enums::controlsVisibility);
     void slot_changeToolBarVisibility(const enums::controlsVisibility);
+    // Greys out the "Never" entry in the other toolbar-visibility comboBox so
+    // both bars cannot be hidden simultaneously (issue #7079).
+    void slot_syncMenuToolBarNeverItem();
     void slot_changeShowIconsOnMenus(const Qt::CheckState);
     void slot_changeGuiLanguage(int);
     void slot_passwordStorageLocationChanged(int);


### PR DESCRIPTION
Fixes #7079

## Summary

In the General tab of the profile preferences dialog, selecting "Never" in
either the **Show menu bar** dropdown or the **Show main toolbar** dropdown now
greys out (deactivates) the "Never" entry of the other dropdown, instead of
silently allowing the selection and then snapping the control back to the
"Until a profile is loaded" option. This makes Mudlet's existing
mutual-exclusion behaviour visible and discoverable rather than resembling a
bug. A small new helper slot `slot_syncMenuToolBarNeverItem` runs whenever one
of the two `currentIndexChanged` signals fires, and is also invoked once from
the constructor so a profile that opens the dialog with one of the visibilities
already saved as "Never" shows the correct disabled state on first paint.

## Test plan

- Manual build verification: this environment has no Qt6 / CMake toolchain so
  the diff was not compiled here. The change should be compiled locally with
  `cmake --build build --target mudlet` (or the platforms listed in
  `AGENTS.md`) before sign-off. Visual smoke test after build:
  1. Open Mudlet, open the profile preferences dialog, go to the General tab.
  2. Set "Show menu bar" to "Never". Confirm the "Never" entry of "Show main
     toolbar" is now greyed out.
  3. Switch "Show menu bar" away from "Never" and confirm the toolbar combo's
     "Never" entry is re-enabled.
  4. Repeat with the roles reversed.
  5. Open Mudlet with one visibility already saved as "Never" and confirm the
     disabled state is present on dialog open without any user interaction.
- Existing snap-back is preserved (still protects against the
  auto-generated `QMainWindow` context menu overriding the setting).

Assisted-by: Claude:claude-opus-4.6
Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>

## AI assistance

This patch was drafted with the help of an AI coding assistant. The
diff was reviewed line by line before submission and the change was
verified independently. Per the repo's AI policy this disclosure is
offered; it is not required.
