### PR TITLE
Fix: colon-form italic styling no longer corrupts underline

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2119,12 +2119,12 @@ void TBuffer::decodeSGR(const QString& sequence)
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence
                                                  << "\") ERROR - unsupported italic parameter element (the second part) in a SGR...;3:" << parameterElements.at(1)
                                                  << ";../m sequence treating it as a one!";
-                    mUnderline = true;
+                    mItalics = true;
                     break;
                 default: // Something unexpected
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR(\"" << sequence << "\") ERROR - unexpected italic parameter element (the second part) in a SGR...;3:" << parameterElements.at(1)
                                                  << ";../m sequence treating it as a zero!";
-                    mUnderline = false;
+                    mItalics = false;
                     break;
                 }
             } else {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The colon sub-parameter branch for italics (`ESC[3:2m` and similar) set the underline state instead of the italics state, so malformed colon-form slant styling corrupted underline rather than setting italics. Two-line fix.

#### Motivation for adding to Mudlet
Correct text styling for servers that use colon-form SGR parameters.

#### Other info (issues closed, discussion etc)
Found via a source-code audit; no linked issue.
