### PR TITLE
fix: show connection details when picking a game on a fresh install

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -240,18 +240,28 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 
     // Listen for password migration completion to refresh the form
     connect(mudlet::self(), &mudlet::signal_passwordsMigratedToSecure, this, [this]() {
-        // Refresh the current profile's password field after migration
+        // Refresh the current profile's password field after migration; this
+        // is not the user picking a game so keep the welcome message up
+        mProgrammaticProfileSelection = true;
         slot_itemClicked(listWidget_profiles->currentItem());
+        mProgrammaticProfileSelection = false;
     });
 
     // Listen for character password migration completion to refresh the form
     connect(mudlet::self(), &mudlet::signal_characterPasswordsMigrated, this, [this]() {
-        // Refresh the current profile's password field after migration
+        // Refresh the current profile's password field after migration; this
+        // is not the user picking a game so keep the welcome message up
+        mProgrammaticProfileSelection = true;
         slot_itemClicked(listWidget_profiles->currentItem());
+        mProgrammaticProfileSelection = false;
     });
 
     connect(mud_description_textedit, &QPlainTextEdit::textChanged, this, &dlgConnectionProfiles::slot_updateDescription);
     connect(listWidget_profiles, &QListWidget::currentItemChanged, this, &dlgConnectionProfiles::slot_itemClicked);
+    // clicking the item that is already current (a profile gets pre-selected
+    // before the dialog is shown) does not change the current item, so it
+    // still needs to reveal the connection details on a fresh install
+    connect(listWidget_profiles, &QListWidget::itemClicked, this, &dlgConnectionProfiles::revealConnectionDetails);
     connect(listWidget_profiles, &QListWidget::itemDoubleClicked, this, &dlgConnectionProfiles::accept);
 
     // website_entry atm is only a label
@@ -782,6 +792,22 @@ void dlgConnectionProfiles::continueProfileSave(QListWidgetItem* pItem, const QS
     }
 }
 
+// On a fresh install with no saved profiles the dialog shows the welcome
+// message in place of the connection details; swap them back in and undo the
+// shrink that was applied to fit the welcome message.
+void dlgConnectionProfiles::revealConnectionDetails()
+{
+    if (mProgrammaticProfileSelection || welcome_message->isHidden()) {
+        return;
+    }
+    welcome_message->hide();
+    tabWidget_connectionInfo->show();
+    informationArea->show();
+    if (mDialogHeightBeforeShrink > height()) {
+        resize(width(), mDialogHeightBeforeShrink);
+    }
+}
+
 void dlgConnectionProfiles::slot_addProfile()
 {
     profile_name_entry->setReadOnly(false);
@@ -792,10 +818,7 @@ void dlgConnectionProfiles::slot_addProfile()
         character_password_entry->setText(QString());
     }
     fillout_form();
-    welcome_message->hide();
-
-    informationArea->show();
-    tabWidget_connectionInfo->show();
+    revealConnectionDetails();
 
     const QString newname = tr("new profile name");
 
@@ -1021,6 +1044,10 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
         return;
     }
 
+    // on a fresh install picking a game has to swap the welcome message for
+    // the connection details, just as creating a new profile does
+    revealConnectionDetails();
+
     const QString profile_name = pItem->data(csmNameRole).toString();
 
     // Prevent rapid duplicate clicks on the same profile
@@ -1226,6 +1253,12 @@ void dlgConnectionProfiles::fillout_form()
     mProfileList = QDir(mudlet::getMudletPath(enums::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     if (mProfileList.isEmpty()) {
+        // remember the height so revealConnectionDetails() can undo the
+        // shrink below, but not when the welcome message is already up as the
+        // dialog is then already shrunken
+        if (!mDialogHeightBeforeShrink || welcome_message->isHidden()) {
+            mDialogHeightBeforeShrink = height();
+        }
         welcome_message->show();
         tabWidget_connectionInfo->hide();
         informationArea->hide();
@@ -1338,9 +1371,12 @@ void dlgConnectionProfiles::fillout_form()
     }
 
     if (toselectRow != -1) {
+        // this automatic selection must not be taken for the user picking a
+        // game, which would dismiss the welcome message shown above
+        mProgrammaticProfileSelection = true;
         listWidget_profiles->setCurrentRow(toselectRow);
+        mProgrammaticProfileSelection = false;
     }
-
 }
 
 void dlgConnectionProfiles::setProfileIcon() const
@@ -1626,8 +1662,8 @@ dlgConnectionProfiles::CopiedProfileData dlgConnectionProfiles::captureProfileDa
 // on-disk, because such profiles only exist in memory until saved. Create the
 // new profile's folder and persist the captured connection data, so the copy is
 // a faithful, functional profile that survives reopening the connection screen.
-// url/port/SSL go through the same writers used when saving a profile (which
-// also re-enable the connect button); the remaining fields are written directly.
+// url/port/SSL go through the same writers used when saving a profile; the
+// remaining fields are written directly.
 void dlgConnectionProfiles::saveDefaultProfileCopy(const QString& profileName, const CopiedProfileData& data, const QString& oldPassword)
 {
     const QDir dir;
@@ -1643,12 +1679,28 @@ void dlgConnectionProfiles::saveDefaultProfileCopy(const QString& profileName, c
     }
 
     mProfileList << profileName;
-    mCopyingProfile = false;
+    // keep the copying flag up to the end: it stops the re-selection below
+    // from blanking the password field and stops validateProfile() from
+    // flagging the half-filled intermediate states
+    mCopyingProfile = true;
+
+    // the copy now exists on disk, so rebuilding the list shows it like any
+    // other saved profile - on a fresh install this also swaps the welcome
+    // message for the connection details, which would otherwise leave the
+    // copy invisible - then select it and fill in its details
+    fillout_form();
+    const auto pCopiedItems = findData(*listWidget_profiles, profileName, csmNameRole);
+    if (!pCopiedItems.isEmpty()) {
+        listWidget_profiles->setCurrentItem(pCopiedItems.first());
+    }
+
     {
+        const QSignalBlocker nameBlocker(profile_name_entry);
         const QSignalBlocker urlBlocker(host_name_entry);
         const QSignalBlocker portBlocker(port_entry);
         const QSignalBlocker sslBlocker(port_ssl_tsl);
         const QSignalBlocker loginBlocker(login_entry);
+        profile_name_entry->setText(profileName);
         host_name_entry->setText(data.host);
         port_entry->setText(data.port);
         port_ssl_tsl->setChecked(data.sslTsl == Qt::Checked);
@@ -1676,6 +1728,8 @@ void dlgConnectionProfiles::saveDefaultProfileCopy(const QString& profileName, c
     if (mudlet::self()->storingPasswordsSecurely() && !oldPassword.trimmed().isEmpty()) {
         writeSecurePassword(profileName, oldPassword);
     }
+    mCopyingProfile = false;
+    validateProfile();
 }
 
 void dlgConnectionProfiles::slot_copyOnlySettingsOfProfile()

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -132,6 +132,7 @@ private:
     void addLetterToProfileSearch(const int);
     void clearNotificationArea();
     void loadPasswordAsync(const QString& profileName);
+    void revealConnectionDetails();
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has
@@ -155,6 +156,11 @@ private:
     QAction* mpAction_revealPassword;
     // true for the duration of the 'Copy profile' action
     bool mCopyingProfile = false;
+    // true while a profile is selected or refreshed programmatically, so that
+    // it is not mistaken for the user picking a game from the list
+    bool mProgrammaticProfileSelection = false;
+    // dialog height before it was shrunk to fit the welcome message
+    int mDialogHeightBeforeShrink = 0;
     QString mDateTimeFormat;
     QVector<QColor> mCustomIconColors;
     QTimer mSearchTextTimer;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Selecting a game on a first-ever launch now swaps the welcome message for the connection details and restores the dialog height
- Programmatic selections (startup pre-selection, password-migration refreshes) still show the welcome message
- Copying a pre-configured game now rebuilds the list and selects the copy with its details filled in

#### Motivation for adding to Mudlet
On a fresh install, clicking a game filled hidden fields and appeared to do nothing - a dead end for the very first thing a new user does.

#### Other info (issues closed, discussion etc)
Closes #3930

**Test case:** Fresh install (empty config dir) → connection dialog shows the welcome message → click any game → connection details appear filled in. Copy a pre-configured game → the copy appears in the list, selected, with editable details.


https://github.com/user-attachments/assets/de6df8fa-e1f0-4564-91e8-c286bebdd791

