### PR TITLE
improve: scripts can now match map menus with their map events

### DIFF
--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1857,7 +1857,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
 int TLuaInterpreter::getMapMenus(lua_State* L)
 {
     bool keyByUniqueName = false;
-    if (lua_gettop(L) > 0) {
+    if (!lua_isnoneornil(L, 1)) {
         keyByUniqueName = getVerifiedBool(L, __func__, 1, "key by unique name", true);
     }
     const Host& host = getHostFromLua(L);

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -1856,6 +1856,10 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapMenus
 int TLuaInterpreter::getMapMenus(lua_State* L)
 {
+    bool keyByUniqueName = false;
+    if (lua_gettop(L) > 0) {
+        keyByUniqueName = getVerifiedBool(L, __func__, 1, "key by unique name", true);
+    }
     const Host& host = getHostFromLua(L);
     if (!(host.mpMap && host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap)) {
         return warnArgumentValue(L, __func__, "you haven't opened a map yet");
@@ -1865,14 +1869,24 @@ int TLuaInterpreter::getMapMenus(lua_State* L)
     QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserMenus);
     while (it.hasNext()) {
         it.next();
-        QString parent, display;
-        QStringList menuInfo = it.value();
-        parent = menuInfo[0];
-        display = menuInfo[1];
-        qDebug() << it.key() << parent << display;
-        lua_pushstring(L, display.toUtf8().constData());
-        lua_pushstring(L, parent.isEmpty() ? "top-level" : parent.toUtf8().constData());
-        lua_settable(L, -3);
+        const QStringList& menuInfo = it.value();
+        const QByteArray parent = menuInfo.at(0).isEmpty() ? QByteArrayLiteral("top-level") : menuInfo.at(0).toUtf8();
+        const QByteArray display = menuInfo.at(1).toUtf8();
+        if (keyByUniqueName) {
+            // Keyed by the unique name so entries can be matched up with the
+            // "parent" returned by getMapEvents():
+            const QByteArray uniqueName = it.key().toUtf8();
+            lua_createtable(L, 0, 2);
+            lua_pushstring(L, display.constData());
+            lua_setfield(L, -2, "display name");
+            lua_pushstring(L, parent.constData());
+            lua_setfield(L, -2, "parent");
+            lua_setfield(L, -2, uniqueName.constData());
+        } else {
+            lua_pushstring(L, display.constData());
+            lua_pushstring(L, parent.constData());
+            lua_settable(L, -3);
+        }
     }
 
     return 1;

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -65,6 +65,13 @@ describe("Tests custom map event and menu functions", function()
       assert.is_nil(menus["TestMenu"])
     end)
 
+    it("should treat a nil argument like no argument", function()
+      addMapMenu("TestMenu")
+
+      local menus = getMapMenus(nil)
+      assert.are.equal("top-level", menus["TestMenu"])
+    end)
+
     it("should key menus by unique name when requested", function()
       addMapMenu("TestMenu", nil, "Test Display Name")
       addMapMenu("TestSubMenu", "TestMenu", "Sub Display Name")

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -56,6 +56,37 @@ describe("Tests custom map event and menu functions", function()
       assert.are.equal("top-level", menus["TestMenu"])
       assert.are.equal("TestMenu", menus["TestSubMenu"])
     end)
+
+    it("should key menus by display name by default", function()
+      addMapMenu("TestMenu", nil, "Test Display Name")
+
+      local menus = getMapMenus()
+      assert.are.equal("top-level", menus["Test Display Name"])
+      assert.is_nil(menus["TestMenu"])
+    end)
+
+    it("should key menus by unique name when requested", function()
+      addMapMenu("TestMenu", nil, "Test Display Name")
+      addMapMenu("TestSubMenu", "TestMenu", "Sub Display Name")
+
+      local menus = getMapMenus(true)
+      assert.is_table(menus["TestMenu"])
+      assert.are.equal("Test Display Name", menus["TestMenu"]["display name"])
+      assert.are.equal("top-level", menus["TestMenu"]["parent"])
+      assert.is_table(menus["TestSubMenu"])
+      assert.are.equal("Sub Display Name", menus["TestSubMenu"]["display name"])
+      assert.are.equal("TestMenu", menus["TestSubMenu"]["parent"])
+    end)
+
+    it("should let getMapEvents parents be resolved via getMapMenus(true)", function()
+      addMapMenu("TestMenu", nil, "Test Display Name")
+      addMapEvent("testEvent1", "myEvent", "TestMenu", "Test Event 1")
+
+      local events = getMapEvents()
+      local menus = getMapMenus(true)
+      assert.is_not_nil(menus[events.testEvent1.parent])
+      assert.are.equal("Test Display Name", menus[events.testEvent1.parent]["display name"])
+    end)
   end)
 
   describe("Tests removeMapEvent", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `getMapEvents()` reports each event's parent menu by its unique name, but `getMapMenus()` only returned display names - the two could not be joined; `getMapMenus(true)` now returns menus keyed by unique name with display name and parent inside
- Removed a stray qDebug that printed every menu to the terminal on each `getMapMenus()` call

#### Motivation for adding to Mudlet
Scripts managing mapper context menus had no way to resolve which menu an event belongs to.

#### Other info (issues closed, discussion etc)
Fixes #8642
Default `getMapMenus()` shape is unchanged. Wiki: getMapMenus needs the new optional argument documented.

**Test case:** `lua addMapMenu("unique_menu", nil, "Some Menu") addMapEvent("unique_event", "SomeEvent", "unique_menu", "Some Event")` then `display(getMapMenus(true))` - the table is keyed by `unique_menu`, matching `getMapEvents().unique_event.parent`. Covered by new Mapper_spec busted tests.


https://github.com/user-attachments/assets/f846bd8e-4631-469b-9b9b-89eacb98848f

