### PR TITLE
Fix: add missing dictionary name

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -990,6 +990,7 @@ void mudlet::loadMaps()
             {qsl("bn_bd"), tr("Bangla (Bangladesh)")},
             {qsl("bn_in"), tr("Bangla (India)")},
             {qsl("bo"), tr("Tibetan")},
+            {qsl("bo_bt"), tr("Tibetan (Tibet)")},
             {qsl("bo_cn"), tr("Tibetan (China)")},
             {qsl("bo_in"), tr("Tibetan (India)")},
             {qsl("br"), tr("Breton")},

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -990,7 +990,7 @@ void mudlet::loadMaps()
             {qsl("bn_bd"), tr("Bangla (Bangladesh)")},
             {qsl("bn_in"), tr("Bangla (India)")},
             {qsl("bo"), tr("Tibetan")},
-            {qsl("bo_bt"), tr("Tibetan (Tibet)")},
+            {qsl("bo_bt"), tr("Tibetan (Bhutan)")},
             {qsl("bo_cn"), tr("Tibetan (China)")},
             {qsl("bo_in"), tr("Tibetan (India)")},
             {qsl("br"), tr("Breton")},


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds the name of a dictionary that is now present in my Devuan (Debian) Linux OS.

#### Motivation for adding to Mudlet
So the full name is displayed in the Spell-checking dictionary selection `QComboBox` box instead of the **`bo_bt`** code with a tooltip to advise the Mudlet Makers about this unknown code.

#### Other info (issues closed, discussion etc)
It seems the country concerned is **Bhutan** it seems that (probably because China believes it owns Tibet) there is not a two letter country code for Tibet - at least not in: this [table](https://www.unicode.org/cldr/charts/48/supplemental/language_territory_information.html)...
