### PR TITLE
infrastructure: decouple profile export and media playback from UI widgets

### DIFF
--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1725,9 +1725,6 @@ void TMainConsole::closePackageDownloadProgress()
     }
 }
 
-// TMedia (Qt Widgets-free core) asks the frontend to attach a QVideoWidget to the
-// TLabel/TConsole named by the media's key. setupSucceeded is filled in synchronously
-// (same-thread direct connection) so TMedia::play() can gate playback on it as before.
 void TMainConsole::setupVideoOutput(TMediaPlayer* player, bool& setupSucceeded)
 {
     setupSucceeded = false;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -32,6 +32,7 @@
 #include "THyperlinkVisibilityManager.h"
 #include "TLabel.h"
 #include "TMap.h"
+#include "TMedia.h"
 #include "TRoomDB.h"
 #include "TTextBox.h"
 #include "TTextEdit.h"
@@ -45,10 +46,12 @@
 #include <QProgressDialog>
 #include <QScrollBar>
 #include <QShortcut>
+#include <QSizePolicy>
 #include <QTextBoundaryFinder>
 #include <QTextCodec>
 #include <QTextStream>
 #include <QPainter>
+#include <QVideoWidget>
 
 
 TMainConsole::TMainConsole(Host* pH, QWidget* parent)
@@ -1719,6 +1722,94 @@ void TMainConsole::closePackageDownloadProgress()
 {
     if (mpPackageDownloadProgressDialog) {
         mpPackageDownloadProgressDialog->close();
+    }
+}
+
+// TMedia (Qt Widgets-free core) asks the frontend to attach a QVideoWidget to the
+// TLabel/TConsole named by the media's key. setupSucceeded is filled in synchronously
+// (same-thread direct connection) so TMedia::play() can gate playback on it as before.
+void TMainConsole::setupVideoOutput(TMediaPlayer* player, bool& setupSucceeded)
+{
+    setupSucceeded = false;
+
+    if (!player || !player->mediaPlayer()) {
+        return;
+    }
+
+    const QString target = player->mediaData().mediaKey();
+
+    if (target.isEmpty()) {
+        qWarning() << qsl("TMainConsole::setupVideoOutput() ERROR - 'key' not specified for video.");
+        return;
+    }
+
+    QString widgetType = TMediaData::MediaWidgetLabel;
+    QWidget* targetWidget = mLabelMap.value(target);
+
+    if (!targetWidget) {
+        targetWidget = mSubConsoleMap.value(target);
+        if (targetWidget) {
+            widgetType = TMediaData::MediaWidgetWindow;
+        }
+    }
+
+    if (!targetWidget) {
+        qWarning() << qsl("TMainConsole::setupVideoOutput() ERROR - No matching widget for 'key' = %1 to present video.").arg(target);
+        return;
+    }
+
+    player->mediaData().setMediaWidget(widgetType);
+
+    QVideoWidget* myVideoWidget = nullptr;
+    if (widgetType == TMediaData::MediaWidgetLabel) {
+        myVideoWidget = qobject_cast<TLabel*>(targetWidget)->mpVideoWidget;
+    } else if (widgetType == TMediaData::MediaWidgetWindow) {
+        myVideoWidget = qobject_cast<TConsole*>(targetWidget)->mpVideoWidget;
+    }
+
+    if (!myVideoWidget) {
+        myVideoWidget = new QVideoWidget();
+        myVideoWidget->setParent(targetWidget);
+        myVideoWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+        if (widgetType == TMediaData::MediaWidgetLabel) {
+            QObject::connect(qobject_cast<TLabel*>(targetWidget), &TLabel::resized, myVideoWidget, [targetWidget, myVideoWidget]() {
+                myVideoWidget->resize(targetWidget->size());
+            });
+        } else if (widgetType == TMediaData::MediaWidgetWindow) {
+            QObject::connect(qobject_cast<TConsole*>(targetWidget), &TConsole::resized, myVideoWidget, [targetWidget, myVideoWidget]() {
+                myVideoWidget->resize(targetWidget->size());
+            });
+        }
+    }
+
+    if (targetWidget->isHidden()) {
+        targetWidget->show();
+    }
+
+    myVideoWidget->resize(targetWidget->size());
+    player->mediaPlayer()->setVideoOutput(myVideoWidget);
+    myVideoWidget->show();
+
+    setupSucceeded = true;
+}
+
+void TMainConsole::hideVideoOutput(TMediaPlayer* player)
+{
+    if (!player || !player->mediaPlayer()) {
+        return;
+    }
+
+    auto* videoOutput = qobject_cast<QVideoWidget*>(player->mediaPlayer()->videoOutput());
+
+    if (!videoOutput) {
+        return;
+    }
+
+    QWidget* parent = videoOutput->parentWidget();
+
+    if (parent && parent->isVisible()) {
+        parent->hide();
     }
 }
 

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -36,6 +36,7 @@
 
 #include <list>
 
+class TMediaPlayer;
 class TTextBox;
 class QProgressDialog;
 
@@ -94,6 +95,8 @@ public:
     void showPackageDownloadProgress(const QString& title, const QString& cancelText);
     void updatePackageDownloadProgress(qint64 got, qint64 total);
     void closePackageDownloadProgress();
+    void setupVideoOutput(TMediaPlayer* player, bool& setupSucceeded);
+    void hideVideoOutput(TMediaPlayer* player);
     const QString& getSystemSpellDictionary() const { return mSpellDic; }
     const QByteArray& getHunspellCodecName_system() const { return mHunspellCodecName_system; }
     Hunhandle* getHunspellHandle_system() const { return mpHunspell_system; }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -29,6 +29,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QMetaMethod>
 #include <QNetworkDiskCache>
 #include <QRandomGenerator>
 #include <QSaveFile>
@@ -1518,6 +1519,10 @@ bool TMedia::setupVideo(const std::shared_ptr<TMediaPlayer>& player)
 {
     if (!player) {
         return false;
+    }
+
+    if (!isSignalConnected(QMetaMethod::fromSignal(&TMedia::signal_setupVideoOutput))) {
+        qWarning() << "TMedia::setupVideo() WARNING - no receiver connected to signal_setupVideoOutput, video cannot be displayed";
     }
 
     bool setupSucceeded = false;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1372,7 +1372,6 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
         player->mediaPlayer()->setSource(QUrl());
 
         if (player->mediaData().mediaWidget() == TMediaData::MediaWidgetLabel && player->mediaData().mediaClose() == TMediaData::MediaCloseEnabled && player->mediaPlayer()->videoOutput() != nullptr) {
-            // The video output is a QVideoWidget the frontend owns; it decides how to hide it.
             emit signal_hideVideoOutput(player.get());
         }
 
@@ -1521,10 +1520,6 @@ bool TMedia::setupVideo(const std::shared_ptr<TMediaPlayer>& player)
         return false;
     }
 
-    // A video output is a QVideoWidget parented to one of the frontend's TLabel/TConsole
-    // widgets; libmudlet keeps this core free of Qt Widgets, so the frontend builds and
-    // owns it. The connection is same-thread and direct, so the frontend fills in
-    // setupSucceeded synchronously and play() can gate on it just as before.
     bool setupSucceeded = false;
     emit signal_setupVideoOutput(player.get(), setupSucceeded);
     return setupSucceeded;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -23,7 +23,6 @@
 
 
 #include "TMedia.h"
-#include "TLabel.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -34,7 +33,6 @@
 #include <QRandomGenerator>
 #include <QSaveFile>
 #include <QStandardPaths>
-#include <QVideoWidget>
 
 // Public
 TMedia::TMedia(Host* pHost, const QString& profileName)
@@ -1374,15 +1372,8 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
         player->mediaPlayer()->setSource(QUrl());
 
         if (player->mediaData().mediaWidget() == TMediaData::MediaWidgetLabel && player->mediaData().mediaClose() == TMediaData::MediaCloseEnabled && player->mediaPlayer()->videoOutput() != nullptr) {
-            QVideoWidget* videoOutput = qobject_cast<QVideoWidget*>(player->mediaPlayer()->videoOutput());
-
-            if (videoOutput != nullptr) {
-                QWidget* parent = videoOutput->parentWidget();
-
-                if (parent != nullptr && parent->isVisible()) {
-                    parent->hide();
-                }
-            }
+            // The video output is a QVideoWidget the frontend owns; it decides how to hide it.
+            emit signal_hideVideoOutput(player.get());
         }
 
         //: This word is part of a sentence like "Music stops" when the music is about to stop.
@@ -1530,73 +1521,13 @@ bool TMedia::setupVideo(const std::shared_ptr<TMediaPlayer>& player)
         return false;
     }
 
-    auto mpConsole = mpHost->mpConsole;
-
-    if (!mpConsole) {
-        return false;
-    }
-
-    auto target = player->mediaData().mediaKey();
-
-    if (target.isEmpty()) {
-        qWarning() << qsl("TMedia::setupVideo() ERROR - 'key' not specified for video.");
-        return false;
-    }
-
-    QString widgetType = TMediaData::MediaWidgetLabel;
-    QWidget* targetWidget = nullptr;
-
-    // Attempt to retrieve the existing widget, labels first
-    targetWidget = mpConsole->mLabelMap.value(target);
-
-    if (!targetWidget) {
-        targetWidget = mpConsole->mSubConsoleMap.value(target);
-        if (targetWidget) {
-            widgetType = TMediaData::MediaWidgetWindow;
-        }
-    }
-
-    // Ensure we now have a valid target widget
-    if (!targetWidget) {
-        qWarning() << qsl("TMedia::setupVideo() ERROR - No matching widget for 'key' = %1 to present video.").arg(target);
-        return false;
-    }
-
-    player->mediaData().setMediaWidget(widgetType);
-
-    // Assign video widget to the target widget
-    QVideoWidget* myVideoWidget = nullptr;
-    if (widgetType == TMediaData::MediaWidgetLabel) {
-        myVideoWidget = qobject_cast<TLabel*>(targetWidget)->mpVideoWidget;
-    } else if (widgetType == TMediaData::MediaWidgetWindow) {
-        myVideoWidget = qobject_cast<TConsole*>(targetWidget)->mpVideoWidget;
-    }
-
-    if (!myVideoWidget) {
-        myVideoWidget = new QVideoWidget();
-        myVideoWidget->setParent(targetWidget);
-        myVideoWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-        if (widgetType == TMediaData::MediaWidgetLabel) {
-            QObject::connect(qobject_cast<TLabel*>(targetWidget), &TLabel::resized, myVideoWidget, [targetWidget, myVideoWidget]() {
-                myVideoWidget->resize(targetWidget->size());
-            });
-        } else if (widgetType == TMediaData::MediaWidgetWindow) {
-            QObject::connect(qobject_cast<TConsole*>(targetWidget), &TConsole::resized, myVideoWidget, [targetWidget, myVideoWidget]() {
-                myVideoWidget->resize(targetWidget->size());
-            });
-        }
-    }
-
-    if (targetWidget->isHidden()) {
-        targetWidget->show();
-    }
-
-    myVideoWidget->resize(targetWidget->size());
-    player->mediaPlayer()->setVideoOutput(myVideoWidget);
-    myVideoWidget->show();
-
-    return true;
+    // A video output is a QVideoWidget parented to one of the frontend's TLabel/TConsole
+    // widgets; libmudlet keeps this core free of Qt Widgets, so the frontend builds and
+    // owns it. The connection is same-thread and direct, so the frontend fills in
+    // setupSucceeded synchronously and play() can gate on it just as before.
+    bool setupSucceeded = false;
+    emit signal_setupVideoOutput(player.get(), setupSucceeded);
+    return setupSucceeded;
 }
 
 void TMedia::play(TMediaData& mediaData)

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -155,9 +155,6 @@ public:
     static bool mediaFilePathEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName);
 
 signals:
-    // The video output is a QVideoWidget, a Qt Widgets class the frontend owns; these
-    // keep TMedia free of Qt Widgets. Both are wired as same-thread direct connections,
-    // so setupSucceeded is filled in synchronously before play() decides to start.
     void signal_setupVideoOutput(TMediaPlayer* player, bool& setupSucceeded);
     void signal_hideVideoOutput(TMediaPlayer* player);
 

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -154,6 +154,13 @@ public:
     // under mediaRoot but points elsewhere. Static so it can be unit-tested without a Host.
     static bool mediaFilePathEscapesMediaDir(const QString& mediaRoot, const QString& mediaFileName);
 
+signals:
+    // The video output is a QVideoWidget, a Qt Widgets class the frontend owns; these
+    // keep TMedia free of Qt Widgets. Both are wired as same-thread direct connections,
+    // so setupSucceeded is filled in synchronously before play() decides to start.
+    void signal_setupVideoOutput(TMediaPlayer* player, bool& setupSucceeded);
+    void signal_hideVideoOutput(TMediaPlayer* player);
+
 private slots:
     void slot_writeFile(QNetworkReply* reply);
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -43,6 +43,7 @@
 #include <QtConcurrentRun>
 #include <QFutureWatcher>
 #include <QFile>
+#include <QGuiApplication>
 #include <QMetaEnum>
 
 #include <sstream>
@@ -962,7 +963,7 @@ void XMLexport::exportToClipboard(TTrigger* pT)
     writeTrigger(mpTrigger, triggerPackage);
     auto xml = saveXml();
 
-    auto clipboard = QApplication::clipboard();
+    auto clipboard = QGuiApplication::clipboard();
     clipboard->setText(xml, QClipboard::Clipboard);
 }
 
@@ -1044,7 +1045,7 @@ void XMLexport::exportToClipboard(TAlias* pT)
     writeAlias(mpAlias, aliasPackage);
     auto xml = saveXml();
 
-    auto clipboard = QApplication::clipboard();
+    auto clipboard = QGuiApplication::clipboard();
     clipboard->setText(xml, QClipboard::Clipboard);
 }
 
@@ -1097,7 +1098,7 @@ void XMLexport::exportToClipboard(TAction* pT)
     writeAction(mpAction, actionPackage);
     auto xml = saveXml();
 
-    auto clipboard = QApplication::clipboard();
+    auto clipboard = QGuiApplication::clipboard();
     clipboard->setText(xml, QClipboard::Clipboard);
 }
 
@@ -1166,7 +1167,7 @@ void XMLexport::exportToClipboard(TTimer* pT)
     writeTimer(mpTimer, timerPackage);
     auto xml = saveXml();
 
-    auto clipboard = QApplication::clipboard();
+    auto clipboard = QGuiApplication::clipboard();
     clipboard->setText(xml, QClipboard::Clipboard);
 }
 
@@ -1222,7 +1223,7 @@ void XMLexport::exportToClipboard(TScript* pT)
     writeScript(mpScript, scriptPackage);
     auto xml = saveXml();
 
-    auto clipboard = QApplication::clipboard();
+    auto clipboard = QGuiApplication::clipboard();
     clipboard->setText(xml, QClipboard::Clipboard);
 }
 
@@ -1277,7 +1278,7 @@ void XMLexport::exportToClipboard(TKey* pT)
     writeKey(mpKey, keyPackage);
     auto xml = saveXml();
 
-    auto clipboard = QApplication::clipboard();
+    auto clipboard = QGuiApplication::clipboard();
     clipboard->setText(xml, QClipboard::Clipboard);
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2198,6 +2198,15 @@ void mudlet::addConsoleForNewHost(Host* pH)
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadProgress, pConsole, &TMainConsole::updatePackageDownloadProgress, Qt::UniqueConnection);
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadFinished, pConsole, &TMainConsole::closePackageDownloadProgress, Qt::UniqueConnection);
 
+    // TMedia (Qt Widgets-free core) hands video-widget ownership to the frontend. The setup
+    // signal returns its result through a bool& out-parameter, which is only valid under a
+    // synchronous direct connection, so that connection type is pinned explicitly rather than
+    // left to AutoConnection resolving to Direct because both objects live on the main thread.
+    if (pH->mpMedia) {
+        connect(pH->mpMedia.data(), &TMedia::signal_setupVideoOutput, pConsole, &TMainConsole::setupVideoOutput, static_cast<Qt::ConnectionType>(Qt::DirectConnection | Qt::UniqueConnection));
+        connect(pH->mpMedia.data(), &TMedia::signal_hideVideoOutput, pConsole, &TMainConsole::hideVideoOutput, Qt::UniqueConnection);
+    }
+
 #if !defined(QT_NO_SSL)
     connect(&pH->mTelnet, &cTelnet::signal_promptTlsAvailable, this, [pH = QPointer<Host>(pH)](const QString& text, const QString& informativeText) {
         // ::exec() spins a nested event loop - a re-entrancy hazard preserved

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2201,7 +2201,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     if (pH->mpMedia) {
         // Pin DirectConnection so the bool& out-parameter is filled synchronously, never queued.
         connect(pH->mpMedia.data(), &TMedia::signal_setupVideoOutput, pConsole, &TMainConsole::setupVideoOutput, static_cast<Qt::ConnectionType>(Qt::DirectConnection | Qt::UniqueConnection));
-        connect(pH->mpMedia.data(), &TMedia::signal_hideVideoOutput, pConsole, &TMainConsole::hideVideoOutput, Qt::UniqueConnection);
+        connect(pH->mpMedia.data(), &TMedia::signal_hideVideoOutput, pConsole, &TMainConsole::hideVideoOutput, static_cast<Qt::ConnectionType>(Qt::DirectConnection | Qt::UniqueConnection));
     }
 
 #if !defined(QT_NO_SSL)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2198,11 +2198,8 @@ void mudlet::addConsoleForNewHost(Host* pH)
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadProgress, pConsole, &TMainConsole::updatePackageDownloadProgress, Qt::UniqueConnection);
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadFinished, pConsole, &TMainConsole::closePackageDownloadProgress, Qt::UniqueConnection);
 
-    // TMedia (Qt Widgets-free core) hands video-widget ownership to the frontend. The setup
-    // signal returns its result through a bool& out-parameter, which is only valid under a
-    // synchronous direct connection, so that connection type is pinned explicitly rather than
-    // left to AutoConnection resolving to Direct because both objects live on the main thread.
     if (pH->mpMedia) {
+        // Pin DirectConnection so the bool& out-parameter is filled synchronously, never queued.
         connect(pH->mpMedia.data(), &TMedia::signal_setupVideoOutput, pConsole, &TMainConsole::setupVideoOutput, static_cast<Qt::ConnectionType>(Qt::DirectConnection | Qt::UniqueConnection));
         connect(pH->mpMedia.data(), &TMedia::signal_hideVideoOutput, pConsole, &TMainConsole::hideVideoOutput, Qt::UniqueConnection);
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Removes the last raw Qt Widgets symbols from `XMLexport.cpp` and `TMedia.{h,cpp}` so they can move into the future Qt Widgets-free `mudlet_core` library
- `XMLexport` copies XML to the clipboard via `QGuiApplication::clipboard()` (QtGui) instead of `QApplication::clipboard()` (QtWidgets); the clipboard singleton is identical, so behaviour is unchanged (6 call sites)
- `TMedia` hands the video-output `QVideoWidget` lifetime to the frontend: it now emits `signal_setupVideoOutput()` / `signal_hideVideoOutput()`, and `TMainConsole` owns the widget construction, geometry, parenting and reuse-lookup that used to live in `TMedia::setupVideo()` and the stop branch of `handlePlayerPlaybackStateChanged()`
- Follows the seam template from #9507: the core emits a signal and the frontend (`mudlet` / `TMainConsole`) owns the actual widgets

#### Motivation for adding to Mudlet
Next step of the re-scoped libmudlet plan (a Widgets-free `mudlet_core` for headless use, testability and WASM). The `bash cmake/audit-core-widgets.sh` count of files that still depend on Qt Widgets drops from **158 to 156**: `XMLexport.cpp` and `TMedia.cpp` are now clean (`TMedia.h` was already clean), removing the flagged `QApplication`, `QWidget` and `QSizePolicy` symbols.

#### Other info (issues closed, discussion etc)
Part of #8681 / #9011. Behaviour-preserving:
- The video-widget code moved verbatim, so playback gating is unchanged: `TMedia::play()` still aborts video when setup fails, and the stop-time hide stays behind the same `mediaWidget == label && mediaClose == enabled` guard.
- The setup path needs a synchronous answer to gate playback, so `signal_setupVideoOutput` returns success through a `bool&` out-parameter. Emitter (`TMedia`) and receiver (`TMainConsole`) are always on the main thread, and the connection is pinned to `Qt::DirectConnection | Qt::UniqueConnection` so the out-parameter is filled before `emit` returns. `mpMedia` is created in the `Host` constructor, so the wiring in `addConsoleForNewHost()` always has a live emitter.
- Two pre-existing quirks were kept as-is rather than "fixed" here to stay behaviour-preserving: `setMediaWidget()` runs on a by-value copy of the media data (a no-op), and a freshly created `QVideoWidget` is never stored back into `TLabel::mpVideoWidget` / `TConsole::mpVideoWidget`.

No dedicated automated seam test is added: `TMedia::setupVideo()` is private and reachable only through the full `play()` pipeline (a live `QMediaPlayer` video output plus a registered target widget and `Host`), which is not deterministically testable headless the way #9507's socket-stub telnet path was. Coverage instead comes from the widgets audit (now enforceable), `TMediaPathTraversalTest`, and the `ProfileRoundTripTest` / `MapRoundTripTest` export round-trips, all green.


Assisted-by: Claude:claude-opus-4-8

**Test case:** Build with `cmake --build .`; `bash cmake/audit-core-widgets.sh` shows `XMLexport.cpp`, `TMedia.cpp` and `TMedia.h` clean (156 offending files). Connect to a game and copy a trigger/alias/script to the clipboard from the editor, then paste it back in - the XML round-trips unchanged. Play a GMCP/API video into a mapped label or user window (`type = video`, `key = <label/window name>`): the `QVideoWidget` appears, resizes with its parent, and on `stop` with `close = 1` the label hides - identical to `development`. Unit + functional suites pass (`TKeySequenceEditTest` is a pre-existing headless flake).




#### Demo (before & after)
Behaviour-preserving refactor, so this proves parity of the user-visible flow: an SMPTE-bars test clip played with `playVideoFile{}` into a label appears embedded in the console, sized to the label, identically on `development` (before) and this branch (after) - the `QVideoWidget` now built by `TMainConsole` behaves exactly as it did when `TMedia` built it.

https://github.com/user-attachments/assets/ad468886-2c4d-42ba-8ca1-437e1fc63ac4
