### PR TITLE
Fix: tempButton and tempButtonToolbar return the created ID

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1207,7 +1207,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
     const QString script{lua_tostring(L, 4)};
     auto [triggerId, message] = pLuaInterpreter->startPermBeginOfLineStringTrigger(name, parent, regList, script);
     if (triggerId == -1) {
-        lua_pushfstring(L, "permRegexTrigger: cannot create trigger (%s)", message.toUtf8().constData());
+        lua_pushfstring(L, "permBeginOfLineStringTrigger: cannot create trigger (%s)", message.toUtf8().constData());
         return lua_error(L);
     }
     lua_pushnumber(L, triggerId);
@@ -2110,8 +2110,8 @@ int TLuaInterpreter::tempButton(lua_State* L)
 
 
     pT->registerAction();
-    // N/U:     int childID = pT->getID();
     host.getActionUnit()->updateAllToolbars();
+    lua_pushnumber(L, pT->getID());
     return 1;
 }
 
@@ -2156,10 +2156,9 @@ int TLuaInterpreter::tempButtonToolbar(lua_State* L)
     pT->setIsFolder(true);
     pT->setIsActive(true);
     pT->registerAction();
-    // N/U:     int childID = pT->getID();
     host.getActionUnit()->updateAllToolbars();
 
-
+    lua_pushnumber(L, pT->getID());
     return 1;
 }
 

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -1456,4 +1456,27 @@ describe("Tests UI functions", function()
       assert.is_true(setLabelReleaseCallback(testLabelName, nil))
     end)
   end)
+
+  describe("tempButtonToolbar and tempButton return values", function()
+    -- unique names as the items cannot be deleted, and would collide on re-runs
+    -- against the same profile otherwise
+    local suffix = ("-%d-%d"):format(os.time(), math.random(100000))
+    local toolbarName = "bustedTempButtonToolbar" .. suffix
+    local buttonName = "bustedTempButton" .. suffix
+
+    it("tempButtonToolbar returns the created toolbar's ID", function()
+      local toolbarId = tempButtonToolbar(toolbarName, 0, 0)
+      assert.are.equal("number", type(toolbarId))
+      assert.is_true(toolbarId > 0)
+      assert.are.equal(1, exists(toolbarId, "button"))
+    end)
+
+    it("tempButton returns the created button's ID", function()
+      local buttonId = tempButton(toolbarName, buttonName, 0)
+      assert.are.equal("number", type(buttonId))
+      assert.is_true(buttonId > 0)
+      assert.are.equal(1, exists(buttonId, "button"))
+      assert.are.equal(1, isActive(buttonId, "button"))
+    end)
+  end)
 end)

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -1462,6 +1462,7 @@ describe("Tests UI functions", function()
     -- against the same profile otherwise
     local suffix = ("-%d-%d"):format(os.time(), math.random(100000))
     local toolbarName = "bustedTempButtonToolbar" .. suffix
+    local buttonToolbarName = "bustedTempButtonParent" .. suffix
     local buttonName = "bustedTempButton" .. suffix
 
     it("tempButtonToolbar returns the created toolbar's ID", function()
@@ -1472,7 +1473,11 @@ describe("Tests UI functions", function()
     end)
 
     it("tempButton returns the created button's ID", function()
-      local buttonId = tempButton(toolbarName, buttonName, 0)
+      -- own toolbar so this test doesn't depend on the previous one
+      local parentId = tempButtonToolbar(buttonToolbarName, 0, 0)
+      assert.are.equal("number", type(parentId))
+
+      local buttonId = tempButton(buttonToolbarName, buttonName, 0)
       assert.are.equal("number", type(buttonId))
       assert.is_true(buttonId > 0)
       assert.are.equal(1, exists(buttonId, "button"))


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`tempButton` and `tempButtonToolbar` both declared one return value but pushed nothing onto the Lua stack, so Lua received whatever leftover garbage was on the stack (in practice, references to Lua functions) instead of the new ID. They now push the real registered action ID, matching every sibling `temp*` creator, so the returned value works with `exists`, `isActive`, `setButtonStyleSheet`, etc.

Also corrects `permBeginOfLineStringTrigger`'s creation-failure message, which incorrectly named `permRegexTrigger`.

#### Motivation for adding to Mudlet

The IDs returned by these two functions were unusable, making it impossible to reliably reference a temp button/toolbar created at runtime. Scripts relying on the return value silently got the wrong value.

#### Other info (issues closed, discussion etc)

Regression-locking cases added to `UI_spec` (they fail without the fix).

Tested by hand. Squash-merge with:
```
Assisted-by: Claude:claude-fable-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
```

https://github.com/user-attachments/assets/b9ca5e7a-47f2-4a0b-893f-433b4447064a
