### PR TITLE
infrastructure: document ASan leak-suppressions usage for local builds

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -192,6 +192,16 @@ The project uses the `.clang-format` configuration in the repo root. This ensure
 
 For complete setup instructions on how to run static analysis during a build see, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Static_Analysis
 
+### Running ASan builds
+
+Local Linux builds enable AddressSanitizer by default (`src/cmake/EnableSanitizers.cmake`). When running Mudlet or its tests directly, always use the leak-suppressions list at the repo root so known third-party leaks (fontconfig, pango, GTK3, Qt platform integration) don't drown out real findings:
+
+```bash
+LSAN_OPTIONS=suppressions=/path/to/repo/asan-suppressions.txt:exitcode=0 ./src/mudlet
+```
+
+This mirrors what CI does in `.github/workflows/build-mudlet*.yml`. The ctest functional tests already set `ASAN_OPTIONS=detect_leaks=0` themselves.
+
 ### Debugging options
 
 `src/CMakeLists.txt` contains commented debugging defines for development (search "Debugging code inclusions"):


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- AI instructions (`docs/ai-instructions.md`, aka `CLAUDE.md`) now tell assistants to run ASan builds of Mudlet/tests with the repo-root `asan-suppressions.txt` via `LSAN_OPTIONS`

#### Motivation for adding to Mudlet
Local Linux builds enable ASan by default; without the suppressions, known third-party leaks (fontconfig, pango, GTK3, Qt) drown out real findings for AI-assisted runs.

#### Other info (issues closed, discussion etc)
Split out of #9458. Mirrors what CI already does in `.github/workflows/build-mudlet*.yml`.

**Test case:** Docs-only; check the rendered section reads correctly.