### PR TITLE
fix: harden the TLS-upgrade question against reconnects and profile closure

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4244,13 +4244,16 @@ void cTelnet::promptTlsConnectionAvailable()
     // on future connections; note that it is unlikely that a literal IP address
     // will be included in a TLS/SSL cert so we can include that in the tests:
     if (mpHost->mMSSPTlsPort && QSslSocket::UnencryptedMode == mpSocket->mode() && mpHost->mAskTlsAvailable && !isIPAddress(mHostUrl)
-        && (mpHost->mMSSPHostName.isEmpty() || mpHost->mMSSPHostName.compare(mHostUrl, Qt::CaseInsensitive) == 0)) {
+        && (mpHost->mMSSPHostName.isEmpty() || mpHost->mMSSPHostName.compare(mHostUrl, Qt::CaseInsensitive) == 0) && !mTlsUpgradePromptInFlight) {
         postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.").arg(QString::number(mpHost->mMSSPTlsPort)));
 
         // The modal Yes/No question is a widget and is shown by the frontend
-        // (see mudlet::addConsoleForNewHost); it calls back
-        // slot_tlsUpgradeResponse() with the user's answer. Keeping the strings
-        // here preserves their existing translation context.
+        // (see mudlet::addConsoleForNewHost) via a queued connection; it calls
+        // back slot_tlsUpgradeResponse() with the user's answer. Keeping the
+        // strings here preserves their existing translation context. Latch now so
+        // a further advertisement arriving while the prompt is pending or open
+        // cannot emit again and stack another dialog.
+        mTlsUpgradePromptInFlight = true;
         emit signal_promptTlsAvailable(tr("For data transfer protection and privacy, this connection advertises a secure port."),
                                        tr("Update to port %1 and connect with encryption?").arg(QString::number(mpHost->mMSSPTlsPort)));
     }
@@ -4258,12 +4261,22 @@ void cTelnet::promptTlsConnectionAvailable()
 
 void cTelnet::slot_tlsUpgradeResponse(const bool accepted)
 {
-    // The frontend's modal dialog spins a nested event loop which can process a
-    // disconnect before the user answers. Neither branch below needs mpSocket, so
-    // guard on mpHost only - also guarding on mpSocket would silently discard the
-    // user's explicit answer whenever a disconnect landed mid-dialog.
+    // The question is now closed regardless of the answer or the current
+    // connection state, so let a later advertisement prompt again.
+    mTlsUpgradePromptInFlight = false;
+
+    // The frontend delivers the dialog through a queued connection and it spins a
+    // nested event loop, so the answer can arrive well after the advertisement -
+    // by which point the profile may have gone or the connection may have dropped,
+    // reconnected, or already upgraded. Only act while the very unencrypted
+    // connection that raised the prompt is still live; otherwise the answer no
+    // longer describes reality. Warn rather than silently discard.
     if (!mpHost) {
         qWarning() << "cTelnet::slot_tlsUpgradeResponse() WARNING - the profile went away while the TLS upgrade prompt was open; discarding the user's answer.";
+        return;
+    }
+    if (!mpSocket || mpSocket->state() != QAbstractSocket::ConnectedState || QSslSocket::UnencryptedMode != mpSocket->mode()) {
+        qWarning() << "cTelnet::slot_tlsUpgradeResponse() WARNING - the unencrypted connection that advertised a secure port is gone or already upgraded; discarding the user's answer.";
         return;
     }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -417,6 +417,12 @@ private:
     // Stores the peer certificate from slot_socketSslError() so it can be
     // used by getPeerCertificate() when mpSocket is null:
     QSslCertificate mPeerCertificate;
+    // Latched true while a TLS-upgrade question is pending or open in the
+    // frontend. The dialog is delivered via a queued connection and so outlives
+    // the emit; this stops a hostile server stacking further prompts by
+    // re-advertising its secure MSSP port while the modal is up. Cleared when the
+    // user answers (slot_tlsUpgradeResponse()).
+    bool mTlsUpgradePromptInFlight = false;
 #endif
     // Could be a URL ("www.game.com") or an IPv4 address ("192.168.1.1") or an
     // IPv6 address ("2001:db8::1"):

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2199,25 +2199,36 @@ void mudlet::addConsoleForNewHost(Host* pH)
     connect(&pH->mTelnet, &cTelnet::signal_packageDownloadFinished, pConsole, &TMainConsole::closePackageDownloadProgress, Qt::UniqueConnection);
 
 #if !defined(QT_NO_SSL)
-    connect(&pH->mTelnet, &cTelnet::signal_promptTlsAvailable, this, [pH = QPointer<Host>(pH)](const QString& text, const QString& informativeText) {
-        // ::exec() spins a nested event loop - a re-entrancy hazard preserved
-        // from the original in-cTelnet implementation
-        auto pMsgBox = new QMessageBox();
-        pMsgBox->setIcon(QMessageBox::Question);
-        pMsgBox->setText(text);
-        pMsgBox->setInformativeText(informativeText);
-        pMsgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        pMsgBox->setDefaultButton(QMessageBox::Yes);
-        // Make using Escape mean no change:
-        pMsgBox->setEscapeButton(QMessageBox::No);
-        const int ret = pMsgBox->exec();
-        delete pMsgBox;
-        if (!pH) {
-            qWarning() << "mudlet: the profile vanished while the TLS upgrade prompt was open; discarding the user's answer.";
-            return;
-        }
-        pH->mTelnet.slot_tlsUpgradeResponse(ret == QMessageBox::Yes);
-    });
+    // A queued connection is essential here. signal_promptTlsAvailable() is
+    // emitted deep inside cTelnet's socket-parsing call stack, and the modal
+    // QMessageBox::exec() below spins a nested event loop. Delivering it queued
+    // lets that parse pass unwind first, so the dialog runs with no cTelnet frames
+    // beneath it: a profile teardown while the dialog is open (e.g. a Lua
+    // closeProfile()) then cannot free the cTelnet whose stack we would otherwise
+    // return into, and the answer cannot mutate the socket mid-parse. The QPointer
+    // capture then fully protects the (now top-level) lambda body.
+    connect(
+            &pH->mTelnet,
+            &cTelnet::signal_promptTlsAvailable,
+            this,
+            [pH = QPointer<Host>(pH)](const QString& text, const QString& informativeText) {
+                auto pMsgBox = new QMessageBox();
+                pMsgBox->setIcon(QMessageBox::Question);
+                pMsgBox->setText(text);
+                pMsgBox->setInformativeText(informativeText);
+                pMsgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                pMsgBox->setDefaultButton(QMessageBox::Yes);
+                // Make using Escape mean no change:
+                pMsgBox->setEscapeButton(QMessageBox::No);
+                const int ret = pMsgBox->exec();
+                delete pMsgBox;
+                if (!pH) {
+                    qWarning() << "mudlet: the profile vanished while the TLS upgrade prompt was open; discarding the user's answer.";
+                    return;
+                }
+                pH->mTelnet.slot_tlsUpgradeResponse(ret == QMessageBox::Yes);
+            },
+            Qt::QueuedConnection);
 #endif
 
     // Apply Host's console buffer size settings to the newly created console

--- a/test/functional_tests/TelnetTlsPromptTest.cpp
+++ b/test/functional_tests/TelnetTlsPromptTest.cpp
@@ -30,6 +30,7 @@
 #include "utils.h"
 
 #include <QProgressDialog>
+#include <QRegularExpression>
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -214,6 +215,87 @@ private slots:
 
         // Stop talking to the local stub before it is destroyed at scope exit.
         host->mTelnet.disconnectIt();
+#endif
+    }
+
+    // F3 (modal stacking): while a TLS-upgrade prompt is pending, a server
+    // re-advertising its secure MSSP port must NOT emit a second prompt. The
+    // in-flight latch collapses repeats to a single emission until the user
+    // answers (which clears it), so a hostile server cannot stack modals.
+    void test_secondTlsAdvertisementWhilePendingDoesNotReprompt()
+    {
+#if defined(QT_NO_SSL)
+        QSKIP("Built without SSL support - the TLS upgrade prompt does not exist.");
+#else
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        // Detach the frontend modal handler so nothing pops up; the latch is set
+        // by the emit itself, independent of who is listening.
+        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, nullptr, nullptr);
+
+        QSignalSpy spy(&host->mTelnet, &cTelnet::signal_promptTlsAvailable);
+        QVERIFY(spy.isValid());
+
+        QByteArray advertise = msspTlsPayload("48000");
+        advertise.reserve(advertise.size() + 16);
+        host->mTelnet.loopbackTest(advertise);
+        if (spy.isEmpty()) {
+            QVERIFY2(spy.wait(2s), "cTelnet did not emit signal_promptTlsAvailable for the first advertisement.");
+        }
+        QCOMPARE(spy.count(), 1);
+
+        // Nobody has answered, so the prompt is still in flight: a repeated
+        // advertisement (as a hostile server could spam) must be swallowed.
+        QByteArray advertiseAgain = msspTlsPayload("48000");
+        advertiseAgain.reserve(advertiseAgain.size() + 16);
+        host->mTelnet.loopbackTest(advertiseAgain);
+        QCOMPARE(spy.count(), 1);
+#endif
+    }
+
+    // With the dialog delivered via a queued connection the answer can arrive
+    // after the connection has dropped. slot_tlsUpgradeResponse() must discard
+    // such a stale answer with a warning rather than act on a gone socket or
+    // crash.
+    void test_tlsUpgradeAnswerAfterDisconnectIsDiscarded()
+    {
+#if defined(QT_NO_SSL)
+        QSKIP("Built without SSL support - the TLS upgrade prompt does not exist.");
+#else
+        startProfile(mHostname, mLocalhost, mPort);
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+
+        disconnect(&host->mTelnet, &cTelnet::signal_promptTlsAvailable, nullptr, nullptr);
+
+        // Advertise so the port is recorded and the latch is set, mirroring a
+        // real pending prompt.
+        QByteArray advertise = msspTlsPayload("48000");
+        advertise.reserve(advertise.size() + 16);
+        host->mTelnet.loopbackTest(advertise);
+
+        const int originalPort = host->getPort();
+        const bool originalSsl = host->mSslTsl;
+
+        // Drop the connection out from under the pending prompt; mpSocket is
+        // reset to null once the disconnect completes. disconnectFromHost() can
+        // emit disconnected() synchronously (empty write buffer), so check for an
+        // already-recorded emission before waiting or wait() would miss it.
+        QSignalSpy disconnectedSpy(&host->mTelnet, &cTelnet::signal_disconnected);
+        host->mTelnet.disconnectIt();
+        if (disconnectedSpy.isEmpty()) {
+            QVERIFY2(disconnectedSpy.wait(5s), "The connection did not drop.");
+        }
+
+        // The late answer must be discarded with a warning and leave the profile
+        // untouched (no port switch, no ssl_tsl flip, no crash).
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("slot_tlsUpgradeResponse.*discarding the user's answer"));
+        host->mTelnet.slot_tlsUpgradeResponse(true);
+
+        QCOMPARE(host->getPort(), originalPort);
+        QCOMPARE(host->mSslTsl, originalSsl);
 #endif
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Follow-up hardening for #9507. Three changes to the MSSP TLS-upgrade prompt:

- The frontend's modal `QMessageBox` is now connected to `signal_promptTlsAvailable` with `Qt::QueuedConnection`, so it runs with no `cTelnet` socket-parsing frames beneath it.
- A new in-flight latch (`mTlsUpgradePromptInFlight`) stops a second MSSP advertisement re-emitting the prompt while one is already pending or open.
- `slot_tlsUpgradeResponse()` now discards a stale answer (with a `qWarning`) when the connection is gone or already upgraded, instead of acting on it.

#### Motivation for adding to Mudlet

An adversarial review of #9507 found three re-entrancy issues, all reachable from a hostile server:

- **Use-after-free:** the prompt was emitted via a direct connection from deep inside `cTelnet::processSocketData()`, and `QMessageBox::exec()` spins a nested event loop under that frame. A Lua `closeProfile()` (a 0 ms `singleShot`) firing in that loop destroys the `Host` and its `cTelnet` member synchronously; unwinding then returns into the destroyed object's signal machinery and `processSocketData()`'s own member writes (e.g. `--mDecompressionRecursionDepth`).
- **Modal stacking:** nothing latched while the modal spun, so further MSSP subnegotiations serviced by the nested loop re-emitted and stacked unbounded dialogs.
- **Mid-parse mutation:** the answer's `disconnectIt()`/`connectIt()` ran beneath the paused parse frame, so the outer loop kept parsing the old buffer against mutated members and sent negotiation replies to the new socket.

Delivering the prompt queued lets the parse pass unwind before the dialog opens (fixing the UAF and the mid-parse mutation; the existing `QPointer<Host>` capture then fully protects the lambda). The latch fixes the stacking. Because the emit now returns immediately, the answer can arrive later, so the slot guards against a connection that has since dropped or upgraded.

#### Other info (issues closed, discussion etc)

Follow-up to #9507; no behavior change for the normal accept/decline paths.

**Test case:**

`TelnetTlsPromptTest` updated and extended (all pass under `ctest`):

- `test_secondTlsAdvertisementWhilePendingDoesNotReprompt` - a repeated MSSP TLS advertisement while a prompt is pending emits exactly once.
- `test_tlsUpgradeAnswerAfterDisconnectIsDiscarded` - an answer arriving after the connection dropped is discarded with a warning and does not crash or mutate the profile.

Assisted-by: Claude:claude-opus-4-8
