### PR TITLE
fix: clickable links could show the wrong colours and styling after heavy output

### DIFF
--- a/src/TLinkStore.cpp
+++ b/src/TLinkStore.cpp
@@ -40,16 +40,11 @@ int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Hos
     if (!oldExpireName.isEmpty()) {
         mExpireToLinks.remove(oldExpireName, mLinkID);
     }
+    mExpireStore.remove(mLinkID);
 
     // Remove old styling and its selection-group index entry too, so a
     // recycled id does not inherit the previous link's styling
-    if (mStylingStore.contains(mLinkID)) {
-        const Mudlet::HyperlinkStyling& oldStyling = mStylingStore[mLinkID];
-        if (oldStyling.selection.hasSelectionSettings) {
-            mSelectionGroupIndex.remove(qMakePair(oldStyling.selection.group, oldStyling.selection.value), mLinkID);
-        }
-        mStylingStore.remove(mLinkID);
-    }
+    clearStyling(mLinkID);
 
     mLinkStore[mLinkID] = links;
     mHintStore[mLinkID] = hints;
@@ -130,16 +125,24 @@ void TLinkStore::removeUnreferencedLinks(const QSet<int>& referencedIds, Host* p
     }
 }
 
+void TLinkStore::clearStyling(int id)
+{
+    if (!mStylingStore.contains(id)) {
+        return;
+    }
+
+    const Mudlet::HyperlinkStyling& oldStyling = mStylingStore[id];
+    if (oldStyling.selection.hasSelectionSettings) {
+        const QPair<QString, QString> key = qMakePair(oldStyling.selection.group, oldStyling.selection.value);
+        mSelectionGroupIndex.remove(key, id);
+    }
+
+    mStylingStore.remove(id);
+}
+
 void TLinkStore::setStyling(int id, const Mudlet::HyperlinkStyling& styling)
 {
-    // Remove old selection group index entry if it exists
-    if (mStylingStore.contains(id)) {
-        const Mudlet::HyperlinkStyling& oldStyling = mStylingStore[id];
-        if (oldStyling.selection.hasSelectionSettings) {
-            QPair<QString, QString> oldKey = qMakePair(oldStyling.selection.group, oldStyling.selection.value);
-            mSelectionGroupIndex.remove(oldKey, id);
-        }
-    }
+    clearStyling(id);
 
     mStylingStore[id] = styling;
 

--- a/src/TLinkStore.cpp
+++ b/src/TLinkStore.cpp
@@ -41,6 +41,16 @@ int TLinkStore::addLinks(const QStringList& links, const QStringList& hints, Hos
         mExpireToLinks.remove(oldExpireName, mLinkID);
     }
 
+    // Remove old styling and its selection-group index entry too, so a
+    // recycled id does not inherit the previous link's styling
+    if (mStylingStore.contains(mLinkID)) {
+        const Mudlet::HyperlinkStyling& oldStyling = mStylingStore[mLinkID];
+        if (oldStyling.selection.hasSelectionSettings) {
+            mSelectionGroupIndex.remove(qMakePair(oldStyling.selection.group, oldStyling.selection.value), mLinkID);
+        }
+        mStylingStore.remove(mLinkID);
+    }
+
     mLinkStore[mLinkID] = links;
     mHintStore[mLinkID] = hints;
     mReferenceStore[mLinkID] = luaReference;

--- a/src/TLinkStore.h
+++ b/src/TLinkStore.h
@@ -71,6 +71,7 @@ public:
 
 private:
     void freeReference(Host* pH, const QVector<int>& luaReference);
+    void clearStyling(int id);
     void removeLinkById(int id, Host* pH);
 
 

--- a/test/TLinkStoreTest.cpp
+++ b/test/TLinkStoreTest.cpp
@@ -1,16 +1,14 @@
 #include <TLinkStore.h>
 #include <QtTest/QtTest>
 
-class TLinkStoreTest : public QObject {
-Q_OBJECT
+class TLinkStoreTest : public QObject
+{
+    Q_OBJECT
 
 private:
-
 private slots:
 
-    void initTestCase()
-    {
-    }
+    void initTestCase() {}
 
     void testAddAndGet()
     {
@@ -226,9 +224,42 @@ private slots:
         QCOMPARE(store.getHintsConst(id2), hints);
     }
 
-    void cleanupTestCase()
+    void testStylingClearedOnIdReuse()
     {
+        TLinkStore store(3);
+
+        QStringList links;
+        links.append("command");
+        QStringList hints;
+        hints.append("hint");
+
+        int id1 = store.addLinks(links, hints);
+        QCOMPARE(id1, 1);
+
+        Mudlet::HyperlinkStyling styling;
+        styling.hasCustomStyling = true;
+        styling.selection.group = "weapons";
+        styling.selection.value = "sword";
+        styling.selection.hasSelectionSettings = true;
+        store.setStyling(id1, styling);
+
+        QVERIFY(store.hasStyling(id1));
+        QCOMPARE(store.getLinkIdsByGroupValue("weapons", "sword"), QList<int>() << id1);
+
+        // Wrap the id counter around so id 1 is recycled by a link
+        // that provides no styling of its own
+        store.addLinks(links, hints);
+        store.addLinks(links, hints);
+        int recycledId = store.addLinks(links, hints);
+        QCOMPARE(recycledId, id1);
+
+        // The recycled id must not inherit the previous link's styling,
+        // nor remain findable under the old selection group/value
+        QVERIFY(!store.hasStyling(recycledId));
+        QVERIFY(store.getLinkIdsByGroupValue("weapons", "sword").isEmpty());
     }
+
+    void cleanupTestCase() {}
 };
 
 #include "TLinkStoreTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Clear a recycled link id's stale styling and selection-group index entry in `TLinkStore::addLinks()` when the id counter wraps around
- Add unit test `testStylingClearedOnIdReuse` covering the wraparound case

#### Motivation for adding to Mudlet
When a game has produced more than 20,000 clickable links, recycled link ids kept the previous link's OSC 8 styling (colours, decorations, selection group) until the new link happened to set its own - so plain MXP/echoLink links could render with another link's styling and respond to the wrong selection group.

#### Other info (issues closed, discussion etc)
Closes #9404. Mirrors the bookkeeping `removeLinkById()` already performs; `addLinks()` previously cleaned up only the expire-name mapping on id reuse.

**Test case:** `TLinkStoreTest` covers it (new test fails without the fix). Manually: on a profile with a small link store this needs 20k+ links to trigger; the unit test exercises the wraparound directly.