### PR TITLE
Fix: show room names menu item again

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -1,8 +1,9 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2016, 2019-2020, 2022 by Stephen Lyons             *
+ *   Copyright (C) 2015-2016, 2019-2020, 2022, 2026 by Stephen Lyons       *
  *                                               - slysven@virginmedia.com *
+ *   Copyright (C) 2026 by Ethan Hussong - ethan@ethanhussong.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -496,12 +497,6 @@ void dlgMapper::slot_toggleShowRoomIDs(int toggle)
     mp2dMap->update();
 }
 
-void dlgMapper::slot_toggleShowRoomNames(int toggle)
-{
-    mpMap->setRoomNamesShown(toggle == Qt::Checked);
-    mp2dMap->update();
-}
-
 void dlgMapper::slot_toggleStrongHighlight(int toggle)
 {
     mpHost->mMapStrongHighlight = (toggle == Qt::Checked);
@@ -883,6 +878,14 @@ void dlgMapper::slot_setupMapperMenu()
     connect(showRoomIdsAction, &QAction::toggled, this, &dlgMapper::slot_toggleShowRoomIDsFromMenu);
     menu->addAction(showRoomIdsAction);
 
+    auto* showRoomNamesAction = new QAction(tr("Show room names"), this);
+    showRoomNamesAction->setCheckable(true);
+    showRoomNamesAction->setChecked(mpMap->getRoomNamesShown());
+    showRoomNamesAction->setToolTip(tr("When enabled, room names will be displayed on the map."));
+
+    connect(showRoomNamesAction, &QAction::toggled, this, &dlgMapper::slot_toggleShowRoomNames);
+    menu->addAction(showRoomNamesAction);
+
     auto* showMapGrid = new QAction(tr("Show map grid"), this);
     showMapGrid->setCheckable(true);
     showMapGrid->setChecked(mpHost->mMapperShowGrid);
@@ -926,6 +929,12 @@ void dlgMapper::slot_toggleShowRoomIDsFromMenu(bool enabled)
 {
     mp2dMap->mShowRoomID = enabled;
     mp2dMap->mpHost->mShowRoomID = enabled;
+    mp2dMap->update();
+}
+
+void dlgMapper::slot_toggleShowRoomNames(const bool enabled)
+{
+    mpMap->setRoomNamesShown(enabled);
     mp2dMap->update();
 }
 

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -4,8 +4,9 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016, 2021-2022 by Stephen Lyons                        *
+ *   Copyright (C) 2016, 2021-2022, 2026 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
+ *   Copyright (C) 2026 by Ethan Hussong - ethan@ethanhussong.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -75,7 +76,6 @@ public slots:
     void updateEmptyStateOverlay();
     void slot_toggleRoundRooms(const bool);
     void slot_toggleShowRoomIDs(int toggle);
-    void slot_toggleShowRoomNames(int toggle);
     void slot_toggleStrongHighlight(int toggle);
     void slot_toggle3DView(const bool);
     void slot_togglePanel();
@@ -89,6 +89,7 @@ public slots:
     void slot_setupMapperMenu();
     void slot_toggleUpperLowerLevels(bool enabled);
     void slot_toggleShowRoomIDsFromMenu(bool enabled);
+    void slot_toggleShowRoomNames(const bool);
     void updateInfoMenu();
     void slot_showSaveWarningMenu();
     void slot_saveErrorChanged(bool hasError);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Re-add a checkable Show room names action to the mapper menu, next to Show room IDs (it was dropped when the menu was rebuilt in `slot_setupMapperMenu()`). The action's checked state reflects the persisted map flag read by `TMap::getRoomNamesShown()`; toggling it calls `setRoomNamesShown()` and repaints the 2D map.

#### Motivation for adding to Mudlet
Restores the only UI control for showing room names on the map — the backing state and 2D renderer support were still present, but the menu entry had gone missing.

#### Other info (issues closed, discussion etc)
Fixes #9297

The pre-existing slot_`toggleShowRoomNames(int)` was not being use and it was previously considering an `enum (Qt::CheckState)` arguement it has been replaced by one using a `bool` argument.

Test case:
* Open a profile with a map and show the mapper.
* Click the mapper menu (☰) → toggle Show room names on → room names appear on the 2D map.
* Toggle it off → room names disappear.
* Reopen the menu → the checkbox reflects the current (persisted) state.

This PR is derived from #9304 by @ehussong who closed and deleted that PR before it could be tested and merged by the Mudlet Core Devs. As such I have assigned them a copyright mention in the files modified.

In passing I note that the dlgMapper (and possibly some related) class(es) now have methods with a `slot_` prefix that are NOT **slot**s - and some others where the reverse is true. Given that there is an overhead to invoking a slot (via a `QObject::connect(...)`ion) it would be wise to update the methods so misnamed so that it is clear which ones are used as a slot.
