### PR TITLE
Fix: cap over-long escape sequences to bound memory use

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -53,6 +53,12 @@ namespace {
 // Maximum length for an OSC sequence before aborting (defense against malformed sequences)
 constexpr size_t MAX_OSC_SEQUENCE_LENGTH = 4096;
 
+// Maximum length for a CSI sequence's parameter string before aborting - a
+// valid one is only a handful of bytes, so this only trips on a malformed or
+// hostile sequence that never sends a final byte (defense against a server
+// growing mIncompleteSequenceBytes without bound across packets)
+constexpr size_t MAX_CSI_SEQUENCE_LENGTH = 4096;
+
 // Helper to interpret JSON values as boolean
 // Accepts both boolean true and numeric non-zero values (servers may send 1 instead of true)
 bool jsonBoolValue(const QJsonValue& val)
@@ -721,6 +727,19 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                                              << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << "\" which Mudlet cannot interpret.";
                 // So skip over it as far as we can - will still possibly have
                 // garbage beyond the end which will still be shown...
+                localBufferPosition += 1 + spanEnd - spanStart;
+                mGotCSI = false;
+                // Go around while loop again:
+                continue;
+            }
+
+            if (spanEnd - spanStart >= MAX_CSI_SEQUENCE_LENGTH) {
+                // The parameter string is far longer than any valid CSI (which
+                // is only a handful of bytes): discard it instead of buffering
+                // it without bound while waiting for a final byte that a hostile
+                // server may never send.
+                qWarning().noquote().nospace() << "TBuffer::translateToPlainText(...) WARNING - CSI sequence exceeded " << MAX_CSI_SEQUENCE_LENGTH
+                                               << " bytes without a final byte, discarding it to recover.";
                 localBufferPosition += 1 + spanEnd - spanStart;
                 mGotCSI = false;
                 // Go around while loop again:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A server sending an unterminated CSI escape sequence (`ESC[` followed by an endless run of parameter bytes with no final byte) grew Mudlet's incomplete-sequence buffer without bound across packets, with O(n²) recopy. This adds a 4096-byte cap on the CSI parameter string - mirroring the cap already applied to OSC sequences - and discards an over-long sequence to recover.

#### Motivation for adding to Mudlet
Prevents a hostile or broken game server from exhausting memory/CPU (a denial of service).

#### Other info (issues closed, discussion etc)
Found via a source-code audit; no linked issue.
