### PR TITLE
fix: certificate warnings now open settings for the right profile

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -865,7 +865,8 @@ void cTelnet::slot_socketDisconnected()
 #if !defined(QT_NO_SSL)
     if (sslerr) {
         // Got a secure connection error that should be shown in the preferences
-        mudlet::self()->showOptionsDialog(qsl("tab_connection"));
+        // of the profile that raised it, not whichever profile is active
+        mudlet::self()->showOptionsDialog(qsl("tab_connection"), mpHost);
     }
 #endif
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3670,9 +3670,11 @@ void mudlet::slot_showActionDialog()
 }
 
 // tab must be the "objectName" of the tab in the preferences NOT the "titleText"
-void mudlet::showOptionsDialog(const QString& tab)
+void mudlet::showOptionsDialog(const QString& tab, Host* pHost)
 {
-    Host* pHost = getActiveHost();
+    if (!pHost) {
+        pHost = getActiveHost();
+    }
 
     auto pPrefs = pHost ? pHost->mpDlgProfilePreferences : mpDlgProfilePreferences;
 
@@ -3710,9 +3712,8 @@ void mudlet::showOptionsDialog(const QString& tab)
 
     // Force reposition after showing, since preferences dialog may be a singleton
     // that restores its position after being shown
-    Host* activeHost = getActiveHost();
-    QWidget* activeConsole = activeHost ? activeHost->mpConsole : nullptr;
-    QWidget* referenceWidget = activeConsole ? activeConsole : this;
+    QWidget* hostConsole = pHost ? pHost->mpConsole : nullptr;
+    QWidget* referenceWidget = hostConsole ? hostConsole : this;
     utils::forceRepositionDialogOnParentScreen(pPrefs, referenceWidget);
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -303,8 +303,8 @@ public:
     bool invertMapZoom() const { return mInvertMapZoom; }
     bool showTabConnectionIndicators() const { return mShowTabConnectionIndicators; }
     // Brings up the preferences dialog and selects the tab whos objectName is
-    // supplied:
-    void showOptionsDialog(const QString&);
+    // supplied, for the given Host - or the active one if none is given:
+    void showOptionsDialog(const QString&, Host* = nullptr);
     void startAutoLogin(const QStringList&);
     bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
     void setStorePasswordsSecurely(const bool storeSecurely) { mStorePasswordsSecurely = storeSecurely; }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- A certificate error on a background profile opened the Preferences window for whichever profile was focused, showing no certificate details
- `showOptionsDialog()` now accepts the affected profile and the SSL error path passes it, so the dialog opens for (and positions over) the erroring profile

#### Motivation for adding to Mudlet
With several profiles open, a bad-certificate warning appeared on the wrong profile with an empty certificate box, leaving no way to see or fix the actual error.

#### Other info (issues closed, discussion etc)
Fixes #7127

**Test case:** open two profiles where the first (backgrounded) one connects via TLS to a server with a self-signed certificate - the Preferences window that pops up is titled with the erroring profile's name and shows its certificate details.

https://github.com/user-attachments/assets/d5d50a63-c1fb-475e-be97-a3699b9bfdd3


