### PR TITLE
fix: keep locks on stub exits when auditing the map

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1581,7 +1581,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             mpRoomDB->mpMap->appendRoomErrorMsg(id, warnMsg, true);
             userData.insert(auditKey, QString::number(exitRoomId));
             if (!exitStubs.contains(dirCode)) {
-                // Add a stub (this is so we can retain doors, though exit weights, custom lines and locks will go)
+                // Add a stub (this is so we can retain doors and locks, though exit weights and custom lines will go)
                 exitStubs.append(dirCode);
                 // Remove a (now valid) stub in this direction from check pool
                 exitStubsPool.remove(dirCode);
@@ -1593,8 +1593,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             // And eliminate the corresponding things from the pools of things
             // that have to be checked:
             // TODO: Add additional warnings if we ARE deleting any data in following
-            exitLocks.removeAll(dirCode);
-            exitLocksPool.remove(dirCode);
+            exitLocksPool.remove(dirCode); // A stub exit can retain a lock so keep any that exists
 
             exitWeights.remove(exitKey);
             exitWeightsPool.remove(exitKey);
@@ -1647,16 +1646,15 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         if (exitStubs.contains(dirCode)) {
             exitStubsPool.remove(dirCode); // Remove the stub in this direction from check pool as we have handled it
         } else {
-            // If NOT we cannot have a door
+            // If NOT we cannot have a door or a lock
             doors.remove(exitKey);
+            exitLocks.removeAll(dirCode);
         }
-        // We have handled whether we can have a door (if there IS a stub) or not (if not)
-        // so remove it from the check pool as we have handled it
         doorsPool.remove(exitKey);
+        exitLocksPool.remove(dirCode);
 
-        // Whether we do or not have a stub exit we cannot have a lock, custom
+        // Whether we do or not have a stub exit we cannot have a custom
         // line or a weight - so remove them if they exist:
-        exitLocks.removeAll(dirCode);
         exitWeights.remove(exitKey);
         customLines.remove(exitKey);
         customLinesColor.remove(exitKey);
@@ -1665,7 +1663,6 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         // Whether we have a stub or not we have handled all the things that we
         // want to check the existence of so take them out of the pools of
         // things left to check after all the exits have been looked at
-        exitLocksPool.remove(dirCode);
         exitWeightsPool.remove(exitKey);
         customLinesPool.remove(exitKey);
         customLinesColorPool.remove(exitKey);
@@ -1692,13 +1689,8 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
         }
         exitStubsPool.remove(dirCode); // Remove the stub in this direction from check pool as we have handled it
 
-        if (exitLocks.contains(dirCode)) {
-            const QString auditKeyLocked = qsl("audit.invalid_exit.%1.isLocked").arg(dirCode);
-            userData.insert(auditKeyLocked, qsl("true"));
-            //: %1 is the audit key for the lock status
-            infoMsg.append(qsl("  %1").arg(tr(R"(It was locked, this is recorded as user data with key: "%1".)").arg(auditKeyLocked)));
-            exitLocks.removeAll(dirCode);
-        }
+        // Any lock on this exit is retained as the stub that replaces it can
+        // also carry a lock
 
         if (exitWeights.contains(exitKey)) {
             const QString auditKeyWeight = qsl("audit.invalid_exit.%1.weight").arg(dirCode);
@@ -2322,6 +2314,9 @@ void TRoom::writeJsonExitStubs(QJsonObject& obj) const
         const QJsonValue stubNameValue{stubName};
         exitStubObj.insert(QLatin1String("name"), stubNameValue);
         writeJsonDoor(exitStubObj, stubName);
+        if (exitLocks.contains(stringToDirCode(stubName))) {
+            exitStubObj.insert(QLatin1String("locked"), true);
+        }
         const QJsonValue exitStubValue{exitStubObj};
         exitStubsArray.append(exitStubValue);
     }
@@ -2361,6 +2356,10 @@ void TRoom::readJsonExitStubs(const QJsonObject& obj)
         // Will only get here for normal exit directions:
         if (exitStubObj.contains(QLatin1String("door")) && exitStubObj.value(QLatin1String("door")).isString()) {
             readJsonDoor(exitStubObj, doorKey);
+        }
+
+        if (exitStubObj.contains(QLatin1String("locked")) && exitStubObj.value(QLatin1String("locked")).isBool() && exitStubObj.value(QLatin1String("locked")).toBool()) {
+            exitLocks.append(dir);
         }
     }
 }


### PR DESCRIPTION




<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The map audit stripped exit locks from any direction without a real exit, so locks set on stub exits never survived a save/load cycle. Keep locks on stubs (including exits the audit itself converts to stubs) and only remove them when there is neither an exit nor a stub. Also round-trip stub locks through the JSON map format.
#### Motivation for adding to Mudlet
Follow-up to #9352
#### Other info (issues closed, discussion etc)
