### PR TITLE
fix: debug console shows its black background again

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5333,7 +5333,6 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     if (showTimeStamp && !timeBuffer.at(row).isEmpty()) {
         // Use the console's background so the timestamp blends in with the
         // rest of the text, as done in TTextEdit::drawLine(...).
-        // TODO: needs updating if we allow the colours to be user set:
         const QColor timeStampBgColor{mpConsole ? mpConsole->getConsoleBgColor() : QColor(Qt::black)};
         s.append(qsl("<span style=\"color: rgb(200,150,0); background: %1; \">%2").arg(timeStampBgColor.name(), timeBuffer.at(row).left(mudlet::smTimeStampFormat.length())));
         // Set the current idea of what the formatting is so we can spot if it

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5331,12 +5331,15 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     // <span timestamp format>Timestamp (13 chars)</span><span default>___padding spaces___</span><span first chunk style>first chunk...
     // we will NOT need a closing "</span>"
     if (showTimeStamp && !timeBuffer.at(row).isEmpty()) {
-        // TODO: formatting according to TTextEdit.cpp: if( i2 < timeOffset ) - needs updating if we allow the colours to be user set:
-        s.append(qsl("<span style=\"color: rgb(200,150,0); background: rgb(22,22,22); \">%1").arg(timeBuffer.at(row).left(mudlet::smTimeStampFormat.length())));
+        // Use the console's background so the timestamp blends in with the
+        // rest of the text, as done in TTextEdit::drawLine(...).
+        // TODO: needs updating if we allow the colours to be user set:
+        const QColor timeStampBgColor{mpConsole ? mpConsole->getConsoleBgColor() : QColor(Qt::black)};
+        s.append(qsl("<span style=\"color: rgb(200,150,0); background: %1; \">%2").arg(timeStampBgColor.name(), timeBuffer.at(row).left(mudlet::smTimeStampFormat.length())));
         // Set the current idea of what the formatting is so we can spot if it
         // changes:
         currentFgColor = QColor(200, 150, 0);
-        currentBgColor = QColor(22, 22, 22);
+        currentBgColor = timeStampBgColor;
         currentFlags = TChar::None;
         // We are no longer before the first span - so we need to flag that
         // there will be one to close:

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -120,7 +120,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     setContentsMargins(0, 0, 0, 0);
     setAttribute(Qt::WA_DeleteOnClose);
-    setAttribute(Qt::WA_OpaquePaintEvent, (mType == MainConsole));
+    setAttribute(Qt::WA_OpaquePaintEvent, (mType == MainConsole || mType == CentralDebugConsole));
 
     const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     const QSizePolicy sizePolicy3(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -130,7 +130,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
 
-    if (mType == MainConsole) {
+    // the central debug console is a top-level window with no main console
+    // behind it, so it must paint its own background like the main console does
+    if (mType == MainConsole || mType == CentralDebugConsole) {
         QPalette framePalette;
         framePalette.setColor(QPalette::Text, QColor(Qt::black));
         framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -457,7 +457,7 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
     QTextBoundaryFinder boundaryFinder(QTextBoundaryFinder::Grapheme, lineText);
     int currentSize = lineText.size();
     if (mpConsole->showTimeStamps()) {
-        TChar timeStampStyle(QColor(200, 150, 0), QColor(22, 22, 22));
+        TChar timeStampStyle(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
         QString timestamp(mpBuffer->timeBuffer.at(lineNumber));
         QVector<QColor> fgColors;
         QVector<QRect> textRects;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Restored the Central Debug Console's painted black background, lost in 4.20.0 when consoles were made transparent for miniconsole opacity (#7917); the OS window color (gray/white) was leaking through
- Timestamps now use the console's background instead of hardcoded rgb(22,22,22), on screen and in copy-as-HTML, so they blend instead of forming a dark band

#### Motivation for adding to Mudlet
Debug output colors (e.g. capture-group purple) were designed for the black canvas and had become unreadable on the leaked gray background.

#### Other info (issues closed, discussion etc)
Fixes #9187. Follows the same approach #7942 used to restore the main console's background.

**Test case:** Open the Central Debug Console (Ctrl+0 in the script editor) and run any command - the console background should be black, all line colors readable, and timestamps should not show a distinct dark band.


https://github.com/user-attachments/assets/ae30b0bb-7977-440d-895a-ac3698c82360

