### PR TITLE
fix: a deleteline logging issue fix

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1425,6 +1425,7 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
         mMudLine.clear();
         mMudBuffer.clear();
         const int line = lineBuffer.size() - 1;
+        const int sizeBeforeTriggers = static_cast<int>(lineBuffer.size());
         if (!mSkipTriggerProcessing) {
             mpHost->mpConsole->runTriggers(line);
         }
@@ -1440,7 +1441,15 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
         const int addedLines = wrapLine(wrapStartLine, mWrapAt, mWrapIndent, mWrapHangingIndent);
 
         // Start a new, but empty line in the various buffers
-        log(lineBuffer.size() - 1, lineBuffer.size() - 1);
+        if (static_cast<int>(lineBuffer.size()) < sizeBeforeTriggers) {
+            // Triggers deleted lines - discard stale buffered log content to
+            // avoid logging deleted lines or duplicating the line above them
+            lastTextToLog.clear();
+            lastLoggedFromLine = -1;
+            lastloggedToLine = -1;
+        } else {
+            log(lineBuffer.size() - 1, lineBuffer.size() - 1);
+        }
 
         ++localBufferPosition;
         // Suppress new empty line IFF echoes already created a new empty line


### PR DESCRIPTION
Fix: log buffer duplicating/logging stale lines when a trigger deletes a line

#### Brief overview of PR changes/additions
When a trigger calls something like deleteLine() during runTriggers(), lineBuffer.size() shrinks between when line is captured and when logging happens, causing the log to duplicate the line above or log content that was just deleted. This fix is intended to detect the size decrease and clear the pending log state instead.

#### Motivation for adding to Mudlet
Cleaner logging

#### Other info (issues closed, discussion etc)
I wanted to add some more granular details about the issue that I am trying to fix.

The `deleteLine()` function leaves a blank line on the main window when it is invoked. It's only a mild annoyance, but it isn't ideal.

To that end, someone created this code for a chat redirector to gag from the main window and circumvent that blank line:
```
lotj.chat.routeMessage("ooc")
if lotj.settings.notif_ooc then
  lotj.layout.markTabUnread(lotj.layout.lowerRightTabData, "ooc")
end

if lotj.settings.gag_ooc then
  deleteLine()                            -- delete the current line
  moveCursor(0,getLineNumber()-1)         -- move the cursor back one line

  if getCurrentLine() == "" then
    deleteLine()                            -- delete the previous line now
  end
end
```

This above code is manually removing the blank line using `moveCursor()` etc. However, this code caused an unanticipated bug in logging. When enabled it would work flawlessly in the main window. However, if you looked at the log it would duplicate the last line in the buffer every time the the trigger fired (every time an OOC message was received and gagged).


