### PR TITLE
fix: apply map label edits immediately in label preview 

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1075,7 +1075,12 @@ void T2DMap::drawScaledLabel(QPainter& painter, const QPointF& position, TMapLab
 {
     const QSize targetSize = paintRect.size().toSize();
     if (!label.text.isEmpty() && !label.font.family().isEmpty()) {
-        const QString cacheKey = qsl("%1_%2_%3x%4").arg(mAreaID).arg(labelKey).arg(targetSize.width()).arg(targetSize.height());
+        // Include the label's visual content in the cache key so that editing
+        // a label's text, font or colours (e.g. live-previewing from the
+        // create label dialog) invalidates the previously cached rendering:
+        const auto contentHash = qHash(
+                qsl("%1|%2|%3|%4|%5").arg(label.text, label.font.toString(), QString::number(label.fgColor.rgba()), QString::number(label.bgColor.rgba()), QString::number(label.outlineColor.rgba())));
+        const QString cacheKey = qsl("%1_%2_%3x%4_%5").arg(mAreaID).arg(labelKey).arg(targetSize.width()).arg(targetSize.height()).arg(contentHash);
         if (!mTextLabelPixmapCache.contains(cacheKey)) {
             addTextLabelToCache(cacheKey, label, targetSize);
         }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
https://github.com/Mudlet/Mudlet/pull/8795 improved textual labels to be crisp at any room levels, but broke the ability to preview them at creation. This fixes it.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
