### PR TITLE
infrastructure: clean vestigial widget includes from the Lua engine files

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4248,7 +4248,7 @@ bool Host::closeWindow(const QString& name)
 bool Host::echoWindow(const QString& name, const QString& text)
 {
     if (!mpConsole) {
-        return -1;
+        return false;
     }
 
     auto pL = mpConsole->mLabelMap.value(name);
@@ -4268,7 +4268,7 @@ bool Host::echoWindow(const QString& name, const QString& text)
 bool Host::pasteWindow(const QString& name)
 {
     if (!mpConsole) {
-        return -1;
+        return false;
     }
 
     auto pC = mpConsole->mSubConsoleMap.value(name);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -59,10 +59,10 @@
 #include <math.h>
 
 #include <QtConcurrentRun>
+#include <QApplication>
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QFileDialog>
 #include <QSettings>
 #if defined(Q_OS_MACOS)
 // Only used for this OS:
@@ -72,11 +72,9 @@
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <QSaveFile>
-#include <QTableWidget>
 #include <QTemporaryDir>
 #include <QTemporaryFile>
 #include <QTextStream>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QVector>
 #include <limits>
@@ -3198,7 +3196,7 @@ int TLuaInterpreter::getOS(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getProcessID
 int TLuaInterpreter::getProcessID(lua_State* L)
 {
-    int pid = QApplication::applicationPid();
+    int pid = QCoreApplication::applicationPid();
     lua_pushinteger(L, pid);
     return 1;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -40,7 +40,6 @@
 #include <QQueue>
 #include <QThread>
 #include <QTimer>
-#include <edbee/texteditorwidget.h>
 #ifdef QT_TEXTTOSPEECH_LIB
 #include <QTextToSpeech>
 #endif // QT_TEXTTOSPEECH_LIB

--- a/src/TLuaInterpreterDiscord.cpp
+++ b/src/TLuaInterpreterDiscord.cpp
@@ -64,9 +64,6 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QFileDialog>
-#include <QTableWidget>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -65,9 +65,6 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QFileDialog>
-#include <QTableWidget>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -84,8 +84,6 @@
 #include <QCoreApplication>
 #include <QDesktopServices>
 #include <QFileDialog>
-#include <QTableWidget>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -61,9 +61,6 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QFileDialog>
-#include <QTableWidget>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>

--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -65,9 +65,6 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QFileDialog>
-#include <QTableWidget>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -30,6 +30,7 @@
 #include "TLuaInterpreter.h"
 
 #include <QClipboard>
+#include <QGuiApplication>
 
 #include "EAction.h"
 #include "Host.h"
@@ -64,9 +65,6 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QFileDialog>
-#include <QTableWidget>
-#include <QToolTip>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>
@@ -1198,7 +1196,7 @@ int TLuaInterpreter::getBorderColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getClipboardText
 int TLuaInterpreter::getClipboardText(lua_State* L)
 {
-    QClipboard* clipboard = QApplication::clipboard();
+    QClipboard* clipboard = QGuiApplication::clipboard();
     lua_pushstring(L, clipboard->text().toUtf8().constData());
     return 1;
 }
@@ -2797,7 +2795,7 @@ int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setClipboardText
 int TLuaInterpreter::setClipboardText(lua_State* L)
 {
-    QClipboard* clipboard = QApplication::clipboard();
+    QClipboard* clipboard = QGuiApplication::clipboard();
     clipboard->setText(getVerifiedString(L, __func__, 1, "text"));
     lua_pushboolean(L, true);
     return 1;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Step 1 of the libmudlet Wave 3 de-widgeting work: a cleanup + correctness pass over the `TLuaInterpreter*` engine files.

- Delete the dead `#include <edbee/texteditorwidget.h>` from `TLuaInterpreter.h` (no `edbee`/`TextEditorWidget` use anywhere in the TLuaInterpreter family).
- Drop the copy-pasted, unused `QFileDialog`/`QTableWidget`/`QToolTip` include block from the seven `TLuaInterpreter*` files carrying it, keeping only the includes each file actually uses. `TLuaInterpreterMudletObjects.cpp` keeps `QFileDialog` (used by `invokeFileDialog`); `TLuaInterpreter.cpp` gains an explicit `<QApplication>` for its remaining `QApplication::alert`, which the removed headers had been supplying transitively.
- Retarget two Widgets-free statics for audit accuracy: `QApplication::clipboard()` -> `QGuiApplication::clipboard()` and `QApplication::applicationPid()` -> `QCoreApplication::applicationPid()` (both are inherited statics, so behaviour is identical).
- Fix a null-path bug: `Host::echoWindow` and `Host::pasteWindow` returned `-1` (which promotes to `true`) when the console is null, a silent success-lie on a torn-down profile. They now return `false`, matching the existing missing-window path, so the checked `echo` caller yields the honest `nil + message` instead of a false success.

#### Motivation for adding to Mudlet

Part of the incremental libmudlet refactor (#8681, #9011) that drives raw Qt Widgets coupling out of `mudlet_core`. This removes 5 files from the `cmake/audit-core-widgets.sh` Widgets-dependent set (156 -> 151) with no behaviour change on the GUI path, and folds in an independent correctness fix for the `-1`->`true` null-path pattern.

#### Other info (issues closed, discussion etc)

Relates to #8681 and #9011. Closes no issues.

**Test case:**

1. Build (this was verified with Qt 6.12.0, Ninja, ASan) and run the C++ suite:
   `ctest --output-on-failure` -> 48/49 pass. The only failure is `TKeySequenceEditTest`, a known pre-existing headless-focus failure (`qWaitForWindowActive` under Xvfb), unrelated to these changes.
2. `bash cmake/audit-core-widgets.sh --summary` reports 151 files depend on Qt Widgets (was 156); the five now-clean files are `TLuaInterpreterUI/Mapper/Networking/Discord/TextToSpeech.cpp`.
3. Lua sanity for the retargeted statics: `getClipboardText()`, `setClipboardText("hi")`, and `getProcessID()` behave exactly as before.
4. Null-path fix: `echo` targeting a window that does not exist returns the honest `nil + "console/label '...' does not exist"` rather than reporting success. (The null-console branch it fixes is reachable when a profile's main console has been torn down.)

Assisted-by: Claude:claude-opus-4-8
