### PR TITLE
fix: hidden terminal control sequences no longer show up as text

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -212,6 +212,7 @@ TBuffer::TBuffer(const TBuffer& other)
 , mGotESC(other.mGotESC)
 , mGotCSI(other.mGotCSI)
 , mGotOSC(other.mGotOSC)
+, mGotString(other.mGotString)
 , mIsDefaultColor(other.mIsDefaultColor)
 , mBlack(other.mBlack)
 , mLightBlack(other.mLightBlack)
@@ -296,6 +297,7 @@ TBuffer& TBuffer::operator=(const TBuffer& other)
         mGotESC = other.mGotESC;
         mGotCSI = other.mGotCSI;
         mGotOSC = other.mGotOSC;
+        mGotString = other.mGotString;
         mIsDefaultColor = other.mIsDefaultColor;
         mBlack = other.mBlack;
         mLightBlack = other.mLightBlack;
@@ -686,12 +688,33 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             }
         }
 
-        if (mGotESC && (ch == '[' || ch == ']')) {
+        if (mGotESC) {
             mGotESC = false;
-            mGotCSI = (ch == '[');
-            mGotOSC = (ch == ']');
-            ++localBufferPosition;
-            continue;
+            if (ch == '[' || ch == ']') {
+                mGotCSI = (ch == '[');
+                mGotOSC = (ch == ']');
+                ++localBufferPosition;
+                continue;
+            }
+            if (ch == 'P' || ch == 'X' || ch == '^' || ch == '_') {
+                // DCS, SOS, PM and APC string sequences carry data that
+                // Mudlet does not use - consume them with the OSC code below
+                // but skip decoding the payload:
+                mGotOSC = true;
+                mGotString = true;
+                ++localBufferPosition;
+                continue;
+            }
+            if (static_cast<unsigned char>(ch) >= 0x20) {
+                // The final byte of some other escape sequence (e.g. ESC 7
+                // or ESC M) that Mudlet does not handle - consume it silently
+                // as a real terminal would instead of showing it as text:
+                ++localBufferPosition;
+                continue;
+            }
+            // A control character straight after the ESC means the escape
+            // sequence is malformed - abandon it and process the character
+            // normally:
         }
 
         if (mGotCSI) {
@@ -864,6 +887,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         } // End of if (mGotCSI)
 
         if (mGotOSC) {
+            // Also reached - with mGotString set - for the DCS, SOS, PM and
+            // APC string sequences which are consumed identically but whose
+            // payload is not decoded.
             // Lookahead and find end of sequence - valid terminators are:
             // - ST (String Terminator): ESC followed by '\' (backslash)
             // - BEL (0x07): Common alternative used by xterm and many MUDs
@@ -880,7 +906,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             size_t spanEnd = spanStart;
             // It is safe to look at spanEnd-1 even at the starting position
             // because we already know that the localBuffer extends backwards
-            // that far (it will be the ']' character!)
+            // that far (it will be the ']' character - or 'P', 'X', '^' or
+            // '_' for a string sequence!)
             // Loop until we find ST (ESC \), BEL, exceed length limit, or run out of data
             while (spanEnd < localBufferLength && (spanEnd - spanStart) < MAX_OSC_SEQUENCE_LENGTH && localBuffer[spanEnd] != '\x07'
                    && !((spanEnd > 0 && localBuffer[spanEnd - 1] == '\033') && localBuffer[spanEnd] == '\\')) {
@@ -894,14 +921,20 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 
             if (foundBEL) {
                 // BEL terminator - sequence content excludes the BEL
-                decodeOSC(QString(localBuffer.substr(spanStart, spanEnd - spanStart).c_str()));
+                if (!mGotString) {
+                    decodeOSC(QString(localBuffer.substr(spanStart, spanEnd - spanStart).c_str()));
+                }
                 mGotOSC = false;
+                mGotString = false;
                 localBufferPosition = spanEnd + 1; // Skip past BEL
                 continue;
             } else if (foundST) {
                 // ST terminator (ESC \) - sequence content excludes the ESC before backslash
-                decodeOSC(QString(localBuffer.substr(spanStart, spanEnd - spanStart - 1).c_str()));
+                if (!mGotString) {
+                    decodeOSC(QString(localBuffer.substr(spanStart, spanEnd - spanStart - 1).c_str()));
+                }
                 mGotOSC = false;
+                mGotString = false;
                 localBufferPosition = spanEnd + 1; // Skip past backslash
                 continue;
             } else if (exceededLength) {
@@ -916,11 +949,13 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                 if (spanEnd < localBufferLength && localBuffer[spanEnd] == '\x07') {
                     // Found BEL - skip to after it
                     mGotOSC = false;
+                    mGotString = false;
                     localBufferPosition = spanEnd + 1;
                     continue;
                 } else if (spanEnd < localBufferLength && spanEnd > 0 && localBuffer[spanEnd - 1] == '\033' && localBuffer[spanEnd] == '\\') {
                     // Found ST - skip to after it
                     mGotOSC = false;
+                    mGotString = false;
                     localBufferPosition = spanEnd + 1;
                     continue;
                 } else {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -434,6 +434,10 @@ private:
     // Second stage in decoding OSC sequences - set true when we see the ASCII
     // ESC character followed by the ']' one:
     bool mGotOSC = false;
+    // Set alongside mGotOSC for the other ANSI string sequences (DCS, SOS, PM
+    // and APC, i.e. ESC followed by 'P', 'X', '^' or '_' respectively) whose
+    // payload must be consumed up to the terminator but not decoded:
+    bool mGotString = false;
     bool mIsDefaultColor = true;
 
 

--- a/src/mudlet-lua/tests/TBufferOSC_spec.lua
+++ b/src/mudlet-lua/tests/TBufferOSC_spec.lua
@@ -86,11 +86,69 @@ describe("Tests TBuffer OSC sequence handling", function()
           clearWindow("oscTestBuffer3")
           echo("oscTestBuffer3", edgeCase)
         end)
-        
+
         assert.is_true(testSuccess, "Edge case " .. i .. " should not crash")
       end
     end)
-    
+
   end)
-  
+
+  describe("Tests ANSI string sequence handling (DCS, SOS, PM, APC)", function()
+
+    -- feedTriggers writes to the main console; fish the line carrying our
+    -- unique marker back out of the buffer to see what actually rendered
+    local function findRecentLine(needle)
+      local lastLine = getLastLineNumber("main")
+      local lines = getLines("main", math.max(0, lastLine - 15), lastLine + 1)
+      for i = #lines, 1, -1 do
+        if lines[i]:find(needle, 1, true) then
+          return lines[i]
+        end
+      end
+      return nil
+    end
+
+    it("should swallow an APC sequence terminated by ST", function()
+      assert.is_true(feedTriggers("APCST1(\027_secret apc payload\027\\)APCST1\n"))
+      assert.equals("APCST1()APCST1", findRecentLine("APCST1"))
+    end)
+
+    it("should swallow a DCS sequence terminated by ST", function()
+      assert.is_true(feedTriggers("DCSST1(\027P+q544e\027\\)DCSST1\n"))
+      assert.equals("DCSST1()DCSST1", findRecentLine("DCSST1"))
+    end)
+
+    it("should swallow PM and SOS sequences terminated by ST", function()
+      assert.is_true(feedTriggers("PMSOS1(\027^privacy message\027\\|\027Xstart of string\027\\)PMSOS1\n"))
+      assert.equals("PMSOS1(|)PMSOS1", findRecentLine("PMSOS1"))
+    end)
+
+    it("should swallow an APC sequence terminated by BEL", function()
+      assert.is_true(feedTriggers("APCBEL1(\027_bel terminated\7)APCBEL1\n"))
+      assert.equals("APCBEL1()APCBEL1", findRecentLine("APCBEL1"))
+    end)
+
+    it("should swallow an APC sequence split across two packets", function()
+      assert.is_true(feedTriggers("APCSPLIT1(\027_first half "))
+      assert.is_true(feedTriggers("second half\027\\)APCSPLIT1\n"))
+      assert.equals("APCSPLIT1()APCSPLIT1", findRecentLine("APCSPLIT1"))
+    end)
+
+    it("should still render OSC 8 hyperlink text", function()
+      assert.is_true(feedTriggers("OSCLINK1(\027]8;;https://example.com\027\\click me\027]8;;\027\\)OSCLINK1\n"))
+      assert.equals("OSCLINK1(click me)OSCLINK1", findRecentLine("OSCLINK1"))
+    end)
+
+    it("should still consume OSC color sequences", function()
+      assert.is_true(feedTriggers("OSCCOLOR1(\027]P1ff0000\027\\)OSCCOLOR1\n"))
+      assert.equals("OSCCOLOR1()OSCCOLOR1", findRecentLine("OSCCOLOR1"))
+    end)
+
+    it("should not treat text after an unhandled two-byte escape as a sequence", function()
+      assert.is_true(feedTriggers("STICKY1(\027" .. "7[not-a-csi)STICKY1\n"))
+      assert.equals("STICKY1([not-a-csi)STICKY1", findRecentLine("STICKY1"))
+    end)
+
+  end)
+
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- APC/DCS/PM/SOS escape sequences (used by some servers for out-of-band data like XTGETTCAP or terminal graphics) printed their entire payload as visible junk; they are now consumed up to the ST/BEL terminator, reusing the hardened OSC scan (length cap, split-packet handling)
- Also fixes a latent parser bug where any unhandled two-byte escape (e.g. ESC 7) left the ESC state armed, so a later plain-text "[" or "]" wrongly started CSI/OSC parsing and corrupted output

#### Motivation for adding to Mudlet
Servers sending standard terminal control strings spilled their raw payloads into the game display.

#### Other info (issues closed, discussion etc)
Fixes #7446

**Test case:** `lua feedTriggers("START>\27_secret payload\27\\<END\n")` shows only `START><END`; OSC 8 hyperlinks and OSC color sequences still work. Covered by 8 new busted tests in TBufferOSC_spec.lua.


https://github.com/user-attachments/assets/361ce8a7-a307-4cb2-aecc-7080590793d7

