### PR TITLE
Improve: map events and menus work before the map widget opens

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4550,8 +4550,11 @@ void T2DMap::slot_toggleMapViewOnly()
 
 void T2DMap::populateUserContextMenus(QMenu& menu)
 {
+    if (!mpMap) {
+        return;
+    }
     QMap<QString, QMenu*> userMenus;
-    QMapIterator<QString, QStringList> menuIterator(mUserMenus);
+    QMapIterator<QString, QStringList> menuIterator(mpMap->mUserMenus);
 
     while (menuIterator.hasNext()) {
         menuIterator.next();
@@ -4576,7 +4579,7 @@ void T2DMap::populateUserContextMenus(QMenu& menu)
         }
     }
 
-    QMapIterator<QString, QStringList> actionIterator(mUserActions);
+    QMapIterator<QString, QStringList> actionIterator(mpMap->mUserActions);
     while (actionIterator.hasNext()) {
         actionIterator.next();
         const QString uniqueName = actionIterator.key();
@@ -4603,7 +4606,7 @@ void T2DMap::populateUserContextMenus(QMenu& menu)
 void T2DMap::slot_userAction(QString uniqueName)
 {
     TEvent event{};
-    QStringList userEvent = mUserActions[uniqueName];
+    const QStringList userEvent = mpMap->mUserActions.value(uniqueName);
     event.mArgumentList.append(userEvent[0]);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(uniqueName);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4605,6 +4605,9 @@ void T2DMap::populateUserContextMenus(QMenu& menu)
 
 void T2DMap::slot_userAction(QString uniqueName)
 {
+    if (!mpMap) {
+        return;
+    }
     TEvent event{};
     const QStringList userEvent = mpMap->mUserActions.value(uniqueName);
     event.mArgumentList.append(userEvent[0]);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -220,13 +220,6 @@ public:
     int mTargetRoomId = 0;
     bool mStartSpeedWalk = false;
 
-
-    // string list: 0 is event name, 1 is menu it is under if it is
-    QMap<QString, QStringList> mUserActions;
-
-    // unique name, List:parent name ("" if null), display name
-    QMap<QString, QStringList> mUserMenus;
-
     bool mRoomBeingMoved = false;
     QPointF mRoomMoveLastMapPoint;
     bool mHasRoomMoveLastMapPoint = false;

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -531,14 +531,12 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
         actionInfo << lua_tostring(L, i);
     }
     const Host& host = getHostFromLua(L);
-    if (host.mpMap) {
-        if (host.mpMap->mpMapper) {
-            if (host.mpMap->mpMapper->mp2dMap) {
-                host.mpMap->mpMapper->mp2dMap->mUserActions.insert(uniqueName, actionInfo);
-            }
-        }
+    if (!host.mpMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
     }
-    return 0;
+    host.mpMap->mUserActions.insert(uniqueName, actionInfo);
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addMapMenu
@@ -559,14 +557,12 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
         menuList << lua_tostring(L, 3);
     }
     const Host& host = getHostFromLua(L);
-    if (host.mpMap) {
-        if (host.mpMap->mpMapper) {
-            if (host.mpMap->mpMapper->mp2dMap) {
-                host.mpMap->mpMapper->mp2dMap->mUserMenus.insert(uniqueName, menuList);
-            }
-        }
+    if (!host.mpMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
     }
-    return 0;
+    host.mpMap->mUserMenus.insert(uniqueName, menuList);
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addRoom
@@ -1746,13 +1742,13 @@ int TLuaInterpreter::getGridMode(lua_State* L)
 int TLuaInterpreter::getMapEvents(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    if (!(host.mpMap && host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap)) {
-        return warnArgumentValue(L, __func__, "you haven't opened a map yet");
+    if (!host.mpMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
     // create the result table
     lua_newtable(L);
-    QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserActions);
+    QMapIterator<QString, QStringList> it(host.mpMap->mUserActions);
     while (it.hasNext()) {
         it.next();
         const QStringList eventInfo = it.value();
@@ -1861,12 +1857,12 @@ int TLuaInterpreter::getMapMenus(lua_State* L)
         keyByUniqueName = getVerifiedBool(L, __func__, 1, "key by unique name", true);
     }
     const Host& host = getHostFromLua(L);
-    if (!(host.mpMap && host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap)) {
-        return warnArgumentValue(L, __func__, "you haven't opened a map yet");
+    if (!host.mpMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
     }
 
     lua_newtable(L);
-    QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserMenus);
+    QMapIterator<QString, QStringList> it(host.mpMap->mUserMenus);
     while (it.hasNext()) {
         it.next();
         const QStringList& menuInfo = it.value();
@@ -2911,14 +2907,12 @@ int TLuaInterpreter::removeMapEvent(lua_State* L)
 {
     const QString displayName = getVerifiedString(L, __func__, 1, "event name");
     const Host& host = getHostFromLua(L);
-    if (host.mpMap) {
-        if (host.mpMap->mpMapper) {
-            if (host.mpMap->mpMapper->mp2dMap) {
-                host.mpMap->mpMapper->mp2dMap->mUserActions.remove(displayName);
-            }
-        }
+    if (!host.mpMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
     }
-    return 0;
+    host.mpMap->mUserActions.remove(displayName);
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeMapMenu
@@ -2926,46 +2920,44 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
 {
     const QString uniqueName = getVerifiedString(L, __func__, 1, "Menu name");
     if (uniqueName.isEmpty()) {
-        return 0;
+        return warnArgumentValue(L, __func__, "the menu name cannot be empty");
     }
     const Host& host = getHostFromLua(L);
-    if (host.mpMap) {
-        if (host.mpMap->mpMapper) {
-            if (host.mpMap->mpMapper->mp2dMap) {
-                host.mpMap->mpMapper->mp2dMap->mUserMenus.remove(uniqueName);
-                //remove all entries with this as parent
-                QStringList removeList;
-                removeList.append(uniqueName);
-                bool newElement = true;
-                while (newElement) {
-                    newElement = false;
-                    QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserMenus);
-                    while (it.hasNext()) {
-                        it.next();
-                        QStringList menuInfo = it.value();
-                        const QString parent = menuInfo[0];
-                        if (removeList.contains(parent)) {
-                            host.mpMap->mpMapper->mp2dMap->mUserMenus.remove(it.key());
-                            if (it.key() != "" && !removeList.contains(it.key())) {
-                                host.mpMap->mpMapper->mp2dMap->mUserMenus.remove(it.key());
-                                removeList.append(it.key());
-                                newElement = true;
-                            }
-                        }
-                    }
-                }
-                QMapIterator<QString, QStringList> it2(host.mpMap->mpMapper->mp2dMap->mUserActions);
-                while (it2.hasNext()) {
-                    it2.next();
-                    const QString actParent = it2.value()[1];
-                    if (removeList.contains(actParent)) {
-                        host.mpMap->mpMapper->mp2dMap->mUserActions.remove(it2.key());
-                    }
+    if (!host.mpMap) {
+        return warnArgumentValue(L, __func__, "no map present or loaded");
+    }
+    host.mpMap->mUserMenus.remove(uniqueName);
+    //remove all entries with this as parent
+    QStringList removeList;
+    removeList.append(uniqueName);
+    bool newElement = true;
+    while (newElement) {
+        newElement = false;
+        QMapIterator<QString, QStringList> it(host.mpMap->mUserMenus);
+        while (it.hasNext()) {
+            it.next();
+            QStringList menuInfo = it.value();
+            const QString parent = menuInfo[0];
+            if (removeList.contains(parent)) {
+                host.mpMap->mUserMenus.remove(it.key());
+                if (it.key() != "" && !removeList.contains(it.key())) {
+                    host.mpMap->mUserMenus.remove(it.key());
+                    removeList.append(it.key());
+                    newElement = true;
                 }
             }
         }
     }
-    return 0;
+    QMapIterator<QString, QStringList> it2(host.mpMap->mUserActions);
+    while (it2.hasNext()) {
+        it2.next();
+        const QString actParent = it2.value()[1];
+        if (removeList.contains(actParent)) {
+            host.mpMap->mUserActions.remove(it2.key());
+        }
+    }
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeSpecialExit

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -261,6 +261,13 @@ public:
     QPointer<dlgMapper> mpMapper;
     QMap<int, int> roomidToIndex;
 
+    // User-registered mapper context menu entries (addMapEvent()/addMapMenu());
+    // session-only state, never saved with the map.
+    // string list: 0 is event name, 1 is menu it is under if it is
+    QMap<QString, QStringList> mUserActions;
+    // unique name, List:parent name ("" if null), display name
+    QMap<QString, QStringList> mUserMenus;
+
     typedef boost::adjacency_list<boost::listS, boost::vecS, boost::directedS, boost::no_property, boost::property<boost::edge_weight_t, cost>> mygraph_t;
     typedef boost::property_map<mygraph_t, boost::edge_weight_t>::type WeightMap;
     typedef mygraph_t::vertex_descriptor vertex;

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -1,11 +1,34 @@
 -- This block must stay first in the file: once a later spec calls
 -- openMapWidget(), the widget persists for the rest of the session and the
--- no-widget branch becomes unreachable.
-describe("Tests getMapEvents before the map widget is opened", function()
-  it("should return nil+message when the map widget was never opened", function()
-    local events, err = getMapEvents()
-    assert.is_nil(events)
-    assert.are.equal("you haven't opened a map yet", err)
+-- pre-widget state becomes unreachable.
+describe("Tests map events and menus before the map widget is opened", function()
+  it("should return an empty table when nothing is registered yet", function()
+    assert.are.same({}, getMapEvents())
+    assert.are.same({}, getMapMenus())
+  end)
+
+  it("should register and remove a map event before the widget is opened", function()
+    assert.is_true(addMapEvent("preWidgetEvent", "myEvent", "", "Pre-widget Event"))
+
+    local events = getMapEvents()
+    assert.is_not_nil(events.preWidgetEvent)
+    assert.are.equal("myEvent", events.preWidgetEvent["event name"])
+    assert.are.equal("Pre-widget Event", events.preWidgetEvent["display name"])
+
+    assert.is_true(removeMapEvent("preWidgetEvent"))
+    assert.is_nil(getMapEvents().preWidgetEvent)
+  end)
+
+  it("should register and remove a map menu before the widget is opened", function()
+    assert.is_true(addMapMenu("PreWidgetMenu"))
+    assert.are.equal("top-level", getMapMenus()["PreWidgetMenu"])
+
+    assert.is_true(removeMapMenu("PreWidgetMenu"))
+    assert.is_nil(getMapMenus()["PreWidgetMenu"])
+  end)
+
+  it("should retain a registration for when the widget opens later", function()
+    assert.is_true(addMapEvent("preWidgetKeptEvent", "myEvent", "", "Kept Event"))
   end)
 end)
 
@@ -20,6 +43,16 @@ describe("Tests custom map event and menu functions", function()
     removeMapEvent("testEvent2")
     removeMapMenu("TestMenu")
     removeMapMenu("TestSubMenu")
+  end)
+
+  describe("Tests that pre-widget registrations survive opening the widget", function()
+    it("should still list an event registered before the widget was opened", function()
+      local events = getMapEvents()
+      assert.is_not_nil(events.preWidgetKeptEvent)
+      assert.are.equal("myEvent", events.preWidgetKeptEvent["event name"])
+      assert.are.equal("Kept Event", events.preWidgetKeptEvent["display name"])
+      removeMapEvent("preWidgetKeptEvent")
+    end)
   end)
 
   describe("Tests addMapEvent and getMapEvents", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`addMapEvent`/`addMapMenu`/`removeMapEvent`/`removeMapMenu` silently no-opped (returned nothing) until the map widget existed, so registrations made beforehand vanished. The registry (`mUserActions`/`mUserMenus`) moves from `T2DMap` to `TMap`, so:

- registrations work whenever a map exists and return `true` on success
- `getMapEvents`/`getMapMenus` always return a table
- all map views share one registry - fixing a second real bug where extra map views (PR #8743's multi-view) had permanently-empty menu registries and never showed Lua-registered entries

The state is session-only and never serialized.

Return-value changes (for the changelog): `addMapEvent`, `addMapMenu`, `removeMapEvent`, and `removeMapMenu` previously returned nothing and now return `true` on success.

#### Motivation for adding to Mudlet

Scripts that register map events/menus at startup - before the user opens the map - had their registrations silently dropped, and multi-view users never saw their custom menu entries. Both now work reliably.

#### Other info (issues closed, discussion etc)

Stacked on #9473 - merge after the base PR. Specs updated, with pre-widget registration survival verified through `openMapWidget`. The wiki docs for these six functions will need updating once shipped.

---

Tested by hand. Squash-merge with:
```
Assisted-by: Claude:claude-fable-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
```

https://github.com/user-attachments/assets/a370ca4b-66e4-429e-87b8-9d5a264a116d
