### PR TITLE
fix: MXP text now shows correctly on non-English games

### DIFF
--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -112,7 +112,7 @@ void TMxpNodeBuilder::processAttribute()
     if (mCurrentTagName.empty()) {
         mCurrentTagName = mCurrentAttrName;
     } else if (!mCurrentAttrName.empty()) {
-        mCurrentTagAttrs.append(MxpTagAttribute(mCurrentAttrName.c_str(), mCurrentAttrValue.c_str()));
+        mCurrentTagAttrs.append(MxpTagAttribute(TStringUtils::decodeBytes(mCurrentAttrName, mEncoding), TStringUtils::decodeBytes(mCurrentAttrValue, mEncoding)));
     }
 }
 void TMxpNodeBuilder::resetCurrentTag()

--- a/src/TMxpNodeBuilder.h
+++ b/src/TMxpNodeBuilder.h
@@ -22,9 +22,15 @@
 #include "MxpTag.h"
 #include "TStringUtils.h"
 
+#include <QByteArray>
+
 class TMxpNodeBuilder
 {
     bool mOptionIgnoreText;
+
+    // Session encoding used to decode attribute bytes; defaults to UTF-8 for
+    // callers (e.g. re-parsing already-decoded definitions) that don't set it.
+    QByteArray mEncoding{QByteArrayLiteral("UTF-8")};
 
     // current tag attrs
     std::string mCurrentTagName;
@@ -82,6 +88,8 @@ public:
 
     void reset();
     void resetForNewTag();
+
+    void setEncoding(const QByteArray& encoding) { mEncoding = encoding; }
 
     inline bool hasTag() const { return isTag() && hasNode(); }
 

--- a/src/TMxpProcessor.cpp
+++ b/src/TMxpProcessor.cpp
@@ -21,7 +21,7 @@
  ***************************************************************************/
 
 #include "TMxpProcessor.h"
-#include "TEncodingHelper.h"
+#include "TStringUtils.h"
 #include <QDebug>
 
 // Static sets of MXP tags from the specification
@@ -291,6 +291,10 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
         return HANDLER_FALL_THROUGH;
     }
 
+    // Keep the tag builder in sync with the session encoding so attribute
+    // bytes are decoded correctly on non-UTF-8 sessions.
+    mMxpTagBuilder.setEncoding(mpMxpClient->getEncoding());
+
     // Newline while inside a tag: MXP tags cannot span lines
     // Reject the partial tag as literal text, then let the newline trigger line commit
     if ((ch == '\n' || ch == '\r') && mMxpTagBuilder.isInsideTag() && !mMxpTagBuilder.hasTag() && !mMxpTagBuilder.isInsideComment()) {
@@ -397,13 +401,7 @@ TMxpProcessingResult TMxpProcessor::processMxpInput(char& ch, bool resolveCustom
 
 QString TMxpProcessor::decodeRawBytes(const std::string& raw, const QByteArray& encoding) const
 {
-    if (encoding == QByteArrayLiteral("UTF-8")) {
-        return QString::fromStdString(raw);
-    } else if (encoding == QByteArrayLiteral("ISO 8859-1")) {
-        return QString::fromLatin1(raw.c_str(), static_cast<int>(raw.length()));
-    } else {
-        return TEncodingHelper::decode(QByteArray::fromRawData(raw.c_str(), raw.length()), encoding);
-    }
+    return TStringUtils::decodeBytes(raw, encoding);
 }
 
 bool TMxpProcessor::isValidTagName(const std::string& tagName) const

--- a/src/TStringUtils.cpp
+++ b/src/TStringUtils.cpp
@@ -18,6 +18,8 @@
  ***************************************************************************/
 #include "TStringUtils.h"
 
+#include "TEncodingHelper.h"
+
 
 bool TStringUtils::isQuote(QChar ch)
 {
@@ -33,4 +35,17 @@ bool TStringUtils::isOneOf(QChar inputCharacter, const QString& characterSet)
     }
 
     return false;
+}
+
+QString TStringUtils::decodeBytes(const std::string& bytes, const QByteArray& encoding)
+{
+    // An unnegotiated (empty) session encoding is treated as UTF-8, matching the
+    // historical default for MXP text and staying a safe pass-through for ASCII.
+    if (encoding.isEmpty() || encoding == QByteArrayLiteral("UTF-8")) {
+        return QString::fromStdString(bytes);
+    }
+    if (encoding == QByteArrayLiteral("ISO 8859-1")) {
+        return QString::fromLatin1(bytes.c_str(), static_cast<int>(bytes.length()));
+    }
+    return TEncodingHelper::decode(QByteArray::fromRawData(bytes.c_str(), bytes.length()), encoding);
 }

--- a/src/TStringUtils.h
+++ b/src/TStringUtils.h
@@ -20,9 +20,11 @@
 #ifndef MUDLET_TSTRINGUTILS_H
 #define MUDLET_TSTRINGUTILS_H
 
+#include <QByteArray>
 #include <QString>
 #include <QStringList>
 #include <functional>
+#include <string>
 #include "utils.h"
 
 #define CHAR_NEW_LINE '\n'
@@ -40,6 +42,11 @@ class TStringUtils
 public:
     static bool isQuote(QChar ch);
     static bool isOneOf(QChar inputCharacter, const QString& characterSet);
+
+    // Decode raw MXP bytes into text using the active session encoding.
+    // Shared by the raw tag/content path and the attribute parser so both
+    // interpret non-ASCII bytes identically.
+    static QString decodeBytes(const std::string& bytes, const QByteArray& encoding);
 };
 
 #endif //MUDLET_TSTRINGUTILS_H

--- a/test/TMxpEntityTagHandlerTest.cpp
+++ b/test/TMxpEntityTagHandlerTest.cpp
@@ -203,6 +203,38 @@ private slots:
     QCOMPARE(processor.getEntityResolver().getResolution("&entity;"), "");
   }
 
+  // <!ENTITY> values must be decoded with the session encoding rather than
+  // hardcoded UTF-8 - covers quoted and unquoted values in a WINDOWS-1251
+  // session ("Гроза" = bytes C3 F0 EE E7 E0)
+  void testNonUtf8SessionEntityValue() {
+    TMxpStubClient stub;
+    stub.mEncoding = QByteArrayLiteral("WINDOWS-1251");
+    TMxpProcessor processor(&stub);
+    processor.setMode(6);
+
+    processInput(processor, "<!ENTITY storm \"\xC3\xF0\xEE\xE7\xE0\">");
+    processInput(processor, "<!ENTITY storm2 \xC3\xF0\xEE\xE7\xE0>");
+
+    TEntityResolver &resolver =
+        processor.getMxpTagProcessor().getEntityResolver();
+    QCOMPARE(resolver.getResolution("&storm;"), QString("Гроза"));
+    QCOMPARE(resolver.getResolution("&storm2;"), QString("Гроза"));
+  }
+
+  // UTF-8 sessions must keep resolving non-Latin1 entity values unchanged
+  void testUtf8SessionEntityValue() {
+    TMxpStubClient stub;
+    TMxpProcessor processor(&stub);
+    processor.setMode(6);
+
+    processInput(processor, "<!ENTITY storm \"Гроза\">");
+
+    QCOMPARE(
+        processor.getMxpTagProcessor().getEntityResolver().getResolution(
+            "&storm;"),
+        QString("Гроза"));
+  }
+
   void testEmptyEntityInterpolation() {
     TMxpStubClient stub;
     TMxpProcessor mxpProcessor(&stub);

--- a/test/TMxpSendTagHandlerTest.cpp
+++ b/test/TMxpSendTagHandlerTest.cpp
@@ -34,6 +34,41 @@ private slots:
     QCOMPARE(stub.mHints[0], "áéíóúñ");
   }
 
+  // Attribute values must be decoded with the session encoding, not hardcoded
+  // UTF-8. On a Latin1 (ISO 8859-1) session, the href bytes "se\xF1or" are
+  // "señor" - decoding them as UTF-8 would corrupt the 0xF1 byte.
+  void testSendHrefNonUtf8FromMxpProcessor() {
+    TMxpStubClient stub;
+    stub.mEncoding = QByteArrayLiteral("ISO 8859-1");
+    TMxpProcessor processor(&stub);
+    processor.setMode(MXP_MODE_CODE_LOCK_SECURE);
+
+    std::string input = "<SEND href=\"se\xF1or\">link</SEND>";
+    for (char &ch : input) {
+      processor.processMxpInput(ch, true);
+    }
+
+    QCOMPARE(stub.mHrefs.size(), 1);
+    QCOMPARE(stub.mHrefs[0], "send([[señor]])");
+  }
+
+  // With no encoding negotiated yet (empty session encoding) attribute values
+  // must still decode as UTF-8, matching the historical default.
+  void testSendHrefEmptyEncodingDefaultsToUtf8() {
+    TMxpStubClient stub;
+    stub.mEncoding = QByteArray();
+    TMxpProcessor processor(&stub);
+    processor.setMode(MXP_MODE_CODE_LOCK_SECURE);
+
+    std::string input = "<SEND href=\"áéíóúñ\">link</SEND>";
+    for (char &ch : input) {
+      processor.processMxpInput(ch, true);
+    }
+
+    QCOMPARE(stub.mHrefs.size(), 1);
+    QCOMPARE(stub.mHrefs[0], "send([[áéíóúñ]])");
+  }
+
   void testSendHrefUTF8() {
     // issue #4368
     QString input = "<SEND href=\"áéíóúñ\" >test link: áéíóúñ</SEND>";

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -66,6 +66,9 @@ public:
     QString version = "Stub-1.0";
     bool linkMode;
 
+    QByteArray mEncoding = QByteArrayLiteral("UTF-8");
+    QByteArray getEncoding() const override { return mEncoding; }
+
     QString sentToServer;
 
     QString fgColor, bgColor;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

MXP element attribute values - such as `SEND` link targets/hints and `<!ENTITY>` values - were always decoded as UTF-8, ignoring the session's negotiated encoding. On non-UTF-8 games (Latin1, GBK, Big5, WINDOWS-1251, ...) any non-ASCII bytes in an attribute were mis-decoded, so MXP links and entities carried garbled text.

This threads the active session encoding into `TMxpNodeBuilder` (set by `TMxpProcessor` before parsing each character) and decodes attribute names/values through a new shared `TStringUtils::decodeBytes` helper. That helper also replaces the duplicated decode logic previously inline in `TMxpProcessor::decodeRawBytes`, so the attribute path and the raw tag/content path now interpret bytes identically. An empty (not-yet-negotiated) encoding continues to be treated as UTF-8, preserving prior behaviour for default sessions.

#### Motivation for adding to Mudlet

Players on non-English MUDs saw corrupted text in MXP links and custom entities whenever those carried accented or non-Latin characters - the attribute parser was the only MXP path still hardcoding UTF-8 while element content already honoured the session encoding.

#### Other info (issues closed, discussion etc)

Added regression tests:
- `TMxpEntityTagHandlerTest`: quoted and unquoted `<!ENTITY>` values in a WINDOWS-1251 session decode to "Гроза"; a UTF-8 session still resolves the same value unchanged.
- `TMxpSendTagHandlerTest`: a `SEND href` with Latin1 bytes decodes to "señor"; an empty (default) session encoding still decodes attributes as UTF-8.

The WINDOWS-1251 entity test was verified to fail on the baseline (producing U+FFFD replacement characters) before the fix. All 14 MXP/encoding/entity unit tests pass.

Assisted-by: Claude:claude-opus-4-8