### PR TITLE
fix: notepad arrows now visible in dark mode

### DIFF
--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -25,6 +25,7 @@
 
 #include "mudlet.h"
 
+#include <QApplication>
 #include <QCloseEvent>
 #include <QDir>
 #include <QHBoxLayout>
@@ -36,6 +37,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
+#include <QPalette>
 #include <QPlainTextEdit>
 #include <QSaveFile>
 #include <QShortcut>
@@ -54,6 +56,8 @@ dlgNotepad::dlgNotepad(Host* pH)
 : mpHost(pH)
 {
     setupUi(this);
+    mUiSetupComplete = true;
+    updateSendControlsToggleIcon();
 
     setupAddTabButton();
 
@@ -592,6 +596,40 @@ void dlgNotepad::closeEvent(QCloseEvent* event)
 {
     saveSettings();
     QMainWindow::closeEvent(event);
+}
+
+// The grey arrows the .ui file gives the send controls toggle are all but invisible
+// against a dark background, so use the brighter green ones (which the .ui file already
+// uses for the hovered-over state) there instead. The background colour is what matters,
+// so go by the palette rather than by mudlet::inDarkMode() - the latter is only set when
+// Mudlet itself applies its dark theme, yet a dark system theme darkens the notepad as well.
+// The application palette is the one to read: when this runs in response to a style change
+// the widgets have not had the new palette propagated down to them yet
+void dlgNotepad::updateSendControlsToggleIcon()
+{
+    const bool darkBackground = QApplication::palette().color(QPalette::Window).lightness() <= 127;
+
+    QIcon icon;
+    if (darkBackground) {
+        icon.addFile(qsl(":/icons/arrow-right-16x.png"), QSize(), QIcon::Normal, QIcon::Off);
+        icon.addFile(qsl(":/icons/arrow-down-16x.png"), QSize(), QIcon::Normal, QIcon::On);
+    } else {
+        icon.addFile(qsl(":/icons/arrow-right_grey-16x.png"), QSize(), QIcon::Normal, QIcon::Off);
+        icon.addFile(qsl(":/icons/arrow-down_grey-16x.png"), QSize(), QIcon::Normal, QIcon::On);
+        icon.addFile(qsl(":/icons/arrow-right-16x.png"), QSize(), QIcon::Active, QIcon::Off);
+        icon.addFile(qsl(":/icons/arrow-down-16x.png"), QSize(), QIcon::Active, QIcon::On);
+    }
+    action_toggleSendControls->setIcon(icon);
+}
+
+void dlgNotepad::changeEvent(QEvent* event)
+{
+    QMainWindow::changeEvent(event);
+
+    // the appearance can be switched between light and dark while the notepad is open
+    if ((event->type() == QEvent::StyleChange || event->type() == QEvent::PaletteChange) && mUiSetupComplete) {
+        updateSendControlsToggleIcon();
+    }
 }
 
 bool dlgNotepad::eventFilter(QObject* obj, QEvent* event)

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -29,6 +29,7 @@
 
 class Host;
 class QCloseEvent;
+class QEvent;
 class QLabel;
 class QLineEdit;
 class QPlainTextEdit;
@@ -83,8 +84,10 @@ private slots:
 private:
     void timerEvent(QTimerEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
+    void changeEvent(QEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
     QPlainTextEdit* currentTextEdit() const;
+    void updateSendControlsToggleIcon();
     void setupAddTabButton();
     void setupFindBar();
     void highlightAllMatches();
@@ -94,6 +97,7 @@ private:
 
     QPointer<Host> mpHost;
     QToolButton* mpAddTabButton = nullptr;
+    bool mUiSetupComplete = false;
     bool mNeedToSave = false;
     QAction* action_stop = nullptr;
     QAction* action_prependText = nullptr;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The notepad's send-controls toggle button (the little arrow that expands/collapses the "Send all / Send line / Send selection" controls) used grey arrow icons baked into the `.ui` file. On a dark theme those grey arrows are all but invisible - dark-on-dark.

This ports the palette-driven icon swap already used by the trigger editor into the notepad. The correct light or dark arrow icons are chosen from the application palette when the notepad opens, and re-applied whenever the theme is switched while it is open (`StyleChange` / `PaletteChange`).

#### Motivation for adding to Mudlet

The toggle arrow was effectively unusable on dark themes because you could not see it. This makes it visible in both light and dark appearances, and keeps it correct if you flip the theme with the notepad already open.

#### Other info (issues closed, discussion etc)

Follows the same approach as the trigger editor's extra-controls toggle fix (`dlgTriggerEditor::updateExtraControlsToggleIcon` + `changeEvent`): it reads `QApplication::palette()` (not `mudlet::inDarkMode()`, and not a child widget's not-yet-propagated palette) so a dark *system* theme is handled too, not just Mudlet's own dark theme.

Assisted-by: Claude:claude-opus-4-8
