### PR TITLE
fix: script editor's info banner no longer glares in dark mode

### DIFF
--- a/src/dlgSystemMessageArea.cpp
+++ b/src/dlgSystemMessageArea.cpp
@@ -22,6 +22,8 @@
 
 #include "dlgSystemMessageArea.h"
 
+#include "mudlet.h"
+
 
 dlgSystemMessageArea::dlgSystemMessageArea(QWidget* pParentWidget)
 : QWidget(pParentWidget)
@@ -41,4 +43,25 @@ dlgSystemMessageArea::dlgSystemMessageArea(QWidget* pParentWidget)
     holdPixmap = notificationAreaIconLabelInformation->pixmap(Qt::ReturnByValue);
     holdPixmap.setDevicePixelRatio(5.3);
     notificationAreaIconLabelInformation->setPixmap(holdPixmap);
+
+    slot_applyAppearance();
+    connect(mudlet::self(), &mudlet::signal_appearanceChanged, this, &dlgSystemMessageArea::slot_applyAppearance);
+}
+
+void dlgSystemMessageArea::slot_applyAppearance()
+{
+    const bool darkMode = mudlet::self()->inDarkMode();
+    const QString background = darkMode ? qsl("rgb(64, 60, 40)") : qsl("rgb(255, 254, 215)");
+    const QString textColor = darkMode ? qsl("rgb(230, 230, 230)") : qsl("black");
+    frame_notificationArea->setStyleSheet(qsl("QFrame#frame_notificationArea {\n"
+                                              "  border: 3px solid;\n"
+                                              "  border-radius: 6px;\n"
+                                              "  background-color: %1;\n"
+                                              "}\n"
+                                              "\n"
+                                              "QLabel{\n"
+                                              "color: %2;\n"
+                                              "background-color: %1;\n"
+                                              "}")
+                                                  .arg(background, textColor));
 }

--- a/src/dlgSystemMessageArea.h
+++ b/src/dlgSystemMessageArea.h
@@ -33,6 +33,9 @@ class dlgSystemMessageArea : public QWidget, public Ui::system_message_area
 public:
     Q_DISABLE_COPY(dlgSystemMessageArea)
     explicit dlgSystemMessageArea(QWidget*);
+
+private slots:
+    void slot_applyAppearance();
 };
 
 #endif // MUDLET_DLGSYSTEMMESSAGEAREA_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -346,6 +346,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, this, &dlgTriggerEditor::hideSystemMessageArea);
     connect(mpSystemMessageArea->notificationAreaMessageBox, &QLabel::linkActivated, this, &dlgTriggerEditor::slot_clickedMessageBox);
+    connect(mudlet::self(), &mudlet::signal_appearanceChanged, this, &dlgTriggerEditor::slot_refreshBannerLinkColors);
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
@@ -10033,6 +10034,13 @@ void dlgTriggerEditor::showInfo(const QString& text)
     }
 }
 
+// Qt's rich text does not understand 'color: inherit' and renders it as
+// black, so the theme's text colour has to be spelled out explicitly
+static QString themedBannerLinkColor()
+{
+    return mudlet::self()->inDarkMode() ? qsl("rgb(230, 230, 230)") : qsl("black");
+}
+
 void dlgTriggerEditor::showIntro(const QString& desiredOption)
 {
     if (!introAddItem.contains(mCurrentView)) {
@@ -10055,9 +10063,7 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
 
     introTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
     QString introTextOptions;
-    // Qt's rich text does not understand 'color: inherit' and renders it as
-    // black, so spell the theme's text colour out explicitly
-    const QString linkColor = mudlet::self()->inDarkMode() ? qsl("rgb(230, 230, 230)") : qsl("black");
+    const QString linkColor = themedBannerLinkColor();
     for (const auto& [name, headline, contents] : std::as_const(introAddCurrentItem.options)) {
         introTextOptions.append((name != desiredOption) ? qsl("<li><a href='%1' style='color: %3; text-decoration: underline;'>%2</a></li>").arg(name, headline, linkColor)
                                                         : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
@@ -14072,9 +14078,9 @@ void dlgTriggerEditor::showBannerUndoToast()
     //: Toast notification shown when user dismisses an editor tip banner. Allows them to undo or permanently hide the tips for this editor view type.
     QString toastMessage = tr("Banner hidden. <a href='undo' style='color: inherit; text-decoration: underline;'>Undo</a> | <a href='hide-permanently' style='color: inherit; text-decoration: "
                               "underline;'>Hide permanently</a>");
-    // Qt's rich text renders 'color: inherit' as black; fix it up here rather
-    // than in the tr() text so existing translations stay valid
-    toastMessage.replace(qsl("color: inherit"), qsl("color: ") + (mudlet::self()->inDarkMode() ? qsl("rgb(230, 230, 230)") : qsl("black")));
+    // Fix up the colour here rather than in the tr() text so existing
+    // translations stay valid
+    toastMessage.replace(qsl("color: inherit"), qsl("color: ") + themedBannerLinkColor());
 
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();
@@ -14095,6 +14101,30 @@ void dlgTriggerEditor::showBannerUndoToast()
             slot_clickedMessageBox(link);
         }
     });
+}
+
+// The banner and toast link colours are baked into the message HTML when it is
+// built, so swap them for the new theme's colour if the appearance changes
+// while a message is still on screen
+void dlgTriggerEditor::slot_refreshBannerLinkColors()
+{
+    const QString freshColor = themedBannerLinkColor();
+    const QString staleColor = freshColor == qsl("black") ? qsl("rgb(230, 230, 230)") : qsl("black");
+    const QString stale = qsl("color: %1;").arg(staleColor);
+    const QString fresh = qsl("color: %1;").arg(freshColor);
+
+    // keep the stored content fresh too, so undoing a dismissal after a theme
+    // switch does not restore links in the old theme's colour
+    mLastDismissedBannerContent.replace(stale, fresh);
+
+    if (!mpSystemMessageArea) {
+        return;
+    }
+    auto* messageBox = mpSystemMessageArea->notificationAreaMessageBox;
+    QString text = messageBox->text();
+    if (text.contains(stale)) {
+        messageBox->setText(text.replace(stale, fresh));
+    }
 }
 
 void dlgTriggerEditor::undoBannerDismiss()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -10055,8 +10055,11 @@ void dlgTriggerEditor::showIntro(const QString& desiredOption)
 
     introTextParts introAddCurrentItem = introAddItem.value(mCurrentView);
     QString introTextOptions;
+    // Qt's rich text does not understand 'color: inherit' and renders it as
+    // black, so spell the theme's text colour out explicitly
+    const QString linkColor = mudlet::self()->inDarkMode() ? qsl("rgb(230, 230, 230)") : qsl("black");
     for (const auto& [name, headline, contents] : std::as_const(introAddCurrentItem.options)) {
-        introTextOptions.append((name != desiredOption) ? qsl("<li><a href='%1' style='color: inherit; text-decoration: underline;'>%2</a></li>").arg(name, headline)
+        introTextOptions.append((name != desiredOption) ? qsl("<li><a href='%1' style='color: %3; text-decoration: underline;'>%2</a></li>").arg(name, headline, linkColor)
                                                         : qsl("<li><strong>%1</strong>%2</li>").arg(headline, contents));
     }
 
@@ -14069,6 +14072,9 @@ void dlgTriggerEditor::showBannerUndoToast()
     //: Toast notification shown when user dismisses an editor tip banner. Allows them to undo or permanently hide the tips for this editor view type.
     QString toastMessage = tr("Banner hidden. <a href='undo' style='color: inherit; text-decoration: underline;'>Undo</a> | <a href='hide-permanently' style='color: inherit; text-decoration: "
                               "underline;'>Hide permanently</a>");
+    // Qt's rich text renders 'color: inherit' as black; fix it up here rather
+    // than in the tr() text so existing translations stay valid
+    toastMessage.replace(qsl("color: inherit"), qsl("color: ") + (mudlet::self()->inDarkMode() ? qsl("rgb(230, 230, 230)") : qsl("black")));
 
     mpSystemMessageArea->notificationAreaIconLabelError->hide();
     mpSystemMessageArea->notificationAreaIconLabelWarning->hide();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -333,6 +333,7 @@ private slots:
     void slot_clickedMessageBox(const QString&);
     void slot_addPattern();
     void slot_bannerDismissClicked();
+    void slot_refreshBannerLinkColors();
     void slot_itemsChanged(EditorViewTypes::EditorViewType viewType, QList<int> affectedItemIDs);
 
     // Per-property immediate save slots for triggers (create individual undo entries)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- the editor's info/intro banner had a hardcoded bright-yellow background; it now styles itself per theme (muted dark amber in dark mode, unchanged in light mode) and follows live theme switches
- the banner's links used 'color: inherit', which Qt rich text renders as black; they now use an explicit theme-appropriate colour so they are readable in dark mode

#### Motivation for adding to Mudlet
The bright yellow banner was glaring against the dark editor, and its links were unreadable once the background went dark.

#### Other info (issues closed, discussion etc)
Fixes #8854.

**Test case:** enable dark mode, open the script editor with nothing selected - the info banner is muted dark amber with readable light text and links; in light mode it looks exactly as before.


https://github.com/user-attachments/assets/5368705f-9759-4ea6-87d5-55ee23eb54c8

