### PR TITLE
fix: tempAnsiColorTrigger can match background colour only

### DIFF
--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1897,7 +1897,12 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
                                      qsl("invalid ANSI color number %1, only %2 (ignore foreground color), %3 (default foregroud color) or 0 to 255 recognised")
                                              .arg(QString::number(value), QString::number(TTrigger::scmIgnored), QString::number(TTrigger::scmDefault)));
         }
-        if (value == TTrigger::scmIgnored && lua_gettop(L) < 4) {
+        // The background colour is optional, so it is only actually omitted
+        // when there are too few arguments AND the second argument is not a
+        // number (the same test used to parse it below). Only in that case is
+        // ignoring the foreground colour invalid; a supplied background colour
+        // with an ignored foreground is the legitimate "background only" form.
+        if (value == TTrigger::scmIgnored && lua_gettop(L) < 4 && !lua_isnumber(L, 2)) {
             return warnArgumentValue(L, __func__, qsl("invalid ANSI color number %1, you cannot ignore both foreground and background color (omitted)").arg(value));
         }
         ansiFgColor = value;

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -145,5 +145,49 @@ describe("Trigger processing", function()
             assert.is_true(fired, "Function callback without an expiry argument should fire")
         end)
 
+        it("should match on background colour alone when the foreground is ignored", function()
+            _G.ansiBackgroundOnlyFired = false
+            -- -1 ignores the foreground colour, ANSI 4 is a blue background:
+            -- match any foreground as long as the background is blue.
+            local colorTrigger, err = tempAnsiColorTrigger(-1, 4, function()
+                _G.ansiBackgroundOnlyFired = true
+            end)
+
+            assert.is_number(colorTrigger, "Ignoring the foreground with a background colour set should create a trigger, got: " .. tostring(err))
+
+            -- Green foreground (32) on a non-matching black background (40): it
+            -- must NOT fire, proving the background is genuinely discriminated
+            -- rather than the trigger having ignored both colours.
+            feedTriggers("\n\27[32;40mAnsiBackgroundNonMatch\27[0m\n")
+            assert.is_false(_G.ansiBackgroundOnlyFired, "A background-only trigger must not fire on a non-matching background")
+
+            -- Red foreground (31) on the matching blue background (44): the
+            -- foreground differs from any fixed value yet the trigger should
+            -- still match on the background alone.
+            feedTriggers("\n\27[31;44mAnsiBackgroundOnlyMatch\27[0m\n")
+
+            local fired = _G.ansiBackgroundOnlyFired
+            if type(colorTrigger) == "number" then
+                killTrigger(colorTrigger)
+            end
+            _G.ansiBackgroundOnlyFired = nil
+
+            assert.is_true(fired, "A background-only ANSI colour trigger (ignored foreground) should fire on a matching background")
+        end)
+
+        it("should still reject ignoring the foreground when the background is omitted", function()
+            -- (-1, code) omits the background, so both colours would be ignored:
+            -- this must remain an error, not create a match-everything trigger.
+            local colorTrigger, err = tempAnsiColorTrigger(-1, function() end)
+
+            if type(colorTrigger) == "number" then
+                killTrigger(colorTrigger)
+            end
+
+            assert.is_nil(colorTrigger, "Ignoring the foreground with the background omitted should be rejected")
+            assert.is_string(err, "A rejection should return an error message")
+            assert.is_truthy(err:find("ignore both foreground and background", 1, true), "The error should explain both colours cannot be ignored, got: " .. tostring(err))
+        end)
+
     end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`tempAnsiColorTrigger(foregroundColor, backgroundColor, code)` rejected the legitimate "ignore foreground, match on background only" form. Passing `-1` (`TTrigger::scmIgnored`) as the foreground together with a real background colour, e.g. `tempAnsiColorTrigger(-1, 4, code)`, was wrongly refused with:

> invalid ANSI color number -1, you cannot ignore both foreground and background color (omitted)

even though the background was clearly supplied.

The cause: because the background argument is optional, the validation used `lua_gettop(L) < 4` as a proxy for "background omitted". With the 3-argument `(-1, bg, code)` form the stack top is 3, so the guard fired despite a valid background being present. The check now also requires that the second argument is not a number (`&& !lua_isnumber(L, 2)`) - the same test already used a few lines below to decide whether the optional background was supplied - so it only rejects the genuinely-omitted case (`(-1, code)`), where both colours would be ignored.

#### Motivation for adding to Mudlet

You could not create a background-only ANSI colour trigger via the temporary API, even though:
- the permanent/legacy `tempColorTrigger` path accepts it (it errors only when *both* fg and bg are ignored), and
- the trigger matching engine fully supports an ignored foreground (`TTrigger.cpp` matches any foreground when `ansiFg == scmIgnored`).

So this was purely an argument-validation bug blocking a supported feature.

#### Other info (issues closed, discussion etc)

Added a busted test (`src/mudlet-lua/tests/Trigger_spec.lua`) that:
- creates `tempAnsiColorTrigger(-1, 4, ...)` and asserts it fires on a matching blue background with a differing (red) foreground,
- asserts it does **not** fire on a non-matching background (proving the background is genuinely discriminated, not a match-everything trigger),
- asserts the still-invalid `(-1, code)` form (background omitted) continues to be rejected.

Verified fail-first: the new test fails against the current `development` baseline with the exact rejection error above, and passes with the fix (full busted suite 590/0).

Assisted-by: Claude:claude-opus-4-8
