### PR TITLE
infrastructure: trigger, alias, key and named-timer Lua API tests

### DIFF
--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -193,4 +193,104 @@ describe("Alias processing", function()
         end)
 
     end)
+
+    describe("tempAlias creation and firing", function()
+
+        after_each(function()
+            _G.AliasSpec = nil
+        end)
+
+        it("fires a string-body alias created from a regex pattern", function()
+            _G.AliasSpec = {fired = false}
+            local id = tempAlias("^spec_temp_alias$", [[_G.AliasSpec.fired = true]])
+            assert.is_number(id)
+            assert.are.equal(1, exists(id, "alias"), "the temp alias should exist after creation")
+            expandAlias("spec_temp_alias")
+            local fired = _G.AliasSpec.fired
+            killAlias(id)
+            assert.is_true(fired, "a string-body temp alias should fire on a matching command")
+        end)
+
+        it("fires a function-callback alias", function()
+            _G.AliasSpec = {fired = false}
+            local id = tempAlias("^spec_temp_alias_fn$", function() _G.AliasSpec.fired = true end)
+            assert.is_number(id)
+            expandAlias("spec_temp_alias_fn")
+            local fired = _G.AliasSpec.fired
+            killAlias(id)
+            assert.is_true(fired, "a function-callback temp alias should fire on a matching command")
+        end)
+
+        it("rejects a non-string, non-function body", function()
+            -- a table is not string-coercible (a number would be accepted as code)
+            assert.has_error(function() tempAlias("^bad$", {}) end)
+        end)
+
+    end)
+
+    describe("permAlias argument validation", function()
+
+        it("errors when the lua code (argument 4) is not a string", function()
+            assert.has_error(function()
+                permAlias("SpecPermAliasBad", "", "^whatever$", 999)
+            end)
+        end)
+
+        it("errors when the regex pattern (argument 3) is missing", function()
+            assert.has_error(function()
+                permAlias("SpecPermAliasBad", "")
+            end)
+        end)
+
+        it("errors when the alias name (argument 1) is missing", function()
+            assert.has_error(function()
+                permAlias()
+            end)
+        end)
+
+    end)
+
+    describe("killAlias, enable/disable and isActive for aliases", function()
+
+        after_each(function()
+            -- perm aliases can't be killed; disable any created above so they
+            -- don't leak into other specs
+            disableAlias("SpecPermAliasKill")
+            disableAlias("SpecPermAliasToggle")
+            _G.AliasSpec = nil
+        end)
+
+        it("killAlias returns true for a temporary alias and false for a missing one", function()
+            local id = tempAlias("^spec_kill_alias$", [[]])
+            assert.are.equal(1, exists(id, "alias"))
+            assert.is_true(killAlias(id), "killing an existing temp alias should return true")
+            assert.is_false(killAlias("no_such_alias_name"), "killing a missing alias should return false")
+        end)
+
+        it("killAlias returns false for a permanent alias (they cannot be killed)", function()
+            local id = permAlias("SpecPermAliasKill", "", "^spec_perm_kill$", [[]])
+            assert.is_true(id > 0)
+            assert.is_false(killAlias("SpecPermAliasKill"), "permanent aliases cannot be removed with killAlias")
+        end)
+
+        it("enableAlias and disableAlias return whether a matching alias was found", function()
+            local id = permAlias("SpecPermAliasToggle", "", "^spec_toggle_alias$", [[]])
+            assert.is_true(id > 0)
+            assert.is_true(disableAlias("SpecPermAliasToggle"), "disableAlias should report it found the alias")
+            assert.is_true(enableAlias("SpecPermAliasToggle"), "enableAlias should report it found the alias")
+            assert.is_false(disableAlias("no_such_alias_name"), "disableAlias should return false when nothing matched")
+            assert.is_false(enableAlias("no_such_alias_name"), "enableAlias should return false when nothing matched")
+        end)
+
+        it("isActive reflects an alias's enabled state", function()
+            local id = tempAlias("^spec_active_alias$", [[]])
+            assert.are.equal(1, isActive(id, "alias"), "a fresh alias should be active")
+            disableAlias(id)
+            assert.are.equal(0, isActive(id, "alias"), "a disabled alias should not be active")
+            enableAlias(id)
+            assert.are.equal(1, isActive(id, "alias"), "a re-enabled alias should be active")
+            killAlias(id)
+        end)
+
+    end)
 end)

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -180,22 +180,118 @@ describe("Tests the functionality of IDMgr", function()
     end)
   end)
 
-  -- timer functionality tests awaiting me figuring out async tests in busted
-  -- functional testing shows it works, and the code paths are the same for timers as
-  -- for events in the underlying IDMgr, just using different core Mudlet API functions
-  -- I have personally functionally tested this though. -- Demonnic
-  -- TODO: write timer tests https://github.com/Mudlet/Mudlet/issues/5520
+  -- The synchronous named-timer lifecycle (register/reset/stop/resume/delete and
+  -- their -All variants) is covered below. Timer *firing* still needs an async
+  -- busted harness and is not exercised here. https://github.com/Mudlet/Mudlet/issues/5520
   describe("Tests the timer functionality", function()
     local user = "test user"
     local timerName = "test timer"
+    -- long interval so the underlying tempTimer never fires during the test:
+    -- these specs cover the synchronous lifecycle only, not firing
     local time = 100
-    pending("Should register a named timer")
-    pending("Should reset a named timer if it is registered a second+ time")
-    pending("Should allow you to stop a named timer")
-    pending("Should allow you to resume a named timer")
-    pending("Should allow you to stop all named timers")
-    pending("Should allow you to delete a named timer")
-    pending("Should allow you to delete all named timers")
+
+    -- clean up the shared per-user manager after each lifecycle test so a stray
+    -- named timer can't leak into later specs (getNewIDManager tests clean their
+    -- own private manager inline).
+    after_each(function()
+      deleteAllNamedTimers(user)
+    end)
+
+    describe("Tests registering, stopping and deleting named timers", function()
+      it("Should register a named timer and list it as active", function()
+        local ok = registerNamedTimer(user, timerName, time, function() end)
+        assert.is_true(ok)
+        assert.are.same({timerName}, getNamedTimers(user))
+        local remaining = remainingNamedTimer(user, timerName)
+        assert.is_number(remaining)
+        assert.is_true(remaining > 0)
+      end)
+
+      it("Should reset a named timer when it is registered a second time", function()
+        -- behaviour-based: the second (shorter) registration must replace the
+        -- first, observable through the remaining time dropping to the new value
+        registerNamedTimer(user, timerName, 5000, function() end)
+        local firstRemaining = remainingNamedTimer(user, timerName)
+        assert.is_number(firstRemaining)
+        assert.is_true(firstRemaining > 100, "the first registration should leave a large remaining time")
+
+        registerNamedTimer(user, timerName, 50, function() end)
+        -- one entry, not two, under the reused name
+        assert.are.same({timerName}, getNamedTimers(user))
+        local secondRemaining = remainingNamedTimer(user, timerName)
+        assert.is_number(secondRemaining)
+        assert.is_true(secondRemaining <= 50, "re-registering must replace the timer with the new, shorter one")
+      end)
+
+      it("Should stop a named timer while leaving it registered", function()
+        registerNamedTimer(user, timerName, time, function() end)
+        local ok = stopNamedTimer(user, timerName)
+        assert.is_true(ok)
+        -- stopped, so no time remains...
+        local remaining, err = remainingNamedTimer(user, timerName)
+        assert.is_nil(remaining)
+        assert.is_equal("timer is inactive", err)
+        -- ...but a stopped timer is still registered (stop is not delete)
+        assert.are.same({timerName}, getNamedTimers(user))
+      end)
+
+      it("Should return false when stopping a timer that is not registered", function()
+        assert.is_false(stopNamedTimer(user, "no such timer"))
+      end)
+
+      it("Should return false when resuming or deleting an unregistered timer", function()
+        assert.is_false(resumeNamedTimer(user, "no such timer"))
+        assert.is_false(deleteNamedTimer(user, "no such timer"))
+      end)
+
+      it("Should resume a stopped named timer", function()
+        registerNamedTimer(user, timerName, time, function() end)
+        stopNamedTimer(user, timerName)
+        local ok = resumeNamedTimer(user, timerName)
+        assert.is_true(ok)
+        local remaining = remainingNamedTimer(user, timerName)
+        assert.is_number(remaining)
+        assert.is_true(remaining > 0)
+      end)
+
+      it("Should stop all named timers for a user", function()
+        local timerName2 = timerName .. "2"
+        registerNamedTimer(user, timerName, time, function() end)
+        registerNamedTimer(user, timerName2, time, function() end)
+
+        assert.is_true(stopAllNamedTimers(user))
+
+        local _, err1 = remainingNamedTimer(user, timerName)
+        local _, err2 = remainingNamedTimer(user, timerName2)
+        assert.is_equal("timer is inactive", err1)
+        assert.is_equal("timer is inactive", err2)
+        -- stopped, not deleted: both remain registered
+        assert.is_equal(2, #getNamedTimers(user))
+      end)
+
+      it("Should delete a single named timer", function()
+        local timerName2 = timerName .. "2"
+        registerNamedTimer(user, timerName, time, function() end)
+        registerNamedTimer(user, timerName2, time, function() end)
+
+        assert.is_true(deleteNamedTimer(user, timerName))
+
+        assert.are.same({timerName2}, getNamedTimers(user))
+        local remaining, err = remainingNamedTimer(user, timerName)
+        assert.is_nil(remaining)
+        assert.is_equal("timer not found", err)
+      end)
+
+      it("Should delete all named timers for a user", function()
+        registerNamedTimer(user, timerName, time, function() end)
+        registerNamedTimer(user, timerName .. "2", time, function() end)
+        assert.is_equal(2, #getNamedTimers(user))
+
+        assert.is_true(deleteAllNamedTimers(user))
+
+        assert.are.same({}, getNamedTimers(user))
+      end)
+    end)
 
     describe("Tests the functionality of remainingNamedTimer", function()
       after_each(function()
@@ -233,6 +329,19 @@ describe("Tests the functionality of IDMgr", function()
         local result, err = mgr:remainingTime(timerName)
         assert.is_nil(result)
         assert.is_equal("timer is inactive", err)
+      end)
+
+      it("Should actually kill the underlying tempTimer when stopped", function()
+        -- The manager's own bookkeeping (handlerID = -1) would report "inactive"
+        -- even if stop failed to kill the tempTimer, so check the raw handle: a
+        -- regression that dropped the killTimer call would leave it firing.
+        local mgr = getNewIDManager()
+        mgr:registerTimer(timerName, time, function() end)
+        local handlerID = mgr.timers[timerName].handlerID
+        assert.is_number(remainingTime(handlerID))
+        mgr:stopTimer(timerName)
+        assert.is_nil(remainingTime(handlerID), "stopping must kill the underlying tempTimer, not just update bookkeeping")
+        mgr:deleteAllTimers()
       end)
     end)
 
@@ -292,6 +401,83 @@ describe("Tests the functionality of IDMgr", function()
 
       assert.error_matches(exec, "registerNamedTimer: bad argument #4 type")
       assert.error_matches(exec2, "registerNamedTimer: bad argument #3 type")
+    end)
+  end)
+
+  -- Unlike named timers, named triggers fire synchronously via feedTriggers, so
+  -- the full lifecycle including the firing effect is exercised here.
+  describe("Tests the named trigger functionality", function()
+    local user = "trig user"
+    local tName = "test trigger"
+
+    after_each(function()
+      deleteAllNamedTriggers(user)
+      _G.NamedTrigFire = nil
+    end)
+
+    it("Should register a named trigger that fires on its substring", function()
+      _G.NamedTrigFire = 0
+      local ok = registerNamedTrigger(user, tName, "named_trig_basic", function() _G.NamedTrigFire = _G.NamedTrigFire + 1 end)
+      assert.is_true(ok)
+      assert.are.same({tName}, getNamedTriggers(user))
+      feedTriggers("\nnamed_trig_basic\n")
+      assert.is_true(_G.NamedTrigFire >= 1, "an active named trigger should fire on its substring")
+    end)
+
+    it("Should stop a named trigger from firing", function()
+      _G.NamedTrigFire = 0
+      registerNamedTrigger(user, tName, "named_trig_stop", function() _G.NamedTrigFire = _G.NamedTrigFire + 1 end)
+      feedTriggers("\nnamed_trig_stop\n")
+      assert.is_true(_G.NamedTrigFire >= 1, "the trigger should fire before being stopped")
+
+      stopNamedTrigger(user, tName)
+      -- the underlying killTrigger defers deletion to the end of the next feed,
+      -- so flush once to let cleanup run...
+      feedTriggers("\nnamed_trig_stop\n")
+      local afterFlush = _G.NamedTrigFire
+      -- ...then confirm the stopped trigger no longer fires
+      feedTriggers("\nnamed_trig_stop\n")
+      assert.is_equal(afterFlush, _G.NamedTrigFire, "a stopped named trigger must not keep firing")
+    end)
+
+    it("Should resume a stopped named trigger", function()
+      _G.NamedTrigFire = 0
+      registerNamedTrigger(user, tName, "named_trig_resume", function() _G.NamedTrigFire = _G.NamedTrigFire + 1 end)
+      stopNamedTrigger(user, tName)
+      feedTriggers("\nnamed_trig_resume\n") -- flush the deferred cleanup
+      resumeNamedTrigger(user, tName)
+      local before = _G.NamedTrigFire
+      feedTriggers("\nnamed_trig_resume\n")
+      assert.is_true(_G.NamedTrigFire > before, "a resumed named trigger should fire again")
+    end)
+
+    it("Should register a regex named trigger and list it", function()
+      registerNamedRegexTrigger(user, "regex_trig", "^whatever_re$", function() end)
+      assert.are.same({"regex_trig"}, getNamedTriggers(user))
+    end)
+
+    it("Should list registered named triggers", function()
+      registerNamedTrigger(user, "sub_one", "whatever_sub_one", function() end)
+      registerNamedTrigger(user, "sub_two", "whatever_sub_two", function() end)
+      local names = getNamedTriggers(user)
+      assert.is_equal(2, #names)
+      local present = {}
+      for _, n in ipairs(names) do present[n] = true end
+      assert.is_true(present["sub_one"] and present["sub_two"], "both named triggers should be listed")
+    end)
+
+    it("Should delete a named trigger", function()
+      registerNamedTrigger(user, tName, "named_trig_del", function() end)
+      assert.is_true(deleteNamedTrigger(user, tName))
+      assert.are.same({}, getNamedTriggers(user))
+    end)
+
+    it("Should delete all named triggers", function()
+      registerNamedTrigger(user, "t1", "named_trig_all_a", function() end)
+      registerNamedTrigger(user, "t2", "named_trig_all_b", function() end)
+      assert.is_equal(2, #getNamedTriggers(user))
+      assert.is_true(deleteAllNamedTriggers(user))
+      assert.are.same({}, getNamedTriggers(user))
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/KeyBinds_spec.lua
+++ b/src/mudlet-lua/tests/KeyBinds_spec.lua
@@ -100,4 +100,140 @@ describe("Tests keybind-related functions", function()
 
   end)
 
+  describe("tempKey creation and cleanup", function()
+
+    it("creates a key from a modifier, key code and string body", function()
+      local id = tempKey(mudlet.keymodifier.Alt, mudlet.key.F5, [[echo("hi")]])
+      assert.is_number(id)
+      assert.are.equal(1, exists(id, "keybind"), "the temp key should exist after creation")
+      local keyCode, modifiers = getKeyCode(id)
+      assert.are.equal(mudlet.key.F5, keyCode)
+      assert.are.equal(mudlet.keymodifier.Alt, modifiers)
+      killKey(id)
+    end)
+
+    it("creates a key from the two-argument (key code, body) form", function()
+      local id = tempKey(mudlet.key.F6, [[echo("hi")]])
+      assert.is_number(id)
+      local keyCode, modifiers = getKeyCode(id)
+      assert.are.equal(mudlet.key.F6, keyCode)
+      assert.are.equal(mudlet.keymodifier.None, modifiers, "the two-arg form should have no modifier")
+      killKey(id)
+    end)
+
+    it("creates a key from a function body", function()
+      -- a key cannot be pressed headlessly, so this only asserts creation
+      local id = tempKey(mudlet.key.F7, function() end)
+      assert.is_number(id)
+      assert.are.equal(1, exists(id, "keybind"))
+      killKey(id)
+    end)
+
+    it("rejects a non-string, non-function body", function()
+      -- a table is not string-coercible (a number would be accepted as code)
+      assert.has_error(function() tempKey(mudlet.key.F8, {}) end)
+    end)
+
+  end)
+
+  describe("permKey creation and validation", function()
+
+    -- permanent keys cannot be removed with killKey, so use unique names and
+    -- disable them after each test so they do not leak into other specs
+    after_each(function()
+      disableKey("SpecPermKeyOne")
+      disableKey("SpecPermKeyTwo")
+    end)
+
+    it("creates a permanent key without a modifier (four-argument form)", function()
+      local id = permKey("SpecPermKeyOne", "", mudlet.key.F9, [[echo("perm")]])
+      assert.is_number(id)
+      assert.is_true(id > 0)
+      local keyCode, modifiers = getKeyCode(id)
+      assert.are.equal(mudlet.key.F9, keyCode)
+      assert.are.equal(mudlet.keymodifier.None, modifiers)
+    end)
+
+    it("creates a permanent key with a modifier (five-argument form)", function()
+      local id = permKey("SpecPermKeyTwo", "", mudlet.keymodifier.Control, mudlet.key.F10, [[echo("perm")]])
+      assert.is_number(id)
+      assert.is_true(id > 0)
+      local keyCode, modifiers = getKeyCode(id)
+      assert.are.equal(mudlet.key.F10, keyCode)
+      assert.are.equal(mudlet.keymodifier.Control, modifiers)
+    end)
+
+    it("errors when the lua code argument is not a string", function()
+      assert.has_error(function()
+        permKey("SpecPermKeyOne", "", mudlet.key.F9, 42)
+      end)
+    end)
+
+  end)
+
+  describe("enable, disable, kill, isActive and exists for keys", function()
+
+    after_each(function()
+      disableKey("SpecPermKeyKill")
+      disableKey("SpecPermKeyToggle")
+      disableKey("SpecDupKeys")
+    end)
+
+    it("killKey returns true for a temp key and false for a missing name", function()
+      local id = tempKey(mudlet.key.F11, [[echo("x")]])
+      assert.are.equal(1, exists(id, "keybind"))
+      assert.is_true(killKey(id), "killing an existing temp key should return true")
+      assert.is_false(killKey("no_such_key_name"), "killing a missing key should return false")
+    end)
+
+    it("killKey returns false for a permanent key (they cannot be killed)", function()
+      local id = permKey("SpecPermKeyKill", "", mudlet.key.F12, [[echo("x")]])
+      assert.is_true(id > 0)
+      assert.is_false(killKey("SpecPermKeyKill"), "permanent keys cannot be removed with killKey")
+    end)
+
+    it("enableKey and disableKey report whether a matching key was found", function()
+      local id = permKey("SpecPermKeyToggle", "", mudlet.key.F12, [[echo("x")]])
+      assert.is_true(id > 0)
+      assert.is_true(disableKey("SpecPermKeyToggle"), "disableKey should report it found the key")
+      assert.is_true(enableKey("SpecPermKeyToggle"), "enableKey should report it found the key")
+      assert.is_false(disableKey("no_such_key_name"), "disableKey should return false when nothing matched")
+      assert.is_false(enableKey("no_such_key_name"), "enableKey should return false when nothing matched")
+    end)
+
+    it("isActive reflects a key's enabled state", function()
+      local id = tempKey(mudlet.key.F11, [[echo("x")]])
+      assert.are.equal(1, isActive(id, "keybind"), "a fresh key should be active")
+      disableKey(id)
+      assert.are.equal(0, isActive(id, "keybind"), "a disabled key should not be active")
+      enableKey(id)
+      assert.are.equal(1, isActive(id, "keybind"), "a re-enabled key should be active")
+      killKey(id)
+    end)
+
+    it("exists reports keys by ID and reports zero for an unknown name", function()
+      local id = tempKey(mudlet.key.F11, [[echo("x")]])
+      assert.are.equal(1, exists(id, "keybind"))
+      assert.are.equal(0, exists("no_such_key_name", "keybind"))
+      killKey(id)
+    end)
+
+    -- KeyUnit carries its own copy of the equal_range duplicate-name fix
+    -- (PR #9366), so enable/disable by name must toggle every same-named key.
+    -- Key firing cannot be synthesised headlessly, so isActive's count is the proxy.
+    it("enableKey/disableKey by name toggle every duplicate-named key", function()
+      local id1 = permKey("SpecDupKeys", "", mudlet.key.F11, [[echo("x")]])
+      local id2 = permKey("SpecDupKeys", "", mudlet.key.F12, [[echo("x")]])
+      assert.is_true(id1 > 0 and id2 > 0)
+      -- invariants rather than exact counts: permanent keys from earlier local
+      -- runs accumulate under this name in the saved profile
+      assert.is_true(exists("SpecDupKeys", "keybind") >= 2, "at least the two duplicate-named keys exist")
+      disableKey("SpecDupKeys")
+      assert.are.equal(0, isActive("SpecDupKeys", "keybind"), "disabling by name must leave zero of the duplicates active")
+      enableKey("SpecDupKeys")
+      assert.are.equal(exists("SpecDupKeys", "keybind"), isActive("SpecDupKeys", "keybind"), "enabling by name must reactivate every duplicate")
+    end)
+
+  end)
+
 end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -190,4 +190,537 @@ describe("Trigger processing", function()
         end)
 
     end)
+
+    -- feedTelnet only performs injection while the telnet socket is unconnected.
+    -- The self-test profile's socket is NOT in the unconnected state (the same
+    -- limitation MXP_spec documents), so feedTelnet refuses here with nil + a
+    -- message; its successful-injection and prompt paths cannot be exercised in
+    -- busted. The type-check happens before the connection check, so the
+    -- argument-type contract is still verifiable.
+    describe("feedTelnet contract", function()
+
+        it("raises an error when the data argument is not a string", function()
+            -- a table is never string-coercible, unlike a number
+            assert.has_error(function() feedTelnet({}) end)
+        end)
+
+        it("refuses to inject while the socket is not unconnected", function()
+            -- safety property: feedTelnet never injects into a live connection.
+            -- In the self-test profile the socket is not unconnected, so it must
+            -- return nil plus a refusal message rather than feeding.
+            local ok, msg = feedTelnet("some server data")
+            assert.is_nil(ok, "feedTelnet must not succeed against a non-unconnected socket")
+            assert.is_string(msg)
+            assert.is_truthy(msg:find("refused", 1, true), "expected a refusal message, got: " .. tostring(msg))
+        end)
+
+    end)
+
+    describe("feedTriggers contract", function()
+
+        it("raises an error when the data argument is not a string", function()
+            assert.has_error(function() feedTriggers({}) end)
+        end)
+
+    end)
+
+    describe("temporary trigger creation and firing", function()
+
+        after_each(function()
+            _G.TrigSpec = nil
+        end)
+
+        it("tempTrigger fires on a substring match", function()
+            _G.TrigSpec = {fired = false}
+            local id = tempTrigger("substr_needle", function() _G.TrigSpec.fired = true end)
+            assert.is_number(id)
+            feedTriggers("\nhere is a substr_needle inside a line\n")
+            local fired = _G.TrigSpec.fired
+            killTrigger(id)
+            assert.is_true(fired, "a substring trigger should fire when its pattern appears anywhere in the line")
+        end)
+
+        it("tempExactMatchTrigger fires only on an exact whole-line match", function()
+            _G.TrigSpec = {count = 0}
+            local id = tempExactMatchTrigger("exact_line_only", function() _G.TrigSpec.count = _G.TrigSpec.count + 1 end)
+            assert.is_number(id)
+            -- superset line must NOT match an exact trigger
+            feedTriggers("\nexact_line_only and more\n")
+            assert.is_equal(0, _G.TrigSpec.count, "an exact-match trigger must not fire on a superset line")
+            feedTriggers("\nexact_line_only\n")
+            local count = _G.TrigSpec.count
+            killTrigger(id)
+            assert.is_equal(1, count, "an exact-match trigger should fire on the exact line")
+        end)
+
+        it("tempBeginOfLineTrigger matches at the start of a line only", function()
+            _G.TrigSpec = {count = 0}
+            local id = tempBeginOfLineTrigger("bol_marker", function() _G.TrigSpec.count = _G.TrigSpec.count + 1 end)
+            assert.is_number(id)
+            feedTriggers("\nnot at start bol_marker\n")
+            assert.is_equal(0, _G.TrigSpec.count, "a begin-of-line trigger must not fire mid-line")
+            feedTriggers("\nbol_marker at the start\n")
+            local count = _G.TrigSpec.count
+            killTrigger(id)
+            assert.is_equal(1, count, "a begin-of-line trigger should fire when the pattern starts the line")
+        end)
+
+        it("tempRegexTrigger accepts a string body and fires on a regex match", function()
+            _G.TrigSpec = {fired = false}
+            local id = tempRegexTrigger("^regex_str_body\\d+$", [[_G.TrigSpec.fired = true]])
+            assert.is_number(id)
+            feedTriggers("\nregex_str_body123\n")
+            local fired = _G.TrigSpec.fired
+            killTrigger(id)
+            assert.is_true(fired, "a regex trigger created from a string body should fire")
+        end)
+
+        it("tempLineTrigger fires for lines inside its window", function()
+            _G.TrigSpec = {count = 0}
+            -- a wide window from the current line so the fed lines fall inside it
+            -- regardless of the exact off-by-one of the window start
+            local id = tempLineTrigger(0, 10, function() _G.TrigSpec.count = _G.TrigSpec.count + 1 end)
+            assert.is_number(id)
+            feedTriggers("\nline_window_one\n")
+            feedTriggers("\nline_window_two\n")
+            feedTriggers("\nline_window_three\n")
+            local count = _G.TrigSpec.count
+            -- a line trigger matches by position, not content, so disable it
+            -- immediately: killTrigger's cleanup is deferred and a still-live line
+            -- trigger would otherwise fire on lines fed by later specs
+            disableTrigger(id)
+            killTrigger(id)
+            -- three content lines fed into a 10-line window, none truncated
+            assert.is_true(count >= 3, "a line trigger should fire for every line inside its window, fired " .. count .. " times")
+        end)
+
+        it("tempLineTrigger requires numeric line arguments", function()
+            assert.has_error(function() tempLineTrigger("start", 2, [[]]) end)
+        end)
+
+    end)
+
+    describe("temporary trigger argument validation", function()
+
+        it("tempTrigger rejects a non-string, non-function body", function()
+            -- a table is not string-coercible (a number would be accepted as code)
+            assert.has_error(function() tempTrigger("pat", {}) end)
+        end)
+
+        it("tempTrigger rejects an expiration count below one", function()
+            local id, err = tempTrigger("pat", [[]], 0)
+            if type(id) == "number" and id > 0 then killTrigger(id) end
+            assert.is_nil(id, "an expiry count of zero should be rejected")
+            assert.is_string(err)
+            assert.is_truthy(err:find("greater than zero", 1, true), "got: " .. tostring(err))
+        end)
+
+        it("tempTrigger rejects a non-number, non-nil expiration count", function()
+            assert.has_error(function() tempTrigger("pat", [[]], "soon") end)
+        end)
+
+        it("tempRegexTrigger rejects a non-string, non-function body", function()
+            assert.has_error(function() tempRegexTrigger("^pat$", {}) end)
+        end)
+
+        it("tempExactMatchTrigger rejects a non-string, non-function body", function()
+            assert.has_error(function() tempExactMatchTrigger("pat", true) end)
+        end)
+
+        it("tempBeginOfLineTrigger rejects a non-number, non-nil expiration count", function()
+            assert.has_error(function() tempBeginOfLineTrigger("pat", [[]], "later") end)
+        end)
+
+    end)
+
+    describe("temporary trigger expiration", function()
+
+        after_each(function()
+            _G.TrigSpecExpire = nil
+        end)
+
+        it("a trigger with expiration count N fires exactly N times", function()
+            _G.TrigSpecExpire = {count = 0}
+            local id = tempTrigger("expire_me", [[_G.TrigSpecExpire.count = _G.TrigSpecExpire.count + 1]], 2)
+            assert.is_number(id)
+            -- fed more times than the expiry count: it must stop after the second
+            feedTriggers("\nexpire_me\n")
+            feedTriggers("\nexpire_me\n")
+            feedTriggers("\nexpire_me\n")
+            feedTriggers("\nexpire_me\n")
+            local count = _G.TrigSpecExpire.count
+            _G.TrigSpecExpire = nil
+            -- if it somehow survived, make sure it is gone
+            if type(id) == "number" and id > 0 then killTrigger(id) end
+            assert.is_equal(2, count, "a trigger set to expire after 2 fires should fire exactly twice")
+        end)
+
+    end)
+
+    describe("tempColorTrigger legacy colour remap", function()
+
+        after_each(function()
+            _G.TrigSpec = nil
+        end)
+
+        -- tempColorTrigger applies a fossilised 0-16 remap table; argument 4 maps
+        -- to Mudlet colour index 1 (red), NOT the ANSI blue that a naive reading
+        -- of "4" would suggest. This pins that remap.
+        it("remaps its colour arguments and matches the remapped SGR colours", function()
+            _G.TrigSpec = {fired = false}
+            -- fg arg 4 -> index 1 (red -> SGR 31); bg arg 2 -> index 0 (black -> SGR 40)
+            local id = tempColorTrigger(4, 2, function() _G.TrigSpec.fired = true end)
+            assert.is_number(id)
+            -- blue foreground (SGR 34) must NOT match: proves 4 is not used literally
+            feedTriggers("\n\27[34;40mColorTrigNoMatch\27[0m\n")
+            local firedOnNonMatch = _G.TrigSpec.fired
+            -- red foreground (SGR 31) on black background (SGR 40) must match
+            feedTriggers("\n\27[31;40mColorTrigMatch\27[0m\n")
+            local fired = _G.TrigSpec.fired
+            -- kill before asserting: a leaked colour trigger matches by SGR and
+            -- would fire on later ANSI-colour specs' fed lines
+            killTrigger(id)
+            assert.is_false(firedOnNonMatch, "arg 4 must remap to red, so blue text must not fire it")
+            assert.is_true(fired, "the remapped red-on-black colour trigger should fire on red-on-black text")
+        end)
+
+        it("rejects ignoring both foreground and background", function()
+            local id, err = tempColorTrigger(-1, -1, function() end)
+            if type(id) == "number" and id > 0 then killTrigger(id) end
+            assert.is_nil(id)
+            assert.is_string(err)
+            assert.is_truthy(err:find("only one of foreground and background", 1, true), "got: " .. tostring(err))
+        end)
+
+        it("rejects a non-string, non-function body", function()
+            assert.has_error(function() tempColorTrigger(1, 1, {}) end)
+        end)
+
+    end)
+
+    describe("tempComplexRegexTrigger", function()
+
+        after_each(function()
+            _G.TrigSpec = nil
+        end)
+
+        -- 14-positional-argument API; here as a plain (non-colour, non-highlight,
+        -- non-sound) perl regex trigger: multiline 0, fg/bg numeric (so not a
+        -- colour trigger), filter 0, matchAll 0, highlight fg/bg numeric, sound
+        -- numeric (so no sound), fireLength 0, lineDelta 0.
+        it("creates a firing perl regex trigger", function()
+            _G.TrigSpec = {fired = false}
+            local id = tempComplexRegexTrigger("SpecComplexOne", "^complex_match$",
+                function() _G.TrigSpec.fired = true end,
+                0, -1, -1, 0, 0, -1, -1, 0, 0, 0)
+            assert.is_number(id)
+            feedTriggers("\ncomplex_match\n")
+            local fired = _G.TrigSpec.fired
+            assert.is_true(killTrigger("SpecComplexOne"), "a temporary complex trigger should be removable by name")
+            assert.is_true(fired, "a complex regex trigger should fire on its pattern")
+        end)
+
+        it("rejects a non-string, non-function body (argument 3)", function()
+            -- a table is not string-coercible (a number would be accepted as code)
+            assert.has_error(function()
+                tempComplexRegexTrigger("SpecComplexBad", "^x$", {}, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0)
+            end)
+        end)
+
+        it("rejects a non-number multiline flag (argument 4)", function()
+            assert.has_error(function()
+                tempComplexRegexTrigger("SpecComplexBad", "^x$", [[]], "yes", -1, -1, 0, 0, -1, -1, 0, 0, 0)
+            end)
+        end)
+
+        it("rejects a non-number filter flag (argument 7)", function()
+            assert.has_error(function()
+                tempComplexRegexTrigger("SpecComplexBad", "^x$", [[]], 0, -1, -1, "no", 0, -1, -1, 0, 0, 0)
+            end)
+        end)
+
+        it("rejects a non-number match-all flag (argument 8)", function()
+            assert.has_error(function()
+                tempComplexRegexTrigger("SpecComplexBad", "^x$", [[]], 0, -1, -1, 0, "no", -1, -1, 0, 0, 0)
+            end)
+        end)
+
+    end)
+
+    describe("permanent triggers", function()
+
+        -- permanent triggers cannot be removed with killTrigger, so give them
+        -- unique names and disable them after each test to avoid leaking firing
+        -- state into other specs.
+        after_each(function()
+            disableTrigger("SpecPermRegex")
+            disableTrigger("SpecPermSubstring")
+            disableTrigger("SpecPermBeginOfLine")
+            disableTrigger("SpecPermExact")
+            _G.TrigSpec = nil
+        end)
+
+        it("permRegexTrigger creates a firing trigger from a pattern table", function()
+            _G.TrigSpec = {fired = false}
+            local id = permRegexTrigger("SpecPermRegex", "", {"^perm_regex_hit$"}, [[_G.TrigSpec.fired = true]])
+            assert.is_number(id)
+            assert.is_true(id > 0)
+            feedTriggers("\nperm_regex_hit\n")
+            assert.is_true(_G.TrigSpec.fired, "a permanent regex trigger should fire on its pattern")
+        end)
+
+        it("permSubstringTrigger creates a firing trigger", function()
+            _G.TrigSpec = {fired = false}
+            local id = permSubstringTrigger("SpecPermSubstring", "", {"perm_sub_hit"}, [[_G.TrigSpec.fired = true]])
+            assert.is_number(id)
+            feedTriggers("\nsomething perm_sub_hit here\n")
+            assert.is_true(_G.TrigSpec.fired, "a permanent substring trigger should fire when the substring appears")
+        end)
+
+        it("permBeginOfLineStringTrigger creates a firing trigger", function()
+            _G.TrigSpec = {fired = false}
+            local id = permBeginOfLineStringTrigger("SpecPermBeginOfLine", "", {"perm_bol_hit"}, [[_G.TrigSpec.fired = true]])
+            assert.is_number(id)
+            feedTriggers("\nnope perm_bol_hit\n")
+            assert.is_false(_G.TrigSpec.fired, "a begin-of-line trigger must not fire mid-line")
+            feedTriggers("\nperm_bol_hit at start\n")
+            assert.is_true(_G.TrigSpec.fired, "a begin-of-line trigger should fire when the string starts the line")
+        end)
+
+        it("permExactMatchTrigger creates a firing trigger", function()
+            _G.TrigSpec = {count = 0}
+            local id = permExactMatchTrigger("SpecPermExact", "", {"perm_exact_hit"}, [[_G.TrigSpec.count = _G.TrigSpec.count + 1]])
+            assert.is_number(id)
+            feedTriggers("\nperm_exact_hit trailing\n")
+            assert.is_equal(0, _G.TrigSpec.count, "an exact-match trigger must not fire on a superset line")
+            feedTriggers("\nperm_exact_hit\n")
+            assert.is_equal(1, _G.TrigSpec.count, "an exact-match trigger should fire on the exact line")
+        end)
+
+        it("permRegexTrigger errors when the pattern argument is not a table", function()
+            assert.has_error(function()
+                permRegexTrigger("SpecPermRegex", "", "^not a table$", [[]])
+            end)
+        end)
+
+        it("permSubstringTrigger errors when the pattern argument is not a table", function()
+            assert.has_error(function()
+                permSubstringTrigger("SpecPermSubstring", "", "not a table", [[]])
+            end)
+        end)
+
+        -- Guards that the error names this function (a past audit flagged a
+        -- sibling message that misreported itself as "permRegexTrigger").
+        it("permBeginOfLineStringTrigger errors when the pattern argument is not a table", function()
+            local ok, err = pcall(function()
+                permBeginOfLineStringTrigger("SpecPermBeginOfLine", "", "not a table", [[]])
+            end)
+            assert.is_false(ok, "a non-table pattern argument should error")
+            assert.is_truthy(tostring(err):find("permBeginOfLineStringTrigger", 1, true),
+                "the error should name permBeginOfLineStringTrigger, got: " .. tostring(err))
+        end)
+
+        it("killTrigger returns false for a permanent trigger (they cannot be killed)", function()
+            local id = permRegexTrigger("SpecPermRegex", "", {"^perm_kill_probe$"}, [[]])
+            assert.is_true(id > 0)
+            assert.is_false(killTrigger("SpecPermRegex"), "permanent triggers cannot be removed with killTrigger")
+        end)
+
+    end)
+
+    describe("enable, disable, isActive and exists for triggers", function()
+
+        after_each(function()
+            _G.TrigSpec = nil
+        end)
+
+        it("disableTrigger stops a trigger firing and enableTrigger restores it", function()
+            _G.TrigSpec = {count = 0}
+            local id = tempRegexTrigger("^toggle_me$", function() _G.TrigSpec.count = _G.TrigSpec.count + 1 end)
+            feedTriggers("\ntoggle_me\n")
+            assert.is_equal(1, _G.TrigSpec.count, "an enabled trigger should fire")
+
+            assert.is_true(disableTrigger(id), "disableTrigger should report it found the trigger")
+            feedTriggers("\ntoggle_me\n")
+            assert.is_equal(1, _G.TrigSpec.count, "a disabled trigger must not fire")
+
+            assert.is_true(enableTrigger(id), "enableTrigger should report it found the trigger")
+            feedTriggers("\ntoggle_me\n")
+            assert.is_equal(2, _G.TrigSpec.count, "a re-enabled trigger should fire again")
+
+            killTrigger(id)
+        end)
+
+        it("enableTrigger and disableTrigger return false for an unknown name", function()
+            assert.is_false(enableTrigger("no_such_trigger_name"))
+            assert.is_false(disableTrigger("no_such_trigger_name"))
+        end)
+
+        it("isActive reflects a trigger's enabled state", function()
+            local id = tempRegexTrigger("^active_probe$", [[]])
+            assert.is_equal(1, isActive(id, "trigger"), "a freshly created trigger should be active")
+            disableTrigger(id)
+            assert.is_equal(0, isActive(id, "trigger"), "a disabled trigger should not be active")
+            enableTrigger(id)
+            assert.is_equal(1, isActive(id, "trigger"), "a re-enabled trigger should be active")
+            killTrigger(id)
+        end)
+
+        it("isActive rejects an invalid item type", function()
+            local ok, err = isActive(1, "notarealtype")
+            assert.is_nil(ok)
+            assert.is_string(err)
+            assert.is_truthy(err:find("invalid item type", 1, true), "got: " .. tostring(err))
+        end)
+
+        it("isActive rejects a negative numeric ID", function()
+            local ok, err = isActive(-5, "trigger")
+            assert.is_nil(ok)
+            assert.is_string(err)
+        end)
+
+        it("exists round-trips a temporary trigger by ID", function()
+            local id = tempRegexTrigger("^exists_probe$", [[]])
+            assert.is_equal(1, exists(id, "trigger"), "the trigger should exist after creation")
+            assert.is_true(killTrigger(id), "killTrigger should report success for a temporary trigger")
+            -- feed a line to let the trigger unit run its deferred cleanup
+            feedTriggers("\nflush\n")
+            assert.is_equal(0, exists(id, "trigger"), "the trigger should be gone after kill and cleanup")
+        end)
+
+        it("killTrigger returns false for a name that does not exist", function()
+            assert.is_false(killTrigger("no_such_trigger_name"))
+        end)
+
+        it("exists rejects an invalid item type", function()
+            local ok, err = exists(1, "notarealtype")
+            assert.is_nil(ok)
+            assert.is_string(err)
+            assert.is_truthy(err:find("invalid item type", 1, true), "got: " .. tostring(err))
+        end)
+
+    end)
+
+    -- enableTrigger/disableTrigger must toggle EVERY trigger sharing a name, not
+    -- just the first (QMultiMap equal_range fix, PR #9366).
+    describe("enable/disable with duplicate trigger names", function()
+
+        before_each(function()
+            _G.DuplicateTrigTest = {fired = {}}
+        end)
+
+        after_each(function()
+            -- permanent triggers cannot be killed; disable so they stop firing
+            disableTrigger("Spec Dup Triggers")
+            disableTrigger("Spec Other Trigger")
+            _G.DuplicateTrigTest = nil
+        end)
+
+        it("toggles every trigger sharing the same name, not just the first", function()
+            local id1 = permRegexTrigger("Spec Dup Triggers", "", {"^trig_dup_one$"}, [[_G.DuplicateTrigTest.fired.one = true]])
+            local id2 = permRegexTrigger("Spec Dup Triggers", "", {"^trig_dup_two$"}, [[_G.DuplicateTrigTest.fired.two = true]])
+            assert.is_true(id1 > 0, "first duplicate-named trigger should be created")
+            assert.is_true(id2 > 0, "second duplicate-named trigger should be created")
+            -- by-name count paths (exists/isActive) walk the whole equal_range;
+            -- assert invariants rather than exact counts, since permanent triggers
+            -- from earlier local runs accumulate under this name in the profile
+            assert.is_true(exists("Spec Dup Triggers", "trigger") >= 2, "at least the two duplicates exist under this name")
+
+            feedTriggers("\ntrig_dup_one\n")
+            feedTriggers("\ntrig_dup_two\n")
+            assert.is_true(_G.DuplicateTrigTest.fired.one, "trigger 1 should fire while enabled")
+            assert.is_true(_G.DuplicateTrigTest.fired.two, "trigger 2 should fire while enabled")
+
+            _G.DuplicateTrigTest.fired = {}
+            disableTrigger("Spec Dup Triggers")
+            assert.is_equal(0, isActive("Spec Dup Triggers", "trigger"), "disabling by name must leave zero of the duplicates active")
+            feedTriggers("\ntrig_dup_one\n")
+            feedTriggers("\ntrig_dup_two\n")
+            assert.is_nil(_G.DuplicateTrigTest.fired.one, "trigger 1 should be disabled")
+            assert.is_nil(_G.DuplicateTrigTest.fired.two, "trigger 2 (the second duplicate) should ALSO be disabled")
+
+            _G.DuplicateTrigTest.fired = {}
+            enableTrigger("Spec Dup Triggers")
+            -- enabling by name reactivates every same-named trigger, so the active
+            -- count equals the total count regardless of how many accumulated
+            assert.is_equal(exists("Spec Dup Triggers", "trigger"), isActive("Spec Dup Triggers", "trigger"),
+                "enabling by name must reactivate every duplicate")
+            feedTriggers("\ntrig_dup_one\n")
+            feedTriggers("\ntrig_dup_two\n")
+            assert.is_true(_G.DuplicateTrigTest.fired.one, "trigger 1 should be re-enabled")
+            assert.is_true(_G.DuplicateTrigTest.fired.two, "trigger 2 (the second duplicate) should ALSO be re-enabled")
+
+            -- a differently-named trigger must stay untouched
+            local idOther = permRegexTrigger("Spec Other Trigger", "", {"^trig_dup_other$"}, [[_G.DuplicateTrigTest.fired.other = true]])
+            assert.is_true(idOther > 0)
+            disableTrigger("Spec Dup Triggers")
+            _G.DuplicateTrigTest.fired = {}
+            feedTriggers("\ntrig_dup_other\n")
+            assert.is_true(_G.DuplicateTrigTest.fired.other, "the differently-named trigger must stay enabled")
+        end)
+
+    end)
+
+    describe("setTriggerStayOpen", function()
+
+        it("requires a numeric number-of-lines argument", function()
+            assert.has_error(function() setTriggerStayOpen("main", "lots") end)
+        end)
+
+        it("accepts a window name and a line count without error", function()
+            -- returns nothing; success is simply not raising
+            local ok = pcall(setTriggerStayOpen, "main", 0)
+            assert.is_true(ok, "setTriggerStayOpen with valid arguments should not error")
+        end)
+
+    end)
+
+    -- Prompt pipeline. Prompt-line *firing* would need feedTelnet to inject an
+    -- IAC GA, but feedTelnet is refused here because the self-test socket is not
+    -- in the unconnected state (see the feedTelnet note above), so only the
+    -- creation contracts and isPrompt's shape are exercised offline.
+    describe("prompt triggers and isPrompt", function()
+
+        after_each(function()
+            disableTrigger("SpecPermPrompt")
+            _G.TrigSpec = nil
+        end)
+
+        it("isPrompt reports false when no prompt has been marked", function()
+            -- no IAC GA is ever injected in this profile, so the current line is
+            -- never a prompt
+            assert.is_false(isPrompt())
+        end)
+
+        it("tempPromptTrigger creates a trigger from a function body", function()
+            local id = tempPromptTrigger(function() end)
+            assert.is_number(id)
+            assert.are.equal(1, exists(id, "trigger"))
+            killTrigger(id)
+        end)
+
+        it("permPromptTrigger creates a trigger and returns its id", function()
+            -- relative baseline: permanent triggers from earlier local runs
+            -- accumulate under this name in the saved profile
+            local before = exists("SpecPermPrompt", "trigger")
+            local id = permPromptTrigger("SpecPermPrompt", "", [[]])
+            assert.is_number(id)
+            assert.is_true(id > 0)
+            assert.are.equal(before + 1, exists("SpecPermPrompt", "trigger"), "creating the prompt trigger should add exactly one")
+        end)
+
+        it("tempPromptTrigger rejects a non-string, non-function body", function()
+            -- a table is not string-coercible (a number would be accepted as code)
+            assert.has_error(function() tempPromptTrigger({}) end)
+        end)
+
+        it("tempPromptTrigger rejects an expiration count below one", function()
+            local id, err = tempPromptTrigger([[]], 0)
+            if type(id) == "number" and id > 0 then killTrigger(id) end
+            assert.is_nil(id)
+            assert.is_string(err)
+            assert.is_truthy(err:find("greater than zero", 1, true), "got: " .. tostring(err))
+        end)
+
+    end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- ~88 new specs across Trigger/Alias/KeyBinds/IDManager spec files: temp*/perm* creation and firing, enable/disable/kill/exists, duplicate-name semantics, tempComplexRegexTrigger arg matrix
- Replaces IDManager_spec's 7 pending stubs with real lifecycle tests incl. named-trigger firing

#### Motivation for adding to Mudlet
Locks in the named-object lifecycle contracts, including the duplicate-name behavior fixed in #9366.

#### Other info (issues closed, discussion etc)
Part of the Lua API test-coverage program (Wave 1). Found getNamedTriggers dropping entries when trigger types mix (filed separately, not pinned). feedTelnet success path unreachable in the self-test profile - contracts only.

**Test case:** run the busted suite - the four spec files pass green, twice.


Assisted-by: Claude:claude-opus-4-8
