### PR TITLE
Infrastructure: clear 5 CodeQL warning-level alerts in src/

### DIFF
--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -77,6 +77,7 @@ struct TFontAttributes
     bool operator==(const TFontAttributes& other) const = default;
     bool operator!=(const TFontAttributes& other) const = default;
 
+    TFontAttributes(const TFontAttributes& other) = default;
     TFontAttributes& operator=(const TFontAttributes& other) = default;
 
     QFont makeFont() const

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1010,7 +1010,7 @@ bool TMap::findPath(int from, int to)
     std::vector<cost> d(vertexCount);
     try {
         astar_search(g, start, distance_heuristic<mygraph_t, cost, std::vector<location>>(locations, goal), predecessor_map(&p[0]).distance_map(&d[0]).visitor(astar_goal_visitor<vertex>(goal)));
-    } catch (found_goal) {
+    } catch (const found_goal&) {
         qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: time elapsed in A*:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
         t.restart();
         if (!roomidToIndex.contains(to)) {

--- a/src/TMatchState.h
+++ b/src/TMatchState.h
@@ -41,7 +41,8 @@ public:
     {
     }
 
-    // Copy constructor:
+    // Copy constructor - deliberately does not carry over the capture
+    // containers, so a copied state starts with empty captures:
     TMatchState(const TMatchState& ms)
     : mNumberOfConditions(ms.mNumberOfConditions)
     , mNextCondition(ms.mNextCondition)
@@ -50,6 +51,13 @@ public:
     , mSpacer(ms.mSpacer)
     {
     }
+
+    // Pair the user-defined copy constructor with an explicit copy assignment
+    // (Rule of Two). Note the two are deliberately asymmetric: unlike the
+    // constructor above, this defaulted assignment copies every member,
+    // capture containers included. That reproduces the previously implicit
+    // assignment exactly, so behaviour is unchanged:
+    TMatchState& operator=(const TMatchState& ms) = default;
 
     int nextCondition() { return mNextCondition; }
     void conditionMatched() { mNextCondition++; }

--- a/src/exitstreewidget.h
+++ b/src/exitstreewidget.h
@@ -34,21 +34,23 @@ class ExitsTreeWidget : public QTreeWidget
     friend class dlgRoomExits;
 
     // The indexes that are used to identify the columns in the special exits
-    // treewidget have been converted to constants so that we can
+    // treewidget have been collected into an enumeration so that we can
     // tweak them and change all of them correctly - and by making the
     // dlgRoomExits class a friend that can use the same set as defined here.
     // Note that if any of these numbers are modified/extended the
     // corresponding headings in the ./src/ui/room_exits.ui file will need
     // to be adjusted as well - and visa versa:
-    static const int colIndex_exitRoomId = 0;
-    static const int colIndex_exitStatus = 1;
-    static const int colIndex_lockExit = 2;
-    static const int colIndex_exitWeight = 3;
-    static const int colIndex_doorNone = 4;
-    static const int colIndex_doorOpen = 5;
-    static const int colIndex_doorClosed = 6;
-    static const int colIndex_doorLocked = 7;
-    static const int colIndex_command = 8;
+    enum ExitsTreeColumn : int {
+        colIndex_exitRoomId = 0,
+        colIndex_exitStatus = 1,
+        colIndex_lockExit = 2,
+        colIndex_exitWeight = 3,
+        colIndex_doorNone = 4,
+        colIndex_doorOpen = 5,
+        colIndex_doorClosed = 6,
+        colIndex_doorLocked = 7,
+        colIndex_command = 8,
+    };
 
 public:
     Q_DISABLE_COPY(ExitsTreeWidget)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Clears five open CodeQL "warning"-level alerts in `src/`, each with a minimal, behavior-preserving fix:

- **`src/TMap.cpp`** (`cpp/catch-by-value`): the A* search catches the `found_goal` sentinel by value. `found_goal` (in `src/TAstar.h`) is an empty struct thrown by the goal visitor purely as a control-flow signal, and the handler never touches the caught object, so it is now caught as `const found_goal&`.
- **`src/exitstreewidget.h`** (`cpp/integer-used-for-enum`, two alerts): the special-exit column indices were `static const int` constants, so the two `switch` statements in `dlgRoomExits::slot_editSpecialExit()` dispatched an `int` over const-int case labels. They are now an unscoped `enum ExitsTreeColumn : int` with identical values (0-8). Unscoped keeps the implicit `int` conversions, so every `ExitsTreeWidget::colIndex_*` call site (all passed to Qt column-index `int` parameters) is unchanged.
- **`src/TMatchState.h`** (`cpp/rule-of-two`): the class had a user-defined copy constructor but only an implicit copy assignment. Added an explicit `= default` copy assignment. The defaulted assignment reproduces the previous implicit one exactly (full member-wise copy); the existing, deliberately partial copy constructor is untouched.
- **`src/TConsole.h`** (`cpp/rule-of-two`): `TFontAttributes` had a `= default` copy assignment but only an implicit copy constructor. Added an explicit `= default` copy constructor. Move operations were already suppressed by the existing user-declared copy assignment, so nothing about copy/move behavior changes.

#### Motivation for adding to Mudlet

Reduces the open CodeQL alert backlog with small, low-risk hygiene fixes that also make the affected types' intent clearer (explicit special members, a named column enum) without altering any runtime behavior.

#### Other info (issues closed, discussion etc)

CodeQL alerts cleared:

- `cpp/catch-by-value` - `src/TMap.cpp` (alert #140)
- `cpp/integer-used-for-enum` - `src/dlgRoomExits.cpp` switch at ~318 (alert #1070)
- `cpp/integer-used-for-enum` - `src/dlgRoomExits.cpp` switch at ~399 (alert #1071)
- `cpp/rule-of-two` - `src/TMatchState.h` (alert #185)
- `cpp/rule-of-two` - `src/TConsole.h` / `TFontAttributes` (alert #2148)

Each fix is behavior-preserving. Verified with a full Ninja build (Qt 6.12.0, ASan) and the adjacent functional tests: `MapRoundTripTest`, `TAreaZLevelIndexTest`, `TAreaGridIndexTest`, `TriggerSameLineMatchTest`, `TFeedTriggersRecursionTest`, `ColorTriggerFilterChildTest`, `EnableDisableByNameTest`, `MainConsoleSelectionTest` - all pass.
