### PR TITLE
fix: pasting several copied items now works for every item type

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -11474,7 +11474,7 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
 {
     QTreeWidget* targetTree = nullptr;
     std::function<bool(int)> itemIsFolder;
-    std::function<void(int, int)> reParentItem;
+    std::function<void(int, int, int, int)> reParentItem;
 
     switch (itemType) {
     case EditorViewType::cmTriggerView:
@@ -11483,8 +11483,8 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
             auto* pItem = mpHost->getTriggerUnit()->getTrigger(id);
             return pItem && pItem->isFolder();
         };
-        reParentItem = [this](int id, int parentId) {
-            mpHost->getTriggerUnit()->reParentTrigger(id, 0, parentId, -1, -1);
+        reParentItem = [this](int id, int parentId, int parentPos, int childPos) {
+            mpHost->getTriggerUnit()->reParentTrigger(id, 0, parentId, parentPos, childPos);
         };
         break;
     case EditorViewType::cmTimerView:
@@ -11493,8 +11493,8 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
             auto* pItem = mpHost->getTimerUnit()->getTimer(id);
             return pItem && pItem->isFolder();
         };
-        reParentItem = [this](int id, int parentId) {
-            mpHost->getTimerUnit()->reParentTimer(id, 0, parentId, -1, -1);
+        reParentItem = [this](int id, int parentId, int parentPos, int childPos) {
+            mpHost->getTimerUnit()->reParentTimer(id, 0, parentId, parentPos, childPos);
         };
         break;
     case EditorViewType::cmAliasView:
@@ -11503,8 +11503,8 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
             auto* pItem = mpHost->getAliasUnit()->getAlias(id);
             return pItem && pItem->isFolder();
         };
-        reParentItem = [this](int id, int parentId) {
-            mpHost->getAliasUnit()->reParentAlias(id, 0, parentId, -1, -1);
+        reParentItem = [this](int id, int parentId, int parentPos, int childPos) {
+            mpHost->getAliasUnit()->reParentAlias(id, 0, parentId, parentPos, childPos);
         };
         break;
     case EditorViewType::cmScriptView:
@@ -11513,8 +11513,8 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
             auto* pItem = mpHost->getScriptUnit()->getScript(id);
             return pItem && pItem->isFolder();
         };
-        reParentItem = [this](int id, int parentId) {
-            mpHost->getScriptUnit()->reParentScript(id, 0, parentId, -1, -1);
+        reParentItem = [this](int id, int parentId, int parentPos, int childPos) {
+            mpHost->getScriptUnit()->reParentScript(id, 0, parentId, parentPos, childPos);
         };
         break;
     case EditorViewType::cmActionView:
@@ -11523,8 +11523,8 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
             auto* pItem = mpHost->getActionUnit()->getAction(id);
             return pItem && pItem->isFolder();
         };
-        reParentItem = [this](int id, int parentId) {
-            mpHost->getActionUnit()->reParentAction(id, 0, parentId, -1, -1);
+        reParentItem = [this](int id, int parentId, int parentPos, int childPos) {
+            mpHost->getActionUnit()->reParentAction(id, 0, parentId, parentPos, childPos);
         };
         break;
     case EditorViewType::cmKeysView:
@@ -11533,8 +11533,8 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
             auto* pItem = mpHost->getKeyUnit()->getKey(id);
             return pItem && pItem->isFolder();
         };
-        reParentItem = [this](int id, int parentId) {
-            mpHost->getKeyUnit()->reParentKey(id, 0, parentId, -1, -1);
+        reParentItem = [this](int id, int parentId, int parentPos, int childPos) {
+            mpHost->getKeyUnit()->reParentKey(id, 0, parentId, parentPos, childPos);
         };
         break;
     case EditorViewType::cmVarsView:
@@ -11556,10 +11556,20 @@ void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int
     QTreeWidgetItem* targetItem = targetTree->itemFromIndex(targetIndex);
     const int targetId = targetIndex.data(Qt::UserRole).toInt();
     const bool isGroup = (targetItem && targetItem->childCount() > 0) || itemIsFolder(targetId);
-    const int newParentId = isGroup ? targetId : targetIndex.parent().data(Qt::UserRole).toInt();
 
-    for (const int itemID : itemIDs) {
-        reParentItem(itemID, newParentId);
+    if (isGroup) {
+        for (const int itemID : itemIDs) {
+            reParentItem(itemID, targetId, -1, -1);
+        }
+    } else {
+        // mirror single-item paste: insert as siblings right after the selected item
+        const QModelIndex parentIndex = targetIndex.parent();
+        const int parentId = parentIndex.data(Qt::UserRole).toInt();
+        const int parentRow = parentIndex.row();
+        int childRow = targetIndex.row() + 1;
+        for (const int itemID : itemIDs) {
+            reParentItem(itemID, parentId, parentRow, childRow++);
+        }
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -96,6 +96,10 @@ using namespace std::chrono_literals;
 // it is disabled):
 static const char* cButtonBaseColor = "baseColor";
 
+// Separates the XML packages of individually copied items on the clipboard so
+// that pasting can import and place each one
+static const QString cMultiItemPasteSeparator = qsl("\n<!--MUDLET_MULTI_ITEM_SEPARATOR-->\n");
+
 // Track whether the shared auto-complete provider has been initialized
 bool dlgTriggerEditor::smAutoCompleteInitialized = false;
 
@@ -11039,7 +11043,7 @@ void dlgTriggerEditor::exportMultipleTriggersToClipboard(const QList<TTrigger*>&
     }
 
     // Combine all XML packages with a special separator that paste can recognize
-    QString combinedXml = xmlPackages.join("\n<!--MUDLET_MULTI_ITEM_SEPARATOR-->\n");
+    QString combinedXml = xmlPackages.join(cMultiItemPasteSeparator);
     QApplication::clipboard()->setText(combinedXml);
 }
 
@@ -11095,7 +11099,7 @@ void dlgTriggerEditor::exportMultipleTimersToClipboard(const QList<TTimer*>& tim
         QApplication::clipboard()->setText(originalClipboard);
     }
 
-    QString combinedXml = xmlParts.join("\n");
+    QString combinedXml = xmlParts.join(cMultiItemPasteSeparator);
     QApplication::clipboard()->setText(combinedXml);
 }
 
@@ -11151,7 +11155,7 @@ void dlgTriggerEditor::exportMultipleAliasesToClipboard(const QList<TAlias*>& al
         QApplication::clipboard()->setText(originalClipboard);
     }
 
-    QString combinedXml = xmlParts.join("\n");
+    QString combinedXml = xmlParts.join(cMultiItemPasteSeparator);
     QApplication::clipboard()->setText(combinedXml);
 }
 
@@ -11207,7 +11211,7 @@ void dlgTriggerEditor::exportMultipleActionsToClipboard(const QList<TAction*>& a
         QApplication::clipboard()->setText(originalClipboard);
     }
 
-    QString combinedXml = xmlParts.join("\n");
+    QString combinedXml = xmlParts.join(cMultiItemPasteSeparator);
     QApplication::clipboard()->setText(combinedXml);
 }
 
@@ -11263,7 +11267,7 @@ void dlgTriggerEditor::exportMultipleScriptsToClipboard(const QList<TScript*>& s
         QApplication::clipboard()->setText(originalClipboard);
     }
 
-    QString combinedXml = xmlParts.join("\n");
+    QString combinedXml = xmlParts.join(cMultiItemPasteSeparator);
     QApplication::clipboard()->setText(combinedXml);
 }
 
@@ -11319,7 +11323,7 @@ void dlgTriggerEditor::exportMultipleKeysToClipboard(const QList<TKey*>& keys)
         QApplication::clipboard()->setText(originalClipboard);
     }
 
-    QString combinedXml = xmlParts.join("\n");
+    QString combinedXml = xmlParts.join(cMultiItemPasteSeparator);
     QApplication::clipboard()->setText(combinedXml);
 }
 
@@ -11464,6 +11468,101 @@ void dlgTriggerEditor::slot_copyXml()
 }
 
 // FIXME: The switch cases in here need to handle EditorViewType::cmVarsView but how is not clear
+// Applies the same placement to every pasted item that pasting a single item
+// would get: into the selected group/folder, or next to the selected item.
+void dlgTriggerEditor::placePastedItems(EditorViewType itemType, const QList<int>& itemIDs)
+{
+    QTreeWidget* targetTree = nullptr;
+    std::function<bool(int)> itemIsFolder;
+    std::function<void(int, int)> reParentItem;
+
+    switch (itemType) {
+    case EditorViewType::cmTriggerView:
+        targetTree = treeWidget_triggers;
+        itemIsFolder = [this](int id) {
+            auto* pItem = mpHost->getTriggerUnit()->getTrigger(id);
+            return pItem && pItem->isFolder();
+        };
+        reParentItem = [this](int id, int parentId) {
+            mpHost->getTriggerUnit()->reParentTrigger(id, 0, parentId, -1, -1);
+        };
+        break;
+    case EditorViewType::cmTimerView:
+        targetTree = treeWidget_timers;
+        itemIsFolder = [this](int id) {
+            auto* pItem = mpHost->getTimerUnit()->getTimer(id);
+            return pItem && pItem->isFolder();
+        };
+        reParentItem = [this](int id, int parentId) {
+            mpHost->getTimerUnit()->reParentTimer(id, 0, parentId, -1, -1);
+        };
+        break;
+    case EditorViewType::cmAliasView:
+        targetTree = treeWidget_aliases;
+        itemIsFolder = [this](int id) {
+            auto* pItem = mpHost->getAliasUnit()->getAlias(id);
+            return pItem && pItem->isFolder();
+        };
+        reParentItem = [this](int id, int parentId) {
+            mpHost->getAliasUnit()->reParentAlias(id, 0, parentId, -1, -1);
+        };
+        break;
+    case EditorViewType::cmScriptView:
+        targetTree = treeWidget_scripts;
+        itemIsFolder = [this](int id) {
+            auto* pItem = mpHost->getScriptUnit()->getScript(id);
+            return pItem && pItem->isFolder();
+        };
+        reParentItem = [this](int id, int parentId) {
+            mpHost->getScriptUnit()->reParentScript(id, 0, parentId, -1, -1);
+        };
+        break;
+    case EditorViewType::cmActionView:
+        targetTree = treeWidget_actions;
+        itemIsFolder = [this](int id) {
+            auto* pItem = mpHost->getActionUnit()->getAction(id);
+            return pItem && pItem->isFolder();
+        };
+        reParentItem = [this](int id, int parentId) {
+            mpHost->getActionUnit()->reParentAction(id, 0, parentId, -1, -1);
+        };
+        break;
+    case EditorViewType::cmKeysView:
+        targetTree = treeWidget_keys;
+        itemIsFolder = [this](int id) {
+            auto* pItem = mpHost->getKeyUnit()->getKey(id);
+            return pItem && pItem->isFolder();
+        };
+        reParentItem = [this](int id, int parentId) {
+            mpHost->getKeyUnit()->reParentKey(id, 0, parentId, -1, -1);
+        };
+        break;
+    case EditorViewType::cmVarsView:
+    case EditorViewType::cmUnknownView:
+        return;
+    }
+
+    QModelIndex targetIndex = targetTree->currentIndex();
+    if (!targetIndex.isValid()) {
+        QList<QTreeWidgetItem*> selectedItems = targetTree->selectedItems();
+        if (!selectedItems.isEmpty()) {
+            targetIndex = targetTree->indexFromItem(selectedItems.first());
+        }
+    }
+    if (!targetIndex.isValid()) {
+        return;
+    }
+
+    QTreeWidgetItem* targetItem = targetTree->itemFromIndex(targetIndex);
+    const int targetId = targetIndex.data(Qt::UserRole).toInt();
+    const bool isGroup = (targetItem && targetItem->childCount() > 0) || itemIsFolder(targetId);
+    const int newParentId = isGroup ? targetId : targetIndex.parent().data(Qt::UserRole).toInt();
+
+    for (const int itemID : itemIDs) {
+        reParentItem(itemID, newParentId);
+    }
+}
+
 void dlgTriggerEditor::slot_pasteXml()
 {
     XMLimport reader(mpHost);
@@ -11497,7 +11596,7 @@ void dlgTriggerEditor::slot_pasteXml()
 
     // Check if clipboard contains multiple items (separated by our delimiter)
     QString clipboardText = QApplication::clipboard()->text();
-    QStringList xmlPackages = clipboardText.split("\n<!--MUDLET_MULTI_ITEM_SEPARATOR-->\n");
+    QStringList xmlPackages = clipboardText.split(cMultiItemPasteSeparator);
 
     EditorViewType importedItemType;
     int importedItemID;
@@ -11535,34 +11634,7 @@ void dlgTriggerEditor::slot_pasteXml()
         if (!importedIDs.isEmpty()) {
             // For multiple items, we need to handle the reparenting here instead of later
             // since the later logic only handles one item at a time
-            if (firstImportType == EditorViewType::cmTriggerView) {
-                QModelIndex targetIndex = treeWidget_triggers->currentIndex();
-                if (!targetIndex.isValid()) {
-                    QList<QTreeWidgetItem*> selectedItems = treeWidget_triggers->selectedItems();
-                    if (!selectedItems.isEmpty()) {
-                        targetIndex = treeWidget_triggers->indexFromItem(selectedItems.first());
-                    }
-                }
-
-                // Apply the same group detection logic for all imported triggers
-                if (targetIndex.isValid()) {
-                    QTreeWidgetItem* targetItem = treeWidget_triggers->itemFromIndex(targetIndex);
-                    int targetId = targetIndex.data(Qt::UserRole).toInt();
-                    TTrigger* targetTrigger = mpHost->getTriggerUnit()->getTrigger(targetId);
-
-                    bool isGroup = (targetItem && targetItem->childCount() > 0) || (targetTrigger && targetTrigger->isFolder());
-
-                    for (const int itemID : std::as_const(importedIDs)) {
-                        if (isGroup) {
-                            mpHost->getTriggerUnit()->reParentTrigger(itemID, 0, targetId, -1, -1);
-                        } else {
-                            auto parent = targetIndex.parent();
-                            auto parentId = parent.data(Qt::UserRole).toInt();
-                            mpHost->getTriggerUnit()->reParentTrigger(itemID, 0, parentId, -1, -1);
-                        }
-                    }
-                }
-            }
+            placePastedItems(firstImportType, importedIDs);
 
             // Use the first imported item's type and ID for the rest of the function
             importedItemType = firstImportType;
@@ -11639,6 +11711,10 @@ void dlgTriggerEditor::slot_pasteXml()
         break;
     }
     case EditorViewType::cmTimerView: {
+        if (xmlPackages.size() > 1) {
+            // multi-item pastes were already reparented above
+            break;
+        }
         QModelIndex targetIndex = treeWidget_timers->currentIndex();
         if (!targetIndex.isValid()) {
             QList<QTreeWidgetItem*> selectedItems = treeWidget_timers->selectedItems();
@@ -11660,6 +11736,10 @@ void dlgTriggerEditor::slot_pasteXml()
         break;
     }
     case EditorViewType::cmAliasView: {
+        if (xmlPackages.size() > 1) {
+            // multi-item pastes were already reparented above
+            break;
+        }
         QModelIndex targetIndex = treeWidget_aliases->currentIndex();
         if (!targetIndex.isValid()) {
             QList<QTreeWidgetItem*> selectedItems = treeWidget_aliases->selectedItems();
@@ -11681,6 +11761,10 @@ void dlgTriggerEditor::slot_pasteXml()
         break;
     }
     case EditorViewType::cmScriptView: {
+        if (xmlPackages.size() > 1) {
+            // multi-item pastes were already reparented above
+            break;
+        }
         QModelIndex targetIndex = treeWidget_scripts->currentIndex();
         if (!targetIndex.isValid()) {
             QList<QTreeWidgetItem*> selectedItems = treeWidget_scripts->selectedItems();
@@ -11702,6 +11786,10 @@ void dlgTriggerEditor::slot_pasteXml()
         break;
     }
     case EditorViewType::cmActionView: {
+        if (xmlPackages.size() > 1) {
+            // multi-item pastes were already reparented above
+            break;
+        }
         QModelIndex targetIndex = treeWidget_actions->currentIndex();
         if (!targetIndex.isValid()) {
             QList<QTreeWidgetItem*> selectedItems = treeWidget_actions->selectedItems();
@@ -11723,6 +11811,10 @@ void dlgTriggerEditor::slot_pasteXml()
         break;
     }
     case EditorViewType::cmKeysView: {
+        if (xmlPackages.size() > 1) {
+            // multi-item pastes were already reparented above
+            break;
+        }
         QModelIndex targetIndex = treeWidget_keys->currentIndex();
         if (!targetIndex.isValid()) {
             QList<QTreeWidgetItem*> selectedItems = treeWidget_keys->selectedItems();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -11596,6 +11596,11 @@ void dlgTriggerEditor::slot_pasteXml()
     // of the currently selected item instead
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView: {
+        if (xmlPackages.size() > 1) {
+            // multi-item pastes were already reparented above; reparenting the
+            // first trigger again would link it into its parent's children twice
+            break;
+        }
         // Handle multi-selection: use the first selected item as reference
         QModelIndex targetIndex = treeWidget_triggers->currentIndex();
         if (!targetIndex.isValid()) {

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -453,6 +453,8 @@ private:
     void exportMultipleScriptsToClipboard(const QList<TScript*>& scripts);
     void exportMultipleKeysToClipboard(const QList<TKey*>& keys);
 
+    void placePastedItems(EditorViewType itemType, const QList<int>& itemIDs);
+
     void clearDocument(edbee::TextEditorWidget* pEditorWidget, const QString& initialText = QString());
 
     void setAllSearchData(QTreeWidgetItem* pItem,

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -23,6 +23,8 @@
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
 #include "TAction.h"
+#include "TAlias.h"
+#include "TKey.h"
 #include "TTimer.h"
 #include "TTreeWidget.h"
 #include "TTrigger.h"
@@ -1914,6 +1916,86 @@ private slots:
     QCOMPARE(mpEditor->mpTriggerBaseItem->child(0)->childCount(), 4);
 
     cleanupAll(mItemTypes[0]);
+  }
+
+  void testMultiAliasPasteIntoGroup() {
+    mpEditor->slot_showAliases();
+    cleanupAll(mItemTypes[2]);
+
+    mpEditor->addAlias(true);
+    QCOMPARE(mpEditor->mpAliasBaseItem->childCount(), 1);
+
+    QTreeWidgetItem *group = mpEditor->mpAliasBaseItem->child(0);
+    int groupID = group->data(0, Qt::UserRole).toInt();
+    TAlias *pGroup = mpHost->getAliasUnit()->getAlias(groupID);
+    QVERIFY(pGroup != nullptr);
+
+    mpEditor->treeWidget_aliases->setCurrentItem(group);
+    mpEditor->addAlias(false);
+    mpEditor->addAlias(false);
+    QCOMPARE(group->childCount(), 2);
+
+    // copy both aliases, then paste them into the group
+    mpEditor->treeWidget_aliases->clearSelection();
+    mpEditor->treeWidget_aliases->setCurrentItem(group->child(0));
+    group->child(0)->setSelected(true);
+    group->child(1)->setSelected(true);
+    mpEditor->slot_copyXml();
+
+    mpEditor->treeWidget_aliases->clearSelection();
+    mpEditor->treeWidget_aliases->setCurrentItem(group);
+    mpEditor->slot_pasteXml();
+
+    // both pasted aliases must land inside the group, each linked exactly once
+    QCOMPARE(static_cast<int>(pGroup->getChildrenList()->size()), 4);
+
+    // re-render the tree: the group shows four children and none at the root
+    QEnterEvent enterEvent{QPointF(), QPointF(), QPointF()};
+    QApplication::sendEvent(mpEditor, &enterEvent);
+    QCOMPARE(mpEditor->mpAliasBaseItem->childCount(), 1);
+    QCOMPARE(mpEditor->mpAliasBaseItem->child(0)->childCount(), 4);
+
+    cleanupAll(mItemTypes[2]);
+  }
+
+  void testMultiKeyPasteIntoGroup() {
+    mpEditor->slot_showKeys();
+    cleanupAll(mItemTypes[4]);
+
+    mpEditor->addKey(true);
+    QCOMPARE(mpEditor->mpKeyBaseItem->childCount(), 1);
+
+    QTreeWidgetItem *group = mpEditor->mpKeyBaseItem->child(0);
+    int groupID = group->data(0, Qt::UserRole).toInt();
+    TKey *pGroup = mpHost->getKeyUnit()->getKey(groupID);
+    QVERIFY(pGroup != nullptr);
+
+    mpEditor->treeWidget_keys->setCurrentItem(group);
+    mpEditor->addKey(false);
+    mpEditor->addKey(false);
+    QCOMPARE(group->childCount(), 2);
+
+    // copy both keys, then paste them into the group
+    mpEditor->treeWidget_keys->clearSelection();
+    mpEditor->treeWidget_keys->setCurrentItem(group->child(0));
+    group->child(0)->setSelected(true);
+    group->child(1)->setSelected(true);
+    mpEditor->slot_copyXml();
+
+    mpEditor->treeWidget_keys->clearSelection();
+    mpEditor->treeWidget_keys->setCurrentItem(group);
+    mpEditor->slot_pasteXml();
+
+    // both pasted keys must land inside the group, each linked exactly once
+    QCOMPARE(static_cast<int>(pGroup->getChildrenList()->size()), 4);
+
+    // re-render the tree: the group shows four children and none at the root
+    QEnterEvent enterEvent{QPointF(), QPointF(), QPointF()};
+    QApplication::sendEvent(mpEditor, &enterEvent);
+    QCOMPARE(mpEditor->mpKeyBaseItem->childCount(), 1);
+    QCOMPARE(mpEditor->mpKeyBaseItem->child(0)->childCount(), 4);
+
+    cleanupAll(mItemTypes[4]);
   }
 
   // ========================================================================

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -1876,6 +1876,46 @@ private slots:
     cleanupAll(mItemTypes[3]);
   }
 
+  void testMultiTriggerPasteIntoGroup() {
+    mpEditor->slot_showTriggers();
+    cleanupAll(mItemTypes[0]);
+
+    mpEditor->addTrigger(true);
+    QCOMPARE(mpEditor->mpTriggerBaseItem->childCount(), 1);
+
+    QTreeWidgetItem *group = mpEditor->mpTriggerBaseItem->child(0);
+    int groupID = group->data(0, Qt::UserRole).toInt();
+    TTrigger *pGroup = mpHost->getTriggerUnit()->getTrigger(groupID);
+    QVERIFY(pGroup != nullptr);
+
+    mpEditor->treeWidget_triggers->setCurrentItem(group);
+    mpEditor->addTrigger(false);
+    mpEditor->addTrigger(false);
+    QCOMPARE(group->childCount(), 2);
+
+    // copy both triggers, then paste them into the group
+    mpEditor->treeWidget_triggers->clearSelection();
+    mpEditor->treeWidget_triggers->setCurrentItem(group->child(0));
+    group->child(0)->setSelected(true);
+    group->child(1)->setSelected(true);
+    mpEditor->slot_copyXml();
+
+    mpEditor->treeWidget_triggers->clearSelection();
+    mpEditor->treeWidget_triggers->setCurrentItem(group);
+    mpEditor->slot_pasteXml();
+
+    // each pasted trigger must be linked into the group exactly once
+    QCOMPARE(static_cast<int>(pGroup->getChildrenList()->size()), 4);
+
+    // re-render the tree and verify the group shows exactly four children
+    QEnterEvent enterEvent{QPointF(), QPointF(), QPointF()};
+    QApplication::sendEvent(mpEditor, &enterEvent);
+    QCOMPARE(mpEditor->mpTriggerBaseItem->childCount(), 1);
+    QCOMPARE(mpEditor->mpTriggerBaseItem->child(0)->childCount(), 4);
+
+    cleanupAll(mItemTypes[0]);
+  }
+
   // ========================================================================
   // CATEGORY 14: UI Pattern Clearing Tests
   // ========================================================================

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -1918,6 +1918,50 @@ private slots:
     cleanupAll(mItemTypes[0]);
   }
 
+  void testMultiTriggerPasteAfterSibling() {
+    mpEditor->slot_showTriggers();
+    cleanupAll(mItemTypes[0]);
+
+    mpEditor->addTrigger(true);
+    QTreeWidgetItem *group = mpEditor->mpTriggerBaseItem->child(0);
+    int groupID = group->data(0, Qt::UserRole).toInt();
+    TTrigger *pGroup = mpHost->getTriggerUnit()->getTrigger(groupID);
+    QVERIFY(pGroup != nullptr);
+
+    mpEditor->treeWidget_triggers->setCurrentItem(group);
+    mpEditor->addTrigger(false);
+    mpEditor->addTrigger(false);
+    QCOMPARE(group->childCount(), 2);
+    const int firstID = group->child(0)->data(0, Qt::UserRole).toInt();
+    const int secondID = group->child(1)->data(0, Qt::UserRole).toInt();
+
+    // copy both triggers, then paste them onto the first (non-folder) trigger
+    mpEditor->treeWidget_triggers->clearSelection();
+    mpEditor->treeWidget_triggers->setCurrentItem(group->child(0));
+    group->child(0)->setSelected(true);
+    group->child(1)->setSelected(true);
+    mpEditor->slot_copyXml();
+
+    mpEditor->treeWidget_triggers->clearSelection();
+    mpEditor->treeWidget_triggers->setCurrentItem(group->child(0));
+    mpEditor->slot_pasteXml();
+
+    // pasted triggers must be inserted right after the selected sibling,
+    // not appended at the end of the group
+    auto *children = pGroup->getChildrenList();
+    QCOMPARE(static_cast<int>(children->size()), 4);
+    QList<int> childIDs;
+    for (auto *child : *children) {
+      childIDs << child->getID();
+    }
+    QCOMPARE(childIDs.at(0), firstID);
+    QVERIFY(childIDs.at(1) != firstID && childIDs.at(1) != secondID);
+    QVERIFY(childIDs.at(2) != firstID && childIDs.at(2) != secondID);
+    QCOMPARE(childIDs.at(3), secondID);
+
+    cleanupAll(mItemTypes[0]);
+  }
+
   void testMultiAliasPasteIntoGroup() {
     mpEditor->slot_showAliases();
     cleanupAll(mItemTypes[2]);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Pasting multiple copied triggers into a group created an extra copy of the first trigger, and the surplus entry could not be deleted - the redundant second reparent is now skipped
- For every other item type (aliases, timers, keys, scripts, buttons) multi-item paste was worse: only the first copied item pasted at all (at the top level), the rest were silently dropped - the multi-item clipboard separator was only used by triggers; all six types now share it and every pasted item is placed into the selected group
- Adds regression tests for trigger, alias, and key multi-paste

#### Motivation for adding to Mudlet
Copy/pasting several items at once has been broken since multi-select was introduced: duplicates for triggers, dropped items for everything else.

#### Other info (issues closed, discussion etc)
Fixes #8872

**Test case:** Create a group with two triggers, select both, Copy, select the group, Paste - exactly two new triggers appear inside it (previously three, with the first duplicated and undeletable). Repeat in the Aliases view - both pasted aliases land inside the group (previously one pasted at top level and the other vanished).