### PR TITLE
infrastructure: merge release-4.22 back into development

### DIFF
--- a/.github/repo-metadata.yml
+++ b/.github/repo-metadata.yml
@@ -2,4 +2,4 @@
 
 milestones:
   # assign new PRs to this milestone
-  next-milestone: 4.22.0
+  next-milestone: 4.23.0

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -318,6 +318,41 @@ jobs:
           exit 1
         fi
 
+    - name: (Windows) Re-upload signed installer to mudlet.org
+      # The deploy step scp'd the installer before signing existed for tag
+      # builds, so overwrite it with the signed version. Non-fatal: the GitHub
+      # release (primary distribution) gets the signed installer either way.
+      if: steps.sign-installer.outcome == 'success' && startsWith(github.ref, 'refs/tags/')
+      shell: msys2 {0}
+      env:
+        DEPLOY_SSH_KEY: ${{secrets.UPLOAD_PRIVATEKEY}}
+        DEPLOY_PATH: ${{secrets.DEPLOY_PATH}}
+      run: |
+        SIGNED_PATH=$(cygpath -au "${ARTIFACT_WINPATHORFILE}")
+        if [ ! -f "${SIGNED_PATH}" ]; then
+          echo "::warning::signed installer not found at ${SIGNED_PATH} - mudlet.org keeps the unsigned installer"
+          exit 0
+        fi
+
+        echo "${DEPLOY_SSH_KEY}" > temp_key_file_signed
+        powershell.exe -Command "icacls.exe temp_key_file_signed /inheritance:r"
+
+        powershell.exe <<EOF
+        \$installerExePath = "${ARTIFACT_WINPATHORFILE}"
+        \$DEPLOY_PATH = "${DEPLOY_PATH}"
+        scp.exe -i temp_key_file_signed -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \$installerExePath mudmachine@make.mudlet.org:\${DEPLOY_PATH}
+        if (\$LASTEXITCODE -ne 0) { exit \$LASTEXITCODE }
+        EOF
+        scp_rc=$?
+
+        shred -u temp_key_file_signed
+
+        if [ "$scp_rc" -ne 0 ]; then
+          echo "::warning::failed to re-upload signed installer to make.mudlet.org (scp exit ${scp_rc}) - mudlet.org keeps the unsigned installer"
+          exit 0
+        fi
+        echo "Signed installer re-uploaded over the unsigned one on make.mudlet.org."
+
     - name: Create intermediate artifact for debugging
       uses: actions/upload-artifact@v7
       if: env.INTERMEDIATE_ARTIFACT_NAME
@@ -330,9 +365,10 @@ jobs:
     - name: Create artifact for later uploading
       # Uploads the zipped contents of ARTIFACT_WINPATHORFILE as an "artifact" with
       # the given name - the Environmental variables are created by the
-      # deploy-mudlet-for-windows.sh script:
+      # deploy-mudlet-for-windows.sh script. PTB-only: on tag builds the installer
+      # reaches mudlet.org via scp in the deploy script instead:
       uses: actions/upload-artifact@v7
-      if: env.ARTIFACT_NAME
+      if: env.ARTIFACT_NAME != '' && !startsWith(github.ref, 'refs/tags/')
       with:
         name: ${{env.ARTIFACT_NAME}}
         path: ${{env.ARTIFACT_WINPATHORFILE}}
@@ -340,7 +376,7 @@ jobs:
 
     - name: Upload artifact to make.mudlet.org
       shell: msys2 {0}
-      if: env.ARTIFACT_NAME
+      if: env.ARTIFACT_NAME != '' && !startsWith(github.ref, 'refs/tags/')
       run: curl --retry 5 -X POST "https://make.mudlet.org/snapshots/gha_queue.php?artifact_name=${{env.ARTIFACT_NAME}}&unzip=${{env.ARTIFACT_UNZIP}}"
 
     - name: Upload release asset for GitHub Release

--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -373,6 +373,13 @@ else
     DBLSQD_CHANNEL="public-test-build"
     CHANGELOG_MODE="ptb"
   else
+    # Expose the installer to the workflow's SignPath steps. Only the PTB branch
+    # above ever set these, so on tag builds the installer-signing chain silently
+    # skipped and releases shipped an unsigned installer wrapper:
+    {
+      echo "ARTIFACT_NAME=${INSTALLER_EXE}"
+      echo "ARTIFACT_WINPATHORFILE=${INSTALLER_EXE_WINPATHFILE}"
+    } >> "${GITHUB_ENV}"
 
     echo "=== Uploading installer to https://www.mudlet.org/wp-content/files/?C=M;O=D ==="
     echo "${DEPLOY_SSH_KEY}" > temp_key_file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ else()
 endif()
 
 # Set APP_VERSION
-set(APP_VERSION 4.21.1)
+set(APP_VERSION 4.22.0)
 
 # Set APP_BUILD based on environment variable MUDLET_VERSION_BUILD. An explicitly
 # empty value must be distinguished from an unset one so release builds (CI exports


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Version bump to 4.22.0 (development shows 4.22.0-dev, next PTBs identify as 4.22.0-ptb)
- Windows installer signing fix: tag builds now export ARTIFACT_NAME/ARTIFACT_WINPATHORFILE so the SignPath installer chain runs on releases (it silently skipped on every SignPath-era release before 4.22.0), PTB-only artifact/gha_queue steps guarded off tags, and the signed installer is re-uploaded over the unsigned one on make.mudlet.org
- next-milestone bumped to 4.23.0

#### Motivation for adding to Mudlet
Standard post-release merge-back per the release checklist; propagates the release pipeline fixes validated by the 4.22.0 release (both SignPath requests fired and the shipped installer is signed - verified against SHA256SUMS).

#### Other info (issues closed, discussion etc)
Squash-merge like #9384. Keep the release-4.22 branch for potential hotfixes until the next release.

**Test case:** validated live by the Mudlet-4.22.0 release: all jobs green, "(Windows) Sign installer with SignPath" and the re-upload step both succeeded, and the published installer's sha256 matches the signed artifact on mudlet.org and in SHA256SUMS.txt.