### PR TITLE
fix: tempAnsiColorTrigger now runs function callbacks

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1931,22 +1931,24 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         }
     }
 
-    if (lua_isstring(L, ++s)) {
-        code = QString::fromUtf8(lua_tostring(L, s));
-    } else if (lua_isfunction(L, s)) {
+    const int codeIndex = ++s;
+    if (lua_isstring(L, codeIndex)) {
+        code = QString::fromUtf8(lua_tostring(L, codeIndex));
+    } else if (lua_isfunction(L, codeIndex)) {
         // leave code as a null QString(), see below
     } else {
-        lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d type (code to run as a string or a function expected, got %s!)", s, luaL_typename(L, s));
+        lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d type (code to run as a string or a function expected, got %s!)", codeIndex, luaL_typename(L, codeIndex));
         return lua_error(L);
     }
 
     int expiryCount = -1;
-    if (lua_isnumber(L, ++s)) {
+    ++s;
+    if (lua_isnumber(L, s)) {
         expiryCount = static_cast<int>(lua_tonumber(L, s));
         if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, qsl("trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
         }
-    } else if (!lua_isnoneornil(L, ++s)) {
+    } else if (!lua_isnoneornil(L, s)) {
         lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d value (trigger expiration count must be a number, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
@@ -1963,7 +1965,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         }
         trigger->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, trigger);
-        lua_pushvalue(L, s - 1);
+        lua_pushvalue(L, codeIndex);
         lua_settable(L, LUA_REGISTRYINDEX);
     }
 

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -126,4 +126,24 @@ describe("Trigger processing", function()
         end)
 
     end)
+
+    describe("tempAnsiColorTrigger callbacks", function()
+
+        it("should fire a function callback when the expiry argument is omitted", function()
+            _G.ansiColorFunctionFired = false
+            -- ANSI 7 = white foreground, ANSI 0 = black background
+            local colorTrigger = tempAnsiColorTrigger(7, 0, function()
+                _G.ansiColorFunctionFired = true
+            end)
+
+            feedTriggers("\n\27[37;40mAnsiColorFunctionCallback\27[0m\n")
+
+            local fired = _G.ansiColorFunctionFired
+            killTrigger(colorTrigger)
+            _G.ansiColorFunctionFired = nil
+
+            assert.is_true(fired, "Function callback without an expiry argument should fire")
+        end)
+
+    end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `tempAnsiColorTrigger(fg, bg, function() ... end)` without the optional expiry argument never ran its callback: the argument index was advanced twice, so nil was registered instead of the function
- The same slip made an invalid expiry argument (e.g. a string) dodge its type check; both are fixed by inspecting each argument at a stable index
- Adds a busted regression test

#### Motivation for adding to Mudlet
Scripts using the documented function-callback form silently did nothing, with no error pointing at the cause.

#### Other info (issues closed, discussion etc)
No linked issue - found while testing color trigger changes. String callbacks and function-callbacks-with-expiry were unaffected.

**Test case:** `lua tempAnsiColorTrigger(7, 0, function() echo("fired") end)` then `lua feedTriggers("\27[37;40mtest\27[0m\n")` - "fired" appears (previously nothing happened).

https://github.com/user-attachments/assets/273db18a-326b-428d-bd98-45f25f0e35dd


