### PR TITLE
fix: flag invalid aliases and block loops while typing them

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6151,18 +6151,9 @@ void dlgTriggerEditor::saveAlias()
     }
     const QString substitution = mpAliasMainArea->lineEdit_alias_command->text();
     //check if sub will trigger regex, ignore if there's nothing in regex - could be an alias group
-    const QRegularExpression rx(regex);
-    const QRegularExpressionMatch match = rx.match(substitution);
-
-    QString itemDescription;
-    if (!regex.isEmpty() && match.capturedStart() != -1) {
+    if (aliasSubstitutionLoops(regex, substitution)) {
         //we have a loop
-        QIcon iconError;
-        iconError.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
-        itemDescription = descError;
-        pItem->setIcon(0, iconError);
-        pItem->setText(0, name);
-        showError(tr("Alias <em>%1</em> has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn't good as it'll call itself forever.").arg(name.toHtmlEscaped()));
+        showAliasLoopWarning(pItem, name);
         return;
     }
 
@@ -6182,54 +6173,7 @@ void dlgTriggerEditor::saveAlias()
 
         QIcon icon;
         QString itemDescription;
-        if (pT->isFolder()) {
-            if (!pT->mPackageName.isEmpty()) {
-                if (pT->isActive()) {
-                    itemDescription = descActiveFolder;
-                    if (pT->ancestorsActive()) {
-                        icon.addPixmap(QPixmap(qsl(":/icons/folder-brown.png")), QIcon::Normal, QIcon::Off);
-                    } else {
-                        icon.addPixmap(QPixmap(qsl(":/icons/folder-grey.png")), QIcon::Normal, QIcon::Off);
-                        itemDescription = descInactiveParent.arg(itemDescription);
-                    }
-                } else {
-                    icon.addPixmap(QPixmap(qsl(":/icons/folder-brown-locked.png")), QIcon::Normal, QIcon::Off);
-                    itemDescription = descInactiveFolder;
-                }
-            } else if (pT->isActive()) {
-                itemDescription = descActiveFolder;
-                if (pT->ancestorsActive()) {
-                    icon.addPixmap(QPixmap(qsl(":/icons/folder-violet.png")), QIcon::Normal, QIcon::Off);
-                } else {
-                    icon.addPixmap(QPixmap(qsl(":/icons/folder-grey.png")), QIcon::Normal, QIcon::Off);
-                    itemDescription = descInactiveParent.arg(itemDescription);
-                }
-            } else {
-                itemDescription = descInactiveFolder;
-                if (pT->ancestorsActive()) {
-                    icon.addPixmap(QPixmap(qsl(":/icons/folder-violet-locked.png")), QIcon::Normal, QIcon::Off);
-                } else {
-                    icon.addPixmap(QPixmap(qsl(":/icons/folder-grey-locked.png")), QIcon::Normal, QIcon::Off);
-                }
-            }
-        } else {
-            if (pT->isActive()) {
-                itemDescription = descActive;
-                if (pT->ancestorsActive()) {
-                    icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked.png")), QIcon::Normal, QIcon::Off);
-                } else {
-                    icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked_grey.png")), QIcon::Normal, QIcon::Off);
-                    itemDescription = descInactiveParent.arg(itemDescription);
-                }
-            } else {
-                itemDescription = descInactive;
-                if (pT->ancestorsActive()) {
-                    icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox.png")), QIcon::Normal, QIcon::Off);
-                } else {
-                    icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox-grey.png")), QIcon::Normal, QIcon::Off);
-                }
-            }
-        }
+        computeAliasIcon(pT, icon, itemDescription);
 
         if (pT->state()) {
             clearEditorNotification();
@@ -6296,6 +6240,122 @@ void dlgTriggerEditor::saveAlias()
                 mpTextUndoStack->clear();
             }
         }
+    }
+}
+
+// Returns true when the substitution would match its own pattern, which makes
+// the alias call itself forever. An invalid pattern can't loop - the faulty-regex
+// check surfaces that instead.
+bool dlgTriggerEditor::aliasSubstitutionLoops(const QString& regex, const QString& substitution) const
+{
+    if (regex.isEmpty()) {
+        return false;
+    }
+    const QRegularExpression rx(regex);
+    if (!rx.isValid()) {
+        return false;
+    }
+    return rx.match(substitution).capturedStart() != -1;
+}
+
+// Computes the tree-item icon and accessible description for a non-error alias,
+// shared by the explicit save and the per-property autosave paths.
+void dlgTriggerEditor::computeAliasIcon(TAlias* pT, QIcon& icon, QString& itemDescription) const
+{
+    if (pT->isFolder()) {
+        if (!pT->mPackageName.isEmpty()) {
+            if (pT->isActive()) {
+                itemDescription = descActiveFolder;
+                if (pT->ancestorsActive()) {
+                    icon.addPixmap(QPixmap(qsl(":/icons/folder-brown.png")), QIcon::Normal, QIcon::Off);
+                } else {
+                    icon.addPixmap(QPixmap(qsl(":/icons/folder-grey.png")), QIcon::Normal, QIcon::Off);
+                    itemDescription = descInactiveParent.arg(itemDescription);
+                }
+            } else {
+                icon.addPixmap(QPixmap(qsl(":/icons/folder-brown-locked.png")), QIcon::Normal, QIcon::Off);
+                itemDescription = descInactiveFolder;
+            }
+        } else if (pT->isActive()) {
+            itemDescription = descActiveFolder;
+            if (pT->ancestorsActive()) {
+                icon.addPixmap(QPixmap(qsl(":/icons/folder-violet.png")), QIcon::Normal, QIcon::Off);
+            } else {
+                icon.addPixmap(QPixmap(qsl(":/icons/folder-grey.png")), QIcon::Normal, QIcon::Off);
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            itemDescription = descInactiveFolder;
+            if (pT->ancestorsActive()) {
+                icon.addPixmap(QPixmap(qsl(":/icons/folder-violet-locked.png")), QIcon::Normal, QIcon::Off);
+            } else {
+                icon.addPixmap(QPixmap(qsl(":/icons/folder-grey-locked.png")), QIcon::Normal, QIcon::Off);
+            }
+        }
+    } else {
+        if (pT->isActive()) {
+            itemDescription = descActive;
+            if (pT->ancestorsActive()) {
+                icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked.png")), QIcon::Normal, QIcon::Off);
+            } else {
+                icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox_checked_grey.png")), QIcon::Normal, QIcon::Off);
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            itemDescription = descInactive;
+            if (pT->ancestorsActive()) {
+                icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox.png")), QIcon::Normal, QIcon::Off);
+            } else {
+                icon.addPixmap(QPixmap(qsl(":/icons/tag_checkbox-grey.png")), QIcon::Normal, QIcon::Off);
+            }
+        }
+    }
+}
+
+// Restores an alias tree item to its non-error appearance and clears the editor notice.
+void dlgTriggerEditor::setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT)
+{
+    clearEditorNotification();
+    if (pT->checkIfNew()) {
+        // A freshly added alias keeps its "unsaved" cue until an explicit Save
+        // activates it - don't recompute it to an active/inactive icon here.
+        pItem->setIcon(0, QIcon(QPixmap(pT->isFolder() ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
+        pItem->setData(0, Qt::AccessibleDescriptionRole, pT->isFolder() ? descNewFolder : descNewItem);
+        return;
+    }
+    QIcon icon;
+    QString itemDescription;
+    computeAliasIcon(pT, icon, itemDescription);
+    pItem->setIcon(0, icon);
+    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+}
+
+// Flags an alias tree item as broken and shows the given error message.
+void dlgTriggerEditor::showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error)
+{
+    QIcon iconError;
+    iconError.addPixmap(QPixmap(qsl(":/icons/tools-report-bug.png")), QIcon::Normal, QIcon::Off);
+    pItem->setIcon(0, iconError);
+    pItem->setText(0, name);
+    pItem->setData(0, Qt::AccessibleDescriptionRole, descError);
+    showError(error);
+}
+
+void dlgTriggerEditor::showAliasLoopWarning(QTreeWidgetItem* pItem, const QString& name)
+{
+    showAliasError(pItem,
+                   name,
+                   tr("Alias <em>%1</em> has an infinite loop - substitution matches its own pattern. Please fix it - this alias isn't good as it'll call itself forever.").arg(name.toHtmlEscaped()));
+}
+
+// Reflects the alias's compile state on its tree item: normal icon when the
+// pattern compiles, faulty-regex error otherwise.
+void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT)
+{
+    if (pT->state()) {
+        setAliasNormalIcon(pItem, pT);
+    } else {
+        showAliasError(pItem, pT->getName(), pT->getError());
     }
 }
 
@@ -14745,11 +14805,21 @@ void dlgTriggerEditor::slot_saveProperty_AliasPattern()
         return;
     }
 
+    // Mirror the explicit-save guard: refuse a pattern that would make the alias loop.
+    const QString substitution = mpAliasMainArea->lineEdit_alias_command->text();
+    if (aliasSubstitutionLoops(newPattern, substitution)) {
+        showAliasLoopWarning(mpCurrentAliasItem, pT->getName());
+        return;
+    }
+
     QString oldStateXML = exportAliasToXML(pT);
     pT->setRegexCode(newPattern);
     QString newStateXML = exportAliasToXML(pT);
 
     pushAliasPropertyCommand(mpUndoStack, mpHost, aliasID, pT->getName(), qsl("pattern"), oldStateXML, newStateXML);
+
+    // Surface a faulty regex the same way the explicit Save button does.
+    applyAliasState(mpCurrentAliasItem, pT);
 }
 
 void dlgTriggerEditor::slot_saveProperty_AliasCommand()
@@ -14770,11 +14840,22 @@ void dlgTriggerEditor::slot_saveProperty_AliasCommand()
         return;
     }
 
+    // Mirror the explicit-save guard: a substitution must not match its own pattern.
+    QString regex = mpAliasMainArea->lineEdit_alias_pattern->text();
+    unmarkQString(&regex);
+    if (aliasSubstitutionLoops(regex, newCommand)) {
+        showAliasLoopWarning(mpCurrentAliasItem, pT->getName());
+        return;
+    }
+
     QString oldStateXML = exportAliasToXML(pT);
     pT->setCommand(newCommand);
     QString newStateXML = exportAliasToXML(pT);
 
     pushAliasPropertyCommand(mpUndoStack, mpHost, aliasID, pT->getName(), qsl("command"), oldStateXML, newStateXML);
+
+    // Refresh the item so a fixed alias loses any stale error flag.
+    applyAliasState(mpCurrentAliasItem, pT);
 }
 
 // =============================================================================

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -395,6 +395,12 @@ private:
     EditorViewType resolveCurrentView();
     void saveTrigger();
     void saveAlias();
+    void computeAliasIcon(TAlias* pT, QIcon& icon, QString& itemDescription) const;
+    void setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT);
+    void showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error);
+    void showAliasLoopWarning(QTreeWidgetItem* pItem, const QString& name);
+    void applyAliasState(QTreeWidgetItem* pItem, TAlias* pT);
+    bool aliasSubstitutionLoops(const QString& regex, const QString& substitution) const;
     void saveTimer();
     void saveKey();
     void saveScript();

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -31,6 +31,7 @@
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgActionMainArea.h"
+#include "dlgAliasMainArea.h"
 #include "dlgConnectionProfiles.h"
 #include "dlgTimersMainArea.h"
 #include "dlgTriggerEditor.h"
@@ -2250,6 +2251,146 @@ private slots:
              "Patterns should be cleared when affectedItemIDs is empty");
 
     mpEditor->mpUndoStack->clear();
+  }
+
+  // ========================================================================
+  // CATEGORY 15: Alias autosave guards mirror the explicit Save button
+  // ========================================================================
+  void testAliasAutosaveFlagsInvalidRegex() {
+    mpEditor->slot_showAliases();
+    cleanupAll(mItemTypes[2]);
+
+    mpEditor->addAlias(false);
+    QVERIFY(mpEditor->mpAliasBaseItem->childCount() > 0);
+
+    QTreeWidgetItem *item = mpEditor->mpAliasBaseItem->child(0);
+    const int aliasID = item->data(0, Qt::UserRole).toInt();
+    TAlias *pT = mpHost->getAliasUnit()->getAlias(aliasID);
+    QVERIFY(pT != nullptr);
+
+    mpEditor->treeWidget_aliases->setCurrentItem(item);
+    mpEditor->slot_aliasSelected(item);
+
+    // Type an invalid pattern and finish editing (the autosave path).
+    mpEditor->mpAliasMainArea->lineEdit_alias_pattern->setText(qsl("("));
+    mpEditor->slot_saveProperty_AliasPattern();
+
+    // The broken pattern must be flagged, just like clicking Save would.
+    QVERIFY2(!pT->state(),
+             "invalid regex should leave the alias in an error state");
+    QCOMPARE(item->data(0, Qt::AccessibleDescriptionRole).toString(),
+             mpEditor->descError);
+
+    // Fixing the pattern must clear the error flag on autosave. This alias was
+    // never explicitly saved, so it recovers to the "unsaved/new" state.
+    mpEditor->mpAliasMainArea->lineEdit_alias_pattern->setText(qsl("^hello$"));
+    mpEditor->slot_saveProperty_AliasPattern();
+    QVERIFY2(pT->state(), "valid regex should clear the error state");
+    QCOMPARE(item->data(0, Qt::AccessibleDescriptionRole).toString(),
+             mpEditor->descNewItem);
+
+    cleanupAll(mItemTypes[2]);
+  }
+
+  void testAliasAutosaveGuardsInfiniteLoop() {
+    mpEditor->slot_showAliases();
+    cleanupAll(mItemTypes[2]);
+
+    mpEditor->addAlias(false);
+    QVERIFY(mpEditor->mpAliasBaseItem->childCount() > 0);
+
+    QTreeWidgetItem *item = mpEditor->mpAliasBaseItem->child(0);
+    const int aliasID = item->data(0, Qt::UserRole).toInt();
+    TAlias *pT = mpHost->getAliasUnit()->getAlias(aliasID);
+    QVERIFY(pT != nullptr);
+
+    mpEditor->treeWidget_aliases->setCurrentItem(item);
+    mpEditor->slot_aliasSelected(item);
+
+    mpEditor->mpAliasMainArea->lineEdit_alias_pattern->setText(qsl("^say"));
+    mpEditor->slot_saveProperty_AliasPattern();
+    QVERIFY(pT->state());
+
+    // A substitution that matches its own pattern would call the alias forever;
+    // the autosave path must reject it, just like the explicit Save button.
+    mpEditor->mpAliasMainArea->lineEdit_alias_command->setText(qsl("say hello"));
+    mpEditor->slot_saveProperty_AliasCommand();
+
+    QVERIFY2(pT->getCommand() != qsl("say hello"),
+             "a self-matching substitution must not be saved");
+    QCOMPARE(item->data(0, Qt::AccessibleDescriptionRole).toString(),
+             mpEditor->descError);
+
+    cleanupAll(mItemTypes[2]);
+  }
+
+  void testAliasAutosavePatternLoopGuard() {
+    mpEditor->slot_showAliases();
+    cleanupAll(mItemTypes[2]);
+
+    mpEditor->addAlias(false);
+    QVERIFY(mpEditor->mpAliasBaseItem->childCount() > 0);
+
+    QTreeWidgetItem *item = mpEditor->mpAliasBaseItem->child(0);
+    const int aliasID = item->data(0, Qt::UserRole).toInt();
+    TAlias *pT = mpHost->getAliasUnit()->getAlias(aliasID);
+    QVERIFY(pT != nullptr);
+
+    mpEditor->treeWidget_aliases->setCurrentItem(item);
+    mpEditor->slot_aliasSelected(item);
+
+    // Give it a command that does not loop with the (empty) pattern.
+    mpEditor->mpAliasMainArea->lineEdit_alias_command->setText(qsl("wave"));
+    mpEditor->slot_saveProperty_AliasCommand();
+    QCOMPARE(pT->getCommand(), qsl("wave"));
+
+    // Editing the pattern so it matches the command must be rejected too - the
+    // loop guard has to fire from the pattern slot, not just the command slot.
+    mpEditor->mpAliasMainArea->lineEdit_alias_pattern->setText(qsl("^wave"));
+    mpEditor->slot_saveProperty_AliasPattern();
+
+    QVERIFY2(pT->getRegexCode() != qsl("^wave"),
+             "a pattern matching its own substitution must not be saved");
+    QCOMPARE(item->data(0, Qt::AccessibleDescriptionRole).toString(),
+             mpEditor->descError);
+
+    cleanupAll(mItemTypes[2]);
+  }
+
+  void testAliasAutosaveClearsErrorAfterFix() {
+    mpEditor->slot_showAliases();
+    cleanupAll(mItemTypes[2]);
+
+    mpEditor->addAlias(false);
+    QVERIFY(mpEditor->mpAliasBaseItem->childCount() > 0);
+
+    QTreeWidgetItem *item = mpEditor->mpAliasBaseItem->child(0);
+    const int aliasID = item->data(0, Qt::UserRole).toInt();
+    TAlias *pT = mpHost->getAliasUnit()->getAlias(aliasID);
+    QVERIFY(pT != nullptr);
+
+    mpEditor->treeWidget_aliases->setCurrentItem(item);
+    mpEditor->slot_aliasSelected(item);
+
+    mpEditor->mpAliasMainArea->lineEdit_alias_pattern->setText(qsl("^say"));
+    mpEditor->slot_saveProperty_AliasPattern();
+    QVERIFY(pT->state());
+
+    // A looping command is rejected and flags the item.
+    mpEditor->mpAliasMainArea->lineEdit_alias_command->setText(qsl("say hi"));
+    mpEditor->slot_saveProperty_AliasCommand();
+    QCOMPARE(item->data(0, Qt::AccessibleDescriptionRole).toString(),
+             mpEditor->descError);
+
+    // Correcting the command must clear the flag and persist the new value.
+    mpEditor->mpAliasMainArea->lineEdit_alias_command->setText(qsl("wave"));
+    mpEditor->slot_saveProperty_AliasCommand();
+    QCOMPARE(pT->getCommand(), qsl("wave"));
+    QVERIFY2(item->data(0, Qt::AccessibleDescriptionRole).toString() !=
+                 mpEditor->descError,
+             "correcting the command must clear the loop error flag");
+
+    cleanupAll(mItemTypes[2]);
   }
 };
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

While editing an alias, Mudlet autosaves each field as you finish it (the per-property "autosave" path, separate from the explicit Save button). That path was missing two safety checks the Save button already performs:

- **Invalid patterns were stored silently.** Typing a pattern that fails to compile left no error icon and no message, so a broken alias was saved with no feedback. Autosave now flags it with the error icon and shows the same faulty-regex message as Save.
- **Infinite-loop aliases were accepted.** An alias whose command matches its own pattern calls itself forever. Save rejects this; autosave did not. The loop guard now runs on both the pattern and the command field.

Shared logic between the two paths was factored into small helpers (`aliasSubstitutionLoops`, `computeAliasIcon`, `setAliasNormalIcon`, `showAliasError`, `showAliasLoopWarning`, `applyAliasState`) so the autosave and explicit-save paths stay in sync. A freshly added alias keeps its "unsaved" cue until an explicit Save, so autosave no longer changes its activation state.

Added four functional tests to `dlgTriggerEditorUndoRedoTest` covering: invalid-regex flagging and recovery, loop rejection from both the command and the pattern field, and error clearing after a fix.

#### Motivation for adding to Mudlet

Users typing an invalid or self-looping alias got no feedback and ended up with a broken, silently-stored alias. This brings the as-you-type autosave to parity with the Save button.

#### Other info (issues closed, discussion etc)

Relates to #8469.

Assisted-by: Claude:claude-opus-4-8
