### PR TITLE
fix: non-English game text no longer garbles after a stray "&"

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1073,10 +1073,15 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
 
                         // We replace the already processed text with the entity value into the buffer and restart
                         // processing it for charset encoding but with limited MXP handling.
-                        // Encode with the session's encoding (not toLatin1(), which would flatten any
-                        // non-Latin1 characters to '?') so the value survives the re-decode below; the
+                        // A CUST value is decoded text, so encode it with the session's encoding
+                        // (not toLatin1(), which would flatten non-Latin1 characters to '?') for the
+                        // re-decode below. A LIT value is the raw, undecoded entity bytes held as one
+                        // Latin1 code unit per byte (see TEntityHandler::handle()), so toLatin1() is
+                        // an exact byte passthrough - re-encoding it would double-encode those bytes
+                        // and orphan any continuation bytes still ahead in the buffer. Either way the
                         // byte length, not the QString length, is what the offset bookkeeping needs.
-                        const QByteArray entityValueBytes = TEncodingHelper::encode(mpHost->mMxpProcessor.getEntityValue(), mEncoding);
+                        const QByteArray entityValueBytes =
+                                result == HANDLER_INSERT_ENTITY_CUST ? TEncodingHelper::encode(mpHost->mMxpProcessor.getEntityValue(), mEncoding) : mpHost->mMxpProcessor.getEntityValue().toLatin1();
                         size_t valueLength = entityValueBytes.size();
                         localBuffer.replace(0, localBufferPosition + 1, entityValueBytes.constData(), entityValueBytes.size());
 

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -41,7 +41,7 @@ class TelnetTextDisplayedTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-Telnet";
-    const QString mpPort = "4000";
+    QString mpPort;
     const QString mpLocalhost = "localhost";
 
 private slots:
@@ -50,7 +50,9 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
+        // Bind an ephemeral port so parallel test runs cannot collide
+        mpServer->start(mpLocalhost, 0);
+        mpPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
@@ -68,6 +70,33 @@ private slots:
         startProfile(mpHostname, mpLocalhost, mpPort);
 
         QVERIFY2(waitForTextInBuffer(messageToExpect), qPrintable(qsl("Expected text '%1' not found in console buffer").arg(messageToExpect)));
+    }
+
+    // An unescaped '&' directly followed by (or running into) a non-ASCII character
+    // is not a valid entity; the original raw bytes must be passed through unchanged
+    // so the charset decoder can reassemble the multi-byte characters (follow-up to #9439)
+    void test_MalformedEntityKeepsNonAsciiBytes()
+    {
+        QString messageFromTheMud("\x1B[1zKäse&Brötchen and &Ф too");
+        QString messageToExpect("Käse&Brötchen and &Ф too");
+
+        mpServer->setWelcomeMessage(messageFromTheMud);
+        startProfile(mpHostname, mpLocalhost, mpPort);
+
+        QVERIFY2(waitForTextInBuffer(messageToExpect), qPrintable(qsl("Expected text '%1' not found in console buffer, which contains:\n%2").arg(messageToExpect, bufferContents())));
+    }
+
+    // A custom <!ENTITY> with a non-Latin1 value must resolve to that value intact
+    // in a UTF-8 session (the case #9439 fixed)
+    void test_CustomEntityKeepsNonAsciiValue()
+    {
+        QString messageFromTheMud("\x1B[1z<!ENTITY storm \"Гроза\">The &storm; rages");
+        QString messageToExpect("The Гроза rages");
+
+        mpServer->setWelcomeMessage(messageFromTheMud);
+        startProfile(mpHostname, mpLocalhost, mpPort);
+
+        QVERIFY2(waitForTextInBuffer(messageToExpect), qPrintable(qsl("Expected text '%1' not found in console buffer, which contains:\n%2").arg(messageToExpect, bufferContents())));
     }
 
     void cleanup()
@@ -130,6 +159,17 @@ private slots:
                     return false;
                 },
                 timeoutMs);
+    }
+
+    // All buffer lines joined together, for failure diagnostics
+    QString bufferContents()
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        QStringList lines;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            lines << console->buffer.line(i);
+        }
+        return lines.join(QChar::LineFeed);
     }
 
     // Utility function


### PR DESCRIPTION
#### Brief overview of the PR

When a game sends a bare `&` that runs straight into non-English (multi-byte) text - which is not a valid MXP entity - Mudlet was re-encoding the recovered bytes, mangling the following characters into mojibake. For example `&Ф` rendered as `&Ð�`, and `Käse&Brötchen` lost its umlaut. This restores the raw-byte passthrough for these malformed/unknown entities while keeping the correct session-encoding handling for custom `<!ENTITY>` values. Non-English text now displays intact.

#### Motivation for adding to Mudlet

#9439 fixed custom MXP entities that carry non-Latin1 values, but the same code path also handles malformed and unknown entities, whose value is raw, still-undecoded bytes (one Latin1 code unit per byte). Encoding those bytes with the session charset double-encoded them and orphaned the UTF-8 continuation bytes still sitting in the buffer, so any non-ASCII text immediately after a stray `&` turned to garbage. Players on games that use Cyrillic, umlauts, CJK and other non-ASCII text were the ones affected.

The fix distinguishes the two cases: a custom entity value is decoded text, so it is re-encoded with the session encoding; a malformed/unknown entity value is raw bytes, so it is passed through unchanged with `toLatin1()`.

#### Other info

Follow-up to #9439.

**Test case:**

Two functional tests were added (using an ephemeral stub port so parallel test runs cannot collide):

- `test_MalformedEntityKeepsNonAsciiBytes` - sends `Käse&Brötchen and &Ф too` and expects it back byte-for-byte. This fails on the pre-fix code (the tail garbles to mojibake) and passes with the fix.
- `test_CustomEntityKeepsNonAsciiValue` - sends `<!ENTITY storm "Гроза">The &storm; rages` and expects `The Гроза rages`, guarding the #9439 behaviour so the new branching does not regress it.

Manual check: connect to a UTF-8 game that emits a bare `&` followed by non-English text (e.g. `&Ф`). Before this fix the following characters render as garbage; after it they render correctly.

Assisted-by: Claude:claude-fable-5
Assisted-by: Claude:claude-opus-4-8
