### PR TITLE
infrastructure: upload Windows Qt debug symbols to Sentry directly

### DIFF
--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -20,8 +20,6 @@
 
 set -e
 
-# sentry-cli 3.5.0+ parses DWARF-in-PE debug companions, which lets us upload the
-# Qt Mingw-w64 ".debug" files directly (see the Windows section below).
 SENTRY_CLI_VERSION="3.6.0"
 
 download_sentry_cli() {
@@ -109,9 +107,9 @@ done
 # and MSYSTEM_PREFIX for the path (supports MINGW64, CLANG64, UCRT64, etc.)
 #
 # On Windows we build with MSYS2 + Mingw-w64, so the Qt libraries we link against
-# ship their debug information as separate DWARF ".debug" companion files rather
-# than PDBs. Since sentry-cli 3.5.0 Sentry parses DWARF-in-PE companions directly,
-# so we upload the ".debug" files as-is - no DWARF-to-PDB conversion needed.
+# ship their debug information as separate DWARF ".debug" companion files. Since
+# sentry-cli 3.5.0+ parses DWARF-in-PE companions, we upload these ".debug" files
+# straight to Sentry.
 # See https://github.com/getsentry/sentry/issues/104738
 if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     MINGW_BIN="${MSYSTEM_PREFIX}/bin"

--- a/CI/send_debug_files_to_sentry.sh
+++ b/CI/send_debug_files_to_sentry.sh
@@ -20,27 +20,32 @@
 
 set -e
 
+# sentry-cli 3.5.0+ parses DWARF-in-PE debug companions, which lets us upload the
+# Qt Mingw-w64 ".debug" files directly (see the Windows section below).
+SENTRY_CLI_VERSION="3.6.0"
+
 download_sentry_cli() {
     local os="$1"
     local arch="$2"
     local file="$3"
     local url=""
+    local base="https://github.com/getsentry/sentry-cli/releases/download/${SENTRY_CLI_VERSION}"
 
     if [[ "$os" == "Darwin" ]]; then
         if [[ "$arch" == "x86_64" ]]; then
-            url="https://github.com/getsentry/sentry-cli/releases/download/2.58.2/sentry-cli-Darwin-x86_64"
+            url="${base}/sentry-cli-Darwin-x86_64"
         elif [[ "$arch" == "arm64" ]]; then
-            url="https://github.com/getsentry/sentry-cli/releases/download/2.58.2/sentry-cli-Darwin-arm64"
+            url="${base}/sentry-cli-Darwin-arm64"
         fi
     elif [[ "$os" == "Linux" ]]; then
         if [[ "$arch" == "x86_64" ]]; then
-            url="https://github.com/getsentry/sentry-cli/releases/download/2.58.2/sentry-cli-Linux-x86_64"
+            url="${base}/sentry-cli-Linux-x86_64"
         fi
     elif [[ "$os" == "MINGW"* || "$os" == "MSYS"* || "$os" == "CYGWIN"* ]]; then
         if [[ "$arch" == "x86_64" ]]; then
-            url="https://github.com/getsentry/sentry-cli/releases/download/2.58.2/sentry-cli-Windows-x86_64.exe"
+            url="${base}/sentry-cli-Windows-x86_64.exe"
         elif [[ "$arch" == "i686" || "$arch" == "i386" ]]; then
-            url="https://github.com/getsentry/sentry-cli/releases/download/2.58.2/sentry-cli-Windows-i686.exe"
+            url="${base}/sentry-cli-Windows-i686.exe"
         fi
     fi
 
@@ -102,115 +107,40 @@ done
 
 # Use MSYSTEM variable for MSYS2 detection (consistent with other CI scripts)
 # and MSYSTEM_PREFIX for the path (supports MINGW64, CLANG64, UCRT64, etc.)
+#
+# On Windows we build with MSYS2 + Mingw-w64, so the Qt libraries we link against
+# ship their debug information as separate DWARF ".debug" companion files rather
+# than PDBs. Since sentry-cli 3.5.0 Sentry parses DWARF-in-PE companions directly,
+# so we upload the ".debug" files as-is - no DWARF-to-PDB conversion needed.
+# See https://github.com/getsentry/sentry/issues/104738
 if [[ -n "$MSYSTEM" && -n "$MSYSTEM_PREFIX" ]]; then
     MINGW_BIN="${MSYSTEM_PREFIX}/bin"
+    QT_PLUGINS_DIR="${MSYSTEM_PREFIX}/share/qt6/plugins"
 
     echo ""
-    echo "=== Converting Qt DWARF debug files to PDB for Sentry ==="
+    echo "=== Collecting Qt DWARF debug companions for Sentry ==="
 
-    # Download cv2pdb (converts MinGW DWARF to PDB format)
-    # Use 64-bit version to handle large debug files like Qt6Core (198MB)
-    CV2PDB_URL="https://github.com/rainers/cv2pdb/releases/download/v0.54/cv2pdb-0.54.zip"
-    echo "Downloading cv2pdb..."
-    curl -sL "$CV2PDB_URL" -o cv2pdb.zip
-    unzip -q cv2pdb.zip
-    CV2PDB="./cv2pdb64.exe"
+    DEBUG_FILES=()
 
-    if [[ -d "$MINGW_BIN" && -x "$CV2PDB" ]]; then
-        # Use absolute Windows path for PDB files (cv2pdb is native Windows app)
-        PDB_DIR="$(pwd)/qt_pdbs"
-        mkdir -p "$PDB_DIR"
-        WIN_PDB_DIR="$(cygpath -w "$PDB_DIR")"
-        PDB_FILES=()
+    # Core Qt6 libraries (Qt6Core.debug, Qt6Gui.debug, ...) live next to their DLLs
+    for debug_file in "$MINGW_BIN"/Qt6*.debug; do
+        [[ -f "$debug_file" ]] && DEBUG_FILES+=("$debug_file")
+    done
 
-        # Function to convert a DLL to PDB format
-        convert_dll_to_pdb() {
-            local dll="$1"
-            local source_dir="$2"
+    # Qt plugins (image formats, platforms, tls, ...) can appear in crash stack
+    # traces too, so upload every plugin companion we can find
+    if [[ -d "$QT_PLUGINS_DIR" ]]; then
+        while IFS= read -r -d '' debug_file; do
+            DEBUG_FILES+=("$debug_file")
+        done < <(find "$QT_PLUGINS_DIR" -type f -name '*.debug' -print0)
+    fi
 
-            if [[ -f "$dll" ]]; then
-                local dll_name=$(basename "$dll")
-                local base_name="${dll_name%.dll}"
-                local debug_file="${source_dir}/${base_name}.debug"
-                local pdb_file="${PDB_DIR}/${base_name}.pdb"
-
-                # Check if companion .debug file exists (contains DWARF debug info)
-                if [[ -f "$debug_file" ]]; then
-                    echo "Converting $dll_name to PDB..."
-                    echo "  Debug file: ${base_name}.debug ($(stat -c%s "$debug_file") bytes)"
-
-                    # cv2pdb converts DWARF to PDB format
-                    # Usage: cv2pdb -l<debug-file> <dll> [<output-dll>] [<pdb>]
-                    # Convert paths to Windows format for native Windows cv2pdb.exe
-                    local win_debug_file=$(cygpath -w "$debug_file")
-                    local win_dll=$(cygpath -w "$dll")
-                    local win_pdb_file="${WIN_PDB_DIR}\\${base_name}.pdb"
-                    if "$CV2PDB" "-l${win_debug_file}" "$win_dll" "$win_dll" "$win_pdb_file" 2>"${pdb_file}.err"; then
-                        if [[ -f "$pdb_file" ]]; then
-                            local pdb_size=$(stat -c%s "$pdb_file")
-                            echo "  Generated PDB: ${base_name}.pdb ($pdb_size bytes)"
-                            PDB_FILES+=("$pdb_file")
-                        else
-                            echo "  Warning: PDB file not created"
-                        fi
-                    else
-                        echo "  cv2pdb failed: $(cat "${pdb_file}.err" 2>/dev/null || echo 'unknown error')"
-                    fi
-                    rm -f "${pdb_file}.err"
-                else
-                    echo "Skipping $dll_name (no .debug file)"
-                fi
-            fi
-        }
-
-        # Process main Qt6 DLLs from bin directory
-        for dll in "$MINGW_BIN"/Qt6*.dll; do
-            convert_dll_to_pdb "$dll" "$MINGW_BIN"
-        done
-
-        # Process Qt plugin DLLs from share/qt6/plugins subdirectories
-        # These plugins can appear in crash stack traces and need debug symbols
-        QT_PLUGINS_DIR="${MSYSTEM_PREFIX}/share/qt6/plugins"
-        if [[ -d "$QT_PLUGINS_DIR" ]]; then
-            echo ""
-            echo "=== Converting Qt plugin debug files ==="
-
-            # Plugin directories and their DLLs (based on what Mudlet uses)
-            declare -A PLUGIN_DLLS=(
-                ["generic"]="qtuiotouchplugin"
-                ["iconengines"]="qsvgicon"
-                ["imageformats"]="qgif qicns qico qjp2 qjpeg qmng qsvg qtga qtiff qwbmp qwebp"
-                ["multimedia"]="ffmpegmediaplugin windowsmediaplugin"
-                ["networkinformation"]="qglib qnetworklistmanager"
-                ["platforms"]="qwindows"
-                ["styles"]="qmodernwindowsstyle"
-                ["texttospeech"]="qtexttospeech_mock qtexttospeech_sapi"
-                ["tls"]="qcertonlybackend qopensslbackend qschannelbackend"
-            )
-
-            for plugin_dir in "${!PLUGIN_DLLS[@]}"; do
-                plugin_path="${QT_PLUGINS_DIR}/${plugin_dir}"
-                if [[ -d "$plugin_path" ]]; then
-                    for plugin_name in ${PLUGIN_DLLS[$plugin_dir]}; do
-                        dll="${plugin_path}/${plugin_name}.dll"
-                        convert_dll_to_pdb "$dll" "$plugin_path"
-                    done
-                fi
-            done
-        fi
-
-        if [[ ${#PDB_FILES[@]} -gt 0 ]]; then
-            echo ""
-            echo "Uploading ${#PDB_FILES[@]} PDB files to Sentry..."
-            ./sentry-cli debug-files upload "${PDB_FILES[@]}" --project "mudlet"
-            echo "Qt PDB symbols uploaded successfully"
-        else
-            echo "No Qt PDB files were generated"
-        fi
-
-        rm -rf "$PDB_DIR"
-    elif [[ ! -x "$CV2PDB" ]]; then
-        echo "Warning: cv2pdb not found at $CV2PDB, skipping Qt debug symbols"
+    if [[ ${#DEBUG_FILES[@]} -gt 0 ]]; then
+        echo "Uploading ${#DEBUG_FILES[@]} Qt debug companion files to Sentry..."
+        ./sentry-cli debug-files upload "${DEBUG_FILES[@]}" --project "mudlet"
+        echo "Qt debug symbols uploaded successfully"
+    else
+        echo "No Qt .debug files found - are the qt6-*-debug packages installed?"
     fi
 
     strip --strip-debug "$MUDLET_EXEC"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Upload Qt's Mingw-w64 `.debug` DWARF companions to Sentry directly, discovered via a recursive glob
- Remove the `cv2pdb` DWARF-to-PDB conversion (no longer needed)
- Bump `sentry-cli` 2.58.2 -> 3.6.0

#### Motivation for adding to Mudlet
sentry-cli 3.5.0+ now parses DWARF-in-PE debug files, so Windows crash reports can resolve Qt stack frames.

#### Other info (issues closed, discussion etc)
Implements the upstream fix tracked in https://github.com/getsentry/sentry/issues/104738

Verified locally with a real MSYS2 CLANG64 Qt debug companion: `sentry-cli debug-files check` reports `Usable: no (missing debug identifier)` on 2.58.2 but a valid Debug ID and `Usable: yes` on 3.6.0.

**Test case:** On a Windows release or PTB build (`SENTRY_SEND_DEBUG=1`), trigger a crash inside a Qt frame and confirm the Sentry event symbolicates the Qt stack frames.
