### PR TITLE
Fix: prevent bogus exit locks from Lua API

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2016, 2018-2023, 2025 by Stephen Lyons             *
+ *   Copyright (C) 2013-2016, 2018-2023, 2025-2026 by Stephen Lyons        *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
@@ -883,6 +883,7 @@ private:
     bool loadLuaModule(
             QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State*);
+    static std::pair<int, QString> roomExitDir(const char*, lua_State*, const int);
 
 
     const int LUA_FUNCTION_MAX_ARGS = 50;

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2022, 2025 by Stephen Lyons                        *
+ *   Copyright (C) 2013-2022, 2025-2026 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
@@ -85,6 +85,33 @@ static bool isMain(const QString& name)
         return true;
     }
     return false;
+}
+
+/* Helper to validate a real room exit direction - could, perhaps, be extended
+ * to handle translated exit directions...*/
+std::pair<int, QString> TLuaInterpreter::roomExitDir(const char* fname, lua_State* lState, const int index)
+{
+    if (lua_isnumber(lState, index)) {
+        int dirCode = lua_tonumber(lState, index);
+        if (dirCode < DIR_NORTH && dirCode > DIR_OUT) {
+            return {0, qsl("direction %1 as a number, is not a valid value").arg(dirCode)};
+        }
+        return {dirCode, QString()};
+    }
+
+    if (lua_isstring(lState, index)) {
+        const QString dirText = lua_tostring(lState, index);
+        int dirCode = dirToNumber(lState, index);
+        if (!dirCode) {
+            return {0, qsl("direction '%1' as a string, is not a valid value").arg(dirText)};
+        }
+        return {dirCode, QString()};
+    }
+
+    lua_pushfstring(lState, "%s: bad argument #%d type (exit direction as number or string expected, got %s!)",
+                   fname, index, luaL_typename(lState, index));
+    lua_error(lState);
+    Q_UNREACHABLE();
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomLines
@@ -1649,16 +1676,15 @@ int TLuaInterpreter::getDoors(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubs
 int TLuaInterpreter::getExitStubs(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    const auto& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
-
-    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) {
-        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
+        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
     }
     QList<int> const stubs = pR->exitStubs;
     lua_newtable(L);
@@ -1673,16 +1699,16 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubs1
 int TLuaInterpreter::getExitStubs1(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    const auto& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
 
-    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) {
-        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
+        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
     }
     QList<int> const stubs = pR->exitStubs;
     lua_newtable(L);
@@ -1697,18 +1723,17 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitStubsNames
 int TLuaInterpreter::getExitStubsNames(lua_State* L)
 {
-    const QStringList stubmap = {"north", "northeast", "northwest", "east", "west", "south", "southeast", "southwest", "up", "down", "in", "out", "other"};
-
-    const Host& host = getHostFromLua(L);
+    const auto& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
-    const int roomId = getVerifiedInt(L, __func__, 1, "roomID");
+    const QStringList stubmap = {"north", "northeast", "northwest", "east", "west", "south", "southeast", "southwest", "up", "down", "in", "out", "other"};
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
 
-    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
     if (!pR) {
-        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomId));
+        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
     }
     QList<int> const stubs = pR->exitStubs;
     lua_newtable(L);
@@ -2539,21 +2564,25 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasExitLock
 int TLuaInterpreter::hasExitLock(lua_State* L)
 {
-    const int id = getVerifiedInt(L, __func__, 1, "roomID");
-
-    const int dir = dirToNumber(L, 2);
+    const auto& host = getHostFromLua(L);
+    if (!host.mpMap || !host.mpMap->mpRoomDB) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
+    }
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
+    if (!pR) {
+        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
+    }
+    const auto [dir, message] = roomExitDir(__func__, L, 2);
     if (!dir) {
-        lua_pushfstring(L, "hasExitLock: bad argument #2 type (direction as number or string expected, got %s!)");
-        return lua_error(L);
+        return warnArgumentValue(L, __func__, message.toUtf8().constData());
+    }
+    if (!pR->hasExit(dir)) {
+        return warnArgumentValue(L, __func__, "there is not a real exit in that direction");
     }
 
-    const Host& host = getHostFromLua(L);
-    TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
-    if (pR) {
-        lua_pushboolean(L, pR->hasExitLock(dir));
-        return 1;
-    }
-    return 0;
+    lua_pushboolean(L, pR->hasExitLock(dir));
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hasSpecialExitLock
@@ -2689,25 +2718,26 @@ int TLuaInterpreter::loadMap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockExit
 int TLuaInterpreter::lockExit(lua_State* L)
 {
-    const int id = getVerifiedInt(L, __func__, 1, "roomID");
-
-    const int dir = dirToNumber(L, 2);
+    const auto& host = getHostFromLua(L);
+    if (!host.mpMap || !host.mpMap->mpRoomDB) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
+    }
+    const int roomID = getVerifiedInt(L, __func__, 1, "roomID");
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
+    if (!pR) {
+        return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(roomID));
+    }
+    const auto [dir, message] = roomExitDir(__func__, L, 2);
     if (!dir) {
-        lua_pushfstring(L, "lockExit: bad argument #2 type (direction as number or string expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
+        return warnArgumentValue(L, __func__, message.toUtf8().constData());
     }
-
-    const bool b = getVerifiedBool(L, __func__, 3, "lockIfTrue");
-
-    const Host& host = getHostFromLua(L);
-    TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
-    if (pR) {
-        pR->setExitLock(dir, b);
-        host.mpMap->setUnsaved(__func__);
-        host.mpMap->updateArea(pR->getArea());
-        host.mpMap->mMapGraphNeedsUpdate = true;
+    if (!pR->hasExit(dir)) {
+        return warnArgumentValue(L, __func__, "there is not a real exit in that direction");
     }
-    return 0;
+    const bool state = getVerifiedBool(L, __func__, 3, "set/reset");
+
+    lua_pushboolean(L, pR->setExitLock(dir, state));
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#lockRoom

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -93,7 +93,7 @@ std::pair<int, QString> TLuaInterpreter::roomExitDir(const char* fname, lua_Stat
 {
     if (lua_isnumber(lState, index)) {
         int dirCode = lua_tonumber(lState, index);
-        if (dirCode < DIR_NORTH && dirCode > DIR_OUT) {
+        if (dirCode < DIR_NORTH || dirCode > DIR_OUT) {
             return {0, qsl("direction %1 as a number, is not a valid value").arg(dirCode)};
         }
         return {dirCode, QString()};

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018, 2020-2021, 2023 by Stephen Lyons       *
+ *   Copyright (C) 2014-2016, 2018, 2020-2021, 2023, 2026 by Stephen Lyons *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2025 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
@@ -642,16 +642,27 @@ QHash<int, int> TRoom::getExits() const
     return exitList;
 }
 
-void TRoom::setExitLock(int exit, bool state)
+bool TRoom::setExitLock(int exit, bool state)
 {
+    bool changed = false;
     if (state) {
         if ((!exitLocks.contains(exit)) && (exit >= DIR_NORTH && exit <= DIR_OUT)) {
             exitLocks.push_back(exit);
+            changed = true;
         }
     } else {
-        exitLocks.removeAll(exit);
+        if (exit >= DIR_NORTH && exit <= DIR_OUT) {
+            changed = exitLocks.removeAll(exit);
+        }
     }
-    mpRoomDB->mpMap->setUnsaved(__func__);
+
+    if (mpRoomDB && mpRoomDB->mpMap && changed) {
+        mpRoomDB->mpMap->setUnsaved(__func__);
+        mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
+        mpRoomDB->mpMap->updateArea(area);
+    }
+
+    return changed;
 }
 
 bool TRoom::setSpecialExitLock(const QString& cmd, const bool doLock)

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2015, 2018, 2021 by Stephen Lyons                  *
+ *   Copyright (C) 2014-2015, 2018, 2021, 2026 by Stephen Lyons            *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -52,7 +52,7 @@ public:
     QHash<int, int> getExits() const;
     bool hasExit(const int) const;
     void setWeight(int);
-    void setExitLock(const int, const bool);
+    bool setExitLock(const int, const bool);
     bool setSpecialExitLock(const QString&, const bool);
     bool hasExitLock(const int to) const;
     bool hasSpecialExitLock(const QString&) const;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Apply the same constraints in the Lua to the `lockExit(...)` function as in the Map GUI - so that it is not possible to lock a stub, or a normal exit direction when there is not a real exit in that direction.

#### Motivation for adding to Mudlet
Closes #9339 but in a manner contrary to the OP expectations.

#### Other info (issues closed, discussion etc)
This is a mutually exclusive alternative to #9352 - that attempts to allow a lock against being used for speed-walking for a stub exit via the map GUI even though this is logically impossible. {That one is currently also incomplete in that it does not revise the map auditing code to allow for the nonsense and it may also not be enabling/disabled the "No route" control correctly either!)

This adds a lua helper function that allows a Lua API function that requires a normal exit direction to better handle both numeric and string arguments. It is intended to a "boilerplate" chunk of code to be used as follows:
```cpp
    const auto [dir, message] = roomExitDir(__func__, L, index);
    if (!dir) {
        return warnArgumentValue(L, __func__, message.toUtf8().constData());
    }
```

where `index` is the Lua function argument to consider. `roomExitDir(...)` will not `return` but instead do the usual `setjmp`/`longjmp` via the `lua_error(lua_State*)` for the unhandled *type* of arguement case. I intend to work it into more functions in the future. It also now returns `true` if the exit was successfully locked/unlocked (or `false` if it worked but no change was actually made).

This PR also renamed some room id variables into a standardised `roomID` form for some related funtions - again I hope to unify this across more in the future.