### PR TITLE
fix: 200 byte leak when loading a map

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -608,6 +608,7 @@ bool TRoomDB::addArea(TArea* pA, const int id, const QString& name)
         return false;
     }
 
+    deleteDisplacedArea(id, pA);
     areas.insert(id, pA);
     areaNamesMap.insert(id, name);
     // Need to force recalculation of limits:
@@ -1309,7 +1310,23 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
 
 void TRoomDB::restoreSingleArea(int areaID, TArea* pA)
 {
+    deleteDisplacedArea(areaID, pA);
     areas[areaID] = pA;
+}
+
+// The default (-1) area created by our constructor gets overwritten when a
+// map that contains it is loaded - delete the displaced TArea so it does not
+// leak:
+void TRoomDB::deleteDisplacedArea(int areaID, TArea* pA)
+{
+    TArea* pExisting = areas.value(areaID);
+    if (!pExisting || pExisting == pA) {
+        return;
+    }
+    // Prevent TArea::~TArea() from re-entrantly calling removeArea(this),
+    // mirroring the pattern in TRoomDB::removeArea(int)
+    pExisting->mpRoomDB = nullptr;
+    delete pExisting;
 }
 
 bool TRoomDB::restoreSingleRoom(int i, TRoom* pT)

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -105,6 +105,7 @@ private:
     TRoomDB() = default;
 
     int createNewAreaID();
+    void deleteDisplacedArea(int, TArea*);
     bool __removeRoom(int id);
     void setAreaRooms(int, const QSet<int>&); // Used by XMLImport to fix rooms data after import
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Delete the TArea being displaced when a map restore or JSON map import overwrites an existing area entry (until now the old area leaked - present since 2015)
- Covers both leak paths: profile open restoring a saved map over the constructor-created default area, and `createMapper()` re-restoring an empty map

#### Motivation for adding to Mudlet
Fixes the Mudlet-side leak in the ASAN report from #9463; every profile open with a saved map leaked one TArea.

#### Other info (issues closed, discussion etc)
Fixes #9463. The remaining entries in that report are NVIDIA driver/fontconfig initialisation noise from system libraries, not Mudlet allocations.

**Test case:** With an ASAN testing build, open a profile that has a saved map, then quit - the LeakSanitizer report no longer shows a `TRoomDB::addArea`/`TMap::restore` leak. Verified before/after with `-DUSE_SANITIZER=Address`; full ctest suite green.