### PR TITLE
infrastructure: decouple telnet engine from UI dialogs

### DIFF
--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1693,14 +1693,12 @@ void TMainConsole::showPackageDownloadProgress(const QString& title, const QStri
         qWarning() << "TMainConsole::showPackageDownloadProgress() WARNING - called with no host; ignoring the download-progress request.";
         return;
     }
-    // A previous download's dialog may still be on screen (e.g. the server
-    // triggers a second Client.GUI mid-download); close it first so we don't
-    // leak a frozen dialog whose Cancel would then abort the wrong download.
+    // a second server-triggered download can arrive mid-download; without the
+    // close, the first dialog leaks frozen and its Cancel aborts the wrong download
     if (mpPackageDownloadProgressDialog) {
         mpPackageDownloadProgressDialog->close();
     }
-    // The 4000000 upper bound mirrors the original range; it is reset to the
-    // real total once the first download-progress update arrives.
+    // placeholder range; reset by the first download-progress update
     mpPackageDownloadProgressDialog = new QProgressDialog(title, cancelText, 0, 4000000, this);
     connect(mpPackageDownloadProgressDialog, &QProgressDialog::canceled, &pHost->mTelnet, &cTelnet::slot_cancelPackageDownload);
     mpPackageDownloadProgressDialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -1710,9 +1708,8 @@ void TMainConsole::showPackageDownloadProgress(const QString& title, const QStri
 void TMainConsole::updatePackageDownloadProgress(qint64 got, qint64 total)
 {
     if (mpPackageDownloadProgressDialog) {
-        // total is -1 for chunked HTTP responses of unknown length; a (0, -1)
-        // range would be nonsensical, so map any non-positive total to the
-        // (0, 0) range that turns the dialog into a busy indicator instead.
+        // total is -1 for chunked HTTP responses of unknown length; a (0, 0)
+        // range turns the dialog into a busy indicator
         mpPackageDownloadProgressDialog->setRange(0, total > 0 ? static_cast<int>(total) : 0);
         mpPackageDownloadProgressDialog->setValue(static_cast<int>(got));
     }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -42,6 +42,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QProgressDialog>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QTextBoundaryFinder>
@@ -865,7 +866,6 @@ std::pair<bool, QString> TMainConsole::createMapper(const QString& windowname, i
             mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mpHost->raiseEvent(mapOpenEvent);
         }
-
     }
     mpMapper->resize(width, height);
     mpMapper->move(x, y);
@@ -1684,6 +1684,35 @@ void TMainConsole::resizeEvent(QResizeEvent* event)
 
     // Update the record of the text area size for NAWS purposes:
     pHost->updateDisplayDimensions();
+}
+
+void TMainConsole::showPackageDownloadProgress(const QString& title, const QString& cancelText)
+{
+    auto pHost = getHost();
+    if (!pHost) {
+        return;
+    }
+    // The 4000000 upper bound mirrors the original range; it is reset to the
+    // real total once the first download-progress update arrives.
+    mpPackageDownloadProgressDialog = new QProgressDialog(title, cancelText, 0, 4000000, this);
+    connect(mpPackageDownloadProgressDialog, &QProgressDialog::canceled, &pHost->mTelnet, &cTelnet::slot_cancelPackageDownload);
+    mpPackageDownloadProgressDialog->setAttribute(Qt::WA_DeleteOnClose);
+    mpPackageDownloadProgressDialog->show();
+}
+
+void TMainConsole::updatePackageDownloadProgress(qint64 got, qint64 total)
+{
+    if (mpPackageDownloadProgressDialog) {
+        mpPackageDownloadProgressDialog->setRange(0, static_cast<int>(total));
+        mpPackageDownloadProgressDialog->setValue(static_cast<int>(got));
+    }
+}
+
+void TMainConsole::closePackageDownloadProgress()
+{
+    if (mpPackageDownloadProgressDialog) {
+        mpPackageDownloadProgressDialog->close();
+    }
 }
 
 void TMainConsole::showStatistics()

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1690,7 +1690,14 @@ void TMainConsole::showPackageDownloadProgress(const QString& title, const QStri
 {
     auto pHost = getHost();
     if (!pHost) {
+        qWarning() << "TMainConsole::showPackageDownloadProgress() WARNING - called with no host; ignoring the download-progress request.";
         return;
+    }
+    // A previous download's dialog may still be on screen (e.g. the server
+    // triggers a second Client.GUI mid-download); close it first so we don't
+    // leak a frozen dialog whose Cancel would then abort the wrong download.
+    if (mpPackageDownloadProgressDialog) {
+        mpPackageDownloadProgressDialog->close();
     }
     // The 4000000 upper bound mirrors the original range; it is reset to the
     // real total once the first download-progress update arrives.
@@ -1703,7 +1710,10 @@ void TMainConsole::showPackageDownloadProgress(const QString& title, const QStri
 void TMainConsole::updatePackageDownloadProgress(qint64 got, qint64 total)
 {
     if (mpPackageDownloadProgressDialog) {
-        mpPackageDownloadProgressDialog->setRange(0, static_cast<int>(total));
+        // total is -1 for chunked HTTP responses of unknown length; a (0, -1)
+        // range would be nonsensical, so map any non-positive total to the
+        // (0, 0) range that turns the dialog into a busy indicator instead.
+        mpPackageDownloadProgressDialog->setRange(0, total > 0 ? static_cast<int>(total) : 0);
         mpPackageDownloadProgressDialog->setValue(static_cast<int>(got));
     }
 }

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -37,6 +37,7 @@
 #include <list>
 
 class TTextBox;
+class QProgressDialog;
 
 class TMainConsole : public TConsole
 {
@@ -90,6 +91,11 @@ public:
     void setSystemSpellDictionary(const QString&);
     void setProfileSpellDictionary();
     void showStatistics();
+    // Owns the modal progress dialog for a server GUI package download; driven
+    // by cTelnet's signal_packageDownload* signals.
+    void showPackageDownloadProgress(const QString& title, const QString& cancelText);
+    void updatePackageDownloadProgress(qint64 got, qint64 total);
+    void closePackageDownloadProgress();
     const QString& getSystemSpellDictionary() const { return mSpellDic; }
     const QByteArray& getHunspellCodecName_system() const { return mHunspellCodecName_system; }
     Hunhandle* getHunspellHandle_system() const { return mpHunspell_system; }
@@ -123,6 +129,7 @@ public:
     QString mLogFileName;
     QTextStream mLogStream;
     bool mLogToLogFile = false;
+    QPointer<QProgressDialog> mpPackageDownloadProgressDialog;
 
 
 public slots:

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -70,9 +70,9 @@ public:
     std::pair<bool, QString> setUserWindowTitle(const QString& name, const QString& text);
     bool setTextFormat(const QString& name, const QColor& fgColor, const QColor& bgColor, const TChar::AttributeFlags& flags);
     TLabel* createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
-    std::pair<bool, QString> createMapper(const QString &windowname, int, int, int, int);
-    std::pair<bool, QString> createCommandLine(const QString &windowname, const QString &name, int, int, int, int);
-    std::pair<bool, QString> createTextBox(const QString &windowname, const QString &name, int, int, int, int);
+    std::pair<bool, QString> createMapper(const QString& windowname, int, int, int, int);
+    std::pair<bool, QString> createCommandLine(const QString& windowname, const QString& name, int, int, int, int);
+    std::pair<bool, QString> createTextBox(const QString& windowname, const QString& name, int, int, int, int);
     QSize getUserWindowSize(const QString& windowname) const;
     std::pair<bool, QString> setCmdLineStyleSheet(const QString& name, const QString& styleSheet);
     std::pair<bool, QString> setLabelStyleSheet(const QString& name, const QString& stylesheet);
@@ -91,8 +91,6 @@ public:
     void setSystemSpellDictionary(const QString&);
     void setProfileSpellDictionary();
     void showStatistics();
-    // Owns the modal progress dialog for a server GUI package download; driven
-    // by cTelnet's signal_packageDownload* signals.
     void showPackageDownloadProgress(const QString& title, const QString& cancelText);
     void updatePackageDownloadProgress(qint64 got, qint64 total);
     void closePackageDownloadProgress();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1497,10 +1497,8 @@ void cTelnet::sendTelnetOption(char type, unsigned char option)
 void cTelnet::slot_replyFinished(QNetworkReply* reply)
 {
     if (reply != mpPackageDownloadReply) {
-        // A stale reply (e.g. a previous, superseded download) finished; do not
-        // emit signal_packageDownloadFinished() here or it would close the
-        // progress dialog belonging to the download that is still running,
-        // leaving it headless and uncancellable.
+        // emitting signal_packageDownloadFinished() for a stale reply would close
+        // the active download's dialog, leaving it headless and uncancellable
         qWarning().nospace().noquote() << "cTelnet::slot_replyFinished(QNetworkReply*) ERROR - download finished, but it wasn't the one we are expecting";
         reply->deleteLater();
     } else {
@@ -4247,14 +4245,10 @@ void cTelnet::promptTlsConnectionAvailable()
 
 void cTelnet::slot_tlsUpgradeResponse(const bool accepted)
 {
-    // Reached synchronously, on the same thread, from inside the emit of
-    // signal_promptTlsAvailable() while the frontend's modal dialog spins a
-    // nested event loop. That loop can process a disconnect, so mpHost may have
-    // been cleared and mpSocket nulled by the time the user answers. Neither
-    // branch below dereferences mpSocket (disconnectIt/connectIt/reconnect
-    // either null-check mpSocket or use the member sockets directly), so guard
-    // on mpHost only: also guarding on mpSocket would silently discard the
-    // user's explicit Yes/No answer whenever a disconnect landed mid-dialog.
+    // The frontend's modal dialog spins a nested event loop which can process a
+    // disconnect before the user answers. Neither branch below needs mpSocket, so
+    // guard on mpHost only - also guarding on mpSocket would silently discard the
+    // user's explicit answer whenever a disconnect landed mid-dialog.
     if (!mpHost) {
         qWarning() << "cTelnet::slot_tlsUpgradeResponse() WARNING - the profile went away while the TLS upgrade prompt was open; discarding the user's answer.";
         return;
@@ -5201,12 +5195,8 @@ Some data loss is likely - please mention this problem to the game admins.)",
             }
         } else {
             if (ch == TN_BELL) {
-                // Detect the telnet bell here rather than in the TTextEdit
-                // class so it fires once per received bell (doing it there
-                // would re-alert every time the screen was refreshed) and so a
-                // test can observe signal_bell() directly. The actual taskbar
-                // flash/beep is a frontend (widget) concern, done in
-                // mudlet::addConsoleForNewHost.
+                // detected here rather than in TTextEdit so it fires once per
+                // received bell, not on every screen refresh
                 emit signal_bell();
             }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1496,12 +1496,16 @@ void cTelnet::sendTelnetOption(char type, unsigned char option)
 
 void cTelnet::slot_replyFinished(QNetworkReply* reply)
 {
-    emit signal_packageDownloadFinished();
-
     if (reply != mpPackageDownloadReply) {
+        // A stale reply (e.g. a previous, superseded download) finished; do not
+        // emit signal_packageDownloadFinished() here or it would close the
+        // progress dialog belonging to the download that is still running,
+        // leaving it headless and uncancellable.
         qWarning().nospace().noquote() << "cTelnet::slot_replyFinished(QNetworkReply*) ERROR - download finished, but it wasn't the one we are expecting";
         reply->deleteLater();
     } else {
+        emit signal_packageDownloadFinished();
+
         // don't process if download was aborted
         if (reply->error() != QNetworkReply::NoError) {
             // Display error message to user when package download fails
@@ -4243,12 +4247,16 @@ void cTelnet::promptTlsConnectionAvailable()
 
 void cTelnet::slot_tlsUpgradeResponse(const bool accepted)
 {
-    // Invoked asynchronously by the frontend after the user answers the modal
-    // question raised via signal_promptTlsAvailable(). mpHost is a QPointer and
-    // the connection could in principle have changed while the dialog was open,
-    // so guard before acting - the original synchronous code could not reach
-    // here with a null host.
-    if (!mpHost || !mpSocket) {
+    // Reached synchronously, on the same thread, from inside the emit of
+    // signal_promptTlsAvailable() while the frontend's modal dialog spins a
+    // nested event loop. That loop can process a disconnect, so mpHost may have
+    // been cleared and mpSocket nulled by the time the user answers. Neither
+    // branch below dereferences mpSocket (disconnectIt/connectIt/reconnect
+    // either null-check mpSocket or use the member sockets directly), so guard
+    // on mpHost only: also guarding on mpSocket would silently discard the
+    // user's explicit Yes/No answer whenever a disconnect landed mid-dialog.
+    if (!mpHost) {
+        qWarning() << "cTelnet::slot_tlsUpgradeResponse() WARNING - the profile went away while the TLS upgrade prompt was open; discarding the user's answer.";
         return;
     }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -53,11 +53,10 @@
 #endif
 #include "MMCPServer.h"
 
+#include <QCoreApplication>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QMessageBox>
 #include <QNetworkProxy>
-#include <QProgressDialog>
 #include <QSettings>
 #include <QSignalBlocker>
 #include <QSslError>
@@ -473,8 +472,8 @@ void cTelnet::sendGMCPSupportsRemove(const QString& package)
 void cTelnet::connectIt(const QString& address, int port)
 {
     // Set early - before the recursion-on-busy-socket block below - so the
-    // qApp->processEvents() call there cannot leave the indicator briefly
-    // showing Disconnected during a reconnect.
+    // QCoreApplication::processEvents() call there cannot leave the indicator
+    // briefly showing Disconnected during a reconnect.
     mLookingUpHost = true;
 
     if (mpHost) {
@@ -518,7 +517,7 @@ void cTelnet::connectIt(const QString& address, int port)
         }
         // Since at least one of them was not ready lets give them a chance to
         // sort themselves out:
-        qApp->processEvents();
+        QCoreApplication::processEvents();
 
         // This looks less than ideal - recursively calling ourselves?
         connectIt(address, port);
@@ -1497,7 +1496,7 @@ void cTelnet::sendTelnetOption(char type, unsigned char option)
 
 void cTelnet::slot_replyFinished(QNetworkReply* reply)
 {
-    mpProgressDialog->close();
+    emit signal_packageDownloadFinished();
 
     if (reply != mpPackageDownloadReply) {
         qWarning().nospace().noquote() << "cTelnet::slot_replyFinished(QNetworkReply*) ERROR - download finished, but it wasn't the one we are expecting";
@@ -1573,8 +1572,14 @@ void cTelnet::slot_replyFinished(QNetworkReply* reply)
 
 void cTelnet::slot_setDownloadProgress(qint64 got, qint64 tot)
 {
-    mpProgressDialog->setRange(0, static_cast<int>(tot));
-    mpProgressDialog->setValue(static_cast<int>(got));
+    emit signal_packageDownloadProgress(got, tot);
+}
+
+void cTelnet::slot_cancelPackageDownload()
+{
+    if (mpPackageDownloadReply) {
+        mpPackageDownloadReply->abort();
+    }
 }
 
 // Helper to format short telnet commands for debugging
@@ -3919,11 +3924,12 @@ void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QSt
     mudlet::self()->setNetworkRequestDefaults(url, request);
     mpPackageDownloadReply = mpDownloader->get(request);
 
-    mpProgressDialog = new QProgressDialog(tr("Downloading game GUI from server..."), tr("Cancel"), 0, 4000000, mpHost && mpHost->mpConsole ? mpHost->mpConsole : nullptr);
     connect(mpPackageDownloadReply, &QNetworkReply::downloadProgress, this, &cTelnet::slot_setDownloadProgress);
-    connect(mpProgressDialog, &QProgressDialog::canceled, mpPackageDownloadReply, &QNetworkReply::abort);
-    mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose);
-    mpProgressDialog->show();
+    // The progress dialog is a widget owned by the frontend (see
+    // TMainConsole::showPackageDownloadProgress); it wires its Cancel button
+    // back to slot_cancelPackageDownload(). Keeping the strings here preserves
+    // their existing translation context.
+    emit signal_packageDownloadStarted(tr("Downloading game GUI from server..."), tr("Cancel"));
 }
 
 // Main logic for handling GUI package installation and upgrades
@@ -4226,39 +4232,38 @@ void cTelnet::promptTlsConnectionAvailable()
         && (mpHost->mMSSPHostName.isEmpty() || mpHost->mMSSPHostName.compare(mHostUrl, Qt::CaseInsensitive) == 0)) {
         postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.").arg(QString::number(mpHost->mMSSPTlsPort)));
 
-        // This QMessageBox is application modal and because we use ::exec() it
-        // spins up it's own event loop - this is not recommended by the Qt
-        // documentation and can cause some dangerous bugs!
-        auto pMsgBox = new QMessageBox();
-        pMsgBox->setIcon(QMessageBox::Question);
-        pMsgBox->setText(tr("For data transfer protection and privacy, this connection advertises a secure port."));
-        pMsgBox->setInformativeText(tr("Update to port %1 and connect with encryption?").arg(QString::number(mpHost->mMSSPTlsPort)));
-        pMsgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        pMsgBox->setDefaultButton(QMessageBox::Yes);
-        // Make using Escape mean no change:
-        pMsgBox->setEscapeButton(QMessageBox::No);
+        // The modal Yes/No question is a widget and is shown by the frontend
+        // (see mudlet::addConsoleForNewHost); it calls back
+        // slot_tlsUpgradeResponse() with the user's answer. Keeping the strings
+        // here preserves their existing translation context.
+        emit signal_promptTlsAvailable(tr("For data transfer protection and privacy, this connection advertises a secure port."),
+                                       tr("Update to port %1 and connect with encryption?").arg(QString::number(mpHost->mMSSPTlsPort)));
+    }
+}
 
-        int ret = pMsgBox->exec();
-        delete pMsgBox;
+void cTelnet::slot_tlsUpgradeResponse(const bool accepted)
+{
+    // Invoked asynchronously by the frontend after the user answers the modal
+    // question raised via signal_promptTlsAvailable(). mpHost is a QPointer and
+    // the connection could in principle have changed while the dialog was open,
+    // so guard before acting - the original synchronous code could not reach
+    // here with a null host.
+    if (!mpHost || !mpSocket) {
+        return;
+    }
 
-        switch (ret) {
-        case QMessageBox::Yes:
-            disconnectIt();
-            mHostPort = mpHost->mMSSPTlsPort;
-            mpHost->setPort(mHostPort);
-            mpHost->mSslTsl = true;
-            mpHost->writeProfileData(QLatin1String("port"), QString::number(mHostPort));
-            mpHost->writeProfileData(QLatin1String("ssl_tsl"), QString::number(Qt::Checked));
-            connectIt(mpHost->getUrl(), mHostPort);
-            break;
-        case QMessageBox::No:
-            disconnectIt();
-            mpHost->mAskTlsAvailable = false; // Don't ask next time
-            reconnect();                      // A no-op (;) is desired, but read buffer does not flush
-            break;
-        default:
-            Q_UNREACHABLE(); // should never be reached
-        }
+    if (accepted) {
+        disconnectIt();
+        mHostPort = mpHost->mMSSPTlsPort;
+        mpHost->setPort(mHostPort);
+        mpHost->mSslTsl = true;
+        mpHost->writeProfileData(QLatin1String("port"), QString::number(mHostPort));
+        mpHost->writeProfileData(QLatin1String("ssl_tsl"), QString::number(Qt::Checked));
+        connectIt(mpHost->getUrl(), mHostPort);
+    } else {
+        disconnectIt();
+        mpHost->mAskTlsAvailable = false; // Don't ask next time
+        reconnect();                      // A no-op (;) is desired, but read buffer does not flush
     }
 }
 #endif
@@ -5188,17 +5193,13 @@ Some data loss is likely - please mention this problem to the game admins.)",
             }
         } else {
             if (ch == TN_BELL) {
-                // Flash taskbar for 3 seconds on the telnet bell, note
-                // by processing it here rather than in the TTextEdit class
-                // it is not possible to fake/test it with a Lua
-                // feedTriggers(...) call - OTOH doing it there would make
-                // a beep every time the screen was refreshed!
-                // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide option to actually make a (void) QApplication::beep() or a user-selected sound (different for each profile) and/or instead of the visual alert
-                QApplication::alert(mudlet::self(), 3000);
-
-                if (!mudlet::self()->muteGame()) {
-                    QApplication::beep();
-                }
+                // Detect the telnet bell here rather than in the TTextEdit
+                // class so it fires once per received bell (doing it there
+                // would re-alert every time the screen was refreshed) and so a
+                // test can observe signal_bell() directly. The actual taskbar
+                // flash/beep is a frontend (widget) concern, done in
+                // mudlet::addConsoleForNewHost.
+                emit signal_bell();
             }
 
             if (ch != '\r' && ch != '\0') {

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -70,7 +70,6 @@
 
 class QNetworkAccessManager;
 class QNetworkReply;
-class QProgressDialog;
 class QTimer;
 
 class Host;
@@ -268,14 +267,19 @@ public:
     bool mFORCE_GA_OFF = false;
     QPointer<dlgComposer> mpComposer;
     QNetworkAccessManager* mpDownloader = nullptr;
-    QPointer<QProgressDialog> mpProgressDialog;
     QString mServerPackage;
     QString mProfileName;
 
 
 public slots:
     void slot_setDownloadProgress(qint64, qint64);
+    void slot_cancelPackageDownload();
     void slot_replyFinished(QNetworkReply*);
+#if !defined(QT_NO_SSL)
+    // Called back by the frontend with the user's answer to the modal question
+    // raised via signal_promptTlsAvailable().
+    void slot_tlsUpgradeResponse(const bool accepted);
+#endif
     void slot_processReplayChunk();
     void slot_socketHostFound(QHostInfo);
     void slot_socketConnected();
@@ -297,6 +301,24 @@ signals:
     // Signal when GA (Go Ahead) or EOR (End of Record) telnet codes are received
     // Used by hyperlink visibility manager to trigger expire actions
     void signal_promptReceived();
+
+    // Telnet BELL received - the frontend flashes the taskbar and (unless the
+    // game is muted) beeps.
+    void signal_bell();
+
+    // Server GUI package download lifecycle - the frontend owns the progress
+    // dialog widget. The started signal carries the (translated) dialog title
+    // and Cancel button text.
+    void signal_packageDownloadStarted(const QString& title, const QString& cancelText);
+    void signal_packageDownloadProgress(qint64 got, qint64 total);
+    void signal_packageDownloadFinished();
+
+#if !defined(QT_NO_SSL)
+    // Ask the frontend to show a modal Yes/No question offering to reconnect on
+    // the secure port advertised via MSSP. The frontend must call back
+    // slot_tlsUpgradeResponse() with the user's answer.
+    void signal_promptTlsAvailable(const QString& text, const QString& informativeText);
+#endif
 
 
 private:

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -276,8 +276,6 @@ public slots:
     void slot_cancelPackageDownload();
     void slot_replyFinished(QNetworkReply*);
 #if !defined(QT_NO_SSL)
-    // Called back by the frontend with the user's answer to the modal question
-    // raised via signal_promptTlsAvailable().
     void slot_tlsUpgradeResponse(const bool accepted);
 #endif
     void slot_processReplayChunk();
@@ -302,21 +300,14 @@ signals:
     // Used by hyperlink visibility manager to trigger expire actions
     void signal_promptReceived();
 
-    // Telnet BELL received - the frontend flashes the taskbar and (unless the
-    // game is muted) beeps.
     void signal_bell();
 
-    // Server GUI package download lifecycle - the frontend owns the progress
-    // dialog widget. The started signal carries the (translated) dialog title
-    // and Cancel button text.
     void signal_packageDownloadStarted(const QString& title, const QString& cancelText);
     void signal_packageDownloadProgress(qint64 got, qint64 total);
     void signal_packageDownloadFinished();
 
 #if !defined(QT_NO_SSL)
-    // Ask the frontend to show a modal Yes/No question offering to reconnect on
-    // the secure port advertised via MSSP. The frontend must call back
-    // slot_tlsUpgradeResponse() with the user's answer.
+    // The frontend must answer this modal question by calling back slot_tlsUpgradeResponse()
     void signal_promptTlsAvailable(const QString& text, const QString& informativeText);
 #endif
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2184,6 +2184,51 @@ void mudlet::addConsoleForNewHost(Host* pH)
     connect(&pH->mTelnet, &cTelnet::signal_connected, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
     connect(&pH->mTelnet, &cTelnet::signal_disconnected, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
 
+    // Widget work for the telnet layer lives here: cTelnet emits, the frontend
+    // shows/updates the widgets (see the seam pattern in libmudlet/PLAN.md).
+    connect(
+            &pH->mTelnet,
+            &cTelnet::signal_bell,
+            this,
+            [this]() {
+                // Flash the taskbar for 3 seconds and, unless the game is muted, beep.
+                // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide an option to make a user-selected sound (per profile) and/or a visual alert instead.
+                QApplication::alert(this, 3000);
+                if (!muteGame()) {
+                    QApplication::beep();
+                }
+            },
+            Qt::UniqueConnection);
+
+    connect(&pH->mTelnet, &cTelnet::signal_packageDownloadStarted, pConsole, &TMainConsole::showPackageDownloadProgress, Qt::UniqueConnection);
+    connect(&pH->mTelnet, &cTelnet::signal_packageDownloadProgress, pConsole, &TMainConsole::updatePackageDownloadProgress, Qt::UniqueConnection);
+    connect(&pH->mTelnet, &cTelnet::signal_packageDownloadFinished, pConsole, &TMainConsole::closePackageDownloadProgress, Qt::UniqueConnection);
+
+#if !defined(QT_NO_SSL)
+    connect(
+            &pH->mTelnet,
+            &cTelnet::signal_promptTlsAvailable,
+            this,
+            [pH](const QString& text, const QString& informativeText) {
+                // Application-modal Yes/No question. Because ::exec() spins its own event
+                // loop this is not recommended by the Qt documentation and can cause
+                // dangerous re-entrancy bugs - the behaviour is preserved from the
+                // original in-cTelnet implementation.
+                auto pMsgBox = new QMessageBox();
+                pMsgBox->setIcon(QMessageBox::Question);
+                pMsgBox->setText(text);
+                pMsgBox->setInformativeText(informativeText);
+                pMsgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                pMsgBox->setDefaultButton(QMessageBox::Yes);
+                // Make using Escape mean no change:
+                pMsgBox->setEscapeButton(QMessageBox::No);
+                const int ret = pMsgBox->exec();
+                delete pMsgBox;
+                pH->mTelnet.slot_tlsUpgradeResponse(ret == QMessageBox::Yes);
+            },
+            Qt::UniqueConnection);
+#endif
+
     // Apply Host's console buffer size settings to the newly created console
     int bufferSize = pH->getConsoleBufferSize();
     if (pH->getUseMaxConsoleBufferSize()) {
@@ -4984,7 +5029,9 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
         const bool skipIntroStep = profile == qsl("Mudlet Tutorial");
         // give the freshly opened profile a moment to finish laying out before
         // the tour starts highlighting parts of it
-        QTimer::singleShot(1s, this, [this, skipIntroStep]() { showUiTour(skipIntroStep); });
+        QTimer::singleShot(1s, this, [this, skipIntroStep]() {
+            showUiTour(skipIntroStep);
+        });
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2184,15 +2184,10 @@ void mudlet::addConsoleForNewHost(Host* pH)
     connect(&pH->mTelnet, &cTelnet::signal_connected, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
     connect(&pH->mTelnet, &cTelnet::signal_disconnected, this, &mudlet::slot_telnetConnectionStateChanged, Qt::UniqueConnection);
 
-    // Widget work for the telnet layer lives here: cTelnet emits, the frontend
-    // shows/updates the widgets (see the seam pattern in libmudlet/PLAN.md).
-    // The lambda/functor connections below deliberately omit Qt::UniqueConnection
-    // because Qt cannot dedupe functor connections with it (it is a no-op and
-    // prints a warning); duplicate wiring is instead prevented by the
-    // `if (pH->mpConsole) return;` early-return at the top of this function.
+    // Qt::UniqueConnection cannot dedupe the functor connections below (a documented
+    // no-op that also prints a warning); duplicate wiring is instead prevented by
+    // the `if (pH->mpConsole) return;` early-return at the top of this function.
     connect(&pH->mTelnet, &cTelnet::signal_bell, this, [this]() {
-        // Flash the taskbar for 3 seconds and, unless the game is muted, beep.
-        // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide an option to make a user-selected sound (per profile) and/or a visual alert instead.
         QApplication::alert(this, 3000);
         if (!muteGame()) {
             QApplication::beep();
@@ -2205,10 +2200,8 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
 #if !defined(QT_NO_SSL)
     connect(&pH->mTelnet, &cTelnet::signal_promptTlsAvailable, this, [pH = QPointer<Host>(pH)](const QString& text, const QString& informativeText) {
-        // Application-modal Yes/No question. Because ::exec() spins its own event
-        // loop this is not recommended by the Qt documentation and can cause
-        // dangerous re-entrancy bugs - the behaviour is preserved from the
-        // original in-cTelnet implementation.
+        // ::exec() spins a nested event loop - a re-entrancy hazard preserved
+        // from the original in-cTelnet implementation
         auto pMsgBox = new QMessageBox();
         pMsgBox->setIcon(QMessageBox::Question);
         pMsgBox->setText(text);
@@ -2219,8 +2212,6 @@ void mudlet::addConsoleForNewHost(Host* pH)
         pMsgBox->setEscapeButton(QMessageBox::No);
         const int ret = pMsgBox->exec();
         delete pMsgBox;
-        // ::exec() spun a nested event loop, during which the profile could
-        // have been destroyed; the QPointer capture lets us detect that.
         if (!pH) {
             qWarning() << "mudlet: the profile vanished while the TLS upgrade prompt was open; discarding the user's answer.";
             return;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2186,47 +2186,47 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
     // Widget work for the telnet layer lives here: cTelnet emits, the frontend
     // shows/updates the widgets (see the seam pattern in libmudlet/PLAN.md).
-    connect(
-            &pH->mTelnet,
-            &cTelnet::signal_bell,
-            this,
-            [this]() {
-                // Flash the taskbar for 3 seconds and, unless the game is muted, beep.
-                // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide an option to make a user-selected sound (per profile) and/or a visual alert instead.
-                QApplication::alert(this, 3000);
-                if (!muteGame()) {
-                    QApplication::beep();
-                }
-            },
-            Qt::UniqueConnection);
+    // The lambda/functor connections below deliberately omit Qt::UniqueConnection
+    // because Qt cannot dedupe functor connections with it (it is a no-op and
+    // prints a warning); duplicate wiring is instead prevented by the
+    // `if (pH->mpConsole) return;` early-return at the top of this function.
+    connect(&pH->mTelnet, &cTelnet::signal_bell, this, [this]() {
+        // Flash the taskbar for 3 seconds and, unless the game is muted, beep.
+        // TODO: https://github.com/Mudlet/Mudlet/issues/5836 - provide an option to make a user-selected sound (per profile) and/or a visual alert instead.
+        QApplication::alert(this, 3000);
+        if (!muteGame()) {
+            QApplication::beep();
+        }
+    });
 
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadStarted, pConsole, &TMainConsole::showPackageDownloadProgress, Qt::UniqueConnection);
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadProgress, pConsole, &TMainConsole::updatePackageDownloadProgress, Qt::UniqueConnection);
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadFinished, pConsole, &TMainConsole::closePackageDownloadProgress, Qt::UniqueConnection);
 
 #if !defined(QT_NO_SSL)
-    connect(
-            &pH->mTelnet,
-            &cTelnet::signal_promptTlsAvailable,
-            this,
-            [pH](const QString& text, const QString& informativeText) {
-                // Application-modal Yes/No question. Because ::exec() spins its own event
-                // loop this is not recommended by the Qt documentation and can cause
-                // dangerous re-entrancy bugs - the behaviour is preserved from the
-                // original in-cTelnet implementation.
-                auto pMsgBox = new QMessageBox();
-                pMsgBox->setIcon(QMessageBox::Question);
-                pMsgBox->setText(text);
-                pMsgBox->setInformativeText(informativeText);
-                pMsgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                pMsgBox->setDefaultButton(QMessageBox::Yes);
-                // Make using Escape mean no change:
-                pMsgBox->setEscapeButton(QMessageBox::No);
-                const int ret = pMsgBox->exec();
-                delete pMsgBox;
-                pH->mTelnet.slot_tlsUpgradeResponse(ret == QMessageBox::Yes);
-            },
-            Qt::UniqueConnection);
+    connect(&pH->mTelnet, &cTelnet::signal_promptTlsAvailable, this, [pH = QPointer<Host>(pH)](const QString& text, const QString& informativeText) {
+        // Application-modal Yes/No question. Because ::exec() spins its own event
+        // loop this is not recommended by the Qt documentation and can cause
+        // dangerous re-entrancy bugs - the behaviour is preserved from the
+        // original in-cTelnet implementation.
+        auto pMsgBox = new QMessageBox();
+        pMsgBox->setIcon(QMessageBox::Question);
+        pMsgBox->setText(text);
+        pMsgBox->setInformativeText(informativeText);
+        pMsgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        pMsgBox->setDefaultButton(QMessageBox::Yes);
+        // Make using Escape mean no change:
+        pMsgBox->setEscapeButton(QMessageBox::No);
+        const int ret = pMsgBox->exec();
+        delete pMsgBox;
+        // ::exec() spun a nested event loop, during which the profile could
+        // have been destroyed; the QPointer capture lets us detect that.
+        if (!pH) {
+            qWarning() << "mudlet: the profile vanished while the TLS upgrade prompt was open; discarding the user's answer.";
+            return;
+        }
+        pH->mTelnet.slot_tlsUpgradeResponse(ret == QMessageBox::Yes);
+    });
 #endif
 
     // Apply Host's console buffer size settings to the newly created console

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 set(FUNCTIONAL_TEST_SOURCES
     TelnetTextDisplayedTest.cpp
     TelnetSubnegotiationTest.cpp
+    TelnetTlsPromptTest.cpp
     TelnetBenchmark.cpp
     ResetProfileTest.cpp
     TOscTest.cpp

--- a/test/functional_tests/TelnetTlsPromptTest.cpp
+++ b/test/functional_tests/TelnetTlsPromptTest.cpp
@@ -22,11 +22,14 @@
 #include <chrono>
 
 #include "MudletInstanceCoordinator.h"
+#include "TMainConsole.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 #include "utils.h"
+
+#include <QProgressDialog>
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -82,9 +85,11 @@ private slots:
 
         // Detach the frontend's modal handler: mudlet::addConsoleForNewHost
         // connects a lambda that would call QMessageBox::exec() and block the
-        // test (there is no user to click it). We just want to observe the
-        // signal and its payload.
-        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, mudlet::self(), nullptr);
+        // test (there is no user to click it). Disconnect by signal alone
+        // (nullptr receiver/slot) rather than by receiver: if the frontend
+        // wiring ever moves off mudlet::self() this still detaches every
+        // handler, so the test cannot hang forever inside exec().
+        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, nullptr, nullptr);
 
         QSignalSpy spy(&host->mTelnet, &cTelnet::signal_promptTlsAvailable);
         QVERIFY(spy.isValid());
@@ -108,7 +113,12 @@ private slots:
 
         host->mTelnet.loopbackTest(data);
 
-        QVERIFY2(spy.wait(2s) || spy.count() == 1, "cTelnet did not emit signal_promptTlsAvailable when MSSP advertised a TLS port.");
+        // The signal is emitted synchronously inside loopbackTest(), so it has
+        // almost certainly already arrived; only wait if it somehow has not,
+        // otherwise an unconditional spy.wait() would burn its full timeout.
+        if (spy.isEmpty()) {
+            QVERIFY2(spy.wait(2s), "cTelnet did not emit signal_promptTlsAvailable when MSSP advertised a TLS port.");
+        }
         QCOMPARE(spy.count(), 1);
 
         // The informative text carries the advertised port, keeping the string
@@ -121,6 +131,151 @@ private slots:
         // cTelnet recorded the advertised port as well.
         QCOMPARE(host->mMSSPTlsPort, tlsPort.toInt());
 #endif
+    }
+
+    // No path: declining the TLS upgrade must leave the port and ssl_tsl
+    // untouched, stop the client asking again this session, and still bring the
+    // connection back (slot_tlsUpgradeResponse() does disconnectIt() +
+    // reconnect() against the stub, which accepts repeat connections).
+    void test_tlsUpgradeDeclinedKeepsPortAndStopsAsking()
+    {
+#if defined(QT_NO_SSL)
+        QSKIP("Built without SSL support - the TLS upgrade prompt does not exist.");
+#else
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        // Detach the frontend modal handler so no dialog blocks the test.
+        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, nullptr, nullptr);
+
+        const int originalPort = host->getPort();
+        const bool originalSsl = host->mSslTsl;
+
+        // Advertise a secure port so mMSSPTlsPort is populated (the handler is
+        // detached, so nothing pops up).
+        QByteArray advertise = msspTlsPayload("48000");
+        advertise.reserve(advertise.size() + 16);
+        host->mTelnet.loopbackTest(advertise);
+
+        // The user answers No; the reconnect that follows must complete.
+        QSignalSpy connectedSpy(&host->mTelnet, &cTelnet::signal_connected);
+        host->mTelnet.slot_tlsUpgradeResponse(false);
+        QVERIFY2(connectedSpy.wait(5s), "Declining the TLS upgrade did not reconnect to the server.");
+
+        QVERIFY2(!host->mAskTlsAvailable, "Declining the TLS upgrade did not stop the client asking again.");
+        QCOMPARE(host->getPort(), originalPort);
+        QCOMPARE(host->mSslTsl, originalSsl);
+
+        // Re-advertising the same secure port must NOT prompt again now that
+        // the user has declined (don't-ask-again is sticky for the session).
+        QSignalSpy promptSpy(&host->mTelnet, &cTelnet::signal_promptTlsAvailable);
+        QByteArray advertiseAgain = msspTlsPayload("48000");
+        advertiseAgain.reserve(advertiseAgain.size() + 16);
+        host->mTelnet.loopbackTest(advertiseAgain);
+        QCOMPARE(promptSpy.count(), 0);
+#endif
+    }
+
+    // Yes path: accepting switches the profile to the advertised secure port
+    // and starts a fresh (encrypted) connection to it. A second plain-TCP stub
+    // stands in for the secure server: connectToHostEncrypted() completes the
+    // TCP accept before the (doomed) TLS handshake, and SSL errors are reported
+    // via postMessage rather than a modal dialog, so nothing blocks.
+    void test_tlsUpgradeAcceptedSwitchesPortAndConnects()
+    {
+#if defined(QT_NO_SSL)
+        QSKIP("Built without SSL support - the TLS upgrade prompt does not exist.");
+#else
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, nullptr, nullptr);
+
+        TelnetServerStub secureStub;
+        secureStub.start(mLocalhost, 0);
+        const quint16 securePort = secureStub.serverPort();
+
+        // Advertise the second stub's port as the secure port.
+        QByteArray advertise = msspTlsPayload(QByteArray::number(securePort));
+        advertise.reserve(advertise.size() + 16);
+        host->mTelnet.loopbackTest(advertise);
+        QCOMPARE(host->mMSSPTlsPort, static_cast<int>(securePort));
+
+        QSignalSpy acceptSpy(&secureStub, &QTcpServer::newConnection);
+        host->mTelnet.slot_tlsUpgradeResponse(true);
+
+        // The port switch and ssl_tsl flag are set synchronously.
+        QCOMPARE(host->getPort(), static_cast<int>(securePort));
+        QVERIFY2(host->mSslTsl, "Accepting the TLS upgrade did not enable ssl_tsl on the profile.");
+        // The encrypted connect reaches the secure stub's TCP accept.
+        QVERIFY2(acceptSpy.wait(5s), "Accepting the TLS upgrade did not open a TCP connection to the secure port.");
+
+        // Stop talking to the local stub before it is destroyed at scope exit.
+        host->mTelnet.disconnectIt();
+#endif
+    }
+
+    // A received telnet BELL (0x07) must emit signal_bell() exactly once per
+    // bell byte so the frontend can flash/beep without re-alerting on redraws.
+    void test_bellEmitsSignalPerBell()
+    {
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        QSignalSpy bellSpy(&host->mTelnet, &cTelnet::signal_bell);
+
+        QByteArray oneBell("\a");
+        oneBell.reserve(oneBell.size() + 16);
+        host->mTelnet.loopbackTest(oneBell);
+        QCOMPARE(bellSpy.count(), 1);
+
+        QByteArray twoBells("\a\a");
+        twoBells.reserve(twoBells.size() + 16);
+        host->mTelnet.loopbackTest(twoBells);
+        QCOMPARE(bellSpy.count(), 3);
+    }
+
+    // I2: a second package-download prompt must replace (not stack on top of)
+    // the first dialog, and cancelling with no active download is a no-op.
+    void test_packageDownloadProgressDialogReplaced()
+    {
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        auto console = host->mpConsole;
+        console->showPackageDownloadProgress("Downloading package 1", "Cancel");
+        console->showPackageDownloadProgress("Downloading package 2", "Cancel");
+
+        // The first dialog closes with WA_DeleteOnClose, so let its queued
+        // deleteLater() run before counting the live dialogs.
+        QTest::qWait(50ms);
+        QCOMPARE(console->findChildren<QProgressDialog*>().count(), 1);
+
+        // Cancelling when no download is in flight must be a harmless no-op.
+        host->mTelnet.slot_cancelPackageDownload();
+        QCOMPARE(console->findChildren<QProgressDialog*>().count(), 1);
+    }
+
+    // Builds an MSSP subnegotiation advertising a secure TLS port:
+    //   IAC SB MSSP  MSSP_VAR "TLS" MSSP_VAL <port>  IAC SE
+    QByteArray msspTlsPayload(const QByteArray& port)
+    {
+        QByteArray data;
+        data.append(TN_IAC);
+        data.append(TN_SB);
+        data.append(OPT_MSSP);
+        data.append(MSSP_VAR);
+        data.append("TLS");
+        data.append(MSSP_VAL);
+        data.append(port);
+        data.append(TN_IAC);
+        data.append(TN_SE);
+        return data;
     }
 
     void cleanup()

--- a/test/functional_tests/TelnetTlsPromptTest.cpp
+++ b/test/functional_tests/TelnetTlsPromptTest.cpp
@@ -1,0 +1,201 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+#include "utils.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForTlsPrompt();
+
+using namespace std::chrono_literals;
+
+// Exercises the widget-free seam introduced when cTelnet was de-widgeted: when
+// MSSP advertises a secure (TLS) port on an unencrypted connection, cTelnet must
+// no longer construct a QMessageBox itself; instead it emits
+// signal_promptTlsAvailable() carrying the (already translated) strings, and the
+// frontend owns the modal dialog. This test verifies the signal is emitted with
+// the expected payload.
+class TelnetTlsPromptTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = "Test-Telnet-Tls-Prompt";
+    const QString mLocalhost = "localhost";
+    QString mPort;
+
+private slots:
+    void initTestCase() { initializeQRCResourcesForTlsPrompt(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        // Bind an ephemeral OS-assigned port so parallel test runs (e.g. across
+        // git worktrees) do not collide on a shared fixed port.
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+    }
+
+    void test_msspTlsPortEmitsPromptSignal()
+    {
+#if defined(QT_NO_SSL)
+        QSKIP("Built without SSL support - the TLS upgrade prompt does not exist.");
+#else
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        // Detach the frontend's modal handler: mudlet::addConsoleForNewHost
+        // connects a lambda that would call QMessageBox::exec() and block the
+        // test (there is no user to click it). We just want to observe the
+        // signal and its payload.
+        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, mudlet::self(), nullptr);
+
+        QSignalSpy spy(&host->mTelnet, &cTelnet::signal_promptTlsAvailable);
+        QVERIFY(spy.isValid());
+
+        // Build an MSSP subnegotiation advertising a secure port:
+        //   IAC SB MSSP  MSSP_VAR "TLS" MSSP_VAL "48000"  IAC SE
+        const QByteArray tlsPort = "48000";
+        QByteArray data;
+        data.append(TN_IAC);
+        data.append(TN_SB);
+        data.append(OPT_MSSP);
+        data.append(MSSP_VAR);
+        data.append("TLS");
+        data.append(MSSP_VAL);
+        data.append(tlsPort);
+        data.append(TN_IAC);
+        data.append(TN_SE);
+        // processSocketData() writes a NUL at in_buffer[size + 1], so give the
+        // backing buffer a little slack before handing it its data pointer.
+        data.reserve(data.size() + 16);
+
+        host->mTelnet.loopbackTest(data);
+
+        QVERIFY2(spy.wait(2s) || spy.count() == 1, "cTelnet did not emit signal_promptTlsAvailable when MSSP advertised a TLS port.");
+        QCOMPARE(spy.count(), 1);
+
+        // The informative text carries the advertised port, keeping the string
+        // (and its translation context) inside cTelnet.
+        const QList<QVariant> arguments = spy.takeFirst();
+        QCOMPARE(arguments.size(), 2);
+        const QString informativeText = arguments.at(1).toString();
+        QVERIFY2(informativeText.contains(QString::fromLatin1(tlsPort)), qPrintable(QString("informativeText did not mention the TLS port: %1").arg(informativeText)));
+
+        // cTelnet recorded the advertised port as well.
+        QCOMPARE(host->mMSSPTlsPort, tlsPort.toInt());
+#endif
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    // Utility function to manually start a profile like a user would do via the
+    // GUI
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5s)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2s)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    // Utility function
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            qInfo() << "Profile directory does not exist:" << path;
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForTlsPrompt()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "TelnetTlsPromptTest.moc"
+QTEST_MAIN(TelnetTlsPromptTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Removes all direct Qt Widgets usage from `ctelnet.{h,cpp}`: the TLS-upgrade question, GUI-download progress dialog, and bell alert/beep now go through Qt signals; the frontend (mudlet/TMainConsole) owns the actual widgets
- Establishes the seam template for the libmudlet split: core emits pre-translated payload -> frontend shows widget -> callback slot with a state guard
- Adds `TelnetTlsPromptTest`: drives a real MSSP `TLS` subnegotiation through a stub server and asserts the new signal fires with the right payload

#### Motivation for adding to Mudlet
First concrete step of the re-scoped libmudlet plan (Widgets-free `mudlet_core` for headless/testability/WASM); this PR is the pattern every later extraction (Host, TMap, XMLexport) will copy, so it's a draft for reviewing the template itself.

#### Other info (issues closed, discussion etc)
Part of #8681 / #9011. Behavior-preserving: the TLS dialog is still modal and synchronous (same-thread direct connection), all strings stay in cTelnet's tr() context so existing translations are unaffected. One hardening: the TLS response slot now guards against the connection dropping while the dialog is open. Functional suite 17/17, unit 27/28 (lone failure is the pre-existing TKeySequenceEditTest headless flake).

Assisted-by: Claude:claude-opus-4-8

**Test case:** Connect to a game; on a server advertising MSSP TLS (e.g. one that sends `IAC SB MSSP` with a TLS port) the upgrade question appears and both Yes/No behave as before; trigger a server BEL and check the taskbar alert/beep; install a server-offered GUI package and check the download progress dialog shows, updates, and its Cancel aborts the download.


#### Demo (before & after)
Behavior-preserving refactor, so this proves parity of the user-visible flow: a server advertising an MSSP `TLS` port raises the modal secure-port question, and clicking **No** reconnects in open mode without re-prompting - identical on `development` (before) and this branch (after).

https://github.com/user-attachments/assets/77955117-fb95-400b-9e52-7bc08157478d
