### PR TITLE
fix: script editor's search box no longer jumps around

### DIFF
--- a/src/dlgSourceEditorFindArea.cpp
+++ b/src/dlgSourceEditorFindArea.cpp
@@ -61,7 +61,7 @@ bool dlgSourceEditorFindArea::eventFilter(QObject* obj, QEvent* event)
             }
         }
     } else {
-        if (event->type() == QEvent::Show || event->type() == QEvent::Hide) {
+        if (event->type() == QEvent::Show || event->type() == QEvent::Hide || event->type() == QEvent::Resize) {
             emit signal_sourceEditorMovementNecessary();
         }
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -408,6 +408,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpSourceEditorFindArea = new dlgSourceEditorFindArea(mpSourceEditorEdbee);
     mpSourceEditorEdbee->horizontalScrollBar()->installEventFilter(mpSourceEditorFindArea);
     mpSourceEditorEdbee->verticalScrollBar()->installEventFilter(mpSourceEditorFindArea);
+    // reposition the find area when the editor itself resizes, e.g. when the
+    // system message area above it appears or disappears
+    mpSourceEditorEdbee->installEventFilter(mpSourceEditorFindArea);
     mpSourceEditorFindArea->hide();
 
     connect(mpSourceEditorFindArea->lineEdit_findText, &QLineEdit::textChanged, this, &dlgTriggerEditor::slot_sourceFindTextChanges);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The find/replace box is positioned absolutely inside the code pane, but the syntax-error banner resizing that pane never triggered a reposition - the box got clipped out of view or left floating mid-editor
- The find area's event filter is now also installed on the editor widget and repositions on its resize events

#### Motivation for adding to Mudlet
Searching while fixing a script error left the find box unusable or misplaced until the window was resized.

#### Other info (issues closed, discussion etc)
Fixes #7649

**Test case:** open a script, press Ctrl+F, type `*` in the code and save so the error banner appears, then close the banner - the find box stays anchored to the pane's bottom-right throughout.


https://github.com/user-attachments/assets/fdfb36b4-ff72-47d4-8082-238be021aefd

