### PR TITLE
fix: keep saved profile passwords working on Windows after qtkeychain library update

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -683,6 +683,21 @@ if(USE_OWN_QTKEYCHAIN)
     target_include_directories(${LIB_MUDLET_TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/3rdparty/qtkeychain)
 endif()
 
+# Surface the linked qtkeychain version for diagnostics - the QTKEYCHAIN_VERSION macro in
+# qtkeychain's own header is stale (hardcoded to 0x000100), so the CMake package version is
+# the only reliable signal. Relevant since qtkeychain 0.17.0 changed the Windows credential
+# naming scheme (see CredentialManager::attemptCompatNamingMigration).
+if(USE_OWN_QTKEYCHAIN)
+  get_directory_property(QTKEYCHAIN_LINKED_VERSION
+    DIRECTORY ${CMAKE_SOURCE_DIR}/3rdparty/qtkeychain
+    DEFINITION QTKEYCHAIN_VERSION)
+else()
+  set(QTKEYCHAIN_LINKED_VERSION ${Qt${QT_MAJOR_VERSION}Keychain_VERSION})
+endif()
+if(QTKEYCHAIN_LINKED_VERSION)
+  target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC QTKEYCHAIN_LINKED_VERSION="${QTKEYCHAIN_LINKED_VERSION}")
+endif()
+
 # Define shader hot-reloading if enabled
 if(USE_SHADER_HOT_RELOAD AND USE_3DMAPPER)
   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC MUDLET_SHADER_HOT_RELOAD=1)

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -926,6 +926,23 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
             Qt::QueuedConnection); // Use queued connection for additional safety
 
     deleteJob->start();
+
+#if defined(Q_OS_WIN)
+    // A pre-0.17 bare entry (TargetName == service) may still exist if it was written by a build
+    // linked against an older qtkeychain and no read has migrated it yet; on 0.17+ the delete
+    // above resolves to "service@service" and would leave that copy behind to be resurrected by
+    // the compat migration on a later read. Sweep the bare name too - on pre-0.17 both deletes
+    // resolve to the same TargetName, so this is a harmless no-op there.
+    auto* bareCleanupJob = new QKeychain::DeletePasswordJob(QString());
+    bareCleanupJob->setKey(service);
+    bareCleanupJob->setAutoDelete(true);
+    connect(bareCleanupJob, &QKeychain::DeletePasswordJob::finished, bareCleanupJob, [bareCleanupJob, service]() {
+        if (bareCleanupJob->error() != QKeychain::NoError && bareCleanupJob->error() != QKeychain::EntryNotFound) {
+            qWarning() << "CredentialManager: Failed to remove pre-0.17 entry for service:" << service << "-" << bareCleanupJob->errorString();
+        }
+    });
+    bareCleanupJob->start();
+#endif
 }
 
 void CredentialManager::isKeychainAvailable(AvailabilityCallback callback)

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -44,6 +44,17 @@
 // Forward declaration to avoid including mudlet.h
 class mudlet;
 
+namespace {
+// Whether a delete job's result means the credential is not left behind. EntryNotFound (nothing
+// to delete) and NoBackendAvailable/NotImplemented (the keychain isn't the store here, so the
+// file fallback is authoritative) are not failures; anything else is a genuine failure to remove
+// an entry that may still exist.
+bool keychainDeleteSucceeded(QKeychain::Error error)
+{
+    return error == QKeychain::NoError || error == QKeychain::EntryNotFound || error == QKeychain::NoBackendAvailable || error == QKeychain::NotImplemented;
+}
+} // namespace
+
 CredentialManager::CredentialManager(QObject* parent)
 : QObject(parent)
 {
@@ -274,12 +285,14 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
     }
 
     if (shouldUseKeychain(profileName)) {
-        // Use keychain storage with fallback chain:
+        // Use keychain storage with a fallback chain (simplified overview; the actual control flow
+        // lives in retrieveCredential and the attempt* helpers):
         // 1. New hash-based format (unique per profile name)
         // 2. Windows only: same format under the pre-0.17 qtkeychain naming scheme
-        // 3. Old colliding format (profiles with similar names may share passwords)
-        // 4. Legacy keychain format (pre-4.20.0)
-        // 5. Encrypted file storage
+        // 3. Old key=account format (pre-Windows-fix, where all profiles shared "character")
+        // 4. Old colliding format (profiles with similar names may share passwords)
+        // 5. Legacy keychain format (pre-4.20.0)
+        // 6. Encrypted file storage
         QString service = generateServiceName(profileName, key);
         QString legacyService = generateLegacyServiceName(profileName, key);
 
@@ -456,7 +469,10 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
                     });
                     cleanupJob->start();
                 } else {
-                    qWarning() << "CredentialManager: Migration to new format failed:" << migrateJob->errorString();
+                    // The password was recovered and is returned below, but persisting it under the
+                    // new format failed - the primary read will keep missing, so this path re-runs
+                    // on every launch until the write succeeds
+                    qWarning() << "CredentialManager: Recovered the password but failed to persist it under the new format (will retry next read):" << migrateJob->errorString();
                 }
 
                 // Return password regardless of migration success
@@ -468,7 +484,14 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
 
             migrateJob->start();
         } else {
-            qDebug() << "CredentialManager: Old format not found, trying other fallbacks";
+            const QKeychain::Error oldFormatError = oldFormatJob->error();
+            if (oldFormatError != QKeychain::NoError && oldFormatError != QKeychain::EntryNotFound) {
+                // Distinguish a hard keychain error from a genuine "not found" so a vanished
+                // password can be diagnosed
+                qWarning() << "CredentialManager: Old-format read failed for account:" << account << "-" << oldFormatJob->errorString();
+            } else {
+                qDebug() << "CredentialManager: Old format not found, trying other fallbacks";
+            }
             // Continue with existing legacy format checks
             // The legacy "Mudlet profile" keychain format was only used for character and password keys
             if (!account.compare(qsl("character")) || !account.compare(qsl("password"))) {
@@ -542,7 +565,10 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
                     }
 #endif
                 } else {
-                    qWarning() << "CredentialManager: Migration to current naming failed:" << migrateJob->errorString();
+                    // The password was recovered and is returned below, but persisting it under the
+                    // current scheme failed - the primary read will keep missing, so this path
+                    // re-runs on every launch until the write succeeds
+                    qWarning() << "CredentialManager: Recovered the password but failed to persist it under the current naming scheme (will retry next read):" << migrateJob->errorString();
                 }
 
                 // Return password regardless of migration success
@@ -554,7 +580,15 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
 
             migrateJob->start();
         } else {
-            qDebug() << "CredentialManager: No pre-0.17 entry found, trying other fallbacks";
+            const QKeychain::Error compatError = compatJob->error();
+            if (compatError != QKeychain::NoError && compatError != QKeychain::EntryNotFound) {
+                // A hard keychain error here is distinct from "no such entry" and is the likely
+                // reason a saved password appears to have vanished - surface it rather than
+                // silently treating it as not found
+                qWarning() << "CredentialManager: Compat-naming read failed for service:" << service << "-" << compatJob->errorString();
+            } else {
+                qDebug() << "CredentialManager: No pre-0.17 entry found, trying other fallbacks";
+            }
             attemptOldFormatMigration(service, account, profileName, callback);
         }
 
@@ -589,14 +623,15 @@ void CredentialManager::removePassword(const QString& profileName, const QString
         QString legacyService = generateLegacyServiceName(profileName, key);
 
         auto combinedCallback = [this, profileName, key, legacyService, callback](bool keychainSuccess, const QString& keychainError) {
-            removeCredential(legacyService, key, profileName, [this, profileName, key, callback, keychainSuccess, keychainError](bool oldSuccess, const QString&) {
-                bool fileSuccess = removeCredentialFromFile(profileName, key);
-
+            removeCredential(legacyService, key, profileName, [profileName, key, callback, keychainSuccess, keychainError](bool oldSuccess, const QString& oldError) {
+                // The credential must be gone from the current-format entry, the legacy colliding
+                // entry, and the file fallback; a failure to remove any of them is a real failure
+                // rather than something the others can paper over
                 if (callback) {
-                    if (keychainSuccess || oldSuccess || fileSuccess) {
+                    if (keychainSuccess && oldSuccess) {
                         callback(true, QString());
                     } else {
-                        callback(false, qsl("Failed to remove from keychain: %1").arg(keychainError));
+                        callback(false, qsl("Failed to remove from keychain: %1").arg(!keychainSuccess ? keychainError : oldError));
                     }
                 }
             });
@@ -898,51 +933,83 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
 
                 cleanupTimeout();
 
-                bool keychainSuccess = (deleteJob->error() == QKeychain::NoError || deleteJob->error() == QKeychain::EntryNotFound);
-
-                bool fileSuccess = removeCredentialFromFile(profileName, account);
-
-                // Consider success if either method succeeded
-                bool success = keychainSuccess || fileSuccess;
-                QString errorMessage;
-
-                if (!success) {
-                    errorMessage = qsl("Failed to remove from both keychain and file storage. Keychain error: %1").arg(deleteJob->errorString());
-                } else if (!keychainSuccess) {
-                    qDebug() << "Keychain removal failed but file removal succeeded:" << deleteJob->errorString();
-                }
-
-                // Final validity check before calling callback
-                if (mCurrentCallback && isOperationValid()) {
-                    auto callback = mCurrentCallback; // Copy callback to avoid use-after-free
-                    mCurrentCallback = nullptr;
-                    mCurrentJob = nullptr;
-
-                    callback(success, errorMessage);
-                }
-
+                const bool primarySuccess = keychainDeleteSucceeded(deleteJob->error());
+                const QString primaryError = primarySuccess ? QString() : deleteJob->errorString();
                 deleteJob->deleteLater();
+
+#if defined(Q_OS_WIN)
+                // A pre-0.17 bare entry (TargetName == service) may still exist if it was written by
+                // a build linked against an older qtkeychain and no read has migrated it yet; on
+                // 0.17+ the delete above resolved to "service@service" and left that copy behind,
+                // where the compat migration would resurrect it on a later read. Sweep the bare name
+                // too, and await it so a genuine failure to remove it is reported rather than
+                // silently dropped. On pre-0.17 both deletes resolve to the same TargetName, so this
+                // sweep is a harmless EntryNotFound no-op.
+                mCurrentJob = nullptr;
+                auto* bareJob = new QKeychain::DeletePasswordJob(QString(), this);
+                bareJob->setKey(service);
+                bareJob->setAutoDelete(false);
+                mCurrentJob = bareJob;
+                setupTimeout();
+
+                connect(
+                        bareJob,
+                        &QKeychain::DeletePasswordJob::finished,
+                        this,
+                        [this, bareJob, service, account, profileName, primarySuccess, primaryError]() {
+                            if (!isOperationValid()) {
+                                qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
+                                bareJob->deleteLater();
+                                return;
+                            }
+
+                            cleanupTimeout();
+
+                            const bool bareSuccess = keychainDeleteSucceeded(bareJob->error());
+                            const QString bareError = bareSuccess ? QString() : bareJob->errorString();
+                            bareJob->deleteLater();
+
+                            const bool keychainSuccess = primarySuccess && bareSuccess;
+                            const QString keychainError = !primarySuccess ? primaryError : bareError;
+                            finishRemoveCredential(account, profileName, keychainSuccess, keychainError);
+                        },
+                        Qt::QueuedConnection);
+
+                bareJob->start();
+#else
+                finishRemoveCredential(account, profileName, primarySuccess, primaryError);
+#endif
             },
             Qt::QueuedConnection); // Use queued connection for additional safety
 
     deleteJob->start();
+}
 
-#if defined(Q_OS_WIN)
-    // A pre-0.17 bare entry (TargetName == service) may still exist if it was written by a build
-    // linked against an older qtkeychain and no read has migrated it yet; on 0.17+ the delete
-    // above resolves to "service@service" and would leave that copy behind to be resurrected by
-    // the compat migration on a later read. Sweep the bare name too - on pre-0.17 both deletes
-    // resolve to the same TargetName, so this is a harmless no-op there.
-    auto* bareCleanupJob = new QKeychain::DeletePasswordJob(QString());
-    bareCleanupJob->setKey(service);
-    bareCleanupJob->setAutoDelete(true);
-    connect(bareCleanupJob, &QKeychain::DeletePasswordJob::finished, bareCleanupJob, [bareCleanupJob, service]() {
-        if (bareCleanupJob->error() != QKeychain::NoError && bareCleanupJob->error() != QKeychain::EntryNotFound) {
-            qWarning() << "CredentialManager: Failed to remove pre-0.17 entry for service:" << service << "-" << bareCleanupJob->errorString();
+void CredentialManager::finishRemoveCredential(const QString& account, const QString& profileName, bool keychainSuccess, const QString& keychainError)
+{
+    const bool fileSuccess = removeCredentialFromFile(profileName, account);
+
+    // A removal only succeeds if the credential is gone from every store it could be in: a hard
+    // keychain error means an entry may still be readable, so it must not be masked by the file
+    // fallback reporting success simply because no file copy existed.
+    const bool success = keychainSuccess && fileSuccess;
+    QString errorMessage;
+
+    if (!success) {
+        if (!keychainSuccess) {
+            errorMessage = qsl("Failed to remove from keychain: %1").arg(keychainError);
+        } else {
+            errorMessage = qsl("Failed to remove encrypted credential file for profile %1").arg(profileName);
         }
-    });
-    bareCleanupJob->start();
-#endif
+    }
+
+    if (mCurrentCallback && isOperationValid()) {
+        auto callback = mCurrentCallback; // Copy callback to avoid use-after-free
+        mCurrentCallback = nullptr;
+        mCurrentJob = nullptr;
+
+        callback(success, errorMessage);
+    }
 }
 
 void CredentialManager::isKeychainAvailable(AvailabilityCallback callback)

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -276,9 +276,10 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
     if (shouldUseKeychain(profileName)) {
         // Use keychain storage with fallback chain:
         // 1. New hash-based format (unique per profile name)
-        // 2. Old colliding format (profiles with similar names may share passwords)
-        // 3. Legacy keychain format (pre-4.20.0)
-        // 4. Encrypted file storage
+        // 2. Windows only: same format under the pre-0.17 qtkeychain naming scheme
+        // 3. Old colliding format (profiles with similar names may share passwords)
+        // 4. Legacy keychain format (pre-4.20.0)
+        // 5. Encrypted file storage
         QString service = generateServiceName(profileName, key);
         QString legacyService = generateLegacyServiceName(profileName, key);
 
@@ -413,11 +414,20 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
     // This function tries to read from the old format and migrate to the new format
     qDebug() << "CredentialManager: Checking for old format (key=account) for service:" << service;
 
-    auto* oldFormatJob = new QKeychain::ReadPasswordJob(service, this);
+#if defined(Q_OS_WIN)
+    // Old-format entries live at TargetName == account; qtkeychain 0.17+ would look up
+    // "account@service" and miss them, while an empty service resolves to the bare key on
+    // every qtkeychain version (pre-0.17 ignores the service entirely)
+    const QString lookupService;
+#else
+    const QString lookupService = service;
+#endif
+
+    auto* oldFormatJob = new QKeychain::ReadPasswordJob(lookupService, this);
     oldFormatJob->setKey(account); // Old format used account as key
     oldFormatJob->setAutoDelete(false);
 
-    connect(oldFormatJob, &QKeychain::ReadPasswordJob::finished, this, [this, oldFormatJob, service, account, profileName, callback]() {
+    connect(oldFormatJob, &QKeychain::ReadPasswordJob::finished, this, [this, oldFormatJob, service, lookupService, account, profileName, callback]() {
         bool found = (oldFormatJob->error() == QKeychain::NoError);
         QString password = found ? oldFormatJob->textData() : QString();
 
@@ -430,11 +440,11 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
             migrateJob->setTextData(password);
             migrateJob->setAutoDelete(false);
 
-            connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, account, password, callback]() {
+            connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, lookupService, account, password, callback]() {
                 if (migrateJob->error() == QKeychain::NoError) {
                     qDebug() << "CredentialManager: Migration to new format successful, cleaning up old entry";
 
-                    auto* cleanupJob = new QKeychain::DeletePasswordJob(service);
+                    auto* cleanupJob = new QKeychain::DeletePasswordJob(lookupService);
                     cleanupJob->setKey(account); // Old format key
                     cleanupJob->setAutoDelete(true);
                     connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
@@ -468,6 +478,71 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
     });
 
     oldFormatJob->start();
+}
+
+void CredentialManager::attemptCompatNamingMigration(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback)
+{
+    // qtkeychain 0.17.0 changed the Windows Credential Manager TargetName from the bare key to
+    // "key@service", so entries stored by builds linked against an older qtkeychain (which used
+    // TargetName == key == service) are no longer found by the primary read. A read with an empty
+    // service resolves to TargetName == key on every qtkeychain version - pre-0.17 ignores the
+    // service and 0.17+ falls back to the bare key - so it recovers those entries on both, and
+    // never fires on pre-0.17 because the primary read already succeeds there.
+    qDebug() << "CredentialManager: Checking for pre-0.17 qtkeychain naming for service:" << service;
+#if defined(QTKEYCHAIN_LINKED_VERSION)
+    qDebug() << "CredentialManager: Linked qtkeychain version:" << QTKEYCHAIN_LINKED_VERSION;
+#endif
+
+    auto* compatJob = new QKeychain::ReadPasswordJob(QString(), this);
+    compatJob->setKey(service);
+    compatJob->setAutoDelete(false);
+
+    connect(compatJob, &QKeychain::ReadPasswordJob::finished, this, [this, compatJob, service, account, profileName, callback]() {
+        const bool found = (compatJob->error() == QKeychain::NoError);
+        const QString password = found ? compatJob->textData() : QString();
+
+        if (found && !password.isEmpty()) {
+            qDebug() << "CredentialManager: Found password under pre-0.17 naming, migrating to current scheme";
+
+            // Re-store through a normal write (key == service) so the entry lands under the
+            // naming scheme of the linked qtkeychain version
+            auto* migrateJob = new QKeychain::WritePasswordJob(service, this);
+            migrateJob->setKey(service);
+            migrateJob->setTextData(password);
+            migrateJob->setAutoDelete(false);
+
+            connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, password, callback]() {
+                if (migrateJob->error() == QKeychain::NoError) {
+                    qDebug() << "CredentialManager: Migration to current naming successful, cleaning up old entry";
+
+                    auto* cleanupJob = new QKeychain::DeletePasswordJob(QString());
+                    cleanupJob->setKey(service);
+                    cleanupJob->setAutoDelete(true);
+                    connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
+                        qDebug() << "CredentialManager: Pre-0.17 entry cleaned up for service:" << service;
+                    });
+                    cleanupJob->start();
+                } else {
+                    qWarning() << "CredentialManager: Migration to current naming failed:" << migrateJob->errorString();
+                }
+
+                // Return password regardless of migration success
+                if (callback) {
+                    callback(true, password, QString());
+                }
+                migrateJob->deleteLater();
+            });
+
+            migrateJob->start();
+        } else {
+            qDebug() << "CredentialManager: No pre-0.17 entry found, trying other fallbacks";
+            attemptOldFormatMigration(service, account, profileName, callback);
+        }
+
+        compatJob->deleteLater();
+    });
+
+    compatJob->start();
 }
 
 void CredentialManager::removePassword(const QString& profileName, const QString& key, CredentialCallback callback)
@@ -725,7 +800,14 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
                     auto originalCallback = mCurrentRetrievalCallback;
                     mCurrentRetrievalCallback = nullptr;
                     mCurrentJob = nullptr;
+#if defined(Q_OS_WIN)
+                    // qtkeychain 0.17.0 started honouring the service name on Windows, moving
+                    // entries from TargetName "<key>" to "<key>@<service>" - recover entries
+                    // written by builds linked against older qtkeychain first
+                    attemptCompatNamingMigration(service, account, profileName, originalCallback);
+#else
                     attemptOldFormatMigration(service, account, profileName, originalCallback);
+#endif
                     readJob->deleteLater();
                     return;
                 }

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -447,8 +447,12 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
                     auto* cleanupJob = new QKeychain::DeletePasswordJob(lookupService);
                     cleanupJob->setKey(account); // Old format key
                     cleanupJob->setAutoDelete(true);
-                    connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
-                        qDebug() << "CredentialManager: Old format entry cleaned up for service:" << service;
+                    connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [cleanupJob, service]() {
+                        if (cleanupJob->error() == QKeychain::NoError || cleanupJob->error() == QKeychain::EntryNotFound) {
+                            qDebug() << "CredentialManager: Old format entry cleaned up for service:" << service;
+                        } else {
+                            qWarning() << "CredentialManager: Failed to clean up old format entry for service:" << service << "-" << cleanupJob->errorString();
+                        }
                     });
                     cleanupJob->start();
                 } else {
@@ -527,8 +531,12 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
                         auto* cleanupJob = new QKeychain::DeletePasswordJob(QString());
                         cleanupJob->setKey(service);
                         cleanupJob->setAutoDelete(true);
-                        connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
-                            qDebug() << "CredentialManager: Pre-0.17 entry cleaned up for service:" << service;
+                        connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [cleanupJob, service]() {
+                            if (cleanupJob->error() == QKeychain::NoError || cleanupJob->error() == QKeychain::EntryNotFound) {
+                                qDebug() << "CredentialManager: Pre-0.17 entry cleaned up for service:" << service;
+                            } else {
+                                qWarning() << "CredentialManager: Failed to clean up pre-0.17 entry for service:" << service << "-" << cleanupJob->errorString();
+                            }
                         });
                         cleanupJob->start();
                     }

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -486,8 +486,10 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
     // "key@service", so entries stored by builds linked against an older qtkeychain (which used
     // TargetName == key == service) are no longer found by the primary read. A read with an empty
     // service resolves to TargetName == key on every qtkeychain version - pre-0.17 ignores the
-    // service and 0.17+ falls back to the bare key - so it recovers those entries on both, and
-    // never fires on pre-0.17 because the primary read already succeeds there.
+    // service and 0.17+ falls back to the bare key - so it recovers those entries on both. On
+    // pre-0.17 this normally stays dormant (the primary read already looks up the bare key), but
+    // a transient primary-read failure can still route here, where the compat read is merely a
+    // retry of the same TargetName.
     qDebug() << "CredentialManager: Checking for pre-0.17 qtkeychain naming for service:" << service;
 #if defined(QTKEYCHAIN_LINKED_VERSION)
     qDebug() << "CredentialManager: Linked qtkeychain version:" << QTKEYCHAIN_LINKED_VERSION;
@@ -513,15 +515,24 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
 
             connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, password, callback]() {
                 if (migrateJob->error() == QKeychain::NoError) {
-                    qDebug() << "CredentialManager: Migration to current naming successful, cleaning up old entry";
+                    qDebug() << "CredentialManager: Migration to current naming successful";
 
-                    auto* cleanupJob = new QKeychain::DeletePasswordJob(QString());
-                    cleanupJob->setKey(service);
-                    cleanupJob->setAutoDelete(true);
-                    connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
-                        qDebug() << "CredentialManager: Pre-0.17 entry cleaned up for service:" << service;
-                    });
-                    cleanupJob->start();
+                    // On pre-0.17 qtkeychain the write above resolves to the same bare TargetName
+                    // as the old entry, so deleting it would remove the credential that was just
+                    // restored - only clean up when the linked qtkeychain uses the new naming scheme
+#if defined(QTKEYCHAIN_LINKED_VERSION)
+                    if (QVersionNumber::fromString(qsl(QTKEYCHAIN_LINKED_VERSION)) >= QVersionNumber(0, 17, 0)) {
+                        qDebug() << "CredentialManager: Cleaning up pre-0.17 entry";
+
+                        auto* cleanupJob = new QKeychain::DeletePasswordJob(QString());
+                        cleanupJob->setKey(service);
+                        cleanupJob->setAutoDelete(true);
+                        connect(cleanupJob, &QKeychain::DeletePasswordJob::finished, cleanupJob, [service]() {
+                            qDebug() << "CredentialManager: Pre-0.17 entry cleaned up for service:" << service;
+                        });
+                        cleanupJob->start();
+                    }
+#endif
                 } else {
                     qWarning() << "CredentialManager: Migration to current naming failed:" << migrateJob->errorString();
                 }

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -122,6 +122,7 @@ private:
     void attemptCollidingMigration(const QString& profileName, const QString& key, const QString& legacyService, const QString& password, CredentialRetrievalCallback callback);
     void attemptLegacyKeychainMigration(const QString& profileName, const QString& key, CredentialRetrievalCallback callback);
     void attemptOldFormatMigration(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback);
+    void attemptCompatNamingMigration(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback);
     void fallbackFileRetrieval(const QString& profileName, const QString& key, CredentialRetrievalCallback callback);
 
     // Current operation state

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -85,6 +85,8 @@ private:
     void storeCredential(const QString& service, const QString& account, const QString& password, const QString& profileName, CredentialCallback callback);
     void retrieveCredential(const QString& service, const QString& account, const QString& profileName, CredentialRetrievalCallback callback);
     void removeCredential(const QString& service, const QString& account, const QString& profileName, CredentialCallback callback);
+    // Combines the keychain delete outcome(s) with the file-fallback removal and reports the result
+    void finishRemoveCredential(const QString& account, const QString& profileName, bool keychainSuccess, const QString& keychainError);
 
     // Check if QtKeychain is available and working (asynchronous)
     void isKeychainAvailable(AvailabilityCallback callback);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(UNIT_TESTS
     TVariableEditorTest
     SecureStringUtilsTest
     CredentialManagerTest
+    CredentialManagerKeychainTest
     DiscordTest
     TTextEditBlinkTest
     TAreaZLevelIndexTest

--- a/test/CredentialManagerKeychainTest.cpp
+++ b/test/CredentialManagerKeychainTest.cpp
@@ -371,6 +371,16 @@ void CredentialManagerKeychainTest::testBareEntryMigration()
         QVERIFY(readTarget(service, &still));
         QCOMPARE(still, secret);
     }
+
+    // A second retrieve must serve the value from the migrated location and must not re-fire
+    // the migration (which would churn the store or resurrect the old entry)
+    const OperationResult again = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(again.success);
+    QCOMPARE(again.password, secret);
+    if (qtkeychainHonoursService()) {
+        QVERIFY(!readTarget(service));
+        QVERIFY(waitUntilTargetHolds(combinedTargetName(service), secret));
+    }
 }
 
 void CredentialManagerKeychainTest::testRemoveSweepsBareEntry()
@@ -420,6 +430,12 @@ void CredentialManagerKeychainTest::testOldFormatMigration()
     const QString service = expectedServiceName(mProfile, mKey);
     QVERIFY(waitUntilTargetHolds(currentTargetName(service), secret));
     QVERIFY(waitUntilTargetGone(mKey));
+
+    // A second retrieve serves from the migrated entry and does not re-create the old one
+    const OperationResult again = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(again.success);
+    QCOMPARE(again.password, secret);
+    QVERIFY(!readTarget(mKey));
 }
 
 void CredentialManagerKeychainTest::testCollidingFormatRecovery()
@@ -451,6 +467,12 @@ void CredentialManagerKeychainTest::testCollidingFormatRecovery()
     if (qtkeychainHonoursService()) {
         QVERIFY(waitUntilTargetGone(combinedTargetName(legacyService)));
     }
+
+    // A second retrieve serves from the migrated entry and does not re-create the colliding one
+    const OperationResult again = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(again.success);
+    QCOMPARE(again.password, secret);
+    QVERIFY(!readTarget(legacyService));
 }
 
 QTEST_GUILESS_MAIN(CredentialManagerKeychainTest)

--- a/test/CredentialManagerKeychainTest.cpp
+++ b/test/CredentialManagerKeychainTest.cpp
@@ -34,7 +34,9 @@
 // Exercises CredentialManager's real keychain paths against the live platform credential
 // store, in particular the migrations for the qtkeychain 0.17.0 Windows naming change
 // (TargetName moved from the bare key to "key@service"). Unlike CredentialManagerTest,
-// this deliberately does NOT set MUDLET_TEST_MODE, which would force file storage.
+// this deliberately does NOT set MUDLET_TEST_MODE, which would force file storage. It is
+// kept as a separate executable so these environment-dependent tests cannot affect that
+// hermetic unit suite, and so ctest can rerun or exclude them independently.
 //
 // The historical entry layouts are simulated with raw QKeychain jobs using an empty
 // service, which resolves to TargetName == key on every qtkeychain version - the same

--- a/test/CredentialManagerKeychainTest.cpp
+++ b/test/CredentialManagerKeychainTest.cpp
@@ -1,0 +1,455 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <CredentialManager.h>
+#include <QtTest/QtTest>
+#include <QCryptographicHash>
+#include <QRegularExpression>
+#include <QUuid>
+#include <QVersionNumber>
+#if defined(INCLUDE_OWN_QT6_KEYCHAIN)
+#include <qtkeychain/keychain.h>
+#else
+#include <qt6keychain/keychain.h>
+#endif
+
+#include <memory>
+
+// Exercises CredentialManager's real keychain paths against the live platform credential
+// store, in particular the migrations for the qtkeychain 0.17.0 Windows naming change
+// (TargetName moved from the bare key to "key@service"). Unlike CredentialManagerTest,
+// this deliberately does NOT set MUDLET_TEST_MODE, which would force file storage.
+//
+// The historical entry layouts are simulated with raw QKeychain jobs using an empty
+// service, which resolves to TargetName == key on every qtkeychain version - the same
+// primitive the migration code itself relies on. That means the pre-0.17, old-format and
+// colliding-format layouts can all be planted and verified regardless of which qtkeychain
+// is linked, and the expected outcomes branch on QTKEYCHAIN_LINKED_VERSION.
+//
+// The scenarios only exist on Windows, so every test skips elsewhere (the bodies still
+// compile on all platforms).
+
+class CredentialManagerKeychainTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void init();
+    void cleanup();
+    void testRoundTrip();
+    void testBareEntryMigration();
+    void testRemoveSweepsBareEntry();
+    void testOldFormatMigration();
+    void testCollidingFormatRecovery();
+
+private:
+    QString mProfile;
+    QString mKey;
+    bool mStoreAvailable = false;
+};
+
+namespace {
+
+constexpr int kWaitMs = 15000;
+
+bool onWindows()
+{
+#if defined(Q_OS_WIN)
+    return true;
+#else
+    return false;
+#endif
+}
+
+// True when the linked qtkeychain honours the service name on Windows (0.17.0+), i.e.
+// a normal key == service write lands at "service@service" instead of the bare service
+bool qtkeychainHonoursService()
+{
+#if defined(QTKEYCHAIN_LINKED_VERSION)
+    return QVersionNumber::fromString(QStringLiteral(QTKEYCHAIN_LINKED_VERSION)) >= QVersionNumber(0, 17, 0);
+#else
+    return false;
+#endif
+}
+
+// TargetName a normal CredentialManager write (key == service) resolves to
+QString currentTargetName(const QString& service)
+{
+    return qtkeychainHonoursService() ? service + QLatin1Char('@') + service : service;
+}
+
+QString combinedTargetName(const QString& service)
+{
+    return service + QLatin1Char('@') + service;
+}
+
+// Starts the job and pumps events until it finishes; the completion flag is shared so a
+// late finish after a timeout cannot write to a dead stack frame
+bool waitForJob(QKeychain::Job* job)
+{
+    auto done = std::make_shared<bool>(false);
+    QObject::connect(job, &QKeychain::Job::finished, job, [done](QKeychain::Job*) {
+        *done = true;
+    });
+    job->start();
+    return QTest::qWaitFor(
+            [done]() {
+                return *done;
+            },
+            kWaitMs);
+}
+
+// Writes a credential at an explicit TargetName (empty service resolves to the bare key
+// on every qtkeychain version)
+bool writeTarget(const QString& targetName, const QString& secret)
+{
+    auto* job = new QKeychain::WritePasswordJob(QString());
+    job->setAutoDelete(false);
+    job->setKey(targetName);
+    job->setTextData(secret);
+    const bool ok = waitForJob(job) && job->error() == QKeychain::NoError;
+    job->disconnect();
+    job->deleteLater();
+    return ok;
+}
+
+bool readTarget(const QString& targetName, QString* secret = nullptr)
+{
+    auto* job = new QKeychain::ReadPasswordJob(QString());
+    job->setAutoDelete(false);
+    job->setKey(targetName);
+    const bool ok = waitForJob(job) && job->error() == QKeychain::NoError;
+    if (ok && secret) {
+        *secret = job->textData();
+    }
+    job->disconnect();
+    job->deleteLater();
+    return ok;
+}
+
+// Missing entries count as success
+bool deleteTarget(const QString& targetName)
+{
+    auto* job = new QKeychain::DeletePasswordJob(QString());
+    job->setAutoDelete(false);
+    job->setKey(targetName);
+    const bool ok = waitForJob(job) && (job->error() == QKeychain::NoError || job->error() == QKeychain::EntryNotFound);
+    job->disconnect();
+    job->deleteLater();
+    return ok;
+}
+
+// The migration chains fire detached cleanup jobs after the user callback, so removals
+// need to be polled rather than asserted immediately
+bool waitUntilTargetGone(const QString& targetName)
+{
+    return QTest::qWaitFor(
+            [&targetName]() {
+                return !readTarget(targetName);
+            },
+            kWaitMs);
+}
+
+bool waitUntilTargetHolds(const QString& targetName, const QString& expectedSecret)
+{
+    return QTest::qWaitFor(
+            [&targetName, &expectedSecret]() {
+                QString secret;
+                return readTarget(targetName, &secret) && secret == expectedSecret;
+            },
+            kWaitMs);
+}
+
+// Deliberately duplicates the private CredentialManager::generateServiceName: the format
+// is persisted in users' credential stores, so this test doubles as a tripwire against
+// changing it and orphaning stored entries
+QString expectedServiceName(const QString& profileName, const QString& key)
+{
+    static const QRegularExpression sanitizePattern(QStringLiteral(R"REGEX([^\w\-\.])REGEX"));
+
+    const QByteArray data = QStringLiteral("%1:%2").arg(profileName, key).toUtf8();
+    const QString hashHex = QString::fromLatin1(QCryptographicHash::hash(data, QCryptographicHash::Sha256).toHex()).left(16);
+
+    auto sanitize = [](QString input) {
+        input.replace(sanitizePattern, QStringLiteral("_"));
+        return input.left(20);
+    };
+
+    return QStringLiteral("Mudlet-%1-%2-%3").arg(sanitize(profileName), sanitize(key), hashHex);
+}
+
+// Duplicates the private CredentialManager::generateLegacyServiceName for the same reason
+QString expectedLegacyServiceName(const QString& profileName, const QString& key)
+{
+    static const QRegularExpression sanitizePattern(QStringLiteral(R"REGEX([^\w\-\.])REGEX"));
+
+    auto sanitize = [](QString input) {
+        input.replace(sanitizePattern, QStringLiteral("_"));
+        return input.left(50);
+    };
+
+    return QStringLiteral("Mudlet-%1-%2").arg(sanitize(profileName), sanitize(key));
+}
+
+struct OperationResult
+{
+    bool done = false;
+    bool success = false;
+    QString password;
+};
+
+// Callback state is heap-shared so a callback arriving after a timed-out wait is harmless
+OperationResult storePassword(CredentialManager& manager, const QString& profile, const QString& key, const QString& password)
+{
+    auto state = std::make_shared<OperationResult>();
+    manager.storePassword(profile, key, password, [state](bool success, const QString&) {
+        state->success = success;
+        state->done = true;
+    });
+    QTest::qWaitFor(
+            [state]() {
+                return state->done;
+            },
+            kWaitMs);
+    return *state;
+}
+
+OperationResult retrievePassword(CredentialManager& manager, const QString& profile, const QString& key)
+{
+    auto state = std::make_shared<OperationResult>();
+    manager.retrievePassword(profile, key, [state](bool success, const QString& password, const QString&) {
+        state->success = success;
+        state->password = password;
+        state->done = true;
+    });
+    QTest::qWaitFor(
+            [state]() {
+                return state->done;
+            },
+            kWaitMs);
+    return *state;
+}
+
+OperationResult removePassword(CredentialManager& manager, const QString& profile, const QString& key)
+{
+    auto state = std::make_shared<OperationResult>();
+    manager.removePassword(profile, key, [state](bool success, const QString&) {
+        state->success = success;
+        state->done = true;
+    });
+    QTest::qWaitFor(
+            [state]() {
+                return state->done;
+            },
+            kWaitMs);
+    return *state;
+}
+
+} // namespace
+
+void CredentialManagerKeychainTest::initTestCase()
+{
+    // CredentialManagerTest forces file storage via this variable; this test exists to
+    // exercise the real credential store, so make sure it is not inherited from the
+    // environment
+    qunsetenv("MUDLET_TEST_MODE");
+
+    if (!onWindows()) {
+        return;
+    }
+
+    const QString probe = QStringLiteral("MudletKCTest-probe-%1").arg(QUuid::createUuid().toString(QUuid::Id128).left(8));
+    mStoreAvailable = writeTarget(probe, QStringLiteral("probe")) && deleteTarget(probe);
+
+    if (!mStoreAvailable) {
+        qWarning() << "CredentialManagerKeychainTest: credential store unavailable, tests will skip";
+    }
+}
+
+void CredentialManagerKeychainTest::init()
+{
+    const QString runId = QUuid::createUuid().toString(QUuid::Id128).left(8);
+    mProfile = QStringLiteral("MudletKCTest-%1").arg(runId);
+    mKey = QStringLiteral("kctest_%1").arg(runId);
+}
+
+void CredentialManagerKeychainTest::cleanup()
+{
+    if (!onWindows() || !mStoreAvailable) {
+        return;
+    }
+
+    // Remove every TargetName a test could have created or migrated to, plus the
+    // encrypted-file fallback copy
+    const QString service = expectedServiceName(mProfile, mKey);
+    const QString legacyService = expectedLegacyServiceName(mProfile, mKey);
+    const QStringList targets = {service, combinedTargetName(service), legacyService, combinedTargetName(legacyService), mKey};
+
+    for (const QString& target : targets) {
+        deleteTarget(target);
+    }
+
+    CredentialManager::removeCredential(mProfile, mKey);
+}
+
+void CredentialManagerKeychainTest::testRoundTrip()
+{
+    if (!onWindows()) {
+        QSKIP("Windows-only: exercises the Windows Credential Manager naming schemes");
+    }
+    if (!mStoreAvailable) {
+        QSKIP("Windows credential store unavailable in this environment");
+    }
+
+    const QString secret = QStringLiteral("roundtrip-secret");
+    CredentialManager manager;
+
+    QVERIFY(storePassword(manager, mProfile, mKey, secret).success);
+
+    // The entry must be in the credential store itself, not the file fallback
+    const QString service = expectedServiceName(mProfile, mKey);
+    QString stored;
+    QVERIFY(readTarget(currentTargetName(service), &stored));
+    QCOMPARE(stored, secret);
+
+    const OperationResult retrieved = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(retrieved.success);
+    QCOMPARE(retrieved.password, secret);
+
+    QVERIFY(removePassword(manager, mProfile, mKey).success);
+    QVERIFY(waitUntilTargetGone(currentTargetName(service)));
+    QVERIFY(waitUntilTargetGone(service));
+}
+
+void CredentialManagerKeychainTest::testBareEntryMigration()
+{
+    if (!onWindows()) {
+        QSKIP("Windows-only: exercises the Windows Credential Manager naming schemes");
+    }
+    if (!mStoreAvailable) {
+        QSKIP("Windows credential store unavailable in this environment");
+    }
+
+    // Plant an entry in the pre-0.17 layout: TargetName == service
+    const QString secret = QStringLiteral("bare-entry-secret");
+    const QString service = expectedServiceName(mProfile, mKey);
+    QVERIFY(writeTarget(service, secret));
+
+    CredentialManager manager;
+    const OperationResult retrieved = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(retrieved.success);
+    QCOMPARE(retrieved.password, secret);
+
+    if (qtkeychainHonoursService()) {
+        // 0.17+: the compat migration re-stores under "service@service" and the
+        // version-gated cleanup removes the bare entry
+        QVERIFY(waitUntilTargetHolds(combinedTargetName(service), secret));
+        QVERIFY(waitUntilTargetGone(service));
+    } else {
+        // pre-0.17: the primary read already resolves to the bare name, so the
+        // migration stays dormant and the entry is untouched
+        QString still;
+        QVERIFY(readTarget(service, &still));
+        QCOMPARE(still, secret);
+    }
+}
+
+void CredentialManagerKeychainTest::testRemoveSweepsBareEntry()
+{
+    if (!onWindows()) {
+        QSKIP("Windows-only: exercises the Windows Credential Manager naming schemes");
+    }
+    if (!mStoreAvailable) {
+        QSKIP("Windows credential store unavailable in this environment");
+    }
+
+    // A deleted password must not be resurrected by the compat migration: removing before
+    // any read has migrated the bare entry must sweep the bare TargetName as well
+    const QString secret = QStringLiteral("swept-secret");
+    const QString service = expectedServiceName(mProfile, mKey);
+    QVERIFY(writeTarget(service, secret));
+
+    CredentialManager manager;
+    QVERIFY(removePassword(manager, mProfile, mKey).success);
+    QVERIFY(waitUntilTargetGone(service));
+
+    const OperationResult retrieved = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(!retrieved.success);
+    QVERIFY(retrieved.password.isEmpty());
+}
+
+void CredentialManagerKeychainTest::testOldFormatMigration()
+{
+    if (!onWindows()) {
+        QSKIP("Windows-only: exercises the Windows Credential Manager naming schemes");
+    }
+    if (!mStoreAvailable) {
+        QSKIP("Windows credential store unavailable in this environment");
+    }
+
+    // Plant an entry in the old (pre-Windows-fix) layout: TargetName == account, the
+    // format that made all profiles share one credential
+    const QString secret = QStringLiteral("old-format-secret");
+    QVERIFY(writeTarget(mKey, secret));
+
+    CredentialManager manager;
+    const OperationResult retrieved = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(retrieved.success);
+    QCOMPARE(retrieved.password, secret);
+
+    // Migrated to the current naming scheme and the old entry cleaned up
+    const QString service = expectedServiceName(mProfile, mKey);
+    QVERIFY(waitUntilTargetHolds(currentTargetName(service), secret));
+    QVERIFY(waitUntilTargetGone(mKey));
+}
+
+void CredentialManagerKeychainTest::testCollidingFormatRecovery()
+{
+    if (!onWindows()) {
+        QSKIP("Windows-only: exercises the Windows Credential Manager naming schemes");
+    }
+    if (!mStoreAvailable) {
+        QSKIP("Windows credential store unavailable in this environment");
+    }
+
+    // Plant an entry in the colliding legacy layout: TargetName == legacy service name
+    // (as written by a pre-0.17 build of Mudlet 4.20.x)
+    const QString secret = QStringLiteral("colliding-secret");
+    const QString legacyService = expectedLegacyServiceName(mProfile, mKey);
+    QVERIFY(writeTarget(legacyService, secret));
+
+    CredentialManager manager;
+    const OperationResult retrieved = retrievePassword(manager, mProfile, mKey);
+    QVERIFY(retrieved.success);
+    QCOMPARE(retrieved.password, secret);
+
+    // Re-stored under the hash-based name; the colliding entry is removed afterwards
+    // (version-gated on APP_VERSION > 4.20.1, which holds for this build)
+    const QString service = expectedServiceName(mProfile, mKey);
+    QVERIFY(waitUntilTargetHolds(currentTargetName(service), secret));
+    QVERIFY(waitUntilTargetGone(legacyService));
+
+    if (qtkeychainHonoursService()) {
+        QVERIFY(waitUntilTargetGone(combinedTargetName(legacyService)));
+    }
+}
+
+QTEST_GUILESS_MAIN(CredentialManagerKeychainTest)
+#include "CredentialManagerKeychainTest.moc"

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -20,8 +20,15 @@
 #include <CredentialManager.h>
 #include <QtTest/QtTest>
 
-class CredentialManagerTest : public QObject {
-Q_OBJECT
+// Hermetic unit tests: MUDLET_TEST_MODE forces encrypted file storage so these run
+// deterministically on every platform without touching a system keychain. The real
+// keychain paths - including the qtkeychain 0.17 Windows naming migrations - are covered
+// by CredentialManagerKeychainTest, kept as a separate executable so its Windows-only,
+// environment-dependent tests cannot affect this suite.
+
+class CredentialManagerTest : public QObject
+{
+    Q_OBJECT
 
 private slots:
     void initTestCase();
@@ -49,10 +56,10 @@ void CredentialManagerTest::testStoreAndRetrieve()
     QString profile = "TestProfile";
     QString key = "test_password";
     QString password = "secret123";
-    
+
     // Store password
     QVERIFY(CredentialManager::storeCredential(profile, key, password));
-    
+
     // Retrieve password
     QString retrieved = CredentialManager::retrieveCredential(profile, key);
     QCOMPARE(retrieved, password);
@@ -65,11 +72,11 @@ void CredentialManagerTest::testProfileIsolation()
     QString key = "shared_key";
     QString password1 = "password1";
     QString password2 = "password2";
-    
+
     // Store different passwords for different profiles
     QVERIFY(CredentialManager::storeCredential(profile1, key, password1));
     QVERIFY(CredentialManager::storeCredential(profile2, key, password2));
-    
+
     // Verify isolation
     QCOMPARE(CredentialManager::retrieveCredential(profile1, key), password1);
     QCOMPARE(CredentialManager::retrieveCredential(profile2, key), password2);
@@ -123,11 +130,11 @@ void CredentialManagerTest::testKeyIsolation()
     QString key2 = "database";
     QString password1 = "proxy_pass";
     QString password2 = "db_pass";
-    
+
     // Store different passwords for different keys
     QVERIFY(CredentialManager::storeCredential(profile, key1, password1));
     QVERIFY(CredentialManager::storeCredential(profile, key2, password2));
-    
+
     // Verify isolation
     QCOMPARE(CredentialManager::retrieveCredential(profile, key1), password1);
     QCOMPARE(CredentialManager::retrieveCredential(profile, key2), password2);
@@ -137,10 +144,10 @@ void CredentialManagerTest::testEmptyPassword()
 {
     QString profile = "TestProfile";
     QString key = "empty_test";
-    
+
     // Store empty password (should remove any existing password)
     QVERIFY(CredentialManager::storeCredential(profile, key, ""));
-    
+
     // Should return empty string
     QString retrieved = CredentialManager::retrieveCredential(profile, key);
     QVERIFY(retrieved.isEmpty());
@@ -151,14 +158,14 @@ void CredentialManagerTest::testRemovePassword()
     QString profile = "TestProfile";
     QString key = "remove_test";
     QString password = "temp_password";
-    
+
     // Store password
     QVERIFY(CredentialManager::storeCredential(profile, key, password));
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), password);
-    
+
     // Remove password
     QVERIFY(CredentialManager::removeCredential(profile, key));
-    
+
     // Should return empty string after removal
     QString retrieved = CredentialManager::retrieveCredential(profile, key);
     QVERIFY(retrieved.isEmpty());
@@ -169,17 +176,17 @@ void CredentialManagerTest::testInputSanitization()
     QString profile = "SanitizationTestProfile";
     QString normalKey = "normal_key";
     QString password = "test_password";
-    
+
     // Test normal key works
     QVERIFY(CredentialManager::storeCredential(profile, normalKey, password));
     QString retrieved = CredentialManager::retrieveCredential(profile, normalKey);
     QCOMPARE(retrieved, password);
-    
+
     // Test with special characters in key names - should be rejected
     QString specialKey = "key/with\\special:chars<>|?*";
     bool specialStored = CredentialManager::storeCredential(profile, specialKey, password);
     QVERIFY(!specialStored); // Should fail due to invalid characters
-    
+
     // Test with Unicode characters in keys
     QString unicodeKey = "key_with_unicode_αβγ_δεζ";
     bool unicodeStored = CredentialManager::storeCredential(profile, unicodeKey, password);
@@ -189,7 +196,7 @@ void CredentialManagerTest::testInputSanitization()
         QCOMPARE(unicodeRetrieved, password);
         CredentialManager::removeCredential(profile, unicodeKey);
     }
-    
+
     // Cleanup
     CredentialManager::removeCredential(profile, normalKey);
 }
@@ -198,35 +205,29 @@ void CredentialManagerTest::testPathTraversalPrevention()
 {
     QString profile = "PathTraversalTestProfile";
     QString password = "test_password";
-    
+
     // Test various path traversal attempts in profile names
     QStringList maliciousProfiles = {
-        "../../../etc/passwd",
-        "..\\..\\windows\\system32",
-        "/etc/shadow",
-        "C:\\Windows\\System32\\config\\SAM",
-        "profile/../../../sensitive",
-        "profile\\..\\..\\sensitive"
-    };
-    
+            "../../../etc/passwd", "..\\..\\windows\\system32", "/etc/shadow", "C:\\Windows\\System32\\config\\SAM", "profile/../../../sensitive", "profile\\..\\..\\sensitive"};
+
     for (const QString& maliciousProfile : maliciousProfiles) {
         QString key = "test_key";
-        
+
         // These should be rejected or sanitized by the security measures
         bool stored = CredentialManager::storeCredential(maliciousProfile, key, password);
-        
+
         // Even if storage fails, this demonstrates that path traversal is prevented
         if (stored) {
             QString retrieved = CredentialManager::retrieveCredential(maliciousProfile, key);
             // If storage succeeded, retrieval should work with same profile name
             QCOMPARE(retrieved, password);
-            
+
             // Cleanup
             CredentialManager::removeCredential(maliciousProfile, key);
         }
         // If storage failed, that's also a valid security response
     }
-    
+
     // Test that a normal profile still works
     QString normalProfile = "NormalProfile";
     QVERIFY(CredentialManager::storeCredential(normalProfile, "test_key", password));
@@ -240,13 +241,13 @@ void CredentialManagerTest::testConcurrentAccess()
     QString profile = "ConcurrentTestProfile";
     QString key = "concurrent_key";
     QString password = "concurrent_password";
-    
+
     // Store initial credential
     QVERIFY(CredentialManager::storeCredential(profile, key, password));
-    
+
     // Simulate concurrent operations (basic test)
     // In a real concurrent test, we'd use threads, but for simplicity:
-    
+
     // Multiple rapid store/retrieve operations
     for (int i = 0; i < 10; ++i) {
         QString testPassword = QString("password_%1").arg(i);
@@ -254,13 +255,13 @@ void CredentialManagerTest::testConcurrentAccess()
         QString retrieved = CredentialManager::retrieveCredential(profile, key);
         QCOMPARE(retrieved, testPassword);
     }
-    
+
     // Verify final state
     QString finalPassword = "final_password";
     QVERIFY(CredentialManager::storeCredential(profile, key, finalPassword));
     QString finalRetrieved = CredentialManager::retrieveCredential(profile, key);
     QCOMPARE(finalRetrieved, finalPassword);
-    
+
     // Cleanup
     CredentialManager::removeCredential(profile, key);
 }
@@ -278,7 +279,7 @@ void CredentialManagerTest::cleanupTestCase()
     CredentialManager::removeCredential("SanitizationTestProfile", "normal_key");
     CredentialManager::removeCredential("PathTraversalTestProfile", "test_key");
     CredentialManager::removeCredential("ConcurrentTestProfile", "concurrent_key");
-    
+
     // Defensive cleanup for special character profile isolation test
     // (ensures cleanup even if test fails early)
     CredentialManager::removeCredential("Game.Server", "password");


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Adds a Windows-only migration that recovers stored passwords after qtkeychain 0.17.0 changes the Windows Credential Manager naming scheme (bare key -> "key@service"), re-storing them under the new name on first read
- Fixes the existing old-format migration reads/cleanup, which relied on the same pre-0.17 service-ignoring behaviour and would silently miss under 0.17+
- Surfaces the linked qtkeychain version as a QTKEYCHAIN_LINKED_VERSION compile definition (the library's own header macro is stale); it gates the old-entry cleanup and is logged for diagnostics
- Adds CredentialManagerKeychainTest: Windows-only ctests that plant the historical credential layouts in the real credential store (via empty-service QKeychain jobs, which resolve to the bare TargetName on every qtkeychain version) and verify round trip, bare-entry migration, no resurrection of deleted passwords, old-format migration, and colliding-format recovery

#### Motivation for adding to Mudlet
Once Windows builds pick up qtkeychain 0.17+ (e.g. via MSYS2), every stored profile password would silently become unreadable and users would have to re-enter them; this makes the transition seamless.

#### Other info (issues closed, discussion etc)
qtkeychain 0.17.0 breaking change: https://github.com/frankosterfeld/qtkeychain/releases/tag/0.17.0. A read with an empty service resolves to the bare key on every qtkeychain version, so the migration layer works regardless of which version is linked. On pre-0.17 builds it is normally dormant (the primary read already looks up the bare key), though a transient read failure can route into it as a harmless retry; deletion of the old entry only happens when the linked qtkeychain is known to be 0.17+, so the recovered credential can never be deleted on older versions. The new keychain tests branch their expectations on QTKEYCHAIN_LINKED_VERSION: on today's MSYS2 they verify the migration stays dormant, and they flip to verifying the actual migration automatically once MSYS2 ships 0.17+. They run on Windows PR CI via ctest and skip on other platforms or when the credential store is unavailable.

**Test case:** CredentialManagerKeychainTest covers the scenarios automatically on Windows CI. Manually: store a profile password, restart, confirm auto-login still works (pre-0.17: migration is a no-op). With a qtkeychain 0.17+ build: store a password using a pre-0.17 build, then run this build - the password should still load, and the Credential Manager entry moves to the "key@service" name.