### PR TITLE
fix: guard against null stopwatch when saving profiles and listing stopwatches

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -771,6 +771,10 @@ int TLuaInterpreter::getStopWatches(lua_State* L)
     for (const int watchId : stopWatchIds) {
         lua_pushnumber(L, watchId);
         auto pStopWatch = host.getStopWatch(watchId);
+        if (!pStopWatch) {
+            lua_pop(L, 1);
+            continue;
+        }
         lua_newtable(L);
         {
             lua_pushstring(L, "name");

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -702,6 +702,9 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         while (itStopWatchId.hasNext()) {
             auto stopWatchId = itStopWatchId.next();
             auto pStopWatch = pHost->getStopWatch(stopWatchId);
+            if (!pStopWatch) {
+                continue;
+            }
             if (pStopWatch->persistent()) {
                 auto stopwatch = stopwatches.append_child("stopwatch");
                 // Three QStrings used here are purely numeric so can be expressed in Latin1 encoding:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Guard `getStopWatch()` results against null before dereferencing in `XMLexport::writeHost` and `TLuaInterpreter::getStopWatches` (skip the entry if null).

#### Motivation for adding to Mudlet
Resolves the two `error`-severity CodeQL `cpp/inconsistent-null-check` alerts - most `getStopWatch` callers null-check the result, these two did not.

**Test case:** Save a profile with persistent stopwatches and call `getStopWatches()` - both behave as before; no crash if a stopwatch id ever resolves to null.
