### PR TITLE
add option to undo the game's own line wrapping

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -672,6 +672,12 @@ public:
     int mWrapAt = 100;
     int mWrapIndentCount = 0;
     int mWrapHangingIndentCount = 0;
+    // Rejoin lines that the game hard-wrapped itself so that triggers see the
+    // whole logical line and Mudlet's own wrapping (mWrapAt) handles display:
+    bool mUndoServerWrap = false;
+    int mUndoServerWrapWidth = 80;
+    // The one-time "this game seems to wrap its own lines" hint was shown:
+    bool mServerWrapHintShown = false;
 
     int mConsoleBufferSize = 100000;
     bool mUseMaxConsoleBufferSize = false;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -192,6 +192,11 @@ TBuffer::~TBuffer()
     if (mTagWatchdog) {
         mTagWatchdog->stop();
     }
+    if (mpServerWrapFlushTimer) {
+        // The timeout lambda captures 'this':
+        mpServerWrapFlushTimer->stop();
+        QObject::disconnect(mpServerWrapFlushTimer, nullptr, nullptr, nullptr);
+    }
 }
 
 TBuffer::TBuffer(const TBuffer& other)
@@ -654,6 +659,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         }
 
         char& ch = localBuffer[localBufferPosition];
+        // Set when a line break is synthesised (MXP <br>/&newline;) rather
+        // than being a genuine newline in the game's output stream:
+        bool forcedLineBreak = false;
         if (ch == '\033') {
             if (!mGotOSC) {
                 // The terminator for an OSC is the String Terminator but that
@@ -956,6 +964,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                         continue;
                     case HANDLER_COMMIT_LINE: // BR tag or &newline;
                         ch = '\n';
+                        forcedLineBreak = true;
                         goto COMMIT_LINE;
                     case HANDLER_INSERT_ENTITY_CUST:
                         // custom entity value set with <!EN>, recurse except for other custom entities
@@ -1086,7 +1095,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
         }
 
     COMMIT_LINE:
-        if (commitLine(ch, localBufferPosition)) {
+        if (commitLine(ch, localBufferPosition, isFromServer, forcedLineBreak)) {
             continue;
         }
         // PLACEMARKER: Incoming text decoding
@@ -1341,137 +1350,328 @@ void TBuffer::resetCurrentTextFormat()
     mAltFont = 0;
 }
 
-bool TBuffer::commitLine(char ch, size_t& localBufferPosition)
+bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFromServer, const bool forcedLineBreak)
 {
-    if (CHAR_IS_COMMIT_CHAR(ch)) {
-        // DE: MUD Zeilen werden immer am Zeilenanfang geschrieben
-        // EN: MUD lines are always written at the beginning of the line
-
-        // FIXME: This is the point where we should renormalise the new text
-        // data - of course there is the theoretical chance that the new
-        // text would alter the prior contents but as that is on a separate
-        // line there should not be any changes to text before a line feed
-        // which sort of seems to be implied by the current value of ch:
-
-        // Check if there's an active MXP DEST - route to destination frame
-        if (mpHost->mMxpFrameManager.hasActiveDestination()) {
-            TConsole* destConsole = mpHost->mMxpFrameManager.getCurrentDestinationConsole();
-            if (destConsole && destConsole != mpHost->mpConsole) {
-                if (!mMudLine.isEmpty()) {
-                    destConsole->printFormatted(mMudLine, mMudBuffer, mLinkStore);
-                }
-                mMudLine.clear();
-                mMudBuffer.clear();
-                ++localBufferPosition;
-                // Skip creating lines in main console while destination is active
-                return true;
-            }
-        }
-
-        // Qt struggles to report blank lines on Windows to screen readers, this is a workaround
-        // https://bugreports.qt.io/browse/QTBUG-105035
-        if (Q_UNLIKELY(mMudLine.isEmpty())) {
-            if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::Hide) {
-                localBufferPosition++;
-                return true;
-            } else if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
-                // Note: we are using the background color for the
-                // foreground color as well so that we are transparent:
-                const TChar c(mBackGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
-                mMudLine.append(QChar::Space);
-                mMudBuffer.push_back(c);
-            }
-        }
-
-        if (static_cast<size_t>(mMudLine.size()) != mMudBuffer.size()) {
-            qWarning() << "TBuffer::translateToPlainText(...) WARNING: mismatch in new text "
-                          "data character and attribute data items!";
-        }
-        if (!lineBuffer.back().isEmpty()) {
-            if (!mMudLine.isEmpty()) {
-                lineBuffer << mMudLine;
-            } else {
-                if (ch == '\r') {
-                    ++localBufferPosition;
-                    return true; //empty timer posting
-                }
-                lineBuffer << QString();
-            }
-            buffer.push_back(mMudBuffer);
-            timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
-            if (ch == '\xff') {
-                promptBuffer.append(true);
-            } else {
-                promptBuffer.append(false);
-            }
-        } else {
-            if (!mMudLine.isEmpty()) {
-                lineBuffer.back().append(mMudLine);
-            } else {
-                if (ch == '\r') {
-                    ++localBufferPosition;
-                    return true; //empty timer posting
-                }
-                lineBuffer.back().append(QString());
-            }
-            buffer.back() = mMudBuffer;
-            timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
-            if (ch == '\xff') {
-                promptBuffer.back() = true;
-            } else {
-                promptBuffer.back() = false;
-            }
-        }
-        mMudLine.clear();
-        mMudBuffer.clear();
-        const int line = lineBuffer.size() - 1;
-        mCommitLineIndices.append(line);
-        if (!mSkipTriggerProcessing) {
-            mpHost->mpConsole->runTriggers(line);
-        }
-
-        // Only use of TBuffer::wrap(), breaks up new text
-        // NOTE: it MAY have been clobbered by the trigger engine!
-        // If deleteLine() was called in a trigger, 'line' may now be past the end
-        // of the buffer; clamp to the last valid line so that any text inserted
-        // via echo() into the preceding line (which may contain embedded '\n'
-        // characters from insertInLine) is still wrapped correctly.
-        const int lastValidLine = static_cast<int>(lineBuffer.size()) - 1;
-        const int wrapStartLine = (lastValidLine >= 0) ? std::min(line, lastValidLine) : 0;
-        const int addedLines = wrapLine(wrapStartLine, mWrapAt, mWrapIndent, mWrapHangingIndent);
-
-        // Skip logging if a trigger deleted the line that was being committed;
-        // deleteLines() has already adjusted the deferred logging state
-        if (mCommitLineIndices.takeLast() >= 0) {
-            log(lineBuffer.size() - 1, lineBuffer.size() - 1);
-        }
-
-        ++localBufferPosition;
-        // Suppress new empty line IFF echoes already created a new empty line
-        // i.e. add newline if no added lines or the lastline isn't empty
-        if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
-            std::deque<TChar> const newLine;
-            buffer.push_back(newLine);
-            lineBuffer.push_back(QString());
-            timeBuffer.push_back(QString());
-            promptBuffer << false;
-        }
-
-        if (static_cast<int>(buffer.size()) > mLinesLimit) {
-            // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
-            // in all other methods where the following is used (because
-            // both need to monitor the number of lines of text in the
-            // buffer) the event that the former may be required to
-            // generate is NOT used for the TMainConsole case whereas this
-            // (translateToPlainText(...)) method is ONLY for that one:
-            shrinkBuffer();
-        }
-
-        applyPendingSelectionStyling();
-
-        return true;
+    if (!CHAR_IS_COMMIT_CHAR(ch)) {
+        return false;
     }
-    return false;
+
+    // DE: MUD Zeilen werden immer am Zeilenanfang geschrieben
+    // EN: MUD lines are always written at the beginning of the line
+
+    // FIXME: This is the point where we should renormalise the new text
+    // data - of course there is the theoretical chance that the new
+    // text would alter the prior contents but as that is on a separate
+    // line there should not be any changes to text before a line feed
+    // which sort of seems to be implied by the current value of ch:
+
+    // Check if there's an active MXP DEST - route to destination frame
+    if (mpHost->mMxpFrameManager.hasActiveDestination()) {
+        TConsole* destConsole = mpHost->mMxpFrameManager.getCurrentDestinationConsole();
+        if (destConsole && destConsole != mpHost->mpConsole) {
+            flushPendingServerWrapJoin();
+            if (!mMudLine.isEmpty()) {
+                destConsole->printFormatted(mMudLine, mMudBuffer, mLinkStore);
+            }
+            mMudLine.clear();
+            mMudBuffer.clear();
+            ++localBufferPosition;
+            // Skip creating lines in main console while destination is active
+            return true;
+        }
+    }
+
+    if (mpHost->mUndoServerWrap && isFromServer && ch == '\n' && !forcedLineBreak && !mMudLine.isEmpty()) {
+        // The game wraps its own output and this is a genuine newline from
+        // it: a segment that runs right up to the game's wrap column is
+        // probably not a whole line, so hold it back and join its
+        // continuation on instead of committing it. Everything else -
+        // prompts ('\xff' from GA/EOR), timer-flushed fragments ('\r'),
+        // MXP <br> breaks and blank lines - is a real line boundary.
+        if (!mServerWrapPendingLine.isEmpty() && ((mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace()) || !looksLikeWrappedProse(mMudLine))) {
+            // A continuation of wrapped prose starts with a word - or with
+            // the single space some games move the break to instead of
+            // swallowing it. Deeper indentation or a symbol-heavy line
+            // instead belongs to centered ASCII art, menu columns, dividers
+            // and the like, so the held line was complete after all:
+            flushPendingServerWrapJoin();
+        }
+        const bool segmentLooksWrapped = endsAtServerWrapColumn() && looksLikeWrappedProse(mMudLine);
+        joinPendingServerWrapOntoCurrent();
+        if (segmentLooksWrapped && mMudLine.size() <= csmServerWrapMaxJoinedLength) {
+            mServerWrapPendingLine.swap(mMudLine);
+            mServerWrapPendingBuffer.swap(mMudBuffer);
+            startServerWrapFlushTimer();
+            ++localBufferPosition;
+            return true;
+        }
+    } else {
+        // Any other kind of line ending means held text was a complete line
+        // after all - commit it on its own first:
+        flushPendingServerWrapJoin();
+    }
+
+    if (isFromServer && ch == '\n' && !forcedLineBreak && !mpHost->mUndoServerWrap && !mpHost->mServerWrapHintShown) {
+        recordLineLengthForWrapDetection(mMudLine.size());
+    }
+
+    QString line;
+    std::deque<TChar> chars;
+    line.swap(mMudLine);
+    chars.swap(mMudBuffer);
+    commitLineData(std::move(line), std::move(chars), ch);
+    ++localBufferPosition;
+    return true;
+}
+
+void TBuffer::commitLineData(QString line, std::deque<TChar> chars, const char ch)
+{
+    // Qt struggles to report blank lines on Windows to screen readers, this is a workaround
+    // https://bugreports.qt.io/browse/QTBUG-105035
+    if (Q_UNLIKELY(line.isEmpty())) {
+        if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::Hide) {
+            return;
+        } else if (mpHost->mBlankLineBehaviour == Host::BlankLineBehaviour::ReplaceWithSpace) {
+            // Note: we are using the background color for the
+            // foreground color as well so that we are transparent:
+            const TChar c(mBackGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
+            line.append(QChar::Space);
+            chars.push_back(c);
+        }
+    }
+
+    if (static_cast<size_t>(line.size()) != chars.size()) {
+        qWarning() << "TBuffer::translateToPlainText(...) WARNING: mismatch in new text "
+                      "data character and attribute data items!";
+    }
+    if (!lineBuffer.back().isEmpty()) {
+        if (!line.isEmpty()) {
+            lineBuffer << line;
+        } else {
+            if (ch == '\r') {
+                return; //empty timer posting
+            }
+            lineBuffer << QString();
+        }
+        buffer.push_back(chars);
+        timeBuffer << QTime::currentTime().toString(mudlet::smTimeStampFormat);
+        if (ch == '\xff') {
+            promptBuffer.append(true);
+        } else {
+            promptBuffer.append(false);
+        }
+    } else {
+        if (!line.isEmpty()) {
+            lineBuffer.back().append(line);
+        } else {
+            if (ch == '\r') {
+                return; //empty timer posting
+            }
+            lineBuffer.back().append(QString());
+        }
+        buffer.back() = chars;
+        timeBuffer.back() = QTime::currentTime().toString(mudlet::smTimeStampFormat);
+        if (ch == '\xff') {
+            promptBuffer.back() = true;
+        } else {
+            promptBuffer.back() = false;
+        }
+    }
+    const int lineIndex = lineBuffer.size() - 1;
+    mCommitLineIndices.append(lineIndex);
+    if (!mSkipTriggerProcessing) {
+        mpHost->mpConsole->runTriggers(lineIndex);
+    }
+
+    // Only use of TBuffer::wrap(), breaks up new text
+    // NOTE: it MAY have been clobbered by the trigger engine!
+    // If deleteLine() was called in a trigger, 'lineIndex' may now be past the
+    // end of the buffer; clamp to the last valid line so that any text
+    // inserted via echo() into the preceding line (which may contain embedded
+    // '\n' characters from insertInLine) is still wrapped correctly.
+    const int lastValidLine = static_cast<int>(lineBuffer.size()) - 1;
+    const int wrapStartLine = (lastValidLine >= 0) ? std::min(lineIndex, lastValidLine) : 0;
+    const int addedLines = wrapLine(wrapStartLine, mWrapAt, mWrapIndent, mWrapHangingIndent);
+
+    // Skip logging if a trigger deleted the line that was being committed;
+    // deleteLines() has already adjusted the deferred logging state
+    if (mCommitLineIndices.takeLast() >= 0) {
+        log(lineBuffer.size() - 1, lineBuffer.size() - 1);
+    }
+
+    // Suppress new empty line IFF echoes already created a new empty line
+    // i.e. add newline if no added lines or the lastline isn't empty
+    if (addedLines == 0 || !lineBuffer.back().isEmpty()) {
+        std::deque<TChar> const newLine;
+        buffer.push_back(newLine);
+        lineBuffer.push_back(QString());
+        timeBuffer.push_back(QString());
+        promptBuffer << false;
+    }
+
+    if (static_cast<int>(buffer.size()) > mLinesLimit) {
+        // Whilst we also include a call to TConsole::handleLinesOverflowEvent(...)
+        // in all other methods where the following is used (because
+        // both need to monitor the number of lines of text in the
+        // buffer) the event that the former may be required to
+        // generate is NOT used for the TMainConsole case whereas this
+        // (translateToPlainText(...)) method is ONLY for that one:
+        shrinkBuffer();
+    }
+
+    applyPendingSelectionStyling();
+}
+
+// A line whose length is within csmServerWrapSlack characters below the
+// configured column ends where the game's own word wrap would have broken it
+// (the game breaks at the last space that fits, so wrapped segments fall up
+// to a word short of the column):
+bool TBuffer::endsAtServerWrapColumn() const
+{
+    const qsizetype width = mpHost->mUndoServerWrapWidth;
+    const qsizetype len = mMudLine.size();
+    return len <= width && len >= width - csmServerWrapSlack;
+}
+
+// Word-wrapped prose breaks between words, so a wrapped segment ends in a
+// word (or a sentence mark that happened to fall on the wrap column) and
+// consists mostly of letters. ASCII art, dividers and table borders - which
+// also run right up to the screen width - end in and are full of symbols;
+// those must not be glued back together:
+bool TBuffer::looksLikeWrappedProse(const QString& line) const
+{
+    // Some games keep the space they broke the line at rather than
+    // swallowing it - but only ever the one. A run of trailing whitespace
+    // means padding (or a blank line), which word wrap never produces:
+    qsizetype end = line.size();
+    while (end > 0 && line.at(end - 1).isSpace()) {
+        --end;
+    }
+    if (end == 0 || line.size() - end > 1) {
+        return false;
+    }
+    static const QString allowedFinals = qsl(".,;:!?'\")");
+    const QChar last = line.at(end - 1);
+    if (!last.isLetterOrNumber() && !allowedFinals.contains(last)) {
+        return false;
+    }
+    qsizetype letters = 0;
+    qsizetype nonSpace = 0;
+    for (const QChar& c : line) {
+        if (c.isSpace()) {
+            continue;
+        }
+        ++nonSpace;
+        if (c.isLetterOrNumber()) {
+            ++letters;
+        }
+    }
+    return nonSpace > 0 && letters * 10 >= nonSpace * 6;
+}
+
+void TBuffer::joinPendingServerWrapOntoCurrent()
+{
+    if (mServerWrapPendingLine.isEmpty()) {
+        return;
+    }
+    // The game's wrapper swallowed the space it broke the line at:
+    if (!mServerWrapPendingLine.endsWith(QChar::Space) && !mMudLine.startsWith(QChar::Space)) {
+        mServerWrapPendingLine.append(QChar::Space);
+        mServerWrapPendingBuffer.push_back(mServerWrapPendingBuffer.empty() ? TChar(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags()) : mServerWrapPendingBuffer.back());
+    }
+    mMudLine.prepend(mServerWrapPendingLine);
+    mMudBuffer.insert(mMudBuffer.begin(), mServerWrapPendingBuffer.begin(), mServerWrapPendingBuffer.end());
+    mServerWrapPendingLine.clear();
+    mServerWrapPendingBuffer.clear();
+}
+
+void TBuffer::flushPendingServerWrapJoin()
+{
+    if (mServerWrapPendingLine.isEmpty()) {
+        return;
+    }
+    QString line;
+    std::deque<TChar> chars;
+    line.swap(mServerWrapPendingLine);
+    chars.swap(mServerWrapPendingBuffer);
+    commitLineData(std::move(line), std::move(chars), '\n');
+}
+
+void TBuffer::startServerWrapFlushTimer()
+{
+    if (!mpServerWrapFlushTimer) {
+        if (!mpConsole) {
+            return;
+        }
+        mpServerWrapFlushTimer = new QTimer(mpConsole);
+        mpServerWrapFlushTimer->setSingleShot(true);
+        mpServerWrapFlushTimer->setInterval(csmServerWrapFlushDelayMs);
+        QObject::connect(mpServerWrapFlushTimer, &QTimer::timeout, mpConsole, [this]() {
+            if (!mpHost || !mpHost->mpConsole) {
+                return;
+            }
+            // Mimic TMainConsole::printOnDisplay() so that trigger-context
+            // functions behave the same as for any other committed line:
+            mpHost->mpConsole->mTriggerEngineMode = true;
+            flushPendingServerWrapJoin();
+            mpHost->mpConsole->mTriggerEngineMode = false;
+        });
+    }
+    mpServerWrapFlushTimer->start();
+}
+
+// Called for every genuine game line while mUndoServerWrap is off: when line
+// lengths pile up against a stable ceiling column, the game is most likely
+// wrapping its own output, so - once per profile - point out the option that
+// undoes that:
+void TBuffer::recordLineLengthForWrapDetection(const qsizetype length)
+{
+    if (length < 40) {
+        // too short to carry any signal
+        return;
+    }
+    ++mWrapDetectCounts[length];
+    if (++mWrapDetectSamples % 100) {
+        return;
+    }
+
+    // The ceiling is the longest line length seen more than incidentally:
+    qsizetype ceiling = 0;
+    for (auto it = mWrapDetectCounts.constBegin(); it != mWrapDetectCounts.constEnd(); ++it) {
+        if (it.value() >= 3) {
+            ceiling = it.key();
+        }
+    }
+    if (ceiling < 60 || ceiling > 160) {
+        return;
+    }
+    int atCeiling = 0;
+    int beyondCeiling = 0;
+    for (auto it = mWrapDetectCounts.constBegin(); it != mWrapDetectCounts.constEnd(); ++it) {
+        if (it.key() > ceiling) {
+            beyondCeiling += it.value();
+        } else if (it.key() >= ceiling - 8) {
+            atCeiling += it.value();
+        }
+    }
+    if (atCeiling < csmWrapDetectThreshold || beyondCeiling > 2) {
+        return;
+    }
+
+    mpHost->mServerWrapHintShown = true;
+    TEvent detectedEvent{};
+    detectedEvent.mArgumentList.append(qsl("sysServerWrapDetected"));
+    detectedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    detectedEvent.mArgumentList.append(QString::number(ceiling));
+    detectedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mpHost->raiseEvent(detectedEvent);
+    //: %1 is the screen column that the game appears to wrap its lines at
+    mpHost->postMessage(QObject::tr("[ INFO ]  - This game seems to wrap its own lines at %1 characters, which makes\n"
+                                    "triggers awkward to write. Mudlet can undo that so that triggers always see\n"
+                                    "whole lines and wrapping follows your window size instead - enable \"Undo the\n"
+                                    "game's own wrapping\" in the settings (Main display), or run:\n"
+                                    "lua setConfig(\"undoServerWrap\", true)")
+                                .arg(QString::number(ceiling)));
 }
 
 void TBuffer::processMxpWatchdogCallback()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1405,6 +1405,9 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
             // and the like, so the held line was complete after all:
             flushPendingServerWrapJoin();
         }
+        // Deliberately judged before the pending line is joined on: ending at
+        // the game's wrap column is a property of the segment as the game
+        // sent it, not of the longer joined line.
         const bool segmentLooksWrapped = endsAtServerWrapColumn() && proseSegment;
         joinPendingServerWrapOntoCurrent();
         if (segmentLooksWrapped && mMudLine.size() <= csmServerWrapMaxJoinedLength) {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1659,12 +1659,6 @@ void TBuffer::recordLineLengthForWrapDetection(const qsizetype length)
     }
 
     mpHost->mServerWrapHintShown = true;
-    TEvent detectedEvent{};
-    detectedEvent.mArgumentList.append(qsl("sysServerWrapDetected"));
-    detectedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    detectedEvent.mArgumentList.append(QString::number(ceiling));
-    detectedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    mpHost->raiseEvent(detectedEvent);
 
     // Deferred so the hint does not interleave with the line being committed:
     QPointer<Host> hostGuard = mpHost;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1675,7 +1675,7 @@ void TBuffer::recordLineLengthForWrapDetection(const qsizetype length)
         QString confirmation = QObject::tr("Done - Mudlet now undoes the game's wrapping, and triggers see whole lines.");
         // the text is embedded in a double-quoted Lua string:
         confirmation.replace(QChar('\\'), qsl("\\\\")).replace(QChar('"'), qsl("\\\""));
-        const QString clickAction = qsl("setConfig(\"undoServerWrapWidth\", %1) setConfig(\"undoServerWrap\", true) cecho(\"\\n<light_green>%2\\n\")").arg(QString::number(ceiling), confirmation);
+        const QString clickAction = qsl("setConfig(\"undoServerWrapWidth\", %1) setConfig(\"undoServerWrap\", true) cecho(\"\\n<green>%2\\n\")").arg(QString::number(ceiling), confirmation);
         QStringList func(clickAction);
         //: Tooltip on the link that enables the option to undo the game's own line wrapping
         QStringList hint(QObject::tr("Turn on \"Undo the game's own wrapping\" - also found in the settings under Main display"));

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1665,13 +1665,31 @@ void TBuffer::recordLineLengthForWrapDetection(const qsizetype length)
     detectedEvent.mArgumentList.append(QString::number(ceiling));
     detectedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
     mpHost->raiseEvent(detectedEvent);
-    //: %1 is the screen column that the game appears to wrap its lines at
-    mpHost->postMessage(QObject::tr("[ INFO ]  - This game seems to wrap its own lines at %1 characters, which makes\n"
-                                    "triggers awkward to write. Mudlet can undo that so that triggers always see\n"
-                                    "whole lines and wrapping follows your window size instead - enable \"Undo the\n"
-                                    "game's own wrapping\" in the settings (Main display), or run:\n"
-                                    "lua setConfig(\"undoServerWrap\", true)")
-                                .arg(QString::number(ceiling)));
+
+    // Deferred so the hint does not interleave with the line being committed:
+    QPointer<Host> hostGuard = mpHost;
+    QTimer::singleShot(0, mpConsole, [hostGuard, ceiling]() {
+        if (!hostGuard || !hostGuard->mpConsole) {
+            return;
+        }
+        //: %1 is the screen column that the game appears to wrap its lines at
+        hostGuard->postMessage(QObject::tr("[ INFO ]  - This game seems to wrap its own lines at %1 characters, which\n"
+                                           "makes triggers awkward to write. Mudlet can undo that, so that triggers\n"
+                                           "always see whole lines and wrapping follows your window size instead:")
+                                       .arg(QString::number(ceiling)));
+        //: Confirmation shown after the player clicks the link that enables undoing the game's own line wrapping
+        QString confirmation = QObject::tr("Done - Mudlet now undoes the game's wrapping, and triggers see whole lines.");
+        // the text is embedded in a double-quoted Lua string:
+        confirmation.replace(QChar('\\'), qsl("\\\\")).replace(QChar('"'), qsl("\\\""));
+        const QString clickAction = qsl("setConfig(\"undoServerWrapWidth\", %1) setConfig(\"undoServerWrap\", true) cecho(\"\\n<light_green>%2\\n\")").arg(QString::number(ceiling), confirmation);
+        QStringList func(clickAction);
+        //: Tooltip on the link that enables the option to undo the game's own line wrapping
+        QStringList hint(QObject::tr("Turn on \"Undo the game's own wrapping\" - also found in the settings under Main display"));
+        //: Clickable link shown in the main window when a game that wraps its own lines is detected
+        const QString linkText = QObject::tr("  ➜ Click here to turn that on now");
+        hostGuard->mpConsole->echoLink(linkText, func, hint, false);
+        hostGuard->mpConsole->print("\n");
+    });
 }
 
 void TBuffer::processMxpWatchdogCallback()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -253,6 +253,10 @@ TBuffer::TBuffer(const TBuffer& other)
 , mAltFont(other.mAltFont)
 , mMudLine(other.mMudLine)
 , mMudBuffer(other.mMudBuffer)
+, mServerWrapPendingLine(other.mServerWrapPendingLine)
+, mServerWrapPendingBuffer(other.mServerWrapPendingBuffer)
+, mWrapDetectCounts(other.mWrapDetectCounts)
+, mWrapDetectSamples(other.mWrapDetectSamples)
 , mIncompleteSequenceBytes(other.mIncompleteSequenceBytes)
 , lastLoggedFromLine(other.lastLoggedFromLine)
 , lastloggedToLine(other.lastloggedToLine)
@@ -337,6 +341,10 @@ TBuffer& TBuffer::operator=(const TBuffer& other)
         mAltFont = other.mAltFont;
         mMudLine = other.mMudLine;
         mMudBuffer = other.mMudBuffer;
+        mServerWrapPendingLine = other.mServerWrapPendingLine;
+        mServerWrapPendingBuffer = other.mServerWrapPendingBuffer;
+        mWrapDetectCounts = other.mWrapDetectCounts;
+        mWrapDetectSamples = other.mWrapDetectSamples;
         mIncompleteSequenceBytes = other.mIncompleteSequenceBytes;
         lastLoggedFromLine = other.lastLoggedFromLine;
         lastloggedToLine = other.lastloggedToLine;
@@ -1388,7 +1396,8 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
         // continuation on instead of committing it. Everything else -
         // prompts ('\xff' from GA/EOR), timer-flushed fragments ('\r'),
         // MXP <br> breaks and blank lines - is a real line boundary.
-        if (!mServerWrapPendingLine.isEmpty() && ((mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace()) || !looksLikeWrappedProse(mMudLine))) {
+        const bool proseSegment = looksLikeWrappedProse(mMudLine);
+        if (!mServerWrapPendingLine.isEmpty() && ((mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace()) || !proseSegment)) {
             // A continuation of wrapped prose starts with a word - or with
             // the single space some games move the break to instead of
             // swallowing it. Deeper indentation or a symbol-heavy line
@@ -1396,7 +1405,7 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
             // and the like, so the held line was complete after all:
             flushPendingServerWrapJoin();
         }
-        const bool segmentLooksWrapped = endsAtServerWrapColumn() && looksLikeWrappedProse(mMudLine);
+        const bool segmentLooksWrapped = endsAtServerWrapColumn() && proseSegment;
         joinPendingServerWrapOntoCurrent();
         if (segmentLooksWrapped && mMudLine.size() <= csmServerWrapMaxJoinedLength) {
             mServerWrapPendingLine.swap(mMudLine);
@@ -1541,17 +1550,25 @@ bool TBuffer::endsAtServerWrapColumn() const
 bool TBuffer::looksLikeWrappedProse(const QString& line) const
 {
     // Some games keep the space they broke the line at rather than
-    // swallowing it - but only ever the one. A run of trailing whitespace
-    // means padding (or a blank line), which word wrap never produces:
+    // swallowing it - but only ever the one, except right after the end of
+    // a sentence: games that put two spaces after a full stop keep both
+    // when the wrap point lands there. Any longer run of trailing
+    // whitespace means padding (or a blank line), which word wrap never
+    // produces:
     qsizetype end = line.size();
     while (end > 0 && line.at(end - 1).isSpace()) {
         --end;
     }
-    if (end == 0 || line.size() - end > 1) {
+    if (end == 0) {
         return false;
     }
     static const QString allowedFinals = qsl(".,;:!?'\")");
+    static const QString sentenceFinals = qsl(".!?'\")");
     const QChar last = line.at(end - 1);
+    const qsizetype trailingSpaces = line.size() - end;
+    if (trailingSpaces > 2 || (trailingSpaces == 2 && !sentenceFinals.contains(last))) {
+        return false;
+    }
     if (!last.isLetterOrNumber() && !allowedFinals.contains(last)) {
         return false;
     }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -46,6 +46,7 @@
 #include <string>
 
 class Host;
+class QTimer;
 class TConsole;
 
 class WrapInfo
@@ -328,6 +329,9 @@ public:
     void clearLastLine();
     QPoint getEndPos();
     void translateToPlainText(std::string& incoming, bool isFromServer = false);
+    // Commits a line held back by the server-wrap undoing (Host::mUndoServerWrap)
+    // - public so that the connection teardown can flush it:
+    void flushPendingServerWrapJoin();
     void flushPendingDestinationContent();
     void resetCurrentTextFormat();
     void append(const QString& chunk, int sub_start, int sub_end, const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
@@ -395,7 +399,13 @@ private:
     void decodeSGR48(const QStringList&, bool isColonSeparated = true);
     void decodeOSC(const QString&);
     void resetColors();
-    bool commitLine(char ch, size_t& localBufferPosition);
+    bool commitLine(char ch, size_t& localBufferPosition, bool isFromServer = false, bool forcedLineBreak = false);
+    void commitLineData(QString line, std::deque<TChar> chars, char ch);
+    bool endsAtServerWrapColumn() const;
+    bool looksLikeWrappedProse(const QString& line) const;
+    void joinPendingServerWrapOntoCurrent();
+    void startServerWrapFlushTimer();
+    void recordLineLengthForWrapDetection(qsizetype length);
     void processMxpWatchdogCallback();
     TChar::AttributeFlags computeCurrentAttributeFlags() const;
 
@@ -484,6 +494,19 @@ private:
 
     QString mMudLine;
     std::deque<TChar> mMudBuffer;
+    // A line that ended at the game's own wrap column (Host::mUndoServerWrap)
+    // is held here instead of being committed, so its continuation can be
+    // joined back on and triggers run once over the whole logical line:
+    QString mServerWrapPendingLine;
+    std::deque<TChar> mServerWrapPendingBuffer;
+    // Commits a held line if the game goes quiet without completing it - a
+    // full-width line that really was the end of the output:
+    QPointer<QTimer> mpServerWrapFlushTimer;
+    // Line length statistics used to detect that a game wraps its own output
+    // even though Host::mUndoServerWrap is off, to hint the option exists;
+    // keyed by line length, value is how often that length was seen:
+    QMap<qsizetype, int> mWrapDetectCounts;
+    int mWrapDetectSamples = 0;
     // Used to hold the unprocessed bytes that could be left at the end of a
     // packet if we detect that there should be more - will be prepended to the
     // next chunk of data - PROVIDED it is flagged as coming from the MUD Server
@@ -538,6 +561,19 @@ private:
 
     // Flag to skip trigger processing during documentation injection
     bool mSkipTriggerProcessing = false;
+
+    // Server wrap undoing: a line no shorter than this many characters below
+    // the configured wrap column is considered a wrapped segment (the game
+    // breaks at the last space, so segments fall a partial word short):
+    static constexpr int csmServerWrapSlack = 15;
+    // Stop joining once a logical line has grown this long - a runaway guard:
+    static constexpr qsizetype csmServerWrapMaxJoinedLength = 10000;
+    // How long to hold a full-width line for its continuation before deciding
+    // it really was complete:
+    static constexpr int csmServerWrapFlushDelayMs = 300;
+    // Wrap detection hint: how many lines ending within 8 characters of a
+    // stable ceiling column are needed before suggesting mUndoServerWrap:
+    static constexpr int csmWrapDetectThreshold = 40;
 
     // Timestamp to prevent duplicate OSC 8 documentation injection
     qint64 mLastOSC8DocsInjectionTime = 0;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7621,6 +7621,18 @@ int TLuaInterpreter::setConfig(lua_State* L)
         host.mEnableNAWS = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("undoServerWrap")) {
+        host.mUndoServerWrap = getVerifiedBool(L, __func__, 2, "value");
+        return success();
+    }
+    if (key == qsl("undoServerWrapWidth")) {
+        const int width = getVerifiedInt(L, __func__, 2, "value");
+        if (width < 20 || width > 500) {
+            return warnArgumentValue(L, __func__, qsl("width %1 is outside of the supported range of 20 to 500").arg(width));
+        }
+        host.mUndoServerWrapWidth = width;
+        return success();
+    }
     if (key == qsl("askTlsAvailable")) {
         host.mAskTlsAvailable = getVerifiedBool(L, __func__, 2, "value");
         return success();
@@ -8026,6 +8038,14 @@ int TLuaInterpreter::getConfig(lua_State* L)
             {qsl("enableNAWS"),
              [&]() {
                  lua_pushboolean(L, host.mEnableNAWS);
+             }},
+            {qsl("undoServerWrap"),
+             [&]() {
+                 lua_pushboolean(L, host.mUndoServerWrap);
+             }},
+            {qsl("undoServerWrapWidth"),
+             [&]() {
+                 lua_pushnumber(L, host.mUndoServerWrapWidth);
              }},
             {qsl("logDirectory"),
              [&]() {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -441,6 +441,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mEnableMNES") = pHost->mEnableMNES ? "yes" : "no";
     host.append_attribute("mEnableMXP") = pHost->mEnableMXP ? "yes" : "no";
     host.append_attribute("mEnableNAWS") = pHost->mEnableNAWS ? "yes" : "no";
+    host.append_attribute("mUndoServerWrap") = pHost->mUndoServerWrap ? "yes" : "no";
+    host.append_attribute("mServerWrapHintShown") = pHost->mServerWrapHintShown ? "yes" : "no";
     host.append_attribute("mEnableCHARSET") = pHost->mEnableCHARSET ? "yes" : "no";
     host.append_attribute("mEnableNEWENVIRON") = pHost->mEnableNEWENVIRON ? "yes" : "no";
     host.append_attribute("mMapStrongHighlight") = pHost->mMapStrongHighlight ? "yes" : "no";
@@ -604,6 +606,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("wrapAt").text().set(QString::number(pHost->mWrapAt).toUtf8().constData());
         host.append_child("wrapIndentCount").text().set(QString::number(pHost->mWrapIndentCount).toUtf8().constData());
         host.append_child("wrapHangingIndentCount").text().set(QString::number(pHost->mWrapHangingIndentCount).toUtf8().constData());
+        host.append_child("undoServerWrapWidth").text().set(QString::number(pHost->mUndoServerWrapWidth).toUtf8().constData());
         host.append_child("consoleBufferSize").text().set(QString::number(pHost->mConsoleBufferSize).toUtf8().constData());
         host.append_child("useMaxConsoleBufferSize").text().set(pHost->mUseMaxConsoleBufferSize ? "yes" : "no");
         host.append_child("mFgColor").text().set(pHost->mFgColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -733,6 +733,8 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttributeWithDefault(qsl("mEnableMNES"), pHost->mEnableMNES, false);
     setBoolAttributeWithDefault(qsl("mEnableMXP"), pHost->mEnableMXP, getBoolValueFromLegacyAttributeOrDefault(qsl("mFORCE_MXP_NEGOTIATION_OFF"), true, true));
     setBoolAttributeWithDefault(qsl("mEnableNAWS"), pHost->mEnableNAWS, true);
+    setBoolAttributeWithDefault(qsl("mUndoServerWrap"), pHost->mUndoServerWrap, false);
+    setBoolAttributeWithDefault(qsl("mServerWrapHintShown"), pHost->mServerWrapHintShown, false);
     setBoolAttributeWithDefault(qsl("mEnableCHARSET"), pHost->mEnableCHARSET, getBoolValueFromLegacyAttributeOrDefault(qsl("mFORCE_CHARSET_NEGOTIATION_OFF"), true, true));
     setBoolAttributeWithDefault(qsl("mEnableNEWENVIRON"), pHost->mEnableNEWENVIRON, getBoolValueFromLegacyAttributeOrDefault(qsl("forceNewEnvironNegotiationOff"), true, true));
 
@@ -1132,6 +1134,8 @@ void XMLimport::readHost(Host* pHost)
                 pHost->mWrapIndentCount = readElementText().toInt();
             } else if (name() == qsl("wrapHangingIndentCount")) {
                 pHost->mWrapHangingIndentCount = readElementText().toInt();
+            } else if (name() == qsl("undoServerWrapWidth")) {
+                pHost->mUndoServerWrapWidth = qBound(20, readElementText().toInt(), 500);
             } else if (name() == qsl("consoleBufferSize")) {
                 pHost->mConsoleBufferSize = readElementText().toInt();
             } else if (name() == qsl("useMaxConsoleBufferSize")) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -724,6 +724,11 @@ void cTelnet::slot_socketDisconnected()
     }
 
     postData();
+    if (mpHost->mpConsole) {
+        // A line held back for server-wrap undoing is complete now that the
+        // connection is gone - commit it before the disconnect messages:
+        mpHost->mpConsole->buffer.flushPendingServerWrapJoin();
+    }
 
     emit signal_disconnected(mpHost);
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -31,6 +31,7 @@
 #include "TAction.h"
 #include "TAlias.h"
 #include "TConsole.h"
+#include "TFeatureCallout.h"
 #include "TKey.h"
 #include "TMainConsole.h"
 #include "TMap.h"
@@ -200,6 +201,9 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         disableHostDetails();
         clearHostDetails();
     }
+
+    connect(tabWidget, &QTabWidget::currentChanged, this, &dlgProfilePreferences::slot_showNewFeatureCallouts);
+    slot_showNewFeatureCallouts();
 
 #if defined(INCLUDE_UPDATER)
     if (mudlet::self()->developmentVersion && !qEnvironmentVariableIsSet("DEV_UPDATER")) {
@@ -811,6 +815,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     wrap_at_spinBox->setValue(pHost->mWrapAt);
     indent_wrapped_spinBox->setValue(pHost->mWrapIndentCount);
     hanging_indent_wrapped_spinBox->setValue(pHost->mWrapHangingIndentCount);
+    checkBox_undoServerWrap->setChecked(pHost->mUndoServerWrap);
+    undo_server_wrap_width_spinBox->setValue(pHost->mUndoServerWrapWidth);
+    undo_server_wrap_width_spinBox->setEnabled(pHost->mUndoServerWrap);
+    connect(checkBox_undoServerWrap, &QCheckBox::toggled, undo_server_wrap_width_spinBox, &QWidget::setEnabled);
 
     console_buffer_size_spinBox->setValue(pHost->getConsoleBufferSize());
     checkBox_useMaxBufferSize->setChecked(pHost->getUseMaxConsoleBufferSize());
@@ -1701,6 +1709,8 @@ void dlgProfilePreferences::clearHostDetails()
 
     wrap_at_spinBox->clear();
     indent_wrapped_spinBox->clear();
+    checkBox_undoServerWrap->setChecked(false);
+    undo_server_wrap_width_spinBox->clear();
 
     show_sent_text_combobox->setCurrentIndex(static_cast<int>(Host::CommandEchoMode::ScriptControl));
     auto_clear_input_line_checkbox->setChecked(false);
@@ -3159,6 +3169,8 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->updateDisplayDimensions();
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mWrapHangingIndentCount = hanging_indent_wrapped_spinBox->value();
+        pHost->mUndoServerWrap = checkBox_undoServerWrap->isChecked();
+        pHost->mUndoServerWrapWidth = undo_server_wrap_width_spinBox->value();
 
         // Save console buffer settings and apply them
         const bool useMaxBuffer = checkBox_useMaxBufferSize->isChecked();
@@ -4885,6 +4897,20 @@ void dlgProfilePreferences::slot_toggleEnableClosedCaption(const bool state)
     }
 }
 
+
+void dlgProfilePreferences::slot_showNewFeatureCallouts()
+{
+    // The balloon only makes sense while its anchor can be seen:
+    if (tabWidget->currentWidget() != tab_display) {
+        return;
+    }
+    TFeatureCallout::maybeShow(qsl("undo-server-wrap"),
+                               checkBox_undoServerWrap,
+                               //: Title of a balloon pointing out a newly added feature
+                               tr("New: undo the game's own wrapping"),
+                               //: Body of the balloon, anchored to the option that rejoins lines the game server wrapped itself so that triggers match whole lines
+                               tr("Games that wrap their own lines make triggers fiddly. Mudlet can now undo that wrapping, so triggers always see whole lines."));
+}
 
 void dlgProfilePreferences::slot_changeWrapAt()
 {

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -142,6 +142,7 @@ private slots:
     void slot_changeShowLineFeedsAndParagraphs(bool);
     void slot_scriptSelected(int index);
     void slot_tabChanged(int tabIndex);
+    void slot_showNewFeatureCallouts();
     void slot_themeSelected(int index);
     void slot_setMapSymbolFont(const QFont&);
     void slot_setMapSymbolFontStrategy(bool);

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1265,6 +1265,7 @@ function getConfig(...)
       "enableMSSP",
       "enableMTTS",
       "enableMXP",
+      "enableNAWS",
       "f3SearchEnabled",
       "fixUnnecessaryLinebreaks",
       "forceNewEnvironNegotiationOff",
@@ -1292,6 +1293,8 @@ function getConfig(...)
       "specialForceGAOff",
       "specialForceMxpNegotiationOff",
       "specialForceMXPProcessorOn",      -- read-only in getConfig
+      "undoServerWrap",
+      "undoServerWrapWidth",
       "versionInTTYPE",
     }
     for _,v in ipairs(list) do

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1161,7 +1161,9 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>Word wrapping</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_groupBox_wrapping">
+         <layout class="QVBoxLayout" name="verticalLayout_groupBox_wrapping">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_groupBox_wrapping">
           <item>
            <widget class="QFrame" name="frame_wrap_at">
             <property name="frameShape">
@@ -1329,6 +1331,58 @@ you can use it but there could be issues with aligning columns of text</string>
              </item>
             </layout>
            </widget>
+          </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_undo_server_wrap">
+            <item>
+             <widget class="QCheckBox" name="checkBox_undoServerWrap">
+              <property name="toolTip">
+               <string>&lt;p&gt;Some games wrap their own lines and offer no way to turn that off, which makes triggers awkward to write: the text a trigger sees can be split mid-sentence. This option joins those wrapped lines back together before triggers run, so triggers always see whole lines and the wrapping above applies for display instead.&lt;/p&gt;&lt;p&gt;Set the column to the width the game wraps at (very often 80). Only lines from the game are affected.&lt;/p&gt;</string>
+              </property>
+              <property name="text">
+               <string>Undo the game's own wrapping at:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="undo_server_wrap_width_spinBox">
+              <property name="minimum">
+               <number>20</number>
+              </property>
+              <property name="maximum">
+               <number>500</number>
+              </property>
+              <property name="value">
+               <number>80</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_undo_server_wrap_characters">
+              <property name="text">
+               <string>characters</string>
+              </property>
+              <property name="buddy">
+               <cstring>undo_server_wrap_width_spinBox</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_undo_server_wrap">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1339,7 +1339,7 @@ you can use it but there could be issues with aligning columns of text</string>
             <item>
              <widget class="QCheckBox" name="checkBox_undoServerWrap">
               <property name="toolTip">
-               <string>&lt;p&gt;Some games wrap their own lines and offer no way to turn that off, which makes triggers awkward to write: the text a trigger sees can be split mid-sentence. This option joins those wrapped lines back together before triggers run, so triggers always see whole lines and the wrapping above applies for display instead.&lt;/p&gt;&lt;p&gt;Set the column to the width the game wraps at (very often 80). Only lines from the game are affected.&lt;/p&gt;</string>
+               <string>&lt;p&gt;Some games wrap their own lines and offer no way to turn that off, which makes triggers awkward to write: the text a trigger sees can be split mid-sentence. This option joins those wrapped lines back together before triggers run, so triggers always see whole lines and the wrapping above applies for display instead.&lt;/p&gt;&lt;p&gt;Set the column to the width the game wraps at (very often 80). Only lines from the game are affected.&lt;/p&gt;&lt;p&gt;&lt;i&gt;This feature is experimental: it tells wrapped prose apart from prompts, tables and ASCII art by their shape, so the occasional line may still be joined or left split when it should not be.&lt;/i&gt;&lt;/p&gt;</string>
               </property>
               <property name="text">
                <string>Undo the game's own wrapping at:</string>

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -15,11 +15,19 @@ set(FUNCTIONAL_TEST_SOURCES
     MainConsoleSelectionTest.cpp
     EnableDisableByNameTest.cpp
     GMCPCharLoginTest.cpp
+    UndoServerWrapTest.cpp
 )
 
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
 )
+
+# Manual replay tool for verifying mUndoServerWrap against captured game
+# output - built but deliberately not registered with ctest:
+add_executable(UndoServerWrapReplay UndoServerWrapReplay.cpp ${FUNCTIONAL_TEST_UTILS})
+add_dependencies(UndoServerWrapReplay ${LIB_MUDLET_TARGET})
+target_link_libraries(UndoServerWrapReplay PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
+set_target_properties(UndoServerWrapReplay PROPERTIES ENABLE_EXPORTS ON)
 
 foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     get_filename_component(test_name ${test_file} NAME_WE)

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -45,6 +45,16 @@ void TelnetServerStub::start(const QString& host, quint16 port)
     }
 }
 
+void TelnetServerStub::sendRaw(const QByteArray& data)
+{
+    if (!mpClient) {
+        qWarning() << "⚠️ sendRaw called without a connected client.";
+        return;
+    }
+    mpClient->write(data);
+    mpClient->flush();
+}
+
 void TelnetServerStub::onNewConnection()
 {
     QTcpSocket* client = nextPendingConnection();
@@ -53,6 +63,7 @@ void TelnetServerStub::onNewConnection()
         qWarning() << "⚠️ onNewConnection called but no pending connection.";
         return;
     }
+    mpClient = client;
     qInfo().noquote() << qsl("🔌 Client connected: %1").arg(client->peerAddress().toString());
 
     QPointer<QTcpSocket> safeClient = client;

--- a/test/functional_tests/TelnetServerStub.h
+++ b/test/functional_tests/TelnetServerStub.h
@@ -20,6 +20,7 @@
 #ifndef TELNET_SERVER_STUB_H
 #define TELNET_SERVER_STUB_H
 
+#include <QPointer>
 #include <QtNetwork/QTcpServer>
 #include <QtNetwork/QTcpSocket>
 #include <QTimer>
@@ -30,12 +31,17 @@ class TelnetServerStub : public QTcpServer
     Q_OBJECT
 
     QString mpWelcomeMessage = "";
+    QPointer<QTcpSocket> mpClient;
 
 public:
     explicit TelnetServerStub(QObject* parent = nullptr);
 
     void start(const QString& host, quint16 port);
     void setWelcomeMessage(const QString& message) { mpWelcomeMessage = message; }
+    // Sends bytes verbatim to the connected client - allows telnet control
+    // bytes like IAC GA to be included:
+    void sendRaw(const QByteArray& data);
+    bool clientConnected() const { return !mpClient.isNull(); }
 
 private slots:
     void onNewConnection();

--- a/test/functional_tests/UndoServerWrapReplay.cpp
+++ b/test/functional_tests/UndoServerWrapReplay.cpp
@@ -1,0 +1,213 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// Manual verification tool, not part of the ctest suite: replays a captured
+// game login stream (JSONL of {"t": seconds, "b64": chunk}) through the real
+// telnet/TBuffer pipeline and dumps the resulting buffer lines, so that the
+// mUndoServerWrap behaviour can be compared off vs on against real games.
+//
+// Environment:
+//   REPLAY_CAPTURE - path to the capture file (required)
+//   REPLAY_OUT     - path to write buffer dump to (required)
+//   REPLAY_UNWRAP  - "1" to enable mUndoServerWrap (default off)
+//   REPLAY_WIDTH   - wrap column to undo (default 80)
+//   REPLAY_PORT    - local stub port (default 4010)
+
+#include <QtTest/QtTest>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResources();
+
+class UndoServerWrapReplay : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    QString mProfileName;
+    QString mPort;
+    const QString mpLocalhost = "localhost";
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mPort = qEnvironmentVariable("REPLAY_PORT", qsl("4010"));
+        mProfileName = qsl("Replay-%1").arg(mPort);
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, mPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+    }
+
+    void test_replay()
+    {
+        const QString capturePath = qEnvironmentVariable("REPLAY_CAPTURE");
+        const QString outPath = qEnvironmentVariable("REPLAY_OUT");
+        if (capturePath.isEmpty() || outPath.isEmpty()) {
+            QSKIP("REPLAY_CAPTURE/REPLAY_OUT not set - this is a manual tool");
+        }
+        QFile captureFile(capturePath);
+        QVERIFY2(captureFile.open(QIODevice::ReadOnly), "cannot open capture file");
+        struct Chunk
+        {
+            double at;
+            QByteArray data;
+        };
+        QList<Chunk> chunks;
+        while (!captureFile.atEnd()) {
+            const QByteArray line = captureFile.readLine().trimmed();
+            if (line.isEmpty()) {
+                continue;
+            }
+            const QJsonObject object = QJsonDocument::fromJson(line).object();
+            chunks.append({object.value(qsl("t")).toDouble(), QByteArray::fromBase64(object.value(qsl("b64")).toString().toLatin1())});
+        }
+        QVERIFY2(!chunks.isEmpty(), "capture file holds no chunks");
+
+        startProfile(mProfileName, mpLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        if (qEnvironmentVariable("REPLAY_UNWRAP") == qsl("1")) {
+            host->mUndoServerWrap = true;
+            host->mUndoServerWrapWidth = qEnvironmentVariable("REPLAY_WIDTH", qsl("80")).toInt();
+        }
+        // Keep display wrapping out of the comparison - only logical lines
+        // are of interest:
+        host->mWrapAt = 1000;
+        host->mpConsole->buffer.mWrapAt = 1000;
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                3000));
+
+        double previous = chunks.first().at;
+        for (const auto& chunk : chunks) {
+            const int gap = qBound(0, static_cast<int>((chunk.at - previous) * 1000), 500);
+            if (gap > 15) {
+                QTest::qWait(gap);
+            }
+            previous = chunk.at;
+            mpServer->sendRaw(chunk.data);
+        }
+        // Give held lines, posting timers and the flush timer time to settle:
+        QTest::qWait(900);
+
+        QFile out(outPath);
+        QVERIFY2(out.open(QIODevice::WriteOnly | QIODevice::Truncate), "cannot open output file");
+        auto console = host->mpConsole;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            const bool prompt = (i < console->buffer.promptBuffer.size()) && console->buffer.promptBuffer.at(i);
+            out.write(prompt ? "P\t" : ".\t");
+            out.write(console->buffer.line(i).toUtf8());
+            out.write("\n");
+        }
+        out.close();
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mProfileName);
+        delete mudlet::self();
+    }
+
+private:
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available.");
+        }
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+};
+
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "UndoServerWrapReplay.moc"
+QTEST_MAIN(UndoServerWrapReplay)

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -1,0 +1,349 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResources();
+
+// Tests Host::mUndoServerWrap: rejoining of lines that the game server
+// hard-wrapped itself, so that triggers see whole logical lines
+class UndoServerWrapTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mpHostname = "Test-UndoServerWrap";
+    const QString mpPort = "4001";
+    const QString mpLocalhost = "localhost";
+
+    // 70 characters, inside the join band for a wrap column of 80:
+    const QString mSegment1 = QString(64, QChar('x')) + qsl(" alpha");
+    const QString mSegment2 = qsl("beta tail.");
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mpHostname);
+    }
+
+    void test_wrappedLinesStaySplitByDefault()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\n" + mSegment2.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(mSegment1), "wrapped segment was not committed as its own line with the option off");
+        QVERIFY2(waitForLineInBuffer(mSegment2), "continuation was not committed as its own line with the option off");
+        QVERIFY2(!bufferHasLine(mSegment1 + QChar::Space + mSegment2), "lines were joined although the option is off");
+    }
+
+    void test_wrappedLinesAreJoined()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\n" + mSegment2.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(mSegment1 + QChar::Space + mSegment2), "wrapped segment and its continuation were not joined into one logical line");
+    }
+
+    void test_promptIsNotJoined()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // The prompt is terminated by IAC GA rather than a newline; the
+        // full-width line before it must not swallow it:
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\nHP:100> \xff\xf9");
+
+        QVERIFY2(waitForLineInBuffer(mSegment1), "full-width final line was not committed on its own when followed by a prompt");
+        QVERIFY2(waitForLineInBuffer(qsl("HP:100> ")), "prompt was not committed on its own");
+    }
+
+    void test_loneFullWidthLineIsFlushed()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // Nothing follows, so the held line has to be committed by the
+        // flush timer once the game goes quiet:
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(mSegment1), "held full-width line was not flushed after the game went quiet");
+    }
+
+    void test_blankLineEndsParagraph()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\n\r\n" + mSegment2.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(mSegment1), "full-width line before a blank line was not committed on its own");
+        QVERIFY2(waitForLineInBuffer(mSegment2), "line after a blank line was not committed on its own");
+        QVERIFY2(!bufferHasLine(mSegment1 + QChar::Space + mSegment2), "lines were joined across a blank line");
+    }
+
+    void test_artAndIndentedLinesAreNotJoined()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // A full-width divider, a full-width prose line followed by an
+        // indented line (menu/centered art), and only then real wrapped
+        // prose - only the last pair may be joined:
+        const QString divider = QString(70, QChar('-'));
+        const QString indented = qsl("   [1] Enter the game");
+        mpServer->sendRaw(divider.toUtf8() + "\r\n" + mSegment1.toUtf8() + "\r\n" + indented.toUtf8() + "\r\n" + mSegment1.toUtf8() + "\r\n" + mSegment2.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(divider), "full-width divider was not committed on its own");
+        QVERIFY2(waitForLineInBuffer(indented), "indented line was joined although it cannot be a wrap continuation");
+        QVERIFY2(waitForLineInBuffer(mSegment1), "full-width line before an indented line was not committed on its own");
+        QVERIFY2(waitForLineInBuffer(mSegment1 + QChar::Space + mSegment2), "genuine wrapped prose was no longer joined");
+    }
+
+    void test_keptBreakSpaceStylesJoin()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // Some games keep the space they broke the line at - either at the
+        // end of the wrapped line or at the start of the continuation.
+        // Either way the rejoined line carries exactly one space:
+        mpServer->sendRaw(mSegment1.toUtf8() + " \r\nbeta trailing.\r\n");
+        QVERIFY2(waitForLineInBuffer(mSegment1 + qsl(" beta trailing.")), "trailing-space wrap style was not joined into one line");
+
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\n gamma leading.\r\n");
+        QVERIFY2(waitForLineInBuffer(mSegment1 + qsl(" gamma leading.")), "leading-space wrap style was not joined into one line");
+    }
+
+    void test_paddedLinesAreNotJoined()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // A line space-padded out to the wrap column is a table row or a
+        // colour fill, not a wrapped segment - word wrap never produces a
+        // run of trailing spaces:
+        const QString padded = qsl("2 - visit the game") + QString(60, QChar::Space);
+        mpServer->sendRaw(padded.toUtf8() + "\r\n" + mSegment2.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(padded), "padded line was not committed on its own");
+        QVERIFY2(waitForLineInBuffer(mSegment2), "line after a padded line was not committed on its own");
+    }
+
+    void test_wrapDetectionRaisesHint()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        QVERIFY(!host->mServerWrapHintShown);
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // 100 lines all ending hard against a 78 column ceiling:
+        QByteArray data;
+        const QByteArray line = QString(QString(72, QChar('y')) + qsl(" hello")).toUtf8();
+        for (int i = 0; i < 100; ++i) {
+            data += line + "\r\n";
+        }
+        mpServer->sendRaw(data);
+
+        QVERIFY2(QTest::qWaitFor(
+                         [&]() {
+                             return host->mServerWrapHintShown;
+                         },
+                         5000),
+                 "wrap detection did not fire on 100 lines against a stable ceiling");
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mpHostname);
+        delete mudlet::self();
+    }
+
+private:
+    void enableUndoServerWrap()
+    {
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mUndoServerWrap = true;
+        host->mUndoServerWrapWidth = 80;
+        // Keep Mudlet's own display wrap out of the way so that logical
+        // lines can be compared with buffer lines verbatim:
+        host->mpConsole->buffer.mWrapAt = 500;
+    }
+
+    // Utility function to manually start a profile like a user would do via the
+    // GUI
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    bool bufferHasLine(const QString& text)
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            if (console->buffer.line(i) == text) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Polls the console buffer until a line exactly matching the expected text
+    // appears, with a timeout
+    bool waitForLineInBuffer(const QString& text, int timeoutMs = 5000)
+    {
+        return QTest::qWaitFor(
+                [&]() {
+                    return bufferHasLine(text);
+                },
+                timeoutMs);
+    }
+
+    // Utility function
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "UndoServerWrapTest.moc"
+QTEST_MAIN(UndoServerWrapTest)

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -210,6 +210,32 @@ private slots:
         QVERIFY2(waitForLineInBuffer(mSegment2), "line after a padded line was not committed on its own");
     }
 
+    void test_sentenceGapWrapJoins()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // Games that put two spaces after a full stop keep both when the
+        // wrap point lands right after a sentence - neither a held line
+        // nor a continuation ending in ".  " is padding:
+        const QString sentenceGap = QString(62, QChar('x')) + qsl(" alpha.  ");
+        mpServer->sendRaw(sentenceGap.toUtf8() + "\r\n" + mSegment2.toUtf8() + "\r\n");
+        QVERIFY2(waitForLineInBuffer(sentenceGap + mSegment2), "line ending in a sentence gap was mistaken for padding and not joined");
+
+        mpServer->sendRaw(mSegment1.toUtf8() + "\r\nbeta done.  \r\n");
+        QVERIFY2(waitForLineInBuffer(mSegment1 + qsl(" beta done.  ")), "continuation ending in a sentence gap was not joined onto the held line");
+
+        // Three or more trailing spaces are still padding, sentence or not:
+        const QString sentencePadded = QString(62, QChar('x')) + qsl(" alpha.") + QString(5, QChar::Space);
+        mpServer->sendRaw(sentencePadded.toUtf8() + "\r\n" + mSegment2.toUtf8() + "\r\n");
+        QVERIFY2(waitForLineInBuffer(sentencePadded), "sentence-final line padded with several spaces was not committed on its own");
+    }
+
     void test_wrapDetectionRaisesHint()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);


### PR DESCRIPTION
https://github.com/user-attachments/assets/49e8a176-899c-43fd-a931-6e04ab5b5efb

#### Brief overview of PR changes/additions
New opt-in profile option that rejoins lines the game hard-wrapped itself, so triggers see the whole logical line and Mudlet's own wrapping handles display. Enable in Settings → Main display, or `setConfig("undoServerWrap", true)`. Prompts, blank lines, MXP `<br>` and script-fed text never join, and prose/indentation gates keep ASCII art, menus and tables intact. A one-time callout points the option out, and games that look like they wrap raise a one-time hint with a click-to-enable link.

#### Motivation for adding to Mudlet
On games that can't disable server-side wrapping, triggers need fragile multiline patterns. This fixes it client-side - as far as we know, a first among MUD clients.

#### Other info (issues closed, discussion etc)
Tests added.