### PR TITLE
Fix: enforce the per-echo character limit

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4336,7 +4336,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     int lineEndPos = sub_end;
 
     if (lineEndPos >= length) {
-        lineEndPos = text.size() - 1;
+        lineEndPos = length - 1;
     }
 
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`MAX_CHARACTERS_PER_ECHO` (1 MB) was computed but never applied: on overflow the clamp reset to the full text length instead of the cap, so an over-limit `echo`/`insertText` appended the entire string. It is now capped correctly. Byte-for-byte identical for any echo at or below the limit.

#### Motivation for adding to Mudlet
Restores the intended guard against a script echoing an enormous string in one call.

#### Other info (issues closed, discussion etc)
Found via a source-code audit; no linked issue.
