### PR TITLE
Add: feature callouts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,7 @@ set(mudlet_SRCS
     TEncodingTable.cpp
     TEntityHandler.cpp
     TEntityResolver.cpp
+    TFeatureCallout.cpp
     TFlipButton.cpp
     TForkedProcess.cpp
     THyperlinkCompactManager.cpp
@@ -362,6 +363,7 @@ set(mudlet_HDRS
     TEntityHandler.h
     TEntityResolver.h
     TEvent.h
+    TFeatureCallout.h
     TFlipButton.h
     TForkedProcess.h
     TGameDetails.h

--- a/src/TFeatureCallout.cpp
+++ b/src/TFeatureCallout.cpp
@@ -19,6 +19,8 @@
 
 #include "TFeatureCallout.h"
 
+#include "mudlet.h"
+
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -26,17 +28,37 @@
 #include <QPainterPath>
 #include <QPushButton>
 #include <QScreen>
+#include <QSettings>
+#include <QTimer>
 #include <QVBoxLayout>
+
+using namespace std::chrono_literals;
 
 namespace {
 constexpr int arrowHeight = 10;
 constexpr int arrowWidth = 18;
 constexpr int cornerRadius = 8;
+// Stop showing a balloon the player keeps ignoring
+constexpr int maximumAppearances = 5;
+// Several features shipping in one release must not stack balloons
+constexpr int maximumPerSession = 2;
+
+QString dismissedKey(const QString& featureId)
+{
+    return qsl("whatsNew/%1/dismissed").arg(featureId);
 }
 
-TFeatureCallout::TFeatureCallout(QWidget* pAnchor, const QString& title, const QString& body)
+QString shownCountKey(const QString& featureId)
+{
+    return qsl("whatsNew/%1/shownCount").arg(featureId);
+}
+} // namespace
+
+TFeatureCallout::TFeatureCallout(const QString& featureId, QWidget* pAnchor, const QString& title, const QString& body)
 : QWidget(pAnchor->window(), Qt::ToolTip | Qt::FramelessWindowHint)
+, mFeatureId(featureId)
 , mpAnchor(pAnchor)
+, mAnnouncement(qsl("%1. %2").arg(title, body))
 {
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_ShowWithoutActivating);
@@ -62,7 +84,10 @@ TFeatureCallout::TFeatureCallout(QWidget* pAnchor, const QString& title, const Q
     //: Button that dismisses a balloon pointing out a newly added feature
     auto* gotItButton = new QPushButton(tr("Got it"), this);
     gotItButton->setCursor(Qt::PointingHandCursor);
-    connect(gotItButton, &QPushButton::clicked, this, &QWidget::close);
+    connect(gotItButton, &QPushButton::clicked, this, [this]() {
+        markDismissed();
+        close();
+    });
     buttonRow->addWidget(gotItButton);
     layout->addLayout(buttonRow);
 
@@ -70,6 +95,41 @@ TFeatureCallout::TFeatureCallout(QWidget* pAnchor, const QString& title, const Q
     for (QWidget* pWidget = pAnchor; pWidget; pWidget = pWidget->parentWidget()) {
         pWidget->installEventFilter(this);
     }
+}
+
+void TFeatureCallout::maybeShow(const QString& featureId, QWidget* pAnchor, const QString& title, const QString& body)
+{
+    if (!pAnchor) {
+        return;
+    }
+    auto* settings = mudlet::getQSettings();
+    // players installing today experience the current interface as the
+    // baseline, so nothing in it is "new" to them
+    if (mudlet::smFirstLaunch) {
+        settings->setValue(dismissedKey(featureId), true);
+        return;
+    }
+    if (settings->value(dismissedKey(featureId), false).toBool()) {
+        return;
+    }
+    if (settings->value(shownCountKey(featureId), 0).toInt() >= maximumAppearances) {
+        return;
+    }
+    if (smSessionShown.contains(featureId) || smSessionShown.size() >= maximumPerSession) {
+        return;
+    }
+    smSessionShown.insert(featureId);
+
+    // let the widget holding the anchor settle into its final place first
+    QTimer::singleShot(800ms, pAnchor, [featureId, pAnchor, title, body]() {
+        if (!pAnchor->isVisible()) {
+            return;
+        }
+        auto* settings = mudlet::getQSettings();
+        settings->setValue(shownCountKey(featureId), settings->value(shownCountKey(featureId), 0).toInt() + 1);
+        auto* pCallout = new TFeatureCallout(featureId, pAnchor, title, body);
+        pCallout->showAnchored();
+    });
 }
 
 void TFeatureCallout::showAnchored()
@@ -81,6 +141,12 @@ void TFeatureCallout::showAnchored()
     reposition();
     show();
     raise();
+    mudlet::self()->announce(mAnnouncement);
+}
+
+void TFeatureCallout::markDismissed()
+{
+    mudlet::getQSettings()->setValue(dismissedKey(mFeatureId), true);
 }
 
 void TFeatureCallout::reposition()
@@ -138,7 +204,12 @@ bool TFeatureCallout::eventFilter(QObject* watched, QEvent* event)
         reposition();
         break;
     case QEvent::Hide:
-        if (watched == mpAnchor) {
+        // any hidden ancestor means the anchor is no longer on screen; not a
+        // dismissal though - the player never engaged with the balloon
+        close();
+        break;
+    case QEvent::WindowStateChange:
+        if (watched->isWidgetType() && static_cast<QWidget*>(watched)->isMinimized()) {
             close();
         }
         break;
@@ -146,6 +217,7 @@ bool TFeatureCallout::eventFilter(QObject* watched, QEvent* event)
         // the anchor got clicked, so the feature has been discovered - the
         // balloon has served its purpose
         if (watched == mpAnchor) {
+            markDismissed();
             close();
         }
         break;

--- a/src/TFeatureCallout.cpp
+++ b/src/TFeatureCallout.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2026 by Vadim Peretokin - vperetokin@hey.com            *
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -118,13 +118,19 @@ void TFeatureCallout::maybeShow(const QString& featureId, QWidget* pAnchor, cons
     if (smSessionShown.contains(featureId) || smSessionShown.size() >= maximumPerSession) {
         return;
     }
-    smSessionShown.insert(featureId);
 
     // let the widget holding the anchor settle into its final place first
     QTimer::singleShot(800ms, pAnchor, [featureId, pAnchor, title, body]() {
         if (!pAnchor->isVisible()) {
             return;
         }
+        // the session budget is claimed only once the balloon really appears,
+        // so an anchor that stayed hidden does not use it up - which is why
+        // the check runs again in here
+        if (smSessionShown.contains(featureId) || smSessionShown.size() >= maximumPerSession) {
+            return;
+        }
+        smSessionShown.insert(featureId);
         auto* settings = mudlet::getQSettings();
         settings->setValue(shownCountKey(featureId), settings->value(shownCountKey(featureId), 0).toInt() + 1);
         auto* pCallout = new TFeatureCallout(featureId, pAnchor, title, body);

--- a/src/TFeatureCallout.cpp
+++ b/src/TFeatureCallout.cpp
@@ -1,0 +1,156 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vperetokin@hey.com            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TFeatureCallout.h"
+
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPushButton>
+#include <QScreen>
+#include <QVBoxLayout>
+
+namespace {
+constexpr int arrowHeight = 10;
+constexpr int arrowWidth = 18;
+constexpr int cornerRadius = 8;
+}
+
+TFeatureCallout::TFeatureCallout(QWidget* pAnchor, const QString& title, const QString& body)
+: QWidget(pAnchor->window(), Qt::ToolTip | Qt::FramelessWindowHint)
+, mpAnchor(pAnchor)
+{
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(16, arrowHeight + 12, 16, 12);
+    layout->setSpacing(6);
+
+    auto* titleLabel = new QLabel(title, this);
+    QFont titleFont = titleLabel->font();
+    titleFont.setBold(true);
+    titleLabel->setFont(titleFont);
+    layout->addWidget(titleLabel);
+
+    auto* bodyLabel = new QLabel(body, this);
+    bodyLabel->setWordWrap(true);
+    bodyLabel->setMaximumWidth(300);
+    layout->addWidget(bodyLabel);
+
+    auto* buttonRow = new QHBoxLayout;
+    buttonRow->addStretch();
+    //: Button that dismisses a balloon pointing out a newly added feature
+    auto* gotItButton = new QPushButton(tr("Got it"), this);
+    gotItButton->setCursor(Qt::PointingHandCursor);
+    connect(gotItButton, &QPushButton::clicked, this, &QWidget::close);
+    buttonRow->addWidget(gotItButton);
+    layout->addLayout(buttonRow);
+
+    // follow the anchor around as docks move and windows resize
+    for (QWidget* pWidget = pAnchor; pWidget; pWidget = pWidget->parentWidget()) {
+        pWidget->installEventFilter(this);
+    }
+}
+
+void TFeatureCallout::showAnchored()
+{
+    if (!mpAnchor) {
+        return;
+    }
+    adjustSize();
+    reposition();
+    show();
+    raise();
+}
+
+void TFeatureCallout::reposition()
+{
+    if (!mpAnchor || !mpAnchor->isVisible()) {
+        return;
+    }
+    const QPoint anchorTopCenter = mpAnchor->mapToGlobal(QPoint(mpAnchor->width() / 2, 0));
+    const QPoint anchorBottomCenter = mpAnchor->mapToGlobal(QPoint(mpAnchor->width() / 2, mpAnchor->height()));
+    const QRect available = mpAnchor->screen()->availableGeometry();
+    mArrowOnTop = anchorBottomCenter.y() + 2 + height() <= available.bottom();
+    layout()->setContentsMargins(16, mArrowOnTop ? arrowHeight + 12 : 12, 16, mArrowOnTop ? 12 : arrowHeight + 12);
+    adjustSize();
+    int x = anchorBottomCenter.x() - width() / 2;
+    x = qBound(available.left(), x, available.right() - width());
+    mArrowX = qBound(cornerRadius + arrowWidth / 2, anchorBottomCenter.x() - x, width() - cornerRadius - arrowWidth / 2);
+    const int y = mArrowOnTop ? anchorBottomCenter.y() + 2 : anchorTopCenter.y() - height() - 2;
+    move(x, y);
+    update();
+}
+
+void TFeatureCallout::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    QPainterPath path;
+    const qreal cardTop = mArrowOnTop ? arrowHeight : 1;
+    path.addRoundedRect(QRectF(1, cardTop, width() - 2, height() - arrowHeight - 1), cornerRadius, cornerRadius);
+
+    QPainterPath arrow;
+    if (mArrowOnTop) {
+        arrow.moveTo(mArrowX - arrowWidth / 2.0, arrowHeight + 1);
+        arrow.lineTo(mArrowX, 1);
+        arrow.lineTo(mArrowX + arrowWidth / 2.0, arrowHeight + 1);
+    } else {
+        arrow.moveTo(mArrowX - arrowWidth / 2.0, height() - arrowHeight - 1);
+        arrow.lineTo(mArrowX, height() - 1);
+        arrow.lineTo(mArrowX + arrowWidth / 2.0, height() - arrowHeight - 1);
+    }
+    arrow.closeSubpath();
+    path = path.united(arrow);
+
+    painter.setPen(QPen(palette().color(QPalette::Highlight), 1.5));
+    painter.setBrush(palette().color(QPalette::Window));
+    painter.drawPath(path);
+}
+
+bool TFeatureCallout::eventFilter(QObject* watched, QEvent* event)
+{
+    switch (event->type()) {
+    case QEvent::Move:
+    case QEvent::Resize:
+        reposition();
+        break;
+    case QEvent::Hide:
+        if (watched == mpAnchor) {
+            close();
+        }
+        break;
+    case QEvent::MouseButtonPress:
+        // the anchor got clicked, so the feature has been discovered - the
+        // balloon has served its purpose
+        if (watched == mpAnchor) {
+            close();
+        }
+        break;
+    default:
+        break;
+    }
+    return QWidget::eventFilter(watched, event);
+}

--- a/src/TFeatureCallout.h
+++ b/src/TFeatureCallout.h
@@ -21,16 +21,25 @@
  ***************************************************************************/
 
 #include <QPointer>
+#include <QSet>
 #include <QWidget>
 
 // A small dismissible balloon anchored to another widget, used to point out
-// a newly added part of the interface without taking over the screen
+// a newly added part of the interface without taking over the screen.
+//
+// Call maybeShow() from the code that owns the anchor widget, at the moment
+// the anchor becomes available; it decides whether this player should still
+// be told about the feature. The balloon goes away for good once the player
+// engages - clicking "Got it" or the anchor itself - and gives up on its own
+// after enough ignored appearances.
 class TFeatureCallout : public QWidget
 {
     Q_OBJECT
 
 public:
-    TFeatureCallout(QWidget* pAnchor, const QString& title, const QString& body);
+    TFeatureCallout(const QString& featureId, QWidget* pAnchor, const QString& title, const QString& body);
+
+    static void maybeShow(const QString& featureId, QWidget* pAnchor, const QString& title, const QString& body);
 
     void showAnchored();
 
@@ -40,14 +49,22 @@ protected:
 
 private:
     void reposition();
+    void markDismissed();
 
+    QString mFeatureId;
     QPointer<QWidget> mpAnchor;
+    // Read out to screen readers when the balloon appears
+    QString mAnnouncement;
     // Horizontal position of the arrow tip within the balloon, kept in sync
     // with wherever the anchor currently sits on screen
     int mArrowX = 0;
     // The balloon prefers hanging below the anchor, but flips above it when
     // there is not enough screen space underneath
     bool mArrowOnTop = true;
+
+    // Features already pointed out this session, also used to keep several
+    // freshly shipped features from ganging up on the player at once
+    inline static QSet<QString> smSessionShown;
 };
 
 #endif // MUDLET_TFEATURECALLOUT_H

--- a/src/TFeatureCallout.h
+++ b/src/TFeatureCallout.h
@@ -2,7 +2,7 @@
 #define MUDLET_TFEATURECALLOUT_H
 
 /***************************************************************************
- *   Copyright (C) 2026 by Vadim Peretokin - vperetokin@hey.com            *
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/TFeatureCallout.h
+++ b/src/TFeatureCallout.h
@@ -1,0 +1,53 @@
+#ifndef MUDLET_TFEATURECALLOUT_H
+#define MUDLET_TFEATURECALLOUT_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vperetokin@hey.com            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QPointer>
+#include <QWidget>
+
+// A small dismissible balloon anchored to another widget, used to point out
+// a newly added part of the interface without taking over the screen
+class TFeatureCallout : public QWidget
+{
+    Q_OBJECT
+
+public:
+    TFeatureCallout(QWidget* pAnchor, const QString& title, const QString& body);
+
+    void showAnchored();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    void reposition();
+
+    QPointer<QWidget> mpAnchor;
+    // Horizontal position of the arrow tip within the balloon, kept in sync
+    // with wherever the anchor currently sits on screen
+    int mArrowX = 0;
+    // The balloon prefers hanging below the anchor, but flips above it when
+    // there is not enough screen space underneath
+    bool mArrowOnTop = true;
+};
+
+#endif // MUDLET_TFEATURECALLOUT_H

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -101,21 +101,12 @@ dlgMapper::dlgMapper(QWidget* parent, Host* pH, TMap* pM)
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
 
-    if (!smRoomNamesCalloutShown) {
-        smRoomNamesCalloutShown = true;
-        // let the mapper settle into its dock before pointing at part of it
-        QTimer::singleShot(800ms, this, [this]() {
-            if (!toolButton_mapperMenu->isVisible()) {
-                return;
-            }
-            //: Title of a balloon pointing out a newly added feature
-            auto* pCallout = new TFeatureCallout(toolButton_mapperMenu,
-                                                 tr("New: room names on the map"),
-                                                 //: Body of the balloon, pointing at the mapper options menu button
-                                                 tr("The map can now show room names. Toggle them from this menu."));
-            pCallout->showAnchored();
-        });
-    }
+    TFeatureCallout::maybeShow(qsl("map-room-names"),
+                               toolButton_mapperMenu,
+                               //: Title of a balloon pointing out a newly added feature
+                               tr("New: room names on the map"),
+                               //: Body of the balloon, pointing at the mapper options menu button
+                               tr("The map can now show room names. Toggle them from this menu."));
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;
     if (mpHost->mShow3DView) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -26,7 +26,6 @@
 
 #include "Host.h"
 #include "TConsole.h"
-#include "TFeatureCallout.h"
 #include "TMainConsole.h"
 #include "TMap.h"
 #include "TRoomDB.h"
@@ -100,13 +99,6 @@ dlgMapper::dlgMapper(QWidget* parent, Host* pH, TMap* pM)
     connect(mpMap, &TMap::signal_saveErrorChanged, this, &dlgMapper::slot_saveErrorChanged);
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
-
-    TFeatureCallout::maybeShow(qsl("map-room-names"),
-                               toolButton_mapperMenu,
-                               //: Title of a balloon pointing out a newly added feature
-                               tr("New: room names on the map"),
-                               //: Body of the balloon, pointing at the mapper options menu button
-                               tr("The map can now show room names. Toggle them from this menu."));
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;
     if (mpHost->mShow3DView) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -26,6 +26,7 @@
 
 #include "Host.h"
 #include "TConsole.h"
+#include "TFeatureCallout.h"
 #include "TMainConsole.h"
 #include "TMap.h"
 #include "TRoomDB.h"
@@ -46,6 +47,7 @@
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QSettings>
+#include <QTimer>
 #include <QVBoxLayout>
 
 using namespace std::chrono_literals;
@@ -98,6 +100,22 @@ dlgMapper::dlgMapper(QWidget* parent, Host* pH, TMap* pM)
     connect(mpMap, &TMap::signal_saveErrorChanged, this, &dlgMapper::slot_saveErrorChanged);
     connect(toolButton_togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
     connect(comboBox_showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
+
+    if (!smRoomNamesCalloutShown) {
+        smRoomNamesCalloutShown = true;
+        // let the mapper settle into its dock before pointing at part of it
+        QTimer::singleShot(800ms, this, [this]() {
+            if (!toolButton_mapperMenu->isVisible()) {
+                return;
+            }
+            //: Title of a balloon pointing out a newly added feature
+            auto* pCallout = new TFeatureCallout(toolButton_mapperMenu,
+                                                 tr("New: room names on the map"),
+                                                 //: Body of the balloon, pointing at the mapper options menu button
+                                                 tr("The map can now show room names. Toggle them from this menu."));
+            pCallout->showAnchored();
+        });
+    }
 #if defined(INCLUDE_3DMAPPER)
     mIs3DMode = mpHost->mShow3DView;
     if (mpHost->mShow3DView) {

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -129,9 +129,6 @@ private:
     QPushButton* mpProgressCancelButton = nullptr;
     bool mEmptyStateDismissed = false;
     bool mIs3DMode = false;
-
-    // Spans all mapper windows so the balloon only appears once per session
-    inline static bool smRoomNamesCalloutShown = false;
 };
 
 #endif // MUDLET_DLGMAPPER_H

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -129,6 +129,9 @@ private:
     QPushButton* mpProgressCancelButton = nullptr;
     bool mEmptyStateDismissed = false;
     bool mIs3DMode = false;
+
+    // Spans all mapper windows so the balloon only appears once per session
+    inline static bool smRoomNamesCalloutShown = false;
 };
 
 #endif // MUDLET_DLGMAPPER_H


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Added feature callouts to highlight new features in an update. A demo callout on the map menu was used during development and has been removed; this PR ships the `TFeatureCallout` infrastructure only.
<img width="2123" height="1579" alt="image" src="https://github.com/user-attachments/assets/8027c426-9f1d-4b83-827a-de61b8821bfc" />

#### Motivation for adding to Mudlet
Closes #5234
#### Other info (issues closed, discussion etc)


Fresh installs deliberately never see callouts (current UI is their baseline), and a balloon gives up after 5 ignored appearances or 2 callouts per session when multiple features ship.