### PR TITLE
Fix console text not redrawing after resizing the window

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -282,6 +282,8 @@ void TTextEdit::updateScreenView()
         mBgColor = mpHost->mBgColor;
         mFgColor = mpHost->mFgColor;
     }
+    const int oldScreenWidth = mScreenWidth;
+    const int oldScreenHeight = mScreenHeight;
     mScreenHeight = visibleRegion().boundingRect().height() / mFontHeight;
     if (!mIsLowerPane) {
         updateScrollBar(mpBuffer->mCursorY);
@@ -298,6 +300,15 @@ void TTextEdit::updateScreenView()
         }
     } else {
         mScreenWidth = currentScreenWidth;
+    }
+    // When the pane dimensions change the cached mScreenMap pixmap no longer
+    // matches the current geometry. A subsequent partial-region repaint would
+    // otherwise reuse that stale cache (see drawForeground) and leave newly
+    // revealed columns/rows unpainted - e.g. growing the pane horizontally
+    // after it has been shrunk. Force a full repaint so the whole pane is
+    // re-rendered and the cache is rebuilt at the new size.
+    if (mScreenWidth != oldScreenWidth || mScreenHeight != oldScreenHeight) {
+        forceUpdate();
     }
     mOldScrollPos = mpBuffer->getLastLineNumber();
 }
@@ -1172,7 +1183,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
         mScrollVector = 0;
         noScroll = true;
     }
-    if ((r.height() < rect().height()) && (lineOffset > 0)) {
+    if ((r.height() < rect().height()) && (lineOffset > 0) && (mScreenWidth * mFontWidth * dpr <= mScreenMap.width()) && (mScreenHeight * mFontHeight * dpr <= mScreenMap.height())) {
         p.drawPixmap(0, 0, mScreenMap);
         reusedCachedScreenContent = true;
         from = y_top;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When the main console has scrolled past its first page, shrinking the window
horizontally and then widening it again left the re-exposed text blank until
you clicked in the console. The console now always repaints fully when its
pane changes size.

#### Motivation for adding to Mudlet
Reproducible on Linux (both the AppImage and a self-built Mudlet): after a
page of output, shrink the window horizontally so text clips off, then grow it
back — the clipped text doesn't return until a click forces a redraw.

Root cause: `TTextEdit::drawForeground()` caches the last rendered frame in
`mScreenMap`. Two of its three cache-reuse paths verify the cache still matches
the current pane width before reusing it; the partial-height path did not, so
after the pane grew it filled the newly exposed columns from a narrower, stale
cache. Fix:
- `updateScreenView()` forces a full repaint whenever the pane's width or
  height changes.
- the partial-height reuse path now carries the same `mScreenMap` size guard
  the other two paths already use.

#### Other info (issues closed, discussion etc)
Tested on Linux / Wayland (running via the X11/xcb platform plugin).
AI-assisted — see the `Assisted-by` trailer on the commit.
