### PR TITLE
Fix: guard sendMSDP against disconnected/unnegotiated state

### DIFF
--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -474,9 +474,22 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
     output += TN_IAC;
     output += TN_SE;
 
+    // Check connection status first (most common issue)
+    if (host.mTelnet.getConnectionState() != QAbstractSocket::ConnectedState) {
+        return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending MSDP"));
+    }
+
+    if (!host.mTelnet.isMSDPEnabled()) {
+        return warnArgumentValue(L, __func__, qsl("MSDP is not currently enabled"));
+    }
+
     // output is in Mud Server Encoding form here:
-    host.mTelnet.socketOutRaw(output);
-    return 0;
+    if (!host.mTelnet.socketOutRaw(output)) {
+        return warnArgumentValue(L, __func__, qsl("failed to send MSDP message - connection may have been lost or a socket write error occurred"));
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#sendTelnetChannel102

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -1,4 +1,17 @@
 describe("Tests C++ functions in the Miscallaneous category", function()
+    describe("Tests the functionality of sendMSDP", function()
+      it("should return nil and an error message when MSDP cannot be sent", function()
+        local ok, err = sendMSDP("CLIENT_NAME", "Mudlet")
+        if ok == true then
+          -- connected to a server which negotiated MSDP, so the send succeeded
+          return
+        end
+        assert.is_nil(ok)
+        assert.is_string(err)
+        assert.is_true(err:find("MSDP") ~= nil)
+      end)
+    end)
+
     describe("Tests the functionality of getOS", function()
       it("should return the correct number of values for the current OS", function()
         local results = {getOS()}

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -2,8 +2,9 @@ describe("Tests C++ functions in the Miscallaneous category", function()
     describe("Tests the functionality of sendMSDP", function()
       it("should return nil and an error message when MSDP cannot be sent", function()
         local ok, err = sendMSDP("CLIENT_NAME", "Mudlet")
-        if ok == true then
+        if ok ~= nil then
           -- connected to a server which negotiated MSDP, so the send succeeded
+          assert.is_true(ok)
           return
         end
         assert.is_nil(ok)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `sendMSDP` now checks for an active connection and that MSDP was actually negotiated before sending, using the existing `isMSDPEnabled()`.
- It returns `true` on success and `nil` + an error message on failure (via `warnArgumentValue`), matching its sibling send functions. Previously it silently attempted the send and returned nothing.

#### Motivation for adding to Mudlet
The sibling send functions received these guards twice already (PR #1852 in 2018, PR #8386 in 2025) and MSDP was missed both times, leaving scripts with no way to tell a failed send from a successful one.

#### Other info (issues closed, discussion etc)
Minor visible change worth a changelog note: `sendMSDP` previously returned nothing and now returns `true`/`nil`+message. A state-agnostic contract spec was added.

Tested by hand. Squash-merge with:
```
Assisted-by: Claude:claude-fable-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
```

https://github.com/user-attachments/assets/46a2dc97-62b6-4042-8f14-9f09655bc8d2
