### PR TITLE
fix: no more crash when viewing Variables after resetting a profile

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -879,6 +879,9 @@ void Host::resetProfile_phase2()
     mEventMap.clear();
     mLuaInterpreter.abortAllDownloads();
     mLuaInterpreter.initLuaGlobals();
+    // initLuaGlobals() closed the old lua_State, so the LuaInterface (and its
+    // VarUnit tree of registry references) must be rebuilt against the new one:
+    mLuaInterface.reset(new LuaInterface(mLuaInterpreter.getLuaGlobalState()));
     mLuaInterpreter.loadGlobal();
 
     // Have to recopy the values into the Lua "color_table"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `resetProfile()` replaces the Lua state, but `LuaInterface` kept a raw pointer to the closed one; opening the editor's Variables view then read freed memory and crashed
- Recreate the `LuaInterface` right after the state swap so the Variables view works on the new state

#### Motivation for adding to Mudlet
Viewing variables after a profile reset reliably crashed Mudlet (reported as a Windows CTD; reproduces on all platforms under ASAN).

#### Other info (issues closed, discussion etc)
Fixes #9382

**Test case:** open a profile, run `lua resetProfile()`, open the editor and click Variables - the list populates instead of crashing.


https://github.com/user-attachments/assets/392992cf-a7d1-449d-a243-caa036a7cb75

