### PR TITLE
fix: Variables view handles decimal numbers and true/false keys properly

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -118,7 +118,7 @@ bool LuaInterface::loadKey(lua_State* L, TVar* var)
             lua_rawgeti(L, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
             if (keyType == LUA_TNUMBER) {
-                lua_pushnumber(L, var->getName().toInt());
+                lua_pushnumber(L, var->getName().toDouble());
             } else if (keyType == LUA_TTABLE) {
             } else if (keyType == LUA_TBOOLEAN) {
                 lua_pushboolean(L, var->getName().toLower() == "true" ? 1 : 0);
@@ -363,7 +363,7 @@ bool LuaInterface::setCValue(QList<TVar*> vars)
             lua_pushstring(mL, var->getValue().toUtf8().constData());
             break;
         case LUA_TNUMBER:
-            lua_pushnumber(mL, var->getValue().toInt());
+            lua_pushnumber(mL, var->getValue().toDouble());
             break;
         case LUA_TBOOLEAN:
             lua_pushboolean(mL, var->getValue().toLower() == "true" ? 1 : 0);
@@ -397,7 +397,8 @@ bool LuaInterface::setValue(TVar* var)
         if (vars[i]->isReference()) {
             return setCValue(vars);
         }
-        if (vars[i]->getKeyType() == LUA_TNUMBER) {
+        const int keyType = vars[i]->getKeyType();
+        if (keyType == LUA_TNUMBER || keyType == LUA_TBOOLEAN) {
             variableChangeCode.append(qsl("[%1]").arg(vars.at(i)->getName()));
         } else {
             variableChangeCode.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
@@ -437,7 +438,8 @@ void LuaInterface::deleteVar(TVar* var)
     QList<TVar*> vars = varOrder(var);
     QString oldName = vars[0]->getName();
     for (int i = 1; i < vars.size(); i++) {
-        if (vars[i]->getKeyType() == LUA_TNUMBER) {
+        const int keyType = vars[i]->getKeyType();
+        if (keyType == LUA_TNUMBER || keyType == LUA_TBOOLEAN) {
             oldName.append(qsl("[%1]").arg(vars[i]->getName()));
         } else {
             oldName.append(qsl(R"(["%1"])").arg(vars[i]->getName()));
@@ -472,8 +474,9 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         for (; i < vars.size() - 1; i++) {
             kType = vars[i]->getKeyType();
             if (kType == LUA_TNUMBER) {
-                lua_pushnumber(mL, QString(vars[i]->getName()).toInt());
+                lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
             } else if (kType == LUA_TTABLE) {
+                // registry references are integer refs so must stay toInt()
                 lua_rawgeti(mL, LUA_REGISTRYINDEX, vars[i]->getName().toInt());
             } else {
                 lua_pushstring(mL, QString(vars[i]->getName()).toUtf8().constData());
@@ -483,7 +486,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
                 //value didn't exist, make it
                 lua_pop(mL, -1);
                 if (kType == LUA_TNUMBER) {
-                    lua_pushnumber(mL, QString(vars[i]->getName()).toInt());
+                    lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
                 } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
                     lua_rawgeti(mL, LUA_REGISTRYINDEX, vars[i]->getName().toInt());
                 } else {
@@ -499,7 +502,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         if (kType == LUA_TSTRING) {
             lua_pushstring(mL, QString(var->getNewName()).toUtf8().constData());
         } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getNewName().toInt());
+            lua_pushnumber(mL, var->getNewName().toDouble());
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
@@ -514,7 +517,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         for (; i < vars.size() - 1; i++) {
             kType = vars[i]->getKeyType();
             if (kType == LUA_TNUMBER) {
-                lua_pushnumber(mL, QString(vars[i]->getName()).toInt());
+                lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
             } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
                 lua_rawgeti(mL, LUA_REGISTRYINDEX, vars[i]->getName().toInt());
             } else {
@@ -528,7 +531,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         if (kType == LUA_TSTRING) {
             lua_pushstring(mL, QString(var->getName()).toUtf8().constData());
         } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getName().toInt());
+            lua_pushnumber(mL, var->getName().toDouble());
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
@@ -544,7 +547,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         if (kType == LUA_TSTRING) {
             lua_pushstring(mL, QString(var->getNewName()).toUtf8().constData());
         } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getNewName().toInt());
+            lua_pushnumber(mL, var->getNewName().toDouble());
         } else if (kType == LUA_TTABLE) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
@@ -561,7 +564,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         if (kType == LUA_TSTRING) {
             lua_pushstring(mL, QString(var->getName()).toUtf8().constData());
         } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getName().toInt());
+            lua_pushnumber(mL, var->getName().toDouble());
         } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
             lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
         } else {
@@ -583,7 +586,7 @@ bool LuaInterface::loadVar(TVar* var)
         const int vType = var->getValueType();
         if (vType == LUA_TTABLE) {
             if (kType == LUA_TNUMBER) {
-                lua_pushnumber(mL, QString(var->getName()).toInt());
+                lua_pushnumber(mL, QString(var->getName()).toDouble());
             } else if (kType == LUA_TTABLE) {
                 lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
             } else {
@@ -597,7 +600,7 @@ bool LuaInterface::loadVar(TVar* var)
                 return false;
             }
         } else if (vType == LUA_TNUMBER) {
-            lua_pushnumber(mL, QString(var->getValue()).toInt());
+            lua_pushnumber(mL, QString(var->getValue()).toDouble());
         } else if (vType == LUA_TBOOLEAN) {
             lua_pushboolean(mL, var->getValue().toLower() == "true" ? 1 : 0);
         } else if (vType == LUA_TSTRING) {
@@ -702,7 +705,11 @@ QString LuaInterface::getValue(TVar* var)
         if (firstVariable->getKeyType() == LUA_TSTRING) {
             lua_getglobal(mL, (firstVariable->getName()).toUtf8().constData());
         } else if (firstVariable->getKeyType() == LUA_TNUMBER) {
-            lua_rawgeti(mL, LUA_GLOBALSINDEX, firstVariable->getName().toInt());
+            lua_pushnumber(mL, firstVariable->getName().toDouble());
+            lua_gettable(mL, LUA_GLOBALSINDEX);
+        } else if (firstVariable->getKeyType() == LUA_TBOOLEAN) {
+            lua_pushboolean(mL, firstVariable->getName().toLower() == "true" ? 1 : 0);
+            lua_gettable(mL, LUA_GLOBALSINDEX);
         }
         if (lua_isnoneornil(mL, lua_gettop(mL))) {
             qDebug() << "LuaInterface::getValue: Couldn't put root value" << firstVariable->getName() << "onto the Lua stack in order to get value of" << var->getName()
@@ -741,6 +748,10 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
             keyName = QString::number(luaL_ref(L, LUA_REGISTRYINDEX)); //this function pops the top item
             lrefs.append(keyName.toInt());
             var->setReference(true);
+        } else if (kType == LUA_TBOOLEAN) {
+            //lua_tostring() returns NULL for booleans, name the key ourselves
+            keyName = lua_toboolean(L, -1) ? qsl("true") : qsl("false");
+            lua_pop(L, 1);
         } else {
             keyName = lua_tostring(L, -1);
             if (kType == LUA_TFUNCTION && keyName.isEmpty()) {

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -629,21 +629,21 @@ void LuaInterface::renameVar(TVar* var)
 
     for (int i = 1; i < vars.size(); i++) {
         const int kType = vars[i]->getKeyType();
-        if (kType == LUA_TNUMBER) {
+        // numbers and booleans use unquoted subscripts: t[3.14], t[true]
+        if (kType == LUA_TNUMBER || kType == LUA_TBOOLEAN) {
             oldVariable.append(qsl("[%1]").arg(vars.at(i)->getName()));
             if (i < vars.size() - 1) {
                 newName.append(qsl("[%1]").arg(vars[i]->getName()));
             }
-
         } else if (kType == LUA_TTABLE) {
             renameCVar(vars);
             return;
-        }
-
-        // That leaves LUA_TSTRING:
-        oldVariable.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
-        if (i < vars.size() - 1) {
-            newName.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
+        } else {
+            // that leaves LUA_TSTRING
+            oldVariable.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
+            if (i < vars.size() - 1) {
+                newName.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
+            }
         }
     }
 
@@ -652,7 +652,7 @@ void LuaInterface::renameVar(TVar* var)
         newName.append(qsl("_G[\"%1\"]").arg(vars.last()->getNewName()));
     } else {
         // this variable is nested in a table
-        if (var->getNewKeyType() == LUA_TNUMBER) {
+        if (var->getNewKeyType() == LUA_TNUMBER || var->getNewKeyType() == LUA_TBOOLEAN) {
             newName.append(qsl("[%1]").arg(vars.last()->getNewName()));
         } else {
             newName.append(qsl(R"(["%1"])").arg(vars.last()->getNewName()));

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6732,14 +6732,21 @@ void dlgTriggerEditor::saveVar()
     //check variable recasting
     const int varRecast = canRecast(pItem, uiNameType, uiValueType);
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
-        if (QString(newName).toInt()) {
+        bool nameNumberOk = false;
+        const double nameAsNumber = newName.toDouble(&nameNumberOk);
+        // the key type combobox cannot express a boolean key, so keep an unchanged one boolean
+        if (variable->getKeyType() == LUA_TBOOLEAN && (newName.toLower() == QLatin1String("true") || newName.toLower() == QLatin1String("false"))) {
+            uiNameType = LUA_TBOOLEAN;
+        } else if (nameNumberOk && nameAsNumber != 0) {
             uiNameType = LUA_TNUMBER;
         } else {
             uiNameType = LUA_TSTRING;
         }
     }
     if ((uiValueType != LUA_TTABLE) && (uiValueType == -1)) {
-        if (newValue.toInt()) {
+        bool valueNumberOk = false;
+        const double valueAsNumber = newValue.toDouble(&valueNumberOk);
+        if (valueNumberOk && valueAsNumber != 0) {
             uiValueType = LUA_TNUMBER;
         } else if (newValue.toLower() == "true" || newValue.toLower() == "false") {
             uiValueType = LUA_TBOOLEAN;
@@ -6772,7 +6779,9 @@ void dlgTriggerEditor::saveVar()
                 int change = 0;
                 if (newName != variable->getName() || uiNameType != variable->getKeyType()) {
                     //let's make sure the nametype works
-                    if (variable->getKeyType() == LUA_TNUMBER && newName.toInt()) {
+                    bool nameNumberOk = false;
+                    const double nameAsNumber = newName.toDouble(&nameNumberOk);
+                    if (variable->getKeyType() == LUA_TNUMBER && nameNumberOk && nameAsNumber != 0) {
                         uiNameType = LUA_TNUMBER;
                     } else {
                         uiNameType = LUA_TSTRING;
@@ -6782,10 +6791,12 @@ void dlgTriggerEditor::saveVar()
                 variable->setNewName(newName, uiNameType);
                 if (variable->getValueType() != LUA_TTABLE && (newValue != variable->getValue() || uiValueType != variable->getValueType())) {
                     //let's check again
+                    bool valueNumberOk = false;
+                    const double valueAsNumber = newValue.toDouble(&valueNumberOk);
                     if (variable->getValueType() == LUA_TTABLE) {
                         //HEIKO: obvious logic error used to be valueType == LUA_TABLE
                         uiValueType = LUA_TTABLE;
-                    } else if (uiValueType == LUA_TNUMBER && newValue.toInt()) {
+                    } else if (uiValueType == LUA_TNUMBER && valueNumberOk && valueAsNumber != 0) {
                         uiValueType = LUA_TNUMBER;
                     } else if (uiValueType == LUA_TBOOLEAN && (newValue.toLower() == "true" || newValue.toLower() == "false")) {
                         uiValueType = LUA_TBOOLEAN;
@@ -6826,9 +6837,11 @@ void dlgTriggerEditor::saveVar()
             int change = 0;
             if (newName != var->getName() || uiNameType != var->getKeyType()) {
                 //let's make sure the nametype works
+                bool nameNumberOk = false;
+                const double nameAsNumber = newName.toDouble(&nameNumberOk);
                 if (uiNameType == LUA_TSTRING) {
                     //do nothing, we can always make key to string
-                } else if (var->getKeyType() == LUA_TNUMBER && newName.toInt()) {
+                } else if (var->getKeyType() == LUA_TNUMBER && nameNumberOk && nameAsNumber != 0) {
                     uiNameType = LUA_TNUMBER;
                 } else {
                     uiNameType = LUA_TSTRING;
@@ -6836,11 +6849,14 @@ void dlgTriggerEditor::saveVar()
                 var->setNewName(newName, uiNameType);
                 change = change | 0x1;
             }
-            if (newValue != var->getValue() || uiValueType != var->getValueType()) {
+            // a table's contents are not shown in the value editor, so a table staying a table is never a value change
+            if ((newValue != var->getValue() || uiValueType != var->getValueType()) && !(uiValueType == LUA_TTABLE && var->getValueType() == LUA_TTABLE)) {
                 //let's check again
+                bool valueNumberOk = false;
+                const double valueAsNumber = newValue.toDouble(&valueNumberOk);
                 if (uiValueType == LUA_TTABLE) {
                     newValue = "{}";
-                } else if (uiValueType == LUA_TNUMBER && newValue.toInt()) {
+                } else if (uiValueType == LUA_TNUMBER && valueNumberOk && valueAsNumber != 0) {
                     uiValueType = LUA_TNUMBER;
                 } else if (uiValueType == LUA_TBOOLEAN && (newValue.toLower() == QLatin1String("true") || newValue.toLower() == QLatin1String("false"))) {
                     uiValueType = LUA_TBOOLEAN;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6733,11 +6733,11 @@ void dlgTriggerEditor::saveVar()
     const int varRecast = canRecast(pItem, uiNameType, uiValueType);
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
         bool nameNumberOk = false;
-        const double nameAsNumber = newName.toDouble(&nameNumberOk);
+        newName.toDouble(&nameNumberOk);
         // the key type combobox cannot express a boolean key, so keep an unchanged one boolean
         if (variable->getKeyType() == LUA_TBOOLEAN && (newName.toLower() == QLatin1String("true") || newName.toLower() == QLatin1String("false"))) {
             uiNameType = LUA_TBOOLEAN;
-        } else if (nameNumberOk && nameAsNumber != 0) {
+        } else if (nameNumberOk) {
             uiNameType = LUA_TNUMBER;
         } else {
             uiNameType = LUA_TSTRING;
@@ -6745,8 +6745,8 @@ void dlgTriggerEditor::saveVar()
     }
     if ((uiValueType != LUA_TTABLE) && (uiValueType == -1)) {
         bool valueNumberOk = false;
-        const double valueAsNumber = newValue.toDouble(&valueNumberOk);
-        if (valueNumberOk && valueAsNumber != 0) {
+        newValue.toDouble(&valueNumberOk);
+        if (valueNumberOk) {
             uiValueType = LUA_TNUMBER;
         } else if (newValue.toLower() == "true" || newValue.toLower() == "false") {
             uiValueType = LUA_TBOOLEAN;
@@ -6780,8 +6780,10 @@ void dlgTriggerEditor::saveVar()
                 if (newName != variable->getName() || uiNameType != variable->getKeyType()) {
                     //let's make sure the nametype works
                     bool nameNumberOk = false;
-                    const double nameAsNumber = newName.toDouble(&nameNumberOk);
-                    if (variable->getKeyType() == LUA_TNUMBER && nameNumberOk && nameAsNumber != 0) {
+                    newName.toDouble(&nameNumberOk);
+                    if (variable->getKeyType() == LUA_TBOOLEAN && (newName.toLower() == QLatin1String("true") || newName.toLower() == QLatin1String("false"))) {
+                        uiNameType = LUA_TBOOLEAN;
+                    } else if (variable->getKeyType() == LUA_TNUMBER && nameNumberOk) {
                         uiNameType = LUA_TNUMBER;
                     } else {
                         uiNameType = LUA_TSTRING;
@@ -6792,11 +6794,11 @@ void dlgTriggerEditor::saveVar()
                 if (variable->getValueType() != LUA_TTABLE && (newValue != variable->getValue() || uiValueType != variable->getValueType())) {
                     //let's check again
                     bool valueNumberOk = false;
-                    const double valueAsNumber = newValue.toDouble(&valueNumberOk);
+                    newValue.toDouble(&valueNumberOk);
                     if (variable->getValueType() == LUA_TTABLE) {
                         //HEIKO: obvious logic error used to be valueType == LUA_TABLE
                         uiValueType = LUA_TTABLE;
-                    } else if (uiValueType == LUA_TNUMBER && valueNumberOk && valueAsNumber != 0) {
+                    } else if (uiValueType == LUA_TNUMBER && valueNumberOk) {
                         uiValueType = LUA_TNUMBER;
                     } else if (uiValueType == LUA_TBOOLEAN && (newValue.toLower() == "true" || newValue.toLower() == "false")) {
                         uiValueType = LUA_TBOOLEAN;
@@ -6838,10 +6840,12 @@ void dlgTriggerEditor::saveVar()
             if (newName != var->getName() || uiNameType != var->getKeyType()) {
                 //let's make sure the nametype works
                 bool nameNumberOk = false;
-                const double nameAsNumber = newName.toDouble(&nameNumberOk);
+                newName.toDouble(&nameNumberOk);
                 if (uiNameType == LUA_TSTRING) {
                     //do nothing, we can always make key to string
-                } else if (var->getKeyType() == LUA_TNUMBER && nameNumberOk && nameAsNumber != 0) {
+                } else if (var->getKeyType() == LUA_TBOOLEAN && (newName.toLower() == QLatin1String("true") || newName.toLower() == QLatin1String("false"))) {
+                    uiNameType = LUA_TBOOLEAN;
+                } else if (var->getKeyType() == LUA_TNUMBER && nameNumberOk) {
                     uiNameType = LUA_TNUMBER;
                 } else {
                     uiNameType = LUA_TSTRING;
@@ -6853,10 +6857,10 @@ void dlgTriggerEditor::saveVar()
             if ((newValue != var->getValue() || uiValueType != var->getValueType()) && !(uiValueType == LUA_TTABLE && var->getValueType() == LUA_TTABLE)) {
                 //let's check again
                 bool valueNumberOk = false;
-                const double valueAsNumber = newValue.toDouble(&valueNumberOk);
+                newValue.toDouble(&valueNumberOk);
                 if (uiValueType == LUA_TTABLE) {
                     newValue = "{}";
-                } else if (uiValueType == LUA_TNUMBER && valueNumberOk && valueAsNumber != 0) {
+                } else if (uiValueType == LUA_TNUMBER && valueNumberOk) {
                     uiValueType = LUA_TNUMBER;
                 } else if (uiValueType == LUA_TBOOLEAN && (newValue.toLower() == QLatin1String("true") || newValue.toLower() == QLatin1String("false"))) {
                     uiValueType = LUA_TBOOLEAN;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Editing a decimal number in the Variables view no longer converts it to a string (type detection and Lua round-trips used toInt(), truncating or reclassifying floats)
- Boolean table keys now display as true/false and are clickable, instead of appearing as blank unnamed entries
- Guards added so clicking a boolean-keyed entry can no longer rewrite the key as a string or wipe a table value

#### Motivation for adding to Mudlet
The Variables view silently corrupted float values on save and made boolean-keyed table entries unusable.

#### Other info (issues closed, discussion etc)
Fixes #6586. Fixes #6585.

**Test case:** Run `lua myFloat = 3.14  b = {[true]="yes", [false]="no", [3.14]="pi"}`, open the Variables view: b's children should read 3.14/false/true. Edit myFloat to 2.71, click another variable, then `lua print(type(myFloat))` - should print number.


https://github.com/user-attachments/assets/2ec42f86-ddd6-4657-bae5-ba38d75c97c2

