### PR TITLE
fix: caret-mode Shift+Arrow selection off-by-one and Ctrl+C copy

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -3760,7 +3760,12 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             mDragStart.setY(mCaretLine);
             mDragStart.setX(mCaretColumn);
             mDragSelectionEnd.setY(newCaretLine);
-            mDragSelectionEnd.setX(mCaretColumn);
+            // Anchor the moving end at the new caret position (mirroring the
+            // continuation branch below). Using the old column here made the
+            // first Shift+Arrow press produce a zero-width selection, so the
+            // selection lagged one character/word behind the caret and an
+            // immediate Ctrl+C copied nothing.
+            mDragSelectionEnd.setX(useNewColumn ? newCaretColumn : mCaretColumn);
             unHighlight();
             normaliseSelection();
             highlightSelection();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -3764,8 +3764,10 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             // continuation branch below). Using the old column here made the
             // first Shift+Arrow press produce a zero-width selection, so the
             // selection lagged one character/word behind the caret and an
-            // immediate Ctrl+C copied nothing.
-            mDragSelectionEnd.setX(useNewColumn ? newCaretColumn : mCaretColumn);
+            // immediate Ctrl+C copied nothing. Guard against the sentinel
+            // newCaretColumn (-1) that Shift+Left leaves when the caret is
+            // already at the top-left (0, 0), keeping the safe fallback.
+            mDragSelectionEnd.setX(useNewColumn && newCaretColumn >= 0 ? newCaretColumn : mCaretColumn);
             unHighlight();
             normaliseSelection();
             highlightSelection();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In the output window's caret mode, the first Shift+Arrow (or
Ctrl+Shift+Arrow) press anchored the moving selection end at the *old*
caret column, producing a zero-width selection. The selection then
lagged one character/word behind the caret, and a Ctrl+C immediately
afterwards copied nothing.

This anchors the moving end at the new caret position, mirroring the
selection-continuation branch already used for subsequent presses.

#### Motivation for adding to Mudlet
Keyboard selection and copy in the output window are core accessibility
features (screen-reader users navigating the buffer). The off-by-one made
single-press selection and immediate copy unreliable.

#### Other info (issues closed, discussion etc)
Assisted-by: Claude:claude-opus-4-8