### PR TITLE
fix: profile reset no longer forgets which variables to save

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -880,9 +880,21 @@ void Host::resetProfile_phase2()
     mLuaInterpreter.abortAllDownloads();
     mLuaInterpreter.initLuaGlobals();
     // initLuaGlobals() closed the old lua_State, so the LuaInterface (and its
-    // VarUnit tree of registry references) must be rebuilt against the new one:
+    // VarUnit tree of registry references) must be rebuilt against the new one.
+    // The VarUnit's name-keyed saved/hidden bookkeeping does not depend on the
+    // lua_State though and is only repopulated by XMLimport at profile open, so
+    // carry it over - otherwise the first save after a reset silently drops all
+    // of the user's saved variables from the profile:
+    const QSet<QString> savedVars = mLuaInterface->getVarUnit()->savedVars;
+    const QSet<QString> hiddenByUserVars = mLuaInterface->getVarUnit()->hiddenByUser;
     mLuaInterface.reset(new LuaInterface(mLuaInterpreter.getLuaGlobalState()));
+    mLuaInterface->getVarUnit()->savedVars = savedVars;
+    mLuaInterface->getVarUnit()->hiddenByUser = hiddenByUserVars;
     mLuaInterpreter.loadGlobal();
+    // Profile load hides Mudlet's own Lua API right after loadGlobal() (see
+    // mudlet::slot_connectionDialogueFinished()); do the same here so the
+    // Variables view keeps showing only the user's variables after a reset:
+    hideMudletsVariables();
 
     // Have to recopy the values into the Lua "color_table"
     mLuaInterpreter.updateAnsi16ColorsInTable();

--- a/test/functional_tests/ResetProfileTest.cpp
+++ b/test/functional_tests/ResetProfileTest.cpp
@@ -35,6 +35,7 @@
 #include <QMouseEvent>
 
 #include "Host.h"
+#include "LuaInterface.h"
 #include "MudletInstanceCoordinator.h"
 #include "TEvent.h"
 #include "TKey.h"
@@ -46,7 +47,10 @@
 #include "TScript.h"
 #include "TTimer.h"
 #include "TTrigger.h"
+#include "TVar.h"
 #include "TelnetServerStub.h"
+#include "VarUnit.h"
+#include "XMLexport.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
@@ -747,8 +751,109 @@ private slots:
   }
 
   // -----------------------------------------------------------------------
+  // Group 17: VarUnit saved/hidden variable bookkeeping (#9430 follow-up)
+  // -----------------------------------------------------------------------
+
+  // The VarUnit's savedVars/hiddenByUser sets are name-keyed and independent
+  // of the lua_State (VarUnit::clear() deliberately preserves them), and
+  // nothing repopulates them after a reset - only XMLimport at profile open
+  // does. If replacing the LuaInterface in resetProfile_phase2() loses them,
+  // the first profile save after a reset silently drops every user-saved
+  // variable and hidden-variable preference from the profile XML.
+  void test_savedAndHiddenVarSetsSurviveReset() {
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    luaL_dostring(L, "resetSavedTestVar = 'important'");
+
+    LuaInterface *lI = mpHost->getLuaInterface();
+    VarUnit *vu = lI->getVarUnit();
+    lI->getVars(false);
+    TVar *var = findGlobalVar(vu, qsl("resetSavedTestVar"));
+    QVERIFY2(var, "test variable not found in the variable tree");
+    // as the Variables view does when the user ticks the save checkbox:
+    vu->addSavedVar(var);
+    // and as it does when the user hides a variable:
+    vu->addHidden(qsl("resetHiddenTestVar"));
+    QVERIFY(vu->savedVars.contains(qsl("resetSavedTestVar")));
+    QVERIFY(vu->hiddenByUser.contains(qsl("resetHiddenTestVar")));
+
+    performReset();
+
+    VarUnit *newVu = mpHost->getLuaInterface()->getVarUnit();
+    QVERIFY2(newVu->savedVars.contains(qsl("resetSavedTestVar")),
+             "user's saved-variable marking should survive resetProfile()");
+    QVERIFY2(newVu->hiddenByUser.contains(qsl("resetHiddenTestVar")),
+             "user's hidden-variable preference should survive resetProfile()");
+  }
+
+  // End-to-end version of the above: the saved variable must still be
+  // written out to profile XML after a reset.
+  void test_savedVariableExportedToXmlAfterReset() {
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    luaL_dostring(L, "xmlSavedTestVar = 'survives'");
+
+    LuaInterface *lI = mpHost->getLuaInterface();
+    VarUnit *vu = lI->getVarUnit();
+    lI->getVars(false);
+    TVar *var = findGlobalVar(vu, qsl("xmlSavedTestVar"));
+    QVERIFY2(var, "test variable not found in the variable tree");
+    vu->addSavedVar(var);
+
+    performReset();
+
+    // the reset wiped the Lua value; user scripts recreate it on
+    // sysLoadEvent, and opening the Variables view rebuilds the tree
+    lua_State *newL = mpHost->mLuaInterpreter.getLuaGlobalState();
+    luaL_dostring(newL, "xmlSavedTestVar = 'survives'");
+    mpHost->getLuaInterface()->getVars(false);
+
+    const QString xmlPath =
+        mudlet::getMudletPath(enums::profileHomePath, mHostname) +
+        qsl("/reset-var-test.xml");
+    auto writer = std::make_shared<XMLexport>(mpHost);
+    QVERIFY(writer->exportPackage(xmlPath, true, false));
+    QFile file(xmlPath);
+    QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString xml = QString::fromUtf8(file.readAll());
+    file.close();
+    QFile::remove(xmlPath);
+    QVERIFY2(xml.contains(qsl("xmlSavedTestVar")),
+             "saved variable should still be exported to profile XML after "
+             "a reset");
+  }
+
+  // A fresh profile load runs hideMudletsVariables() right after
+  // loadGlobal() so the Variables view only shows the user's variables;
+  // a reset must do the same or the view fills up with Mudlet's entire
+  // internal Lua API.
+  void test_mudletInternalVariablesHiddenAfterReset() {
+    mpHost->hideMudletsVariables();
+    VarUnit *vu = mpHost->getLuaInterface()->getVarUnit();
+    QVERIFY(vu->hidden.contains(qsl("color_table")));
+    QVERIFY(vu->hidden.contains(qsl("Geyser")));
+
+    performReset();
+
+    VarUnit *newVu = mpHost->getLuaInterface()->getVarUnit();
+    QVERIFY2(newVu->hidden.contains(qsl("color_table")),
+             "Mudlet's internal variables should be re-hidden after reset, "
+             "as on profile load");
+    QVERIFY2(newVu->hidden.contains(qsl("Geyser")),
+             "Mudlet's internal variables should be re-hidden after reset, "
+             "as on profile load");
+  }
+
+  // -----------------------------------------------------------------------
   // Helpers (reused from TOscTerminatorTest pattern)
   // -----------------------------------------------------------------------
+
+  TVar *findGlobalVar(VarUnit *vu, const QString &name) {
+    for (auto *child : vu->getBase()->getChildren(false)) {
+      if (child->getName() == name) {
+        return child;
+      }
+    }
+    return nullptr;
+  }
 
   void startProfile(const QString &hostname, const QString &address,
                     const QString &port) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Carry the Variables view's "save this variable" and "hidden by user" sets across resetProfile(), instead of losing them with the rebuilt Lua state
- Re-hide Mudlet's internal Lua API after reset (same call the normal profile load uses), so the Variables view shows user variables only
- 3 regression tests including an end-to-end check that a saved variable still lands in the profile XML after a reset

#### Motivation for adding to Mudlet
Since the #9430 crash fix, the first profile save after resetProfile() silently stripped all user-saved variables from the profile, and the Variables view flooded with hundreds of internal entries.

#### Other info (issues closed, discussion etc)
Follow-up to #9430; found by a post-merge QA audit and confirmed with a failing test before the fix.

**Test case:** Mark a variable as saved in the Variables view, run `lua resetProfile()`, save the profile - the variable survives a restart, and the Variables view lists only user variables.

Assisted-by: Claude:claude-fable-5