### PR TITLE
infrastructure: don't run DangerJS on release PRs

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -15,6 +15,10 @@ concurrency:
 
 jobs:
   danger:
+    # Skip release PRs (development -> main): their head branch is `development`, so every
+    # push to development re-triggers danger and stamps a failing commit status onto each
+    # dev commit. Contributor PRs target `development` and are unaffected.
+    if: github.event.pull_request.base.ref != 'main'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout base branch for danger config

--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -15,9 +15,8 @@ concurrency:
 
 jobs:
   danger:
-    # Skip release PRs (development -> main): their head branch is `development`, so every
-    # push to development re-triggers danger and stamps a failing commit status onto each
-    # dev commit. Contributor PRs target `development` and are unaffected.
+    # Skip release PRs (base main): their head is `development`, so every dev push
+    # would re-run danger and stamp a failing status onto each dev commit.
     if: github.event.pull_request.base.ref != 'main'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Skip the DangerJS job when a PR's base is `main` (i.e. release PRs).

#### Motivation for adding to Mudlet
The open release PR (development -> main) has `development` as its head, so every dev push re-ran DangerJS and stamped a failing/pending `Danger` required status onto each dev commit. Contributor PRs (base `development`) are unaffected.

**Test case:** Push to `development` -> danger job is skipped, no `Danger` status posted. Open a normal PR -> danger runs as before.
