### PR TITLE
fix: color triggers now work inside 'only pass matches' trigger groups

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -211,7 +211,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
     return state;
 }
 
-bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternNumber, int posOffset)
+bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternNumber, int posOffset, int lineNumber)
 {
     assert(mRegexMap.contains(patternNumber));
 
@@ -241,14 +241,21 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         return false;
     }
 
-    processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, haystackCLength, match_data, rc);
+    processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, haystackCLength, match_data, rc, lineNumber);
 
     pcre2_match_data_free(match_data);
     return true;
 }
 
-void TTrigger::processRegexMatch(
-        const char* haystackC, const QString& haystack, int patternNumber, int posOffset, const QSharedPointer<pcre2_code>& re, int haystackCLength, pcre2_match_data* match_data, int rc)
+void TTrigger::processRegexMatch(const char* haystackC,
+                                 const QString& haystack,
+                                 int patternNumber,
+                                 int posOffset,
+                                 const QSharedPointer<pcre2_code>& re,
+                                 int haystackCLength,
+                                 pcre2_match_data* match_data,
+                                 int rc,
+                                 int lineNumber)
 {
     PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(match_data);
 
@@ -422,10 +429,10 @@ END: {
                         // to enable people to highlight capture groups if there are any
                         // otherwise highlight complete expression match
                         if (filterPosition % numberOfCaptureGroups != 1) {
-                            filter(s, begin);
+                            filter(s, begin, lineNumber);
                         }
                     } else {
-                        filter(s, begin);
+                        filter(s, begin, lineNumber);
                     }
                 }
             }
@@ -435,16 +442,16 @@ END: {
 }
 }
 
-bool TTrigger::match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset)
+bool TTrigger::match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber)
 {
     if (haystack.startsWith(needle)) {
-        processBeginOfLine(needle, patternNumber, posOffset);
+        processBeginOfLine(needle, patternNumber, posOffset, lineNumber);
         return true;
     }
     return false;
 }
 
-void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int posOffset)
+void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int posOffset, int lineNumber)
 {
     std::list<std::string> captureList;
     std::list<int> posList;
@@ -491,7 +498,7 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
         pL->clearCaptureGroups();
         if (mFilterTrigger) {
             if (!captureList.empty()) {
-                filter(captureList.front(), posList.front());
+                filter(captureList.front(), posList.front(), lineNumber);
             }
         }
     }
@@ -539,14 +546,14 @@ void TTrigger::updateMultistates(int regexNumber, std::list<std::string>& captur
     }
 }
 
-void TTrigger::filter(std::string& capture, int& posOffset)
+void TTrigger::filter(std::string& capture, int& posOffset, int lineNumber)
 {
     if (capture.empty()) {
         return;
     }
     const QString text = QString::fromStdString(capture);
     for (auto& trigger : *mpMyChildrenList) {
-        trigger->match(capture.data(), text, -1, posOffset);
+        trigger->match(capture.data(), text, lineNumber, posOffset);
     }
 }
 
@@ -560,17 +567,17 @@ void TTrigger::setExpiryCount(int expiryCount)
     mExpiryCount = expiryCount;
 }
 
-bool TTrigger::match_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset)
+bool TTrigger::match_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber)
 {
     const int where = haystack.indexOf(needle);
     if (where != -1) {
-        processSubstringMatch(haystack, needle, patternNumber, posOffset, where);
+        processSubstringMatch(haystack, needle, patternNumber, posOffset, where, lineNumber);
         return true;
     }
     return false;
 }
 
-void TTrigger::processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where)
+void TTrigger::processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where, int lineNumber)
 {
     std::list<std::string> captureList;
     std::list<int> posList;
@@ -624,13 +631,13 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
         pL->clearCaptureGroups();
         if (mFilterTrigger) {
             if (!captureList.empty()) {
-                filter(captureList.front(), posList.front());
+                filter(captureList.front(), posList.front(), lineNumber);
             }
         }
     }
 }
 
-bool TTrigger::match_color_pattern(int line, int patternNumber)
+bool TTrigger::match_color_pattern(int line, int patternNumber, int posOffset, int length)
 {
     if (patternNumber >= mColorPatternList.size()) {
         return false;
@@ -646,7 +653,12 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
     }
     std::deque<TChar>& bufferLine = mpHost->mpConsole->buffer.buffer[line];
     const QString& lineBuffer = mpHost->mpConsole->buffer.lineBuffer[line];
-    int pos = 0;
+    // Filter ("only pass matches") parents hand children just the matched
+    // capture, so restrict the scan to that window; for top-level triggers
+    // the window covers the whole line:
+    const int start = qBound(0, posOffset, static_cast<int>(bufferLine.size()));
+    const int end = qBound(start, posOffset + length, static_cast<int>(bufferLine.size()));
+    int pos = start;
     int matchBegin = -1;
     bool matching = false;
 
@@ -661,7 +673,7 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
         return false; // no color settings to match against
     }
 
-    for (auto it = bufferLine.begin(); it != bufferLine.end(); ++it, ++pos) {
+    for (auto it = bufferLine.begin() + start; pos < end; ++it, ++pos) {
         // This now allows matching against the current default colours (-1) and
         // allows ONE of the foreground or background to NOT be considered (-2)
         // Ideally we should base the matching on only the ANSI code but not
@@ -677,7 +689,7 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
             matching = false;
         }
 
-        if ((!matching) || (matching && (pos + 1 >= static_cast<int>(bufferLine.size())))) {
+        if ((!matching) || (matching && (pos + 1 >= end))) {
             if (matchBegin > -1) {
                 std::string got;
                 if (matching) {
@@ -695,13 +707,13 @@ bool TTrigger::match_color_pattern(int line, int patternNumber)
     }
 
     if (canExecute) {
-        processColorPattern(patternNumber, captureList, posList);
+        processColorPattern(patternNumber, captureList, posList, line);
         return true;
     }
     return false;
 }
 
-void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList)
+void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList, int lineNumber)
 {
     if (mIsColorizerTrigger) {
         const int r1 = mBgColor.red();
@@ -745,7 +757,7 @@ void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& ca
                 auto it1 = captureList.begin();
                 auto it2 = posList.begin();
                 for (; it1 != captureList.end(); it1++, it2++) {
-                    filter(*it1, *it2);
+                    filter(*it1, *it2, lineNumber);
                 }
             }
         }
@@ -826,7 +838,7 @@ void TTrigger::processPromptMatch(int patternNumber)
     execute();
 }
 
-bool TTrigger::match_exact_match(const QString& haystack, const QString& needle, int patternNumber, int posOffset)
+bool TTrigger::match_exact_match(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber)
 {
     QString text = haystack;
     if (text.endsWith(QChar('\n'))) {
@@ -834,17 +846,17 @@ bool TTrigger::match_exact_match(const QString& haystack, const QString& needle,
     }
 
     if (text == needle) {
-        processExactMatch(needle, patternNumber, posOffset);
+        processExactMatch(needle, patternNumber, posOffset, lineNumber);
         return true;
     }
     return false;
 }
 
-void TTrigger::processExactMatch(const QString& line, int patternNumber, int posOffset)
+void TTrigger::processExactMatch(const QString& needle, int patternNumber, int posOffset, int lineNumber)
 {
     std::list<std::string> captureList;
     std::list<int> posList;
-    captureList.emplace_back(line.toUtf8().constData());
+    captureList.emplace_back(needle.toUtf8().constData());
     posList.push_back(0 + posOffset);
     if (mudlet::smDebugMode) {
         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
@@ -886,7 +898,7 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
         pL->clearCaptureGroups();
         if (mFilterTrigger) {
             if (!captureList.empty()) {
-                filter(captureList.front(), posList.front());
+                filter(captureList.front(), posList.front(), lineNumber);
             }
         }
     }
@@ -944,19 +956,19 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
             ret = false;
             switch (mPatternKinds.value(patternNumber)) {
             case REGEX_SUBSTRING:
-                ret = match_substring(haystack, mPatterns.at(patternNumber), patternNumber, posOffset);
+                ret = match_substring(haystack, mPatterns.at(patternNumber), patternNumber, posOffset, line);
                 break;
 
             case REGEX_PERL:
-                ret = match_perl(haystackC, haystack, patternNumber, posOffset);
+                ret = match_perl(haystackC, haystack, patternNumber, posOffset, line);
                 break;
 
             case REGEX_BEGIN_OF_LINE_SUBSTRING:
-                ret = match_begin_of_line_substring(haystack, mPatterns.at(patternNumber), patternNumber, posOffset);
+                ret = match_begin_of_line_substring(haystack, mPatterns.at(patternNumber), patternNumber, posOffset, line);
                 break;
 
             case REGEX_EXACT_MATCH:
-                ret = match_exact_match(haystack, mPatterns.at(patternNumber), patternNumber, posOffset);
+                ret = match_exact_match(haystack, mPatterns.at(patternNumber), patternNumber, posOffset, line);
                 break;
 
             case REGEX_LUA_CODE:
@@ -968,7 +980,9 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                 break;
 
             case REGEX_COLOR_PATTERN:
-                ret = match_color_pattern(line, patternNumber);
+                // for a filter child the haystack is just the parent's capture,
+                // so its length bounds the color scan window on that line
+                ret = match_color_pattern(line, patternNumber, posOffset, static_cast<int>(haystack.length()));
                 break;
 
             case REGEX_PROMPT:
@@ -1019,12 +1033,14 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                                 for (int i = 1; its != (*mit).end(); ++its, i++) {
                                     std::string s = *its;
                                     int p = 0;
+                                    // multiline captures may come from earlier lines, so no
+                                    // single line number applies here
                                     if (total > 1) {
                                         if (i % total != 1) {
-                                            filter(s, p);
+                                            filter(s, p, -1);
                                         }
                                     } else {
-                                        filter(s, p);
+                                        filter(s, p, -1);
                                     }
                                 }
                             }

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -122,13 +122,13 @@ public:
     void enableTrigger(const QString&);
     void disableTrigger(const QString&);
     TTrigger* killTrigger(const QString&);
-    bool match_substring(const QString&, const QString&, int, int posOffset = 0);
-    bool match_perl(char*, const QString&, int, int posOffset = 0);
-    bool match_exact_match(const QString&, const QString&, int, int posOffset = 0);
-    bool match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset = 0);
+    bool match_substring(const QString&, const QString&, int, int posOffset, int lineNumber);
+    bool match_perl(char*, const QString&, int, int posOffset, int lineNumber);
+    bool match_exact_match(const QString&, const QString&, int, int posOffset, int lineNumber);
+    bool match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber);
     bool match_lua_code(int);
     bool match_line_spacer(int patternNumber);
-    bool match_color_pattern(int, int);
+    bool match_color_pattern(int line, int patternNumber, int posOffset, int length);
     bool match_prompt(int patternNumber);
     void setConditionLineDelta(int delta) { mConditionLineDelta = delta; }
     int getConditionLineDelta() const { return mConditionLineDelta; }
@@ -177,13 +177,20 @@ private:
     TTrigger() = default;
 
     inline void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
-    inline void filter(std::string&, int&);
-    void processExactMatch(const QString& line, int patternNumber, int posOffset);
-    void processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
-                           const QSharedPointer<pcre2_code>& re, int haystackCLength, pcre2_match_data* match_data, int rc);
-    void processBeginOfLine(const QString& needle, int patternNumber, int posOffset);
-    void processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where);
-    void processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList);
+    inline void filter(std::string&, int&, int lineNumber);
+    void processExactMatch(const QString& needle, int patternNumber, int posOffset, int lineNumber);
+    void processRegexMatch(const char* haystackC,
+                           const QString& haystack,
+                           int patternNumber,
+                           int posOffset,
+                           const QSharedPointer<pcre2_code>& re,
+                           int haystackCLength,
+                           pcre2_match_data* match_data,
+                           int rc,
+                           int lineNumber);
+    void processBeginOfLine(const QString& needle, int patternNumber, int posOffset, int lineNumber);
+    void processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where, int lineNumber);
+    void processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList, int lineNumber);
     void processPromptMatch(int patternNumber);
 
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(FUNCTIONAL_TEST_SOURCES
     dlgTriggerEditorUndoRedoTest.cpp
     TDiscordModeTest.cpp
     EnableDisableByNameTest.cpp
+    ColorTriggerFilterChildTest.cpp
 )
 
 set(FUNCTIONAL_TEST_UTILS

--- a/test/functional_tests/ColorTriggerFilterChildTest.cpp
+++ b/test/functional_tests/ColorTriggerFilterChildTest.cpp
@@ -1,0 +1,253 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * A color-pattern trigger that is the child of a filter parent ("only pass
+ * matches") must fire when the filtered capture carries the wanted colors.
+ * Filter parents re-run their children on just the capture text, so the
+ * child's color scan has to be aimed at the right buffer line and bounded to
+ * the capture's window within it. Covers: a top-level color trigger control,
+ * the filter-child case, and that the child only scans the parent's capture
+ * rather than the whole line.
+ *
+ * Run with: ctest -R ColorTriggerFilterChildTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
+}
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForColorTriggerFilterChildTest();
+
+class ColorTriggerFilterChildTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    // ANSI 3 is yellow, i.e. the SGR 33 foreground:
+    static constexpr int ansiYellow = 3;
+
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "ColorTriggerFilterChild-Test";
+    const QString mPort = "4006";
+    const QString mLocalhost = "localhost";
+
+    void runLua(const QString& code)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        luaL_dostring(L, code.toUtf8().constData());
+    }
+
+    bool luaGlobalTrue(const char* name)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, name);
+        const bool value = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        return value;
+    }
+
+    TTrigger* makeFilterParent(const QString& name, const QString& pattern)
+    {
+        auto* pT = new TTrigger(nullptr, mpHost);
+        pT->setIsFolder(false);
+        pT->setTemporary(true);
+        pT->setRegexCodeList({pattern}, {REGEX_PERL});
+        pT->mFilterTrigger = true;
+        pT->registerTrigger();
+        pT->setScript(QString());
+        pT->setName(name);
+        pT->setIsActive(true);
+        return pT;
+    }
+
+    TTrigger* makeYellowColorTrigger(TTrigger* pParent, const QString& name, const QString& script)
+    {
+        auto* pT = new TTrigger(pParent, mpHost);
+        pT->setIsFolder(false);
+        pT->setTemporary(true);
+        pT->setupTmpColorTrigger(ansiYellow, TTrigger::scmIgnored);
+        pT->registerTrigger();
+        pT->setScript(script);
+        pT->setName(name);
+        pT->setIsActive(true);
+        return pT;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForColorTriggerFilterChildTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, mPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+
+        startProfile(mHostname, mLocalhost, mPort);
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    void test_topLevelColorTriggerFires()
+    {
+        auto* pTop = makeYellowColorTrigger(nullptr, qsl("top level yellow"), qsl("topLevelFired = true"));
+
+        runLua(qsl("topLevelFired = false"));
+        runLua(qsl("feedTriggers('\\27[33mtop level control\\27[0m\\n')"));
+        QVERIFY2(luaGlobalTrue("topLevelFired"), "top-level color trigger should fire on yellow text");
+
+        pTop->setIsActive(false);
+    }
+
+    void test_colorChildUnderFilterParentFires()
+    {
+        auto* pParent = makeFilterParent(qsl("filter parent"), qsl("^(hello world)$"));
+        auto* pChild = makeYellowColorTrigger(pParent, qsl("yellow filter child"), qsl("filterChildFired = true"));
+
+        runLua(qsl("filterChildFired = false"));
+        runLua(qsl("feedTriggers('\\27[33mhello world\\27[0m\\n')"));
+        QVERIFY2(luaGlobalTrue("filterChildFired"), "color trigger child of a filter parent should fire on a yellow capture");
+
+        pParent->setIsActive(false);
+        pChild->setIsActive(false);
+    }
+
+    void test_colorChildScansOnlyParentCapture()
+    {
+        auto* pParent = makeFilterParent(qsl("filter capture parent"), qsl("(world)$"));
+        auto* pChild = makeYellowColorTrigger(pParent, qsl("yellow capture child"), qsl("captureChildFired = true"));
+
+        // only "hello" is yellow while the filter passes just "world" through,
+        // so the child must not see any yellow text
+        runLua(qsl("captureChildFired = false"));
+        runLua(qsl("feedTriggers('\\27[33mhello\\27[0m world\\n')"));
+        QVERIFY2(!luaGlobalTrue("captureChildFired"), "color child must not fire when the yellow text lies outside the parent's capture");
+
+        runLua(qsl("feedTriggers('hello \\27[33mworld\\27[0m\\n')"));
+        QVERIFY2(luaGlobalTrue("captureChildFired"), "color child should fire when the parent's capture is yellow");
+
+        pParent->setIsActive(false);
+        pChild->setIsActive(false);
+    }
+
+    // Helpers (reused from ResetProfileTest pattern)
+
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(500)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForColorTriggerFilterChildTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "ColorTriggerFilterChildTest.moc"
+QTEST_MAIN(ColorTriggerFilterChildTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- A color-pattern trigger nested under an "only pass matches" (filter) parent could never fire: the filter ran children with no buffer line to read colors from
- The real line number is now passed through, and the color scan is limited to the parent's matched text so filter semantics hold; top-level color triggers behave exactly as before

#### Motivation for adding to Mudlet
Filter chains are the standard way to scope triggers, and color patterns silently did nothing inside them.

#### Other info (issues closed, discussion etc)
Fixes #8198
Known limitation: children of *multiline* filter parents still can't use color patterns (a multiline match spans several lines, so no single line applies).

**Test case:** create a perl-regex trigger `^(hello world)$` with "only pass matches" ticked, nest a color trigger (foreground ANSI yellow) under it with `echo("CHILD FIRED\n")`, then `lua feedTriggers("\27[33mhello world\27[0m\n")` - the child fires. Covered by the new ColorTriggerFilterChildTest (ctest).


https://github.com/user-attachments/assets/011d8e7f-f428-4727-b38c-51031202f35d

