### PR TITLE
infrastructure: memory leaks found during CI tests now fail the build

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -450,7 +450,7 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}
-        LSAN_OPTIONS: ${{ matrix.enable_asan == 'true' && format('suppressions={0}/asan-suppressions.txt:exitcode=0', github.workspace) || '' }}
+        LSAN_OPTIONS: ${{ matrix.enable_asan == 'true' && format('suppressions={0}/asan-suppressions.txt:exitcode=1', github.workspace) || '' }}
 
     - name: (macOS) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -486,7 +486,7 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}
-        LSAN_OPTIONS: ${{ matrix.enable_asan == 'true' && format('suppressions={0}/asan-suppressions.txt:exitcode=0', github.workspace) || '' }}
+        LSAN_OPTIONS: ${{ matrix.enable_asan == 'true' && format('suppressions={0}/asan-suppressions.txt:exitcode=1', github.workspace) || '' }}
 
     - name: (macOS) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'

--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -67,3 +67,11 @@ leak:QTranslatorPrivate::do_load
 
 # Qt array data allocation (internal caching)
 leak:QArrayData::allocate2
+
+# ==============================================================================
+# OpenSSL 3 provider initialization leaks
+# One-time allocations made when Qt's OpenSSL TLS backend loads the default
+# provider on first TLS use; seen with Qt 6.12's qtlsbackend_openssl
+# ==============================================================================
+leak:OSSL_PROVIDER_try_load
+leak:OSSL_DECODER_do_all_provided


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Leak detection in the Lua-test CI job has been report-only since #8316 (`LSAN_OPTIONS` `exitcode=0`); flip to `exitcode=1` in both `build-mudlet.yml` and `build-mudlet-pr.yml` so any newly introduced leak fails the job
- Add two narrow suppressions for OpenSSL 3 provider init noise (`OSSL_PROVIDER_try_load`, `OSSL_DECODER_do_all_provided`) so the check stays green when CI's Qt is bumped (these show up from Qt 6.12's `qtlsbackend_openssl`)

#### Motivation for adding to Mudlet
New memory leaks should break tests instead of scrolling past unnoticed - CI is currently leak-clean, so enforcement can be switched on at no cost.

#### Other info (issues closed, discussion etc)
Supersedes and closes #8366 - the leak fixes it bundled have since landed separately (remaining `TArea` one is in #9464), leaving only this exit-code flip outstanding. Verified end-to-end against the actual PTB binary from run 29674747600: a deliberately injected 1337-byte leak fails the busted suite with the configured exit code, and the current clean suite passes with `exitcode=1`. Note #8366 only patched `build-mudlet.yml`; this also covers `build-mudlet-pr.yml`, which PR builds actually use. One quirk: when LSan fails a run it exits without flushing stdout, so the busted summary won't print on leak-failing runs - the leak report on stderr is what to read.

**Test case:** CI on this PR - the "ubuntu / gcc / lua tests + leak detection" job must pass with the new `exitcode=1` setting.

Assisted-by: Claude:claude-fable-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>