### PR TITLE
fix: script output no longer breaks the game's colour and control codes

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -261,6 +261,7 @@ TBuffer::TBuffer(const TBuffer& other)
 , mLocalGotESC(other.mLocalGotESC)
 , mLocalGotCSI(other.mLocalGotCSI)
 , mLocalGotOSC(other.mLocalGotOSC)
+, mLocalGotString(other.mLocalGotString)
 , mLocalIncompleteSequenceBytes(other.mLocalIncompleteSequenceBytes)
 , mProcessingLocalFeed(other.mProcessingLocalFeed)
 , lastLoggedFromLine(other.lastLoggedFromLine)
@@ -351,6 +352,7 @@ TBuffer& TBuffer::operator=(const TBuffer& other)
         mLocalGotESC = other.mLocalGotESC;
         mLocalGotCSI = other.mLocalGotCSI;
         mLocalGotOSC = other.mLocalGotOSC;
+        mLocalGotString = other.mLocalGotString;
         mLocalIncompleteSequenceBytes = other.mLocalIncompleteSequenceBytes;
         mProcessingLocalFeed = other.mProcessingLocalFeed;
         lastLoggedFromLine = other.lastLoggedFromLine;
@@ -571,13 +573,15 @@ void TBuffer::swapParserSequenceState()
     std::swap(mGotESC, mLocalGotESC);
     std::swap(mGotCSI, mLocalGotCSI);
     std::swap(mGotOSC, mLocalGotOSC);
+    std::swap(mGotString, mLocalGotString);
     std::swap(mIncompleteSequenceBytes, mLocalIncompleteSequenceBytes);
 }
 
 void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServer)
 {
-    // mGotESC/mGotCSI/mGotOSC and mIncompleteSequenceBytes persist between
-    // calls so that a sequence split across Game Server packets still parses.
+    // mGotESC/mGotCSI/mGotOSC/mGotString and mIncompleteSequenceBytes persist
+    // between calls so that a sequence split across Game Server packets still
+    // parses.
     // Locally generated text (feedTriggers(), MMCP chat messages, MXP
     // insertions) runs through the same parser, so swap in a separate set of
     // that state for the duration of such a feed - otherwise local text
@@ -763,17 +767,8 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                 continue;
             }
             // A control character straight after the ESC means the escape
-            // sequence is malformed - abandon it and process the character
-            // normally:
-        }
-
-        if (mGotESC) {
-            // ESC was not followed by '[' or ']', so it does not introduce a
-            // CSI or OSC sequence (e.g. ESC c, ESC 7, or a charset designator
-            // like ESC(B). Clear the latch here - otherwise it stays set and a
-            // later literal '[' or ']' anywhere in the stream is misparsed as a
-            // sequence introducer, swallowing the text that follows it.
-            mGotESC = false;
+            // sequence is malformed - abandon it (the latch was already
+            // cleared above) and process the character normally:
         }
 
         if (mGotCSI) {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -497,7 +497,7 @@ private:
     // translateToPlainText()}:
     std::string mIncompleteSequenceBytes;
 
-    // The parser sequence state (mGotESC, mGotCSI, mGotOSC and
+    // The parser sequence state (mGotESC, mGotCSI, mGotOSC, mGotString and
     // mIncompleteSequenceBytes) for whichever of the two data channels - Game
     // Server stream or locally generated text - is not currently being
     // processed; translateToPlainText() swaps it in around a local feed so
@@ -506,6 +506,7 @@ private:
     bool mLocalGotESC = false;
     bool mLocalGotCSI = false;
     bool mLocalGotOSC = false;
+    bool mLocalGotString = false;
     std::string mLocalIncompleteSequenceBytes;
     // Set whilst a locally generated feed is being processed, so a nested feed
     // (e.g. an MXP <HR> inside locally fed text) does not swap the state again:

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -54,7 +54,9 @@ private:
   TelnetServerStub *mpServer = nullptr;
   Host *mpHost = nullptr;
   const QString mHostname = "OSC-Test-Host";
-  const QString mPort = "4002";
+  // Assigned the stub's actual loopback port in initTestCase - binding to an
+  // ephemeral port (0) keeps concurrent test runs from colliding:
+  QString mPort;
   const QString mLocalhost = "localhost";
 
   // Injects raw telnet data into the processing pipeline via loopback and
@@ -186,7 +188,10 @@ private slots:
     initializeQRCResourcesForOscTest();
 
     mpServer = new TelnetServerStub(qApp);
-    mpServer->start(mLocalhost, mPort.toUShort());
+    mpServer->start(mLocalhost, 0);
+    QVERIFY2(mpServer->isListening(),
+             "TelnetServerStub failed to bind a loopback port");
+    mPort = QString::number(mpServer->serverPort());
     mudlet::start();
     mudlet::self()->setupConfig();
     mudlet::self()->takeOwnershipOfInstanceCoordinator(
@@ -262,6 +267,10 @@ private slots:
         << QString("\x1b]P0FF0000\x07Hello") << qsl("Hello") << true;
     QTest::newRow("empty OSC sequence")
         << QString("\x1b]\x07Normal text") << qsl("Normal text") << true;
+    QTest::newRow("stray ESC c then literal bracket text")
+        << QString("\x1b"
+                   "c[literal] text")
+        << qsl("[literal] text") << true;
     QTest::newRow("OSC exceeds length limit")
         << QString("\x1b]2;") + QString(5000, 'A') + QString("\x07Normal text")
         << qsl("Normal text") << true;
@@ -333,6 +342,65 @@ private slots:
     QVERIFY2(allText.contains(qsl("local tick")),
              qPrintable(qsl("Locally fed text went missing from: '%1'")
                             .arg(allText)));
+  }
+
+  // The don't-decode-this-payload flag set by a DCS/SOS/PM/APC introducer
+  // (mGotString) is carry-over parser state just like mGotOSC and must swap
+  // with the rest of it around a local feed. If it leaks: a complete OSC in
+  // the local feed is consumed but silently not decoded, and the server's DCS
+  // payload is wrongly decoded as an OSC when its terminator arrives.
+  void test_SplitDcsStringStateDoesNotLeakAcrossChannels() {
+    const bool savedMayRedefine = mpHost->getMayRedefineColors();
+    mpHost->setMayRedefineColors(true);
+    const QColor savedRed = mpHost->mRed;
+    const QColor savedGreen = mpHost->mGreen;
+
+    // First server packet ends inside a DCS (ESC P) with no terminator; its
+    // payload is shaped like an OSC colour redefinition for ANSI colour 2 so
+    // that wrongly feeding it to the OSC decoder is observable:
+    std::string part1{"Before\n\x1bPP2665544"};
+    mpHost->mpConsole->printOnDisplay(part1, true);
+
+    // Interleaved local feed carrying a complete OSC colour redefinition for
+    // ANSI colour 1 that must be decoded:
+    std::string localText{"\x1b]P1223344\x07local tick\n"};
+    mpHost->mpConsole->printOnDisplay(localText, false);
+
+    // The server DCS terminator arrives; the payload must be consumed
+    // without being decoded:
+    std::string part2{"\x07"
+                      "After\n"};
+    mpHost->mpConsole->printOnDisplay(part2, true);
+
+    const QColor redAfter = mpHost->mRed;
+    const QColor greenAfter = mpHost->mGreen;
+    const QString allText = allBufferText();
+
+    // Restore profile colour state before asserting so a failure does not
+    // poison later tests:
+    mpHost->mRed = savedRed;
+    mpHost->mGreen = savedGreen;
+    mpHost->setMayRedefineColors(savedMayRedefine);
+
+    QVERIFY2(allText.contains(qsl("After")),
+             qPrintable(
+                 qsl("Text after the split sequence went missing from: '%1'")
+                     .arg(allText)));
+    QVERIFY2(allText.contains(qsl("local tick")),
+             qPrintable(qsl("Locally fed text went missing from: '%1'")
+                            .arg(allText)));
+    QVERIFY2(!allText.contains(qsl("P2665544")),
+             qPrintable(qsl("DCS payload leaked into display: '%1'")
+                            .arg(allText)));
+    QVERIFY2(redAfter == QColor(0x22, 0x33, 0x44),
+             qPrintable(qsl("Complete OSC inside the local feed was not "
+                            "decoded: expected colour 1 to become #223344 "
+                            "but it is %1")
+                            .arg(redAfter.name())));
+    QVERIFY2(greenAfter == savedGreen,
+             qPrintable(qsl("Server DCS payload was wrongly fed to the OSC "
+                            "decoder: colour 2 changed to %1")
+                            .arg(greenAfter.name())));
   }
 
   // =====================================================================


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Include `mGotString` (DCS/SOS/PM/APC parser state) in the server<->local channel swap so string-sequence state no longer leaks between the game stream and local feeds
- Remove the stray-ESC clear block #9436 added, which #9433 already made unreachable
- Add the regression test #9436 lacked; `TOscTest` now uses an ephemeral telnet-stub port so concurrent runs cannot collide

#### Motivation for adding to Mudlet
Without the swap, a local OSC was silently not decoded and a split game-side DCS payload was wrongly decoded as an OSC, corrupting colour/control-code handling.

#### Other info (issues closed, discussion etc)
Follow-up to #9436 (found during a post-merge QA review).

**Test case:** Run the functional test suite; `TOscTest` covers the DCS-leak and stray-ESC scenarios. Manually: send a DCS payload split across two packets from the game and confirm it is not misdecoded, and feed a local OSC and confirm it is decoded.

Assisted-by: Claude:claude-fable-5