### PR TITLE
infrastructure: replace test mocks with real API assertions; config, stopwatch and utils tests

### DIFF
--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -738,7 +738,12 @@ describe("Tests Other.lua functions", function()
     -- and the numeric/table keys) are handled in dedicated tests below; map keys
     -- (which need an open mapper to set) are exercised only when settable.
     local originalValues = {}
-    local skipInGenericLoop = { showSentText = true }
+    -- show3dMapView is skipped because flipping it to true opens the 3D OpenGL
+    -- map view. Initialising the software GL stack under headless CI leaks
+    -- one-time allocations in a GL driver module that is unloaded before exit,
+    -- so leak detection flags it and it cannot be name-suppressed. The 3D view
+    -- is not what this config round-trip is meant to exercise.
+    local skipInGenericLoop = { showSentText = true, show3dMapView = true }
 
     local function snapshot(key)
       if originalValues[key] == nil then

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -1,25 +1,17 @@
 describe("Tests Other.lua functions", function()
 
   describe("Tests the functionality of sendAll", function()
-    setup(function()
-      _G.echo      = function() end
-      _G.send      = function() end
-      _G.tempTimer = function(time, code)
-        if type(code) == "string" then
-          loadstring(code)()
-        elseif type(code) == "function" then
-          code()
-        else
-          error("tempTimer: Code must be a string or a function.")
-        end
-      end
-    end)
+    -- sendAll and the speedwalk family below drive the real send() function.
+    -- Offline (the self-test profile is not connected) send() is a no-op on the
+    -- wire, so we spy on the real function (pass-through) rather than replacing
+    -- it with a mock, and assert the actual dispatch it performs.
 
     it("should send one command if it is only given one parameter", function()
       local send = spy.on(_G, "send")
       sendAll("look")
       assert.spy(send).was.called(1)
       assert.spy(send).was.called_with("look", true)
+      send:revert()
     end)
 
     it("should send multiple commands when given multiple string parameters", function()
@@ -34,194 +26,145 @@ describe("Tests Other.lua functions", function()
       for _,command in ipairs(commands) do
         assert.spy(send).was.called_with(command, true)
       end
+      send:revert()
     end)
 
-    it("should pass along the final boolean argument to all sends if provided", function()
+    it("should pass along a final boolean argument of false to all sends", function()
       local send = spy.on(_G, "send")
       sendAll("get gold from pouch", "buy potion", "put gold in pouch", false)
       assert.spy(send).was.called(3)
       assert.spy(send).was.called_with("get gold from pouch", false)
       assert.spy(send).was.called_with("buy potion", false)
       assert.spy(send).was.called_with("put gold in pouch", false)
+      send:revert()
     end)
 
-    it("should pass along the final boolean argument to all sends if provided", function()
+    it("should pass along a final boolean argument of true to all sends", function()
       local send = spy.on(_G, "send")
       sendAll("get gold from pouch", "buy potion", "put gold in pouch", true)
       assert.spy(send).was.called(3)
       assert.spy(send).was.called_with("get gold from pouch", true)
       assert.spy(send).was.called_with("buy potion", true)
       assert.spy(send).was.called_with("put gold in pouch", true)
+      send:revert()
+    end)
+
+    it("schedules a tempTimer per command instead of sending when the first argument is a delay", function()
+      local send = spy.on(_G, "send")
+      -- Wrap the real tempTimer (pass-through) purely to capture the ids it
+      -- returns so we can cancel the scheduled timers; sendAll discards them.
+      local scheduledIds = {}
+      local realTempTimer = _G.tempTimer
+      _G.tempTimer = function(...)
+        local id = realTempTimer(...)
+        scheduledIds[#scheduledIds + 1] = id
+        return id
+      end
+      finally(function()
+        _G.tempTimer = realTempTimer
+        for _, id in ipairs(scheduledIds) do
+          pcall(killTimer, id)
+        end
+        send:revert()
+      end)
+
+      sendAll(5, "north", "south")
+      assert.spy(send).was_not_called()
+      assert.equals(2, #scheduledIds)
+    end)
+  end)
+
+  describe("Tests the functionality of sendCmdLine", function()
+    -- sendCmdLine sets the active command line's text (no wire traffic to
+    -- observe offline), which is readable back with getCmdLine. We clear the
+    -- command line afterwards so no text is left behind.
+    after_each(function()
+      pcall(clearCmdLine)
+    end)
+
+    it("sets the command line text and returns true", function()
+      assert.is_true(sendCmdLine("look"))
+      assert.equals("look", getCmdLine())
+    end)
+
+    it("errors when given no argument", function()
+      assert.has_error(function() sendCmdLine() end)
+    end)
+
+    it("errors when the argument is not a string", function()
+      assert.has_error(function() sendCmdLine({}) end)
     end)
   end)
 
   describe("Tests the functionality of permGroup", function()
+    -- permGroup creates *permanent* items, which have no public removal API and
+    -- are written to disk when the profile saves. To verify the real dispatch
+    -- and the documented default arguments without polluting the profile we use
+    -- a parent that does not exist: each underlying perm* function marshals its
+    -- arguments and then fails at the parent lookup before creating anything.
+    local nonexistentParent = "permGroupSpecNonexistentParent"
 
-    describe("success", function()
-      setup(function()
-        _G.oldPermTimer = _G.permTimer
-        _G.oldPermSubstringTrigger = _G.permSubstringTrigger
-        _G.oldPermAlias = _G.permAlias
-        _G.oldPermKey = _G.permKey
-        _G.oldPermScript = _G.permScript
-        _G.permTimer = function() return 1 end
-        _G.permSubstringTrigger = function() return 1 end
-        _G.permAlias = function() return 1 end
-        _G.permKey = function() return 1 end
-        _G.permScript = function() return 1 end
-      end)
-
-      teardown(function()
-        _G.permTimer = _G.oldPermTimer
-        _G.permSubstringTrigger = _G.oldPermSubstringTrigger
-        _G.permAlias = _G.oldPermAlias
-        _G.permKey = _G.oldPermKey
-        _G.permScript = _G.oldPermScript
-        _G.oldPermTimer = nil
-        _G.oldPermSubstringTrigger = nil
-        _G.oldPermAlias = nil
-        _G.oldPermKey = nil
-        _G.oldPermScript = nil
-      end)
-
-      it("should return true if the timer group was created", function()
+    -- The default-parent-of-"" branch (permGroup(name, type) with no parent) is
+    -- deliberately not covered: an empty parent makes the underlying perm*
+    -- succeed and create a real, unremovable top-level item, so it cannot be
+    -- exercised without either polluting the profile or mocking a real function.
+    describe("dispatches to the correct underlying function with the documented defaults", function()
+      -- Each test also asserts pcall failed, which self-checks the assumption
+      -- that the nonexistent parent prevents any item from actually being created.
+      it("uses permTimer(name, parent, 0, '') for timers", function()
         local permTimer = spy.on(_G, "permTimer")
-        local name = "TestTimer"
-        local parent = "Parent"
-        local successful = permGroup(name, "timer", parent)
-        assert.spy(permTimer).was.called_with(name, parent, 0, "")
-        assert.is_true(successful)
+        local ok = pcall(permGroup, "permGroupSpecTimer", "timer", nonexistentParent)
+        assert.is_false(ok)
+        assert.spy(permTimer).was.called_with("permGroupSpecTimer", nonexistentParent, 0, "")
+        permTimer:revert()
       end)
 
-      it("should return true if the alias group was created", function()
+      it("uses permSubstringTrigger(name, parent, {}, '') for triggers", function()
+        local permSubstringTrigger = spy.on(_G, "permSubstringTrigger")
+        local ok = pcall(permGroup, "permGroupSpecTrigger", "trigger", nonexistentParent)
+        assert.is_false(ok)
+        assert.spy(permSubstringTrigger).was.called_with("permGroupSpecTrigger", nonexistentParent, {}, "")
+        permSubstringTrigger:revert()
+      end)
+
+      it("uses permAlias(name, parent, '', '') for aliases", function()
         local permAlias = spy.on(_G, "permAlias")
-        local name = "TestAlias"
-        local parent = "Parent"
-        local successful = permGroup(name, "alias", parent)
-        assert.spy(permAlias).was.called_with(name, parent, "", "")
-        assert.is_true(successful)
+        local ok = pcall(permGroup, "permGroupSpecAlias", "alias", nonexistentParent)
+        assert.is_false(ok)
+        assert.spy(permAlias).was.called_with("permGroupSpecAlias", nonexistentParent, "", "")
+        permAlias:revert()
       end)
 
-      it("should return true if the trigger group was created", function()
-        local permTrigger = spy.on(_G, "permSubstringTrigger")
-        local name = "TestTrigger"
-        local parent = "Parent"
-        local successful = permGroup(name, "trigger", parent)
-        assert.spy(permTrigger).was.called_with(name, parent, {}, "")
-        assert.is_true(successful)
-      end)
-
-      it("should return true if the key group was created", function()
+      it("uses permKey(name, parent, -1, '') for keys", function()
         local permKey = spy.on(_G, "permKey")
-        local name = "TestKey"
-        local parent = "Parent"
-        local successful = permGroup(name, "key", parent)
-        assert.spy(permKey).was.called_with(name, parent, -1, "")
-        assert.is_true(successful)
+        local ok = pcall(permGroup, "permGroupSpecKey", "key", nonexistentParent)
+        assert.is_false(ok)
+        assert.spy(permKey).was.called_with("permGroupSpecKey", nonexistentParent, -1, "")
+        permKey:revert()
       end)
 
-      it("should return true if the script group was created", function()
+      it("uses permScript(name, parent, '', '') for scripts", function()
         local permScript = spy.on(_G, "permScript")
-        local name = "TestScript"
-        local parent = "Parent"
-        local successful = permGroup(name, "script", parent)
-        assert.spy(permScript).was.called_with(name, parent, "", "")
-        assert.is_true(successful)
-      end)
-
-      it("should use empty string as default parent when parent is not provided", function()
-        local permTimer = spy.on(_G, "permTimer")
-        local name = "TestTimer"
-        local successful = permGroup(name, "timer")
-        assert.spy(permTimer).was.called_with(name, "", 0, "")
-        assert.is_true(successful)
+        local ok = pcall(permGroup, "permGroupSpecScript", "script", nonexistentParent)
+        assert.is_false(ok)
+        assert.spy(permScript).was.called_with("permGroupSpecScript", nonexistentParent, "", "")
+        permScript:revert()
       end)
     end)
 
-    describe("failure", function()
-      setup(function()
-        _G.oldPermTimer = _G.permTimer
-        _G.oldPermSubstringTrigger = _G.permSubstringTrigger
-        _G.oldPermAlias = _G.permAlias
-        _G.oldPermKey = _G.permKey
-        _G.oldPermScript = _G.permScript
-        _G.permTimer = function() return -1 end
-        _G.permSubstringTrigger = function() return -1 end
-        _G.permAlias = function() return -1 end
-        _G.permKey = function() return -1 end
-        _G.permScript = function() return -1 end
-      end)
-
-      teardown(function()
-        _G.permTimer = _G.oldPermTimer
-        _G.permSubstringTrigger = _G.oldPermSubstringTrigger
-        _G.permAlias = _G.oldPermAlias
-        _G.permKey = _G.oldPermKey
-        _G.permScript = _G.oldPermScript
-        _G.oldPermTimer = nil
-        _G.oldPermSubstringTrigger = nil
-        _G.oldPermAlias = nil
-        _G.oldPermKey = nil
-        _G.oldPermScript = nil
-      end)
-
-      it("should return false if the timer group was not created", function()
-        local permTimer = spy.on(_G, "permTimer")
-        local name = "TestTimer"
-        local parent = "Parent"
-        local successful = permGroup(name, "timer", parent)
-        assert.spy(permTimer).was.called_with(name, parent, 0, "")
-        assert.is_false(successful)
-      end)
-
-      it("should return false if the alias group was not created", function()
-        local permAlias = spy.on(_G, "permAlias")
-        local name = "TestAlias"
-        local parent = "Parent"
-        local successful = permGroup(name, "alias", parent)
-        assert.spy(permAlias).was.called_with(name, parent, "", "")
-        assert.is_false(successful)
-      end)
-
-      it("should return false if the trigger group was not created", function()
-        local permTrigger = spy.on(_G, "permSubstringTrigger")
-        local name = "TestTrigger"
-        local parent = "Parent"
-        local successful = permGroup(name, "trigger", parent)
-        assert.spy(permTrigger).was.called_with(name, parent, {}, "")
-        assert.is_false(successful)
-      end)
-
-      it("should return false if the key group was not created", function()
-        local permKey = spy.on(_G, "permKey")
-        local name = "TestKey"
-        local parent = "Parent"
-        local successful = permGroup(name, "key", parent)
-        assert.spy(permKey).was.called_with(name, parent, -1, "")
-        assert.is_false(successful)
-      end)
-
-      it("should return false if the script group was not created", function()
-        local permScript = spy.on(_G, "permScript")
-        local name = "TestScript"
-        local parent = "Parent"
-        local successful = permGroup(name, "script", parent)
-        assert.spy(permScript).was.called_with(name, parent, "", "")
-        assert.is_false(successful)
+    describe("propagates the underlying creation error instead of returning false", function()
+      -- group_creation_functions in Other.lua checks `perm*(...) == -1`, but the
+      -- real perm* bindings raise a Lua error on failure rather than returning
+      -- -1, so that check is dead code and a failed permGroup errors instead of
+      -- returning false.
+      it("raises an error when the parent group does not exist", function()
+        assert.has_error(function()
+          permGroup("permGroupSpecOrphan", "timer", nonexistentParent)
+        end)
       end)
     end)
 
     describe("error handling", function()
-      setup(function()
-        _G.oldPermTimer = _G.permTimer
-        _G.permTimer = function() return 1 end
-      end)
-
-      teardown(function()
-        _G.permTimer = _G.oldPermTimer
-        _G.oldPermTimer = nil
-      end)
-
       it("should raise an error if name is not a string", function()
         assert.has_error(function()
           permGroup(123, "timer")
@@ -268,7 +211,7 @@ describe("Tests Other.lua functions", function()
     it("should return true if a is true and b is false", function()
       assert.is_true(xor(false,true))
     end)
-    
+
     it("should return false if a is true and b is true", function()
       assert.is_false(xor(true, true))
     end)
@@ -279,20 +222,15 @@ describe("Tests Other.lua functions", function()
   end)
 
   describe("Tests the functionality of speedwalking", function()
-    -- Note that busted insulates changes in each test file, so
-    -- these changes won't escape outside this file.
-    setup(function()
-      _G.echo      = function() end
-      _G.send      = function() end
-      _G.tempTimer = function(time, code)
-        if type(code) == "string" then
-          loadstring(code)()
-        elseif type(code) == "function" then
-          code()
-        else
-          error("tempTimer: Code must be a string or a function.")
-        end
-      end
+    -- speedwalk with no delay dispatches synchronously through the real send();
+    -- the delayed form is covered by an immediate-contract test below and the
+    -- speedwalk state machine (stop/pause/resume) has its own describe block.
+    -- Real timer firing is intentionally out of scope here (no sleeps).
+
+    after_each(function()
+      -- if the delayed-walk test's assertion fails before it cleans up, cancel
+      -- the scheduled timer chain so it cannot fire during later tests
+      pcall(stopSpeedwalk)
     end)
 
     it("Tests basic speedwalk() with chained directions", function()
@@ -305,43 +243,133 @@ describe("Tests Other.lua functions", function()
       assert.spy(send).was.called_with("se", true)
       assert.spy(send).was.called_with("u", true)
       assert.spy(send).was_not_called_with("e", true)
+      send:revert()
     end)
 
     it("Tests basic speedwalk() with commas as separators", function()
       local send = spy.on(_G, "send")
 
-      -- Will walk twice northeast, thrice east, twice north, once east. All in immediate succession.")
+      -- Will walk twice northeast, thrice east, twice north, once east. All in immediate succession.
       speedwalk('2ne,3e,2n,e')
       assert.spy(send).was.called(8)
       assert.spy(send).was.called_with("ne", true)
       assert.spy(send).was.called_with("e", true)
       assert.spy(send).was.called_with("n", true)
+      send:revert()
     end)
 
     it("tests reverse speedwalk", function()
       local send = spy.on(_G, "send")
 
       speedwalk("5sw - 3s - 2n - w", true)
-      -- Will walk backwards: east, twice south, thrice, north, five times northeast. All in immediate succession.
+      -- Will walk backwards: east, twice south, thrice north, five times northeast. All in immediate succession.
       assert.spy(send).was.called(11)
       assert.spy(send).was.called_with("ne", true)
       assert.spy(send).was.called_with("n", true)
       assert.spy(send).was.called_with("s", true)
       assert.spy(send).was.called_with("e", true)
-      assert.spy(send).was.was_not_called_with("w", true)
+      assert.spy(send).was_not_called_with("w", true)
+      send:revert()
     end)
 
-    it("tests reverse speedwalk with a delay", function()
-      local send           = spy.on(_G, "send")
-      local speedwalktimer = spy.on(_G, "speedwalktimer")
-      local tempTimer      = spy.on(_G, "tempTimer")
+    it("dispatches only the first step synchronously when a delay is given", function()
+      local send = spy.on(_G, "send")
 
+      -- With a delay the remaining steps are scheduled on real tempTimers
+      -- (Wave 2 territory); only the first step happens synchronously.
       speedwalk("3w, 2ne, w, u", true, 1.25)
-      -- Will walk backwards: down, east, twice southwest, thrice east, with 1.25 seconds delay between every move.
+      assert.spy(send).was.called(1)
 
-      assert.spy(speedwalktimer).was.called()
-      assert.spy(send).was.called(7)
-      assert.spy(tempTimer).was.called(6)
+      -- Cancel the scheduled continuation so it does not fire during later tests.
+      local stopped = stopSpeedwalk()
+      assert.is_true(stopped)
+      send:revert()
+    end)
+  end)
+
+  describe("Tests the speedwalk state machine", function()
+    -- stopSpeedwalk/pauseSpeedwalk/resumeSpeedwalk drive a shared upvalue state
+    -- machine and raise sys* events (raiseEvent dispatches synchronously in
+    -- process). We start a delayed speedwalk to enter the running state, then
+    -- assert the control functions' return contracts and events without sleeps.
+
+    after_each(function()
+      -- Fully clear any active OR paused speedwalk so no timer chain or leftover
+      -- walklist survives into the next test. resumeSpeedwalk re-arms a paused
+      -- walk so the subsequent stopSpeedwalk can clear its list.
+      pcall(resumeSpeedwalk)
+      pcall(stopSpeedwalk)
+    end)
+
+    it("stopSpeedwalk returns nil and a message when nothing is walking", function()
+      local ok, err = stopSpeedwalk()
+      assert.is_nil(ok)
+      assert.equals("stopSpeedwalk(): no active speedwalk found", err)
+    end)
+
+    it("pauseSpeedwalk returns nil and a message when nothing is walking", function()
+      local ok, err = pauseSpeedwalk()
+      assert.is_nil(ok)
+      assert.equals("pauseSpeedwalk(): no active speedwalk found", err)
+    end)
+
+    it("resumeSpeedwalk refuses to resume when there is no walklist", function()
+      local ok, err = resumeSpeedwalk()
+      assert.is_nil(ok)
+      assert.equals("resumeSpeedwalk(): attempted to resume a speedwalk but no active speedwalk found", err)
+    end)
+
+    it("raises sysSpeedwalkStarted when a walk begins", function()
+      local started = false
+      local handler = registerAnonymousEventHandler("sysSpeedwalkStarted", function() started = true end)
+      finally(function() killAnonymousEventHandler(handler) end)
+      speedwalk("2n", false, 1)
+      assert.is_true(started)
+    end)
+
+    it("raises sysSpeedwalkStopped when a running walk is stopped", function()
+      local stopped = false
+      local handler = registerAnonymousEventHandler("sysSpeedwalkStopped", function() stopped = true end)
+      finally(function() killAnonymousEventHandler(handler) end)
+      speedwalk("2n1e", false, 1)
+      assert.is_true(stopSpeedwalk())
+      assert.is_true(stopped)
+    end)
+
+    it("pause then resume raises the paused and resumed events, resuming dispatches the next step", function()
+      local paused, resumed = false, false
+      local hPause = registerAnonymousEventHandler("sysSpeedwalkPaused", function() paused = true end)
+      local hResume = registerAnonymousEventHandler("sysSpeedwalkResumed", function() resumed = true end)
+      finally(function()
+        killAnonymousEventHandler(hPause)
+        killAnonymousEventHandler(hResume)
+      end)
+
+      speedwalk("2n1e", false, 1)
+      assert.is_true(pauseSpeedwalk())
+      assert.is_true(paused)
+
+      -- resuming sends the next queued step synchronously before re-scheduling
+      local send = spy.on(_G, "send")
+      finally(function() send:revert() end)
+      assert.is_true(resumeSpeedwalk())
+      assert.is_true(resumed)
+      assert.spy(send).was.called(1)
+    end)
+
+    it("pauseSpeedwalk a second time returns nil and a message", function()
+      speedwalk("2n1e", false, 1)
+      assert.is_true(pauseSpeedwalk())
+      local ok, err = pauseSpeedwalk()
+      assert.is_nil(ok)
+      assert.equals("pauseSpeedwalk(): no active speedwalk found", err)
+    end)
+
+    it("resumeSpeedwalk refuses to resume an already running speedwalk", function()
+      speedwalk("2n1e", false, 1)
+      local ok, err = resumeSpeedwalk()
+      assert.is_nil(ok)
+      assert.equals("resumeSpeedwalk(): attempted to resume an already running speedwalk", err)
     end)
   end)
 
@@ -465,12 +493,16 @@ describe("Tests Other.lua functions", function()
       local lastLine = getCurrentLine()
       assert.equal("This line should not be deleted", lastLine)
       _G.multimatches = {}
+      s:revert()
     end)
   end)
 
 
   describe("Tests timeframe", function()
     teardown(function()
+      -- timeframe schedules a real cleanup tempTimer; cancel any pending ones
+      -- and clear the test variable.
+      killtimeframe("TIMEFRAME_TEST_VARIABLE")
       TIMEFRAME_TEST_VARIABLE = nil
     end)
 
@@ -493,7 +525,386 @@ describe("Tests Other.lua functions", function()
     end)
   end)
 
-    --[[ 
+  describe("Tests the stopwatch family", function()
+    -- Stopwatches are non-persistent by default, so they are not written to the
+    -- profile, but every stopwatch created here is deleted in teardown anyway.
+    -- A stopped stopwatch does not advance, so adjustStopWatch on one gives an
+    -- exact, deterministic elapsed time with no sleeping. Only the running case
+    -- (stopStopWatch below) needs a tolerance for wall-clock drift.
+    local createdIds = {}
+
+    local function track(id)
+      table.insert(createdIds, id)
+      return id
+    end
+
+    local function assertClose(expected, actual, tolerance)
+      tolerance = tolerance or 0.5
+      assert.is_true(math.abs(expected - actual) <= tolerance,
+        string.format("expected roughly %s but got %s", tostring(expected), tostring(actual)))
+    end
+
+    teardown(function()
+      for _, id in ipairs(createdIds) do
+        pcall(deleteStopWatch, id)
+      end
+      createdIds = {}
+    end)
+
+    describe("createStopWatch", function()
+      it("returns a numeric id and autostarts by default", function()
+        local id = track(createStopWatch())
+        assert.is_number(id)
+        local watches = getStopWatches()
+        assert.is_table(watches[id])
+        assert.is_true(watches[id].isRunning)
+      end)
+
+      it("does not autostart when given a name (string form)", function()
+        local id = track(createStopWatch("stopwatchSpecNamed"))
+        assert.is_number(id)
+        assert.is_false(getStopWatches()[id].isRunning)
+        assert.equals("stopwatchSpecNamed", getStopWatches()[id].name)
+      end)
+
+      it("honours an explicit autostart boolean", function()
+        local id = track(createStopWatch(false))
+        assert.is_false(getStopWatches()[id].isRunning)
+      end)
+
+      it("errors on an unsupported first argument type", function()
+        assert.has_error(function() createStopWatch({}) end)
+      end)
+
+      it("refuses to create a second stopwatch with an existing name", function()
+        track(createStopWatch("stopwatchSpecDuplicate"))
+        local ok, err = createStopWatch("stopwatchSpecDuplicate")
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+    end)
+
+    describe("getStopWatchTime and adjustStopWatch", function()
+      it("adjustStopWatch shifts the elapsed time of a stopped stopwatch deterministically", function()
+        local id = track(createStopWatch(false))
+        -- adjusting an as-yet-unstarted stopwatch initialises it at that value
+        assert.is_true(adjustStopWatch(id, 12.5))
+        assert.equals(12.5, getStopWatchTime(id))
+        assert.is_true(adjustStopWatch(id, -2.5))
+        assert.equals(10.0, getStopWatchTime(id))
+      end)
+
+      it("getStopWatchTime resolves a stopwatch by its name", function()
+        local id = track(createStopWatch("stopwatchSpecByName"))
+        adjustStopWatch(id, 5)
+        assert.equals(5, getStopWatchTime("stopwatchSpecByName"))
+      end)
+
+      it("returns nil and a message for an unknown numeric id", function()
+        local ok, err = getStopWatchTime(999999)
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+
+      it("returns nil and a message for an unknown name", function()
+        local ok, err = getStopWatchTime("stopwatchSpecNoSuchName")
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+
+      it("errors when the first argument is neither number nor string", function()
+        assert.has_error(function() getStopWatchTime({}) end)
+      end)
+    end)
+
+    describe("start, stop and reset", function()
+      it("stopStopWatch returns the elapsed time and freezes it", function()
+        local id = track(createStopWatch(false))
+        startStopWatch(id)
+        adjustStopWatch(id, 7)
+        local elapsed = stopStopWatch(id)
+        assertClose(7, elapsed)
+        assert.is_false(getStopWatches()[id].isRunning)
+      end)
+
+      it("resetStopWatch zeroes a stopped, initialised stopwatch", function()
+        local id = track(createStopWatch(false))
+        adjustStopWatch(id, 30)
+        assert.is_true(resetStopWatch(id))
+        assert.equals(0, getStopWatchTime(id))
+      end)
+
+      it("startStopWatch on an unknown id returns nil and a message", function()
+        local ok, err = startStopWatch(888888)
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+    end)
+
+    describe("setStopWatchName", function()
+      it("renames a stopwatch identified by id", function()
+        local id = track(createStopWatch(false))
+        assert.is_true(setStopWatchName(id, "stopwatchSpecRenamed"))
+        assert.equals("stopwatchSpecRenamed", getStopWatches()[id].name)
+        -- and it is now resolvable by the new name
+        assert.is_number(getStopWatchTime("stopwatchSpecRenamed"))
+      end)
+
+      it("returns nil and a message when renaming an unknown id", function()
+        local ok, err = setStopWatchName(777777, "stopwatchSpecNope")
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+    end)
+
+    describe("setStopWatchPersistence", function()
+      it("marks a stopwatch persistent and this is reflected in getStopWatches", function()
+        local id = track(createStopWatch(false))
+        assert.is_false(getStopWatches()[id].isPersistent)
+        assert.is_true(setStopWatchPersistence(id, true))
+        assert.is_true(getStopWatches()[id].isPersistent)
+        -- reset persistence so the stopwatch is never written to the profile
+        assert.is_true(setStopWatchPersistence(id, false))
+      end)
+
+      it("returns nil and a message for an unknown id", function()
+        local ok, err = setStopWatchPersistence(666666, true)
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+    end)
+
+    describe("getStopWatchBrokenDownTime", function()
+      it("returns a table broken down into days/hours/minutes/seconds", function()
+        local id = track(createStopWatch(false))
+        -- 1 day, 2 hours, 3 minutes, 4 seconds
+        adjustStopWatch(id, 4 + 3*60 + 2*3600 + 1*86400)
+        local t = getStopWatchBrokenDownTime(id)
+        assert.is_table(t)
+        assert.equals(1, t.days)
+        assert.equals(2, t.hours)
+        assert.equals(3, t.minutes)
+        assert.equals(4, t.seconds)
+        assert.is_boolean(t.negative)
+      end)
+
+      it("flags negative elapsed time with the negative field", function()
+        local id = track(createStopWatch(false))
+        adjustStopWatch(id, -90) -- one minute thirty seconds in the past
+        local t = getStopWatchBrokenDownTime(id)
+        assert.is_true(t.negative)
+        assert.equals(1, t.minutes)
+        assert.equals(30, t.seconds)
+      end)
+    end)
+
+    describe("deleteStopWatch", function()
+      it("removes a stopwatch so it can no longer be read back", function()
+        local id = createStopWatch(false)
+        adjustStopWatch(id, 1)
+        assert.is_table(getStopWatches()[id])
+        assert.is_true(deleteStopWatch(id))
+        assert.is_nil(getStopWatches()[id])
+        local ok = getStopWatchTime(id)
+        assert.is_nil(ok)
+      end)
+
+      it("returns nil and a message for an unknown id", function()
+        local ok, err = deleteStopWatch(555555)
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+    end)
+
+    describe("getStopWatches", function()
+      it("reports name, running, persistent and elapsed time for each stopwatch", function()
+        local id = track(createStopWatch("stopwatchSpecReport"))
+        adjustStopWatch(id, 3)
+        local entry = getStopWatches()[id]
+        assert.equals("stopwatchSpecReport", entry.name)
+        assert.is_boolean(entry.isRunning)
+        assert.is_boolean(entry.isPersistent)
+        assert.is_table(entry.elapsedTime)
+        assert.equals(3, entry.elapsedTime.decimalSeconds)
+      end)
+    end)
+  end)
+
+  describe("Tests getConfig and setConfig round-trips", function()
+    -- The supported option list is discovered from getConfig() at runtime rather
+    -- than hard-coded, so this adapts to whichever build runs it. Every value
+    -- changed here is restored (config is written to the profile on close). Keys
+    -- with lossy or multi-valued representations (showSentText, the string enums
+    -- and the numeric/table keys) are handled in dedicated tests below; map keys
+    -- (which need an open mapper to set) are exercised only when settable.
+    local originalValues = {}
+    local skipInGenericLoop = { showSentText = true }
+
+    local function snapshot(key)
+      if originalValues[key] == nil then
+        originalValues[key] = getConfig(key)
+      end
+    end
+
+    local function restore(key)
+      if originalValues[key] ~= nil then
+        setConfig(key, originalValues[key])
+        originalValues[key] = nil
+      end
+    end
+
+    teardown(function()
+      -- safety net for anything a failing assertion left changed
+      for key, value in pairs(originalValues) do
+        pcall(setConfig, key, value)
+      end
+      originalValues = {}
+    end)
+
+    it("returns a table of the current configuration when called with no arguments", function()
+      local cfg = getConfig()
+      assert.is_table(cfg)
+      assert.is_boolean(cfg.enableGMCP)
+      assert.is_boolean(cfg.editorAutoComplete)
+    end)
+
+    it("round-trips every boolean configuration option", function()
+      local settable = 0
+      for key, value in pairs(getConfig()) do
+        if type(value) == "boolean" and not skipInGenericLoop[key] then
+          snapshot(key)
+          local ok = setConfig(key, not value)
+          if ok then
+            assert.equals(not value, getConfig(key), "round-trip failed for boolean config key: " .. key)
+            settable = settable + 1
+          else
+            -- not settable in this environment (e.g. a map option with the
+            -- mapper closed); the getter still returns a boolean
+            assert.is_boolean(getConfig(key), "expected boolean for config key: " .. key)
+          end
+          restore(key)
+        end
+      end
+      assert.is_true(settable > 0, "expected at least one settable boolean config option")
+    end)
+
+    it("round-trips the showSentText enum without losing the mode", function()
+      -- getConfig(key, true) returns the string form; the boolean form collapses
+      -- 'always' and 'script' both onto true, so restore using the string form.
+      -- Register the string original in originalValues so the teardown safety net
+      -- can restore it if an assertion below fails partway through.
+      local original = getConfig("showSentText", true)
+      assert.is_string(original)
+      originalValues.showSentText = original
+      for _, mode in ipairs({"never", "always", "script"}) do
+        assert.is_true(setConfig("showSentText", mode))
+        assert.equals(mode, getConfig("showSentText", true))
+      end
+      -- the legacy boolean form reads false only for 'never'
+      assert.is_true(setConfig("showSentText", "never"))
+      assert.is_false(getConfig("showSentText"))
+      assert.is_true(setConfig("showSentText", "always"))
+      assert.is_true(getConfig("showSentText"))
+      setConfig("showSentText", original)
+      assert.equals(original, getConfig("showSentText", true))
+      originalValues.showSentText = nil
+    end)
+
+    it("round-trips the string enum options", function()
+      local enums = {
+        caretShortcut = {"none", "tab", "ctrltab", "f6"},
+        blankLinesBehaviour = {"show", "hide", "replacewithspace"},
+        controlCharacterHandling = {"asis", "oem", "picture"},
+        ambiguousEAsianWidthCharacters = {"narrow", "wide", "auto"},
+      }
+      local exercised = 0
+      for key, values in pairs(enums) do
+        if getConfig(key) ~= nil then
+          snapshot(key)
+          for _, value in ipairs(values) do
+            assert.is_true(setConfig(key, value), "could not set " .. key .. " to " .. value)
+            assert.equals(value, getConfig(key))
+          end
+          restore(key)
+          exercised = exercised + 1
+        end
+      end
+      assert.is_true(exercised > 0, "expected at least one string enum config option")
+    end)
+
+    it("errors on a wrongly typed value for a boolean option", function()
+      -- setConfig defers to getVerifiedBool, which raises rather than silently
+      -- coercing; the flag is never assigned so there is nothing to restore.
+      assert.has_error(function() setConfig("enableGMCP", "not a boolean") end)
+    end)
+
+    it("rejects an invalid string for an enum option", function()
+      snapshot("caretShortcut")
+      local ok, err = setConfig("caretShortcut", "definitelyNotAValidShortcut")
+      assert.is_nil(ok)
+      assert.is_string(err)
+      restore("caretShortcut")
+    end)
+
+    it("round-trips commandLineHistorySaveSize (numeric option)", function()
+      snapshot("commandLineHistorySaveSize")
+      assert.is_true(setConfig("commandLineHistorySaveSize", 42))
+      assert.equals(42, getConfig("commandLineHistorySaveSize"))
+      restore("commandLineHistorySaveSize")
+    end)
+
+    it("validates the undoServerWrapWidth range when the option exists", function()
+      if getConfig("undoServerWrapWidth") == nil then
+        -- option not present in this build; setting it is rejected as unknown
+        assert.is_nil((setConfig("undoServerWrapWidth", 42)))
+        return
+      end
+      snapshot("undoServerWrapWidth")
+      assert.is_true(setConfig("undoServerWrapWidth", 42))
+      assert.equals(42, getConfig("undoServerWrapWidth"))
+      assert.is_nil((setConfig("undoServerWrapWidth", 10)))  -- below the minimum of 20
+      assert.is_nil((setConfig("undoServerWrapWidth", 600))) -- above the maximum of 500
+      restore("undoServerWrapWidth")
+    end)
+
+    it("returns nil and a message for an unknown key", function()
+      local value, message = getConfig("totallyBogusConfigKey")
+      assert.is_nil(value)
+      assert.is_string(message)
+    end)
+
+    it("setConfig returns nil and a message for an unknown key", function()
+      local ok, message = setConfig("totallyBogusConfigKey", true)
+      assert.is_nil(ok)
+      assert.is_string(message)
+    end)
+
+    it("getConfig and setConfig reject an empty key", function()
+      assert.is_nil((getConfig("")))
+      assert.is_nil((setConfig("", true)))
+    end)
+
+    it("setConfig applies a table of options in one call", function()
+      snapshot("enableGMCP")
+      snapshot("editorAutoComplete")
+      local target = not getConfig("enableGMCP")
+      local target2 = not getConfig("editorAutoComplete")
+      setConfig({ enableGMCP = target, editorAutoComplete = target2 })
+      assert.equals(target, getConfig("enableGMCP"))
+      assert.equals(target2, getConfig("editorAutoComplete"))
+      restore("enableGMCP")
+      restore("editorAutoComplete")
+    end)
+
+    it("getConfig returns a keyed table when given a list of keys", function()
+      local result = getConfig({ "enableGMCP", "editorAutoComplete" })
+      assert.is_table(result)
+      assert.equals(getConfig("enableGMCP"), result.enableGMCP)
+      assert.equals(getConfig("editorAutoComplete"), result.editorAutoComplete)
+    end)
+  end)
+
+    --[[
     TODO:
       remember()
       loadVars()
@@ -509,7 +920,6 @@ describe("Tests Other.lua functions", function()
       registerAnonymousEventHandler()
       killAnonymousEventHandler()
       dispatchEventToFunctions()
-      timeframe()
       killtimeframe()
       translateTable()
   ]]

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -65,6 +65,14 @@ describe("Tests StringUtils.lua functions", function()
       local suffix = "system"
       assert.is_false(string.ends(s, suffix))
     end)
+
+    it("should return true for an empty suffix", function()
+      assert.is_true(("This is a test"):ends(""))
+    end)
+
+    it("should return false when the suffix is longer than the string", function()
+      assert.is_false(("hi"):ends("this is far too long"))
+    end)
   end)
 
   describe("Tests the functionality of string.genNocasePattern", function()
@@ -138,6 +146,25 @@ describe("Tests StringUtils.lua functions", function()
       local actual = str:split("")
       assert.same(expected, actual)
     end)
+
+    it("should split on a multi-character delimiter", function()
+      local str = "alpha::beta::gamma"
+      local expected = { "alpha", "beta", "gamma" }
+      assert.same(expected, str:split("::"))
+    end)
+
+    it("should treat the delimiter as a Lua pattern, not a plain string", function()
+      -- '.' is the 'any character' pattern, so it does not split on literal dots;
+      -- the dot must be escaped to split on real dots.
+      assert.same({ "1", "2", "3" }, ("1.2.3"):split("%."))
+      assert.are_not.same({ "1", "2", "3" }, ("1.2.3"):split("."))
+    end)
+
+    it("should produce empty leading and trailing segments when the delimiter is at the edges", function()
+      local str = ",a,b,"
+      local expected = { "", "a", "b", "" }
+      assert.same(expected, str:split(","))
+    end)
   end)
 
   describe("Tests the functionality of string.starts", function()
@@ -149,6 +176,15 @@ describe("Tests StringUtils.lua functions", function()
     it("should return false if str does not start with prefix", function()
       local str = "This is a test"
       assert.is_false(str:starts("Elephant"))
+    end)
+
+    it("should return true for an empty prefix", function()
+      assert.is_true(("This is a test"):starts(""))
+    end)
+
+    it("should return true when the prefix is the whole string", function()
+      local str = "This is a test"
+      assert.is_true(str:starts(str))
     end)
   end)
 
@@ -170,6 +206,14 @@ describe("Tests StringUtils.lua functions", function()
       local str = {}
       local errfn = function() string.title(str) end
       assert.has_error(errfn, "string.title: bad argument #1 type (string to title as string expected, got table!)")
+    end)
+
+    it("should return an empty string unchanged", function()
+      assert.equals("", string.title(""))
+    end)
+
+    it("should leave a string that does not start with a lowercase letter unchanged", function()
+      assert.equals("123abc", string.title("123abc"))
     end)
   end)
 
@@ -194,6 +238,10 @@ describe("Tests StringUtils.lua functions", function()
       local str = "This is a test"
       assert.equals(str, string.trim(str))
       assert.equals(str, str:trim())
+    end)
+
+    it("should strip leading and trailing tabs and newlines, not just spaces", function()
+      assert.equals("this is a test", ("\t\n  this is a test \n\t"):trim())
     end)
   end)
 

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -105,8 +105,9 @@ describe("Tests TableUtils.lua functions", function()
     end)
   end)
 
-  -- methods skipped here: printTable, _printTable, listPrint, listAdd, listRemove
-  -- they are undocumented and unused in our own code.
+  -- __printTable is an internal helper of printTable and is not tested directly;
+  -- printTable, listPrint, listAdd and listRemove are covered near the end of
+  -- this file.
 
   describe("Tests the functionality of table.size", function()
 
@@ -794,6 +795,103 @@ describe("Tests TableUtils.lua functions", function()
       local expected = {enabled = {feature1 = true, feature2 = false}}
       local actual = table.update(tblA, tblB)
       assert.same(expected, actual)
+    end)
+  end)
+
+  describe("Tests the functionality of table.deepcopy nested independence", function()
+    it("should copy nested tables so mutating the copy does not affect the original", function()
+      local original = { a = 1, nested = { b = 2, deep = { c = 3 } } }
+      local copy = table.deepcopy(original)
+      copy.nested.b = 20
+      copy.nested.deep.c = 30
+      assert.equals(2, original.nested.b)
+      assert.equals(3, original.nested.deep.c)
+      -- the nested tables are distinct references
+      assert.are_not.equal(original.nested, copy.nested)
+      assert.are_not.equal(original.nested.deep, copy.nested.deep)
+    end)
+
+    it("should preserve the metatable of the copied table", function()
+      local mt = { __index = function() return "default" end }
+      local original = setmetatable({}, mt)
+      local copy = table.deepcopy(original)
+      assert.equals(mt, getmetatable(copy))
+      assert.equals("default", copy.anything)
+    end)
+
+    it("should return non-table values unchanged", function()
+      assert.equals(5, table.deepcopy(5))
+      assert.equals("text", table.deepcopy("text"))
+    end)
+  end)
+
+  describe("Tests the functionality of spairs on an empty table", function()
+    it("should iterate zero times over an empty table", function()
+      local count = 0
+      for _ in spairs({}) do
+        count = count + 1
+      end
+      assert.equals(0, count)
+    end)
+  end)
+
+  describe("Tests the functionality of listAdd", function()
+    it("should append an item to the end of the list", function()
+      local list = { "one", "two" }
+      listAdd(list, "three")
+      assert.same({ "one", "two", "three" }, list)
+    end)
+
+    it("should append to an empty list", function()
+      local list = {}
+      listAdd(list, "only")
+      assert.same({ "only" }, list)
+    end)
+  end)
+
+  describe("Tests the functionality of listRemove", function()
+    -- listRemove removes during an ipairs loop, so consecutive duplicates are a
+    -- known skip bug (removing index i shifts i+1 into i, which the loop then
+    -- skips). That buggy behaviour is deliberately NOT pinned here; only the
+    -- single-match and no-match paths, which the quirk cannot affect, are tested.
+    it("should remove a matching item from the list", function()
+      local list = { "one", "two", "three" }
+      listRemove(list, "two")
+      assert.same({ "one", "three" }, list)
+    end)
+
+    it("should leave the list unchanged when the item is not present", function()
+      local list = { "one", "two" }
+      listRemove(list, "missing")
+      assert.same({ "one", "two" }, list)
+    end)
+  end)
+
+  describe("Tests the contract of printTable", function()
+    -- printTable/listPrint write to the screen via echo; we spy on the real
+    -- echo (pass-through) to assert the framing lines without mocking it.
+    it("should echo a header, a line per key/value pair and a footer", function()
+      local echo = spy.on(_G, "echo")
+      printTable({ alpha = "one", beta = "two" })
+      -- header + 2 pairs + footer; header and footer are the same dashed string,
+      -- so the count is what pins that both framing lines are present
+      assert.spy(echo).was.called(4)
+      assert.spy(echo).was.called_with("-------------------------------------------------------\n")
+      assert.spy(echo).was.called_with("key=alpha value=one\n")
+      assert.spy(echo).was.called_with("key=beta value=two\n")
+      echo:revert()
+    end)
+  end)
+
+  describe("Tests the contract of listPrint", function()
+    it("should echo a numbered line for each list entry framed by dashed lines", function()
+      local echo = spy.on(_G, "echo")
+      listPrint({ "first", "second" })
+      -- header + 2 entries + footer
+      assert.spy(echo).was.called(4)
+      assert.spy(echo).was.called_with("1. ) first\n")
+      assert.spy(echo).was.called_with("2. ) second\n")
+      echo:revert()
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -872,6 +872,7 @@ describe("Tests TableUtils.lua functions", function()
     -- echo (pass-through) to assert the framing lines without mocking it.
     it("should echo a header, a line per key/value pair and a footer", function()
       local echo = spy.on(_G, "echo")
+      finally(function() echo:revert() end)
       printTable({ alpha = "one", beta = "two" })
       -- header + 2 pairs + footer; header and footer are the same dashed string,
       -- so the count is what pins that both framing lines are present
@@ -879,19 +880,18 @@ describe("Tests TableUtils.lua functions", function()
       assert.spy(echo).was.called_with("-------------------------------------------------------\n")
       assert.spy(echo).was.called_with("key=alpha value=one\n")
       assert.spy(echo).was.called_with("key=beta value=two\n")
-      echo:revert()
     end)
   end)
 
   describe("Tests the contract of listPrint", function()
     it("should echo a numbered line for each list entry framed by dashed lines", function()
       local echo = spy.on(_G, "echo")
+      finally(function() echo:revert() end)
       listPrint({ "first", "second" })
       -- header + 2 entries + footer
       assert.spy(echo).was.called(4)
       assert.spy(echo).was.called_with("1. ) first\n")
       assert.spy(echo).was.called_with("2. ) second\n")
-      echo:revert()
     end)
   end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Removes Other_spec's global mocks of real API functions (send/echo/tempTimer/perm*) - tests now assert genuine behavior via spies
- New specs: speedwalk state machine, full stopwatch family, getConfig/setConfig round-trips, string/table utils
- Every test leaves zero persistent state in the profile

#### Motivation for adding to Mudlet
The mocks made coverage look real while testing nothing; they also masked a dead failure branch in permGroup.

#### Other info (issues closed, discussion etc)
Part of the Lua API test-coverage program (Wave 1). Found permGroup dead -1 branch and listRemove consecutive-duplicate skip (filed separately, not pinned).

**Test case:** run the busted suite - Other_spec, StringUtils_spec and TableUtils_spec pass green, twice; getStopWatches starts empty on a repeat run.

Awaiting build/test by a maintainer; squash-merge with:
Assisted-by: Claude:claude-opus-4-8
(Signed-off-by to be added at squash after testing)