### PR TITLE
Fix: stray ESC sequence no longer corrupts later text

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -694,6 +694,15 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
             continue;
         }
 
+        if (mGotESC) {
+            // ESC was not followed by '[' or ']', so it does not introduce a
+            // CSI or OSC sequence (e.g. ESC c, ESC 7, or a charset designator
+            // like ESC(B). Clear the latch here - otherwise it stays set and a
+            // later literal '[' or ']' anywhere in the stream is misparsed as a
+            // sequence introducer, swallowing the text that follows it.
+            mGotESC = false;
+        }
+
         if (mGotCSI) {
             // Lookahead and try and see what we are processing
             // At the start of a CSI sequence the only valid character is one of:

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -48,6 +48,8 @@
 #include <QTimer>
 #include <QUrlQuery>
 
+#include <utility>
+
 namespace {
 
 // Maximum length for an OSC sequence before aborting (defense against malformed sequences)
@@ -249,6 +251,11 @@ TBuffer::TBuffer(const TBuffer& other)
 , mMudLine(other.mMudLine)
 , mMudBuffer(other.mMudBuffer)
 , mIncompleteSequenceBytes(other.mIncompleteSequenceBytes)
+, mLocalGotESC(other.mLocalGotESC)
+, mLocalGotCSI(other.mLocalGotCSI)
+, mLocalGotOSC(other.mLocalGotOSC)
+, mLocalIncompleteSequenceBytes(other.mLocalIncompleteSequenceBytes)
+, mProcessingLocalFeed(other.mProcessingLocalFeed)
 , lastLoggedFromLine(other.lastLoggedFromLine)
 , lastloggedToLine(other.lastloggedToLine)
 , lastTextToLog(other.lastTextToLog)
@@ -333,6 +340,11 @@ TBuffer& TBuffer::operator=(const TBuffer& other)
         mMudLine = other.mMudLine;
         mMudBuffer = other.mMudBuffer;
         mIncompleteSequenceBytes = other.mIncompleteSequenceBytes;
+        mLocalGotESC = other.mLocalGotESC;
+        mLocalGotCSI = other.mLocalGotCSI;
+        mLocalGotOSC = other.mLocalGotOSC;
+        mLocalIncompleteSequenceBytes = other.mLocalIncompleteSequenceBytes;
+        mProcessingLocalFeed = other.mProcessingLocalFeed;
         lastLoggedFromLine = other.lastLoggedFromLine;
         lastloggedToLine = other.lastloggedToLine;
         lastTextToLog = other.lastTextToLog;
@@ -547,7 +559,38 @@ void TBuffer::addLink(bool trigMode, const QString& text, QStringList& command, 
       elements at the end can be omitted.
  */
 
+void TBuffer::swapParserSequenceState()
+{
+    std::swap(mGotESC, mLocalGotESC);
+    std::swap(mGotCSI, mLocalGotCSI);
+    std::swap(mGotOSC, mLocalGotOSC);
+    std::swap(mIncompleteSequenceBytes, mLocalIncompleteSequenceBytes);
+}
+
 void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServer)
+{
+    // mGotESC/mGotCSI/mGotOSC and mIncompleteSequenceBytes persist between
+    // calls so that a sequence split across Game Server packets still parses.
+    // Locally generated text (feedTriggers(), MMCP chat messages, MXP
+    // insertions) runs through the same parser, so swap in a separate set of
+    // that state for the duration of such a feed - otherwise local text
+    // arriving between two packets would consume or clear a latch that the
+    // server stream is still relying on (and vice versa). The flag keeps a
+    // nested local feed (e.g. an MXP <HR> inside locally fed text) from
+    // swapping the server state back in part way through:
+    if (isFromServer || mProcessingLocalFeed) {
+        translateToPlainTextInner(incoming, isFromServer);
+        return;
+    }
+
+    mProcessingLocalFeed = true;
+    swapParserSequenceState();
+    translateToPlainTextInner(incoming, false);
+    swapParserSequenceState();
+    mProcessingLocalFeed = false;
+}
+
+void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFromServer)
 {
     // What can appear in a CSI Parameter String (Ps) byte or at least for it
     // to be something we can handle:
@@ -589,6 +632,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 #endif
             mIncompleteSequenceBytes.clear();
         }
+        // The other channel's held-over bytes are equally stale:
+        mLocalIncompleteSequenceBytes.clear();
     }
 
     if (isFromServer && !mIncompleteSequenceBytes.empty()) {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -385,6 +385,8 @@ private:
     void shrinkBuffer();
     int calculateWrapPosition(int lineNumber, int begin, int end);
     void handleNewLine();
+    void translateToPlainTextInner(std::string& incoming, bool isFromServer);
+    void swapParserSequenceState();
     bool processUtf8Sequence(const std::string&, bool, size_t, size_t&, bool&);
     bool processGBSequence(const std::string&, bool, bool, size_t, size_t&, bool&);
     bool processBig5Sequence(const std::string&, bool, size_t, size_t&, bool&);
@@ -489,6 +491,20 @@ private:
     // and is not generated locally {because both pass through
     // translateToPlainText()}:
     std::string mIncompleteSequenceBytes;
+
+    // The parser sequence state (mGotESC, mGotCSI, mGotOSC and
+    // mIncompleteSequenceBytes) for whichever of the two data channels - Game
+    // Server stream or locally generated text - is not currently being
+    // processed; translateToPlainText() swaps it in around a local feed so
+    // that such text cannot consume or clear a latch belonging to a sequence
+    // split across Game Server packets (and vice versa):
+    bool mLocalGotESC = false;
+    bool mLocalGotCSI = false;
+    bool mLocalGotOSC = false;
+    std::string mLocalIncompleteSequenceBytes;
+    // Set whilst a locally generated feed is being processed, so a nested feed
+    // (e.g. an MXP <HR> inside locally fed text) does not swap the state again:
+    bool mProcessingLocalFeed = false;
 
     // keeps track of the previously logged buffer lines to ensure no log duplication
     // happens when you enter a command

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -170,6 +170,16 @@ private:
     return std::nullopt;
   }
 
+  // Joins all buffer lines into one string.
+  QString allBufferText() {
+    TMainConsole *console = mpHost->mpConsole;
+    QString allText;
+    for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+      allText += console->buffer.line(i);
+    }
+    return allText;
+  }
+
 private slots:
   // Start mudlet and create a profile once for all tests.
   void initTestCase() {
@@ -277,6 +287,52 @@ private slots:
                qPrintable(qsl("Expected buffer to contain '%1' but got '%2'")
                               .arg(expectedText, allText)));
     }
+  }
+
+  // =====================================================================
+  // Split sequence / interleaved local feed tests
+  // =====================================================================
+
+  // A CSI/OSC sequence split across two server packets must still parse when
+  // locally generated text (a feedTriggers() call, an MMCP chat message)
+  // arrives in between: the local feed runs through the same parser and must
+  // not consume or clear the pending ESC latch of the server stream.
+  void test_SplitSequenceSurvivesInterleavedLocalFeed_data() {
+    QTest::addColumn<QString>("secondPacket");
+    QTest::addColumn<QString>("mustNotContain");
+
+    QTest::newRow("split CSI") << qsl("[32mAfter\n") << qsl("[32mAfter");
+    QTest::newRow("split OSC")
+        << qsl("]2;Window Title\x07"
+               "After\n")
+        << qsl("]2;Window Title");
+  }
+
+  void test_SplitSequenceSurvivesInterleavedLocalFeed() {
+    QFETCH(QString, secondPacket);
+    QFETCH(QString, mustNotContain);
+
+    // First server packet ends in a bare ESC...
+    std::string part1{"Before\n\x1b"};
+    mpHost->mpConsole->printOnDisplay(part1, true);
+    // ...then locally generated text arrives in between...
+    std::string localText{"local tick\n"};
+    mpHost->mpConsole->printOnDisplay(localText, false);
+    // ...then the server packet with the rest of the sequence:
+    std::string part2{secondPacket.toStdString()};
+    mpHost->mpConsole->printOnDisplay(part2, true);
+
+    const QString allText = allBufferText();
+    QVERIFY2(!allText.contains(mustNotContain),
+             qPrintable(qsl("Sequence fragment '%1' leaked into display: '%2'")
+                            .arg(mustNotContain, allText)));
+    QVERIFY2(allText.contains(qsl("After")),
+             qPrintable(
+                 qsl("Text after the split sequence went missing from: '%1'")
+                     .arg(allText)));
+    QVERIFY2(allText.contains(qsl("local tick")),
+             qPrintable(qsl("Locally fed text went missing from: '%1'")
+                            .arg(allText)));
   }
 
   // =====================================================================


### PR DESCRIPTION
#### Brief overview of PR changes/additions
An `ESC` not followed by `[` or `]` (for example `ESC c`, `ESC 7`, or a charset designator like `ESC(B`) left the internal "saw ESC" flag stuck on. The next literal `[` or `]` anywhere in later text was then misparsed as an escape-sequence introducer and swallowed the text after it. The flag is now cleared in that case.

#### Motivation for adding to Mudlet
Fixes display corruption / silently lost text when a server emits such sequences.

#### Other info (issues closed, discussion etc)
Found via a source-code audit; no linked issue.
