### PR TITLE
fix: game information sent via MXP is no longer all-lowercase

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7587,6 +7587,10 @@ int TLuaInterpreter::setConfig(lua_State* L)
         host.mPromptedForMXPProcessorOn = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("specialForceMXPProcessorOn")) {
+        host.setForceMXPProcessorOn(getVerifiedBool(L, __func__, 2, "value"));
+        return success();
+    }
     if (key == qsl("promptForVersionInTTYPE")) {
         host.mPromptedForVersionInTTYPE = getVerifiedBool(L, __func__, 2, "value");
         return success();

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -105,7 +105,7 @@ TMxpTagHandlerResult TMxpMudlet::tagHandled(MxpTag* tag, TMxpTagHandlerResult re
 {
     if (tag->isStartTag()) {
         if (context.getElementRegistry().containsElement(tag->getName())) {
-            enqueueMxpEvent(tag->asStartTag());
+            enqueueMxpEvent(tag->asStartTag(), context.getElementRegistry().getElement(tag->getName()));
         } else if (tag->isNamed("SEND")) {
             // send events are queued on closing tag so the caption is available
             TMxpEvent event;
@@ -123,12 +123,26 @@ TMxpTagHandlerResult TMxpMudlet::tagHandled(MxpTag* tag, TMxpTagHandlerResult re
     return result;
 }
 
-void TMxpMudlet::enqueueMxpEvent(MxpStartTag* tag)
+void TMxpMudlet::enqueueMxpEvent(MxpStartTag* tag, const TMxpElement& element)
 {
     TMxpEvent mxpEvent;
     mxpEvent.name = tag->getName();
     for (const auto& attrName : tag->getAttributesNames()) {
         mxpEvent.attrs[attrName] = tag->getAttributeValue(attrName);
+    }
+    // Also resolve the element's declared (ATT) attribute names - like
+    // TMxpCustomElementTagHandler::parseFlagAttributes() does - so a
+    // positional token like <RMob "Urthguk"> is reachable under a stable,
+    // case-preserving key: mxp.rmob.name = "Urthguk" for ATT="Name"
+    for (int i = 0, total = element.attrs.size(); i < total; ++i) {
+        const QString& attrName = element.attrs.at(i);
+        if (tag->hasAttribute(attrName)) {
+            mxpEvent.attrs[attrName] = tag->getAttributeValue(attrName);
+        } else if (tag->getAttributesCount() > i) {
+            mxpEvent.attrs[attrName] = tag->getAttribute(i).getName();
+        } else if (element.defaultValues.contains(attrName)) {
+            mxpEvent.attrs[attrName] = element.defaultValues.value(attrName);
+        }
     }
     mxpEvent.actions = getLinkStore().getCurrentLinks();
     mxpEvent.caption.clear();

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -131,7 +131,7 @@ public:
 
     TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result, TMxpContext& context) override;
 
-    void enqueueMxpEvent(MxpStartTag* tag);
+    void enqueueMxpEvent(MxpStartTag* tag, const TMxpElement& element);
     TLinkStore& getLinkStore();
 
     QList<QColor> fgColors;

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -1,0 +1,50 @@
+describe("Tests MXP handling", function()
+
+  setup(function()
+    -- feedTelnet cannot negotiate MXP here as the test profile's socket is
+    -- not in the unconnected state, so force the MXP processor on instead -
+    -- that also locks secure mode, letting feedTriggers carry MXP tags
+    setConfig("specialForceMXPProcessorOn", true)
+  end)
+
+  teardown(function()
+    -- turn the MXP processor back off so later specs are not affected
+    setConfig("specialForceMXPProcessorOn", false)
+  end)
+
+  describe("Tests custom element events populate the mxp table", function()
+    it("should expose positional values under declared (ATT) attribute names", function()
+      feedTriggers([[<!ELEMENT RMob FLAG="RoomMob" ATT="Name">]] .. "\n")
+      feedTriggers([[<RMob "Urthguk">Urthguk, a hulking half-ogre</RMob>]] .. "\n")
+
+      assert.is_table(mxp)
+      assert.is_table(mxp.rmob)
+      -- declared attribute resolves the positional token, value case intact
+      assert.are.equal("Urthguk", mxp.rmob.name)
+      -- the legacy lowercased token key remains for older scripts
+      assert.is_not_nil(mxp.rmob.urthguk)
+      assert.is_nil(mxp.rmob.Urthguk)
+    end)
+
+    it("should lowercase named attribute keys", function()
+      feedTriggers([[<!ELEMENT RExit FLAG="RoomExit">]] .. "\n")
+      feedTriggers([[<RExit Dir="North">north</RExit>]] .. "\n")
+
+      assert.is_table(mxp)
+      assert.is_table(mxp.rexit)
+      assert.are.equal("North", mxp.rexit.dir)
+      assert.is_nil(mxp.rexit.Dir)
+    end)
+
+    it("should keep positional token keys lowercased without a declared attribute", function()
+      feedTriggers([[<!ELEMENT RItem FLAG="RoomItem">]] .. "\n")
+      feedTriggers([[<RItem "Sword">a gleaming sword</RItem>]] .. "\n")
+
+      assert.is_table(mxp)
+      assert.is_table(mxp.ritem)
+      assert.is_not_nil(mxp.ritem.sword)
+      assert.is_nil(mxp.ritem.Sword)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- MXP custom-element events now also expose positional values under the element's declared (ATT) attribute names, with case preserved: `<RMob "Urthguk">` declared with `ATT="Name"` gives `mxp.rmob.name = "Urthguk"`
- Legacy lowercased token keys are kept, so existing scripts keep working
- Adds `setConfig("specialForceMXPProcessorOn", ...)` to mirror the existing `getConfig` key, used by the new busted specs to enable MXP without a live connection

#### Motivation for adding to Mudlet
Scripts could only reach a positional attribute's value as a lowercased key with an empty value, losing the original capitalisation and the declared attribute name.

#### Other info (issues closed, discussion etc)
Fixes #7275


https://github.com/user-attachments/assets/ad097dc3-61d7-48ee-9a01-de37af93593b


