### PR TITLE
Infrastructure: ignore speech-dispatcher's one-time startup leak in leak detection

### DIFF
--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -69,6 +69,15 @@ leak:libgobject-2.0.so
 leak:libexpat.so
 
 # ==============================================================================
+# speech-dispatcher client library leak
+# One-time allocation in the speech-dispatcher client (libspeechd) when its
+# connection is first opened, reached via QtTextToSpeech's speechd engine.
+# Only surfaces when a speech-dispatcher daemon is reachable and something
+# touches the tts* API; no Mudlet frames are involved.
+# ==============================================================================
+leak:libspeechd.so
+
+# ==============================================================================
 # Qt internal leaks (Qt's integration with system libraries)
 # These are typically initialization leaks in Qt's platform integration
 # ==============================================================================


### PR DESCRIPTION
#### Brief overview
Add a single LeakSanitizer suppression for the one-time speech-dispatcher client-library (`libspeechd`) allocation reached through QtTextToSpeech.

#### Motivation
Qt's speech-dispatcher TTS engine leaks ~428 bytes once at init inside `libspeechd` (`spd_execute_command_with_list_reply`, via `QTextToSpeechEngineSpeechd::connectToSpeechDispatcher()`), with zero Mudlet frames. It only surfaces when a build has QtTextToSpeech **and** a speech-dispatcher daemon is reachable **and** something touches the `tts*` API. That combination makes the "ubuntu gcc lua tests + leak detection" CI job exit 1 for PRs whose tests exercise `tts*`.

#### Other info
- This unblocks the leak-detection job on #9471, whose new busted tests are the first to exercise the `tts*` API (and therefore the first to trip this leak).
- The leak is third-party, one-time init noise, not Mudlet code: the reported stack contains no Mudlet frames, only `libspeechd.so.2` and Qt's speechd plugin.
- The entry matches the module that actually allocates (`libspeechd`), consistent with the file's other module-level entries; `leak:libspeechd.so` matches the versioned `libspeechd.so.2` via LSan's substring matching.

**Test case:**
Verified locally with an ASan build (`-DUSE_SANITIZER=Address`) and a running speech-dispatcher daemon, running a busted spec that calls `ttsGetQueue()` under the CI recipe (`AUTORUN_BUSTED_TESTS`, `MUDLET_TEST_MODE`, `ASAN_OPTIONS=detect_leaks=1`, `LSAN_OPTIONS=suppressions=asan-suppressions.txt:exitcode=1`, under Xvfb):

- **Without** the suppression: exit 1, LeakSanitizer reports 428 bytes in 3 allocations (408 direct + 20 indirect) in `spd_execute_command_with_list_reply` &larr; `QTextToSpeechEngineSpeechd::connectToSpeechDispatcher()`.
- **With** the suppression: exit 0, and LSan's "Suppressions used" summary shows `3  428  libspeechd.so`.
