### PR TITLE
fix: Copy button no longer oversized on the connection screen

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -174,7 +174,6 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
         copy_profile_toolbutton->setIcon(QIcon::fromTheme(qsl("edit-copy"), QIcon(qsl(":/icons/edit-copy.png"))));
         copy_profile_toolbutton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-        copy_profile_toolbutton->setIconSize(new_profile_button->iconSize());
         mpCopyProfile->setIcon(QIcon::fromTheme(qsl("edit-copy"), QIcon(qsl(":/icons/edit-copy.png"))));
 
         QTextCursor cursor = pWelcome_document->find(qsl("NEW_PROFILE_ICON"), 0, QTextDocument::FindWholeWords);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -174,6 +174,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
         copy_profile_toolbutton->setIcon(QIcon::fromTheme(qsl("edit-copy"), QIcon(qsl(":/icons/edit-copy.png"))));
         copy_profile_toolbutton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+        copy_profile_toolbutton->setIconSize(new_profile_button->iconSize());
         mpCopyProfile->setIcon(QIcon::fromTheme(qsl("edit-copy"), QIcon(qsl(":/icons/edit-copy.png"))));
 
         QTextCursor cursor = pWelcome_document->find(qsl("NEW_PROFILE_ICON"), 0, QTextDocument::FindWholeWords);

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -403,11 +403,6 @@
                 <height>25</height>
                </size>
               </property>
-              <property name="font">
-               <font>
-                <pointsize>13</pointsize>
-               </font>
-              </property>
               <property name="text">
                <string>Copy</string>
               </property>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Removed a stray 13pt font override on the Copy button that made it render larger than its Remove/New siblings
- Pinned the Copy button's icon size to match the neighbouring buttons

#### Motivation for adding to Mudlet
The connection screen's profile buttons should look uniform; the oversized Copy button was a 4.21.0 regression.

#### Other info (issues closed, discussion etc)
Fixes #9330. Regression introduced in #9198.

**Test case:** Open Mudlet's connection screen and compare the Remove | Copy | New buttons - all three should have the same size and text height.


https://github.com/user-attachments/assets/93cfe22a-7ed4-4159-afc8-2d4b64cd9f48

