### PR TITLE
Fix: cap telnet subnegotiation length to bound memory use

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -362,13 +362,6 @@ TBuffer& TBuffer::operator=(const TBuffer& other)
     return *this;
 }
 
-// user-defined literal to represent megabytes
-// C++ standard requires unsigned long long parameter for integer literal operators
-auto operator""_MB(unsigned long long const x) -> int64_t // NOLINT(runtime/int)
-{
-    return 1024LL * 1024LL * x;
-}
-
 void TBuffer::setBufferSize(int requestedLinesLimit, int batch)
 {
     if (requestedLinesLimit < 100) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -146,6 +146,7 @@ void cTelnet::reset()
     iac = false;
     iac2 = false;
     insb = false;
+    mDiscardingOversizedSubnegotiation = false;
     // Stop any pending password mode timeout
     if (mTimerPasswordModeTimeout) {
         mTimerPasswordModeTimeout->stop();
@@ -4993,6 +4994,25 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
                 command = "";
                 iac = false;
             } else if (insb) {
+                if (mDiscardingOversizedSubnegotiation) {
+                    // Past the size cap for this subnegotiation: drop the rest
+                    // of it (do not buffer, interpret or display it) until the
+                    // closing IAC SE arrives, then resume normal processing.
+                    if (iac) {
+                        if (ch == TN_SE) {
+                            mDiscardingOversizedSubnegotiation = false;
+                            insb = false;
+                        }
+                        // IAC SE ends it; an escaped IAC IAC (or any other IAC
+                        // pair) is just more discarded payload - either way stop
+                        // tracking this IAC.
+                        iac = false;
+                    } else if (ch == TN_IAC) {
+                        iac = true;
+                    }
+                    continue;
+                }
+
                 // IAC SB COMPRESS WILL SE for MCCP v1 (unterminated invalid telnet sequence)
                 // IAC SB COMPRESS2 IAC SE for MCCP v2
                 if ((mMCCP_version_1 || mMCCP_version_2) && (!mNeedDecompression)) {
@@ -5044,14 +5064,16 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
                 command += ch;
 
                 if (command.size() > MAX_TELNET_SUBNEGOTIATION_LENGTH) {
-                    // The server opened an IAC SB but never sent IAC SE: abort
-                    // the subnegotiation instead of buffering its payload
-                    // without bound, and resume normal processing.
+                    // The server opened an IAC SB but is flooding its payload
+                    // with no IAC SE: stop buffering (to bound memory) and drop
+                    // the rest of the subnegotiation until IAC SE, rather than
+                    // resuming normal processing and leaking the unterminated
+                    // payload into the display/command stream.
                     qWarning().nospace() << "cTelnet::processSocketData(...) WARNING - telnet subnegotiation exceeded " << MAX_TELNET_SUBNEGOTIATION_LENGTH
-                                         << " bytes without an IAC SE terminator, discarding it to recover.";
+                                         << " bytes without an IAC SE terminator, dropping the rest until IAC SE.";
                     command = "";
+                    mDiscardingOversizedSubnegotiation = true;
                     iac = false;
-                    insb = false;
                     continue;
                 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -69,6 +69,12 @@ constexpr int AUTO_LOGIN_PASSWORD_DELAY_MS = 1000;
 constexpr int AUTO_LOGIN_MAX_DELAY_MS = 60000;
 
 constexpr size_t BUFFER_SIZE = 100000L;
+
+// Upper bound on a single telnet subnegotiation (IAC SB ... IAC SE). Real ones
+// (GMCP/MSDP/ATCP/...) are far smaller; this only guards against a server that
+// opens an IAC SB and never sends IAC SE, which would otherwise grow the
+// accumulation buffer without bound across reads.
+constexpr size_t MAX_TELNET_SUBNEGOTIATION_LENGTH = 1024 * 1024;
 // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (1 of 7) - investigate switching from using `char[]` to `std::array<char>`
 char loadBuffer[BUFFER_SIZE + 1];
 int loadedBytes;
@@ -5036,6 +5042,18 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
 
                 //7. inside IAC SB
                 command += ch;
+
+                if (command.size() > MAX_TELNET_SUBNEGOTIATION_LENGTH) {
+                    // The server opened an IAC SB but never sent IAC SE: abort
+                    // the subnegotiation instead of buffering its payload
+                    // without bound, and resume normal processing.
+                    qWarning().nospace() << "cTelnet::processSocketData(...) WARNING - telnet subnegotiation exceeded " << MAX_TELNET_SUBNEGOTIATION_LENGTH
+                                         << " bytes without an IAC SE terminator, discarding it to recover.";
+                    command = "";
+                    iac = false;
+                    insb = false;
+                    continue;
+                }
 
                 if (iac && (ch == TN_SE)) { //IAC SE - end of subcommand
                     processTelnetCommand(command);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -43,6 +43,7 @@
 #include "GMCPAuthenticator.h"
 #include "TTextCodec.h"
 #include "TEncodingHelper.h"
+#include "utils.h"
 #include "TTextEdit.h"
 #include "dlgComposer.h"
 #include "dlgMapper.h"
@@ -74,7 +75,7 @@ constexpr size_t BUFFER_SIZE = 100000L;
 // (GMCP/MSDP/ATCP/...) are far smaller; this only guards against a server that
 // opens an IAC SB and never sends IAC SE, which would otherwise grow the
 // accumulation buffer without bound across reads.
-constexpr size_t MAX_TELNET_SUBNEGOTIATION_LENGTH = 1024 * 1024;
+constexpr size_t MAX_TELNET_SUBNEGOTIATION_LENGTH = 5_MB;
 // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (1 of 7) - investigate switching from using `char[]` to `std::array<char>`
 char loadBuffer[BUFFER_SIZE + 1];
 int loadedBytes;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -421,6 +421,9 @@ private:
     bool iac = false;
     bool iac2 = false;
     bool insb = false;
+    // Set once a subnegotiation passes the size cap: drop the rest of it until
+    // IAC SE instead of buffering or leaking the unterminated payload.
+    bool mDiscardingOversizedSubnegotiation = false;
     // Set if we have negotiated the use of the option by us:
     std::bitset<256> myOptionState;
     // Set if he has negotiated the use of the option by him:

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,9 +30,22 @@
 #include <QScreen>
 #include <QWidget>
 
+#include <cstdint>
 #include <cstring>
 
 #define qsl(s) QStringLiteral(s)
+
+// user-defined literals to represent kilobytes and megabytes
+// C++ standard requires unsigned long long parameter for integer literal operators
+constexpr auto operator""_KB(unsigned long long const x) -> int64_t // NOLINT(runtime/int)
+{
+    return 1024LL * x;
+}
+
+constexpr auto operator""_MB(unsigned long long const x) -> int64_t // NOLINT(runtime/int)
+{
+    return 1024LL * 1024LL * x;
+}
 
 using TEnterEvent = QEnterEvent;
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ endif()
 
 set(FUNCTIONAL_TEST_SOURCES
     TelnetTextDisplayedTest.cpp
+    TelnetSubnegotiationTest.cpp
     TelnetBenchmark.cpp
     ResetProfileTest.cpp
     TOscTest.cpp

--- a/test/functional_tests/TelnetSubnegotiationTest.cpp
+++ b/test/functional_tests/TelnetSubnegotiationTest.cpp
@@ -1,0 +1,192 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForSubnegotiation();
+
+// Exercises recovery from a hostile/broken telnet subnegotiation: an IAC SB
+// whose payload runs past the size cap without ever sending IAC SE. The rest of
+// that subnegotiation must be dropped (not buffered without bound, and not
+// leaked into the displayed stream) until the closing IAC SE, after which
+// normal processing resumes.
+class TelnetSubnegotiationTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = "Test-Telnet-Subnegotiation";
+    const QString mPort = "4002";
+    const QString mLocalhost = "localhost";
+
+private slots:
+    void initTestCase() { initializeQRCResourcesForSubnegotiation(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, mPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+    }
+
+    void test_oversizedSubnegotiationIsDroppedUntilSE()
+    {
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        // MAX_TELNET_SUBNEGOTIATION_LENGTH in ctelnet.cpp is 1 MiB; send more
+        // than that inside the subnegotiation, with no IAC SE, then a marker
+        // that (only if recovery is broken) would leak into the display, then
+        // the real IAC SE and a line of ordinary text.
+        constexpr int overCapPadding = 1024 * 1024 + 1024;
+        QByteArray data;
+        data.append(TN_IAC);
+        data.append(TN_SB);
+        data.append(static_cast<char>(0x2d)); // an unused option; its value is irrelevant here
+        data.append(QByteArray(overCapPadding, 'A'));
+        data.append("SUBNEG_LEAK_MARKER");
+        data.append(TN_IAC);
+        data.append(TN_SE);
+        data.append("SUBNEG_RECOVERED\r\n");
+        // processSocketData() writes a NUL at in_buffer[size + 1], so give the
+        // backing buffer a little slack before handing it its data pointer.
+        data.reserve(data.size() + 16);
+
+        host->mTelnet.loopbackTest(data);
+
+        QVERIFY2(waitForBufferToContain("SUBNEG_RECOVERED"), "Ordinary text after an oversized subnegotiation was not displayed - recovery failed.");
+        QVERIFY2(!bufferContains("SUBNEG_LEAK_MARKER"), "Subnegotiation payload past the size cap leaked into the display instead of being dropped until IAC SE.");
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    // Utility function to manually start a profile like a user would do via the
+    // GUI
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    // True if any line in the main console buffer contains the given substring
+    bool bufferContains(const QString& text)
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            if (console->buffer.line(i).contains(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Polls the console buffer until the expected substring appears, with a timeout
+    bool waitForBufferToContain(const QString& text, int timeoutMs = 5000)
+    {
+        return QTest::qWaitFor(
+                [&]() {
+                    return bufferContains(text);
+                },
+                timeoutMs);
+    }
+
+    // Utility function
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            qInfo() << "Profile directory does not exist:" << path;
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForSubnegotiation()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "TelnetSubnegotiationTest.moc"
+QTEST_MAIN(TelnetSubnegotiationTest)

--- a/test/functional_tests/TelnetSubnegotiationTest.cpp
+++ b/test/functional_tests/TelnetSubnegotiationTest.cpp
@@ -17,13 +17,17 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QDeadlineTimer>
 #include <QtTest/QtTest>
+
+#include <chrono>
 
 #include "MudletInstanceCoordinator.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+#include "utils.h"
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -31,6 +35,8 @@ extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResourcesForSubnegotiation();
+
+using namespace std::chrono_literals;
 
 // Exercises recovery from a hostile/broken telnet subnegotiation: an IAC SB
 // whose payload runs past the size cap without ever sending IAC SE. The rest of
@@ -68,11 +74,11 @@ private slots:
         auto host = mudlet::self()->getActiveHost();
         QVERIFY2(host, "No active host available for the test.");
 
-        // MAX_TELNET_SUBNEGOTIATION_LENGTH in ctelnet.cpp is 1 MiB; send more
+        // MAX_TELNET_SUBNEGOTIATION_LENGTH in ctelnet.cpp is 5MB; send more
         // than that inside the subnegotiation, with no IAC SE, then a marker
         // that (only if recovery is broken) would leak into the display, then
         // the real IAC SE and a line of ordinary text.
-        constexpr int overCapPadding = 1024 * 1024 + 1024;
+        constexpr qsizetype overCapPadding = 5_MB + 1_KB;
         QByteArray data;
         data.append(TN_IAC);
         data.append(TN_SB);
@@ -106,24 +112,24 @@ private slots:
     {
         QTimer::singleShot(0, qApp, [hostname, address, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 
         QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
-        if (!spy.wait(5000)) {
+        if (!spy.wait(5s)) {
             QFAIL("Profile took too long to load.");
         }
         auto host = mudlet::self()->getActiveHost();
@@ -132,7 +138,7 @@ private slots:
         }
 
         QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
-        if (!spy2.wait(2000)) {
+        if (!spy2.wait(2s)) {
             QFAIL("Could not connect with the host.");
         }
     }
@@ -150,13 +156,13 @@ private slots:
     }
 
     // Polls the console buffer until the expected substring appears, with a timeout
-    bool waitForBufferToContain(const QString& text, int timeoutMs = 5000)
+    bool waitForBufferToContain(const QString& text, std::chrono::milliseconds timeout = 5s)
     {
         return QTest::qWaitFor(
                 [&]() {
                     return bufferContains(text);
                 },
-                timeoutMs);
+                QDeadlineTimer(timeout));
     }
 
     // Utility function


### PR DESCRIPTION
#### Brief overview of PR changes/additions
An `IAC SB` (subnegotiation begin) with no matching `IAC SE` grew the subnegotiation buffer without bound across socket reads (the existing missing-SE recovery only triggers on an embedded IAC byte). This aborts a subnegotiation that exceeds 5MB - far larger than any real GMCP/MSDP/ATCP payload - and recovers.

#### Motivation for adding to Mudlet
Prevents a hostile or broken game server from exhausting memory (a denial of service).

#### Other info (issues closed, discussion etc)
Found via a source-code audit; no linked issue. The 5MB cap is easily tunable.
