### PR TITLE
fix: package description images now work for packages with spaces in their name

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1069,8 +1069,9 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
             }
             //replaces spaces with %20 in image file name to create a compatible url
             const QString imageName = QUrl::toPercentEncoding(imageFile.fileName()).constData();
-            //replace temporary path with the path that is now inside the package
-            plainDescription.replace(qsl("$%1").arg(imageFile.fileName()), qsl("$packagePath/.mudlet/description_images/%1").arg(imageName));
+            //replace temporary path with the path that is now inside the package; angle brackets
+            //keep the Markdown link destination intact once $packagePath expands to a path with spaces
+            plainDescription.replace(qsl("$%1").arg(imageFile.fileName()), qsl("<$packagePath/.mudlet/description_images/%1>").arg(imageName));
         }
     }
     return plainDescription;

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1357,7 +1357,9 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
     qEnableNtfsPermissionChecks();
 #endif
 #endif // defined(Q_OS_WINDOWS)
-    QDirIterator stagingFile(stagingDirName, QDir::NoDotAndDotDot | QDir::AllDirs | QDir::Files, QDirIterator::Subdirectories);
+    // QDir::Hidden is needed so the .mudlet staging directory (description
+    // images and other assets) makes it into the archive on Unix systems:
+    QDirIterator stagingFile(stagingDirName, QDir::NoDotAndDotDot | QDir::Hidden | QDir::AllDirs | QDir::Files, QDirIterator::Subdirectories);
     // relative names to use in archive:
     QStringList directoryEntries;
     // Key is relative name to use in archive


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The description's stored Markdown image URL is now wrapped in angle brackets, so the path survives when the package name (and thus the install path) contains spaces
- On Linux/macOS the hidden `.mudlet` staging folder was skipped entirely when zipping, so description images never shipped inside exported packages - the iterator now includes hidden entries

#### Motivation for adding to Mudlet
Packages with spaces in their name showed broken/missing description images after install; on Linux/macOS the images were not even inside the exported .mpackage.

#### Other info (issues closed, discussion etc)
Fixes #8177

**Test case:** export a package named e.g. "RPS test" with an image pasted into its description, install the .mpackage, view the description in the Package Manager - the image renders (and `unzip -l` shows `.mudlet/description_images/` inside the package).


https://github.com/user-attachments/assets/48b028e0-7f4a-4bad-883e-16c047754b3e

