### PR TITLE
fix: prevent crash from a trigger that endlessly feeds itself

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1076,7 +1076,7 @@ int TLuaInterpreter::feedTelnet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#feedTriggers
 int TLuaInterpreter::feedTriggers(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L,
                         "feedTriggers: bad argument #1 type (imitation game server text as string\n"
@@ -1084,6 +1084,29 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
+
+    // A self-feeding trigger recurses the C++ stack one level per re-match; abort
+    // with a catchable Lua error before that overflows the stack into a crash.
+    auto* triggerUnit = host.getTriggerUnit();
+    if (triggerUnit->processingDepth() >= TriggerUnit::scmMaxProcessingDepth) {
+        qWarning().nospace() << "TLuaInterpreter::feedTriggers(...) aborting: trigger processing recursion reached the limit of " << TriggerUnit::scmMaxProcessingDepth
+                             << " - probably an endless feedTriggers loop.";
+        const QString* pName = triggerUnit->currentExecutingTriggerName();
+        QString message;
+        if (pName && !pName->isEmpty()) {
+            //: Lua error raised when feedTriggers() detects an endless loop; %1 is the offending trigger's name
+            message = tr("feedTriggers stopped to prevent a crash: trigger '%1' (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing "
+                         "it again and again. Change the trigger's pattern or the fed text so they don't match each other.")
+                              .arg(*pName);
+        } else {
+            //: Lua error raised when feedTriggers() detects an endless loop and the offending trigger has no name
+            message = tr("feedTriggers stopped to prevent a crash: a trigger (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing it "
+                         "again and again. Change the trigger's pattern or the fed text so they don't match each other.");
+        }
+        lua_pushstring(L, message.toUtf8().constData());
+        return lua_error(L);
+    }
+
     const QByteArray data{lua_tostring(L, 1)};
     bool dataIsUtf8Encoded = true;
     if (lua_gettop(L) > 1) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1058,6 +1058,26 @@ int TLuaInterpreter::feedTelnet(lua_State* L)
         lua_pushstring(L, "feedTelnet: refused, telnet connection socket is not in the unconnected state");
         return 2;
     }
+
+    // Same self-feeding-loop guard as feedTriggers(), but each nested telnet
+    // processing frame is large - see scmMaxLoopbackProcessingDepth.
+    if (host.mTelnet.loopbackProcessingDepth() >= cTelnet::scmMaxLoopbackProcessingDepth) {
+        qWarning().nospace() << "TLuaInterpreter::feedTelnet(...) aborting: nested telnet data processing reached the limit of " << cTelnet::scmMaxLoopbackProcessingDepth
+                             << " - probably an endless feedTelnet loop.";
+        const QString* pName = host.getTriggerUnit()->currentExecutingTriggerName();
+        if (pName && !pName->isEmpty()) {
+            lua_pushfstring(L,
+                            "feedTelnet stopped to prevent a crash: trigger '%s' (or another trigger it feeds) is stuck in an endless loop - the data being fed keeps re-matching a trigger and "
+                            "firing it again and again. Change the trigger's pattern or the fed data so they don't match each other.",
+                            pName->toUtf8().constData());
+        } else {
+            lua_pushstring(L,
+                           "feedTelnet stopped to prevent a crash: a trigger (or another trigger it feeds) is stuck in an endless loop - the data being fed keeps re-matching a trigger and firing "
+                           "it again and again. Change the trigger's pattern or the fed data so they don't match each other.");
+        }
+        return lua_error(L);
+    }
+
     const QByteArray rawData{lua_tostring(L, 1)};
     // We need to convert any "<*>" codes to their raw byte forms:
     QByteArray cookedData{parseTelnetCodes(rawData)};
@@ -1092,22 +1112,16 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         qWarning().nospace() << "TLuaInterpreter::feedTriggers(...) aborting: trigger processing recursion reached the limit of " << TriggerUnit::scmMaxProcessingDepth
                              << " - probably an endless feedTriggers loop.";
         const QString* pName = triggerUnit->currentExecutingTriggerName();
-        // Scoped so the QString is destroyed before lua_error()'s longjmp, which skips C++ destructors.
-        {
-            QString message;
-            if (pName && !pName->isEmpty()) {
-                //: Lua error raised when feedTriggers() detects an endless loop; %1 is the offending trigger's name
-                message = tr("feedTriggers stopped to prevent a crash: trigger '%1' (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and "
-                             "firing "
-                             "it again and again. Change the trigger's pattern or the fed text so they don't match each other.")
-                                  .arg(*pName);
-            } else {
-                //: Lua error raised when feedTriggers() detects an endless loop and the offending trigger has no name
-                message = tr(
-                        "feedTriggers stopped to prevent a crash: a trigger (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing it "
-                        "again and again. Change the trigger's pattern or the fed text so they don't match each other.");
-            }
-            lua_pushstring(L, message.toUtf8().constData());
+        // The QByteArray temporary dies before lua_error()'s longjmp, which skips C++ destructors.
+        if (pName && !pName->isEmpty()) {
+            lua_pushfstring(L,
+                            "feedTriggers stopped to prevent a crash: trigger '%s' (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and "
+                            "firing it again and again. Change the trigger's pattern or the fed text so they don't match each other.",
+                            pName->toUtf8().constData());
+        } else {
+            lua_pushstring(L,
+                           "feedTriggers stopped to prevent a crash: a trigger (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing "
+                           "it again and again. Change the trigger's pattern or the fed text so they don't match each other.");
         }
         return lua_error(L);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1092,18 +1092,23 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         qWarning().nospace() << "TLuaInterpreter::feedTriggers(...) aborting: trigger processing recursion reached the limit of " << TriggerUnit::scmMaxProcessingDepth
                              << " - probably an endless feedTriggers loop.";
         const QString* pName = triggerUnit->currentExecutingTriggerName();
-        QString message;
-        if (pName && !pName->isEmpty()) {
-            //: Lua error raised when feedTriggers() detects an endless loop; %1 is the offending trigger's name
-            message = tr("feedTriggers stopped to prevent a crash: trigger '%1' (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing "
-                         "it again and again. Change the trigger's pattern or the fed text so they don't match each other.")
-                              .arg(*pName);
-        } else {
-            //: Lua error raised when feedTriggers() detects an endless loop and the offending trigger has no name
-            message = tr("feedTriggers stopped to prevent a crash: a trigger (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing it "
-                         "again and again. Change the trigger's pattern or the fed text so they don't match each other.");
+        // Scoped so the QString is destroyed before lua_error()'s longjmp, which skips C++ destructors.
+        {
+            QString message;
+            if (pName && !pName->isEmpty()) {
+                //: Lua error raised when feedTriggers() detects an endless loop; %1 is the offending trigger's name
+                message = tr("feedTriggers stopped to prevent a crash: trigger '%1' (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and "
+                             "firing "
+                             "it again and again. Change the trigger's pattern or the fed text so they don't match each other.")
+                                  .arg(*pName);
+            } else {
+                //: Lua error raised when feedTriggers() detects an endless loop and the offending trigger has no name
+                message = tr(
+                        "feedTriggers stopped to prevent a crash: a trigger (or another trigger it feeds) is stuck in an endless loop - the text being fed keeps re-matching a trigger and firing it "
+                        "again and again. Change the trigger's pattern or the fed text so they don't match each other.");
+            }
+            lua_pushstring(L, message.toUtf8().constData());
         }
-        lua_pushstring(L, message.toUtf8().constData());
         return lua_error(L);
     }
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1264,8 +1264,33 @@ bool TTrigger::compileScript()
     }
 }
 
+namespace {
+// Tracks the innermost trigger running its script so feedTriggers() can name the
+// culprit when aborting an endless loop; RAII restores the prior value on exit.
+class ExecutingTriggerNameGuard
+{
+public:
+    ExecutingTriggerNameGuard(TriggerUnit* pUnit, const QString* pName)
+    : mpUnit(pUnit)
+    , mpPrevious(pUnit->currentExecutingTriggerName())
+    {
+        mpUnit->setCurrentExecutingTriggerName(pName);
+    }
+    ~ExecutingTriggerNameGuard() { mpUnit->setCurrentExecutingTriggerName(mpPrevious); }
+
+    ExecutingTriggerNameGuard(const ExecutingTriggerNameGuard&) = delete;
+    ExecutingTriggerNameGuard& operator=(const ExecutingTriggerNameGuard&) = delete;
+
+private:
+    TriggerUnit* mpUnit;
+    const QString* mpPrevious;
+};
+} // namespace
+
 void TTrigger::execute()
 {
+    const ExecutingTriggerNameGuard executingTriggerNameGuard(mpHost->getTriggerUnit(), &mName);
+
     if (mSoundTrigger) { /* eventually something should be added to the gui to change sound volumes. 100=full volume */
         QString mediaFileName = mSoundFile;
 

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -76,6 +76,17 @@ public:
     void uninstall(const QString&);
     void _uninstall(TTrigger* pChild, const QString& packageName);
 
+    int processingDepth() const { return mProcessingDepth; }
+    // Raw pointer is safe: a trigger outlives its own execute() frame, as deletion
+    // is deferred to doCleanup() once mProcessingDepth returns to 0.
+    const QString* currentExecutingTriggerName() const { return mpCurrentExecutingTriggerName; }
+    void setCurrentExecutingTriggerName(const QString* pName) { mpCurrentExecutingTriggerName = pName; }
+    // Turns an endless self-feeding-trigger loop into a catchable Lua error before
+    // it overflows the stack. Sized for the smallest platform stack (~1MB on
+    // Windows, where the original crash hit before Lua's own 200-C-call guard):
+    // a few times any legitimate nesting, comfortably below the native limit.
+    inline static const int scmMaxProcessingDepth = 50;
+
     QList<TTrigger*> uninstallList;
 
 private:
@@ -99,6 +110,7 @@ private:
     int statsPatternsActive = 0;
     // Counter for nested processing; cleanup deferred until 0
     int mProcessingDepth = 0;
+    const QString* mpCurrentExecutingTriggerName = nullptr;
 };
 
 #endif // MUDLET_TRIGGERUNIT_H

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4623,11 +4623,16 @@ void cTelnet::postData()
         return;
     }
 
+    // Detach the pending data first: a trigger fired inside printOnDisplay() can
+    // call feedTelnet(), re-entering here - it must not post this data again.
+    std::string data{std::move(mMudData)};
+    mMudData.clear();
+
     // All data goes through main console's printOnDisplay which calls
     // translateToPlainText - MXP DEST routing happens inside that process
-    mpHost->mpConsole->printOnDisplay(mMudData, true);
+    mpHost->mpConsole->printOnDisplay(data, true);
     if (mpHost->mMMCPServer && !mpHost->mIsRemoteEchoingActive) {
-        mpHost->mMMCPServer->receiveFromPlayer(mMudData);
+        mpHost->mMMCPServer->receiveFromPlayer(data);
     }
 }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -234,7 +234,17 @@ public:
     std::tuple<QString, int, bool> getConnectionInfo() const;
     void setPostingTimeout(const int);
     int getPostingTimeout() const { return mTimeOut; }
-    void loopbackTest(QByteArray& data) { processSocketData(data.data(), data.size(), true); }
+    void loopbackTest(QByteArray& data)
+    {
+        ++mLoopbackProcessingDepth;
+        processSocketData(data.data(), data.size(), true);
+        --mLoopbackProcessingDepth;
+    }
+    int loopbackProcessingDepth() const { return mLoopbackProcessingDepth; }
+    // Each nested processSocketData() puts ~100KB of buffers on the stack, so a
+    // self-feeding feedTelnet() loop overflows a 1MB (Windows) stack in only ~8
+    // levels - hence a much lower cap than TriggerUnit::scmMaxProcessingDepth.
+    inline static const int scmMaxLoopbackProcessingDepth = 5;
     void cancelLoginTimers();
     void terminateConnection();
     bool currentlySecure() const
@@ -401,6 +411,7 @@ private:
     // True between connectIt() and slot_socketHostFound, so
     // getConnectionState() reports HostLookupState during DNS lookup.
     bool mLookingUpHost = false;
+    int mLoopbackProcessingDepth = 0;
     std::queue<int> mCommandQueue;
 
     z_stream mZstream = {};

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TOscTest.cpp
     TUserWindowTest.cpp
     TriggerEditorTest.cpp
+    TFeedTriggersRecursionTest.cpp
     dlgTriggerEditorUndoRedoTest.cpp
     TDiscordModeTest.cpp
 )

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -1,0 +1,192 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by the Mudlet project                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TriggerUnit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResources();
+
+// Validates the guard that stops a self-feeding trigger (one whose action calls
+// feedTriggers() with text that re-matches it) from recursing the C++ stack into
+// an EXCEPTION_STACK_OVERFLOW crash - see Sentry event fbda193d. The guard must
+// abort the loop with a catchable Lua error while leaving legitimate feedTriggers()
+// use untouched.
+class TFeedTriggersRecursionTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mpHostname = "Test-FeedTriggersRecursion";
+    const QString mpPort = "4000";
+    const QString mpLocalhost = "localhost";
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mpHostname);
+    }
+
+    // A trigger that feeds itself must be stopped at the depth limit with a
+    // catchable Lua error, not crash the process via stack overflow.
+    void test_selfFeedingTriggerIsStopped()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("loopCount = 0\n"
+                                                               "tempRegexTrigger('^loopme$', [[loopCount = loopCount + 1; feedTriggers('loopme\\n')]])\n"
+                                                               "feedTriggers('loopme\\n')\n"));
+
+        // The whole recursion runs synchronously inside the call above; if the
+        // guard works we are back here (no crash) with everything unwound.
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("stuck in an endless loop")), "Expected the feedTriggers loop-abort error in the console buffer");
+
+        // The trigger should have fired exactly up to the limit and no further.
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("echo('LOOPCOUNT='..loopCount..'\\n')"));
+        QVERIFY2(bufferContains(qsl("LOOPCOUNT=%1").arg(TriggerUnit::scmMaxProcessingDepth)), qPrintable(qsl("Expected the trigger to fire exactly %1 times").arg(TriggerUnit::scmMaxProcessingDepth)));
+    }
+
+    // A single, non-self-matching feedTriggers() must still work normally and not
+    // be flagged as a loop.
+    void test_normalFeedTriggersIsUnaffected()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("normalCount = 0\n"
+                                                               "tempRegexTrigger('^hello$', [[normalCount = normalCount + 1]])\n"
+                                                               "feedTriggers('hello\\n')\n"
+                                                               "echo('NORMALCOUNT='..normalCount..'\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(!bufferContains(qsl("stuck in an endless loop")), "A normal feedTriggers() call must not be treated as a loop");
+        QVERIFY2(bufferContains(qsl("NORMALCOUNT=1")), "Expected the non-looping trigger to fire exactly once");
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mpHostname);
+        delete mudlet::self();
+    }
+
+    // Starts a profile the way a user would via the GUI (mirrors the helper in
+    // TelnetTextDisplayedTest).
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    bool bufferContains(const QString& needle)
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            if (console->buffer.line(i).contains(needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "TFeedTriggersRecursionTest.moc"
+QTEST_MAIN(TFeedTriggersRecursionTest)

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2026 by the Mudlet project                              *
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,11 +36,11 @@ extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResources();
 
-// Validates the guard that stops a self-feeding trigger (one whose action calls
-// feedTriggers() with text that re-matches it) from recursing the C++ stack into
-// an EXCEPTION_STACK_OVERFLOW crash - see Sentry event fbda193d. The guard must
-// abort the loop with a catchable Lua error while leaving legitimate feedTriggers()
-// use untouched.
+// Validates the guards that stop a self-feeding trigger (one whose action calls
+// feedTriggers() or feedTelnet() with text that re-matches it) from recursing the
+// C++ stack into an EXCEPTION_STACK_OVERFLOW crash - see Sentry event fbda193d.
+// The guards must abort the loop with a catchable Lua error while leaving
+// legitimate feedTriggers()/feedTelnet() use untouched.
 class TFeedTriggersRecursionTest : public QObject
 {
     Q_OBJECT
@@ -113,6 +113,65 @@ private slots:
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
         QVERIFY2(!bufferContains(qsl("stuck in an endless loop")), "A normal feedTriggers() call must not be treated as a loop");
         QVERIFY2(bufferContains(qsl("NORMALCOUNT=1")), "Expected the non-looping trigger to fire exactly once");
+    }
+
+    // A trigger that re-feeds its own output through feedTelnet() must likewise be
+    // stopped - at a much lower depth limit, as each nested telnet processing frame
+    // holds ~100KB of stack, overflowing a 1MB (Windows) stack in only ~8 levels.
+    void test_selfFeedingTelnetTriggerIsStopped()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        host->mEchoLuaErrors = true;
+
+        // feedTelnet() refuses to work unless the profile is offline
+        host->mTelnet.disconnectIt();
+        QTRY_COMPARE(host->mTelnet.getConnectionState(), QAbstractSocket::UnconnectedState);
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("telnetLoopCount = 0\n"
+                                                               "telnetLoopTriggerId = tempRegexTrigger('^loopme$', [[telnetLoopCount = telnetLoopCount + 1; feedTelnet('loopme\\n')]])\n"
+                                                               "feedTelnet('loopme\\n')\n"));
+
+        QCOMPARE(host->mTelnet.loopbackProcessingDepth(), 0);
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("feedTelnet stopped to prevent a crash")), "Expected the feedTelnet loop-abort error in the console buffer");
+
+        lua_State* L = host->getLuaInterpreter()->getLuaGlobalState();
+        lua_getglobal(L, "telnetLoopTriggerId");
+        const int telnetLoopTriggerId = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        QVERIFY2(bufferContains(qsl("trigger '%1'").arg(telnetLoopTriggerId)), "Expected the abort message to name the offending trigger by its id");
+
+        // Unlike the linear feedTriggers path, nested telnet processing re-posts the
+        // ancestors' not-yet-cleared lines (mMudData in cTelnet is shared across the
+        // nested calls), so the trigger fires more often than the depth limit - just
+        // check the loop was cut off to a small bounded count rather than running away.
+        lua_getglobal(L, "telnetLoopCount");
+        const int telnetLoopCount = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        QVERIFY2(telnetLoopCount >= cTelnet::scmMaxLoopbackProcessingDepth && telnetLoopCount < 100,
+                 qPrintable(qsl("Expected the trigger to fire a small bounded number of times (>= %1, < 100), got %2").arg(cTelnet::scmMaxLoopbackProcessingDepth).arg(telnetLoopCount)));
+    }
+
+    // A single, non-self-matching feedTelnet() must still work normally and not be
+    // flagged as a loop.
+    void test_normalFeedTelnetIsUnaffected()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        host->mEchoLuaErrors = true;
+
+        host->mTelnet.disconnectIt();
+        QTRY_COMPARE(host->mTelnet.getConnectionState(), QAbstractSocket::UnconnectedState);
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("normalTelnetCount = 0\n"
+                                                               "tempRegexTrigger('^hello$', [[normalTelnetCount = normalTelnetCount + 1]])\n"
+                                                               "feedTelnet('hello\\n')\n"
+                                                               "echo('NORMALTELNETCOUNT='..normalTelnetCount..'\\n')\n"));
+
+        QCOMPARE(host->mTelnet.loopbackProcessingDepth(), 0);
+        QVERIFY2(!bufferContains(qsl("stuck in an endless loop")), "A normal feedTelnet() call must not be treated as a loop");
+        QVERIFY2(bufferContains(qsl("NORMALTELNETCOUNT=1")), "Expected the non-looping trigger to fire exactly once");
     }
 
     void cleanup()

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -75,13 +75,22 @@ private slots:
         host->mEchoLuaErrors = true;
 
         host->getLuaInterpreter()->compileAndExecuteScript(qsl("loopCount = 0\n"
-                                                               "tempRegexTrigger('^loopme$', [[loopCount = loopCount + 1; feedTriggers('loopme\\n')]])\n"
+                                                               "loopTriggerId = tempRegexTrigger('^loopme$', [[loopCount = loopCount + 1; feedTriggers('loopme\\n')]])\n"
                                                                "feedTriggers('loopme\\n')\n"));
 
         // The whole recursion runs synchronously inside the call above; if the
         // guard works we are back here (no crash) with everything unwound.
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
         QVERIFY2(bufferContains(qsl("stuck in an endless loop")), "Expected the feedTriggers loop-abort error in the console buffer");
+
+        // The abort message must name the offending trigger (a temp trigger's name
+        // is its id), proving the name-tracking guard actually identifies the culprit
+        // rather than silently falling back to the unnamed branch.
+        lua_State* L = host->getLuaInterpreter()->getLuaGlobalState();
+        lua_getglobal(L, "loopTriggerId");
+        const int loopTriggerId = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        QVERIFY2(bufferContains(qsl("trigger '%1'").arg(loopTriggerId)), "Expected the abort message to name the offending trigger by its id");
 
         // The trigger should have fired exactly up to the limit and no further.
         host->getLuaInterpreter()->compileAndExecuteScript(qsl("echo('LOOPCOUNT='..loopCount..'\\n')"));
@@ -151,15 +160,18 @@ private slots:
         }
     }
 
+    // Joins every physical buffer line and normalises whitespace before matching,
+    // so a long needle that the console word-wraps (with added indents) across
+    // lines is still found - a per-line scan would miss it depending on where the
+    // wrap lands, which shifts with the trigger id width and console geometry.
     bool bufferContains(const QString& needle)
     {
         auto console = mudlet::self()->getActiveHost()->mpConsole;
+        QString allText;
         for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
-            if (console->buffer.line(i).contains(needle)) {
-                return true;
-            }
+            allText.append(console->buffer.line(i)).append(QChar::Space);
         }
-        return false;
+        return allText.simplified().contains(needle);
     }
 
     void deleteProfileDirectory(const QString& profileName)

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -142,15 +142,16 @@ private slots:
         lua_pop(L, 1);
         QVERIFY2(bufferContains(qsl("trigger '%1'").arg(telnetLoopTriggerId)), "Expected the abort message to name the offending trigger by its id");
 
-        // Unlike the linear feedTriggers path, nested telnet processing re-posts the
-        // ancestors' not-yet-cleared lines (mMudData in cTelnet is shared across the
-        // nested calls), so the trigger fires more often than the depth limit - just
-        // check the loop was cut off to a small bounded count rather than running away.
+        // Exactly one abort for the whole loop: postData() detaches the pending data
+        // before posting, so the unwinding ancestor frames must not re-post the line
+        // and fire the trigger - and its abort error - all over again.
+        QCOMPARE(static_cast<int>(joinedBuffer().count(qsl("feedTelnet stopped to prevent a crash"))), 1);
+
+        // The trigger should have fired exactly up to the limit and no further.
         lua_getglobal(L, "telnetLoopCount");
         const int telnetLoopCount = static_cast<int>(lua_tointeger(L, -1));
         lua_pop(L, 1);
-        QVERIFY2(telnetLoopCount >= cTelnet::scmMaxLoopbackProcessingDepth && telnetLoopCount < 100,
-                 qPrintable(qsl("Expected the trigger to fire a small bounded number of times (>= %1, < 100), got %2").arg(cTelnet::scmMaxLoopbackProcessingDepth).arg(telnetLoopCount)));
+        QCOMPARE(telnetLoopCount, cTelnet::scmMaxLoopbackProcessingDepth);
     }
 
     // A single, non-self-matching feedTelnet() must still work normally and not be
@@ -223,15 +224,17 @@ private slots:
     // so a long needle that the console word-wraps (with added indents) across
     // lines is still found - a per-line scan would miss it depending on where the
     // wrap lands, which shifts with the trigger id width and console geometry.
-    bool bufferContains(const QString& needle)
+    QString joinedBuffer()
     {
         auto console = mudlet::self()->getActiveHost()->mpConsole;
         QString allText;
         for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
             allText.append(console->buffer.line(i)).append(QChar::Space);
         }
-        return allText.simplified().contains(needle);
+        return allText.simplified();
     }
+
+    bool bufferContains(const QString& needle) { return joinedBuffer().contains(needle); }
 
     void deleteProfileDirectory(const QString& profileName)
     {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Abort with a Lua error (naming the trigger) when trigger processing recurses past a depth limit, instead of overflowing the stack. Covers both `feedTriggers()` and `feedTelnet()` loops, each with a limit sized to its stack usage.

#### Motivation for adding to Mudlet
A trigger whose action calls `feedTriggers()` with text that re-matches it recurses the C++ stack until Mudlet hard-crashes (Sentry `fbda193d`, `EXCEPTION_STACK_OVERFLOW`); this turns that into a clear, recoverable script error. Review found `feedTelnet()` crashes the same way, so it gets the same treatment.

#### Other info (issues closed, discussion etc)
Crash seen on Windows in Sentry. The same loop on Linux/macOS only reaches Lua's own `C stack overflow` guard (~200 nested C calls) - cryptic, but no crash; Windows' smaller ~1 MB stack dies first. The fix's depth limit (50) trips before either, so every platform gets the same clear, named error.

`feedTelnet()` needs a much lower limit (5): each nested telnet processing level holds ~100KB of stack buffers, so a 1MB stack dies after ~8 levels. Fixing this also surfaced a reentrancy bug where nested `feedTelnet()` re-posted the ancestors' pending `mMudData`, duplicating output lines and abort errors; `postData()` now detaches the data before posting.

**Test case:**
1. New regex trigger: pattern `^loopme$`, script `feedTriggers("loopme\n")`.
2. Run `feedTriggers("loopme\n")`.
3. Before: crash (Windows) / `<C stack overflow>` (Linux). After: it stops with an error naming the trigger and stays running.
4. Same with `feedTelnet("loopme\n")` in the trigger and prompt (on a disconnected profile): stops with a single error instead of crashing.