### PR TITLE
infrastructure: test suites no longer clash when run at the same time

### DIFF
--- a/test/functional_tests/EnableDisableByNameTest.cpp
+++ b/test/functional_tests/EnableDisableByNameTest.cpp
@@ -77,7 +77,7 @@ private:
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
     const QString mHostname = "EnableDisableByName-Test";
-    const QString mPort = "4005";
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
     const QString mLocalhost = "localhost";
 
     void runLua(const QString& code)
@@ -125,7 +125,8 @@ private slots:
         initializeQRCResourcesForEnableDisableByNameTest();
 
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mLocalhost, mPort.toUShort());
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/MainConsoleSelectionTest.cpp
+++ b/test/functional_tests/MainConsoleSelectionTest.cpp
@@ -46,7 +46,7 @@ class MainConsoleSelectionTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-Selection";
-    const QString mpPort = "4000";
+    QString mpPort; // assigned the stub's actual ephemeral port in init()
     const QString mpLocalhost = "localhost";
 
     // Send a screenful of text so a click in the middle of the upper pane lands
@@ -84,7 +84,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mpServer->start(mpLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mpPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/ResetProfileTest.cpp
+++ b/test/functional_tests/ResetProfileTest.cpp
@@ -77,7 +77,7 @@ private:
   TelnetServerStub *mpServer = nullptr;
   Host *mpHost = nullptr;
   const QString mHostname = "ResetProfile-Test";
-  const QString mPort = "4003";
+  QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
   const QString mLocalhost = "localhost";
 
   void performReset() {
@@ -110,7 +110,8 @@ private slots:
     initializeQRCResourcesForResetProfileTest();
 
     mpServer = new TelnetServerStub(qApp);
-    mpServer->start(mLocalhost, mPort.toUShort());
+    mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+    mPort = QString::number(mpServer->serverPort());
     mudlet::start();
     mudlet::self()->setupConfig();
     mudlet::self()->takeOwnershipOfInstanceCoordinator(

--- a/test/functional_tests/TDiscordModeTest.cpp
+++ b/test/functional_tests/TDiscordModeTest.cpp
@@ -56,7 +56,7 @@ private:
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
     const QString mHostname = "Discord-Mode-Test";
-    const QString mPort = "4003";
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
     const QString mLocalhost = "localhost";
 
 private slots:
@@ -65,7 +65,8 @@ private slots:
         initializeQRCResourcesForDiscordModeTest();
 
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mLocalhost, mPort.toUShort());
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -48,7 +48,7 @@ class TFeedTriggersRecursionTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-FeedTriggersRecursion";
-    const QString mpPort = "4000";
+    QString mpPort; // assigned the stub's actual ephemeral port in init()
     const QString mpLocalhost = "localhost";
 
 private slots:
@@ -57,7 +57,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mpServer->start(mpLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mpPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -54,7 +54,7 @@ private:
   TelnetServerStub *mpServer = nullptr;
   Host *mpHost = nullptr;
   const QString mHostname = "OSC-Test-Host";
-  const QString mPort = "4002";
+  QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
   const QString mLocalhost = "localhost";
 
   // Injects raw telnet data into the processing pipeline via loopback and
@@ -186,7 +186,8 @@ private slots:
     initializeQRCResourcesForOscTest();
 
     mpServer = new TelnetServerStub(qApp);
-    mpServer->start(mLocalhost, mPort.toUShort());
+    mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+    mPort = QString::number(mpServer->serverPort());
     mudlet::start();
     mudlet::self()->setupConfig();
     mudlet::self()->takeOwnershipOfInstanceCoordinator(

--- a/test/functional_tests/TUserWindowTest.cpp
+++ b/test/functional_tests/TUserWindowTest.cpp
@@ -58,7 +58,7 @@ private:
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
     const QString mHostname = "UserWindow-Test-Host";
-    const QString mPort = "4004";
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
     const QString mLocalhost = "localhost";
 
 private slots:
@@ -68,7 +68,8 @@ private slots:
         initializeQRCResourcesForUserWindowTest();
 
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mLocalhost, mPort.toUShort());
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/TelnetBenchmark.cpp
+++ b/test/functional_tests/TelnetBenchmark.cpp
@@ -49,7 +49,7 @@ class TelnetBenchmark : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mHostname = "Benchmark-Host";
-    const QString mPort = "4001";
+    QString mPort; // assigned the stub's actual ephemeral port in init()
     const QString mLocalhost = "localhost";
     Host* mpHost = nullptr;
 
@@ -144,7 +144,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mLocalhost, mPort.toUShort());
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -37,9 +37,7 @@ void TelnetServerStub::start(const QString& host, quint16 port)
     Q_UNUSED(host)
     const QHostAddress addr = QHostAddress::LocalHost;
     if (listen(addr, port)) {
-        qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1:%2")
-                    .arg(addr.toString())
-                    .arg(port);
+        qInfo().noquote() << qsl("✅ TelnetServerStub listening on %1:%2").arg(addr.toString()).arg(serverPort());
     } else {
         qCritical().noquote() << qsl("❌ Failed to start TelnetServerStub: %1").arg(errorString());
     }

--- a/test/functional_tests/TelnetServerStub.h
+++ b/test/functional_tests/TelnetServerStub.h
@@ -34,7 +34,10 @@ class TelnetServerStub : public QTcpServer
 public:
     explicit TelnetServerStub(QObject* parent = nullptr);
 
-    void start(const QString& host, quint16 port);
+    // Bind to a caller-chosen port, or to an ephemeral OS-assigned port when port is 0 (the default).
+    // Binding 0 lets concurrent test runs avoid colliding on a shared fixed port; the caller reads the
+    // actual bound port back via serverPort() (inherited from QTcpServer) once start() has succeeded.
+    void start(const QString& host, quint16 port = 0);
     void setWelcomeMessage(const QString& message) { mpWelcomeMessage = message; }
 
 private slots:

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -41,7 +41,7 @@ class TelnetTextDisplayedTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-Telnet";
-    const QString mpPort = "4000";
+    QString mpPort; // assigned the stub's actual ephemeral port in init()
     const QString mpLocalhost = "localhost";
 
 private slots:
@@ -50,7 +50,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mpServer->start(mpLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mpPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/TriggerEditorTest.cpp
+++ b/test/functional_tests/TriggerEditorTest.cpp
@@ -47,7 +47,7 @@ private:
   TelnetServerStub *mpServer = nullptr;
   Host *mpHost = nullptr;
   const QString mHostname = "TriggerEditor-Test";
-  const QString mPort = "4004";
+  QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
   const QString mLocalhost = "localhost";
 
   void startProfile(const QString &hostname, const QString &address,
@@ -100,7 +100,8 @@ private slots:
     initializeQRCResourcesForTriggerEditorTest();
 
     mpServer = new TelnetServerStub(qApp);
-    mpServer->start(mLocalhost, mPort.toUShort());
+    mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+    mPort = QString::number(mpServer->serverPort());
     mudlet::start();
     mudlet::self()->setupConfig();
     mudlet::self()->takeOwnershipOfInstanceCoordinator(

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -66,7 +66,7 @@ private:
   dlgTriggerEditor *mpEditor = nullptr;
   Host *mpHost = nullptr;
   const QString mProfileName = qsl("UndoRedo-Test-Profile");
-  const QString mPort = qsl("23456");
+  QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
   const QString mLocalhost = qsl("localhost");
 
   struct ItemTypeInfo {
@@ -160,10 +160,11 @@ private slots:
     initializeQRCResources();
 
     mpServer = new TelnetServerStub(qApp);
-    mpServer->start(mLocalhost, mPort.toUShort());
+    mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
     QVERIFY2(mpServer->isListening(),
              qPrintable(qsl("TelnetServerStub failed to start: %1")
                             .arg(mpServer->errorString())));
+    mPort = QString::number(mpServer->serverPort());
     mudlet::start();
     mudlet::self()->setupConfig();
     mudlet::self()->takeOwnershipOfInstanceCoordinator(


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- TelnetServerStub now binds an OS-assigned (ephemeral) port; its log reports the actual bound port
- All 11 functional tests that hardcoded listen ports (three shared port 4000, two pairs shared 4003/4004) now read the real port back via serverPort()

#### Motivation for adding to Mudlet
Concurrent test runs (parallel CI jobs, multiple checkouts on one machine) collided on the fixed ports, causing flaky bind failures and tests connecting to the wrong run's server.

#### Other info (issues closed, discussion etc)
Follows the pattern GMCPCharLoginTest already used. Verified by running two copies of TelnetTextDisplayedTest simultaneously - both passed on distinct ports (37503/42303), impossible before.

**Test case:** Run the functional suite twice in parallel (two build dirs or ctest -j2 repeated); no "address already in use" failures.

Assisted-by: Claude:claude-opus-4-8