### PR TITLE
infrastructure: use std::chrono literals for time durations

### DIFF
--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -34,6 +34,9 @@
 #include <QPointer>
 #include <QTimer>
 #include <QUrl>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 namespace {
 // Human-readable labels for the provider ids that arrive as lowercase strings on the wire, so the
@@ -687,7 +690,7 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
         mReconnectRejected = true;
         //: Shown when a saved password-less sign-in is no longer accepted; Mudlet reconnects so the user can sign in again.
         mpHost->postMessage(tr("[ INFO ]  - Your saved sign-in has expired; reconnecting so you can sign in again."));
-        QTimer::singleShot(0, mpHost, [safeHost]() {
+        QTimer::singleShot(0ms, mpHost, [safeHost]() {
             if (safeHost) {
                 safeHost->mTelnet.reconnect();
             }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -371,7 +371,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     }
 
     if (mudlet::self()->smFirstLaunch) {
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             if (mpConsole) {
                 mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
             }
@@ -848,7 +848,7 @@ bool Host::resetProfile_phase1()
     mKeyUnit.stopAllTriggers();
     mResetProfile = true;
 
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         resetProfile_phase2();
     });
     return true;
@@ -2168,7 +2168,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     // Defer raising install events until the next event loop iteration
     // This ensures all package installation is complete (including variable loading)
     // before event handlers execute, preventing Lua state corruption
-    QTimer::singleShot(0, this, [this, thing, packageName, fileName]() {
+    QTimer::singleShot(0ms, this, [this, thing, packageName, fileName]() {
         // Don't raise events if Host is shutting down to avoid handlers executing during teardown
         if (isClosingDown()) {
             return;
@@ -2222,7 +2222,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     // Save profile to ensure modules persist and appear in module manager
     if (thing != enums::PackageModuleType::Package) {
         // Use a timer to save profile after module installation completes
-        QTimer::singleShot(100, this, [this]() {
+        QTimer::singleShot(100ms, this, [this]() {
             saveProfile();
         });
     }
@@ -2392,7 +2392,7 @@ bool Host::uninstallPackage(const QString& packageName, enums::PackageModuleType
         mSaveTimer = true;
         // save the profile on the next Qt main loop cycle in order for the asyncronous save mechanism
         // not to try to write to disk a package/module that just got uninstalled and removed from memory
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             mSaveTimer = false;
             if (auto [ok, filename, error] = saveProfile(); !ok) {
                 qDebug() << qsl("Host::uninstallPackage: Couldn't save '%1' to '%2' because: %3").arg(getName(), filename, error);
@@ -4892,13 +4892,13 @@ void Host::setFocusOnHostActiveCommandLine()
 
             // For Steam Deck and other environments where focus might be unreliable,
             // add additional focus attempts with slight delays
-            QTimer::singleShot(10, this, [targetCommandLine]() {
+            QTimer::singleShot(10ms, this, [targetCommandLine]() {
                 if (targetCommandLine && !targetCommandLine->hasFocus()) {
                     targetCommandLine->setFocus(Qt::OtherFocusReason);
                 }
             });
 
-            QTimer::singleShot(50, this, [targetCommandLine]() {
+            QTimer::singleShot(50ms, this, [targetCommandLine]() {
                 if (targetCommandLine && !targetCommandLine->hasFocus()) {
                     targetCommandLine->setFocus(Qt::OtherFocusReason);
                 }
@@ -4908,7 +4908,7 @@ void Host::setFocusOnHostActiveCommandLine()
         mFocusTimerRunning = false;
     };
 
-    QTimer::singleShot(0, this, setCommandLineFocus);
+    QTimer::singleShot(0ms, this, setCommandLineFocus);
 }
 
 void Host::recordActiveCommandLine(TCommandLine* pCommandLine)

--- a/src/MMCPClient.cpp
+++ b/src/MMCPClient.cpp
@@ -28,6 +28,9 @@
 #include <QTcpSocket>
 #include <QRegularExpression>
 #include <QtGlobal>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 QString convertToIPv4(QHostAddress addr)
 {
@@ -283,7 +286,7 @@ void MMCPClient::slot_readData()
                     // Start 60 second timeout for pending connection
                     // We don't know what client the peer is using, their client may timeout the socket, or may not
                     // Regardless, we'll time it out after 60 seconds
-                    mPendingTimer.start(60000);
+                    mPendingTimer.start(1min);
                 }
             }
         }

--- a/src/MudletInstanceCoordinator.cpp
+++ b/src/MudletInstanceCoordinator.cpp
@@ -22,6 +22,9 @@
 #include "Host.h"
 #include "mudlet.h"
 #include <QLocalSocket>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 const int WAIT_FOR_RESPONSE_MS = 500;
 
@@ -113,7 +116,7 @@ void MudletInstanceCoordinator::handleReadyRead()
         if (message.startsWith(qsl("TELNET_URI:"))) {
             const QString uri = message.mid(11);
 
-            QTimer::singleShot(0, this, [uri]() {
+            QTimer::singleShot(0ms, this, [uri]() {
                 mudlet* app = mudlet::self();
                 if (app) {
                     app->handleTelnetUri(uri);
@@ -134,7 +137,7 @@ void MudletInstanceCoordinator::handleReadyRead()
 // Find the active host and install queued packages to it
 void MudletInstanceCoordinator::installPackagesLocally()
 {
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         mudlet* mudletApp = mudlet::self();
         Q_ASSERT(mudletApp);
         Host* activeHost = mudletApp->getActiveHost();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -49,6 +49,9 @@
 #include <QUrlQuery>
 
 #include <utility>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -1606,7 +1609,7 @@ void TBuffer::processMxpWatchdogCallback()
             const TChar style(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
             QPointer<Host> hostGuard = mpHost;
             QPointer<TConsole> consoleGuard = mpConsole;
-            QTimer::singleShot(0, mpConsole, [this, style, hostGuard, consoleGuard]() {
+            QTimer::singleShot(0ms, mpConsole, [this, style, hostGuard, consoleGuard]() {
                 if (!hostGuard || !consoleGuard) {
                     return;
                 }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -40,6 +40,9 @@
 #include <QSaveFile>
 #include <QToolButton>
 #include <QIcon>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 TCommandLine::TCommandLine(Host* pHost, const QString& name, CommandLineType type, TConsole* pConsole, QWidget* parent)
 : QPlainTextEdit(parent)
@@ -512,7 +515,7 @@ bool TCommandLine::event(QEvent* event)
         case Qt::Key_PageUp:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 mpConsole->scrollUp(0);
-                QTimer::singleShot(0, this, [this]() {
+                QTimer::singleShot(0ms, this, [this]() {
                     mpConsole->scrollUp(mpConsole->mUpperPane->getScreenHeight());
                 });
                 ke->accept();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -59,6 +59,9 @@
 #include <QSplitter>
 #include <QTextBoundaryFinder>
 #include <QVideoWidget>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 const QString TConsole::cmLuaLineVariable("line");
 
@@ -627,7 +630,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     // Need to delay doing this because it uses elements that may not have
     // been constructed yet:
     if (mType == MainConsole) {
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             setProxyForFocus(mpCommandLine);
         });
     }
@@ -734,7 +737,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
             const int cols = qMax(40, paneWidthPx / fontWidth);
             if (cols > 0 && cols != host->mScreenWidth) {
                 host->setScreenDimensions(cols, host->mScreenHeight);
-                QTimer::singleShot(0, host, &Host::updateDisplayDimensions);
+                QTimer::singleShot(0ms, host, &Host::updateDisplayDimensions);
             }
         };
 
@@ -1168,7 +1171,7 @@ void TConsole::scrollUp(int lines)
     mLowerPane->forceUpdate();
 
     if (lowerAppears) {
-        QTimer::singleShot(0, this, [this, lines]() {
+        QTimer::singleShot(0ms, this, [this, lines]() {
             mUpperPane->scrollUp(mLowerPane->getRowCount() + lines);
         });
         if (mudlet::self()->showSplitscreenTutorial()) {
@@ -2621,7 +2624,7 @@ void TConsole::setCaretMode(bool enabled)
     } else {
 #if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX)
         // NVDA breaks focus reset, so do it on a timer
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             mUpperPane->releaseKeyboard();
         });
 #endif

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -28,6 +28,10 @@
 #include "TTabBar.h"
 #include "mudlet.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 TDebug::TDebug(const QColor& c, const QColor& d)
 : fgColor(c)
 , bgColor(d)
@@ -239,7 +243,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
         // here as the profile's tab has not been added to the tabbar yet.
         // Instead arrange for all the tabs to be refreshed when we are next
         // idle:
-        QTimer::singleShot(0, mudlet::self(), []() {
+        QTimer::singleShot(0ms, mudlet::self(), []() {
             mudlet::self()->refreshTabBar();
         });
     }

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -59,6 +59,9 @@
 #include <QDockWidget>
 #include <QDesktopServices>
 #include <QUrl>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 TDetachedWindow::TDetachedWindow(const QString& profileName, TMainConsole* console, QWidget* parent, bool toolbarVisible)
 : QMainWindow(parent)
@@ -648,7 +651,7 @@ void TDetachedWindow::moveEvent(QMoveEvent* event)
     QMainWindow::moveEvent(event);
 
     // Check if we should offer to merge with another detached window
-    QTimer::singleShot(100, this, &TDetachedWindow::checkForWindowMergeOpportunity);
+    QTimer::singleShot(100ms, this, &TDetachedWindow::checkForWindowMergeOpportunity);
 }
 
 void TDetachedWindow::resizeEvent(QResizeEvent* event)
@@ -679,7 +682,7 @@ void TDetachedWindow::hideEvent(QHideEvent* event)
         qDebug() << "TDetachedWindow::hideEvent: Preventing window hide - has" << mpTabBar->count() << "profiles";
 #endif
         // Force the window to stay visible - but only if not minimized
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             if (mpTabBar && mpTabBar->count() > 0 && !mIsBeingMinimized) {
                 setVisible(true);
                 show();
@@ -713,7 +716,7 @@ void TDetachedWindow::onReattachAction()
         emit reattachRequested(mCurrentProfileName);
 
         // Reset the flag after a short delay to allow for the operation to complete
-        QTimer::singleShot(500, this, [this]() {
+        QTimer::singleShot(500ms, this, [this]() {
             mReattachInProgress = false;
         });
     }
@@ -1612,7 +1615,7 @@ void TDetachedWindow::slot_toggleAlwaysOnTop()
     show(); // Required after changing window flags
 
     // Reset flag after a short delay to allow the window operations to complete
-    QTimer::singleShot(100, this, [this]() {
+    QTimer::singleShot(100ms, this, [this]() {
         mIsChangingWindowFlags = false;
     });
 }
@@ -2008,7 +2011,7 @@ bool TDetachedWindow::addProfile(const QString& profileName, TMainConsole* conso
     repaint();
 
     // Schedule a delayed update to handle any Qt layout timing issues
-    QTimer::singleShot(10, this, [this, profileName]() {
+    QTimer::singleShot(10ms, this, [this, profileName]() {
         auto console = mProfileConsoleMap.value(profileName);
 
         if (console) {
@@ -2187,7 +2190,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
 
         // Also schedule a delayed visibility restoration in case the drag operation
         // affects window state after this method returns
-        QTimer::singleShot(100, this, [this, profileName]() {
+        QTimer::singleShot(100ms, this, [this, profileName]() {
             if (mpTabBar->count() > 0) {
                 setVisible(true);
                 show();
@@ -2298,7 +2301,7 @@ void TDetachedWindow::switchToProfile(const QString& profileName)
     repaint();
 
     // Schedule a delayed update to handle any Qt layout timing issues
-    QTimer::singleShot(10, this, [this, profileName]() {
+    QTimer::singleShot(10ms, this, [this, profileName]() {
         auto console = mProfileConsoleMap.value(profileName);
 
         if (console) {
@@ -2413,7 +2416,7 @@ void TDetachedWindow::closeProfileByIndex(int index)
         // so we need to notify the main window about the window closure here
         emit windowClosed(profileName);
 
-        QTimer::singleShot(0, this, [this] {
+        QTimer::singleShot(0ms, this, [this] {
             close();
         });
     }
@@ -2504,7 +2507,7 @@ void TDetachedWindow::performWindowMerge(TDetachedWindow* otherWindow)
     }
 
     // Automatically merge without prompting - defer the operation to avoid timing issues
-    QTimer::singleShot(0, this, [this, otherWindow, ourProfiles, mergePair]() {
+    QTimer::singleShot(0ms, this, [this, otherWindow, ourProfiles, mergePair]() {
         // Check if the other window is still valid
         if (!otherWindow) {
             return;
@@ -2523,7 +2526,7 @@ void TDetachedWindow::performWindowMerge(TDetachedWindow* otherWindow)
     });
 
     // Clean up the active merge tracking after a delay
-    QTimer::singleShot(100, [mergePair]() {
+    QTimer::singleShot(100ms, [mergePair]() {
         activeMergeOperations.remove(mergePair);
     });
 }

--- a/src/THyperlinkVisibilityManager.cpp
+++ b/src/THyperlinkVisibilityManager.cpp
@@ -29,7 +29,10 @@
 #include <QAccessible>
 #include <QDateTime>
 #include <QDebug>
+#include <chrono>
 #include <limits>
+
+using namespace std::chrono_literals;
 
 THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsole* pConsole)
 : QObject(nullptr)
@@ -38,7 +41,7 @@ THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsole* pConsole)
     Q_ASSERT(pConsole);
 
     mpTimer = new QTimer(this);
-    mpTimer->setInterval(100); // Check every 100ms for timer-based concealments
+    mpTimer->setInterval(100ms); // Check every 100ms for timer-based concealments
     connect(mpTimer, &QTimer::timeout, this, &THyperlinkVisibilityManager::slot_checkTimers);
 
     mpOutputGapTimer = new QTimer(this);
@@ -47,7 +50,7 @@ THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsole* pConsole)
 
     mpAnnouncementTimer = new QTimer(this);
     mpAnnouncementTimer->setSingleShot(true);
-    mpAnnouncementTimer->setInterval(300);
+    mpAnnouncementTimer->setInterval(300ms);
     connect(mpAnnouncementTimer, &QTimer::timeout, this, &THyperlinkVisibilityManager::slot_announceHiddenLinks);
 }
 

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -33,7 +33,9 @@
 #include <QTimer>
 #include <QUrl>
 #include <QtEvents>
+#include <chrono>
 
+using namespace std::chrono_literals;
 
 TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
 : QLabel(pW)
@@ -413,7 +415,7 @@ void TLabel::slot_linkActivated(const QString& link)
                 commandLine->setTextCursor(cursor);
                 // Defer the focus operation to avoid issues with QPointer manipulation
                 // during the signal handler execution
-                QTimer::singleShot(0, commandLine.data(), [commandLine]() {
+                QTimer::singleShot(0ms, commandLine.data(), [commandLine]() {
                     if (commandLine) {
                         commandLine->setFocus();
                     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -46,7 +46,9 @@
 #include <QPixmap>
 #include <QProgressDialog>
 #include <QSizeF>
+#include <chrono>
 
+using namespace std::chrono_literals;
 
 namespace {
 // Restores font information from userData that was stored during binary serialization.
@@ -3494,7 +3496,7 @@ void TMap::updateArea(int areaId)
     static bool debounce;
     if (!debounce) {
         debounce = true;
-        QTimer::singleShot(0, this, [this, areaId]() {
+        QTimer::singleShot(0ms, this, [this, areaId]() {
             debounce = false;
 
 #if defined(INCLUDE_3DMAPPER)

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -61,6 +61,8 @@
 #include <QWidgetAction>
 #include <QVersionNumber>
 
+using namespace std::chrono_literals;
+
 // Renders text on screen
 // Text data stored separately in a TBuffer
 TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLowerPane)
@@ -110,7 +112,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
     // Scroll optimizations may use cached screen data, missing blinking content detection
     mpScrollStoppedTimer = new QTimer(this);
     mpScrollStoppedTimer->setSingleShot(true);
-    mpScrollStoppedTimer->setInterval(150);
+    mpScrollStoppedTimer->setInterval(150ms);
     connect(mpScrollStoppedTimer, &QTimer::timeout, this, &TTextEdit::slot_scrollStoppedTimeout);
 
     showNewLines();
@@ -2563,7 +2565,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
     // We have already bailed out before here for the Central Debug Console and
     // the editor Error console so those will avoid the focus being changed to
     // this profile now:
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         if (mpHost) {
             mudlet::self()->activateProfile(mpHost);
         }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -25,6 +25,9 @@
 
 #include <QtDebug>
 #include <QHash>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 // Uncomment this to provide some additional qDebug() output:
 // #define DEBUG_DISCORD 1
@@ -109,12 +112,12 @@ Discord::Discord(QObject* parent)
     // call initializeRpc() on demand when there's an active host.
 
     // mudlet instance is not available in this constructor as it's still being initialised, so postpone the connection
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         Q_ASSERT(mudlet::self());
         connect(mudlet::self(), &mudlet::signal_tabChanged, this, &Discord::UpdatePresence);
 
         // process Discord callbacks every 50ms once we are all set up:
-        startTimer(50);
+        startTimer(50ms);
     });
 }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1122,7 +1122,7 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
         timer->setSingleShot(true);
         timer->setProperty("profileName", profile_name);
         connect(timer, &QTimer::timeout, this, &dlgConnectionProfiles::slot_loadPasswordAsync);
-        timer->start(0);
+        timer->start(0ms);
     }
 
     val = readProfileData(profile_name, qsl("login"));
@@ -2552,7 +2552,7 @@ void dlgConnectionProfiles::slot_passwordTextChanged()
     } else {
         mPasswordSaveTimer = new QTimer(this);
         mPasswordSaveTimer->setSingleShot(true);
-        mPasswordSaveTimer->setInterval(500); // 500ms debounce
+        mPasswordSaveTimer->setInterval(500ms); // 500ms debounce
         connect(mPasswordSaveTimer, &QTimer::timeout, this, [this]() {
             if (!mPendingPasswordSaveProfile.isEmpty()) {
                 // Check if this profile is STILL selected - if not, don't save

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -43,6 +43,7 @@
 #include <QTextDocument>
 #include <QTimer>
 #include <QToolButton>
+#include <chrono>
 
 using namespace std::chrono;
 
@@ -504,7 +505,7 @@ void dlgNotepad::startSendingLines(const QStringList& lines)
     }
 
     action_stop->setEnabled(true);
-    mSendTimer->start(300);
+    mSendTimer->start(300ms);
 }
 
 void dlgNotepad::slot_sendNextLine()

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -46,6 +46,9 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <QUrl>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 // We are now using code that won't work with really old versions of libzip;
 // some of the error handling was improved in 1.0 . Unfortunately libzip 1.7.0
@@ -1948,7 +1951,7 @@ void dlgPackageExporter::slot_recountItems(QTreeWidgetItem* item)
     static bool debounce;
     if (!debounce) {
         debounce = true;
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             debounce = false;
 
             const int itemsToExport = countCheckedItems();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -80,6 +80,7 @@
 #include <QRegularExpression>
 #include <QToolButton>
 #include <QToolBar>
+#include <chrono>
 #include <sstream>
 #include <pugixml.hpp>
 #include <QVBoxLayout>
@@ -1959,7 +1960,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             mpSourceEditorEdbee->controller()->moveCaretTo(line, column, false);
                         }
@@ -2016,7 +2017,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             auto controller = mpSourceEditorEdbee->controller();
                             controller->moveCaretTo(line, column, false);
@@ -2069,7 +2070,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             mpSourceEditorEdbee->controller()->moveCaretTo(line, column, false);
                         }
@@ -2127,7 +2128,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             mpSourceEditorEdbee->controller()->moveCaretTo(line, column, false);
                         }
@@ -2195,7 +2196,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             mpSourceEditorEdbee->controller()->moveCaretTo(line, column, false);
                         }
@@ -2242,7 +2243,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             mpSourceEditorEdbee->controller()->moveCaretTo(line, column, false);
                         }
@@ -2306,7 +2307,7 @@ void dlgTriggerEditor::slot_itemSelectedInSearchResults(QTreeWidgetItem* pItem)
                     const auto line = static_cast<size_t>(pItem->data(0, PatternOrLineRole).toInt());
                     const auto column = static_cast<size_t>(pItem->data(0, PositionRole).toInt());
                     mpSourceEditorEdbee->setFocus();
-                    QTimer::singleShot(0, this, [this, line, column]() {
+                    QTimer::singleShot(0ms, this, [this, line, column]() {
                         if (mpSourceEditorEdbee) {
                             mpSourceEditorEdbee->controller()->moveCaretTo(line, column, false);
                         }
@@ -9843,7 +9844,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     // (selection handlers will also re-enable via restoreEditorState, but this
     // is a fallback in case no item is selected in the new view)
     if (mpSourceEditorEdbee && !mpSourceEditorEdbee->updatesEnabled()) {
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             if (mpSourceEditorEdbee) {
                 mpSourceEditorEdbee->setUpdatesEnabled(true);
             }
@@ -12268,7 +12269,7 @@ void dlgTriggerEditor::doCleanReset()
 
     mCleanResetQueued = true;
 
-    QTimer::singleShot(0, this, [=, this]() {
+    QTimer::singleShot(0ms, this, [=, this]() {
         mCleanResetQueued = false;
 
         runScheduledCleanReset();
@@ -12906,7 +12907,7 @@ void dlgTriggerEditor::restoreEditorState(EditorViewType viewType, int itemId)
     const bool hasState = mEditorStates.contains(viewType) && mEditorStates[viewType].contains(itemId);
     const EditorState state = hasState ? mEditorStates[viewType][itemId] : EditorState{};
 
-    QTimer::singleShot(0, this, [this, state, hasState]() {
+    QTimer::singleShot(0ms, this, [this, state, hasState]() {
         if (!mpSourceEditorEdbee) {
             return;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1077,12 +1077,12 @@ int main(int argc, char* argv[])
 
     mudlet::self()->show();
     if (parser.isSet(startFullscreen)) {
-        QTimer::singleShot(0, [=]() {
+        QTimer::singleShot(0ms, [=]() {
             mudlet::self()->showFullScreen();
         });
     }
 
-    QTimer::singleShot(0, qApp, [cliProfiles, telnetUri]() {
+    QTimer::singleShot(0ms, qApp, [cliProfiles, telnetUri]() {
         // Migrate portable password files to secure storage before any
         // profile dialog or auto-login code runs.  The migration is
         // synchronous (uses static CredentialManager helpers) so it is

--- a/src/modern_glwidget.cpp
+++ b/src/modern_glwidget.cpp
@@ -35,7 +35,9 @@
 #include <QDebug>
 #include <QPainter>
 #include <QKeyEvent>
+#include <chrono>
 
+using namespace std::chrono_literals;
 
 ModernGLWidget::ModernGLWidget(TMap* pMap, Host* pHost, QWidget* parent)
 : QOpenGLWidget(parent)
@@ -57,7 +59,7 @@ ModernGLWidget::ModernGLWidget(TMap* pMap, Host* pHost, QWidget* parent)
 
     // Initialize smooth camera animation
     mCameraAnimationTimer = new QTimer(this);
-    mCameraAnimationTimer->setInterval(17); // ~60fps updates for smoother animation
+    mCameraAnimationTimer->setInterval(17ms); // ~60fps updates for smoother animation
     connect(mCameraAnimationTimer, &QTimer::timeout, this, &ModernGLWidget::onCameraAnimationTick);
     mEasingCurve.setType(QEasingCurve::OutQuart); // Natural deceleration
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -91,6 +91,7 @@
 
 #include <QRandomGenerator>
 
+#include <chrono>
 #include <cmath>
 #include <memory>
 #include <zip.h>
@@ -778,14 +779,14 @@ void mudlet::init()
     setupTrayIcon();
 
     // emit the signal for adjusting accessible names
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         emit signal_adjustAccessibleNames();
     });
 
     // 200ms interval for WCAG 2.3.1 compliance (max 3 Hz)
     // 4-state counter per ISO/IEC 8613-6: slow blink < 150 cycles/min, fast > 150
     mpBlinkTimer = new QTimer(this);
-    mpBlinkTimer->setInterval(33);
+    mpBlinkTimer->setInterval(33ms);
     connect(mpBlinkTimer, &QTimer::timeout, this, [this]() {
         // Use actual elapsed time so the animation phase stays accurate even
         // when the main thread is busy (map loads, incoming MUD data floods, etc.)
@@ -1664,7 +1665,7 @@ void mudlet::slot_closeProfileRequested(int tab)
         return;
     }
 
-    QTimer::singleShot(0, this, [this, name] {
+    QTimer::singleShot(0ms, this, [this, name] {
         closeHost(name);
         // Update main window title based on remaining profiles
         updateMainWindowTitle();
@@ -1687,7 +1688,7 @@ void mudlet::slot_closeProfileByName(const QString& profileName)
         return;
     }
 
-    QTimer::singleShot(0, this, [this, profileName] {
+    QTimer::singleShot(0ms, this, [this, profileName] {
         closeHost(profileName);
         // Update main window toolbar state in case this was the active profile
         updateMainWindowToolbarState();
@@ -2216,7 +2217,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
     // Set up a timer to refresh tab indicators after a few seconds
     // This catches connection status changes that typically happen shortly after profile creation
-    QTimer::singleShot(3000, this, &mudlet::slot_refreshTabIndicatorsDelayed);
+    QTimer::singleShot(3s, this, &mudlet::slot_refreshTabIndicatorsDelayed);
 }
 
 
@@ -2688,7 +2689,7 @@ void mudlet::showEvent(QShowEvent* event)
         startupValidationDone = true;
 
         // Use a timer to defer this check until after full initialization
-        QTimer::singleShot(1000, this, [this]() {
+        QTimer::singleShot(1s, this, [this]() {
             QStringList orphanedProfiles = getOrphanedProfiles();
 
             if (!orphanedProfiles.isEmpty()) {
@@ -3201,7 +3202,7 @@ void mudlet::slot_showConnectionDialog()
 
     // Use a timer to ensure the main window is ready before showing the dialog
     // This is especially important at startup when the main window might not be fully initialized
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         // Ensure the main window is visible and ready
         if (!isVisible()) {
             show();
@@ -3246,7 +3247,7 @@ void mudlet::slot_showEditorDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -3289,7 +3290,7 @@ void mudlet::slot_showTriggerDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -3328,7 +3329,7 @@ void mudlet::slot_showAliasDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -3364,7 +3365,7 @@ void mudlet::slot_showTimerDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -3392,7 +3393,7 @@ void mudlet::slot_showTimerDialog()
 void mudlet::restoreProfileFocus(const QString& profileName)
 {
     // Small delay to ensure the dialog window is fully processed
-    QTimer::singleShot(50, [profileName]() {
+    QTimer::singleShot(50ms, [profileName]() {
         auto mudletInstance = mudlet::self();
         if (!mudletInstance) {
             return;
@@ -3446,7 +3447,7 @@ void mudlet::setupEditorFocusRestoration(dlgTriggerEditor* pEditor, const QStrin
         // If a specific target window is provided (detached window), focus that
         if (targetWindow) {
             // Small delay to ensure the editor window is fully processed
-            QTimer::singleShot(50, [profileName, targetWindow]() {
+            QTimer::singleShot(50ms, [profileName, targetWindow]() {
                 targetWindow->show();
                 targetWindow->raise();
                 targetWindow->activateWindow();
@@ -3577,7 +3578,7 @@ void mudlet::slot_showKeyDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -3613,7 +3614,7 @@ void mudlet::slot_showVariableDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -3649,7 +3650,7 @@ void mudlet::slot_showActionDialog()
 
     // Set up focus restoration to return to this main window when the editor closes
     connect(pEditor, &QObject::destroyed, this, [this]() {
-        QTimer::singleShot(50, this, [this]() {
+        QTimer::singleShot(50ms, this, [this]() {
             // Activate the main window
             this->show();
             this->raise();
@@ -4324,7 +4325,7 @@ void mudlet::slot_reconnect()
 
     // Set up a timer to refresh tab indicators after a few seconds
     // This catches connection status changes that typically happen shortly after reconnection
-    QTimer::singleShot(3000, this, &mudlet::slot_refreshTabIndicatorsDelayed);
+    QTimer::singleShot(3s, this, &mudlet::slot_refreshTabIndicatorsDelayed);
 }
 
 void mudlet::slot_disconnect()
@@ -4879,7 +4880,7 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
         const bool skipIntroStep = profile == qsl("Mudlet Tutorial");
         // give the freshly opened profile a moment to finish laying out before
         // the tour starts highlighting parts of it
-        QTimer::singleShot(1000, this, [this, skipIntroStep]() { showUiTour(skipIntroStep); });
+        QTimer::singleShot(1s, this, [this, skipIntroStep]() { showUiTour(skipIntroStep); });
     }
 }
 
@@ -5288,7 +5289,7 @@ bool mudlet::replayStart()
     mpLabelReplaySpeedDisplay->setText(qsl("<font size=25><b>%1</b></font>").arg(tr("Speed: X%1").arg(mReplaySpeed)));
 
     mpTimerReplay = new QTimer(this);
-    mpTimerReplay->setInterval(1000);
+    mpTimerReplay->setInterval(1s);
     mpTimerReplay->setSingleShot(false);
     connect(mpTimerReplay.data(), &QTimer::timeout, this, &mudlet::slot_replayTimeChanged);
 
@@ -6120,7 +6121,7 @@ bool mudlet::migratePasswordsToSecureStorage()
     }
 
     // Always emit the signal (either immediately or after migrations complete)
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         emit signal_passwordsMigratedToSecure();
     });
 
@@ -6174,7 +6175,7 @@ bool mudlet::migratePasswordsToProfileStorage()
 
     // If no old-format entries need to be checked, emit signal immediately
     if (mProfilePasswordsToMigrate.isEmpty()) {
-        QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0ms, this, [this]() {
             emit signal_passwordsMigratedToProfiles();
         });
     }
@@ -6981,7 +6982,7 @@ void mudlet::activateProfile(Host* pHost)
         mpCurrentActiveHost->mpConsole->refresh();
         // Defer subconsole refresh to allow Qt to fully process the show event
         // and update widget geometry before we try to recalculate screen dimensions
-        QTimer::singleShot(0, mpCurrentActiveHost->mpConsole, &TMainConsole::refreshSubconsoles);
+        QTimer::singleShot(0ms, mpCurrentActiveHost->mpConsole, &TMainConsole::refreshSubconsoles);
         mpCurrentActiveHost->mpConsole->mpCommandLine->repaint();
 
         // If NOT in multiview mode, hide all other consoles in the main window
@@ -7024,7 +7025,7 @@ void mudlet::activateProfile(Host* pHost)
     // When switching profiles, Qt widget geometry isn't updated until the event loop processes
     // show/hide events. Calling adjustHeight() immediately would use incorrect document width,
     // causing the input bar to have the wrong height.
-    QTimer::singleShot(0, mpCurrentActiveHost->mpConsole->mpCommandLine, &TCommandLine::adjustHeight);
+    QTimer::singleShot(0ms, mpCurrentActiveHost->mpConsole->mpCommandLine, &TCommandLine::adjustHeight);
 
     // Update the main application window title based on active profiles in main window
     updateMainWindowTitle();
@@ -7039,7 +7040,7 @@ void mudlet::activateProfile(Host* pHost)
     // otherwise mScreenWidth hits its qMax(40, ...) floor and the server
     // pre-wraps output too narrowly. Receiver-form singleShot is safe if the
     // Host is destroyed first - do not change to a lambda.
-    QTimer::singleShot(0, mpCurrentActiveHost.data(), &Host::updateDisplayDimensions);
+    QTimer::singleShot(0ms, mpCurrentActiveHost.data(), &Host::updateDisplayDimensions);
 
     // Currently used to update the Discord Rich Presence
     emit signal_tabChanged(mpCurrentActiveHost->getName());
@@ -7297,7 +7298,7 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
 // to be done on the next Qt event loop iteration:
 void mudlet::armForceClose()
 {
-    QTimer::singleShot(0, this, [this]() {
+    QTimer::singleShot(0ms, this, [this]() {
         forceClose();
     });
 }
@@ -7473,7 +7474,7 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
         Host* pHost = mHostManager.getHost(profileName);
         if (pHost) {
             if (pHost->requestClose()) {
-                QTimer::singleShot(0, this, [this, profileName] {
+                QTimer::singleShot(0ms, this, [this, profileName] {
                     closeHost(profileName);
                     // Check to see if there are any profiles left...
                     if (!mHostManager.getHostCount() && !mIsGoingDown) {

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -490,7 +490,7 @@ void Updater::slot_installOrRestartClicked(QAbstractButton* button, const QStrin
     // if the update is already installed, then the button says 'Restart' - do so
     if (mUpdateInstalled) {
         // defer to next event loop iteration so the dialog close happens after the button click handler returns
-        QTimer::singleShot(0, this, [=, this]() {
+        QTimer::singleShot(0ms, this, [=, this]() {
             updateDialog->close();
             updateDialog->done(0);
         });

--- a/test/functional_tests/EnableDisableByNameTest.cpp
+++ b/test/functional_tests/EnableDisableByNameTest.cpp
@@ -29,6 +29,7 @@
  */
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include <functional>
 
@@ -61,6 +62,8 @@ extern "C" {
 #include <lualib.h>
 #endif
 }
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -277,21 +280,21 @@ private slots:
 
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
-        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -24,6 +24,7 @@
 // authentication.
 
 #include <QtTest/QtTest>
+#include <chrono>
 #include <QtNetwork/QTcpServer>
 #include <QtNetwork/QTcpSocket>
 #include <QDesktopServices>
@@ -37,6 +38,8 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -523,7 +526,7 @@ private slots:
         mpServer->clearReceived();
         mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Reconnect token expired\"}"));
         QVERIFY2(waitForConsoleContains(host, qsl("saved sign-in has expired")), "the second rejection should be reported, not retried");
-        QTest::qWait(300);
+        QTest::qWait(300ms);
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
     }
 
@@ -601,7 +604,7 @@ private slots:
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not autofill stored credentials");
         QCOMPARE(sent.value(qsl("account")).toString(), qsl("player"));
         QCOMPARE(sent.value(qsl("password")).toString(), qsl("secret"));
-        QTest::qWait(300);
+        QTest::qWait(300ms);
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
     }
 
@@ -689,21 +692,21 @@ private:
     Host* connectAndNegotiate()
     {
         const QString port = QString::number(mPort);
-        QTimer::singleShot(0, qApp, [this, port]() {
+        QTimer::singleShot(0ms, qApp, [this, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mHostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), qsl("localhost"));
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/MainConsoleSelectionTest.cpp
+++ b/test/functional_tests/MainConsoleSelectionTest.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
@@ -27,6 +28,8 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -102,7 +105,7 @@ private slots:
         QVERIFY2(waitForTextInBuffer(QString(100, QLatin1Char('X'))), "Filler text never reached the buffer");
 
         mudlet::self()->resize(1200, 800);
-        QTest::qWait(100);
+        QTest::qWait(100ms);
 
         TTextEdit* pane = upperPane();
         QVERIFY2(pane, "No upper pane available");
@@ -132,7 +135,7 @@ private slots:
         QVERIFY2(waitForTextInBuffer(QString(100, QLatin1Char('X'))), "Filler text never reached the buffer");
 
         mudlet::self()->resize(1200, 800);
-        QTest::qWait(100);
+        QTest::qWait(100ms);
 
         TTextEdit* pane = upperPane();
         QVERIFY2(pane, "No upper pane available");
@@ -159,7 +162,7 @@ private slots:
         QVERIFY2(waitForTextInBuffer(QString(100, QLatin1Char('X'))), "Filler text never reached the buffer");
 
         mudlet::self()->resize(1200, 800);
-        QTest::qWait(100);
+        QTest::qWait(100ms);
 
         TTextEdit* pane = upperPane();
         QVERIFY2(pane, "No upper pane available");
@@ -200,21 +203,21 @@ private slots:
 private:
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
-        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/ResetProfileTest.cpp
+++ b/test/functional_tests/ResetProfileTest.cpp
@@ -32,6 +32,7 @@
  */
 
 #include <QtTest/QtTest>
+#include <chrono>
 #include <QMouseEvent>
 
 #include "Host.h"
@@ -62,6 +63,8 @@ extern "C" {
 #include <lualib.h>
 #endif
 }
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -752,22 +755,22 @@ private slots:
 
   void startProfile(const QString &hostname, const QString &address,
                     const QString &port) {
-    QTimer::singleShot(0, qApp, [hostname, address, port]() {
+    QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
       mudlet::self()->startAutoLogin({});
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button,
                         Qt::LeftButton);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), hostname);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), address);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), port);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
     });
 

--- a/test/functional_tests/TDiscordModeTest.cpp
+++ b/test/functional_tests/TDiscordModeTest.cpp
@@ -29,12 +29,15 @@
  */
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "MudletInstanceCoordinator.h"
 #include "TelnetServerStub.h"
 #include "discord.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -76,21 +79,21 @@ private slots:
         const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
         QDir(path).removeRecursively();
 
-        QTimer::singleShot(0, qApp, [this]() {
+        QTimer::singleShot(0ms, qApp, [this]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mHostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mPort);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
@@ -28,6 +29,8 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -187,21 +190,21 @@ private slots:
     // TelnetTextDisplayedTest).
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
-        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -29,6 +29,7 @@
 
 #include <QKeyEvent>
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "MudletInstanceCoordinator.h"
 #include "TAccessibleTextEdit.h"
@@ -39,6 +40,8 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -62,7 +65,7 @@ private:
   void injectData(const QString &message) {
     QByteArray data = (message + qsl("\r\n")).toUtf8();
     mpHost->mTelnet.loopbackTest(data);
-    QTest::qWait(50);
+    QTest::qWait(50ms);
   }
 
   // Scans backward through the buffer to find the first hyperlink and returns
@@ -199,22 +202,22 @@ private slots:
         mudlet::getMudletPath(enums::profileHomePath, mHostname);
     QDir(path).removeRecursively();
 
-    QTimer::singleShot(0, qApp, [this]() {
+    QTimer::singleShot(0ms, qApp, [this]() {
       mudlet::self()->startAutoLogin({});
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button,
                         Qt::LeftButton);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), mHostname);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), mPort);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
     });
 

--- a/test/functional_tests/TUserWindowTest.cpp
+++ b/test/functional_tests/TUserWindowTest.cpp
@@ -34,6 +34,7 @@
 
 #include <QSignalSpy>
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
@@ -42,6 +43,8 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -78,21 +81,21 @@ private slots:
         const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
         QDir(path).removeRecursively();
 
-        QTimer::singleShot(0, qApp, [this]() {
+        QTimer::singleShot(0ms, qApp, [this]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mHostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), mPort);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 
@@ -153,7 +156,7 @@ private slots:
 
         // Let the deferred deleteLater() run - this is when the orphaned dock's
         // widget() used to become null.
-        QTest::qWait(50);
+        QTest::qWait(50ms);
         QCoreApplication::processEvents();
 
         // Querying the (now absent) window must not crash - it falls back to the
@@ -172,7 +175,7 @@ private slots:
 
         // Tidy up.
         console->deleteMiniConsole(name);
-        QTest::qWait(50);
+        QTest::qWait(50ms);
         QCoreApplication::processEvents();
     }
 };

--- a/test/functional_tests/TelnetBenchmark.cpp
+++ b/test/functional_tests/TelnetBenchmark.cpp
@@ -28,12 +28,15 @@
  */
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "MudletInstanceCoordinator.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -84,21 +87,21 @@ private:
 
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
-        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -26,6 +26,10 @@
 #include "TelnetServerStub.h"
 #include "utils.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 TelnetServerStub::TelnetServerStub(QObject* parent)
     : QTcpServer(parent)
 {
@@ -57,7 +61,7 @@ void TelnetServerStub::onNewConnection()
 
     QPointer<QTcpSocket> safeClient = client;
 
-    QTimer::singleShot(100, [safeClient, welcomeMessage = mpWelcomeMessage]()
+    QTimer::singleShot(100ms, [safeClient, welcomeMessage = mpWelcomeMessage]()
     {
         if (!safeClient) {
             return;

--- a/test/functional_tests/TelnetTextDisplayedTest.cpp
+++ b/test/functional_tests/TelnetTextDisplayedTest.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include <cstdlib>
 
@@ -26,6 +27,8 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -82,21 +85,21 @@ private slots:
     // GUI
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
-        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
+            QTest::qWait(100ms);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/TriggerEditorTest.cpp
+++ b/test/functional_tests/TriggerEditorTest.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include <QClipboard>
 
@@ -32,6 +33,8 @@
 #include "TelnetServerStub.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -52,22 +55,22 @@ private:
 
   void startProfile(const QString &hostname, const QString &address,
                     const QString &port) {
-    QTimer::singleShot(0, qApp, [hostname, address, port]() {
+    QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
       mudlet::self()->startAutoLogin({});
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button,
                         Qt::LeftButton);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), hostname);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), address);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), port);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
     });
 

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 #include <QtTest/QtTest>
+#include <chrono>
 
 #include "EditorUndoStack.h"
 #include "Host.h"
@@ -37,6 +38,8 @@
 #include "dlgTriggerPatternEdit.h"
 #include "dlgTriggersMainArea.h"
 #include "mudlet.h"
+
+using namespace std::chrono_literals;
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -109,9 +112,9 @@ private:
 
   void startProfile(const QString &profileName, const QString &address,
                     const QString &port) {
-    QTimer::singleShot(0, qApp, [profileName, address, port]() {
+    QTimer::singleShot(0ms, qApp, [profileName, address, port]() {
       mudlet::self()->startAutoLogin({});
-      QTest::qWait(100);
+      QTest::qWait(100ms);
 
       // Verify connection dialog is available before UI interactions
       Q_ASSERT_X(mudlet::self()->mpConnectionDialog, "startProfile",
@@ -121,21 +124,21 @@ private:
 
       QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button,
                         Qt::LeftButton);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
 
       Q_ASSERT_X(QApplication::focusWidget(), "startProfile",
                  "No widget has focus after clicking new profile button");
 
       QTest::keyClicks(QApplication::focusWidget(), profileName);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), address);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClicks(QApplication::focusWidget(), port);
-      QTest::qWait(100);
+      QTest::qWait(100ms);
       QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
     });
 
@@ -176,7 +179,7 @@ private slots:
 
     // Open the editor dialog (it's created lazily)
     mudlet::self()->slot_showScriptDialog();
-    QTest::qWait(100);
+    QTest::qWait(100ms);
 
     mpEditor = mpHost->mpEditorDialog;
     QVERIFY2(mpEditor != nullptr, "Editor dialog should be created");
@@ -366,7 +369,7 @@ private slots:
       if (itemType.viewType == EditorViewType::cmKeysView ||
           itemType.viewType == EditorViewType::cmActionView) {
         QCoreApplication::processEvents();
-        QThread::msleep(10);
+        QThread::sleep(10ms);
       }
 
       QTreeWidgetItem *folder = itemType.baseItem()->child(0);
@@ -421,7 +424,7 @@ private slots:
       if (itemType.viewType == EditorViewType::cmKeysView ||
           itemType.viewType == EditorViewType::cmActionView) {
         QCoreApplication::processEvents();
-        QThread::msleep(10);
+        QThread::sleep(10ms);
       }
 
       QTreeWidgetItem *folder = itemType.baseItem()->child(0);
@@ -467,7 +470,7 @@ private slots:
       if (itemType.viewType == EditorViewType::cmKeysView ||
           itemType.viewType == EditorViewType::cmActionView) {
         QCoreApplication::processEvents();
-        QThread::msleep(10);
+        QThread::sleep(10ms);
       }
 
       QTreeWidgetItem *grandparent = itemType.baseItem()->child(0);
@@ -1377,7 +1380,7 @@ private slots:
       if (itemType.viewType == EditorViewType::cmKeysView ||
           itemType.viewType == EditorViewType::cmActionView) {
         QCoreApplication::processEvents();
-        QThread::msleep(10);
+        QThread::sleep(10ms);
       }
 
       QTreeWidgetItem *grandparent = itemType.baseItem()->child(0);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Convert raw millisecond integer literals at time-duration call sites to `std::chrono` literals, and add `#include <chrono>` to each touched translation unit. Examples:

- `QTimer::singleShot(0, ...)` → `QTimer::singleShot(0ms, ...)`
- `mpTimerReplay->setInterval(1000)` → `setInterval(1s)`
- `mPendingTimer.start(60000)` → `start(1min)`
- `QObject::startTimer(50)` → `startTimer(50ms)`
- `QTest::qWait(100)` → `QTest::qWait(100ms)`
- `QThread::msleep(10)` → `QThread::sleep(10ms)`

This is a semantics-preserving refactor - every duration is kept exactly equal to before (e.g. `1000` ms becomes `1s`, `60000` ms becomes `1min`). No behavioural change.

#### Motivation for adding to Mudlet

Chrono literals make time durations self-documenting and type-safe. `1s` / `100ms` read unambiguously where a bare `1000` / `100` forces the reader to remember each API's unit, and the compiler now rejects unit mismatches. Only genuine duration arguments were converted - loop counts, scroll-line counts, sizes, ports and the like were deliberately left as plain integers.

All targeted APIs provide `std::chrono` overloads in the minimum supported Qt (6.8.2): `QTimer::singleShot`/`start`/`setInterval` (5.8), `QObject::startTimer` (5.9), `QThread::sleep(std::chrono::nanoseconds)` (6.6) and `QTest::qWait(std::chrono::milliseconds)` (6.7).

#### Other info (issues closed, discussion etc)

Test case: the full application builds cleanly and the entire functional `ctest` suite passes. The only failing test is the known, pre-existing `PasswordMigrationTest` LSan exit-leak (GTK3/fontconfig noise), which is unrelated to this change.

Assisted-by: Claude:claude-opus-4-8
