### PR TITLE
Fix: remove duplicate cechoLink/dechoLink/hechoLink in GeyserMiniConsole

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -356,24 +356,6 @@ function Geyser.MiniConsole:hinsertLink(...)
   hinsertLink(self.name, ...)
 end
 
---- inserts color name formatted clickable text into the miniconsole at the end of the current line.
--- see: https://wiki.mudlet.org/w/Manual:UI_Functions#cechoLink
-function Geyser.MiniConsole:cechoLink(...)
-  cechoLink(self.name, ...)
-end
-
---- inserts decimal color formatted clickable text into the miniconsole at the end of the current line.
--- see: https://wiki.mudlet.org/w/Manual:UI_Functions#dechoLink
-function Geyser.MiniConsole:dechoLink(...)
-  dechoLink(self.name, ...)
-end
-
---- inserts hexadecimal color formatted clickable text into the miniconsole at the end of the current line.
--- see: https://wiki.mudlet.org/w/Manual:UI_Functions#hechoLink
-function Geyser.MiniConsole:hechoLink(...)
-  hechoLink(self.name, ...)
-end
-
 --- inserts color name formatted clickable text with right-click menu into the miniconsole at the end of the current line.
 -- see: https://wiki.mudlet.org/w/Manual:UI_Functions#cechoPopup
 function Geyser.MiniConsole:cechoPopup(...)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Removes duplicate `cechoLink`/`dechoLink`/`hechoLink` definitions in `Geyser.MiniConsole`. The three methods were defined twice - byte-identical copies stemming from a single 2019 copy-paste in PR #3009. The later definitions silently overwrote the earlier ones, making the out-of-place second block dead code ever since. That block (18 lines) is removed.

#### Motivation for adding to Mudlet

Dead, duplicated code is confusing to maintain and invites accidental divergence between the two copies. This is a zero-behavior-change cleanup.

#### Other info (issues closed, discussion etc)

`luac` parse-verified; the rest of `geyser/` was swept for the same duplicate-definition pattern (none found).

Tested by hand. Squash-merge with:
```
Assisted-by: Claude:claude-fable-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
```

