### PR TITLE
Infrastructure: resolve CodeQL warnings in the telnet code

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4583,7 +4583,6 @@ void cTelnet::gotPrompt(std::string& mud_data)
                 while (j < s) {
                     if (mMudData[j] == 'm') {
                         goto NEXT;
-                        break;
                     }
                     ++j;
                 }
@@ -4756,6 +4755,10 @@ int cTelnet::decompressBuffer(char*& in_buffer, int& length, char* out_buffer)
     length = mZstream.avail_in;
     in_buffer = (char*)mZstream.next_in;
 
+    // Drop the borrowed caller-buffer pointers now that inflate() is done with
+    // them: mZstream is a member, so leaving them set would keep it referencing
+    // the caller's stack buffer after we return - a dangling pointer. mZstream
+    // should only reference them for the duration of the inflate() call above.
     mZstream.next_in = Z_NULL;
     mZstream.next_out = Z_NULL;
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Resolves the three open CodeQL "warning"-level alerts in `src/ctelnet.cpp`:

- **`cpp/dead-code-goto`** (alert #2179): removed an unreachable `break;` that sat directly after a `goto NEXT;` inside `cTelnet::gotPrompt()`'s IRE-driver GA/EOR prompt-fixup loop. The `goto` is live control flow and is kept; only the dead `break;` is deleted.
- **`cpp/stack-address-escape`** (alerts #1068 and #1069): the two `mZstream.next_in`/`next_out` assignments in `cTelnet::decompressBuffer()`. No code change to the flagged lines; added a `why` comment documenting the safety invariant that already makes them safe.

No user-visible behaviour change.

#### Motivation for adding to Mudlet

Keeps the CodeQL static-analysis results clean so genuine issues stand out, and documents a non-obvious lifetime invariant in the MCCP decompression path.

#### Other info (issues closed, discussion etc)

Per-alert analysis and how it was verified:

**1. `cpp/dead-code-goto` (alert #2179) - REAL dead code, fixed in code.**
Inside `cTelnet::gotPrompt()` the inner escape-skipping loop had:

```cpp
if (mMudData[j] == 'm') {
    goto NEXT;
    break;   // unreachable
}
```

`goto` transfers control unconditionally, so the following `break;` could never execute. Removed it. The `goto NEXT;` (jump to the `NEXT:` label, which does `++j` then re-enters the outer `while` loop) is live and preserved, as are the two reachable `break;` statements later in the loop. Traced against the recent telnet subnegotiation (#9440) and MCCP work - this loop is the IRE GA/EOR prompt fixup and is untouched by those. Behaviour is byte-for-byte identical.

**2 & 3. `cpp/stack-address-escape` (alerts #1068, #1069) - FALSE POSITIVES.**
`decompressBuffer(char*& in_buffer, int& length, char* out_buffer)` stores the caller's stack buffers into the member `z_stream mZstream` (`next_in`/`next_out`), calls `inflate()` once, then resets both to `Z_NULL` before returning. CodeQL flags "a stack address which arrived via a parameter may be assigned to a non-local variable" because it is flow-insensitive about that reset. Verified no stack pointer actually outlives its scope:

- Both call sites pass stack arrays (`char out_buffer[BUFFER_SIZE + 10]` and the socket `in_buffer`) that are alive for the whole `decompressBuffer` call.
- The `next_in = Z_NULL; next_out = Z_NULL;` reset runs on straight-line code immediately after `inflate()`, before every return path (the error branch and the fall-through), so `mZstream` never retains the pointers past return.
- No code outside `decompressBuffer` reads `mZstream.next_in`/`next_out` as buffers (grep-confirmed); zlib's persistent `state` owns its own window, not the caller's buffer.

Because these are genuine false positives, the flagged assignment lines are left unchanged (no forced churn on the hot decompression path); a comment now documents why the pointers are nulled so the safety invariant is not accidentally removed later. Recommend dismissing alerts #1068 and #1069 as "False positive" in the Security tab - this PR intentionally does not alter the flagged lines, so CodeQL will keep reporting them until dismissed.

**Verification:**
- Configured + built with `cmake -G Ninja` against Qt 6.12.0 (ASan build), full build clean, plus an incremental rebuild after the final wording tweak - both exit 0.
- Ran the telnet/OSC/MXP functional suites under `flock /tmp/mudlet-functional-tests.lock`: `TelnetTextDisplayedTest`, `TelnetSubnegotiationTest`, `TelnetSgrDefaultColorTest`, `TelnetTlsPromptTest`, `TelnetBenchmark`, `TOscTest`, and all `TMxp*` tests - 16/16 passed. (No dedicated MCCP/compression test exists; the decompression path is exercised via the telnet data pipeline and the `decompressBuffer` change is comment-only.)
- Reviewed by the `code-reviewer` and `silent-failure-hunter` agents: no Critical or Important findings; one sub-threshold wording nit on the comment was addressed.

Assisted-by: Claude:claude-opus-4-8
