### PR TITLE
fix: main display no longer leaves a blank strip when the top border shrinks

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -696,7 +696,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     // Move before resizing: resizing first could leave the display overrunning
     // its parent frame, clipping it and making TTextEdit::updateScreenView()
-    // undercount the visible rows (issue #7693):
+    // undercount the visible rows:
     mpMainDisplay->move(mBorders.left(), mBorders.top());
     if (mType & (MainConsole | SubConsole | UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
@@ -827,7 +827,7 @@ void TConsole::refresh()
         y -= mpTopToolBar->height();
     }
 
-    // Move before resizing, see comment in resizeEvent() (issue #7693):
+    // Move before resizing, see comment in resizeEvent():
     mpMainDisplay->move(mBorders.left(), mBorders.top());
     mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -694,6 +694,10 @@ void TConsole::resizeEvent(QResizeEvent* event)
         layoutLayer2->activate();
     }
 
+    // Move before resizing: resizing first could leave the display overrunning
+    // its parent frame, clipping it and making TTextEdit::updateScreenView()
+    // undercount the visible rows (issue #7693):
+    mpMainDisplay->move(mBorders.left(), mBorders.top());
     if (mType & (MainConsole | SubConsole | UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
@@ -706,7 +710,6 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mpMainFrame->resize(x, y);
         mpMainDisplay->resize(x, y);
     }
-    mpMainDisplay->move(mBorders.left(), mBorders.top());
 
     if (mType & (CentralDebugConsole | ErrorConsole)) {
         layerCommandLine->hide();
@@ -824,13 +827,14 @@ void TConsole::refresh()
         y -= mpTopToolBar->height();
     }
 
+    // Move before resizing, see comment in resizeEvent() (issue #7693):
+    mpMainDisplay->move(mBorders.left(), mBorders.top());
     mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
 
     if (!mpCommandLine.isNull()) {
         mpCommandLine->adjustHeight();
     }
 
-    mpMainDisplay->move(mBorders.left(), mBorders.top());
     x = width();
     y = height();
     const QSize s = QSize(x, y);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- the main display is now moved to its new position before being resized in TConsole::resizeEvent() and refresh(); resizing first left the enlarged display clipped by its parent frame, so the visible row count was computed too small

#### Motivation for adding to Mudlet
Shrinking the top border via setBorderTop() left a permanent blank strip at the bottom of the main display until new output arrived.

#### Other info (issues closed, discussion etc)
Fixes #7693.

**Test case:** fill the screen with text, `lua setBorderTop(300)` then `lua setBorderTop(0)` - text reflows to fill the full window height immediately (previously a ~300px blank strip remained at the bottom).


https://github.com/user-attachments/assets/fdb3ddf3-f9fb-4ab6-93a4-fb509c2a2ea6

