### PR TITLE
fix: updater not running on close, showing empty changelog

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -726,7 +726,11 @@ void mudlet::init()
     connect(this, &mudlet::signal_windowStateChanged, this, &mudlet::slot_windowStateChanged);
 
 #if defined(INCLUDE_UPDATER)
-    pUpdater = new Updater(this, mpSettings, !releaseVersion);
+    // The main window deletes itself on close (WA_DeleteOnClose). The updater
+    // shows its "an update is ready" dialog only after the last window closes,
+    // so it must outlive the main window - parent it to the application, not to
+    // the window that is about to be destroyed:
+    pUpdater = new Updater(qApp, mpSettings, !releaseVersion);
     connect(pUpdater, &Updater::signal_updateAvailable, this, &mudlet::slot_updateAvailable);
     connect(pUpdater, &Updater::signal_updateCheckFailed, this, &mudlet::slot_updateCheckFailed);
     connect(dactionUpdate, &QAction::triggered, this, &mudlet::slot_manualUpdateCheck);
@@ -5785,8 +5789,15 @@ void mudlet::slot_updateInstalled()
 
     // rejig to restart Mudlet instead
     connect(dactionUpdate, &QAction::triggered, this, [=, this]() {
+#if defined(Q_OS_WINDOWS)
+        // On Windows the new binary is not in place yet - the downloaded
+        // installer still has to run, which slot_installOrRestartClicked
+        // arranges via a batch file that waits for Mudlet to exit:
+        pUpdater->slot_installOrRestartClicked(nullptr, QString());
+#else
         forceClose();
         QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+#endif
     });
     dactionUpdate->setText(tr("Update installed - restart to apply"));
 #endif // !Q_OS_MACOS

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -621,6 +621,11 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
 // Records a timestamp on disk so shouldShowChangelog() can detect automatic updates on next launch
 void Updater::recordUpdateTime() const
 {
+    // The updater outlives the main window; without it there is no config
+    // path to write the changelog marker to:
+    if (!mudlet::self()) {
+        return;
+    }
     QSaveFile file(mudlet::getMudletPath(enums::mainDataItemPath, qsl("mudlet_updated_at")));
     bool opened = file.open(QIODevice::WriteOnly);
     if (!opened) {
@@ -642,6 +647,11 @@ void Updater::recordUpdateTime() const
 // the changelog on next startup for the latest version only
 void Updater::recordUpdatedVersion() const
 {
+    // The updater outlives the main window; without it there is no config
+    // path to write the changelog marker to:
+    if (!mudlet::self()) {
+        return;
+    }
     QSaveFile file(mudlet::getMudletPath(enums::mainDataItemPath, qsl("mudlet_updated_from")));
     bool opened = file.open(QIODevice::WriteOnly);
     if (!opened) {
@@ -653,7 +663,9 @@ void Updater::recordUpdatedVersion() const
     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
         ofs.setVersion(mudlet::scmQDataStreamFormat_5_12);
     }
-    ofs << APP_VERSION;
+    // The full version (including any -ptb suffix) so shouldShowChangelog()
+    // can tell whether the running version actually changed:
+    ofs << QCoreApplication::applicationVersion();
     if (!file.commit()) {
         qWarning() << "Updater::recordUpdatedVersion: error saving old mudlet version:" << file.errorString();
     }
@@ -697,16 +709,32 @@ bool Updater::shouldShowChangelog()
 
     file.remove();
 
+    // The markers are also written when an update was downloaded but never
+    // installed (e.g. the user declined the restart). If the "updated from"
+    // version is still the one running, no update actually happened - don't
+    // show a changelog for it:
+    if (readPreviousVersionFile(false) == QCoreApplication::applicationVersion()) {
+        QFile::remove(mudlet::self()->getMudletPath(enums::mainDataItemPath, qsl("mudlet_updated_from")));
+        return false;
+    }
+
     return minsSinceUpdate >= 5;
 }
 
 QString Updater::getPreviousVersion() const
 {
+    return readPreviousVersionFile(true);
+}
+
+QString Updater::readPreviousVersionFile(const bool removeAfterRead) const
+{
     QFile file(mudlet::self()->getMudletPath(enums::mainDataItemPath, qsl("mudlet_updated_from")));
     bool opened = file.open(QIODevice::ReadOnly);
     QString previousVersion;
     if (!opened) {
-        file.remove();
+        if (removeAfterRead) {
+            file.remove();
+        }
         return QString();
     }
     QDataStream ifs(&file);
@@ -715,7 +743,9 @@ QString Updater::getPreviousVersion() const
     }
     ifs >> previousVersion;
     file.close();
-    file.remove();
+    if (removeAfterRead) {
+        file.remove();
+    }
 
     if (ifs.status() != QDataStream::Ok) {
         qWarning() << "Failed to read previous version file, treating as missing";

--- a/src/updater.h
+++ b/src/updater.h
@@ -89,6 +89,7 @@ private:
     void recordUpdateTime() const;
     void recordUpdatedVersion() const;
     QString getPreviousVersion() const;
+    QString readPreviousVersionFile(const bool removeAfterRead) const;
     bool downloadReleaseIfValid(const dblsqd::Release& release);
     void finishSetup();
     void showDialogManually() const;

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -292,13 +292,19 @@ void UpdateDialog::showIfUpdatesAvailable()
 void UpdateDialog::showIfUpdatesAvailableOrQuit()
 {
     if (mType == OnLastWindowClosed) {
-        auto* app = qobject_cast<QGuiApplication*>(QApplication::instance());
-        app->setQuitOnLastWindowClosed(true);
-        disconnect(app, &QGuiApplication::lastWindowClosed, this, &UpdateDialog::showIfUpdatesAvailableOrQuit);
+        disconnect(qApp, &QGuiApplication::lastWindowClosed, this, &UpdateDialog::showIfUpdatesAvailableOrQuit);
     }
     QString latestVersion = mLatestRelease.getVersion();
     bool skipRelease = (settingsValue(qsl("skipRelease"), "", mSettings).toString() == latestVersion);
     if (!latestVersion.isEmpty() && !skipRelease) {
+        // The main window is already gone, so this dialog is the only thing
+        // keeping Mudlet alive - quit once the user dismisses it. We keep
+        // quitOnLastWindowClosed disabled: re-enabling it makes Qt quit the
+        // instant this dialog is shown (the lastWindowClosed re-check runs
+        // before the user can act on it), which is the whole bug being fixed.
+        KDToolBox::connectSingleShot(this, &QDialog::finished, qApp, []() {
+            QCoreApplication::quit();
+        });
         show();
     } else {
         QCoreApplication::quit();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Parent the updater to the application instead of the main window, which self-deletes on close (`WA_DeleteOnClose`) - its on-close "update ready" dialog was being destroyed with the window it needed to outlive, leaving Mudlet running invisibly instead of updating.
- Keep `quitOnLastWindowClosed` disabled while the on-close dialog is shown and quit when the user dismisses the dialog - re-enabling it made Qt tear the app down the instant the dialog appeared.
- Guard the changelog markers against a null main window (the updater now outlives it) and record the exact running version so a downloaded-but-declined update no longer shows an empty "what's new" on next launch.
- On Windows, route "Update installed - restart" through the installer (the mudlet.cpp half of #9248).

#### Motivation for adding to Mudlet
The in-app updater did not actually apply updates: closing Mudlet with an update pending left a zombie process behind instead of prompting to install, so users could not upgrade from within the app.

#### Other info (issues closed, discussion etc)
Supersedes #9248 (same root cause; that PR switched the dialog to `Manual` mode, dropping the on-close update prompt, and is stale against the #9125 GitHub-releases refactor).

**Test case:** With auto-download on and an update available, close Mudlet's main window: the update dialog should appear (rather than the process lingering), and dismissing it should exit cleanly. Verified on Linux (Xvfb) - old build leaves a zombie process on close, fixed build shows the dialog and exits cleanly when it is closed. Windows behaviour to be confirmed on a signed PTB build.

