### PR TITLE
fix: block malicious game servers from writing files outside the media folder

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -71,6 +71,11 @@ void TMedia::playMedia(TMediaData& mediaData)
     if (mediaData.mediaInput() == TMediaData::MediaInputStream) {
         TMedia::setupMediaAbsolutePathFileName(mediaData);
     } else if (mediaData.mediaInput() == TMediaData::MediaInputFile) {
+        if (TMedia::mediaFileNameEscapesMediaDir(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()), mediaData.mediaFileName())) {
+            qWarning() << qsl("TMedia::playMedia() WARNING - refused a media file name that would escape the profile media directory: %1").arg(mediaData.mediaFileName());
+            return;
+        }
+
         const bool fileRelative = TMedia::isFileRelative(mediaData);
 
         if (!fileRelative && (mediaData.mediaProtocol() == TMediaData::MediaProtocolMSP || mediaData.mediaProtocol() == TMediaData::MediaProtocolGMCP)) {
@@ -657,6 +662,22 @@ bool TMedia::isFileRelative(TMediaData& mediaData)
     return isFileRelative;
 }
 
+// A relative file name is not enough to keep server- or script-supplied media inside the
+// profile's media directory: "../" segments are relative yet still escape it. Resolve the
+// name against the media directory and confirm it stays within, so legitimate sub-directories
+// and wildcards keep working while traversal is refused.
+bool TMedia::mediaFileNameEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName)
+{
+    if (mediaFileName.isEmpty()) {
+        return false;
+    }
+
+    const QString root = QDir::cleanPath(mediaRoot);
+    const QString resolved = QDir::cleanPath(qsl("%1/%2").arg(root, mediaFileName));
+
+    return resolved != root && !resolved.startsWith(root + QLatin1Char('/'));
+}
+
 QStringList TMedia::parseFileNameList(TMediaData& mediaData, QDir& dir)
 {
     QStringList fileNameList;
@@ -926,6 +947,15 @@ void TMedia::downloadFile(TMediaData& mediaData)
     if (!TMedia::isValidUrl(fileUrl)) {
         return;
     }
+
+    // Media is fetched from the network only. Refuse other schemes (e.g. file://) so a
+    // server-supplied media URL cannot turn this download into a local file read.
+    const QString scheme = fileUrl.scheme();
+    if (scheme != qsl("http") && scheme != qsl("https")) {
+        qWarning() << qsl("TMedia::downloadFile() WARNING - refused to download media from a non-HTTP(S) URL: %1").arg(fileUrl.toString());
+        return;
+    }
+
     QNetworkRequest request = QNetworkRequest(fileUrl);
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
@@ -2002,6 +2032,11 @@ void TMedia::parseJSONForMediaLoad(QJsonObject& json)
     mediaData.setMediaFileName(mediaData.mediaFileName().replace(QLatin1Char('\\'), QLatin1Char('/')));
 
     if (!TMedia::isFileRelative(mediaData)) {
+        return;
+    }
+
+    if (TMedia::mediaFileNameEscapesMediaDir(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()), mediaData.mediaFileName())) {
+        qWarning() << qsl("TMedia::parseJSONForMediaLoad() WARNING - refused a media file name that would escape the profile media directory: %1").arg(mediaData.mediaFileName());
         return;
     }
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -666,6 +666,14 @@ bool TMedia::isFileRelative(TMediaData& mediaData)
 // profile's media directory: "../" segments are relative yet still escape it. Resolve the
 // name against the media directory and confirm it stays within, so legitimate sub-directories
 // and wildcards keep working while traversal is refused.
+//
+// Two layers:
+//  1. A lexical check (QDir::cleanPath) rejects "../" traversal without touching the disk.
+//  2. A canonical check resolves symlinks in the existing path components, so a symlink that
+//     already lives under the media directory but points elsewhere cannot be used to escape.
+//     The target file itself normally does not exist yet (it is about to be downloaded), so we
+//     canonicalise the deepest ancestor that does exist and re-check containment against the
+//     canonicalised media root.
 bool TMedia::mediaFileNameEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName)
 {
     if (mediaFileName.isEmpty()) {
@@ -675,7 +683,44 @@ bool TMedia::mediaFileNameEscapesMediaDir(const QString& mediaRoot, const QStrin
     const QString root = QDir::cleanPath(mediaRoot);
     const QString resolved = QDir::cleanPath(qsl("%1/%2").arg(root, mediaFileName));
 
-    return resolved != root && !resolved.startsWith(root + QLatin1Char('/'));
+    // Layer 1 - lexical containment.
+    if (resolved != root && !resolved.startsWith(root + QLatin1Char('/'))) {
+        return true;
+    }
+
+    // Layer 2 - canonical containment (symlink-aware).
+    const QString canonicalRoot = QFileInfo(root).canonicalFilePath();
+
+    if (canonicalRoot.isEmpty()) {
+        // The media root does not exist yet, so there are no symlink components to follow; the
+        // lexical check above is authoritative.
+        return false;
+    }
+
+    QString ancestor = resolved;
+    QString canonicalAncestor;
+
+    while (!ancestor.isEmpty()) {
+        canonicalAncestor = QFileInfo(ancestor).canonicalFilePath();
+
+        if (!canonicalAncestor.isEmpty()) {
+            break; // deepest existing ancestor found
+        }
+
+        const int lastSlash = ancestor.lastIndexOf(QLatin1Char('/'));
+
+        if (lastSlash <= 0) {
+            break;
+        }
+
+        ancestor = ancestor.left(lastSlash);
+    }
+
+    if (canonicalAncestor.isEmpty()) {
+        return false;
+    }
+
+    return canonicalAncestor != canonicalRoot && !canonicalAncestor.startsWith(canonicalRoot + QLatin1Char('/'));
 }
 
 QStringList TMedia::parseFileNameList(TMediaData& mediaData, QDir& dir)

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -147,6 +147,12 @@ public:
     void printClosedCaption(const TMediaData& mediaData, const QString& action) const;
     void stopAllMediaPlayers();
 
+    // Returns true if mediaFileName would resolve to a location outside mediaRoot (e.g.
+    // via "../" traversal). Legitimate relative sub-directories and wildcards stay within
+    // mediaRoot and are permitted; only escaping paths are rejected. Static and pure so it
+    // can be unit-tested without a Host.
+    static bool mediaFileNameEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName);
+
 private slots:
     void slot_writeFile(QNetworkReply* reply);
 

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -147,9 +147,10 @@ public:
     void printClosedCaption(const TMediaData& mediaData, const QString& action) const;
     void stopAllMediaPlayers();
 
-    // Returns true if mediaFileName would resolve to a location outside mediaRoot (e.g.
-    // via "../" traversal). Legitimate relative sub-directories and wildcards stay within
-    // mediaRoot and are permitted; only escaping paths are rejected. Static and pure so it
+    // Returns true if mediaFileName would resolve to a location outside mediaRoot, either
+    // lexically (e.g. via "../" traversal) or through a symlink component that already exists
+    // under mediaRoot but points elsewhere. Legitimate relative sub-directories and wildcards
+    // stay within mediaRoot and are permitted; only escaping paths are rejected. Static so it
     // can be unit-tested without a Host.
     static bool mediaFileNameEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(UNIT_TESTS
     TKeySequenceEditTest
     TEncodingHelperTest
     PasswordMigrationTest
+    TMediaPathTraversalTest
 )
 
 foreach(test_name ${UNIT_TESTS})

--- a/test/TMediaPathTraversalTest.cpp
+++ b/test/TMediaPathTraversalTest.cpp
@@ -20,6 +20,9 @@
 #include "TMedia.h"
 
 #include <QtTest/QtTest>
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
 
 /*
  * Regression guard for the media path-traversal fix.
@@ -89,6 +92,45 @@ private slots:
 
     // Dives into a sub-directory, then climbs out past the media root.
     void traversal_subDirThenOut_refused() { QVERIFY(escapes(QStringLiteral("sounds/../../evil.wav"))); }
+
+    // -------------------------------------------------------------------------
+    // Symlink containment - a lexical check alone is bypassable by a symlink that
+    // lives inside the media directory but points outside it. The canonical layer
+    // must catch it, while a genuine sub-directory of the media root stays allowed.
+    // -------------------------------------------------------------------------
+
+    void symlink_escapingMediaDir_refused()
+    {
+        QTemporaryDir base;
+        QVERIFY(base.isValid());
+
+        const QString root = base.filePath(QStringLiteral("media"));
+        const QString outside = base.filePath(QStringLiteral("outside"));
+        QVERIFY(QDir().mkpath(root));
+        QVERIFY(QDir().mkpath(outside));
+
+        // A symlink inside the media directory pointing outside it.
+        const QString link = root + QStringLiteral("/escape");
+        if (!QFile::link(outside, link)) {
+            QSKIP("Filesystem does not support symlinks");
+        }
+
+        // A path beneath the escaping symlink passes the lexical prefix test but must be
+        // refused by the canonical layer.
+        QVERIFY(TMedia::mediaFileNameEscapesMediaDir(root, QStringLiteral("escape/evil.wav")));
+    }
+
+    void symlink_realSubDir_allowed()
+    {
+        QTemporaryDir base;
+        QVERIFY(base.isValid());
+
+        const QString root = base.filePath(QStringLiteral("media"));
+        QVERIFY(QDir().mkpath(root + QStringLiteral("/sounds")));
+
+        // A genuine sub-directory of the media root must remain permitted.
+        QVERIFY(!TMedia::mediaFileNameEscapesMediaDir(root, QStringLiteral("sounds/ok.wav")));
+    }
 };
 
 QTEST_GUILESS_MAIN(TMediaPathTraversalTest)

--- a/test/TMediaPathTraversalTest.cpp
+++ b/test/TMediaPathTraversalTest.cpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mike Conley - mike.conley@stickmud.com          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMedia.h"
+
+#include <QtTest/QtTest>
+
+/*
+ * Regression guard for the media path-traversal fix.
+ *
+ * A remote game server (or a script) supplies the media file name used by MSP,
+ * MXP, GMCP Client.Media.Load/Play and the Lua media API. Before the fix the
+ * only containment check was "is the path relative?", which accepts "../"
+ * because a traversal string is still relative. That let a server escape the
+ * profile media directory and have downloaded, attacker-controlled content
+ * written anywhere the process could write (arbitrary file write), and read
+ * arbitrary local files back for playback.
+ *
+ * TMedia::mediaFileNameEscapesMediaDir() is the pure containment check every
+ * download/write and read/playback path now funnels through. It resolves the
+ * file name against the media directory and returns true only when the result
+ * escapes it - so legitimate sub-directories and wildcards keep working while
+ * traversal is refused. The check is lexical (QDir::cleanPath), so no files
+ * need to exist and the test is platform-independent. Backslash normalisation
+ * happens in the caller, so this contract operates on forward-slash paths.
+ */
+class TMediaPathTraversalTest : public QObject
+{
+    Q_OBJECT
+
+    // A representative, absolute profile media directory. Its existence is
+    // irrelevant - the containment check is purely lexical.
+    static QString mediaRoot() { return QStringLiteral("/home/user/.config/mudlet/profiles/Default/media"); }
+
+    static bool escapes(const QString& fileName) { return TMedia::mediaFileNameEscapesMediaDir(mediaRoot(), fileName); }
+
+private slots:
+
+    // -------------------------------------------------------------------------
+    // Legitimate names must be permitted (no false positives).
+    // -------------------------------------------------------------------------
+
+    void benign_topLevelFile_allowed() { QVERIFY(!escapes(QStringLiteral("beep.wav"))); }
+
+    void benign_subDirFile_allowed() { QVERIFY(!escapes(QStringLiteral("sounds/beep.wav"))); }
+
+    void benign_nestedSubDirFile_allowed() { QVERIFY(!escapes(QStringLiteral("a/b/c/beep.wav"))); }
+
+    void benign_wildcard_allowed() { QVERIFY(!escapes(QStringLiteral("*.wav"))); }
+
+    void benign_wildcardInSubDir_allowed() { QVERIFY(!escapes(QStringLiteral("sounds/*.wav"))); }
+
+    void benign_dotSlash_allowed() { QVERIFY(!escapes(QStringLiteral("./beep.wav"))); }
+
+    // "../" that stays inside the media directory is harmless and must not be blocked.
+    void benign_internalDotDot_allowed() { QVERIFY(!escapes(QStringLiteral("sounds/../beep.wav"))); }
+
+    void empty_allowed() { QVERIFY(!escapes(QString())); }
+
+    // -------------------------------------------------------------------------
+    // Traversal must be refused (the vulnerability).
+    // -------------------------------------------------------------------------
+
+    void traversal_singleLevel_refused() { QVERIFY(escapes(QStringLiteral("../evil.wav"))); }
+
+    void traversal_deep_refused() { QVERIFY(escapes(QStringLiteral("../../../../../../etc/passwd"))); }
+
+    // The classic payload: a media-looking name that lands in the user's home.
+    void traversal_intoHome_refused() { QVERIFY(escapes(QStringLiteral("../../../../.config/mudlet/evil.wav"))); }
+
+    // Escapes to a sibling of the media directory (note: same prefix, different dir).
+    void traversal_siblingDir_refused() { QVERIFY(escapes(QStringLiteral("../media_other/evil.wav"))); }
+
+    // Dives into a sub-directory, then climbs out past the media root.
+    void traversal_subDirThenOut_refused() { QVERIFY(escapes(QStringLiteral("sounds/../../evil.wav"))); }
+};
+
+QTEST_GUILESS_MAIN(TMediaPathTraversalTest)
+
+#include "TMediaPathTraversalTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Media file names sent by a game server (MSP, MXP, GMCP `Client.Media.Load`/`Play`) or the Lua media API are now confined to the profile's media directory; `../` traversal is refused while legitimate sub-directories and wildcards keep working.
- Added `TMedia::mediaFileNameEscapesMediaDir()` and enforced it at the two points every download/write and read/playback path funnels through: `playMedia()` and `parseJSONForMediaLoad()` (the GMCP `Client.Media.Load` path that does not go through `playMedia`).
- `downloadFile()` now refuses non-HTTP(S) media URLs, so a server-supplied `file://` URL can't turn a media download into a local-file read.
- Added `TMediaPathTraversalTest` as a regression guard.

#### Motivation for adding to Mudlet
The only check on a server-supplied media name was "is it relative?" — but `../../../evil.wav` is relative, so a hostile server could download attacker-controlled content and write it anywhere the user can write (arbitrary file write), create directories anywhere, or read back arbitrary local files.

#### Other info (issues closed, discussion etc)
Security hardening of the untrusted media input path. No user-visible behaviour change for legitimate media.

**Test case:** Connect to a server that sends GMCP `Client.Media.Play {"name": "beep.wav"}` and `{"name": "sub/beep.wav"}` — both download and play from inside the media folder as before. A server sending `{"name": "../../../../evil.wav"}` is refused (warning logged, nothing fetched, no file written outside the media folder). `busted`/CI unit test `TMediaPathTraversalTest` covers benign vs. traversal names.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXp6NfVcA6Ljk7rBWXsZVR)_