### PR TITLE
infrastructure: mock TTS engine and local HTTP server for tests

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -440,6 +440,31 @@ jobs:
         cd ~/Desktop
         sudo codesign --remove-signature ~/Desktop/Mudlet.app
 
+    - name: (Linux/macOS) Start fixture HTTP server for Lua tests
+      if: matrix.run_tests == 'true'
+      shell: bash
+      run: |
+        port_file="${{runner.temp}}/mudlet-http-fixture-port"
+        rm -f "${port_file}"
+        MUDLET_TEST_HTTP_PORT_FILE="${port_file}" nohup python3 "${{github.workspace}}/CI/http-fixture-server.py" > "${{runner.temp}}/http-fixture-server.log" 2>&1 &
+        for _ in $(seq 1 50); do
+          [ -s "${port_file}" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${port_file}" ]; then
+          echo "fixture HTTP server failed to start" >&2
+          cat "${{runner.temp}}/http-fixture-server.log" 2>/dev/null || true
+          exit 1
+        fi
+        port="$(cat "${port_file}")"
+        if ! curl -fsS "http://127.0.0.1:${port}/fixture.txt" > /dev/null; then
+          echo "fixture HTTP server is not serving fixtures" >&2
+          cat "${{runner.temp}}/http-fixture-server.log" 2>/dev/null || true
+          exit 1
+        fi
+        echo "MUDLET_TEST_HTTP_PORT=${port}" >> "${GITHUB_ENV}"
+        echo "fixture HTTP server ready on 127.0.0.1:${port}"
+
     - name: (Linux) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'Linux'
       timeout-minutes: 1
@@ -447,6 +472,7 @@ jobs:
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
+        MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -485,6 +485,7 @@ jobs:
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
+        MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: detect_leaks=0

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -521,6 +521,7 @@ jobs:
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
+        MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: detect_leaks=0

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -476,6 +476,31 @@ jobs:
         cd ~/Desktop
         sudo codesign --remove-signature ~/Desktop/Mudlet.app
 
+    - name: (Linux/macOS) Start fixture HTTP server for Lua tests
+      if: matrix.run_tests == 'true'
+      shell: bash
+      run: |
+        port_file="${{runner.temp}}/mudlet-http-fixture-port"
+        rm -f "${port_file}"
+        MUDLET_TEST_HTTP_PORT_FILE="${port_file}" nohup python3 "${{github.workspace}}/CI/http-fixture-server.py" > "${{runner.temp}}/http-fixture-server.log" 2>&1 &
+        for _ in $(seq 1 50); do
+          [ -s "${port_file}" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${port_file}" ]; then
+          echo "fixture HTTP server failed to start" >&2
+          cat "${{runner.temp}}/http-fixture-server.log" 2>/dev/null || true
+          exit 1
+        fi
+        port="$(cat "${port_file}")"
+        if ! curl -fsS "http://127.0.0.1:${port}/fixture.txt" > /dev/null; then
+          echo "fixture HTTP server is not serving fixtures" >&2
+          cat "${{runner.temp}}/http-fixture-server.log" 2>/dev/null || true
+          exit 1
+        fi
+        echo "MUDLET_TEST_HTTP_PORT=${port}" >> "${GITHUB_ENV}"
+        echo "fixture HTTP server ready on 127.0.0.1:${port}"
+
     - name: (Linux) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'Linux'
       timeout-minutes: 1
@@ -483,6 +508,7 @@ jobs:
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
+        MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}

--- a/CI/http-fixture-server.py
+++ b/CI/http-fixture-server.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Minimal fixture HTTP server for Mudlet's busted networking specs.
+
+Serves the sibling ``http-fixtures/`` directory over localhost so the Lua test
+suite can exercise getHTTP/downloadFile against a real, local endpoint instead
+of the public internet.
+
+An OS-assigned (ephemeral) port is used rather than a fixed one: Mudlet CI may
+run several jobs on the same machine, and a hard-coded port would risk
+collisions there. The chosen port is written to the file named by the
+``MUDLET_TEST_HTTP_PORT_FILE`` environment variable so the launching CI step can
+forward it to Mudlet as ``MUDLET_TEST_HTTP_PORT``.
+"""
+
+import http.server
+import os
+import socketserver
+
+FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "http-fixtures")
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=FIXTURES_DIR, **kwargs)
+
+    def log_message(self, *args):
+        # Keep CI logs quiet; the tests assert on effects, not on server chatter.
+        pass
+
+
+def main():
+    with socketserver.TCPServer(("127.0.0.1", 0), QuietHandler) as httpd:
+        port = httpd.server_address[1]
+        port_file = os.environ.get("MUDLET_TEST_HTTP_PORT_FILE")
+        if port_file:
+            # Write then rename so the launcher never reads a torn/empty port.
+            tmp_file = port_file + ".tmp"
+            with open(tmp_file, "w", encoding="utf-8") as handle:
+                handle.write(str(port))
+            os.replace(tmp_file, port_file)
+        print(f"Serving Mudlet test fixtures on http://127.0.0.1:{port}", flush=True)
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/CI/http-fixtures/fixture.txt
+++ b/CI/http-fixtures/fixture.txt
@@ -1,0 +1,1 @@
+Mudlet self-test HTTP fixture.

--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -92,11 +92,14 @@ void TLuaInterpreter::ttsBuild()
         return;
     }
 
-    // Under automated tests select Qt's deterministic "mock" engine when it is
-    // installed, so specs do not depend on a real speech-dispatcher daemon
-    // (which is absent on headless CI). Outside test mode the default engine is
-    // built exactly as before.
-    if (qEnvironmentVariableIsSet("MUDLET_TEST_MODE") && QTextToSpeech::availableEngines().contains(qsl("mock"))) {
+    // Under automated tests always request Qt's deterministic "mock" engine and
+    // never fall back to a real backend, which would speak aloud and make specs
+    // host-dependent. When the mock plugin is absent Qt leaves the engine in the
+    // Error state with no voices, so the TTS specs skip (or fail where the mock
+    // is mandatory) instead of exercising a developer's real speech engine. This
+    // also makes a non-empty voice list a reliable proof that the mock was
+    // selected. Outside test mode the default engine is built exactly as before.
+    if (qEnvironmentVariableIsSet("MUDLET_TEST_MODE")) {
         speechUnit = new QTextToSpeech(qsl("mock"));
     } else {
         speechUnit = new QTextToSpeech();

--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -92,7 +92,15 @@ void TLuaInterpreter::ttsBuild()
         return;
     }
 
-    speechUnit = new QTextToSpeech();
+    // Under automated tests select Qt's deterministic "mock" engine when it is
+    // installed, so specs do not depend on a real speech-dispatcher daemon
+    // (which is absent on headless CI). Outside test mode the default engine is
+    // built exactly as before.
+    if (qEnvironmentVariableIsSet("MUDLET_TEST_MODE") && QTextToSpeech::availableEngines().contains(qsl("mock"))) {
+        speechUnit = new QTextToSpeech(qsl("mock"));
+    } else {
+        speechUnit = new QTextToSpeech();
+    }
     bSpeechBuilt = true;
     bSpeechQueueing = false;
 

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -93,4 +93,102 @@ describe("Tests C++ functions in the Miscallaneous category", function()
         assert.is_true(err:find("module doesn't exist", 1, true) ~= nil)
       end)
     end)
+
+    describe("Tests the text-to-speech mock engine", function()
+      -- ttsBuild() selects Qt's deterministic mock engine under MUDLET_TEST_MODE,
+      -- so these specs only run in test mode and never drive a developer's real
+      -- speech engine. Where the mock plugin is absent they skip so local runs
+      -- still pass; CI sets MUDLET_TEST_REQUIRE_TTS_MOCK to turn that skip into a
+      -- failure, so a broken mock selection cannot hide behind a green skip. Async
+      -- speech events (ttsSpeechStarted...) need the waitForEvent helper and are
+      -- left to the post-enabler TTS specs.
+      local testMode = os.getenv("MUDLET_TEST_MODE")
+      local requireMock = os.getenv("MUDLET_TEST_REQUIRE_TTS_MOCK")
+
+      local function ttsEngineAvailable()
+        return testMode and type(ttsGetVoices) == "function" and type(ttsGetVoices()) == "table" and #ttsGetVoices() > 0
+      end
+
+      -- Returns true when the caller should stop because no engine is available
+      -- and skipping is permitted; fails hard where the mock is mandatory.
+      local function ttsEngineUnavailable()
+        if ttsEngineAvailable() then
+          return false
+        end
+        if requireMock then
+          assert.is_true(false, "MUDLET_TEST_REQUIRE_TTS_MOCK is set but the mock TTS engine has no voices - it was not selected")
+        end
+        pending("mock TTS engine unavailable (run with MUDLET_TEST_MODE and Qt's mock plugin)")
+        return true
+      end
+
+      it("ttsGetVoices returns a non-empty list of voice-name strings", function()
+        if ttsEngineUnavailable() then
+          return
+        end
+        local voices = ttsGetVoices()
+        assert.is_table(voices)
+        assert.is_true(#voices > 0)
+        for _, name in ipairs(voices) do
+          assert.is_string(name)
+        end
+        -- ttsGetState maps the freshly built engine's ready state to its string
+        assert.equals("ttsSpeechReady", ttsGetState())
+      end)
+
+      it("ttsSpeak accepts valid text and rejects whitespace-only text", function()
+        if ttsEngineUnavailable() then
+          return
+        end
+        -- valid text is accepted without leaving the engine in the error state
+        ttsSpeak("Mudlet self test speaking")
+        assert.is_true(ttsGetState() ~= "ttsSpeechError")
+        ttsSkip()
+        -- contract: whitespace-only text is rejected with nil + message
+        local ok, err = ttsSpeak("   ")
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+    end)
+
+    describe("Tests HTTP requests against the local fixture server", function()
+      -- Exercises getHTTP/downloadFile against the fixture server started by the
+      -- "Start fixture HTTP server" workflow step, whose port is handed over in
+      -- MUDLET_TEST_HTTP_PORT. Skips cleanly when that is unset (a local run with
+      -- no fixture server) so the suite still passes. The wire response is
+      -- asynchronous (sysDownloadDone); asserting on it needs the waitForEvent
+      -- helper and is left to the post-enabler HTTP specs.
+      local port = os.getenv("MUDLET_TEST_HTTP_PORT")
+
+      -- Runs everywhere (no server needed): an invalid url is rejected up front.
+      it("getHTTP rejects an invalid url with nil and a message", function()
+        local ok, err = getHTTP("")
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+
+      it("getHTTP accepts a request to the local fixture server", function()
+        if not port then
+          pending("MUDLET_TEST_HTTP_PORT not set (fixture HTTP server not running)")
+          return
+        end
+        local ok, actualUrl = getHTTP("http://127.0.0.1:" .. port .. "/fixture.txt")
+        assert.is_true(ok)
+        assert.is_string(actualUrl)
+        assert.is_true(actualUrl:find("127.0.0.1:" .. port, 1, true) ~= nil)
+      end)
+
+      it("downloadFile accepts a request to the local fixture server", function()
+        if not port then
+          pending("MUDLET_TEST_HTTP_PORT not set (fixture HTTP server not running)")
+          return
+        end
+        local target = getMudletHomeDir() .. "/busted-http-fixture.txt"
+        os.remove(target)
+        local ok, actualUrl = downloadFile(target, "http://127.0.0.1:" .. port .. "/fixture.txt")
+        assert.is_true(ok)
+        assert.is_string(actualUrl)
+        assert.is_true(actualUrl:find("127.0.0.1:" .. port, 1, true) ~= nil)
+      end)
+    end)
   end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Test mode selects Qt's mock text-to-speech engine, making TTS functions testable headlessly
- CI busted runs get a local fixture HTTP server for download/HTTP specs
- Smoke specs in Miscallaneous_spec.lua that skip cleanly when mock/server are absent

#### Motivation for adding to Mudlet
Unlocks TTS and HTTP Lua API coverage in CI with no real speech engine or network egress.

#### Other info (issues closed, discussion etc)
Part of the Lua API test-coverage program (Wave 0). No behavior change outside MUDLET_TEST_MODE.

**Test case:** run the busted suite with the env vars from the workflow - TTS and HTTP smoke specs pass (or skip with a message when infra is absent).

Awaiting build/test by a maintainer; squash-merge with:
Assisted-by: Claude:claude-opus-4-8
(Signed-off-by to be added at squash after testing)