### PR TITLE
fix: deleting lines in triggers no longer corrupts the log file

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1425,6 +1425,7 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
         mMudLine.clear();
         mMudBuffer.clear();
         const int line = lineBuffer.size() - 1;
+        mCommitLineIndex = line;
         if (!mSkipTriggerProcessing) {
             mpHost->mpConsole->runTriggers(line);
         }
@@ -1439,8 +1440,12 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
         const int wrapStartLine = (lastValidLine >= 0) ? std::min(line, lastValidLine) : 0;
         const int addedLines = wrapLine(wrapStartLine, mWrapAt, mWrapIndent, mWrapHangingIndent);
 
-        // Start a new, but empty line in the various buffers
-        log(lineBuffer.size() - 1, lineBuffer.size() - 1);
+        // Skip logging if a trigger deleted the line that was being committed;
+        // deleteLines() has already adjusted the deferred logging state
+        if (mCommitLineIndex >= 0) {
+            log(lineBuffer.size() - 1, lineBuffer.size() - 1);
+        }
+        mCommitLineIndex = -1;
 
         ++localBufferPosition;
         // Suppress new empty line IFF echoes already created a new empty line
@@ -5101,6 +5106,22 @@ bool TBuffer::deleteLines(int from, int to)
         }
 
         buffer.erase(buffer.begin() + from, buffer.begin() + to + 1);
+
+        // Keep the deferred logging state in step with the removed lines so
+        // pending text is only dropped when the line it holds was deleted
+        if (lastloggedToLine >= from && lastLoggedFromLine <= to) {
+            lastTextToLog.clear();
+            lastLoggedFromLine = -1;
+            lastloggedToLine = -1;
+        } else if (lastLoggedFromLine > to) {
+            lastLoggedFromLine -= delta;
+            lastloggedToLine -= delta;
+        }
+        if (mCommitLineIndex >= from && mCommitLineIndex <= to) {
+            mCommitLineIndex = -1;
+        } else if (mCommitLineIndex > to) {
+            mCommitLineIndex -= delta;
+        }
         return true;
     }
     return false;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1425,7 +1425,7 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
         mMudLine.clear();
         mMudBuffer.clear();
         const int line = lineBuffer.size() - 1;
-        mCommitLineIndex = line;
+        mCommitLineIndices.append(line);
         if (!mSkipTriggerProcessing) {
             mpHost->mpConsole->runTriggers(line);
         }
@@ -1442,10 +1442,9 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
 
         // Skip logging if a trigger deleted the line that was being committed;
         // deleteLines() has already adjusted the deferred logging state
-        if (mCommitLineIndex >= 0) {
+        if (mCommitLineIndices.takeLast() >= 0) {
             log(lineBuffer.size() - 1, lineBuffer.size() - 1);
         }
-        mCommitLineIndex = -1;
 
         ++localBufferPosition;
         // Suppress new empty line IFF echoes already created a new empty line
@@ -4682,6 +4681,15 @@ void TBuffer::log(int fromLine, int toLine)
         mpHost->mpConsole->mLogStream.flush();
     }
 
+    // record the last log call into a temporary buffer - we'll actually log
+    // on the next iteration after duplication detection has run
+    lastTextToLog = assembleLog(fromLine, toLine);
+    lastLoggedFromLine = fromLine;
+    lastloggedToLine = toLine;
+}
+
+QString TBuffer::assembleLog(int fromLine, int toLine)
+{
     QStringList linesToLog;
     for (int i = fromLine; i <= toLine; ++i) {
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
@@ -4691,12 +4699,7 @@ void TBuffer::log(int fromLine, int toLine)
             linesToLog << ((mpHost->mIsLoggingTimestamps && !timeBuffer.at(i).isEmpty()) ? timeBuffer.at(i).left(mudlet::smTimeStampFormat.length()) : QString()) % lineBuffer.at(i) % QChar::LineFeed;
         }
     }
-
-    // record the last log call into a temporary buffer - we'll actually log
-    // on the next iteration after duplication detection has run
-    lastTextToLog = linesToLog.join(QString());
-    lastLoggedFromLine = fromLine;
-    lastloggedToLine = toLine;
+    return linesToLog.join(QString());
 }
 
 // logs the remaining output when logging gets stopped, without duplication checks
@@ -5078,6 +5081,21 @@ void TBuffer::shrinkBuffer()
     // away:
     mpConsole->mCurrentSearchResult = qMax(0, mpConsole->mCurrentSearchResult - mBatchDeleteSize);
 
+    // The removed leading lines shift every remaining index down; keep the
+    // deferred logging state pointing at the same lines
+    if (lastloggedToLine >= mBatchDeleteSize) {
+        lastLoggedFromLine = qMax(0, lastLoggedFromLine - mBatchDeleteSize);
+        lastloggedToLine -= mBatchDeleteSize;
+    } else if (lastLoggedFromLine >= 0) {
+        lastLoggedFromLine = -1;
+        lastloggedToLine = -1;
+    }
+    for (auto& commitLineIndex : mCommitLineIndices) {
+        if (commitLineIndex >= 0) {
+            commitLineIndex = (commitLineIndex < mBatchDeleteSize) ? -1 : commitLineIndex - mBatchDeleteSize;
+        }
+    }
+
     // Clean up unreferenced links after removing old lines
     clearLinkState();
 
@@ -5108,19 +5126,29 @@ bool TBuffer::deleteLines(int from, int to)
         buffer.erase(buffer.begin() + from, buffer.begin() + to + 1);
 
         // Keep the deferred logging state in step with the removed lines so
-        // pending text is only dropped when the line it holds was deleted
+        // pending text is only dropped when the lines it holds were deleted
         if (lastloggedToLine >= from && lastLoggedFromLine <= to) {
-            lastTextToLog.clear();
-            lastLoggedFromLine = -1;
-            lastloggedToLine = -1;
+            if ((from <= lastLoggedFromLine && lastloggedToLine <= to) || lastTextToLog.isEmpty() || mpHost.isNull()) {
+                lastTextToLog.clear();
+                lastLoggedFromLine = -1;
+                lastloggedToLine = -1;
+            } else {
+                // only part of the pending range was deleted - rebuild the
+                // pending text from the lines that survived
+                lastLoggedFromLine = (lastLoggedFromLine < from) ? lastLoggedFromLine : from;
+                lastloggedToLine = (lastloggedToLine > to) ? lastloggedToLine - delta : from - 1;
+                lastTextToLog = assembleLog(lastLoggedFromLine, lastloggedToLine);
+            }
         } else if (lastLoggedFromLine > to) {
             lastLoggedFromLine -= delta;
             lastloggedToLine -= delta;
         }
-        if (mCommitLineIndex >= from && mCommitLineIndex <= to) {
-            mCommitLineIndex = -1;
-        } else if (mCommitLineIndex > to) {
-            mCommitLineIndex -= delta;
+        for (auto& commitLineIndex : mCommitLineIndices) {
+            if (commitLineIndex >= from && commitLineIndex <= to) {
+                commitLineIndex = -1;
+            } else if (commitLineIndex > to) {
+                commitLineIndex -= delta;
+            }
         }
         return true;
     }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -301,6 +301,7 @@ public:
     void expandLine(int y, int count, TChar&);
     int wrapLine(int startLine, int maxWidth, int indentSize, int hangingIndentSize);
     void log(int, int);
+    QString assembleLog(int fromLine, int toLine);
     inline int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, const TChar& format, const QVector<int>& luaReference = QVector<int>());
     QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0, int spacePadding = 0);
@@ -495,10 +496,11 @@ private:
     int lastLoggedFromLine = 0;
     int lastloggedToLine = 0;
     QString lastTextToLog;
-    // index of the line being committed while its triggers run, -1 otherwise;
-    // deleteLines() adjusts it so commitLine() can tell whether that line
-    // survived trigger processing
-    int mCommitLineIndex = -1;
+    // indices of lines being committed while their triggers run - a stack,
+    // because a trigger calling feedTriggers() re-enters commitLine();
+    // deleteLines() adjusts the entries so commitLine() can tell whether its
+    // line survived trigger processing
+    QList<int> mCommitLineIndices;
 
     QByteArray mEncoding;
 

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -495,6 +495,10 @@ private:
     int lastLoggedFromLine = 0;
     int lastloggedToLine = 0;
     QString lastTextToLog;
+    // index of the line being committed while its triggers run, -1 otherwise;
+    // deleteLines() adjusts it so commitLine() can tell whether that line
+    // survived trigger processing
+    int mCommitLineIndex = -1;
 
     QByteArray mEncoding;
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `TBuffer::deleteLines()` now keeps the deferred logging state consistent: pending log text is dropped only when its lines were actually deleted, partially-deleted pending ranges are rebuilt from the surviving lines, and indices shift when older lines are deleted
- `commitLine()` skips logging only when the just-committed line itself was deleted by a trigger; commit lines are tracked as a stack because `feedTriggers()` from a trigger re-enters `commitLine()`
- `shrinkBuffer()` shifts the tracked indices when it trims the buffer front

#### Motivation for adding to Mudlet
Gagging lines with `deleteLine()` in triggers could write deleted lines to the log, duplicate the line above them, or silently drop valid lines from the log.

#### Other info (issues closed, discussion etc)
Alternative to #9428 - that approach infers deletions from a buffer size comparison, which can't tell whether the deleted line was the committed one or an older one, so it drops a valid line from the log on every trigger `deleteLine()` (see the scenario comparison below).

Tested six scenarios against development, #9428, and this branch: delete current line; delete current + previous (the #9428 LOTJ case); delete previous only; delete an older line; delete one segment of a wrapped multi-line echo; nested `feedTriggers()` with nested deletions:

| Defect | development | #9428 | this PR |
|---|---|---|---|
| Deleted line still written to log | bug | fixed | fixed |
| Line above a multi-line gag duplicated | bug | fixed | fixed |
| Valid previous line dropped on plain single gag | ok | bug | fixed |
| Surviving triggered line dropped when previous line gagged | ok | bug | fixed |
| Pending line lost when an older line is deleted | bug | bug | fixed |
| Deleting one wrapped segment logs deleted text / drops the rest | logs deleted text | - | fixed |
| Surviving line lost after nested feed + delete | bug | - | fixed |

**Test case:** enable logging, create trigger `moveCursor(0, getLineNumber()-1) deleteLine()` on the word ZULU, then `lua feedTriggers("aaa\n") feedTriggers("bbb\n") feedTriggers("ZULU\n") feedTriggers("ccc\n") feedTriggers("ddd\n")` - the log should contain aaa, ZULU, ccc, ddd (no bbb, no duplicates)