### PR TITLE
improve: embed leak suppressions file in Mudlet binary

### DIFF
--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -3,10 +3,28 @@
 # typically one-time initialization leaks or false positives from library
 # internal caching mechanisms.
 #
-# Usage: Set the LSAN_OPTIONS environment variable before running:
+# This file is embedded into sanitizer-enabled builds at compile time (see
+# LsanSuppressions.h.in and __lsan_default_suppressions in main.cpp), so
+# testing/PTB builds apply it automatically. To supply additional
+# suppressions at runtime:
 #   export LSAN_OPTIONS=suppressions=/path/to/asan-suppressions.txt
 #
+# Prefer listing the modules that ALLOCATE the leaked memory (graphics
+# drivers, font stacks, theme engines). Be wary of adding libraries that
+# appear mid-stack while dispatching events into Mudlet code (libX11, libxcb,
+# Qt modules) - a suppression matches if ANY frame does, so those can hide
+# genuine Mudlet leaks too.
+#
 # See: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
+
+# ==============================================================================
+# GPU driver leaks
+# One-time initialization allocations in the NVIDIA driver (cuInit is invoked
+# via FFmpeg/Qt Multimedia) and in Mesa's DRI drivers
+# ==============================================================================
+leak:libcuda.so
+leak:nvidia
+leak:_dri.so
 
 # ==============================================================================
 # Fontconfig library leaks

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -764,6 +764,18 @@ if(USE_UPDATER)
   target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif(USE_UPDATER)
 
+# Embed the LeakSanitizer suppression list into the binary so that
+# sanitizer-enabled builds (PTBs, testing AppImages) filter third-party noise
+# out of leak reports without needing LSAN_OPTIONS set at runtime; picked up
+# by __lsan_default_suppressions() in main.cpp
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${mudlet_SOURCE_DIR}/asan-suppressions.txt")
+file(READ "${mudlet_SOURCE_DIR}/asan-suppressions.txt" MUDLET_LSAN_SUPPRESSIONS_CONTENT)
+string(REPLACE "\\" "\\\\" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPRESSIONS_CONTENT}")
+string(REPLACE "\"" "\\\"" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPRESSIONS_CONTENT}")
+string(REPLACE "\n" "\\n" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPRESSIONS_CONTENT}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/LsanSuppressions.h.in" "${CMAKE_CURRENT_BINARY_DIR}/LsanSuppressions.h" @ONLY)
+target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 if(USE_3DMAPPER)
   target_link_libraries(${LIB_MUDLET_TARGET} OpenGL::GLU)
   target_link_libraries(${LIB_MUDLET_TARGET} assimp::assimp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -761,7 +761,6 @@ endif (SYSINFO_INCLUDE_DIR)
 
 if(USE_UPDATER)
   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC INCLUDE_UPDATER)
-  target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 endif(USE_UPDATER)
 
 # Embed the LeakSanitizer suppression list into the binary so that

--- a/src/LsanSuppressions.h.in
+++ b/src/LsanSuppressions.h.in
@@ -1,0 +1,7 @@
+#ifndef MUDLET_LSANSUPPRESSIONS_H
+#define MUDLET_LSANSUPPRESSIONS_H
+
+// Generated from asan-suppressions.txt at configure time - do not edit.
+constexpr const char* mudletLsanSuppressions = "@MUDLET_LSAN_SUPPRESSIONS_CONTENT@";
+
+#endif // MUDLET_LSANSUPPRESSIONS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,29 @@
 
 using namespace std::chrono_literals;
 
+#include "LsanSuppressions.h"
+
+// These hooks are only consulted when the LeakSanitizer runtime is linked in
+// (USE_SANITIZER builds, i.e. PTBs and testing builds); elsewhere they are two
+// inert functions. They cannot be guarded with an "is ASAN on" macro check:
+// Mudlet only applies -fsanitize=address at link time, so no compiler macro is
+// set, and Qt's qcompilerdetection.h shims __has_feature to 0 on GCC anyway.
+
+// Embeds the suppression list into the binary so leak reports shown to users
+// by testing/PTB builds exclude third-party noise (GPU drivers, font stack)
+// with no LSAN_OPTIONS needed at runtime:
+extern "C" const char* __lsan_default_suppressions()
+{
+    return mudletLsanSuppressions;
+}
+
+// Without this, LeakSanitizer appends a "Suppressions used" summary to every
+// clean exit, which reads like an error to users:
+extern "C" const char* __lsan_default_options()
+{
+    return "print_suppressions=0";
+}
+
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@
 #include "TAccessibleConsole.h"
 #include "TAccessibleTextEdit.h"
 #include "FileOpenHandler.h"
+#include "LsanSuppressions.h"
 #include "SentryWrapper.h"
 #include "utils.h"
 #include <QFileInfo>
@@ -76,8 +77,6 @@
 #endif
 
 using namespace std::chrono_literals;
-
-#include "LsanSuppressions.h"
 
 // These hooks are only consulted when the LeakSanitizer runtime is linked in
 // (USE_SANITIZER builds, i.e. PTBs and testing builds); elsewhere they are two


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Embed `asan-suppressions.txt` into the binary at build time via LeakSanitizer's `__lsan_default_suppressions()` hook, so testing/PTB builds apply it automatically - no `LSAN_OPTIONS` needed
- Add GPU driver suppressions (NVIDIA `cuInit`, Mesa) seen in #9463; suppress the "Suppressions used" summary on clean exits

#### Motivation for adding to Mudlet
Users running testing builds get leak reports full of driver/font-stack noise (#9463 was ~97% NVIDIA driver init) which drowns out real Mudlet leaks and causes alarm.

#### Other info (issues closed, discussion etc)
Related to #9463 (the genuine leak there is fixed by #9464). The hooks are compiled unconditionally - Mudlet applies `-fsanitize=address` only at link time so no detection macro exists, and Qt shims `__has_feature` to 0 on GCC; in regular builds they are two inert functions.

**Test case:** With a `-DUSE_SANITIZER=Address` build, open a profile with a saved map and quit: report drops from ~40KB across ~1,500 allocations of mostly fontconfig/pango noise to only the genuine leaks (verified: the two 200-byte TArea leaks from #9464 still show). Regular build unaffected; ctest 39/39 green.