### PR TITLE
fix: stop a malicious game from writing files outside the media folder

### DIFF
--- a/src/TEntityResolver.cpp
+++ b/src/TEntityResolver.cpp
@@ -89,6 +89,11 @@ bool TEntityResolver::unregisterEntity(const QString& entity)
 
 QString TEntityResolver::resolveCode(const QString& entityValue)
 {
+    if (entityValue.isEmpty()) {
+        // A malformed numeric entity such as "&#;" yields an empty value here;
+        // guard against calling front() on it (undefined behaviour).
+        return entityValue;
+    }
     return entityValue.front() == 'x' ? resolveCode(entityValue.mid(1), 16) : resolveCode(entityValue, 10);
 }
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -77,6 +77,14 @@ void TMedia::playMedia(TMediaData& mediaData)
             return; // MSP and GMCP files should not have absolute paths.
         }
 
+        // A relative path can still escape the profile's media directory via ".."
+        // segments; reject those so a hostile server cannot read or overwrite
+        // files elsewhere on disk (relative sub-directories remain permitted).
+        if ((mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP) && mediaFilePathEscapesMediaDir(mediaData)) {
+            qWarning() << qsl("TMedia::playMedia() WARNING - rejected a media file name that escapes the profile media directory: %1.").arg(mediaData.mediaFileName());
+            return;
+        }
+
         if (!mediaData.mediaFileName().contains(QLatin1Char('*')) && !mediaData.mediaFileName().contains(QLatin1Char('?'))) { // File path wildcards are * and ?
             // Append appropriate file extension for MSP files
             if (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP && !mediaData.mediaFileName().contains(QLatin1Char('.'))) {
@@ -655,6 +663,13 @@ bool TMedia::isFileRelative(TMediaData& mediaData)
     }
 
     return isFileRelative;
+}
+
+bool TMedia::mediaFilePathEscapesMediaDir(TMediaData& mediaData) const
+{
+    const QString mediaDir = QDir::cleanPath(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()));
+    const QString resolved = QDir::cleanPath(qsl("%1/%2").arg(mediaDir, mediaData.mediaFileName()));
+    return resolved != mediaDir && !resolved.startsWith(mediaDir + QLatin1Char('/'));
 }
 
 QStringList TMedia::parseFileNameList(TMediaData& mediaData, QDir& dir)

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -667,9 +667,64 @@ bool TMedia::isFileRelative(TMediaData& mediaData)
 
 bool TMedia::mediaFilePathEscapesMediaDir(TMediaData& mediaData) const
 {
-    const QString mediaDir = QDir::cleanPath(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()));
-    const QString resolved = QDir::cleanPath(qsl("%1/%2").arg(mediaDir, mediaData.mediaFileName()));
-    return resolved != mediaDir && !resolved.startsWith(mediaDir + QLatin1Char('/'));
+    return mediaFilePathEscapesMediaDir(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()), mediaData.mediaFileName());
+}
+
+// Returns true if mediaFileName would resolve to a location outside mediaRoot. Two layers:
+//  1. A lexical check (QDir::cleanPath) rejects "../" traversal without touching the disk.
+//  2. A canonical check resolves symlinks in the existing path components, so a symlink that
+//     already lives under the media directory but points elsewhere cannot be used to escape.
+//     The target file itself normally does not exist yet (it is about to be downloaded), so we
+//     canonicalise the deepest ancestor that does exist and re-check containment against the
+//     canonicalised media root. Legitimate relative sub-directories and wildcards stay inside
+//     mediaRoot and are permitted.
+bool TMedia::mediaFilePathEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName)
+{
+    if (mediaFileName.isEmpty()) {
+        return false;
+    }
+
+    const QString root = QDir::cleanPath(mediaRoot);
+    const QString resolved = QDir::cleanPath(qsl("%1/%2").arg(root, mediaFileName));
+
+    // Layer 1 - lexical containment.
+    if (resolved != root && !resolved.startsWith(root + QLatin1Char('/'))) {
+        return true;
+    }
+
+    // Layer 2 - canonical containment (symlink-aware).
+    const QString canonicalRoot = QFileInfo(root).canonicalFilePath();
+
+    if (canonicalRoot.isEmpty()) {
+        // The media root does not exist yet, so there are no symlink components to follow; the
+        // lexical check above is authoritative.
+        return false;
+    }
+
+    QString ancestor = resolved;
+    QString canonicalAncestor;
+
+    while (!ancestor.isEmpty()) {
+        canonicalAncestor = QFileInfo(ancestor).canonicalFilePath();
+
+        if (!canonicalAncestor.isEmpty()) {
+            break; // deepest existing ancestor found
+        }
+
+        const int lastSlash = ancestor.lastIndexOf(QLatin1Char('/'));
+
+        if (lastSlash <= 0) {
+            break;
+        }
+
+        ancestor = ancestor.left(lastSlash);
+    }
+
+    if (canonicalAncestor.isEmpty()) {
+        return false;
+    }
+
+    return canonicalAncestor != canonicalRoot && !canonicalAncestor.startsWith(canonicalRoot + QLatin1Char('/'));
 }
 
 QStringList TMedia::parseFileNameList(TMediaData& mediaData, QDir& dir)
@@ -950,6 +1005,15 @@ void TMedia::downloadFile(TMediaData& mediaData)
     if (!TMedia::isValidUrl(fileUrl)) {
         return;
     }
+
+    // Media is fetched from the network only. Refuse other schemes (e.g. file://) so a
+    // server-supplied media URL cannot turn this download into a local file read.
+    const QString scheme = fileUrl.scheme();
+    if (scheme != qsl("http") && scheme != qsl("https")) {
+        qWarning() << qsl("TMedia::downloadFile() WARNING - refused to download media from a non-HTTP(S) URL: %1").arg(fileUrl.toString());
+        return;
+    }
+
     QNetworkRequest request = QNetworkRequest(fileUrl);
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -909,6 +909,15 @@ void TMedia::slot_writeFile(QNetworkReply* reply)
 
 void TMedia::downloadFile(TMediaData& mediaData)
 {
+    // Central guard for every download/write path (Client.Media.Play preloads
+    // via playMedia(), Client.Media.Load via parseJSONForMediaLoad()): never
+    // write a server-supplied file name that escapes the profile media
+    // directory through ".." segments.
+    if (mediaFilePathEscapesMediaDir(mediaData)) {
+        qWarning() << qsl("TMedia::downloadFile() WARNING - refused a media file name that escapes the profile media directory: %1.").arg(mediaData.mediaFileName());
+        return;
+    }
+
     const QString mediaPath = mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName());
     const QDir mediaDir(mediaPath);
 

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -147,6 +147,11 @@ public:
     void printClosedCaption(const TMediaData& mediaData, const QString& action) const;
     void stopAllMediaPlayers();
 
+    // Returns true if mediaFileName would resolve to a location outside mediaRoot, either
+    // lexically (e.g. via "../" traversal) or through a symlink component that already exists
+    // under mediaRoot but points elsewhere. Static so it can be unit-tested without a Host.
+    static bool mediaFilePathEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName);
+
 private slots:
     void slot_writeFile(QNetworkReply* reply);
 

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -161,6 +161,7 @@ private:
     QUrl parseUrl(TMediaData& mediaData);
     static bool isValidUrl(QUrl& url);
     static bool isFileRelative(TMediaData& mediaData);
+    bool mediaFilePathEscapesMediaDir(TMediaData& mediaData) const;
     QStringList parseFileNameList(TMediaData& mediaData, QDir& dir);
     QStringList getFileNameList(TMediaData& mediaData);
     QUrl getFileUrl(TMediaData& mediaData);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(UNIT_TESTS
     TKeySequenceEditTest
     TEncodingHelperTest
     PasswordMigrationTest
+    TMediaPathTraversalTest
 )
 
 foreach(test_name ${UNIT_TESTS})

--- a/test/TEntityResolverTest.cpp
+++ b/test/TEntityResolverTest.cpp
@@ -60,6 +60,17 @@ private slots:
 
     }
 
+    void testMalformedNumericEntity()
+    {
+        TEntityResolver resolver;
+
+        // A numeric entity with no digits ("&#;") leaves an empty value that was
+        // previously passed to QString::front() (undefined behaviour). It must
+        // now resolve safely rather than crash/assert.
+        QCOMPARE(resolver.getResolution("&#;"), "");
+        QCOMPARE(resolver.getResolution("&#x;"), "");
+    }
+
     void testRegisteredEntities()
     {
         TEntityResolver resolver;

--- a/test/TMediaPathTraversalTest.cpp
+++ b/test/TMediaPathTraversalTest.cpp
@@ -115,6 +115,16 @@ private slots:
             QSKIP("Filesystem does not support symlinks");
         }
 
+        // Only meaningful where the platform created a *followed* symlink: on Windows
+        // QFile::link() writes a .lnk shortcut that the filesystem does not traverse, so
+        // there is no escape to catch there. Confirm the link actually redirects to the
+        // outside directory at the canonical level before asserting.
+        const QString linkCanonical = QFileInfo(link).canonicalFilePath();
+        const QString outsideCanonical = QFileInfo(outside).canonicalFilePath();
+        if (linkCanonical.isEmpty() || linkCanonical != outsideCanonical) {
+            QSKIP("Filesystem did not create a followed symlink (e.g. Windows .lnk shortcut)");
+        }
+
         // A path beneath the escaping symlink passes the lexical prefix test but must be
         // refused by the canonical layer.
         QVERIFY(TMedia::mediaFilePathEscapesMediaDir(root, QStringLiteral("escape/evil.wav")));

--- a/test/TMediaPathTraversalTest.cpp
+++ b/test/TMediaPathTraversalTest.cpp
@@ -1,0 +1,138 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMedia.h"
+
+#include <QtTest/QtTest>
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+/*
+ * Regression guard for the media path-traversal fix.
+ *
+ * A remote game server (or a script) supplies the media file name used by MSP,
+ * MXP, GMCP Client.Media.Load/Play and the Lua media API. The original
+ * containment check was "is the path relative?", which accepts "../" because a
+ * traversal string is still relative. That let a server escape the profile media
+ * directory and have downloaded, attacker-controlled content written anywhere
+ * the process could write (arbitrary file write), and read arbitrary local files
+ * back for playback.
+ *
+ * TMedia::mediaFilePathEscapesMediaDir() is the containment check every
+ * download/write and read/playback path funnels through. It resolves the file
+ * name against the media directory and returns true only when the result escapes
+ * it - so legitimate sub-directories and wildcards keep working while traversal
+ * is refused. The first (lexical) layer is platform-independent and needs no
+ * files on disk; the second (canonical) layer defeats symlink components and is
+ * exercised with a real temporary directory below.
+ */
+class TMediaPathTraversalTest : public QObject
+{
+    Q_OBJECT
+
+    // A representative, absolute profile media directory. Its existence is
+    // irrelevant for the lexical cases - the first-layer check is purely textual.
+    static QString mediaRoot() { return QStringLiteral("/home/user/.config/mudlet/profiles/Default/media"); }
+
+    static bool escapes(const QString& fileName) { return TMedia::mediaFilePathEscapesMediaDir(mediaRoot(), fileName); }
+
+private slots:
+
+    // -------------------------------------------------------------------------
+    // Legitimate names must be permitted (no false positives).
+    // -------------------------------------------------------------------------
+
+    void benign_topLevelFile_allowed() { QVERIFY(!escapes(QStringLiteral("beep.wav"))); }
+
+    void benign_subDirFile_allowed() { QVERIFY(!escapes(QStringLiteral("sounds/beep.wav"))); }
+
+    void benign_nestedSubDirFile_allowed() { QVERIFY(!escapes(QStringLiteral("a/b/c/beep.wav"))); }
+
+    void benign_wildcard_allowed() { QVERIFY(!escapes(QStringLiteral("*.wav"))); }
+
+    void benign_wildcardInSubDir_allowed() { QVERIFY(!escapes(QStringLiteral("sounds/*.wav"))); }
+
+    void benign_dotSlash_allowed() { QVERIFY(!escapes(QStringLiteral("./beep.wav"))); }
+
+    // "../" that stays inside the media directory is harmless and must not be blocked.
+    void benign_internalDotDot_allowed() { QVERIFY(!escapes(QStringLiteral("sounds/../beep.wav"))); }
+
+    void empty_allowed() { QVERIFY(!escapes(QString())); }
+
+    // -------------------------------------------------------------------------
+    // Traversal must be refused (the vulnerability).
+    // -------------------------------------------------------------------------
+
+    void traversal_singleLevel_refused() { QVERIFY(escapes(QStringLiteral("../evil.wav"))); }
+
+    void traversal_deep_refused() { QVERIFY(escapes(QStringLiteral("../../../../../../etc/passwd"))); }
+
+    // The classic payload: a media-looking name that lands in the user's home.
+    void traversal_intoHome_refused() { QVERIFY(escapes(QStringLiteral("../../../../.config/mudlet/evil.wav"))); }
+
+    // Escapes to a sibling of the media directory (note: same prefix, different dir).
+    void traversal_siblingDir_refused() { QVERIFY(escapes(QStringLiteral("../media_other/evil.wav"))); }
+
+    // Dives into a sub-directory, then climbs out past the media root.
+    void traversal_subDirThenOut_refused() { QVERIFY(escapes(QStringLiteral("sounds/../../evil.wav"))); }
+
+    // -------------------------------------------------------------------------
+    // Symlink containment - a lexical check alone is bypassable by a symlink that
+    // lives inside the media directory but points outside it. The canonical layer
+    // must catch it, while a genuine sub-directory of the media root stays allowed.
+    // -------------------------------------------------------------------------
+
+    void symlink_escapingMediaDir_refused()
+    {
+        QTemporaryDir base;
+        QVERIFY(base.isValid());
+
+        const QString root = base.filePath(QStringLiteral("media"));
+        const QString outside = base.filePath(QStringLiteral("outside"));
+        QVERIFY(QDir().mkpath(root));
+        QVERIFY(QDir().mkpath(outside));
+
+        // A symlink inside the media directory pointing outside it.
+        const QString link = root + QStringLiteral("/escape");
+        if (!QFile::link(outside, link)) {
+            QSKIP("Filesystem does not support symlinks");
+        }
+
+        // A path beneath the escaping symlink passes the lexical prefix test but must be
+        // refused by the canonical layer.
+        QVERIFY(TMedia::mediaFilePathEscapesMediaDir(root, QStringLiteral("escape/evil.wav")));
+    }
+
+    void symlink_realSubDir_allowed()
+    {
+        QTemporaryDir base;
+        QVERIFY(base.isValid());
+
+        const QString root = base.filePath(QStringLiteral("media"));
+        QVERIFY(QDir().mkpath(root + QStringLiteral("/sounds")));
+
+        // A genuine sub-directory of the media root must remain permitted.
+        QVERIFY(!TMedia::mediaFilePathEscapesMediaDir(root, QStringLiteral("sounds/ok.wav")));
+    }
+};
+
+QTEST_GUILESS_MAIN(TMediaPathTraversalTest)
+
+#include "TMediaPathTraversalTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Reject MSP/GMCP media file names containing `..` that resolve outside the profile's media directory (relative sub-directories and wildcards still work).
- Guard `TEntityResolver::resolveCode()` against the empty value from a malformed numeric entity like `&#;`, which previously called `QString::front()` on an empty string (undefined behaviour).
- Add a `TEntityResolver` regression test for the malformed-entity case.

#### Motivation for adding to Mudlet
A connected game server could use a crafted MSP `!!SOUND`/`!!MUSIC` or GMCP `Client.Media` file name to download and write attacker-controlled content to an arbitrary path (e.g. an autostart entry), or read/play an arbitrary local file — with no user interaction, since both protocols are enabled by default.

#### Other info (issues closed, discussion etc)
Security hardening of the server-facing media path. `isFileRelative()` only rejected absolute paths, so a relative `..` traversal passed validation before being concatenated onto the media directory.

**Test case:** Connect a profile to a server that sends `!!SOUND(../../evil.wav U=http://example/evil.wav)` — it is now rejected with a `WARNING - rejected a media file name that escapes the profile media directory` log line, while a normal `!!SOUND(hit.wav U=...)` still downloads and plays.

---
_Generated by [Claude Code](https://claude.ai/code/session_011XUZefuDuy8F1M4bHq5jMZ)_