### PR TITLE
fix: save new modules to the location you choose

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -45,6 +45,7 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QUrl>
 
 // We are now using code that won't work with really old versions of libzip;
 // some of the error handling was improved in 1.0 . Unfortunately libzip 1.7.0
@@ -638,8 +639,11 @@ void dlgPackageExporter::slot_importIcon()
     }
     lastDir = QFileInfo(fileName).absolutePath();
     settings.setValue("lastFileDialogLocation", lastDir);
-    mPackagePath = lastDir;
-    emit signal_exportLocationChanged(mPackagePath);
+    if (!mIsModuleCreationMode) {
+        // browsing for an icon must not redirect where the module gets saved
+        mPackagePath = lastDir;
+        emit signal_exportLocationChanged(mPackagePath);
+    }
     mPackageIconPath = fileName;
     const QIcon myIcon(mPackageIconPath);
     ui->Icon->clear();
@@ -962,10 +966,11 @@ void dlgPackageExporter::slot_exportPackage()
                     if (mIsModuleCreationMode) {
                         auto [installSuccess, installMessage] = mpHost->installPackage(mPackagePathFileName, enums::PackageModuleType::ModuleFromUI);
                         if (installSuccess) {
+                            const QString savedDir = QFileInfo(mPackagePathFileName).absolutePath();
+                            const QString savedDirLink = qsl("<a href=\"%1\">%2</a>").arg(QUrl::fromLocalFile(savedDir).toString(QUrl::FullyEncoded).toHtmlEscaped(), savedDir.toHtmlEscaped());
                             // Show embedded success message (better UX than popup)
                             //: %1 is the module name, %2 is a clickable link to the folder the module file was saved in
-                            displayResultMessage(tr("Module \"%1\" created and installed successfully! Saved to: %2. You can now close this dialog.")
-                                                         .arg(mPackageName.toHtmlEscaped(), qsl("<a href=\"file:///%1\">%1</a>").arg(QFileInfo(mPackagePathFileName).absolutePath().toHtmlEscaped())),
+                            displayResultMessage(tr("Module \"%1\" created and installed successfully! Saved to: %2. You can now close this dialog.").arg(mPackageName.toHtmlEscaped(), savedDirLink),
                                                  true);
 
                             // Clear the form to allow creating another module
@@ -1554,8 +1559,11 @@ void dlgPackageExporter::slot_addFiles()
 
         lastDir = fDialog->directory().absolutePath();
         settings.setValue("lastFileDialogLocation", lastDir);
-        mPackagePath = lastDir;
-        emit signal_exportLocationChanged(mPackagePath);
+        if (!mIsModuleCreationMode) {
+            // adding asset files must not redirect where the module gets saved
+            mPackagePath = lastDir;
+            emit signal_exportLocationChanged(mPackagePath);
+        }
     }
     fDialog->deleteLater();
 }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -857,9 +857,9 @@ void dlgPackageExporter::slot_exportPackage()
 
     // if packageName changed allow to create a new package in the same path
     if (mIsModuleCreationMode) {
-        // For modules, save to the profile directory instead of user's last dialog location
-        QString profileDir = mudlet::getMudletPath(enums::profileHomePath, mpHost->getName());
-        mPackagePathFileName = qsl("%1/%2.mpackage").arg(profileDir, mPackageName);
+        // Modules default to the profile directory unless the user picked a save location
+        const QString moduleDir = mPackagePath.isEmpty() ? mudlet::getMudletPath(enums::profileHomePath, mpHost->getName()) : mPackagePath;
+        mPackagePathFileName = qsl("%1/%2.mpackage").arg(moduleDir, mPackageName);
     } else {
         mPackagePathFileName = qsl("%1/%2.mpackage").arg(getActualPath(), mPackageName);
     }
@@ -963,7 +963,10 @@ void dlgPackageExporter::slot_exportPackage()
                         auto [installSuccess, installMessage] = mpHost->installPackage(mPackagePathFileName, enums::PackageModuleType::ModuleFromUI);
                         if (installSuccess) {
                             // Show embedded success message (better UX than popup)
-                            displayResultMessage(tr("Module \"%1\" created and installed successfully! You can now close this dialog.").arg(mPackageName.toHtmlEscaped()), true);
+                            //: %1 is the module name, %2 is a clickable link to the folder the module file was saved in
+                            displayResultMessage(tr("Module \"%1\" created and installed successfully! Saved to: %2. You can now close this dialog.")
+                                                         .arg(mPackageName.toHtmlEscaped(), qsl("<a href=\"file:///%1\">%1</a>").arg(QFileInfo(mPackagePathFileName).absolutePath().toHtmlEscaped())),
+                                                 true);
 
                             // Clear the form to allow creating another module
                             ui->lineEdit_packageName->clear();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- "Create Module" now writes the .mpackage to the folder chosen via "Select where to save module" instead of always using the profile directory
- Profile directory remains the default when no folder is picked
- The success message now shows a clickable link to the save location

#### Motivation for adding to Mudlet
The dialog invites you to pick a save location and then silently ignored it, leaving users unable to find their module.

#### Other info (issues closed, discussion etc)
Fixes #9372

**Test case:** Script editor > Create Module, name it, tick an item, click "Select where to save module" and pick a folder, Create - the .mpackage lands in that folder and the message links to it. Without picking a folder, it still lands in the profile directory.


https://github.com/user-attachments/assets/6dc5e0b4-8c76-4dc0-806d-fe1702f6ace4

