### PR TITLE
fix: word wrap changed by scripts now shows correctly in Preferences

### DIFF
--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3454,6 +3454,15 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
     auto console = CONSOLE(L, windowName);
     console->setWrapAt(luaFrom);
+    if (console->getType() == TConsole::MainConsole) {
+        Host& host = getHostFromLua(L);
+        const int priorWrapAt = host.mWrapAt;
+        host.mWrapAt = luaFrom;
+        if (priorWrapAt != luaFrom) {
+            host.mTelnet.sendInfoNewEnvironValue(qsl("WORD_WRAP"));
+        }
+        host.updateDisplayDimensions();
+    }
     return 0;
 }
 
@@ -3464,6 +3473,10 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
+    if (console->getType() == TConsole::MainConsole) {
+        Host& host = getHostFromLua(L);
+        host.mWrapIndentCount = luaFrom;
+    }
     return 0;
 }
 
@@ -3474,6 +3487,10 @@ int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setHangingIndentCount(luaFrom);
+    if (console->getType() == TConsole::MainConsole) {
+        Host& host = getHostFromLua(L);
+        host.mWrapHangingIndentCount = luaFrom;
+    }
     return 0;
 }
 

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3454,7 +3454,9 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
     auto console = CONSOLE(L, windowName);
     console->setWrapAt(luaFrom);
-    if (console->getType() == TConsole::MainConsole) {
+    // only mirror values the preferences dialog itself accepts into the
+    // profile, otherwise an invalid width would reach NAWS and get saved
+    if (luaFrom >= 1 && console->getType() == TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         const int priorWrapAt = host.mWrapAt;
         host.mWrapAt = luaFrom;
@@ -3473,7 +3475,7 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setIndentCount(luaFrom);
-    if (console->getType() == TConsole::MainConsole) {
+    if (luaFrom >= 0 && console->getType() == TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         host.mWrapIndentCount = luaFrom;
     }
@@ -3487,7 +3489,7 @@ int TLuaInterpreter::setWindowWrapHangingIndent(lua_State* L)
     const int luaFrom = getVerifiedInt(L, __func__, 2, "wrapTo");
     auto console = CONSOLE(L, windowName);
     console->setHangingIndentCount(luaFrom);
-    if (console->getType() == TConsole::MainConsole) {
+    if (luaFrom >= 0 && console->getType() == TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         host.mWrapHangingIndentCount = luaFrom;
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- setWindowWrap() and the indent variants now update the profile's stored wrap settings when applied to the main console, so Preferences and profile saving reflect the scripted value
- wrap changes also notify the game via NEW_ENVIRON `WORD_WRAP` and NAWS, matching what the Preferences dialog does

#### Motivation for adding to Mudlet
Scripts and the Preferences dialog no longer disagree about the current word wrap.

#### Other info (issues closed, discussion etc)
Fixes #8522. Includes the game-notification flow that was missing from the earlier attempt in #8523.

**Test case:** run `lua setWindowWrap("main", 55)`, open Preferences > Main display - "Wrap lines at" shows 55 (previously stayed at the old value).

https://github.com/user-attachments/assets/656a3ff4-34e1-47eb-b36e-54123651f86d


