### PR TITLE
Add: sign in to supported games using your browser (e.g. Google, Discord, or the game's own account)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ set(mudlet_SRCS
     mudlet.cpp
     MudletInstanceCoordinator.cpp
     MxpTag.cpp
+    OAuthClientFlow.cpp
     PackageItemDelegate.cpp
     PanInteractionHandler.cpp
     RoomContextMenuHandler.cpp
@@ -330,6 +331,7 @@ set(mudlet_HDRS
     mudlet.h
     MudletInstanceCoordinator.h
     MxpTag.h
+    OAuthClientFlow.h
     PackageItemDelegate.h
     PanInteractionHandler.h
     RoomContextMenuHandler.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -650,6 +650,9 @@ add_library(${LIB_MUDLET_TARGET} STATIC
 # * Produce qDebug() messages about undo/redo operations in the trigger editor,
 #   including command execution, stack operations, and edbee text undo integration:
 # target_compile_definitions(${LIB_MUDLET_TARGET} PRIVATE DEBUG_UNDO_REDO)
+#
+# * Produce qDebug() messages about the GMCP Char.Login authentication flow:
+# target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC DEBUG_GMCP_AUTHENTICATION)
 
 # target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC DEBUG_PLAYER_ICON_CONTROLS)
 

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -21,9 +21,21 @@
 #include "GMCPAuthenticator.h"
 
 #include "Host.h"
+#include "CredentialManager.h"
 #include "SecureStringUtils.h"
 #include "ctelnet.h"
+#include "mudlet.h"
+#include <QAccessible>
+#include <QCheckBox>
+#include <QComboBox>
 #include <QDebug>
+#include <QDesktopServices>
+#include <QDialogButtonBox>
+#include <QHash>
+#include <QLabel>
+#include <QPointer>
+#include <QUrl>
+#include <QVBoxLayout>
 
 GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 : mpHost(pHost)
@@ -45,11 +57,29 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     }
     auto jsonObj = jsonDoc.object();
 
+    mSupportedAuthTypes.clear();
     if (jsonObj.contains("type")) {
         QJsonArray typesArray = jsonObj["type"].toArray();
         for (const auto& type : std::as_const(typesArray)) {
             mSupportedAuthTypes.append(type.toString());
         }
+    }
+
+    mOAuthProviders.clear();
+    if (jsonObj.contains("providers")) {
+        const QJsonArray providersArray = jsonObj["providers"].toArray();
+        for (const auto& provider : std::as_const(providersArray)) {
+            mOAuthProviders.append(provider.toString());
+        }
+    }
+
+    // Remember (persistently) that this game presents a Char.Login sign-in choice, i.e. it offers both
+    // OAuth and password-credentials. This gates the profile's "always use character name and password"
+    // preference so that option is only ever shown for games that actually use this flow. It is sticky:
+    // once seen it stays set so the preference (and its undo) remains available even if a later
+    // connection advertises fewer methods.
+    if (mSupportedAuthTypes.contains(qsl("oauth")) && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
+        mpHost->mSeenCharLoginSignInChoice = true;
     }
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
@@ -99,6 +129,220 @@ void GMCPAuthenticator::sendCredentials()
 }
 
 
+void GMCPAuthenticator::promptForOAuthProvider()
+{
+    //: Title of the dialog asking which provider to use for a web/OAuth sign-in.
+    const QString title = tr("Choose sign-in provider");
+    //: Label prompting the user to pick a provider to sign in with.
+    const QString label = tr("Sign in with:");
+
+    // Server providers arrive as lowercase ids (e.g. "github"); show human-readable labels so screen
+    // readers announce them clearly, while keeping a map back to the id we must send over the wire.
+    static const QHash<QString, QString> brandNames{
+            {qsl("apple"), qsl("Apple")},
+            {qsl("discord"), qsl("Discord")},
+            {qsl("github"), qsl("GitHub")},
+            {qsl("google"), qsl("Google")},
+            {qsl("microsoft"), qsl("Microsoft")},
+            {qsl("slack"), qsl("Slack")},
+            {qsl("twitch"), qsl("Twitch")},
+            {qsl("x"), qsl("X")},
+    };
+
+    auto* dialog = new QDialog(mudlet::self());
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setWindowModality(Qt::WindowModal);
+    dialog->setWindowTitle(title);
+
+    auto* layout = new QVBoxLayout(dialog);
+    auto* promptLabel = new QLabel(label, dialog);
+    layout->addWidget(promptLabel);
+
+    auto* combo = new QComboBox(dialog);
+    promptLabel->setBuddy(combo);
+    for (const auto& id : std::as_const(mOAuthProviders)) {
+        QString display = brandNames.value(id.toLower());
+        if (display.isEmpty()) {
+            display = id;
+            if (!display.isEmpty()) {
+                display[0] = display[0].toUpper();
+            }
+        }
+        combo->addItem(display, id);
+    }
+
+    // When the server also accepts classic login, offer it in the same picker beneath the providers so a
+    // player with a traditional character name and password can pick it instead of an external provider.
+    if (mSupportedAuthTypes.contains(qsl("password-credentials")) && combo->count() > 0) {
+        combo->insertSeparator(combo->count());
+        //: Provider-picker entry for signing in with a game-native character name and password instead of an external provider.
+        combo->addItem(tr("Character name and password"), qsl("password-credentials"));
+    }
+    layout->addWidget(combo);
+
+    //: Checkbox letting the user stay signed in on this device for future connections.
+    auto* rememberMe = new QCheckBox(tr("Remember me on this device"), dialog);
+    layout->addWidget(rememberMe);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, dialog);
+    layout->addWidget(buttons);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
+
+    QObject::connect(dialog, &QDialog::accepted, dialog, [this, combo, rememberMe]() {
+        const QString choice = combo->currentData().toString();
+        if (choice.isEmpty()) {
+            return;
+        }
+        if (choice == qsl("password-credentials")) {
+            // "Remember me" here means "always sign in this way": persist the choice so future connects
+            // skip this picker entirely (see selectAuthMethod). Classic login never mints a reconnect
+            // token, so drop any previously stored one.
+            if (rememberMe->isChecked()) {
+                mpHost->mUseCharacterNamePasswordLogin = true;
+                discardReconnectToken();
+            }
+            sendCredentials();
+            return;
+        }
+        mTokenPersistEnabled = rememberMe->isChecked();
+        sendOAuth(choice);
+    });
+    QObject::connect(dialog, &QDialog::rejected, mpHost, [this]() {
+        mpHost->mTelnet.setDontReconnect(true);
+        //: Shown when the user dismisses the provider-selection dialog instead of signing in.
+        mpHost->postMessage(tr("[ INFO ]  - Sign-in cancelled."));
+    });
+    dialog->open();
+}
+
+void GMCPAuthenticator::sendOAuth(const QString& provider)
+{
+    QJsonObject payload;
+    payload[qsl("provider")] = provider;
+    QString gmcpMessage = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+
+    std::string output;
+    output += TN_IAC;
+    output += TN_SB;
+    output += OPT_GMCP;
+    output += "Char.Login.OAuth ";
+    output += mpHost->mTelnet.encodeAndCookBytes(gmcpMessage.toStdString());
+    output += TN_IAC;
+    output += TN_SE;
+
+    mpHost->mTelnet.socketOutRaw(output);
+
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+    qDebug() << "Sent GMCP OAuth provider:" << provider;
+#endif
+}
+
+void GMCPAuthenticator::sendReconnect(const QString& account, const QString& token)
+{
+    QJsonObject payload;
+    payload[qsl("account")] = account;
+    payload[qsl("token")] = token;
+    QString gmcpMessage = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+    payload = QJsonObject();
+
+    std::string output;
+    output += TN_IAC;
+    output += TN_SB;
+    output += OPT_GMCP;
+    output += "Char.Login.Reconnect ";
+    output += mpHost->mTelnet.encodeAndCookBytes(gmcpMessage.toStdString());
+    output += TN_IAC;
+    output += TN_SE;
+
+    mpHost->mTelnet.socketOutRaw(output);
+
+    // The reconnect token is a bearer secret, so scrub our copy of the message once it is sent.
+    SecureStringUtils::secureStringClear(gmcpMessage);
+
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+    qDebug() << "Sent GMCP reconnect for account:" << account;
+#endif
+}
+
+void GMCPAuthenticator::storeReconnectToken(const QString& account, const QString& token)
+{
+    QJsonObject obj;
+    obj[qsl("account")] = account;
+    obj[qsl("token")] = token;
+    const QString payload = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+
+    QPointer<CredentialManager> credentialManager = new CredentialManager();
+    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [credentialManager](bool success, const QString& errorMessage) {
+        if (!success) {
+            qWarning().noquote() << "GMCP Char.Login.Token - failed to store reconnect token:" << errorMessage;
+        }
+        if (credentialManager) {
+            credentialManager->deleteLater();
+        }
+    });
+}
+
+void GMCPAuthenticator::discardReconnectToken()
+{
+    mTokenPersistEnabled = false;
+
+    QPointer<CredentialManager> credentialManager = new CredentialManager();
+    credentialManager->removePassword(mpHost->getName(), qsl("reconnect"), [credentialManager](bool, const QString&) {
+        if (credentialManager) {
+            credentialManager->deleteLater();
+        }
+    });
+}
+
+void GMCPAuthenticator::handleAuthUrl(const QString& packageMessage, const QString& data)
+{
+    QJsonParseError parseError;
+    auto doc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString() << " at offset " << parseError.offset << ". Received data: \"" << data
+                                       << "\"";
+        return;
+    }
+    if (!doc.isObject()) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got " << (doc.isArray() ? "array" : doc.isNull() ? "null" : "unknown type") << ".";
+        return;
+    }
+
+    const auto url = doc.object()[qsl("url")].toString();
+    if (url.isEmpty()) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Missing 'url' field.";
+        return;
+    }
+
+    // The URL arrives unauthenticated over the wire and is opened without a user click, so only hand
+    // http(s) links to the OS to avoid launching arbitrary scheme handlers (file:, javascript:, etc.).
+    const QUrl parsedUrl(url);
+    if (!parsedUrl.isValid() || (parsedUrl.scheme() != qsl("http") && parsedUrl.scheme() != qsl("https"))) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Refusing to open sign-in link with unsupported scheme: \"" << url << "\"";
+        mpHost->postMessage(tr("[ WARN ]  - The game sent an invalid sign-in link; cannot continue."));
+        return;
+    }
+
+    if (!QDesktopServices::openUrl(parsedUrl)) {
+        //: %1 is the sign-in web address the user should open manually in their browser.
+        mpHost->postMessage(tr("[ WARN ]  - Could not open your browser. Open this link manually to sign in: %1").arg(url));
+        return;
+    }
+
+    //: Shown after the user's browser is launched to complete an OAuth/web sign-in.
+    const QString message = tr("[ INFO ]  - Opening your browser to sign in. Complete the login there, then return here.");
+    mpHost->postMessage(message);
+
+    // The browser handoff happens with no focused control to announce it, so push an explicit
+    // announcement to assistive technology (VoiceOver/NVDA/Orca) instead of relying on the console.
+    if (auto* mainWindow = mudlet::self()) {
+        QAccessibleAnnouncementEvent announcement(mainWindow, message);
+        QAccessible::updateAccessibility(&announcement);
+    }
+}
+
+
 void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QString& data)
 {
     QJsonParseError parseError;
@@ -118,6 +362,26 @@ void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QS
     auto result = obj[qsl("success")];
     bool success = (result.isBool() && result.toBool()) || (result.isString() && result.toString() == "true");
     auto message = obj[qsl("message")].toString();
+
+    // A failed password-less reconnect is not a dead end: discard the stale token and fall back to the
+    // normal sign-in (browser pairing or credentials) instead of giving up on the connection.
+    if (mAwaitingReconnectResult) {
+        mAwaitingReconnectResult = false;
+        if (success) {
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+            qDebug() << "GMCP reconnect successful";
+#endif
+            return;
+        }
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+        qDebug() << "GMCP reconnect rejected, falling back:" << message;
+#endif
+        discardReconnectToken();
+        //: Shown when a saved password-less sign-in is no longer accepted and the user must sign in again.
+        mpHost->postMessage(tr("[ INFO ]  - Your saved sign-in has expired; please sign in again."));
+        selectAuthMethod();
+        return;
+    }
 
     if (success) {
 #if defined(DEBUG_GMCP_AUTHENTICATION)
@@ -143,14 +407,22 @@ void GMCPAuthenticator::handleAuthGMCP(const QString& packageMessage, const QStr
     if (packageMessage == qsl("Char.Login.Default")) {
         saveSupportsSet(packageMessage, data);
 
-        if (mSupportedAuthTypes.contains(qsl("password-credentials"))) {
-            mpHost->mTelnet.cancelLoginTimers();
-            sendCredentials();
-        } else {
-#if defined(DEBUG_GMCP_AUTHENTICATION)
-            qDebug() << "Server does not support credentials authentication and we don't support any other";
-#endif
-        }
+        // A fresh Char.Login.Default starts a new sign-in; reset the per-connection token state before
+        // deciding how to authenticate.
+        mAwaitingReconnectResult = false;
+        mTokenPersistEnabled = false;
+
+        attemptReconnect();
+        return;
+    }
+
+    if (packageMessage == qsl("Char.Login.URL")) {
+        handleAuthUrl(packageMessage, data);
+        return;
+    }
+
+    if (packageMessage == qsl("Char.Login.Token")) {
+        handleAuthToken(packageMessage, data);
         return;
     }
 
@@ -162,4 +434,135 @@ void GMCPAuthenticator::handleAuthGMCP(const QString& packageMessage, const QStr
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Unknown GMCP auth package:" << packageMessage;
 #endif
+}
+
+void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QString& data)
+{
+    QJsonParseError parseError;
+    auto doc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString() << " at offset " << parseError.offset << ". Received data: \"" << data
+                                       << "\"";
+        return;
+    }
+    if (!doc.isObject()) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Expected JSON object but got " << (doc.isArray() ? "array" : doc.isNull() ? "null" : "unknown type") << ".";
+        return;
+    }
+
+    const auto obj = doc.object();
+    const auto account = obj[qsl("account")].toString();
+    const auto token = obj[qsl("token")].toString();
+    if (account.isEmpty() || token.isEmpty()) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Missing 'account' or 'token' field.";
+        return;
+    }
+
+    // Only persist when the user opted into "remember me" this sign-in, or when we are rotating a token
+    // that was already remembered (a saved token was loaded at connect). Otherwise drop it on the floor.
+    if (!mTokenPersistEnabled) {
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+        qDebug() << "GMCP reconnect token discarded - persistence not enabled for account:" << account;
+#endif
+        return;
+    }
+
+    storeReconnectToken(account, token);
+
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+    qDebug() << "Stored GMCP reconnect token for account:" << account;
+#endif
+}
+
+void GMCPAuthenticator::attemptReconnect()
+{
+    mpHost->mTelnet.cancelLoginTimers();
+
+    // A standing "always use character name and password" preference takes precedence over any saved
+    // OAuth reconnect token: hand off to method selection, which will send the credentials.
+    if (mpHost->mUseCharacterNamePasswordLogin && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
+        selectAuthMethod();
+        return;
+    }
+
+    // Reconnect tokens are part of the version 2 OAuth capability; if the server is not offering oauth
+    // there is nothing to reconnect against, so go straight to the normal method selection.
+    if (!mSupportedAuthTypes.contains(qsl("oauth"))) {
+        selectAuthMethod();
+        return;
+    }
+
+    QPointer<Host> safeHost = mpHost;
+    QPointer<CredentialManager> credentialManager = new CredentialManager();
+    credentialManager->retrievePassword(mpHost->getName(), qsl("reconnect"), [this, safeHost, credentialManager](bool success, const QString& value, const QString&) {
+        if (credentialManager) {
+            credentialManager->deleteLater();
+        }
+        // The Host (which owns this authenticator) may have gone away while the keychain read was in
+        // flight; bail out without touching any members if so.
+        if (!safeHost) {
+            return;
+        }
+
+        if (success && !value.isEmpty()) {
+            const auto doc = QJsonDocument::fromJson(value.toUtf8());
+            if (doc.isObject()) {
+                const auto account = doc.object()[qsl("account")].toString();
+                const auto token = doc.object()[qsl("token")].toString();
+                if (!account.isEmpty() && !token.isEmpty()) {
+                    // A remembered token implies the user already opted in, so keep persistence enabled
+                    // to capture any rotated token the server sends back.
+                    mTokenPersistEnabled = true;
+                    mAwaitingReconnectResult = true;
+                    sendReconnect(account, token);
+                    return;
+                }
+            }
+        }
+
+        selectAuthMethod();
+    });
+}
+
+void GMCPAuthenticator::selectAuthMethod()
+{
+    const bool haveCredentials = !mpHost->getLogin().isEmpty() && !mpHost->getPass().isEmpty();
+
+    // If the user chose to always sign in with a character name and password, honour that whenever the
+    // server offers it, skipping the provider picker regardless of the server's preferred order.
+    if (mpHost->mUseCharacterNamePasswordLogin && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
+        mpHost->mTelnet.cancelLoginTimers();
+        sendCredentials();
+        return;
+    }
+
+    // mSupportedAuthTypes preserves the server's advertised order (see saveSupportsSet), so the
+    // first method we can satisfy is the server's most-preferred one.
+    for (const auto& type : std::as_const(mSupportedAuthTypes)) {
+        if (type == qsl("oauth")) {
+            // We can only drive the server-driven flow when the server told us which providers it
+            // accepts; without that list fall through to the next advertised method.
+            if (!mOAuthProviders.isEmpty()) {
+                mpHost->mTelnet.cancelLoginTimers();
+                promptForOAuthProvider();
+                return;
+            }
+        } else if (type == qsl("password-credentials") && haveCredentials) {
+            mpHost->mTelnet.cancelLoginTimers();
+            sendCredentials();
+            return;
+        }
+    }
+
+    // The loop only sends password-credentials when we have a stored login/password. If the server
+    // offers it but we have none, send anyway so the server can prompt for or reject the credentials.
+    if (mSupportedAuthTypes.contains(qsl("password-credentials"))) {
+        mpHost->mTelnet.cancelLoginTimers();
+        sendCredentials();
+    } else {
+        // Nothing the server offered is satisfiable; tell the user rather than stalling silently.
+        mpHost->mTelnet.cancelLoginTimers();
+        mpHost->mTelnet.setDontReconnect(true);
+        mpHost->postMessage(tr("[ WARN ]  - The game offered no sign-in method this client supports."));
+    }
 }

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -59,6 +59,9 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     // act only on the current input, never on outdated capabilities.
     mSupportedAuthTypes.clear();
     mOAuthProviders.clear();
+    // Reset to the version 1 default; a server that speaks version 2 or higher reports the negotiated
+    // version below, and its absence (a version 1 server) leaves us correctly acting as version 1.
+    mNegotiatedVersion = 1;
 
     QJsonParseError parseError;
     auto jsonDoc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
@@ -72,6 +75,13 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
         return;
     }
     auto jsonObj = jsonDoc.object();
+
+    // The server reports the negotiated Char.Login version here; treat a missing, non-numeric, or
+    // out-of-range value as version 1 (per the spec, the version is a positive, non-zero integer).
+    if (jsonObj.contains("version")) {
+        const int reportedVersion = jsonObj["version"].toInt(1);
+        mNegotiatedVersion = (reportedVersion >= 1) ? reportedVersion : 1;
+    }
 
     if (jsonObj.contains("type")) {
         QJsonArray typesArray = jsonObj["type"].toArray();
@@ -125,6 +135,9 @@ void GMCPAuthenticator::sendCredentials()
     if (!character.isEmpty() && !password.isEmpty()) {
         credentials["account"] = character;
         credentials["password"] = password;
+        // Echo the negotiated version so the server can confirm both ends agree. The empty-object
+        // fallback below is left untouched: {} is the deliberate "fall back to interactive login" signal.
+        credentials["version"] = mNegotiatedVersion;
     }
 
     QJsonDocument doc(credentials);
@@ -267,6 +280,8 @@ void GMCPAuthenticator::sendOAuth(const QString& provider)
 {
     QJsonObject payload;
     payload[qsl("provider")] = provider;
+    // Echo the negotiated version so the server can confirm both ends agree.
+    payload[qsl("version")] = mNegotiatedVersion;
     QString gmcpMessage = QJsonDocument(payload).toJson(QJsonDocument::Compact);
 
     std::string output;
@@ -290,6 +305,8 @@ void GMCPAuthenticator::sendReconnect(const QString& account, const QString& tok
     QJsonObject payload;
     payload[qsl("account")] = account;
     payload[qsl("token")] = token;
+    // Echo the negotiated version so the server can confirm both ends agree.
+    payload[qsl("version")] = mNegotiatedVersion;
     QByteArray json = QJsonDocument(payload).toJson(QJsonDocument::Compact);
     QString gmcpMessage = QString::fromUtf8(json);
     payload = QJsonObject();

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -300,7 +300,7 @@ void GMCPAuthenticator::sendOAuth(const QString& provider)
 #endif
 }
 
-void GMCPAuthenticator::sendReconnect(const QString& account, const QString& token)
+void GMCPAuthenticator::sendReconnect(const QString& account, QString token)
 {
     QJsonObject payload;
     payload[qsl("account")] = account;
@@ -328,8 +328,10 @@ void GMCPAuthenticator::sendReconnect(const QString& account, const QString& tok
 
     mpHost->mTelnet.socketOutRaw(output);
 
-    // The reconnect token is a bearer secret, so scrub every copy once it is sent: the JSON message, the
+    // The reconnect token is a bearer secret, so scrub every copy once it is sent: the token argument
+    // (taken by value and moved in from the caller, so we own the sole copy), the JSON message, the
     // plaintext and encoded payloads, and the assembled telnet frame, which also holds the (encoded) token.
+    SecureStringUtils::secureStringClear(token);
     SecureStringUtils::secureStringClear(gmcpMessage);
     SecureStringUtils::secureStdStringClear(plaintext);
     SecureStringUtils::secureStdStringClear(encoded);
@@ -340,7 +342,7 @@ void GMCPAuthenticator::sendReconnect(const QString& account, const QString& tok
 #endif
 }
 
-void GMCPAuthenticator::storeReconnectToken(const QString& account, const QString& token)
+void GMCPAuthenticator::storeReconnectToken(const QString& account, QString token)
 {
     QJsonObject obj;
     obj[qsl("account")] = account;
@@ -369,8 +371,10 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, const QStrin
         }
     });
 
-    // The token is a bearer secret; storePassword has already taken its own copy, so scrub ours.
+    // The token is a bearer secret; storePassword has already taken its own copy (inside payload), so
+    // scrub both our serialized payload and the caller-owned token argument we took by value.
     SecureStringUtils::secureStringClear(payload);
+    SecureStringUtils::secureStringClear(token);
 }
 
 void GMCPAuthenticator::discardReconnectToken()
@@ -561,7 +565,7 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
 
     const auto obj = doc.object();
     const auto account = obj[qsl("account")].toString();
-    const auto token = obj[qsl("token")].toString();
+    auto token = obj[qsl("token")].toString();
     if (account.isEmpty() || token.isEmpty()) {
         qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Missing 'account' or 'token' field.";
         return;
@@ -576,7 +580,8 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
         return;
     }
 
-    storeReconnectToken(account, token);
+    // Move the token in so storeReconnectToken owns the sole copy and can scrub it after persisting.
+    storeReconnectToken(account, std::move(token));
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Stored GMCP reconnect token for account:" << account;
@@ -626,13 +631,14 @@ void GMCPAuthenticator::attemptReconnect()
             const auto doc = QJsonDocument::fromJson(value.toUtf8());
             if (doc.isObject()) {
                 const auto account = doc.object()[qsl("account")].toString();
-                const auto token = doc.object()[qsl("token")].toString();
+                auto token = doc.object()[qsl("token")].toString();
                 if (!account.isEmpty() && !token.isEmpty()) {
                     // A remembered token implies the user already opted in, so keep persistence enabled
                     // to capture any rotated token the server sends back.
                     mTokenPersistEnabled = true;
                     mAwaitingReconnectResult = true;
-                    sendReconnect(account, token);
+                    // Move the token in so sendReconnect owns the sole copy and can scrub it after sending.
+                    sendReconnect(account, std::move(token));
                     return;
                 }
             }

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -59,6 +59,10 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     // act only on the current input, never on outdated capabilities.
     mSupportedAuthTypes.clear();
     mOAuthProviders.clear();
+    mOAuthDiscoveryUrl.clear();
+    mOAuthClientId.clear();
+    mOAuthScopes.clear();
+    mOAuthNonceRequired = false;
     // Reset to the version 1 default; a server that speaks version 2 or higher reports the negotiated
     // version below, and its absence (a version 1 server) leaves us correctly acting as version 1.
     mNegotiatedVersion = 1;
@@ -80,7 +84,9 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     // out-of-range value as version 1 (per the spec, the version is a positive, non-zero integer).
     if (jsonObj.contains("version")) {
         const int reportedVersion = jsonObj["version"].toInt(1);
-        mNegotiatedVersion = (reportedVersion >= 1) ? reportedVersion : 1;
+        // Clamp to the highest version this client implements: the negotiated version is
+        // min(client, server), so we never act on - or echo back - a version we do not understand.
+        mNegotiatedVersion = qBound(1, reportedVersion, 2);
     }
 
     if (jsonObj.contains("type")) {
@@ -111,6 +117,28 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
         }
     }
 
+    // The optional client-driven OAuth fields (the server is itself an OpenID Provider). Per the spec
+    // these are only meaningful over an encrypted transport - the flow ends in a Char.Login.AuthCode
+    // that carries the authorization code and PKCE verifier together, which must never travel in the
+    // clear - so on a cleartext connection ignore them even if a non-conformant server sends them,
+    // which transparently steers the sign-in to the server-driven flow.
+    if (mpHost->mTelnet.currentlySecure()) {
+        mOAuthDiscoveryUrl = jsonObj["location"].toString();
+        mOAuthClientId = jsonObj["client_id"].toString();
+        if (jsonObj.contains("scopes")) {
+            const QJsonArray scopesArray = jsonObj["scopes"].toArray();
+            for (const auto& scope : std::as_const(scopesArray)) {
+                const QString scopeName = scope.toString();
+                if (scopeName.isEmpty()) {
+                    qWarning().noquote().nospace() << "GMCP " << packageMessage << " - ignoring a malformed (non-string or empty) OAuth scope entry.";
+                    continue;
+                }
+                mOAuthScopes.append(scopeName);
+            }
+        }
+        mOAuthNonceRequired = jsonObj["nonce"].toBool();
+    }
+
     // Remember (persistently) that this game presents a Char.Login sign-in choice, i.e. it offers both
     // OAuth and password-credentials. This gates the profile's "always use character name and password"
     // preference so that option is only ever shown for games that actually use this flow. It is sticky:
@@ -123,6 +151,13 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Supported auth types:" << mSupportedAuthTypes;
 #endif
+}
+
+bool GMCPAuthenticator::clientDrivenOAuthAvailable() const
+{
+    // Both fields are only ever stored when the connection is encrypted (see saveSupportsSet), so
+    // their presence also means the transport is acceptable for Char.Login.AuthCode.
+    return mSupportedAuthTypes.contains(qsl("oauth")) && !mOAuthDiscoveryUrl.isEmpty() && !mOAuthClientId.isEmpty();
 }
 
 void GMCPAuthenticator::sendCredentials()

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -41,13 +41,22 @@
 GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 : mpHost(pHost)
 {
+    resetPerConnectionState();
+}
+
+void GMCPAuthenticator::resetPerConnectionState()
+{
+    // mReconnectRejected is deliberately not reset here: it is a one-shot latch consumed by
+    // attemptReconnect() on the very next connection, so it must survive the reconnect it triggers.
+    mAwaitingReconnectResult = false;
+    mTokenPersistEnabled = false;
 }
 
 void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QString& data)
 {
     // Clear the cached capabilities up front so a malformed frame (an early return below) cannot leave
-    // stale provider/auth lists from a previous connection in place - reconnect decisions must be based
-    // only on the current input, and must never send a saved token off outdated capabilities.
+    // stale provider/auth lists from a previous connection in place - later reconnect/auth decisions must
+    // act only on the current input, never on outdated capabilities.
     mSupportedAuthTypes.clear();
     mOAuthProviders.clear();
 
@@ -67,14 +76,28 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     if (jsonObj.contains("type")) {
         QJsonArray typesArray = jsonObj["type"].toArray();
         for (const auto& type : std::as_const(typesArray)) {
-            mSupportedAuthTypes.append(type.toString());
+            // A non-string or empty entry yields an empty QString; drop it so it cannot masquerade as a
+            // real method later (an all-empty list would otherwise slip past our isEmpty() guards).
+            const QString typeName = type.toString();
+            if (typeName.isEmpty()) {
+                qWarning().noquote().nospace() << "GMCP " << packageMessage << " - ignoring a malformed (non-string or empty) auth type entry.";
+                continue;
+            }
+            mSupportedAuthTypes.append(typeName);
         }
     }
 
     if (jsonObj.contains("providers")) {
         const QJsonArray providersArray = jsonObj["providers"].toArray();
         for (const auto& provider : std::as_const(providersArray)) {
-            mOAuthProviders.append(provider.toString());
+            // Skip empty/garbage ids so promptForOAuthProvider() never shows a blank picker row and
+            // mOAuthProviders.isEmpty() reliably means "no usable providers".
+            const QString providerId = provider.toString();
+            if (providerId.isEmpty()) {
+                qWarning().noquote().nospace() << "GMCP " << packageMessage << " - ignoring a malformed (non-string or empty) OAuth provider entry.";
+                continue;
+            }
+            mOAuthProviders.append(providerId);
         }
     }
 
@@ -84,7 +107,7 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     // once seen it stays set so the preference (and its undo) remains available even if a later
     // connection advertises fewer methods.
     if (mSupportedAuthTypes.contains(qsl("oauth")) && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
-        mpHost->mSeenCharLoginSignInChoice = true;
+        mpHost->markSeenCharLoginSignInChoice();
     }
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
@@ -119,7 +142,6 @@ void GMCPAuthenticator::sendCredentials()
     std::string plaintext = gmcpMessage.toStdString();
     std::string encoded = mpHost->mTelnet.encodeAndCookBytes(plaintext);
 
-    // Build and send the GMCP message
     std::string output;
     output += TN_IAC;
     output += TN_SB;
@@ -129,7 +151,6 @@ void GMCPAuthenticator::sendCredentials()
     output += TN_IAC;
     output += TN_SE;
 
-    // Send credentials to server
     mpHost->mTelnet.socketOutRaw(output);
 
     // Scrub every copy of the secret: the JSON message, the plaintext and encoded payloads, and the
@@ -212,6 +233,12 @@ void GMCPAuthenticator::promptForOAuthProvider()
     QObject::connect(dialog, &QDialog::accepted, mpHost, [this, combo, rememberMe]() {
         const QString choice = combo->currentData().toString();
         if (choice.isEmpty()) {
+            // The picker is only opened with usable entries, so an empty choice means something went
+            // wrong rather than a user decision; give feedback and a deterministic state instead of a
+            // silent no-op that leaves login stalled with the timers already cancelled.
+            mpHost->mTelnet.setDontReconnect(true);
+            //: Shown when the sign-in provider picker had no usable choice to act on.
+            mpHost->postMessage(tr("[ WARN ]  - No sign-in method was available to use."));
             return;
         }
         if (choice == qsl("password-credentials")) {
@@ -219,7 +246,7 @@ void GMCPAuthenticator::promptForOAuthProvider()
             // skip this picker entirely (see selectAuthMethod). Classic login never mints a reconnect
             // token, so drop any previously stored one.
             if (rememberMe->isChecked()) {
-                mpHost->mUseCharacterNamePasswordLogin = true;
+                mpHost->setUseCharacterNamePasswordLogin(true);
                 discardReconnectToken();
             }
             sendCredentials();
@@ -307,10 +334,18 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, const QStrin
     obj = QJsonObject();
     SecureStringUtils::secureByteArrayClear(json);
 
+    // One reconnect token per profile: the fixed "reconnect" key means signing a profile into a second
+    // account overwrites the first account's token. A stale-account token is simply rejected on the next
+    // connect and falls back to a fresh sign-in, so this is safe under the one-account-per-profile model.
+    QPointer<Host> safeHost = mpHost;
     QPointer<CredentialManager> credentialManager = new CredentialManager();
-    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [credentialManager](bool success, const QString& errorMessage) {
+    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [safeHost, credentialManager](bool success, const QString& errorMessage) {
         if (!success) {
             qWarning().noquote() << "GMCP Char.Login.Token - failed to store reconnect token:" << errorMessage;
+            if (safeHost) {
+                //: Shown when the user opted to stay signed in but saving the sign-in token failed, so they will have to sign in again next time.
+                safeHost->postMessage(tr("[ WARN ]  - Could not save your sign-in for next time; you may need to sign in again."));
+            }
         }
         if (credentialManager) {
             credentialManager->deleteLater();
@@ -326,7 +361,12 @@ void GMCPAuthenticator::discardReconnectToken()
     mTokenPersistEnabled = false;
 
     QPointer<CredentialManager> credentialManager = new CredentialManager();
-    credentialManager->removePassword(mpHost->getName(), qsl("reconnect"), [credentialManager](bool, const QString&) {
+    credentialManager->removePassword(mpHost->getName(), qsl("reconnect"), [credentialManager](bool success, const QString& errorMessage) {
+        // A failed removal leaves a now-invalid bearer token on disk, so make it visible rather than
+        // swallowing it - the security intent of this flow is to not keep stale tokens around.
+        if (!success) {
+            qWarning().noquote() << "GMCP Char.Login - failed to remove stored reconnect token:" << errorMessage;
+        }
         if (credentialManager) {
             credentialManager->deleteLater();
         }
@@ -358,6 +398,7 @@ void GMCPAuthenticator::handleAuthUrl(const QString& packageMessage, const QStri
     const QUrl parsedUrl(url);
     if (!parsedUrl.isValid() || (parsedUrl.scheme() != qsl("http") && parsedUrl.scheme() != qsl("https"))) {
         qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Refusing to open sign-in link with unsupported scheme: \"" << url << "\"";
+        //: Shown when the game sends a sign-in link with an unsupported or invalid address (not an http/https web link).
         mpHost->postMessage(tr("[ WARN ]  - The game sent an invalid sign-in link; cannot continue."));
         return;
     }
@@ -402,7 +443,7 @@ void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QS
     auto message = obj[qsl("message")].toString();
 
     // A failed password-less reconnect is not a dead end: discard the stale token and fall back to the
-    // normal sign-in (browser pairing or credentials) instead of giving up on the connection.
+    // normal sign-in (provider picker or credentials) instead of giving up on the connection.
     if (mAwaitingReconnectResult) {
         mAwaitingReconnectResult = false;
         if (success) {
@@ -459,8 +500,7 @@ void GMCPAuthenticator::handleAuthGMCP(const QString& packageMessage, const QStr
 
         // A fresh Char.Login.Default starts a new sign-in; reset the per-connection token state before
         // deciding how to authenticate.
-        mAwaitingReconnectResult = false;
-        mTokenPersistEnabled = false;
+        resetPerConnectionState();
 
         attemptReconnect();
         return;
@@ -541,7 +581,7 @@ void GMCPAuthenticator::attemptReconnect()
 
     // A standing "always use character name and password" preference takes precedence over any saved
     // OAuth reconnect token: hand off to method selection, which will send the credentials.
-    if (mpHost->mUseCharacterNamePasswordLogin && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
+    if (mpHost->useCharacterNamePasswordLogin() && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
         selectAuthMethod();
         return;
     }
@@ -591,7 +631,7 @@ void GMCPAuthenticator::selectAuthMethod()
 
     // If the user chose to always sign in with a character name and password, honour that whenever the
     // server offers it, skipping the provider picker regardless of the server's preferred order.
-    if (mpHost->mUseCharacterNamePasswordLogin && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
+    if (mpHost->useCharacterNamePasswordLogin() && mSupportedAuthTypes.contains(qsl("password-credentials"))) {
         mpHost->mTelnet.cancelLoginTimers();
         sendCredentials();
         return;
@@ -624,6 +664,7 @@ void GMCPAuthenticator::selectAuthMethod()
         // Nothing the server offered is satisfiable; tell the user rather than stalling silently.
         mpHost->mTelnet.cancelLoginTimers();
         mpHost->mTelnet.setDontReconnect(true);
+        //: Shown when none of the sign-in methods the game advertised can be used by this client.
         mpHost->postMessage(tr("[ WARN ]  - The game offered no sign-in method this client supports."));
     }
 }

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -34,6 +34,7 @@
 #include <QHash>
 #include <QLabel>
 #include <QPointer>
+#include <QTimer>
 #include <QUrl>
 #include <QVBoxLayout>
 
@@ -44,6 +45,12 @@ GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 
 void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QString& data)
 {
+    // Clear the cached capabilities up front so a malformed frame (an early return below) cannot leave
+    // stale provider/auth lists from a previous connection in place - reconnect decisions must be based
+    // only on the current input, and must never send a saved token off outdated capabilities.
+    mSupportedAuthTypes.clear();
+    mOAuthProviders.clear();
+
     QJsonParseError parseError;
     auto jsonDoc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError) {
@@ -57,7 +64,6 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
     }
     auto jsonObj = jsonDoc.object();
 
-    mSupportedAuthTypes.clear();
     if (jsonObj.contains("type")) {
         QJsonArray typesArray = jsonObj["type"].toArray();
         for (const auto& type : std::as_const(typesArray)) {
@@ -65,7 +71,6 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
         }
     }
 
-    mOAuthProviders.clear();
     if (jsonObj.contains("providers")) {
         const QJsonArray providersArray = jsonObj["providers"].toArray();
         for (const auto& provider : std::as_const(providersArray)) {
@@ -120,8 +125,13 @@ void GMCPAuthenticator::sendCredentials()
     // Send credentials to server
     mpHost->mTelnet.socketOutRaw(output);
 
-    // Clear message from memory
+    // Scrub both copies of the secret: the JSON message and the assembled telnet frame, which also holds
+    // the (encoded) password.
     SecureStringUtils::secureStringClear(gmcpMessage);
+    for (char& byte : output) {
+        byte = '\0';
+    }
+    output.clear();
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Sent GMCP credentials";
@@ -189,7 +199,11 @@ void GMCPAuthenticator::promptForOAuthProvider()
     QObject::connect(buttons, &QDialogButtonBox::accepted, dialog, &QDialog::accept);
     QObject::connect(buttons, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
 
-    QObject::connect(dialog, &QDialog::accepted, dialog, [this, combo, rememberMe]() {
+    // Bind to the Host lifetime (not the dialog's): the lambda dereferences mpHost, so if the Host and
+    // this authenticator are torn down while the picker is still open, the connection is dropped and the
+    // handler cannot run against freed state. combo/rememberMe are children of the dialog and are alive
+    // whenever accepted() fires.
+    QObject::connect(dialog, &QDialog::accepted, mpHost, [this, combo, rememberMe]() {
         const QString choice = combo->currentData().toString();
         if (choice.isEmpty()) {
             return;
@@ -257,8 +271,13 @@ void GMCPAuthenticator::sendReconnect(const QString& account, const QString& tok
 
     mpHost->mTelnet.socketOutRaw(output);
 
-    // The reconnect token is a bearer secret, so scrub our copy of the message once it is sent.
+    // The reconnect token is a bearer secret, so scrub both copies once it is sent: the JSON message and
+    // the assembled telnet frame, which also holds the (encoded) token.
     SecureStringUtils::secureStringClear(gmcpMessage);
+    for (char& byte : output) {
+        byte = '\0';
+    }
+    output.clear();
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Sent GMCP reconnect for account:" << account;
@@ -270,7 +289,9 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, const QStrin
     QJsonObject obj;
     obj[qsl("account")] = account;
     obj[qsl("token")] = token;
-    const QString payload = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+    QString payload = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+    // Release the JSON object that also holds the plaintext token.
+    obj = QJsonObject();
 
     QPointer<CredentialManager> credentialManager = new CredentialManager();
     credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [credentialManager](bool success, const QString& errorMessage) {
@@ -281,6 +302,9 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, const QStrin
             credentialManager->deleteLater();
         }
     });
+
+    // The token is a bearer secret; storePassword has already taken its own copy, so scrub ours.
+    SecureStringUtils::secureStringClear(payload);
 }
 
 void GMCPAuthenticator::discardReconnectToken()
@@ -374,12 +398,24 @@ void GMCPAuthenticator::handleAuthResult(const QString& packageMessage, const QS
             return;
         }
 #if defined(DEBUG_GMCP_AUTHENTICATION)
-        qDebug() << "GMCP reconnect rejected, falling back:" << message;
+        qDebug() << "GMCP reconnect rejected, reconnecting for a fresh sign-in:" << message;
 #endif
+        // The saved token is no good. Servers commonly drop the connection right after rejecting a
+        // reconnect (and Mudlet will not auto-reconnect from such a fast rejection), which would leave the
+        // in-session sign-in picker writing into a dead socket - nothing happens when a provider is
+        // chosen. Discard the token and reconnect so the full sign-in runs on a fresh, stable connection.
+        // mReconnectRejected makes that next connection skip the now-asynchronously-clearing saved token
+        // instead of racing it and looping straight back into another rejected reconnect.
         discardReconnectToken();
-        //: Shown when a saved password-less sign-in is no longer accepted and the user must sign in again.
-        mpHost->postMessage(tr("[ INFO ]  - Your saved sign-in has expired; please sign in again."));
-        selectAuthMethod();
+        mReconnectRejected = true;
+        //: Shown when a saved password-less sign-in is no longer accepted; Mudlet reconnects so the user can sign in again.
+        mpHost->postMessage(tr("[ INFO ]  - Your saved sign-in has expired; reconnecting so you can sign in again."));
+        QPointer<Host> safeHost = mpHost;
+        QTimer::singleShot(0, mpHost, [safeHost]() {
+            if (safeHost) {
+                safeHost->mTelnet.reconnect();
+            }
+        });
         return;
     }
 
@@ -441,8 +477,10 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
     QJsonParseError parseError;
     auto doc = QJsonDocument::fromJson(data.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString() << " at offset " << parseError.offset << ". Received data: \"" << data
-                                       << "\"";
+        // The payload carries the reconnect token (a bearer secret), so never log its contents - report
+        // only the parse error and a non-sensitive length summary.
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - Failed to parse JSON: " << parseError.errorString() << " at offset " << parseError.offset << " (withholding "
+                                       << data.length() << "-character payload as it may contain a token).";
         return;
     }
     if (!doc.isObject()) {
@@ -477,6 +515,15 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
 void GMCPAuthenticator::attemptReconnect()
 {
     mpHost->mTelnet.cancelLoginTimers();
+
+    // We reconnected after a rejected token (see handleAuthResult) to sign in cleanly. The stored token
+    // is being removed asynchronously, so skip it explicitly this once rather than risk reading a
+    // not-yet-removed token and looping straight back into another rejected reconnect.
+    if (mReconnectRejected) {
+        mReconnectRejected = false;
+        selectAuthMethod();
+        return;
+    }
 
     // A standing "always use character name and password" preference takes precedence over any saved
     // OAuth reconnect token: hand off to method selection, which will send the credentials.

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -22,6 +22,7 @@
 
 #include "Host.h"
 #include "CredentialManager.h"
+#include "OAuthClientFlow.h"
 #include "SecureStringUtils.h"
 #include "ctelnet.h"
 #include "mudlet.h"
@@ -38,6 +39,12 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
+namespace {
+// Picker item-data marking the client-driven OAuth entry. Provider ids come off the wire, so use a
+// control character no sane server would put in an id to keep the two namespaces apart.
+const QString clientDrivenChoice = qsl("\u0001client-driven");
+} // namespace
+
 GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 : mpHost(pHost)
 {
@@ -50,6 +57,8 @@ void GMCPAuthenticator::resetPerConnectionState()
     // attemptReconnect() on the very next connection, so it must survive the reconnect it triggers.
     mAwaitingReconnectResult = false;
     mTokenPersistEnabled = false;
+    // A fresh sign-in supersedes any browser dance still in flight from the previous connection.
+    cancelClientDrivenOAuth();
 }
 
 void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QString& data)
@@ -245,6 +254,14 @@ void GMCPAuthenticator::promptForOAuthProvider()
 
     auto* combo = new QComboBox(dialog);
     promptLabel->setBuddy(combo);
+
+    // The optional client-driven flow - the game itself is the OpenID Provider - goes first: a server
+    // advertising itself is its own most-preferred provider, ahead of the brokered external ones.
+    if (clientDrivenOAuthAvailable()) {
+        //: Provider-picker entry for signing in with the game's own account through the user's web browser.
+        combo->addItem(tr("This game (in your browser)"), clientDrivenChoice);
+    }
+
     for (const auto& id : std::as_const(mOAuthProviders)) {
         QString display = brandNames.value(id.toLower());
         if (display.isEmpty()) {
@@ -287,6 +304,11 @@ void GMCPAuthenticator::promptForOAuthProvider()
             mpHost->mTelnet.setDontReconnect(true);
             //: Shown when the sign-in provider picker had no usable choice to act on.
             mpHost->postMessage(tr("[ WARN ]  - No sign-in method was available to use."));
+            return;
+        }
+        if (choice == clientDrivenChoice) {
+            mTokenPersistEnabled = rememberMe->isChecked();
+            startClientDrivenOAuth();
             return;
         }
         if (choice == qsl("password-credentials")) {
@@ -465,6 +487,11 @@ void GMCPAuthenticator::handleAuthUrl(const QString& packageMessage, const QStri
         return;
     }
 
+    announceBrowserHandoff();
+}
+
+void GMCPAuthenticator::announceBrowserHandoff()
+{
     //: Shown after the user's browser is launched to complete an OAuth/web sign-in.
     const QString message = tr("[ INFO ]  - Opening your browser to sign in. Complete the login there, then return here.");
     mpHost->postMessage(message);
@@ -475,6 +502,96 @@ void GMCPAuthenticator::handleAuthUrl(const QString& packageMessage, const QStri
         QAccessibleAnnouncementEvent announcement(mainWindow, message);
         QAccessible::updateAccessibility(&announcement);
     }
+}
+
+void GMCPAuthenticator::startClientDrivenOAuth()
+{
+    cancelClientDrivenOAuth();
+
+    // Parented to the Host so the flow (and its loopback listener) cannot outlive the profile.
+    mpOAuthFlow = new OAuthClientFlow(mpHost);
+    QObject::connect(mpOAuthFlow, &OAuthClientFlow::authorizationCaptured, mpHost, [this](const QString& code, const QString& codeVerifier, const QString& redirectUri) {
+        sendAuthCode(code, codeVerifier, redirectUri);
+    });
+    QObject::connect(mpOAuthFlow, &OAuthClientFlow::browserOpened, mpHost, [this]() {
+        announceBrowserHandoff();
+    });
+    QObject::connect(mpOAuthFlow, &OAuthClientFlow::browserOpenFailed, mpHost, [this](const QString& url) {
+        //: %1 is the sign-in web address the user should open manually in their browser.
+        mpHost->postMessage(tr("[ WARN ]  - Could not open your browser. Open this link manually to sign in: %1").arg(url));
+    });
+    QObject::connect(mpOAuthFlow, &OAuthClientFlow::flowFailed, mpHost, [this](const QString& logDetail) {
+        qWarning().noquote() << "GMCP Char.Login client-driven OAuth failed:" << logDetail;
+        mpHost->mTelnet.setDontReconnect(true);
+        //: Shown when a browser-based sign-in with the game's own account could not be completed.
+        mpHost->postMessage(tr("[ WARN ]  - The browser sign-in could not be completed; reconnect to try again."));
+    });
+
+    mpOAuthFlow->start(QUrl(mOAuthDiscoveryUrl), mOAuthClientId, mOAuthScopes, mOAuthNonceRequired);
+}
+
+void GMCPAuthenticator::cancelClientDrivenOAuth()
+{
+    if (mpOAuthFlow) {
+        mpOAuthFlow->abort();
+        mpOAuthFlow->deleteLater();
+        mpOAuthFlow = nullptr;
+    }
+}
+
+void GMCPAuthenticator::sendAuthCode(const QString& code, QString codeVerifier, const QString& redirectUri)
+{
+    // The spec forbids Char.Login.AuthCode on a cleartext connection: the authorization code and PKCE
+    // verifier together would let an eavesdropper redeem the code at the provider. The flow only starts
+    // on an encrypted connection, but re-check at send time in case the transport changed underneath us.
+    if (!mpHost->mTelnet.currentlySecure()) {
+        SecureStringUtils::secureStringClear(codeVerifier);
+        qWarning().noquote() << "GMCP Char.Login.AuthCode - refusing to send the authorization code over an unencrypted connection.";
+        mpHost->mTelnet.setDontReconnect(true);
+        //: Shown when a browser sign-in finished but the game connection is not encrypted, so completing it would be unsafe.
+        mpHost->postMessage(tr("[ WARN ]  - Cannot complete the sign-in because the connection is not encrypted."));
+        return;
+    }
+
+    QJsonObject payload;
+    payload[qsl("code")] = code;
+    payload[qsl("code_verifier")] = codeVerifier;
+    payload[qsl("redirect_uri")] = redirectUri;
+    // Echo the negotiated version so the server can confirm both ends agree.
+    payload[qsl("version")] = mNegotiatedVersion;
+    QByteArray json = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+    QString gmcpMessage = QString::fromUtf8(json);
+    payload = QJsonObject();
+    SecureStringUtils::secureByteArrayClear(json);
+
+    // Keep the plaintext and its telnet-cooked form in named buffers so both can be wiped; the
+    // toStdString()/encodeAndCookBytes() temporaries would otherwise leave un-scrubbed copies behind.
+    std::string plaintext = gmcpMessage.toStdString();
+    std::string encoded = mpHost->mTelnet.encodeAndCookBytes(plaintext);
+
+    std::string output;
+    output += TN_IAC;
+    output += TN_SB;
+    output += OPT_GMCP;
+    output += "Char.Login.AuthCode ";
+    output += encoded;
+    output += TN_IAC;
+    output += TN_SE;
+
+    mpHost->mTelnet.socketOutRaw(output);
+
+    // The authorization code and PKCE verifier are single-use secrets; scrub every copy once sent: the
+    // verifier argument (taken by value), the JSON message, the plaintext and encoded payloads, and the
+    // assembled telnet frame.
+    SecureStringUtils::secureStringClear(codeVerifier);
+    SecureStringUtils::secureStringClear(gmcpMessage);
+    SecureStringUtils::secureStdStringClear(plaintext);
+    SecureStringUtils::secureStdStringClear(encoded);
+    SecureStringUtils::secureStdStringClear(output);
+
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+    qDebug() << "Sent GMCP AuthCode to complete the client-driven OAuth sign-in";
+#endif
 }
 
 
@@ -699,9 +816,10 @@ void GMCPAuthenticator::selectAuthMethod()
     // first method we can satisfy is the server's most-preferred one.
     for (const auto& type : std::as_const(mSupportedAuthTypes)) {
         if (type == qsl("oauth")) {
-            // We can only drive the server-driven flow when the server told us which providers it
-            // accepts; without that list fall through to the next advertised method.
-            if (!mOAuthProviders.isEmpty()) {
+            // We can drive the server-driven flow when the server told us which providers it accepts,
+            // or the client-driven flow when it advertised itself as an OpenID Provider (over an
+            // encrypted transport); with neither, fall through to the next advertised method.
+            if (!mOAuthProviders.isEmpty() || clientDrivenOAuthAvailable()) {
                 mpHost->mTelnet.cancelLoginTimers();
                 promptForOAuthProvider();
                 return;

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -105,12 +105,19 @@ void GMCPAuthenticator::sendCredentials()
     }
 
     QJsonDocument doc(credentials);
-    QString gmcpMessage = doc.toJson(QJsonDocument::Compact);
+    QByteArray json = doc.toJson(QJsonDocument::Compact);
+    QString gmcpMessage = QString::fromUtf8(json);
 
     // Clear sensitive data from memory as soon as possible
     credentials = QJsonObject();                    // Clear JSON object
     doc = QJsonDocument();                          // Clear document
     SecureStringUtils::secureStringClear(password); // Clear password copy
+    SecureStringUtils::secureByteArrayClear(json);  // Clear the plaintext JSON bytes toJson() produced
+
+    // Keep the plaintext and its telnet-cooked form in named buffers so both can be wiped; passing the
+    // toStdString()/encodeAndCookBytes() temporaries inline would leave un-scrubbed copies behind.
+    std::string plaintext = gmcpMessage.toStdString();
+    std::string encoded = mpHost->mTelnet.encodeAndCookBytes(plaintext);
 
     // Build and send the GMCP message
     std::string output;
@@ -118,20 +125,19 @@ void GMCPAuthenticator::sendCredentials()
     output += TN_SB;
     output += OPT_GMCP;
     output += "Char.Login.Credentials ";
-    output += mpHost->mTelnet.encodeAndCookBytes(gmcpMessage.toStdString());
+    output += encoded;
     output += TN_IAC;
     output += TN_SE;
 
     // Send credentials to server
     mpHost->mTelnet.socketOutRaw(output);
 
-    // Scrub both copies of the secret: the JSON message and the assembled telnet frame, which also holds
-    // the (encoded) password.
+    // Scrub every copy of the secret: the JSON message, the plaintext and encoded payloads, and the
+    // assembled telnet frame, which also holds the (encoded) password.
     SecureStringUtils::secureStringClear(gmcpMessage);
-    for (char& byte : output) {
-        byte = '\0';
-    }
-    output.clear();
+    SecureStringUtils::secureStdStringClear(plaintext);
+    SecureStringUtils::secureStdStringClear(encoded);
+    SecureStringUtils::secureStdStringClear(output);
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Sent GMCP credentials";
@@ -257,27 +263,33 @@ void GMCPAuthenticator::sendReconnect(const QString& account, const QString& tok
     QJsonObject payload;
     payload[qsl("account")] = account;
     payload[qsl("token")] = token;
-    QString gmcpMessage = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+    QByteArray json = QJsonDocument(payload).toJson(QJsonDocument::Compact);
+    QString gmcpMessage = QString::fromUtf8(json);
     payload = QJsonObject();
+    SecureStringUtils::secureByteArrayClear(json);
+
+    // Keep the plaintext and its telnet-cooked form in named buffers so both can be wiped; the
+    // toStdString()/encodeAndCookBytes() temporaries would otherwise leave un-scrubbed token copies.
+    std::string plaintext = gmcpMessage.toStdString();
+    std::string encoded = mpHost->mTelnet.encodeAndCookBytes(plaintext);
 
     std::string output;
     output += TN_IAC;
     output += TN_SB;
     output += OPT_GMCP;
     output += "Char.Login.Reconnect ";
-    output += mpHost->mTelnet.encodeAndCookBytes(gmcpMessage.toStdString());
+    output += encoded;
     output += TN_IAC;
     output += TN_SE;
 
     mpHost->mTelnet.socketOutRaw(output);
 
-    // The reconnect token is a bearer secret, so scrub both copies once it is sent: the JSON message and
-    // the assembled telnet frame, which also holds the (encoded) token.
+    // The reconnect token is a bearer secret, so scrub every copy once it is sent: the JSON message, the
+    // plaintext and encoded payloads, and the assembled telnet frame, which also holds the (encoded) token.
     SecureStringUtils::secureStringClear(gmcpMessage);
-    for (char& byte : output) {
-        byte = '\0';
-    }
-    output.clear();
+    SecureStringUtils::secureStdStringClear(plaintext);
+    SecureStringUtils::secureStdStringClear(encoded);
+    SecureStringUtils::secureStdStringClear(output);
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Sent GMCP reconnect for account:" << account;
@@ -289,9 +301,11 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, const QStrin
     QJsonObject obj;
     obj[qsl("account")] = account;
     obj[qsl("token")] = token;
-    QString payload = QJsonDocument(obj).toJson(QJsonDocument::Compact);
-    // Release the JSON object that also holds the plaintext token.
+    QByteArray json = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+    QString payload = QString::fromUtf8(json);
+    // Release the JSON object and the plaintext bytes that also hold the token.
     obj = QJsonObject();
+    SecureStringUtils::secureByteArrayClear(json);
 
     QPointer<CredentialManager> credentialManager = new CredentialManager();
     credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [credentialManager](bool success, const QString& errorMessage) {

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -49,9 +49,9 @@ private:
     void handleAuthUrl(const QString& packageMessage, const QString& data);
     void selectAuthMethod();
     void attemptReconnect();
-    void sendReconnect(const QString& account, const QString& token);
+    void sendReconnect(const QString& account, QString token);
     void handleAuthToken(const QString& packageMessage, const QString& data);
-    void storeReconnectToken(const QString& account, const QString& token);
+    void storeReconnectToken(const QString& account, QString token);
     void discardReconnectToken();
     void resetPerConnectionState();
 

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -53,6 +53,7 @@ private:
     void handleAuthToken(const QString& packageMessage, const QString& data);
     void storeReconnectToken(const QString& account, const QString& token);
     void discardReconnectToken();
+    void resetPerConnectionState();
 
     Host* mpHost;
     QStringList mSupportedAuthTypes;

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -63,6 +63,10 @@ private:
     // True while we are waiting for the Char.Login.Result that answers a Char.Login.Reconnect attempt,
     // so a failure can discard the stale token and fall back instead of aborting the login.
     bool mAwaitingReconnectResult = false;
+    // Set when a reconnect token is rejected and we reconnect for a clean sign-in. The saved token is
+    // cleared asynchronously, so this makes the next connection skip it explicitly rather than racing
+    // the keychain removal and looping back into another rejected reconnect.
+    bool mReconnectRejected = false;
 };
 
 #endif // MUDLET_AUTHENTICATOR_H

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -58,6 +58,10 @@ private:
     Host* mpHost;
     QStringList mSupportedAuthTypes;
     QStringList mOAuthProviders;
+    // The negotiated Char.Login protocol version the server reported in Char.Login.Default. Absent (a
+    // version 1 server or legacy exchange) is treated as 1; we echo this back on our client->server
+    // messages so both ends agree on the version even though base GMCP negotiation is one-directional.
+    int mNegotiatedVersion = 1;
     // True once the user opts into "remember me" for a fresh sign-in, or once a saved token is loaded
     // at connect time (so a rotated token from the server overwrites the stored one).
     bool mTokenPersistEnabled = false;

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -55,9 +55,19 @@ private:
     void discardReconnectToken();
     void resetPerConnectionState();
 
+    bool clientDrivenOAuthAvailable() const;
+
     Host* mpHost;
     QStringList mSupportedAuthTypes;
     QStringList mOAuthProviders;
+    // Version 2 client-driven OAuth capability, advertised by a server that is itself an OpenID
+    // Provider. Only populated when the connection is encrypted: the flow's completing
+    // Char.Login.AuthCode message must never travel in the clear, so on plain telnet these stay
+    // empty and the sign-in transparently uses the server-driven flow instead.
+    QString mOAuthDiscoveryUrl;
+    QString mOAuthClientId;
+    QStringList mOAuthScopes;
+    bool mOAuthNonceRequired = false;
     // The negotiated Char.Login protocol version the server reported in Char.Login.Default. Absent (a
     // version 1 server or legacy exchange) is treated as 1; we echo this back on our client->server
     // messages so both ends agree on the version even though base GMCP negotiation is one-directional.

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -26,8 +26,11 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QPointer>
 #include <QString>
 #include <QVariantMap>
+
+class OAuthClientFlow;
 
 
 class GMCPAuthenticator
@@ -47,6 +50,10 @@ private:
     void sendOAuth(const QString& provider);
     void promptForOAuthProvider();
     void handleAuthUrl(const QString& packageMessage, const QString& data);
+    void startClientDrivenOAuth();
+    void cancelClientDrivenOAuth();
+    void announceBrowserHandoff();
+    void sendAuthCode(const QString& code, QString codeVerifier, const QString& redirectUri);
     void selectAuthMethod();
     void attemptReconnect();
     void sendReconnect(const QString& account, QString token);
@@ -68,6 +75,9 @@ private:
     QString mOAuthClientId;
     QStringList mOAuthScopes;
     bool mOAuthNonceRequired = false;
+    // The in-flight client-driven OAuth flow, if any. Parented to the Host so it cannot outlive the
+    // profile; guarded so a new Char.Login.Default aborts a stale attempt before starting over.
+    QPointer<OAuthClientFlow> mpOAuthFlow;
     // The negotiated Char.Login protocol version the server reported in Char.Login.Default. Absent (a
     // version 1 server or legacy exchange) is treated as 1; we echo this back on our client->server
     // messages so both ends agree on the version even though base GMCP negotiation is one-directional.

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -35,7 +35,6 @@ class GMCPAuthenticator
     Q_DECLARE_TR_FUNCTIONS(GMCPAuthenticator)
 
 public:
-
     explicit GMCPAuthenticator(Host* pHost);
     ~GMCPAuthenticator() = default;
 
@@ -45,8 +44,25 @@ public:
     void handleAuthGMCP(const QString& packageMessage, const QString& data);
 
 private:
+    void sendOAuth(const QString& provider);
+    void promptForOAuthProvider();
+    void handleAuthUrl(const QString& packageMessage, const QString& data);
+    void selectAuthMethod();
+    void attemptReconnect();
+    void sendReconnect(const QString& account, const QString& token);
+    void handleAuthToken(const QString& packageMessage, const QString& data);
+    void storeReconnectToken(const QString& account, const QString& token);
+    void discardReconnectToken();
+
     Host* mpHost;
     QStringList mSupportedAuthTypes;
+    QStringList mOAuthProviders;
+    // True once the user opts into "remember me" for a fresh sign-in, or once a saved token is loaded
+    // at connect time (so a rotated token from the server overwrites the stored one).
+    bool mTokenPersistEnabled = false;
+    // True while we are waiting for the Char.Login.Result that answers a Char.Login.Reconnect attempt,
+    // so a failure can discard the stale token and fall back instead of aborting the login.
+    bool mAwaitingReconnectResult = false;
 };
 
 #endif // MUDLET_AUTHENTICATOR_H

--- a/src/Host.h
+++ b/src/Host.h
@@ -546,6 +546,18 @@ public:
     bool mEnableNEWENVIRON = true;
     bool mPromptedForMXPProcessorOn = false;
     bool mAskTlsAvailable = true;
+    bool mPromptedForVersionInTTYPE = false;
+
+    // GMCP Char.Login sign-in preference/state. Kept private so their invariants live with the data:
+    // markSeenCharLoginSignInChoice() is set-only-true (the "seen" flag is sticky). XML (de)serialisation
+    // and the preferences dialog are friend classes and still touch the members directly.
+public:
+    bool useCharacterNamePasswordLogin() const { return mUseCharacterNamePasswordLogin; }
+    void setUseCharacterNamePasswordLogin(const bool b) { mUseCharacterNamePasswordLogin = b; }
+    bool seenCharLoginSignInChoice() const { return mSeenCharLoginSignInChoice; }
+    void markSeenCharLoginSignInChoice() { mSeenCharLoginSignInChoice = true; }
+
+private:
     // When true and the game offers GMCP Char.Login "password-credentials", skip the sign-in provider
     // picker and log in with the profile's character name and password directly.
     bool mUseCharacterNamePasswordLogin = false;
@@ -553,8 +565,8 @@ public:
     // password-credentials). Gates visibility of the "always use character name and password" option so
     // it never appears for the vast majority of games that do not use this flow.
     bool mSeenCharLoginSignInChoice = false;
-    bool mPromptedForVersionInTTYPE = false;
 
+public:
     int mMSSPTlsPort = 0;
     QString mMSSPHostName;
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -172,11 +172,7 @@ public:
     };
     Q_DECLARE_FLAGS(DiscordOptionFlags, DiscordOptionFlag)
 
-    enum DiscordMode {
-        DiscordDisabled = 0,
-        DiscordShowMudletOnly = 1,
-        DiscordShowGameDetails = 2
-    };
+    enum DiscordMode { DiscordDisabled = 0, DiscordShowMudletOnly = 1, DiscordShowGameDetails = 2 };
 
 
     QString getName() { return mHostName; }
@@ -550,6 +546,13 @@ public:
     bool mEnableNEWENVIRON = true;
     bool mPromptedForMXPProcessorOn = false;
     bool mAskTlsAvailable = true;
+    // When true and the game offers GMCP Char.Login "password-credentials", skip the sign-in provider
+    // picker and log in with the profile's character name and password directly.
+    bool mUseCharacterNamePasswordLogin = false;
+    // Sticky once true: set when a game advertises a GMCP Char.Login sign-in choice (both oauth and
+    // password-credentials). Gates visibility of the "always use character name and password" option so
+    // it never appears for the vast majority of games that do not use this flow.
+    bool mSeenCharLoginSignInChoice = false;
     bool mPromptedForVersionInTTYPE = false;
 
     int mMSSPTlsPort = 0;

--- a/src/OAuthClientFlow.cpp
+++ b/src/OAuthClientFlow.cpp
@@ -19,10 +19,16 @@
 
 #include "OAuthClientFlow.h"
 
+#include "SecureStringUtils.h"
 #include "utils.h"
 
 #include <QCryptographicHash>
+#include <QDesktopServices>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
 #include <QRandomGenerator>
+#include <QTcpSocket>
 #include <QUrlQuery>
 
 namespace {
@@ -38,6 +44,23 @@ QString randomUrlSafeToken(int byteCount)
     QRandomGenerator::system()->fillRange(reinterpret_cast<quint32*>(bytes.data()), byteCount / static_cast<int>(sizeof(quint32)));
     return base64Url(bytes);
 }
+
+// OAuth endpoints must be https; plain http is permitted solely for loopback addresses so
+// self-hosted and test setups work without certificates (mirroring RFC 8252 loopback redirects).
+bool acceptableEndpointUrl(const QUrl& url)
+{
+    if (!url.isValid() || url.host().isEmpty()) {
+        return false;
+    }
+    if (url.scheme() == qsl("https")) {
+        return true;
+    }
+    if (url.scheme() != qsl("http")) {
+        return false;
+    }
+    const QString host = url.host();
+    return host == qsl("127.0.0.1") || host == qsl("::1") || host.compare(qsl("localhost"), Qt::CaseInsensitive) == 0;
+}
 } // namespace
 
 OAuthClientFlow::OAuthClientFlow(QObject* parent)
@@ -45,7 +68,11 @@ OAuthClientFlow::OAuthClientFlow(QObject* parent)
 {
 }
 
-OAuthClientFlow::~OAuthClientFlow() = default;
+OAuthClientFlow::~OAuthClientFlow()
+{
+    // The verifier is the PKCE secret; make sure it does not outlive the flow in memory.
+    SecureStringUtils::secureStringClear(mCodeVerifier);
+}
 
 QString OAuthClientFlow::generateCodeVerifier()
 {
@@ -79,38 +106,192 @@ QUrl OAuthClientFlow::buildAuthorizationUrl(
     return url;
 }
 
+// Single-use: create a fresh OAuthClientFlow for each sign-in attempt.
 void OAuthClientFlow::start(const QUrl& discoveryUrl, const QString& clientId, const QStringList& scopes, bool includeNonce)
 {
-    Q_UNUSED(discoveryUrl)
-    Q_UNUSED(clientId)
-    Q_UNUSED(scopes)
-    Q_UNUSED(includeNonce)
+    mClientId = clientId;
+    // The spec defaults the scopes to ["openid"] when the server sends none.
+    mScopes = scopes.isEmpty() ? QStringList{qsl("openid")} : scopes;
+    mNonce = includeNonce ? randomUrlSafeToken(16) : QString();
+
+    if (!acceptableEndpointUrl(discoveryUrl)) {
+        fail(qsl("discovery URL must be https (or http on loopback): %1").arg(discoveryUrl.toString()));
+        return;
+    }
+
+    // One deadline covers the whole flow - discovery fetch, browser sign-in, and redirect - so an
+    // abandoned attempt cannot leave the loopback listener open indefinitely.
+    mTimeoutTimer.setSingleShot(true);
+    connect(&mTimeoutTimer, &QTimer::timeout, this, [this]() {
+        fail(qsl("timed out waiting for the browser sign-in to complete"));
+    });
+    mTimeoutTimer.start(std::chrono::minutes(5));
+
+    QNetworkRequest request(discoveryUrl);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    QNetworkReply* reply = mNetworkManager.get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        handleDiscoveryReply(reply);
+    });
 }
 
-void OAuthClientFlow::abort() {}
+void OAuthClientFlow::abort()
+{
+    if (mCompleted) {
+        return;
+    }
+    mCompleted = true;
+    cleanup();
+    SecureStringUtils::secureStringClear(mCodeVerifier);
+}
 
 void OAuthClientFlow::handleDiscoveryReply(QNetworkReply* reply)
 {
-    Q_UNUSED(reply)
+    reply->deleteLater();
+    if (mCompleted) {
+        return;
+    }
+    if (reply->error() != QNetworkReply::NoError) {
+        fail(qsl("could not fetch the OpenID discovery document: %1").arg(reply->errorString()));
+        return;
+    }
+
+    QJsonParseError parseError;
+    const auto doc = QJsonDocument::fromJson(reply->readAll(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        fail(qsl("the OpenID discovery document is not a JSON object: %1").arg(parseError.errorString()));
+        return;
+    }
+    const QUrl authorizationEndpoint(doc.object()[qsl("authorization_endpoint")].toString());
+    if (!acceptableEndpointUrl(authorizationEndpoint)) {
+        fail(qsl("the discovery document has no usable https authorization_endpoint"));
+        return;
+    }
+
+    if (!mRedirectServer.listen(QHostAddress::LocalHost, 0)) {
+        fail(qsl("could not open a loopback port for the browser redirect: %1").arg(mRedirectServer.errorString()));
+        return;
+    }
+    connect(&mRedirectServer, &QTcpServer::newConnection, this, &OAuthClientFlow::handleRedirectConnection);
+    mRedirectUri = qsl("http://127.0.0.1:%1/").arg(mRedirectServer.serverPort());
+
+    mCodeVerifier = generateCodeVerifier();
+    mState = randomUrlSafeToken(16);
+    const QUrl authorizationUrl = buildAuthorizationUrl(authorizationEndpoint, mClientId, mScopes, mRedirectUri, mState, codeChallengeS256(mCodeVerifier), mNonce);
+
+    if (QDesktopServices::openUrl(authorizationUrl)) {
+        emit browserOpened(authorizationUrl.toString());
+    } else {
+        // Keep the listener up: the user can still open the link by hand and complete the sign-in.
+        emit browserOpenFailed(authorizationUrl.toString());
+    }
 }
 
-void OAuthClientFlow::handleRedirectConnection() {}
+void OAuthClientFlow::handleRedirectConnection()
+{
+    while (mRedirectServer.hasPendingConnections()) {
+        QTcpSocket* socket = mRedirectServer.nextPendingConnection();
+        connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
+            readRedirectRequest(socket);
+        });
+        connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+        connect(socket, &QObject::destroyed, this, [this, socket]() {
+            mRequestBuffers.remove(socket);
+        });
+    }
+}
 
 void OAuthClientFlow::readRedirectRequest(QTcpSocket* socket)
 {
-    Q_UNUSED(socket)
+    QByteArray& buffer = mRequestBuffers[socket];
+    buffer += socket->readAll();
+    const int lineEnd = buffer.indexOf("\r\n");
+    if (lineEnd < 0) {
+        // A request line has no business being this long; drop the connection rather than buffer more.
+        if (buffer.size() > 8192) {
+            mRequestBuffers.remove(socket);
+            socket->abort();
+        }
+        return;
+    }
+    const QByteArray requestLine = buffer.left(lineEnd);
+    mRequestBuffers.remove(socket);
+
+    if (mCompleted) {
+        respond(socket, "404 Not Found", QString());
+        return;
+    }
+
+    // "GET /path?query HTTP/1.1" - only the request target matters.
+    const QList<QByteArray> parts = requestLine.split(' ');
+    if (parts.size() < 2 || parts.at(0) != "GET") {
+        respond(socket, "400 Bad Request", QString());
+        return;
+    }
+    const QUrlQuery query{QUrl(QString::fromUtf8(parts.at(1)))};
+
+    // Browsers also ask for things like /favicon.ico; only a request carrying the provider's
+    // code or error is the redirect we are waiting for - answer anything else and keep waiting.
+    if (!query.hasQueryItem(qsl("code")) && !query.hasQueryItem(qsl("error"))) {
+        respond(socket, "404 Not Found", QString());
+        return;
+    }
+
+    if (query.queryItemValue(qsl("state")) != mState) {
+        //: Shown in the user's web browser when a browser sign-in attempt could not be verified as the one Mudlet started.
+        respond(socket, "400 Bad Request", tr("This sign-in attempt could not be verified. Please return to Mudlet and try again."));
+        fail(qsl("redirect state did not match the authorization request"));
+        return;
+    }
+
+    if (query.hasQueryItem(qsl("error"))) {
+        //: Shown in the user's web browser when the identity provider reported that the sign-in did not complete.
+        respond(socket, "200 OK", tr("The sign-in was not completed. You can close this tab and return to Mudlet."));
+        fail(qsl("the provider returned an error: %1").arg(query.queryItemValue(qsl("error"))));
+        return;
+    }
+
+    const QString code = query.queryItemValue(qsl("code"), QUrl::FullyDecoded);
+    //: Shown in the user's web browser after a successful browser sign-in.
+    respond(socket, "200 OK", tr("You are signed in. You can close this tab and return to Mudlet."));
+
+    mCompleted = true;
+    cleanup();
+    emit authorizationCaptured(code, mCodeVerifier, mRedirectUri);
+    // The receiver has taken (and is responsible for scrubbing) its own copy; drop ours now.
+    SecureStringUtils::secureStringClear(mCodeVerifier);
 }
 
 void OAuthClientFlow::respond(QTcpSocket* socket, const QByteArray& status, const QString& body)
 {
-    Q_UNUSED(socket)
-    Q_UNUSED(status)
-    Q_UNUSED(body)
+    // Fixed, non-reflected content only: nothing from the request may be echoed into the page.
+    const QByteArray content =
+            body.isEmpty() ? QByteArray() : qsl("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Mudlet</title></head><body><p>%1</p></body></html>").arg(body.toHtmlEscaped()).toUtf8();
+    QByteArray response = "HTTP/1.1 " + status + "\r\n";
+    response += "Content-Type: text/html; charset=utf-8\r\n";
+    response += "Content-Length: " + QByteArray::number(content.size()) + "\r\n";
+    response += "Connection: close\r\n\r\n";
+    response += content;
+    socket->write(response);
+    socket->disconnectFromHost();
 }
 
 void OAuthClientFlow::fail(const QString& logDetail)
 {
-    Q_UNUSED(logDetail)
+    if (mCompleted) {
+        return;
+    }
+    mCompleted = true;
+    cleanup();
+    SecureStringUtils::secureStringClear(mCodeVerifier);
+    emit flowFailed(logDetail);
 }
 
-void OAuthClientFlow::cleanup() {}
+void OAuthClientFlow::cleanup()
+{
+    mTimeoutTimer.stop();
+    if (mRedirectServer.isListening()) {
+        mRedirectServer.close();
+    }
+    mRequestBuffers.clear();
+}

--- a/src/OAuthClientFlow.cpp
+++ b/src/OAuthClientFlow.cpp
@@ -1,0 +1,116 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "OAuthClientFlow.h"
+
+#include "utils.h"
+
+#include <QCryptographicHash>
+#include <QRandomGenerator>
+#include <QUrlQuery>
+
+namespace {
+QString base64Url(const QByteArray& bytes)
+{
+    return QString::fromLatin1(bytes.toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals));
+}
+
+// byteCount must be a multiple of sizeof(quint32); the system generator is the OS CSPRNG.
+QString randomUrlSafeToken(int byteCount)
+{
+    QByteArray bytes(byteCount, '\0');
+    QRandomGenerator::system()->fillRange(reinterpret_cast<quint32*>(bytes.data()), byteCount / static_cast<int>(sizeof(quint32)));
+    return base64Url(bytes);
+}
+} // namespace
+
+OAuthClientFlow::OAuthClientFlow(QObject* parent)
+: QObject(parent)
+{
+}
+
+OAuthClientFlow::~OAuthClientFlow() = default;
+
+QString OAuthClientFlow::generateCodeVerifier()
+{
+    // 32 random bytes base64url-encoded without padding gives a 43-character verifier, the RFC 7636
+    // minimum length, from the required unreserved character set.
+    return randomUrlSafeToken(32);
+}
+
+QString OAuthClientFlow::codeChallengeS256(const QString& codeVerifier)
+{
+    // The verifier is ASCII by construction; RFC 7636 hashes its ASCII bytes.
+    return base64Url(QCryptographicHash::hash(codeVerifier.toLatin1(), QCryptographicHash::Sha256));
+}
+
+QUrl OAuthClientFlow::buildAuthorizationUrl(
+        const QUrl& authorizationEndpoint, const QString& clientId, const QStringList& scopes, const QString& redirectUri, const QString& state, const QString& codeChallenge, const QString& nonce)
+{
+    QUrl url = authorizationEndpoint;
+    QUrlQuery query(url);
+    query.addQueryItem(qsl("response_type"), qsl("code"));
+    query.addQueryItem(qsl("client_id"), clientId);
+    query.addQueryItem(qsl("redirect_uri"), redirectUri);
+    query.addQueryItem(qsl("scope"), scopes.join(QChar::Space));
+    query.addQueryItem(qsl("state"), state);
+    query.addQueryItem(qsl("code_challenge"), codeChallenge);
+    query.addQueryItem(qsl("code_challenge_method"), qsl("S256"));
+    if (!nonce.isEmpty()) {
+        query.addQueryItem(qsl("nonce"), nonce);
+    }
+    url.setQuery(query);
+    return url;
+}
+
+void OAuthClientFlow::start(const QUrl& discoveryUrl, const QString& clientId, const QStringList& scopes, bool includeNonce)
+{
+    Q_UNUSED(discoveryUrl)
+    Q_UNUSED(clientId)
+    Q_UNUSED(scopes)
+    Q_UNUSED(includeNonce)
+}
+
+void OAuthClientFlow::abort() {}
+
+void OAuthClientFlow::handleDiscoveryReply(QNetworkReply* reply)
+{
+    Q_UNUSED(reply)
+}
+
+void OAuthClientFlow::handleRedirectConnection() {}
+
+void OAuthClientFlow::readRedirectRequest(QTcpSocket* socket)
+{
+    Q_UNUSED(socket)
+}
+
+void OAuthClientFlow::respond(QTcpSocket* socket, const QByteArray& status, const QString& body)
+{
+    Q_UNUSED(socket)
+    Q_UNUSED(status)
+    Q_UNUSED(body)
+}
+
+void OAuthClientFlow::fail(const QString& logDetail)
+{
+    Q_UNUSED(logDetail)
+}
+
+void OAuthClientFlow::cleanup() {}

--- a/src/OAuthClientFlow.h
+++ b/src/OAuthClientFlow.h
@@ -1,0 +1,89 @@
+#ifndef MUDLET_OAUTHCLIENTFLOW_H
+#define MUDLET_OAUTHCLIENTFLOW_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QHash>
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QStringList>
+#include <QTcpServer>
+#include <QTimer>
+#include <QUrl>
+
+class QNetworkReply;
+class QTcpSocket;
+
+// Runs the client-driven GMCP Char.Login v2 OAuth flow: fetches the server's OpenID Connect
+// discovery document, opens the provider's authorization URL in the system browser with a PKCE
+// (S256) challenge, and captures the authorization code on a loopback (RFC 8252) redirect
+// listener. The token exchange itself stays on the game server - this class only produces the
+// {code, code_verifier, redirect_uri} triple that GMCPAuthenticator sends as Char.Login.AuthCode.
+class OAuthClientFlow : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit OAuthClientFlow(QObject* parent = nullptr);
+    ~OAuthClientFlow() override;
+
+    void start(const QUrl& discoveryUrl, const QString& clientId, const QStringList& scopes, bool includeNonce);
+    void abort();
+
+    static QString generateCodeVerifier();
+    static QString codeChallengeS256(const QString& codeVerifier);
+    static QUrl buildAuthorizationUrl(const QUrl& authorizationEndpoint,
+                                      const QString& clientId,
+                                      const QStringList& scopes,
+                                      const QString& redirectUri,
+                                      const QString& state,
+                                      const QString& codeChallenge,
+                                      const QString& nonce);
+
+signals:
+    void authorizationCaptured(const QString& code, const QString& codeVerifier, const QString& redirectUri);
+    void browserOpened(const QString& url);
+    void browserOpenFailed(const QString& url);
+    void flowFailed(const QString& logDetail);
+
+private:
+    void handleDiscoveryReply(QNetworkReply* reply);
+    void handleRedirectConnection();
+    void readRedirectRequest(QTcpSocket* socket);
+    void respond(QTcpSocket* socket, const QByteArray& status, const QString& body);
+    void fail(const QString& logDetail);
+    void cleanup();
+
+    QNetworkAccessManager mNetworkManager;
+    QTcpServer mRedirectServer;
+    QTimer mTimeoutTimer;
+    QHash<QTcpSocket*, QByteArray> mRequestBuffers;
+    QString mClientId;
+    QStringList mScopes;
+    QString mCodeVerifier;
+    QString mState;
+    QString mNonce;
+    QString mRedirectUri;
+    // Latches once the flow has reached a terminal outcome (code captured, failed, or aborted) so a
+    // late redirect request or the shared timeout cannot produce a second, contradictory signal.
+    bool mCompleted = false;
+};
+
+#endif // MUDLET_OAUTHCLIENTFLOW_H

--- a/src/SecureStringUtils.cpp
+++ b/src/SecureStringUtils.cpp
@@ -119,6 +119,19 @@ void SecureStringUtils::secureByteArrayClear(QByteArray& array)
     }
 }
 
+void SecureStringUtils::secureStdStringClear(std::string& str)
+{
+    // Overwrite through a volatile pointer so the compiler cannot treat the zeroing as a dead store and
+    // elide it (the buffer is not read again before it is cleared/freed).
+    if (!str.empty()) {
+        volatile char* data = str.data();
+        for (std::string::size_type i = 0; i < str.size(); ++i) {
+            data[i] = '\0';
+        }
+        str.clear();
+    }
+}
+
 QByteArray SecureStringUtils::generateKey(const QByteArray& password, const QByteArray& salt, int iterations)
 {
     // Use iterative SHA-256 hashing to implement PBKDF2-like key derivation

--- a/src/SecureStringUtils.h
+++ b/src/SecureStringUtils.h
@@ -71,12 +71,20 @@ public:
 
     /**
      * @brief Securely clear a QString from memory
+     *
+     * Assumes sole ownership: because QString is implicitly shared, clearing a string that is still
+     * referenced elsewhere detaches and zeroes this copy while leaving the shared buffer intact. The
+     * overwrite is also not guaranteed against dead-store elimination - use secureStdStringClear() for
+     * the strongest guarantee. Pass only uniquely-owned secrets here.
      * @param str String to clear
      */
     static void secureStringClear(QString& str);
 
     /**
      * @brief Securely clear a QByteArray from memory
+     *
+     * Same ownership/elision caveats as secureStringClear(): implicitly shared, so pass only
+     * uniquely-owned buffers; secureStdStringClear() gives the strongest (elision-proof) guarantee.
      * @param array Array to clear
      */
     static void secureByteArrayClear(QByteArray& array);

--- a/src/SecureStringUtils.h
+++ b/src/SecureStringUtils.h
@@ -23,6 +23,8 @@
 #include <QString>
 #include <QByteArray>
 
+#include <string>
+
 /**
  * @brief Utility class for secure string operations
  *
@@ -78,6 +80,15 @@ public:
      * @param array Array to clear
      */
     static void secureByteArrayClear(QByteArray& array);
+
+    /**
+     * @brief Securely clear a std::string from memory
+     *
+     * Overwrites the buffer through a volatile pointer so the zeroing cannot be
+     * removed by dead-store elimination, unlike a plain assignment loop.
+     * @param str String to clear
+     */
+    static void secureStdStringClear(std::string& str);
 
     /**
      * @brief Check SSL backend configuration and report potential issues
@@ -196,9 +207,7 @@ private:
      * @param hmac Output parameter for 32-byte HMAC
      * @return Encrypted data, or empty on failure
      */
-    static QByteArray encryptData(const QByteArray& plaintext, const QByteArray& key,
-                                 const QByteArray& salt, const QByteArray& nonce,
-                                 QByteArray& hmac);
+    static QByteArray encryptData(const QByteArray& plaintext, const QByteArray& key, const QByteArray& salt, const QByteArray& nonce, QByteArray& hmac);
 
     /**
      * @brief Decrypt data using XOR cipher + HMAC-SHA256
@@ -209,17 +218,15 @@ private:
      * @param hmac 32-byte HMAC for verification
      * @return Decrypted data, or empty on failure/authentication error
      */
-    static QByteArray decryptData(const QByteArray& ciphertext, const QByteArray& key,
-                                 const QByteArray& salt, const QByteArray& nonce,
-                                 const QByteArray& hmac);
+    static QByteArray decryptData(const QByteArray& ciphertext, const QByteArray& key, const QByteArray& salt, const QByteArray& nonce, const QByteArray& hmac);
 
     // Constants for the encrypted format
     static constexpr quint8 ENCRYPTION_VERSION_CURRENT = 2; // Current version
     static constexpr int SALT_SIZE = 16;
-    static constexpr int NONCE_SIZE = 16; // Nonce size
-    static constexpr int HMAC_SIZE = 32;  // HMAC-SHA256 size
-    static constexpr int KEY_SIZE = 32;   // 256-bit key
-    static constexpr int PBKDF2_ITERATIONS = 100000; // Strong key derivation
+    static constexpr int NONCE_SIZE = 16;                                             // Nonce size
+    static constexpr int HMAC_SIZE = 32;                                              // HMAC-SHA256 size
+    static constexpr int KEY_SIZE = 32;                                               // 256-bit key
+    static constexpr int PBKDF2_ITERATIONS = 100000;                                  // Strong key derivation
     static constexpr int MIN_ENCRYPTED_SIZE = 1 + SALT_SIZE + NONCE_SIZE + HMAC_SIZE; // version + salt + nonce + hmac + at least some data
 };
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -514,6 +514,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mSslIgnoreSelfSigned") = pHost->mSslIgnoreSelfSigned ? "yes" : "no";
     host.append_attribute("mSslIgnoreAll") = pHost->mSslIgnoreAll ? "yes" : "no";
     host.append_attribute("mAskTlsAvailable") = pHost->mAskTlsAvailable ? "yes" : "no";
+    host.append_attribute("mUseCharacterNamePasswordLogin") = pHost->mUseCharacterNamePasswordLogin ? "yes" : "no";
+    host.append_attribute("mSeenCharLoginSignInChoice") = pHost->mSeenCharLoginSignInChoice ? "yes" : "no";
     host.append_attribute("mDiscordAccessFlags") = QString::number(pHost->mDiscordAccessFlags).toUtf8().constData();
     host.append_attribute("mDiscordMode") = static_cast<int>(pHost->mDiscordMode);
     host.append_attribute("mRequiredDiscordUserName") = pHost->mRequiredDiscordUserName.toUtf8().constData();

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -795,6 +795,8 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mSslIgnoreSelfSigned"), pHost->mSslIgnoreSelfSigned);
     setBoolAttribute(qsl("mSslIgnoreAll"), pHost->mSslIgnoreAll);
     setBoolAttribute(qsl("mAskTlsAvailable"), pHost->mAskTlsAvailable);
+    setBoolAttribute(qsl("mUseCharacterNamePasswordLogin"), pHost->mUseCharacterNamePasswordLogin);
+    setBoolAttribute(qsl("mSeenCharLoginSignInChoice"), pHost->mSeenCharLoginSignInChoice);
     setBoolAttribute(qsl("mUseProxy"), pHost->mUseProxy);
     setBoolAttribute(qsl("f3SearchEnabled"), pHost->mF3SearchEnabled);
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2732,7 +2732,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 if (mpHost->mDiscordMode == Host::DiscordShowGameDetails && mudlet::self()->mDiscord.libraryLoaded()) {
                     supportsList += R"(, "External.Discord 1")";
                 }
-                supportsList += R"(, "Client.Media 1", "Char.Login 1"])";
+                supportsList += R"(, "Client.Media 1", "Char.Login 2"])";
                 output += supportsList;
             }
             output += TN_IAC;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1328,6 +1328,14 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     checkBox_askTlsAvailable->setChecked(pHost->mAskTlsAvailable);
 
+    checkBox_useCharacterNamePasswordLogin->setChecked(pHost->mUseCharacterNamePasswordLogin);
+    // Only show this option for profiles that have actually seen a GMCP Char.Login sign-in choice; the
+    // overwhelming majority of games never use this flow, so hiding it avoids tempting their users into
+    // toggling an option that does not apply to them.
+    checkBox_useCharacterNamePasswordLogin->setVisible(pHost->mSeenCharLoginSignInChoice);
+    // Even when shown, the preference only has meaning while GMCP is enabled for this profile.
+    checkBox_useCharacterNamePasswordLogin->setEnabled(mEnableGMCP->isChecked());
+
     groupBox_proxy->setEnabled(true);
     groupBox_proxy->setChecked(pHost->mUseProxy);
     lineEdit_proxyAddress->setText(pHost->mProxyAddress);
@@ -1412,6 +1420,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(pushButton_mapGridColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapGridColor);
 
     connect(mEnableGMCP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
+    // The "always use character name and password" preference is only meaningful when GMCP is on.
+    connect(mEnableGMCP, &QAction::toggled, checkBox_useCharacterNamePasswordLogin, &QWidget::setEnabled);
     connect(mEnableMSDP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMSSP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMSP, &QAction::toggled, need_reconnect_for_data_protocol, &QWidget::show);
@@ -1730,6 +1740,9 @@ void dlgProfilePreferences::clearHostDetails()
     groupBox_ssl_certificate->hide();
     frame_notificationArea->hide();
     checkBox_askTlsAvailable->setChecked(false);
+    checkBox_useCharacterNamePasswordLogin->setChecked(false);
+    checkBox_useCharacterNamePasswordLogin->setEnabled(false);
+    checkBox_useCharacterNamePasswordLogin->setVisible(false);
     groupBox_proxy->setDisabled(true);
 
     // Remove the reference to the Host/profile in the title:
@@ -3162,6 +3175,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mSslIgnoreSelfSigned = checkBox_self_signed->isChecked();
         pHost->mSslIgnoreAll = checkBox_ignore_all->isChecked();
         pHost->mAskTlsAvailable = checkBox_askTlsAvailable->isChecked();
+        pHost->mUseCharacterNamePasswordLogin = checkBox_useCharacterNamePasswordLogin->isChecked();
 
         if (console) {
             console->changeColors();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4353,6 +4353,22 @@ you can use it but there could be issues with aligning columns of text</string>
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="checkBox_useCharacterNamePasswordLogin">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;p&gt;When this game asks how you want to sign in, always use the character name and password from this profile instead of showing the sign-in chooser. If those fields are blank, the game's own login screen is used.&lt;/p&gt;</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>When this game asks how you want to sign in, always use the character name and password from this profile instead of showing the sign-in chooser. If those fields are blank, the game's own login screen is used.</string>
+         </property>
+         <property name="text">
+          <string>When asked how to sign in, always use character name and password</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox_proxy">
          <property name="title">
           <string>Connect to the game via proxy</string>
@@ -5280,6 +5296,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_ignore_all</tabstop>
   <tabstop>checkBox_expired</tabstop>
   <tabstop>checkBox_askTlsAvailable</tabstop>
+  <tabstop>checkBox_useCharacterNamePasswordLogin</tabstop>
   <tabstop>groupBox_proxy</tabstop>
   <tabstop>lineEdit_proxyAddress</tabstop>
   <tabstop>lineEdit_proxyPort</tabstop>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UNIT_TESTS
     TVariableEditorTest
     SecureStringUtilsTest
     CredentialManagerTest
+    OAuthClientFlowTest
     DiscordTest
     TTextEditBlinkTest
     TAreaZLevelIndexTest

--- a/test/OAuthClientFlowTest.cpp
+++ b/test/OAuthClientFlowTest.cpp
@@ -1,0 +1,98 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <OAuthClientFlow.h>
+#include <QtTest/QtTest>
+#include <QRegularExpression>
+#include <QUrlQuery>
+
+class OAuthClientFlowTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testCodeVerifierFormat();
+    void testCodeVerifierUnique();
+    void testCodeChallengeRfc7636Vector();
+    void testBuildAuthorizationUrl();
+    void testBuildAuthorizationUrlOmitsEmptyNonce();
+};
+
+void OAuthClientFlowTest::testCodeVerifierFormat()
+{
+    const QString verifier = OAuthClientFlow::generateCodeVerifier();
+    // RFC 7636 requires 43-128 characters from the unreserved set; 32 random bytes
+    // base64url-encoded without padding is exactly 43.
+    QCOMPARE(verifier.length(), 43);
+    const QRegularExpression unreserved(QStringLiteral("^[A-Za-z0-9\\-._~]+$"));
+    QVERIFY(unreserved.match(verifier).hasMatch());
+}
+
+void OAuthClientFlowTest::testCodeVerifierUnique()
+{
+    QVERIFY(OAuthClientFlow::generateCodeVerifier() != OAuthClientFlow::generateCodeVerifier());
+}
+
+void OAuthClientFlowTest::testCodeChallengeRfc7636Vector()
+{
+    // Test vector from RFC 7636 Appendix B.
+    const QString verifier = QStringLiteral("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
+    QCOMPARE(OAuthClientFlow::codeChallengeS256(verifier), QStringLiteral("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"));
+}
+
+void OAuthClientFlowTest::testBuildAuthorizationUrl()
+{
+    const QUrl url = OAuthClientFlow::buildAuthorizationUrl(QUrl(QStringLiteral("https://example.com/authorize")),
+                                                            QStringLiteral("mud-native-client"),
+                                                            {QStringLiteral("openid"), QStringLiteral("profile")},
+                                                            QStringLiteral("http://127.0.0.1:49152/"),
+                                                            QStringLiteral("test-state"),
+                                                            QStringLiteral("test-challenge"),
+                                                            QStringLiteral("test-nonce"));
+    QVERIFY(url.isValid());
+    QCOMPARE(url.scheme(), QStringLiteral("https"));
+    QCOMPARE(url.host(), QStringLiteral("example.com"));
+    QCOMPARE(url.path(), QStringLiteral("/authorize"));
+
+    const QUrlQuery query(url);
+    QCOMPARE(query.queryItemValue(QStringLiteral("response_type")), QStringLiteral("code"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("client_id")), QStringLiteral("mud-native-client"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded), QStringLiteral("http://127.0.0.1:49152/"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("scope"), QUrl::FullyDecoded), QStringLiteral("openid profile"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("state")), QStringLiteral("test-state"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("code_challenge")), QStringLiteral("test-challenge"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("code_challenge_method")), QStringLiteral("S256"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("nonce")), QStringLiteral("test-nonce"));
+}
+
+void OAuthClientFlowTest::testBuildAuthorizationUrlOmitsEmptyNonce()
+{
+    const QUrl url = OAuthClientFlow::buildAuthorizationUrl(QUrl(QStringLiteral("https://example.com/authorize")),
+                                                            QStringLiteral("mud-native-client"),
+                                                            {QStringLiteral("openid")},
+                                                            QStringLiteral("http://127.0.0.1:49152/"),
+                                                            QStringLiteral("test-state"),
+                                                            QStringLiteral("test-challenge"),
+                                                            QString());
+    const QUrlQuery query(url);
+    QVERIFY(!query.hasQueryItem(QStringLiteral("nonce")));
+}
+
+#include "OAuthClientFlowTest.moc"
+QTEST_MAIN(OAuthClientFlowTest)

--- a/test/OAuthClientFlowTest.cpp
+++ b/test/OAuthClientFlowTest.cpp
@@ -19,20 +19,87 @@
 
 #include <OAuthClientFlow.h>
 #include <QtTest/QtTest>
+#include <QDesktopServices>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QRegularExpression>
+#include <QTcpServer>
+#include <QTcpSocket>
 #include <QUrlQuery>
+
+// Serves a static OpenID Connect discovery document over loopback HTTP so the
+// flow's QNetworkAccessManager fetch has something real to talk to.
+class MiniDiscoveryServer : public QObject
+{
+public:
+    explicit MiniDiscoveryServer(const QString& authorizationEndpoint, QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        mBody = QJsonDocument(QJsonObject{{QStringLiteral("authorization_endpoint"), authorizationEndpoint}}).toJson(QJsonDocument::Compact);
+        mServer.listen(QHostAddress::LocalHost, 0);
+        connect(&mServer, &QTcpServer::newConnection, this, [this]() {
+            while (mServer.hasPendingConnections()) {
+                QTcpSocket* socket = mServer.nextPendingConnection();
+                connect(socket, &QTcpSocket::readyRead, socket, [this, socket]() {
+                    socket->readAll();
+                    QByteArray response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " + QByteArray::number(mBody.size()) + "\r\nConnection: close\r\n\r\n" + mBody;
+                    socket->write(response);
+                    socket->disconnectFromHost();
+                });
+                connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+            }
+        });
+    }
+
+    QUrl discoveryUrl() const { return QUrl(QStringLiteral("http://127.0.0.1:%1/.well-known/openid-configuration").arg(mServer.serverPort())); }
+
+private:
+    QTcpServer mServer;
+    QByteArray mBody;
+};
 
 class OAuthClientFlowTest : public QObject
 {
     Q_OBJECT
 
+public slots:
+    void captureBrowserUrl(const QUrl& url) { mBrowserUrl = url; }
+
 private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
     void testCodeVerifierFormat();
     void testCodeVerifierUnique();
     void testCodeChallengeRfc7636Vector();
     void testBuildAuthorizationUrl();
     void testBuildAuthorizationUrlOmitsEmptyNonce();
+    void testFullFlowCapturesAuthorizationCode();
+    void testStateMismatchFailsFlow();
+    void testNonRedirectRequestIgnored();
+    void testDiscoveryFetchFailureFailsFlow();
+    void testNonLoopbackHttpDiscoveryUrlRejected();
+    void testProviderErrorFailsFlow();
+
+private:
+    QUrl mBrowserUrl;
 };
+
+void OAuthClientFlowTest::initTestCase()
+{
+    QDesktopServices::setUrlHandler(QStringLiteral("http"), this, "captureBrowserUrl");
+}
+
+void OAuthClientFlowTest::cleanupTestCase()
+{
+    QDesktopServices::unsetUrlHandler(QStringLiteral("http"));
+}
+
+void OAuthClientFlowTest::init()
+{
+    mBrowserUrl.clear();
+}
+
 
 void OAuthClientFlowTest::testCodeVerifierFormat()
 {
@@ -92,6 +159,142 @@ void OAuthClientFlowTest::testBuildAuthorizationUrlOmitsEmptyNonce()
                                                             QString());
     const QUrlQuery query(url);
     QVERIFY(!query.hasQueryItem(QStringLiteral("nonce")));
+}
+
+void OAuthClientFlowTest::testFullFlowCapturesAuthorizationCode()
+{
+    MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
+    OAuthClientFlow flow;
+    QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
+    QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
+    QSignalSpy openedSpy(&flow, &OAuthClientFlow::browserOpened);
+
+    flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, true);
+    QTRY_VERIFY(!mBrowserUrl.isEmpty());
+    QCOMPARE(openedSpy.count(), 1);
+
+    const QUrlQuery query(mBrowserUrl);
+    QCOMPARE(query.queryItemValue(QStringLiteral("response_type")), QStringLiteral("code"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("client_id")), QStringLiteral("test-client"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("scope"), QUrl::FullyDecoded), QStringLiteral("openid"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("code_challenge_method")), QStringLiteral("S256"));
+    QVERIFY(!query.queryItemValue(QStringLiteral("state")).isEmpty());
+    QVERIFY(!query.queryItemValue(QStringLiteral("nonce")).isEmpty());
+    const QString challenge = query.queryItemValue(QStringLiteral("code_challenge"));
+    QVERIFY(!challenge.isEmpty());
+    const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
+    QCOMPARE(redirectUri.host(), QStringLiteral("127.0.0.1"));
+    QVERIFY(redirectUri.port() > 0);
+
+    // Simulate the provider redirecting the browser back to the loopback listener.
+    QTcpSocket browser;
+    browser.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+    QVERIFY(browser.waitForConnected(3000));
+    browser.write("GET /?code=test-auth-code&state=" + query.queryItemValue(QStringLiteral("state")).toLatin1() + " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+    QTRY_COMPARE(capturedSpy.count(), 1);
+    const auto args = capturedSpy.takeFirst();
+    QCOMPARE(args.at(0).toString(), QStringLiteral("test-auth-code"));
+    QCOMPARE(OAuthClientFlow::codeChallengeS256(args.at(1).toString()), challenge);
+    QCOMPARE(args.at(2).toString(), redirectUri.toString());
+    QCOMPARE(failedSpy.count(), 0);
+
+    QTRY_VERIFY(browser.bytesAvailable() > 0);
+    QVERIFY(browser.readAll().startsWith("HTTP/1.1 200"));
+}
+
+void OAuthClientFlowTest::testStateMismatchFailsFlow()
+{
+    MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
+    OAuthClientFlow flow;
+    QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
+    QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
+
+    flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
+    QTRY_VERIFY(!mBrowserUrl.isEmpty());
+    const QUrlQuery query(mBrowserUrl);
+    const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
+
+    QTcpSocket browser;
+    browser.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+    QVERIFY(browser.waitForConnected(3000));
+    browser.write(QByteArray("GET /?code=test-auth-code&state=wrong-state HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"));
+
+    QTRY_COMPARE(failedSpy.count(), 1);
+    QCOMPARE(capturedSpy.count(), 0);
+
+    QTRY_VERIFY(browser.bytesAvailable() > 0);
+    QVERIFY(browser.readAll().startsWith("HTTP/1.1 400"));
+}
+
+void OAuthClientFlowTest::testNonRedirectRequestIgnored()
+{
+    MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
+    OAuthClientFlow flow;
+    QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
+    QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
+
+    flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
+    QTRY_VERIFY(!mBrowserUrl.isEmpty());
+    const QUrlQuery query(mBrowserUrl);
+    const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
+
+    // A browser side-request (no code/error) must be answered without ending the flow.
+    QTcpSocket sideRequest;
+    sideRequest.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+    QVERIFY(sideRequest.waitForConnected(3000));
+    sideRequest.write(QByteArray("GET /favicon.ico HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"));
+    QTRY_VERIFY(sideRequest.bytesAvailable() > 0);
+    QVERIFY(sideRequest.readAll().startsWith("HTTP/1.1 404"));
+    QCOMPARE(failedSpy.count(), 0);
+
+    // The real redirect still completes afterwards.
+    QTcpSocket browser;
+    browser.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+    QVERIFY(browser.waitForConnected(3000));
+    browser.write("GET /?code=test-auth-code&state=" + query.queryItemValue(QStringLiteral("state")).toLatin1() + " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+    QTRY_COMPARE(capturedSpy.count(), 1);
+    QCOMPARE(failedSpy.count(), 0);
+}
+
+void OAuthClientFlowTest::testDiscoveryFetchFailureFailsFlow()
+{
+    OAuthClientFlow flow;
+    QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
+    // Port 1 on loopback refuses connections, so the discovery fetch cannot succeed.
+    flow.start(QUrl(QStringLiteral("http://127.0.0.1:1/.well-known/openid-configuration")), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
+    QTRY_COMPARE_WITH_TIMEOUT(failedSpy.count(), 1, 15000);
+}
+
+void OAuthClientFlowTest::testNonLoopbackHttpDiscoveryUrlRejected()
+{
+    OAuthClientFlow flow;
+    QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
+    // Plain http is only acceptable for loopback hosts; anything else must be refused
+    // before any network activity happens.
+    flow.start(QUrl(QStringLiteral("http://example.com/.well-known/openid-configuration")), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
+    QCOMPARE(failedSpy.count(), 1);
+}
+
+void OAuthClientFlowTest::testProviderErrorFailsFlow()
+{
+    MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
+    OAuthClientFlow flow;
+    QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
+    QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
+
+    flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
+    QTRY_VERIFY(!mBrowserUrl.isEmpty());
+    const QUrlQuery query(mBrowserUrl);
+    const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
+
+    QTcpSocket browser;
+    browser.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+    QVERIFY(browser.waitForConnected(3000));
+    browser.write("GET /?error=access_denied&state=" + query.queryItemValue(QStringLiteral("state")).toLatin1() + " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+    QTRY_COMPARE(failedSpy.count(), 1);
+    QCOMPARE(capturedSpy.count(), 0);
 }
 
 #include "OAuthClientFlowTest.moc"

--- a/test/SecureStringUtilsTest.cpp
+++ b/test/SecureStringUtilsTest.cpp
@@ -20,6 +20,7 @@
 #include <SecureStringUtils.h>
 #include <QtTest/QtTest>
 #include <QVersionNumber>
+#include <string>
 
 class SecureStringUtilsTest : public QObject {
 Q_OBJECT
@@ -156,6 +157,14 @@ void SecureStringUtilsTest::testSecureMemoryClearing()
     SecureStringUtils::secureByteArrayClear(testArray);
     QVERIFY(testArray.isEmpty());
     QVERIFY(testArray != originalArray);
+
+    // Test std::string clearing
+    std::string testStdString = "sensitive_std_data";
+    std::string originalStdString = testStdString;
+
+    SecureStringUtils::secureStdStringClear(testStdString);
+    QVERIFY(testStdString.empty());
+    QVERIFY(testStdString != originalStdString);
 }
 
 void SecureStringUtilsTest::testProfileKeyPersistence()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds full support for the GMCP Char.Login v2 sign-in flow. When a game offers it, Mudlet shows a chooser to sign in with an OAuth provider (Google, Discord, GitHub, etc.) via the browser, with the game's own account via the browser (on encrypted connections), or with a classic character name and password. When the server issues a reconnect token for "remember me", it is persisted via the credential manager for subsequent automatic, password-less sign-ins. A per-profile "always use character name and password" preference is available for games that support this flow, and is hidden everywhere else.

#### Motivation for adding to Mudlet

Modern games are moving to browser-based single sign-on; this lets Mudlet players use those accounts directly instead of managing separate credentials, while still supporting classic logins.

#### Other info (issues closed, discussion etc)

Inspired by #9354. Covers the complete v2 specification: version negotiation, both sign-in flows (server-driven browser pairing for any connection, and the client-driven flow for games that are their own OpenID Provider, only over encrypted connections), and password-less reconnect tokens with rotation.

Try it out on StickMUD.

https://github.com/user-attachments/assets/e5ca2e3d-9765-4968-875f-fba83efdeb39