### PR TITLE
fix: enable/disable only affecting some same-named items on Windows

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -340,11 +340,11 @@ std::vector<int> AliasUnit::findItems(const QString& name, const bool exactMatch
 bool AliasUnit::enableAlias(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
-        TAlias* pT = it.value();
-        pT->setIsActive(true);
-        ++it;
+    // equal_range visits every same-named alias; constFind() + (++it) can start
+    // mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
+        it.value()->setIsActive(true);
         found = true;
     }
     return found;
@@ -353,11 +353,11 @@ bool AliasUnit::enableAlias(const QString& name)
 bool AliasUnit::disableAlias(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
-        TAlias* pT = it.value();
-        pT->setIsActive(false);
-        ++it;
+    // equal_range visits every same-named alias; constFind() + (++it) can start
+    // mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
+        it.value()->setIsActive(false);
         found = true;
     }
     return found;

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -179,15 +179,16 @@ std::vector<int> KeyUnit::findItems(const QString& name, const bool exactMatch, 
 bool KeyUnit::enableKey(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
+    // equal_range visits every same-named key; constFind() + (++it) can start
+    // mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
         TKey* pT = it.value();
         // Unlike the TTriggerUnit version of this code we directly set
         // the mActive flag (and it shows up in the editor) rather than the
         // mUserActiveState one (which does not)
         // So do not use pT->setIsActive(true) here:
         pT->enableKey(name);
-        ++it;
         found = true;
     }
     return found;
@@ -196,15 +197,16 @@ bool KeyUnit::enableKey(const QString& name)
 bool KeyUnit::disableKey(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
+    // equal_range visits every same-named key; constFind() + (++it) can start
+    // mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
         TKey* pT = it.value();
         // Unlike the TTriggerUnit version of this code we directly clear
         // the mActive flag (and it shows up in the editor) rather than the
         // mUserActiveState one (which does not)
         // So do not use pT->setIsActive(false) here:
         pT->disableKey(name);
-        ++it;
         found = true;
     }
     return found;

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -947,14 +947,15 @@ int TLuaInterpreter::isActive(lua_State* L)
             auto pT = host.getTimerUnit()->getTimer(id);
             cnt = (static_cast<bool>(pT) && (pT->isOffsetTimer() ? pT->shouldBeActive() : pT->isActive()) && (!checkAncestors || pT->shouldAncestorsBeActive())) ? 1 : 0;
         } else {
-            auto itpItem = host.getTimerUnit()->mLookupTable.constFind(nameOrId);
-            while (itpItem != host.getTimerUnit()->mLookupTable.cend() && itpItem.key() == nameOrId) {
+            // equal_range visits every same-named item; constFind() + (++it) can
+            // start mid-run and skip duplicates on some QMultiMap implementations
+            const auto [begin, end] = host.getTimerUnit()->mLookupTable.equal_range(nameOrId);
+            for (auto itpItem = begin; itpItem != end; ++itpItem) {
                 auto pT = itpItem.value();
                 // Offset timer have their active state recorded differently
                 if ((pT->isOffsetTimer() ? pT->shouldBeActive() : pT->isActive()) && (!checkAncestors || pT->shouldAncestorsBeActive())) {
                     ++cnt;
                 }
-                ++itpItem;
             }
         }
 
@@ -963,13 +964,12 @@ int TLuaInterpreter::isActive(lua_State* L)
             auto pT = host.getTriggerUnit()->getTrigger(id);
             cnt = (static_cast<bool>(pT) && pT->isActive()) ? 1 : 0;
         } else {
-            auto itpItem = host.getTriggerUnit()->mLookupTable.constFind(nameOrId);
-            while (itpItem != host.getTriggerUnit()->mLookupTable.cend() && itpItem.key() == nameOrId) {
+            const auto [begin, end] = host.getTriggerUnit()->mLookupTable.equal_range(nameOrId);
+            for (auto itpItem = begin; itpItem != end; ++itpItem) {
                 auto pT = itpItem.value();
                 if (pT->isActive() && (!checkAncestors || pT->ancestorsActive())) {
                     ++cnt;
                 }
-                ++itpItem;
             }
         }
 
@@ -978,13 +978,12 @@ int TLuaInterpreter::isActive(lua_State* L)
             auto pT = host.getAliasUnit()->getAlias(id);
             cnt = (static_cast<bool>(pT) && pT->isActive()) ? 1 : 0;
         } else {
-            auto itpItem = host.getAliasUnit()->mLookupTable.constFind(nameOrId);
-            while (itpItem != host.getAliasUnit()->mLookupTable.cend() && itpItem.key() == nameOrId) {
+            const auto [begin, end] = host.getAliasUnit()->mLookupTable.equal_range(nameOrId);
+            for (auto itpItem = begin; itpItem != end; ++itpItem) {
                 auto pT = itpItem.value();
                 if (pT->isActive() && (!checkAncestors || pT->ancestorsActive())) {
                     ++cnt;
                 }
-                ++itpItem;
             }
         }
 
@@ -993,13 +992,12 @@ int TLuaInterpreter::isActive(lua_State* L)
             auto pT = host.getKeyUnit()->getKey(id);
             cnt = (static_cast<bool>(pT) && pT->isActive()) ? 1 : 0;
         } else {
-            auto itpItem = host.getKeyUnit()->mLookupTable.constFind(nameOrId);
-            while (itpItem != host.getKeyUnit()->mLookupTable.cend() && itpItem.key() == nameOrId) {
+            const auto [begin, end] = host.getKeyUnit()->mLookupTable.equal_range(nameOrId);
+            for (auto itpItem = begin; itpItem != end; ++itpItem) {
                 auto pT = itpItem.value();
                 if (pT->isActive() && (!checkAncestors || pT->ancestorsActive())) {
                     ++cnt;
                 }
-                ++itpItem;
             }
         }
 

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -296,8 +296,10 @@ void TimerUnit::_removeTimer(TTimer* pT)
 bool TimerUnit::enableTimer(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
+    // equal_range visits every same-named timer; constFind() + (++it) can start
+    // mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
         TTimer* pT = it.value();
 
         if (!pT->isOffsetTimer()) {
@@ -326,7 +328,6 @@ bool TimerUnit::enableTimer(const QString& name)
             }
         }
 
-        ++it;
         found = true;
     }
     return found;
@@ -335,8 +336,10 @@ bool TimerUnit::enableTimer(const QString& name)
 bool TimerUnit::disableTimer(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
+    // equal_range visits every same-named timer; constFind() + (++it) can start
+    // mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
         TTimer* pT = it.value();
         if (pT->isOffsetTimer()) {
             pT->setShouldBeActive(false);
@@ -345,7 +348,6 @@ bool TimerUnit::disableTimer(const QString& name)
         }
 
         pT->disableTimer();
-        ++it;
         found = true;
     }
     return found;

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -374,11 +374,11 @@ std::vector<int> TriggerUnit::findItems(const QString& name, const bool exactMat
 bool TriggerUnit::enableTrigger(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
-        TTrigger* pT = it.value();
-        pT->setIsActive(true);
-        ++it;
+    // equal_range visits every same-named trigger; constFind() + (++it) can
+    // start mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
+        it.value()->setIsActive(true);
         found = true;
     }
     return found;
@@ -387,11 +387,11 @@ bool TriggerUnit::enableTrigger(const QString& name)
 bool TriggerUnit::disableTrigger(const QString& name)
 {
     bool found = false;
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
-        TTrigger* pT = it.value();
-        pT->setIsActive(false);
-        ++it;
+    // equal_range visits every same-named trigger; constFind() + (++it) can
+    // start mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
+        it.value()->setIsActive(false);
         found = true;
     }
     return found;
@@ -399,11 +399,11 @@ bool TriggerUnit::disableTrigger(const QString& name)
 
 void TriggerUnit::setTriggerStayOpen(const QString& name, int lines)
 {
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
-        TTrigger* pT = it.value();
-        pT->mKeepFiring = lines;
-        ++it;
+    // equal_range visits every same-named trigger; constFind() + (++it) can
+    // start mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
+        it.value()->mKeepFiring = lines;
     }
 }
 

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -150,6 +150,13 @@ describe("Alias processing", function()
             _G.DuplicateAliasTest = {fired = {}}
         end)
 
+        -- permAlias aliases can't be removed via killAlias(); disable them here so
+        -- a failed assertion above doesn't leave them firing for later tests
+        after_each(function()
+            disableAlias("Druid Aliases")
+            disableAlias("Other Aliases")
+        end)
+
         it("toggles every alias sharing the same name, not just the first", function()
             -- permanent so two can share one name; distinct patterns reveal which fired
             local id1 = permAlias("Druid Aliases", "", "^druid_dup_one$", [[_G.DuplicateAliasTest.fired.one = true]])
@@ -183,10 +190,6 @@ describe("Alias processing", function()
             _G.DuplicateAliasTest.fired = {}
             expandAlias("druid_dup_other")
             assert.is_true(_G.DuplicateAliasTest.fired.other, "differently-named alias must stay enabled")
-
-            -- killAlias() only removes temporary aliases; leave these disabled
-            disableAlias("Druid Aliases")
-            disableAlias("Other Aliases")
         end)
 
     end)

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -141,15 +141,9 @@ describe("Alias processing", function()
 
     end)
 
-    -- Reproduces a user report that enableAlias()/disableAlias() only affect the
-    -- FIRST item sharing a given name when several aliases share that name (e.g.
-    -- two alias groups both called "Druid Aliases"). AliasUnit::enableAlias and
-    -- AliasUnit::disableAlias iterate the whole multimap of same-named entries,
-    -- so EVERY alias with that name must be toggled, not just the first found.
-    --
-    -- killAlias() only removes temporary aliases, and there is no Lua API to
-    -- delete permanent ones, so these aliases are given a unique name and left
-    -- disabled at the end to avoid interfering with other specs.
+    -- enableAlias()/disableAlias() must toggle EVERY alias sharing a name, not
+    -- just the first, since AliasUnit iterates the whole multimap of same-named
+    -- entries.
     describe("enable/disable with duplicate names", function()
 
         before_each(function()
@@ -157,20 +151,17 @@ describe("Alias processing", function()
         end)
 
         it("toggles every alias sharing the same name, not just the first", function()
-            -- permanent aliases so two of them can share one name; distinct
-            -- patterns let us tell which one actually fired
+            -- permanent so two can share one name; distinct patterns reveal which fired
             local id1 = permAlias("Druid Aliases", "", "^druid_dup_one$", [[_G.DuplicateAliasTest.fired.one = true]])
             local id2 = permAlias("Druid Aliases", "", "^druid_dup_two$", [[_G.DuplicateAliasTest.fired.two = true]])
             assert.is_true(id1 > 0, "first duplicate-named alias should be created")
             assert.is_true(id2 > 0, "second duplicate-named alias should be created")
 
-            -- sanity: permAlias creates them active, so both fire
             expandAlias("druid_dup_one")
             expandAlias("druid_dup_two")
             assert.is_true(_G.DuplicateAliasTest.fired.one, "alias 1 should fire while enabled")
             assert.is_true(_G.DuplicateAliasTest.fired.two, "alias 2 should fire while enabled")
 
-            -- disableAlias must disable BOTH, not only the first one found
             _G.DuplicateAliasTest.fired = {}
             disableAlias("Druid Aliases")
             expandAlias("druid_dup_one")
@@ -178,7 +169,6 @@ describe("Alias processing", function()
             assert.is_nil(_G.DuplicateAliasTest.fired.one, "alias 1 should be disabled")
             assert.is_nil(_G.DuplicateAliasTest.fired.two, "alias 2 (the second duplicate) should ALSO be disabled")
 
-            -- enableAlias must re-enable BOTH
             _G.DuplicateAliasTest.fired = {}
             enableAlias("Druid Aliases")
             expandAlias("druid_dup_one")
@@ -186,7 +176,7 @@ describe("Alias processing", function()
             assert.is_true(_G.DuplicateAliasTest.fired.one, "alias 1 should be re-enabled")
             assert.is_true(_G.DuplicateAliasTest.fired.two, "alias 2 (the second duplicate) should ALSO be re-enabled")
 
-            -- aliases with a DIFFERENT name must be unaffected (control)
+            -- a differently-named alias must stay untouched
             local idOther = permAlias("Other Aliases", "", "^druid_dup_other$", [[_G.DuplicateAliasTest.fired.other = true]])
             assert.is_true(idOther > 0)
             disableAlias("Druid Aliases")
@@ -194,7 +184,7 @@ describe("Alias processing", function()
             expandAlias("druid_dup_other")
             assert.is_true(_G.DuplicateAliasTest.fired.other, "differently-named alias must stay enabled")
 
-            -- no Lua API removes permanent aliases; leave them disabled
+            -- killAlias() only removes temporary aliases; leave these disabled
             disableAlias("Druid Aliases")
             disableAlias("Other Aliases")
         end)

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -140,4 +140,64 @@ describe("Alias processing", function()
         end)
 
     end)
+
+    -- Reproduces a user report that enableAlias()/disableAlias() only affect the
+    -- FIRST item sharing a given name when several aliases share that name (e.g.
+    -- two alias groups both called "Druid Aliases"). AliasUnit::enableAlias and
+    -- AliasUnit::disableAlias iterate the whole multimap of same-named entries,
+    -- so EVERY alias with that name must be toggled, not just the first found.
+    --
+    -- killAlias() only removes temporary aliases, and there is no Lua API to
+    -- delete permanent ones, so these aliases are given a unique name and left
+    -- disabled at the end to avoid interfering with other specs.
+    describe("enable/disable with duplicate names", function()
+
+        before_each(function()
+            _G.DuplicateAliasTest = {fired = {}}
+        end)
+
+        it("toggles every alias sharing the same name, not just the first", function()
+            -- permanent aliases so two of them can share one name; distinct
+            -- patterns let us tell which one actually fired
+            local id1 = permAlias("Druid Aliases", "", "^druid_dup_one$", [[_G.DuplicateAliasTest.fired.one = true]])
+            local id2 = permAlias("Druid Aliases", "", "^druid_dup_two$", [[_G.DuplicateAliasTest.fired.two = true]])
+            assert.is_true(id1 > 0, "first duplicate-named alias should be created")
+            assert.is_true(id2 > 0, "second duplicate-named alias should be created")
+
+            -- sanity: permAlias creates them active, so both fire
+            expandAlias("druid_dup_one")
+            expandAlias("druid_dup_two")
+            assert.is_true(_G.DuplicateAliasTest.fired.one, "alias 1 should fire while enabled")
+            assert.is_true(_G.DuplicateAliasTest.fired.two, "alias 2 should fire while enabled")
+
+            -- disableAlias must disable BOTH, not only the first one found
+            _G.DuplicateAliasTest.fired = {}
+            disableAlias("Druid Aliases")
+            expandAlias("druid_dup_one")
+            expandAlias("druid_dup_two")
+            assert.is_nil(_G.DuplicateAliasTest.fired.one, "alias 1 should be disabled")
+            assert.is_nil(_G.DuplicateAliasTest.fired.two, "alias 2 (the second duplicate) should ALSO be disabled")
+
+            -- enableAlias must re-enable BOTH
+            _G.DuplicateAliasTest.fired = {}
+            enableAlias("Druid Aliases")
+            expandAlias("druid_dup_one")
+            expandAlias("druid_dup_two")
+            assert.is_true(_G.DuplicateAliasTest.fired.one, "alias 1 should be re-enabled")
+            assert.is_true(_G.DuplicateAliasTest.fired.two, "alias 2 (the second duplicate) should ALSO be re-enabled")
+
+            -- aliases with a DIFFERENT name must be unaffected (control)
+            local idOther = permAlias("Other Aliases", "", "^druid_dup_other$", [[_G.DuplicateAliasTest.fired.other = true]])
+            assert.is_true(idOther > 0)
+            disableAlias("Druid Aliases")
+            _G.DuplicateAliasTest.fired = {}
+            expandAlias("druid_dup_other")
+            assert.is_true(_G.DuplicateAliasTest.fired.other, "differently-named alias must stay enabled")
+
+            -- no Lua API removes permanent aliases; leave them disabled
+            disableAlias("Druid Aliases")
+            disableAlias("Other Aliases")
+        end)
+
+    end)
 end)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TriggerEditorTest.cpp
     dlgTriggerEditorUndoRedoTest.cpp
     TDiscordModeTest.cpp
+    EnableDisableByNameTest.cpp
 )
 
 set(FUNCTIONAL_TEST_UTILS

--- a/test/functional_tests/EnableDisableByNameTest.cpp
+++ b/test/functional_tests/EnableDisableByNameTest.cpp
@@ -1,0 +1,311 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * enableX()/disableX() look an item up by name and must toggle EVERY item
+ * sharing that name, not just the first one found (e.g. two groups both named
+ * "Druid Aliases"). This covers all scriptable item types - aliases, triggers,
+ * timers, keys and scripts - by creating two same-named items plus a
+ * differently-named control, toggling them through the real Lua functions, and
+ * checking each item's active state directly.
+ *
+ * Run with: ctest -R EnableDisableByNameTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <functional>
+
+#include "AliasUnit.h"
+#include "Host.h"
+#include "KeyUnit.h"
+#include "MudletInstanceCoordinator.h"
+#include "ScriptUnit.h"
+#include "TAlias.h"
+#include "TKey.h"
+#include "TLuaInterpreter.h"
+#include "TScript.h"
+#include "TTimer.h"
+#include "TTrigger.h"
+#include "TimerUnit.h"
+#include "TriggerUnit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
+}
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForEnableDisableByNameTest();
+
+class EnableDisableByNameTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "EnableDisableByName-Test";
+    const QString mPort = "4005";
+    const QString mLocalhost = "localhost";
+
+    void runLua(const QString& code)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        luaL_dostring(L, code.toUtf8().constData());
+    }
+
+    // Drives one item type through the shared expectation: enableX(dupName)
+    // activates BOTH same-named items, disableX(dupName) deactivates BOTH while
+    // leaving the differently-named control untouched, and enableX(dupName)
+    // brings both back. `active` reads an item's live state by id.
+    void checkToggleAffectsAllMatches(const QString& typeName,
+                                      const QString& dupName,
+                                      const QString& soloName,
+                                      int id1,
+                                      int id2,
+                                      int idControl,
+                                      const QString& enableFn,
+                                      const QString& disableFn,
+                                      std::function<bool(int)> active)
+    {
+        runLua(qsl("%1('%2')").arg(enableFn, dupName));
+        runLua(qsl("%1('%2')").arg(enableFn, soloName));
+        QVERIFY2(active(id1) && active(id2), qPrintable(qsl("both same-named %1s should start enabled").arg(typeName)));
+        QVERIFY2(active(idControl), qPrintable(qsl("control %1 should start enabled").arg(typeName)));
+
+        runLua(qsl("%1('%2')").arg(disableFn, dupName));
+        QVERIFY2(!active(id1), qPrintable(qsl("first %1 should be disabled").arg(typeName)));
+        QVERIFY2(!active(id2), qPrintable(qsl("second same-named %1 should ALSO be disabled").arg(typeName)));
+        QVERIFY2(active(idControl), qPrintable(qsl("differently-named %1 must stay enabled").arg(typeName)));
+
+        runLua(qsl("%1('%2')").arg(enableFn, dupName));
+        QVERIFY2(active(id1), qPrintable(qsl("first %1 should be re-enabled").arg(typeName)));
+        QVERIFY2(active(id2), qPrintable(qsl("second same-named %1 should ALSO be re-enabled").arg(typeName)));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForEnableDisableByNameTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, mPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+
+        startProfile(mHostname, mLocalhost, mPort);
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    void test_aliasEnableDisableAffectsAllMatches()
+    {
+        auto [id1, m1] = mpHost->mLuaInterpreter.startPermAlias(qsl("Dup Aliases"), qsl(""), qsl("^dup_alias_1$"), qsl(""));
+        auto [id2, m2] = mpHost->mLuaInterpreter.startPermAlias(qsl("Dup Aliases"), qsl(""), qsl("^dup_alias_2$"), qsl(""));
+        auto [id3, m3] = mpHost->mLuaInterpreter.startPermAlias(qsl("Solo Alias"), qsl(""), qsl("^dup_alias_3$"), qsl(""));
+        QVERIFY2(id1 > 0, qPrintable(m1));
+        QVERIFY2(id2 > 0, qPrintable(m2));
+        QVERIFY2(id3 > 0, qPrintable(m3));
+
+        auto* unit = mpHost->getAliasUnit();
+        checkToggleAffectsAllMatches(qsl("alias"), qsl("Dup Aliases"), qsl("Solo Alias"), id1, id2, id3, qsl("enableAlias"), qsl("disableAlias"), [unit](int id) {
+            auto* p = unit->getAlias(id);
+            return p && p->isActive();
+        });
+    }
+
+    void test_triggerEnableDisableAffectsAllMatches()
+    {
+        QStringList p1{qsl("dup_trig_1")};
+        QStringList p2{qsl("dup_trig_2")};
+        QStringList p3{qsl("dup_trig_3")};
+        auto [id1, m1] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("Dup Triggers"), qsl(""), p1, qsl(""));
+        auto [id2, m2] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("Dup Triggers"), qsl(""), p2, qsl(""));
+        auto [id3, m3] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("Solo Trigger"), qsl(""), p3, qsl(""));
+        QVERIFY2(id1 > 0, qPrintable(m1));
+        QVERIFY2(id2 > 0, qPrintable(m2));
+        QVERIFY2(id3 > 0, qPrintable(m3));
+
+        auto* unit = mpHost->getTriggerUnit();
+        checkToggleAffectsAllMatches(qsl("trigger"), qsl("Dup Triggers"), qsl("Solo Trigger"), id1, id2, id3, qsl("enableTrigger"), qsl("disableTrigger"), [unit](int id) {
+            auto* p = unit->getTrigger(id);
+            return p && p->isActive();
+        });
+    }
+
+    void test_timerEnableDisableAffectsAllMatches()
+    {
+        auto [id1, m1] = mpHost->mLuaInterpreter.startPermTimer(qsl("Dup Timers"), qsl(""), 60.0, qsl(""));
+        auto [id2, m2] = mpHost->mLuaInterpreter.startPermTimer(qsl("Dup Timers"), qsl(""), 60.0, qsl(""));
+        auto [id3, m3] = mpHost->mLuaInterpreter.startPermTimer(qsl("Solo Timer"), qsl(""), 60.0, qsl(""));
+        QVERIFY2(id1 > 0, qPrintable(m1));
+        QVERIFY2(id2 > 0, qPrintable(m2));
+        QVERIFY2(id3 > 0, qPrintable(m3));
+
+        auto* unit = mpHost->getTimerUnit();
+        checkToggleAffectsAllMatches(qsl("timer"), qsl("Dup Timers"), qsl("Solo Timer"), id1, id2, id3, qsl("enableTimer"), qsl("disableTimer"), [unit](int id) {
+            auto* p = unit->getTimer(id);
+            return p && p->isActive();
+        });
+    }
+
+    void test_keyEnableDisableAffectsAllMatches()
+    {
+        QString n1 = qsl("Dup Keys");
+        QString n2 = qsl("Dup Keys");
+        QString n3 = qsl("Solo Key");
+        QString parent;
+        QString func;
+        int mod = Qt::NoModifier;
+        int kc1 = Qt::Key_F7;
+        int kc2 = Qt::Key_F8;
+        int kc3 = Qt::Key_F9;
+        auto [id1, m1] = mpHost->mLuaInterpreter.startPermKey(n1, parent, kc1, mod, func);
+        auto [id2, m2] = mpHost->mLuaInterpreter.startPermKey(n2, parent, kc2, mod, func);
+        auto [id3, m3] = mpHost->mLuaInterpreter.startPermKey(n3, parent, kc3, mod, func);
+        QVERIFY2(id1 > 0, qPrintable(m1));
+        QVERIFY2(id2 > 0, qPrintable(m2));
+        QVERIFY2(id3 > 0, qPrintable(m3));
+
+        auto* unit = mpHost->getKeyUnit();
+        checkToggleAffectsAllMatches(qsl("key"), qsl("Dup Keys"), qsl("Solo Key"), id1, id2, id3, qsl("enableKey"), qsl("disableKey"), [unit](int id) {
+            auto* p = unit->getKey(id);
+            return p && p->isActive();
+        });
+    }
+
+    void test_scriptEnableDisableAffectsAllMatches()
+    {
+        auto makeScript = [this](const QString& name) {
+            auto* pScript = new TScript(name, mpHost);
+            pScript->setScript(qsl(""));
+            mpHost->getScriptUnit()->registerScript(pScript);
+            pScript->setIsActive(true);
+            pScript->compile();
+            return pScript->getID();
+        };
+        int id1 = makeScript(qsl("Dup Scripts"));
+        int id2 = makeScript(qsl("Dup Scripts"));
+        int id3 = makeScript(qsl("Solo Script"));
+        QVERIFY(id1 > 0);
+        QVERIFY(id2 > 0);
+        QVERIFY(id3 > 0);
+
+        auto* unit = mpHost->getScriptUnit();
+        checkToggleAffectsAllMatches(qsl("script"), qsl("Dup Scripts"), qsl("Solo Script"), id1, id2, id3, qsl("enableScript"), qsl("disableScript"), [unit](int id) {
+            auto* p = unit->getScript(id);
+            return p && p->isActive();
+        });
+    }
+
+    // Helpers (reused from ResetProfileTest pattern)
+
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(500)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForEnableDisableByNameTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "EnableDisableByNameTest.moc"
+QTEST_MAIN(EnableDisableByNameTest)

--- a/test/functional_tests/EnableDisableByNameTest.cpp
+++ b/test/functional_tests/EnableDisableByNameTest.cpp
@@ -178,6 +178,32 @@ private slots:
         });
     }
 
+    // setTriggerStayOpen() looks triggers up by name through the same path as the
+    // enable/disable functions, so it must update EVERY same-named trigger too.
+    void test_setTriggerStayOpenAffectsAllMatches()
+    {
+        QStringList p1{qsl("stayopen_trig_1")};
+        QStringList p2{qsl("stayopen_trig_2")};
+        QStringList p3{qsl("stayopen_trig_3")};
+        auto [id1, m1] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("StayOpen Triggers"), qsl(""), p1, qsl(""));
+        auto [id2, m2] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("StayOpen Triggers"), qsl(""), p2, qsl(""));
+        auto [id3, m3] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("Solo StayOpen"), qsl(""), p3, qsl(""));
+        QVERIFY2(id1 > 0, qPrintable(m1));
+        QVERIFY2(id2 > 0, qPrintable(m2));
+        QVERIFY2(id3 > 0, qPrintable(m3));
+
+        auto* unit = mpHost->getTriggerUnit();
+        auto* t1 = unit->getTrigger(id1);
+        auto* t2 = unit->getTrigger(id2);
+        auto* t3 = unit->getTrigger(id3);
+        QVERIFY(t1 && t2 && t3);
+
+        runLua(qsl("setTriggerStayOpen('StayOpen Triggers', 5)"));
+        QVERIFY2(t1->mKeepFiring == 5, "first trigger should be set to stay open");
+        QVERIFY2(t2->mKeepFiring == 5, "second same-named trigger should ALSO be set to stay open");
+        QVERIFY2(t3->mKeepFiring == 0, "differently-named trigger must stay untouched");
+    }
+
     void test_timerEnableDisableAffectsAllMatches()
     {
         auto [id1, m1] = mpHost->mLuaInterpreter.startPermTimer(qsl("Dup Timers"), qsl(""), 60.0, qsl(""));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes a Windows-only bug where `enableAlias`/`disableAlias` and the trigger/timer/key equivalents (plus `setTriggerStayOpen`) only toggled some items when several shared a name, e.g. two groups both named "Druid Aliases". The cause was `mLookupTable.constFind(name)` + forward iteration, which could start mid-run in the `QMultiMap` and skip duplicates depending on the platform's iteration order - fine on Linux/macOS, broken on Windows; it now uses `equal_range()`, which is correct everywhere.

#### Motivation for adding to Mudlet
Windows users with items sharing a name (commonly alias/trigger groups) could only partly enable/disable them, silently leaving the rest in the wrong state.

#### Other info (issues closed, discussion etc)
Adds a busted spec and a C++ functional test covering aliases, triggers, timers, keys and scripts. The functional test failed on the Windows CI runner and passed on Linux/macOS, pinning it to the platform-dependent `QMultiMap` iteration. Scripts were already correct (they iterate all matches).

**Test case:** on Windows, two alias groups both named "Druid Aliases" → `disableAlias("Druid Aliases")` stops both, `enableAlias("Druid Aliases")` re-enables both. Covered by `EnableDisableByNameTest` and `Alias_spec.lua`.