### PR TITLE
fix: alias patterns no longer break after editing them

### DIFF
--- a/src/TrailingWhitespaceMarker.cpp
+++ b/src/TrailingWhitespaceMarker.cpp
@@ -51,7 +51,7 @@ void markQString(QString* text)
         auto lastNonSpace = std::find_if_not(text->rbegin(), text->rend(), [](QChar c) {
             return c == QChar(' ');
         });
-        std::replace(lastNonSpace, text->rend(), QChar(' '), middleDot);
+        std::replace(text->rbegin(), lastNonSpace, QChar(' '), middleDot);
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -14524,7 +14524,8 @@ void dlgTriggerEditor::slot_saveProperty_AliasPattern()
         return;
     }
 
-    const QString newPattern = mpAliasMainArea->lineEdit_alias_pattern->text();
+    QString newPattern = mpAliasMainArea->lineEdit_alias_pattern->text();
+    unmarkQString(&newPattern);
 
     if (pT->getRegexCode() == newPattern) {
         return;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The alias pattern field's autosave now strips the visual whitespace-marker dots before saving, matching the Save Item path - previously the dots were saved into the live regex, so the alias only matched literal middle-dot characters
- Fixed the whitespace marker bulleting every interior space when a pattern ends in '$' (wrong std::replace range - it marked everything except the actual trailing spaces)

#### Motivation for adding to Mudlet
Editing an alias pattern ending in '$' silently broke the alias until it was re-saved through the toolbar.

#### Other info (issues closed, discussion etc)
Fixes #9377. The autosave path was added by the editor undo/redo work (#8469).

**Test case:** Create an alias with pattern `^map todo(?: (.+))?$` - interior spaces must display as spaces, not dots. Edit the pattern field and click away, then type a matching command - the alias must still fire.




https://github.com/user-attachments/assets/70503ae0-2dfb-461b-a763-9a83d4c516f4


