### PR TITLE
infrastructure: PTBs shipping without all platforms' installers

### DIFF
--- a/CI/deploy-mudlet-for-windows.sh
+++ b/CI/deploy-mudlet-for-windows.sh
@@ -196,8 +196,19 @@ else
           if [[ -n "${BUILD_COMMIT}" ]] \
               && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \
                 || [[ "${existing_commit}" == "${BUILD_COMMIT}"* ]]; }; then
-            echo "=== PTB already exists for commit ${BUILD_COMMIT} (${existing_tag}), aborting public test build generation ==="
-            exit 0
+            # A PTB exists for this commit, but the platforms build in parallel
+            # and share one release - only skip if the Windows asset is already
+            # published. Otherwise a sibling platform (or a re-run) created the
+            # release first and we still owe it our asset, so one platform racing
+            # ahead or failing never blocks the others.
+            if gh release view "${existing_tag}" --repo "${GITHUB_REPOSITORY}" \
+                  --json assets --jq '.assets[].name' 2>/dev/null \
+                  | grep -q -- '-windows-64\.exe$'; then
+              echo "=== PTB ${existing_tag} already has the Windows asset for ${BUILD_COMMIT}, skipping rebuild ==="
+              exit 0
+            fi
+            echo "=== PTB ${existing_tag} exists for ${BUILD_COMMIT} but has no Windows asset yet - building to add it ==="
+            break
           fi
         done <<< "${existing_ptb_tags}"
       else

--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -86,8 +86,19 @@ then
             if [[ -n "${BUILD_COMMIT}" ]] \
                 && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \
                   || [[ "${existing_commit}" == "${BUILD_COMMIT}"* ]]; }; then
-              echo "== PTB already exists for commit ${BUILD_COMMIT} (${existing_tag}), aborting public test build generation =="
-              exit 0
+              # A PTB exists for this commit, but the platforms build in parallel
+              # and share one release - only skip if this platform's asset is
+              # already published. Otherwise a sibling platform (or a re-run)
+              # created the release first and we still owe it our asset, so one
+              # platform racing ahead or failing never blocks the others.
+              if gh release view "${existing_tag}" --repo "${GITHUB_REPOSITORY}" \
+                    --json assets --jq '.assets[].name' 2>/dev/null \
+                    | grep -q -- '-linux-x64\.AppImage\.tar$'; then
+                echo "== PTB ${existing_tag} already has the Linux asset for ${BUILD_COMMIT}, skipping rebuild =="
+                exit 0
+              fi
+              echo "== PTB ${existing_tag} exists for ${BUILD_COMMIT} but has no Linux asset yet - building to add it =="
+              break
             fi
           done <<< "${existing_ptb_tags}"
         else

--- a/CI/osx.after_success.sh
+++ b/CI/osx.after_success.sh
@@ -123,8 +123,19 @@ if [ "${DEPLOY}" = "deploy" ]; then
             if [[ -n "${BUILD_COMMIT}" ]] \
                 && { [[ "${BUILD_COMMIT}" == "${existing_commit}"* ]] \
                   || [[ "${existing_commit}" == "${BUILD_COMMIT}"* ]]; }; then
-              echo "== PTB already exists for commit ${BUILD_COMMIT} (${existing_tag}), aborting public test build generation =="
-              exit 0
+              # A PTB exists for this commit, but the platforms (and each macOS
+              # arch) build in parallel and share one release - only skip if this
+              # arch's .dmg is already published. Otherwise a sibling build (or a
+              # re-run) created the release first and we still owe it our asset,
+              # so one build racing ahead or failing never blocks the others.
+              if gh release view "${existing_tag}" --repo "${GITHUB_REPOSITORY}" \
+                    --json assets --jq '.assets[].name' 2>/dev/null \
+                    | grep -q -- "-${ARCH}\.dmg$"; then
+                echo "== PTB ${existing_tag} already has the ${ARCH} macOS asset for ${BUILD_COMMIT}, skipping rebuild =="
+                exit 0
+              fi
+              echo "== PTB ${existing_tag} exists for ${BUILD_COMMIT} but has no ${ARCH} macOS asset yet - building to add it =="
+              break
             fi
           done <<< "${existing_ptb_tags}"
         else


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Platforms build in parallel but share one GitHub Release, so the first to finish got the release created and the slower ones then aborted as "PTB already exists" - shipping PTBs missing the Linux `.AppImage.tar` and/or macOS `.dmg`.
- Each platform now skips only when *its own* asset is already published, otherwise it builds to add it (macOS checked per-arch).

#### Motivation for adding to Mudlet
PTBs regularly shipped missing whole platforms, leaving testers on those platforms nothing to download.

#### Other info (issues closed, discussion etc)
Resilience preserved: a platform that fails to build no longer takes the others' assets down with it.

**Test case:** Trigger a PTB build; confirm the prerelease contains all of `*-linux-x64.AppImage.tar`, `*-arm64.dmg`, `*-x86_64.dmg`, `*-windows-64.exe` regardless of which platform finishes first.