### PR TITLE
Infrastructure: remove unregistered setMiniConsoleFontSize implementation

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -495,7 +495,6 @@ public:
     static int getMainWindowSize(lua_State*);
     static int getUserWindowSize(lua_State*);
     static int getMousePosition(lua_State*);
-    static int setMiniConsoleFontSize(lua_State*);
     static int setProfileIcon(lua_State*);
     static int resetProfileIcon(lua_State*);
     static int getCurrentLine(lua_State*);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3113,20 +3113,6 @@ int TLuaInterpreter::setMapWindowTitle(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMiniConsoleFontSize
-int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
-{
-    const QString windowName = getVerifiedString(L, __func__, 1, "miniconsole name");
-    const int size = getVerifiedInt(L, __func__, 2, "font size");
-    auto console = CONSOLE(L, windowName);
-    if (size < 1) {
-        return warnArgumentValue(L, __func__, qsl("setting font size of '%1' failed").arg(windowName));
-    }
-    console->setFontSize(size);
-    lua_pushboolean(L, true);
-    return 1;
-}
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovie
 int TLuaInterpreter::setMovie(lua_State* L)
 {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Removes the unreachable `setMiniConsoleFontSize` C++ implementation and its header declaration (15-line deletion).

#### Motivation for adding to Mudlet
PR #4186 (2020) made the Lua `setMiniConsoleFontSize` name an alias of `setFontSize` ("the latter is now an alias to the former" per its commit message) but forgot to delete the now-unreachable implementation; two later refactors carried it along.

#### Other info (issues closed, discussion etc)
Pure code cleanup with no runtime change - the live `setFontSize` binding is a strict superset of the dead code, and behavior was verified byte-identical before and after.

Tested by hand. Squash-merge with:
```
Assisted-by: Claude:claude-fable-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
```
