### PR TITLE
Fix: skip duplicate-room warning during map load in TRoomDB::addRoom()

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -108,7 +108,15 @@ bool TRoomDB::addRoom(int id, TRoom* pR, bool isMapLoading)
         updateEntranceMap(pR, isMapLoading);
         return true;
     }
-    if (rooms.contains(id)) {
+    if (rooms.contains(id) && !isMapLoading) {
+        // A map can end up being restored more than once in the same session
+        // (for example Host::loadMap() runs at profile startup, and then
+        // TMainConsole::createMapper() restores it again the first time an
+        // embedded mapper widget is created). The second restore re-inserts
+        // every room that is already in memory, so without this guard the
+        // warning fires once per room in the whole map instead of only for
+        // an actual duplicate room id bug, which can add many seconds to
+        // startup on a large map for no useful diagnostic benefit.
         qWarning() << "TRoomDB::addRoom() - Room" << id << "already exists";
     }
     if (id <= 0) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`TRoomDB::addRoom()` warns whenever it's asked to insert a room id that's already in the database. That warning also fires when a map gets restored a second time in the same session, which already happens for any package that uses an embedded `Geyser.Mapper` widget: `Host::loadMap()` restores the map once at profile startup, and `TMainConsole::createMapper()` restores it again, unconditionally, the first time an embedded mapper widget is created, even though the room database is already fully populated by then.

On a map with a few thousand rooms, that second restore ends up firing this warning once per room, which turns what should be a fast, silent reload into a multi second freeze. This PR guards the warning with the `isMapLoading` flag that's already threaded through `addRoom()`, so it only fires for an actual duplicate room id bug outside of a map load.

#### Motivation for adding to Mudlet

I ran into this working on a package that uses an embedded `Geyser.Mapper` inside a custom pane layout, with a map that's grown to about 4,600 rooms over time. Every session start took close to 14 seconds just building the mapper widget, with nothing wrong in the map file itself.

Traced it down to the "already exists" warning added in #8758 (per room border colour support). That warning is unrelated to what #8758 was actually adding, it's a side effect of adding diagnostics to a code path that already runs thousands of times during a completely ordinary map load.

Confirmed with a minimal repro: a stock profile with no custom packages, a saved map of about 4,600 rooms, and a single `Geyser.Mapper:new()` call with no `dockPosition` (so it takes the embedded path). The profile's `log/errors.txt` shows two restores per session for the same file: `Host::loadMap()`'s own restore at startup, and the one triggered by `createMapper()`. Before #8758 both would have been well under a tenth of a second for this size of map. After #8758, the second restore takes on the order of 14 seconds, purely from the warning firing on every room that's already loaded.

#### Other info (issues closed, discussion etc)

This doesn't address the underlying redundant restore itself. `TMainConsole::createMapper()` calls `restore()` unconditionally whenever `mpMapper` is null, without checking whether the map database is already populated. That's a separate, larger change, and I didn't want to touch mapper widget lifecycle behavior in a fix aimed at the warning spam. Happy to look into that separately if it's wanted, but wanted to keep this one small and low risk.

The other two warnings in the same function (invalid room id, null room pointer) are left unconditional since they aren't expected during a normal map load and aren't implicated in the slowdown.

**Test case:**
1. Load a profile with a large saved map (a few thousand rooms or more).
2. In a package or with a raw Lua snippet, call `Geyser.Mapper:new({name="testmapper", x="0%", y="0%", width="100%", height="100%"})` with no `dockPosition`, right after the session starts.
3. Time how long the call takes to return, or check `log/errors.txt` in the profile folder for the two "Successfully read the map file" timings.
4. Before this fix, the second restore (triggered by the `Geyser.Mapper:new()` call) is dramatically slower than the first (`Host::loadMap()`'s automatic restore at startup) for the same file. After this fix, both are close to the same, fast time.
