### PR TITLE
infrastructure: stop known ASan leak noise failing the password migration test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ set(UNIT_TESTS
     TAreaGridIndexTest
     TKeySequenceEditTest
     TEncodingHelperTest
+    PasswordMigrationTest
 )
 
 foreach(test_name ${UNIT_TESTS})
@@ -46,11 +47,6 @@ foreach(test_name ${UNIT_TESTS})
         ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
     )
 endforeach()
-
-add_executable(PasswordMigrationTest PasswordMigrationTest.cpp)
-add_dependencies(PasswordMigrationTest ${LIB_MUDLET_TARGET})
-target_link_libraries(PasswordMigrationTest PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
-add_test(NAME PasswordMigrationTest COMMAND $<TARGET_FILE:PasswordMigrationTest>)
 
 # Build-file consistency check. Independent of the Mudlet library: it only reads
 # src/CMakeLists.txt and the src/ directory, so it does not link LIB_MUDLET_TARGET.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Fold `PasswordMigrationTest` into the `UNIT_TESTS` loop in `test/CMakeLists.txt` so it gets `ASAN_OPTIONS=detect_leaks=0` like every other unit test

#### Motivation for adding to Mudlet
The test was the only one missing that property (left over from when it compiled its own sources), so local ASan builds failed it on ~24KB of GTK3/pango/fontconfig leaks from Qt's platform theme - none of them Mudlet's.

#### Other info (issues closed, discussion etc)
ASan's memory-error detection stays active; only the exit-time leak scan is disabled, matching all sibling tests.

**Test case:** On a Linux ASan build, `ctest -R PasswordMigrationTest` passes; without this change the bare binary exits 1 with a LeakSanitizer report of GTK3/fontconfig leaks.