### PR TITLE
improve: honor XDG_CONFIG_HOME for Mudlet's config directory

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,11 +232,7 @@ static void applyHighDpiRoundingPolicyFromConfig(int argc, char* argv[])
     const QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
     const QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
 
-    // Keep the config root in sync with setupConfig()'s MUDLET_CONFIG_DIR override.
-    const QString overrideConfDir = qEnvironmentVariable("MUDLET_CONFIG_DIR");
-    if (!overrideConfDir.isEmpty()) {
-        confPath = QDir::cleanPath(overrideConfDir);
-    } else if (QFileInfo(markerExecDir).isFile()) {
+    if (QFileInfo(markerExecDir).isFile()) {
         QFile file(markerExecDir);
         QString portPath;
         if (file.open(QIODevice::ReadOnly)) {
@@ -254,7 +250,9 @@ static void applyHighDpiRoundingPolicyFromConfig(int argc, char* argv[])
         }
         confPath = utils::pathResolveRelative(QDir::cleanPath(portPath), execDir);
     } else {
-        confPath = confDirDefault;
+        // Mirror setupConfig()'s XDG_CONFIG_HOME resolution so this early
+        // Mudlet.ini read looks in the same config root.
+        confPath = utils::xdgConfigDir(confDirDefault).path;
     }
 
     if (confPath.isEmpty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,7 +232,11 @@ static void applyHighDpiRoundingPolicyFromConfig(int argc, char* argv[])
     const QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
     const QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
 
-    if (QFileInfo(markerExecDir).isFile()) {
+    // Keep the config root in sync with setupConfig()'s MUDLET_CONFIG_DIR override.
+    const QString overrideConfDir = qEnvironmentVariable("MUDLET_CONFIG_DIR");
+    if (!overrideConfDir.isEmpty()) {
+        confPath = QDir::cleanPath(overrideConfDir);
+    } else if (QFileInfo(markerExecDir).isFile()) {
         QFile file(markerExecDir);
         QString portPath;
         if (file.open(QIODevice::ReadOnly)) {

--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -72,26 +72,25 @@ caller can detect it.
 By default Mudlet reads and writes `~/.config/mudlet`, so two runs started at the
 same time (for example from different checkouts) share one `Mudlet self-test`
 profile and collide on its sqlite databases, and leftover state from a previous
-run is not cleaned up. To give a run its own pristine, isolated config root set:
+run is not cleaned up. To give a run its own pristine, isolated config root:
 
-- `MUDLET_CONFIG_DIR` - absolute path used instead of `~/.config/mudlet` for
-  profiles, sqlite databases and settings. Created if missing, and it takes
-  precedence over portable-mode `portable.txt` markers.
+- `XDG_CONFIG_HOME` - Mudlet uses `$XDG_CONFIG_HOME/mudlet` as its config root
+  (profiles, sqlite databases, settings, and password storage). Because an
+  existing `~/.config/mudlet` otherwise wins (so a system-wide `XDG_CONFIG_HOME`
+  export never strands real profiles), a test harness must **pre-create**
+  `$XDG_CONFIG_HOME/mudlet` to opt in.
 - `MUDLET_TEST_FAILURE_MARKER` - absolute path for the failure marker, so it is
   not shared either.
-- `XDG_CONFIG_HOME` - optional. Password/keychain-fallback storage resolves via
-  `QStandardPaths` rather than `MUDLET_CONFIG_DIR`; set this too if a run stores
-  credentials. The busted suite does not, so it is not required for it.
 
 ```sh
 CONFIG_DIR=$(mktemp -d)
+mkdir -p "$CONFIG_DIR/mudlet"   # pre-create to opt into the isolated config root
 AUTORUN_BUSTED_TESTS=true \
 MUDLET_TEST_MODE=1 \
 QUIT_MUDLET_AFTER_TESTS=true \
 TESTS_DIRECTORY=<full path>/src/mudlet-lua/tests \
-MUDLET_CONFIG_DIR="$CONFIG_DIR" \
+XDG_CONFIG_HOME="$CONFIG_DIR" \
 MUDLET_TEST_FAILURE_MARKER="$CONFIG_DIR/busted-tests-failed" \
-XDG_CONFIG_HOME="$CONFIG_DIR/xdg" \
 xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror
 ```
 

--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -54,6 +54,47 @@ runTests <full path>/src/mudlet-lua/tests
 runTests <full path>/src/mudlet-lua/tests/StringUtils_spec.lua
 ```
 
+## Running tests headlessly (and in parallel)
+
+The suite can also be run without touching the GUI, which is how CI runs it:
+
+```sh
+AUTORUN_BUSTED_TESTS=true \
+MUDLET_TEST_MODE=1 \
+QUIT_MUDLET_AFTER_TESTS=true \
+TESTS_DIRECTORY=<full path>/src/mudlet-lua/tests \
+xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror
+```
+
+A failure writes a marker file (`/tmp/busted-tests-failed` on Linux/macOS) so the
+caller can detect it.
+
+By default Mudlet reads and writes `~/.config/mudlet`, so two runs started at the
+same time (for example from different checkouts) share one `Mudlet self-test`
+profile and collide on its sqlite databases, and leftover state from a previous
+run is not cleaned up. To give a run its own pristine, isolated config root set:
+
+- `MUDLET_CONFIG_DIR` - absolute path used instead of `~/.config/mudlet` for
+  profiles, sqlite databases and settings. Created if missing, and it takes
+  precedence over portable-mode `portable.txt` markers.
+- `MUDLET_TEST_FAILURE_MARKER` - absolute path for the failure marker, so it is
+  not shared either.
+- `XDG_CONFIG_HOME` - optional. Password/keychain-fallback storage resolves via
+  `QStandardPaths` rather than `MUDLET_CONFIG_DIR`; set this too if a run stores
+  credentials. The busted suite does not, so it is not required for it.
+
+```sh
+CONFIG_DIR=$(mktemp -d)
+AUTORUN_BUSTED_TESTS=true \
+MUDLET_TEST_MODE=1 \
+QUIT_MUDLET_AFTER_TESTS=true \
+TESTS_DIRECTORY=<full path>/src/mudlet-lua/tests \
+MUDLET_CONFIG_DIR="$CONFIG_DIR" \
+MUDLET_TEST_FAILURE_MARKER="$CONFIG_DIR/busted-tests-failed" \
+XDG_CONFIG_HOME="$CONFIG_DIR/xdg" \
+xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror
+```
+
 ## Creating tests
 
 See [Busted manual](https://lunarmodules.github.io/busted/) and currently existing tests for examples on how to write tests.

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -924,7 +924,17 @@ void mudlet::setupConfig()
     QString execDir = findExecutableDir();
     QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
     QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
-    if (QFileInfo(markerExecDir).isFile()) {
+    // MUDLET_CONFIG_DIR relocates the entire config root (profiles, sqlite
+    // databases, settings) so isolated/parallel test runs cannot clobber each
+    // other or a developer's real profiles. QDir::homePath() ignores
+    // XDG_CONFIG_HOME, so this dedicated variable is the only supported override.
+    const QString overrideConfDir = qEnvironmentVariable("MUDLET_CONFIG_DIR");
+    if (!overrideConfDir.isEmpty()) {
+        confPath = QDir::cleanPath(overrideConfDir);
+        if (!QDir().mkpath(confPath)) {
+            qWarning() << "mudlet::setupConfig() WARNING: could not create MUDLET_CONFIG_DIR:" << confPath;
+        }
+    } else if (QFileInfo(markerExecDir).isFile()) {
         QString portPath = readMarkerFile(markerExecDir);
         if (portPath.isEmpty()) {
             portPath = qsl("./portable"); // fallback value for empty portable.txt

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -924,17 +924,7 @@ void mudlet::setupConfig()
     QString execDir = findExecutableDir();
     QString markerExecDir = qsl("%1/portable.txt").arg(execDir);
     QString markerHomeDir = qsl("%1/portable.txt").arg(confDirDefault);
-    // MUDLET_CONFIG_DIR relocates the entire config root (profiles, sqlite
-    // databases, settings) so isolated/parallel test runs cannot clobber each
-    // other or a developer's real profiles. QDir::homePath() ignores
-    // XDG_CONFIG_HOME, so this dedicated variable is the only supported override.
-    const QString overrideConfDir = qEnvironmentVariable("MUDLET_CONFIG_DIR");
-    if (!overrideConfDir.isEmpty()) {
-        confPath = QDir::cleanPath(overrideConfDir);
-        if (!QDir().mkpath(confPath)) {
-            qWarning() << "mudlet::setupConfig() WARNING: could not create MUDLET_CONFIG_DIR:" << confPath;
-        }
-    } else if (QFileInfo(markerExecDir).isFile()) {
+    if (QFileInfo(markerExecDir).isFile()) {
         QString portPath = readMarkerFile(markerExecDir);
         if (portPath.isEmpty()) {
             portPath = qsl("./portable"); // fallback value for empty portable.txt
@@ -952,7 +942,15 @@ void mudlet::setupConfig()
         }
         confPath = portPath;
     } else {
-        confPath = confDirDefault;
+        // Honor XDG_CONFIG_HOME (with a migration guard), falling back to the
+        // legacy ~/.config/mudlet when it is unset. Isolated/parallel test runs
+        // opt in by pre-creating $XDG_CONFIG_HOME/mudlet before launch.
+        const auto resolution = utils::xdgConfigDir(confDirDefault);
+        confPath = resolution.path;
+        if (resolution.migrationPending) {
+            qInfo().nospace() << "mudlet::setupConfig() INFO: XDG_CONFIG_HOME is set but $XDG_CONFIG_HOME/mudlet is not a Mudlet config directory yet, so the existing " << confPath
+                              << " is still in use. Move it to $XDG_CONFIG_HOME/mudlet to migrate.";
+        }
     }
     qDebug() << "mudlet::setupConfig() INFO:" << "using config dir:" << confPath;
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -942,9 +942,6 @@ void mudlet::setupConfig()
         }
         confPath = portPath;
     } else {
-        // Honor XDG_CONFIG_HOME (with a migration guard), falling back to the
-        // legacy ~/.config/mudlet when it is unset. Isolated/parallel test runs
-        // opt in by pre-creating $XDG_CONFIG_HOME/mudlet before launch.
         const auto resolution = utils::xdgConfigDir(confDirDefault);
         confPath = resolution.path;
         if (resolution.migrationPending) {

--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -569,7 +569,7 @@ function logTestError()
 
   -- MUDLET_TEST_FAILURE_MARKER lets parallel runs each use their own failure
   -- marker; without it the shared /tmp path leaks failures between runs. Treat an
-  -- empty value as unset to match the C++ MUDLET_CONFIG_DIR handling.
+  -- empty value as unset, matching how the C++ side treats empty env vars.
   local markerPath = os.getenv("MUDLET_TEST_FAILURE_MARKER")
   if not markerPath or markerPath == "" then
     local os_name = getOS()

--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -565,8 +565,8 @@ end
 
 local errorLogged = false
 
--- Platform default failure-marker path, or nil on an OS we don't know how to
--- signal on (e.g. Windows with no TEMP set).
+-- Returns nil on an OS we don't know how to signal on (e.g. Windows with no
+-- TEMP set).
 local function defaultFailureMarkerPath()
   local os_name = getOS()
   if os_name == "linux" or os_name == "mac" then

--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -564,35 +564,60 @@ function autoRunTests()
 end
 
 local errorLogged = false
+
+-- Platform default failure-marker path, or nil on an OS we don't know how to
+-- signal on (e.g. Windows with no TEMP set).
+local function defaultFailureMarkerPath()
+  local os_name = getOS()
+  if os_name == "linux" or os_name == "mac" then
+    return "/tmp/busted-tests-failed"
+  elseif os_name == "windows" then
+    local temp_directory = os.getenv("TEMP")
+    if temp_directory and temp_directory ~= "" then
+      return temp_directory.."\\busted-tests-failed"
+    end
+    return nil
+  end
+  ioprint("Tests failed, but did not know where to write the failure marker for "..tostring(os_name))
+  return nil
+end
+
+local function tryWriteFailureMarker(markerPath)
+  if not markerPath or markerPath == "" then
+    return false
+  end
+  local file = io.open(markerPath, "w")
+  if not file then
+    return false
+  end
+  file:write("Lua busted tests failed")
+  file:close()
+  return true
+end
+
 function logTestError()
   if errorLogged then return end
 
   -- MUDLET_TEST_FAILURE_MARKER lets parallel runs each use their own failure
-  -- marker; without it the shared /tmp path leaks failures between runs. Treat an
-  -- empty value as unset, matching how the C++ side treats empty env vars.
-  local markerPath = os.getenv("MUDLET_TEST_FAILURE_MARKER")
-  if not markerPath or markerPath == "" then
-    local os_name = getOS()
-    if os_name == "linux" or os_name == "mac" then
-      markerPath = "/tmp/busted-tests-failed"
-    elseif os_name == "windows" then
-      markerPath = os.getenv("TEMP").."\\busted-tests-failed"
-    else
-      ioprint("Tests failed, but did not know how to log the error for "..os_name)
-      errorLogged = true
-      return
-    end
+  -- marker; without it the shared platform default is used. Treat an empty value
+  -- as unset, matching how the C++ side treats empty env vars.
+  local configuredMarker = os.getenv("MUDLET_TEST_FAILURE_MARKER")
+  if configuredMarker == "" then
+    configuredMarker = nil
   end
+  local defaultMarker = defaultFailureMarkerPath()
 
-  -- If the marker cannot be written the run must not look like it passed, so
-  -- shout about it rather than crashing the failure handler on a nil file.
-  local file = io.open(markerPath, "w")
-  if not file then
-    ioprint("Tests failed, but could not write the failure marker to "..markerPath)
+  -- A failed run must never look like it passed. Try the configured marker
+  -- first, then always fall back to the platform default, so an unwritable
+  -- MUDLET_TEST_FAILURE_MARKER (bad path, missing parent, read-only fs) still
+  -- leaves the well-known signal automation checks. Only if nothing can be
+  -- written do we shout to the log rather than crash on a nil file.
+  if tryWriteFailureMarker(configuredMarker) or (defaultMarker ~= configuredMarker and tryWriteFailureMarker(defaultMarker)) then
+    errorLogged = true
     return
   end
-  file:write("Lua busted tests failed")
-  file:close()
+
+  ioprint("Tests failed, but could not write any failure marker (tried "..tostring(configuredMarker).." then "..tostring(defaultMarker)..")")
   errorLogged = true
 end</script>
 			<eventHandlerList>

--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -567,19 +567,32 @@ local errorLogged = false
 function logTestError()
   if errorLogged then return end
 
-  local os_name = getOS()
-  if os_name == "linux" or os_name == "mac" then
-    file = io.open("/tmp/busted-tests-failed", "w")
-    file:write("Lua busted tests failed")
-    file:close()
-  elseif os_name == "windows" then
-    temp_directory = os.getenv("TEMP")
-    file = io.open(temp_directory.."\\busted-tests-failed", "w")
-    file:write("Lua busted tests failed")
-    file:close()
-  else
-    ioprint("Tests failed, but did not know how to log the error for "..os_name)
+  -- MUDLET_TEST_FAILURE_MARKER lets parallel runs each use their own failure
+  -- marker; without it the shared /tmp path leaks failures between runs. Treat an
+  -- empty value as unset to match the C++ MUDLET_CONFIG_DIR handling.
+  local markerPath = os.getenv("MUDLET_TEST_FAILURE_MARKER")
+  if not markerPath or markerPath == "" then
+    local os_name = getOS()
+    if os_name == "linux" or os_name == "mac" then
+      markerPath = "/tmp/busted-tests-failed"
+    elseif os_name == "windows" then
+      markerPath = os.getenv("TEMP").."\\busted-tests-failed"
+    else
+      ioprint("Tests failed, but did not know how to log the error for "..os_name)
+      errorLogged = true
+      return
+    end
   end
+
+  -- If the marker cannot be written the run must not look like it passed, so
+  -- shout about it rather than crashing the failure handler on a nil file.
+  local file = io.open(markerPath, "w")
+  if not file then
+    ioprint("Tests failed, but could not write the failure marker to "..markerPath)
+    return
+  end
+  file:write("Lua busted tests failed")
+  file:close()
   errorLogged = true
 end</script>
 			<eventHandlerList>

--- a/src/utils.h
+++ b/src/utils.h
@@ -115,6 +115,48 @@ public:
         return QDir::cleanPath(base + "/" + path);
     }
 
+    struct ConfigDirResolution
+    {
+        QString path;
+        // True only in the migration-guard case: XDG_CONFIG_HOME is set but
+        // $XDG_CONFIG_HOME/mudlet is not (yet) Mudlet's, so an existing legacy
+        // dir is used instead. The caller can then hint the user how to migrate.
+        bool migrationPending = false;
+    };
+
+    // Resolve Mudlet's config root honoring XDG_CONFIG_HOME, with a migration
+    // guard. The caller handles portable.txt first (it still wins); this covers
+    // the rest:
+    //  - XDG_CONFIG_HOME unset/empty/relative   -> legacyDefault (~/.config/mudlet)
+    //  - $XDG_CONFIG_HOME/mudlet is Mudlet's      -> it (already migrated / opt-in)
+    //  - not Mudlet's but legacyDefault exists    -> legacyDefault, so exporting
+    //    XDG_CONFIG_HOME never strands existing profiles
+    //  - neither is usable                        -> $XDG_CONFIG_HOME/mudlet (fresh)
+    // "Mudlet's" means the dir holds a Mudlet.ini or profiles/, or is an empty
+    // opt-in dir a test harness pre-created. This deliberately ignores the stale
+    // $XDG_CONFIG_HOME/mudlet/Mudlet.conf that pre-4.19 Mudlet wrote there (its
+    // NativeFormat settings) while profiles stayed in ~/.config/mudlet - treating
+    // that leftover as the config root would hide such a user's profiles.
+    static ConfigDirResolution xdgConfigDir(const QString& legacyDefault)
+    {
+        const QString xdgConfigHome = qEnvironmentVariable("XDG_CONFIG_HOME");
+        // The XDG base-dir spec requires an absolute path; a relative (or empty)
+        // value must be ignored, which also avoids a surprising CWD-relative root.
+        if (xdgConfigHome.isEmpty() || !QDir::isAbsolutePath(xdgConfigHome)) {
+            return {legacyDefault, false};
+        }
+        const QString xdgTarget = QDir::cleanPath(qsl("%1/mudlet").arg(xdgConfigHome));
+        const QDir xdgDir(xdgTarget);
+        const bool xdgIsMudlets = xdgDir.exists() && (QFileInfo::exists(qsl("%1/Mudlet.ini").arg(xdgTarget)) || QDir(qsl("%1/profiles").arg(xdgTarget)).exists() || xdgDir.isEmpty());
+        if (xdgIsMudlets) {
+            return {xdgTarget, false};
+        }
+        if (QDir(legacyDefault).exists()) {
+            return {legacyDefault, true};
+        }
+        return {xdgTarget, false};
+    }
+
     inline static const auto scmfileSystemUnsafeChars = QRegularExpression(qsl(R"REGEX([/\\:*?"<>|])REGEX"));
     // Sanitize a string for safe use as filename/path component
     // Replaces filesystem-unsafe characters with underscores and limits length

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ if(NOT WIN32)
 endif()
 
 set(FUNCTIONAL_TEST_SOURCES
+    ConfigDirOverrideTest.cpp
     TelnetTextDisplayedTest.cpp
     TelnetSubnegotiationTest.cpp
     TelnetSgrDefaultColorTest.cpp

--- a/test/functional_tests/ConfigDirOverrideTest.cpp
+++ b/test/functional_tests/ConfigDirOverrideTest.cpp
@@ -18,13 +18,17 @@
  ***************************************************************************/
 
 /*
- * Locks in the MUDLET_CONFIG_DIR contract used to isolate the Lua busted suite
- * (and any parallel run) from the real ~/.config/mudlet. The failure mode this
- * guards against is a future setupConfig() refactor silently dropping the
- * override, which resurfaces as hard-to-diagnose parallel-run sqlite flakiness.
+ * Locks in the XDG_CONFIG_HOME resolution that the Lua busted suite (and any
+ * parallel run) relies on to isolate itself from the real ~/.config/mudlet, plus
+ * the migration guard that keeps existing users on their legacy config dir. The
+ * failure mode guarded against is a future refactor quietly dropping XDG support
+ * or the guard, which resurfaces as parallel-run sqlite flakiness or, worse,
+ * users' profiles appearing to vanish on upgrade.
  *
- * Only setupConfig()'s path resolution is exercised, so the mudlet singleton is
- * created but never init()'d.
+ * The resolution logic lives in utils::xdgConfigDir(legacyDefault), which takes
+ * the legacy candidate as an argument, so most cases test it directly and stay
+ * platform-independent (no HOME/USERPROFILE juggling). A couple of cases drive
+ * the real mudlet::setupConfig() to prove the wiring end-to-end.
  *
  * Run with: ctest -R ConfigDirOverrideTest -V
  */
@@ -32,63 +36,205 @@
 #include <QtTest/QtTest>
 
 #include "mudlet.h"
+#include "utils.h"
 
 class ConfigDirOverrideTest : public QObject
 {
     Q_OBJECT
 
+private:
+    QByteArray mSavedXdg;
+
+    QString mudletUnder(const QString& dir) const { return QDir::cleanPath(qsl("%1/mudlet").arg(dir)); }
+
+    // setupConfig() consults portable.txt beside the executable and in the home
+    // config dir before the XDG/default logic; the setupConfig() integration
+    // cases skip if one is present rather than report a baffling failure.
+    bool portableMarkerPresent() const
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
 private slots:
-    void initTestCase() { mudlet::start(); }
-
-    void cleanup() { qunsetenv("MUDLET_CONFIG_DIR"); }
-
-    // The singleton is intentionally not deleted: it was never init()'d, so its
-    // destructor would touch members only set up by init(). The process exits
-    // right after the suite, so leaking it is harmless.
-
-    void test_overrideRelocatesAndCreatesConfigRoot()
+    void initTestCase()
     {
-        QTemporaryDir tmp;
-        QVERIFY(tmp.isValid());
-        // A not-yet-existing subdirectory, so we also prove mkpath() runs.
-        const QString target = QDir::cleanPath(tmp.path() + qsl("/isolated/config"));
+        mudlet::start();
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+    }
+
+    void cleanupTestCase()
+    {
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+        // The singleton is intentionally not deleted: it was never init()'d, so
+        // its destructor would touch members only set up by init(), and the
+        // process exits right after anyway.
+    }
+
+    // --- utils::xdgConfigDir() resolution table -------------------------------
+
+    void test_unsetUsesLegacy()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        const QString legacy = qsl("/home/someone/.config/mudlet");
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, legacy);
+        QVERIFY(!r.migrationPending);
+    }
+
+    void test_emptyBehavesLikeUnset()
+    {
+        qputenv("XDG_CONFIG_HOME", QByteArray());
+        const QString legacy = qsl("/home/someone/.config/mudlet");
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, legacy);
+        QVERIFY(!r.migrationPending);
+    }
+
+    // A relative XDG_CONFIG_HOME is invalid per the spec and must be ignored, not
+    // turned into a cwd-relative config root.
+    void test_relativeXdgIgnored()
+    {
+        qputenv("XDG_CONFIG_HOME", QByteArray("relative/config"));
+        const QString legacy = qsl("/home/someone/.config/mudlet");
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, legacy);
+        QVERIFY(!r.migrationPending);
+    }
+
+    // An empty pre-created dir is the test-harness opt-in and wins over legacy.
+    void test_emptyXdgDirIsOptInAndWinsOverLegacy()
+    {
+        QTemporaryDir xdg;
+        QTemporaryDir legacyHome;
+        QVERIFY(xdg.isValid() && legacyHome.isValid());
+        const QString target = mudletUnder(xdg.path());
+        QVERIFY(QDir().mkpath(target)); // empty opt-in dir
+        const QString legacy = mudletUnder(legacyHome.path() + qsl("/.config"));
+        QVERIFY(QDir().mkpath(legacy)); // legacy exists too
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, target);
+        QVERIFY(!r.migrationPending);
+    }
+
+    // A populated (already-migrated) XDG dir wins over an existing legacy dir.
+    void test_migratedXdgDirWinsOverLegacy()
+    {
+        QTemporaryDir xdg;
+        QTemporaryDir legacyHome;
+        QVERIFY(xdg.isValid() && legacyHome.isValid());
+        const QString target = mudletUnder(xdg.path());
+        QVERIFY(QDir().mkpath(qsl("%1/profiles").arg(target))); // looks like Mudlet's
+        const QString legacy = mudletUnder(legacyHome.path() + qsl("/.config"));
+        QVERIFY(QDir().mkpath(legacy));
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, target);
+        QVERIFY(!r.migrationPending);
+    }
+
+    // Regression: a stale $XDG_CONFIG_HOME/mudlet holding only the pre-4.19
+    // NativeFormat Mudlet.conf (no profiles) must NOT shadow the user's real
+    // profiles in the legacy dir - it must fall back and flag a migration.
+    void test_staleNativeFormatDirDoesNotShadowProfiles()
+    {
+        QTemporaryDir xdg;
+        QTemporaryDir legacyHome;
+        QVERIFY(xdg.isValid() && legacyHome.isValid());
+        const QString target = mudletUnder(xdg.path());
+        QVERIFY(QDir().mkpath(target));
+        QFile stale(qsl("%1/Mudlet.conf").arg(target)); // the leftover, no Mudlet.ini/profiles
+        QVERIFY(stale.open(QIODevice::WriteOnly));
+        stale.close();
+        const QString legacy = mudletUnder(legacyHome.path() + qsl("/.config"));
+        QVERIFY(QDir().mkpath(qsl("%1/profiles").arg(legacy))); // real profiles live here
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, legacy);
+        QVERIFY2(r.migrationPending, "a stale non-Mudlet XDG dir must not shadow real profiles");
+    }
+
+    // Guard: XDG target absent while a legacy dir exists -> keep legacy, flag it.
+    void test_guardKeepsLegacyWhenXdgTargetMissing()
+    {
+        QTemporaryDir xdg;
+        QTemporaryDir legacyHome;
+        QVERIFY(xdg.isValid() && legacyHome.isValid());
+        QVERIFY(!QDir(mudletUnder(xdg.path())).exists());
+        const QString legacy = mudletUnder(legacyHome.path() + qsl("/.config"));
+        QVERIFY(QDir().mkpath(legacy));
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, legacy);
+        QVERIFY(r.migrationPending);
+    }
+
+    // Fresh install: XDG set, neither dir usable -> honor XDG, no migration.
+    void test_freshInstallUsesXdgWhenNeitherExists()
+    {
+        QTemporaryDir xdg;
+        QTemporaryDir legacyHome;
+        QVERIFY(xdg.isValid() && legacyHome.isValid());
+        const QString target = mudletUnder(xdg.path());
         QVERIFY(!QDir(target).exists());
+        const QString legacy = mudletUnder(legacyHome.path() + qsl("/.config"));
+        QVERIFY(!QDir(legacy).exists());
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
 
-        qputenv("MUDLET_CONFIG_DIR", target.toUtf8());
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, target);
+        QVERIFY(!r.migrationPending);
+    }
+
+    // With XDG_CONFIG_HOME=$HOME/.config the XDG target IS the legacy dir; an
+    // existing one must not be reported as a pending migration (it would
+    // otherwise nag the user on every startup).
+    void test_noMigrationWhenXdgTargetEqualsLegacy()
+    {
+        QTemporaryDir cfg; // stands in for $HOME/.config
+        QVERIFY(cfg.isValid());
+        const QString legacy = mudletUnder(cfg.path());
+        QVERIFY(QDir().mkpath(legacy)); // the one and only (empty) config dir
+        qputenv("XDG_CONFIG_HOME", cfg.path().toUtf8());
+
+        const auto r = utils::xdgConfigDir(legacy);
+        QCOMPARE(r.path, legacy);
+        QVERIFY2(!r.migrationPending, "no migration when the XDG target and legacy dir are the same");
+    }
+
+    // --- mudlet::setupConfig() end-to-end wiring ------------------------------
+
+    // The isolation opt-in used by the busted harness: a pre-created
+    // $XDG_CONFIG_HOME/mudlet becomes the config root.
+    void test_setupConfigUsesPreCreatedXdgTarget()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - setupConfig() takes the portable branch");
+        }
+        QTemporaryDir xdg;
+        QVERIFY(xdg.isValid());
+        const QString target = mudletUnder(xdg.path());
+        QVERIFY(QDir().mkpath(target));
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+
         mudlet::self()->setupConfig();
-
         QCOMPARE(mudlet::getMudletPath(enums::mainPath), target);
-        QCOMPARE(mudlet::getMudletPath(enums::profilesPath), target + qsl("/profiles"));
-        QVERIFY2(QDir(target).exists(), "MUDLET_CONFIG_DIR should be created when missing");
     }
 
-    // An empty value must be treated as unset, matching setupConfig()'s isEmpty()
-    // gate, so a blank env var never silently redirects the config root.
-    void test_emptyValueBehavesLikeUnset()
+    // With XDG unset, the config root is the usual ~/.config/mudlet, so normal
+    // users are unaffected. Uses the real home dir - no HOME override.
+    void test_setupConfigUnsetUsesHomeConfigDir()
     {
-        qputenv("MUDLET_CONFIG_DIR", QByteArray());
-        mudlet::self()->setupConfig();
-        const QString withEmpty = mudlet::getMudletPath(enums::mainPath);
-
-        qunsetenv("MUDLET_CONFIG_DIR");
-        mudlet::self()->setupConfig();
-        const QString withUnset = mudlet::getMudletPath(enums::mainPath);
-
-        QCOMPARE(withEmpty, withUnset);
-    }
-
-    // With the override unset (and no portable install), the config root is the
-    // usual ~/.config/mudlet - i.e. normal users are unaffected.
-    void test_unsetFallsBackToHomeConfigDir()
-    {
-        qunsetenv("MUDLET_CONFIG_DIR");
-        mudlet::self()->setupConfig();
-
-        const QString homeDefault = qsl("%1/.config/mudlet").arg(QDir::homePath());
-        if (QFileInfo::exists(qsl("%1/portable.txt").arg(homeDefault))) {
+        if (portableMarkerPresent()) {
             QSKIP("portable.txt present - config root is deliberately relocated");
         }
-        QCOMPARE(mudlet::getMudletPath(enums::mainPath), homeDefault);
+        qunsetenv("XDG_CONFIG_HOME");
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/.config/mudlet").arg(QDir::homePath()));
     }
 };
 

--- a/test/functional_tests/ConfigDirOverrideTest.cpp
+++ b/test/functional_tests/ConfigDirOverrideTest.cpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Locks in the MUDLET_CONFIG_DIR contract used to isolate the Lua busted suite
+ * (and any parallel run) from the real ~/.config/mudlet. The failure mode this
+ * guards against is a future setupConfig() refactor silently dropping the
+ * override, which resurfaces as hard-to-diagnose parallel-run sqlite flakiness.
+ *
+ * Only setupConfig()'s path resolution is exercised, so the mudlet singleton is
+ * created but never init()'d.
+ *
+ * Run with: ctest -R ConfigDirOverrideTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "mudlet.h"
+
+class ConfigDirOverrideTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase() { mudlet::start(); }
+
+    void cleanup() { qunsetenv("MUDLET_CONFIG_DIR"); }
+
+    // The singleton is intentionally not deleted: it was never init()'d, so its
+    // destructor would touch members only set up by init(). The process exits
+    // right after the suite, so leaking it is harmless.
+
+    void test_overrideRelocatesAndCreatesConfigRoot()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        // A not-yet-existing subdirectory, so we also prove mkpath() runs.
+        const QString target = QDir::cleanPath(tmp.path() + qsl("/isolated/config"));
+        QVERIFY(!QDir(target).exists());
+
+        qputenv("MUDLET_CONFIG_DIR", target.toUtf8());
+        mudlet::self()->setupConfig();
+
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), target);
+        QCOMPARE(mudlet::getMudletPath(enums::profilesPath), target + qsl("/profiles"));
+        QVERIFY2(QDir(target).exists(), "MUDLET_CONFIG_DIR should be created when missing");
+    }
+
+    // An empty value must be treated as unset, matching setupConfig()'s isEmpty()
+    // gate, so a blank env var never silently redirects the config root.
+    void test_emptyValueBehavesLikeUnset()
+    {
+        qputenv("MUDLET_CONFIG_DIR", QByteArray());
+        mudlet::self()->setupConfig();
+        const QString withEmpty = mudlet::getMudletPath(enums::mainPath);
+
+        qunsetenv("MUDLET_CONFIG_DIR");
+        mudlet::self()->setupConfig();
+        const QString withUnset = mudlet::getMudletPath(enums::mainPath);
+
+        QCOMPARE(withEmpty, withUnset);
+    }
+
+    // With the override unset (and no portable install), the config root is the
+    // usual ~/.config/mudlet - i.e. normal users are unaffected.
+    void test_unsetFallsBackToHomeConfigDir()
+    {
+        qunsetenv("MUDLET_CONFIG_DIR");
+        mudlet::self()->setupConfig();
+
+        const QString homeDefault = qsl("%1/.config/mudlet").arg(QDir::homePath());
+        if (QFileInfo::exists(qsl("%1/portable.txt").arg(homeDefault))) {
+            QSKIP("portable.txt present - config root is deliberately relocated");
+        }
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), homeDefault);
+    }
+};
+
+#include "ConfigDirOverrideTest.moc"
+QTEST_MAIN(ConfigDirOverrideTest)

--- a/test/functional_tests/ConfigDirOverrideTest.cpp
+++ b/test/functional_tests/ConfigDirOverrideTest.cpp
@@ -101,7 +101,6 @@ private slots:
         QVERIFY(!r.migrationPending);
     }
 
-    // An empty pre-created dir is the test-harness opt-in and wins over legacy.
     void test_emptyXdgDirIsOptInAndWinsOverLegacy()
     {
         QTemporaryDir xdg;
@@ -110,7 +109,7 @@ private slots:
         const QString target = mudletUnder(xdg.path());
         QVERIFY(QDir().mkpath(target)); // empty opt-in dir
         const QString legacy = mudletUnder(legacyHome.path() + qsl("/.config"));
-        QVERIFY(QDir().mkpath(legacy)); // legacy exists too
+        QVERIFY(QDir().mkpath(legacy));
         qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
 
         const auto r = utils::xdgConfigDir(legacy);
@@ -118,7 +117,6 @@ private slots:
         QVERIFY(!r.migrationPending);
     }
 
-    // A populated (already-migrated) XDG dir wins over an existing legacy dir.
     void test_migratedXdgDirWinsOverLegacy()
     {
         QTemporaryDir xdg;
@@ -157,7 +155,6 @@ private slots:
         QVERIFY2(r.migrationPending, "a stale non-Mudlet XDG dir must not shadow real profiles");
     }
 
-    // Guard: XDG target absent while a legacy dir exists -> keep legacy, flag it.
     void test_guardKeepsLegacyWhenXdgTargetMissing()
     {
         QTemporaryDir xdg;
@@ -173,7 +170,6 @@ private slots:
         QVERIFY(r.migrationPending);
     }
 
-    // Fresh install: XDG set, neither dir usable -> honor XDG, no migration.
     void test_freshInstallUsesXdgWhenNeitherExists()
     {
         QTemporaryDir xdg;
@@ -198,7 +194,7 @@ private slots:
         QTemporaryDir cfg; // stands in for $HOME/.config
         QVERIFY(cfg.isValid());
         const QString legacy = mudletUnder(cfg.path());
-        QVERIFY(QDir().mkpath(legacy)); // the one and only (empty) config dir
+        QVERIFY(QDir().mkpath(legacy));
         qputenv("XDG_CONFIG_HOME", cfg.path().toUtf8());
 
         const auto r = utils::xdgConfigDir(legacy);
@@ -208,8 +204,6 @@ private slots:
 
     // --- mudlet::setupConfig() end-to-end wiring ------------------------------
 
-    // The isolation opt-in used by the busted harness: a pre-created
-    // $XDG_CONFIG_HOME/mudlet becomes the config root.
     void test_setupConfigUsesPreCreatedXdgTarget()
     {
         if (portableMarkerPresent()) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Mudlet now honors `XDG_CONFIG_HOME` (it previously hardcoded `~/.config/mudlet`): precedence is portable.txt (unchanged) > `$XDG_CONFIG_HOME/mudlet` when set and absolute > legacy `~/.config/mudlet`
- Migration guard: users who already export `XDG_CONFIG_HOME` keep their legacy profiles (a one-time hint explains how to migrate); a stale pre-4.19 `Mudlet.conf` leftover cannot shadow real profiles
- Test harnesses opt into isolation by pre-creating an empty `$XDG_CONFIG_HOME/mudlet` - fixes parallel busted runs colliding on the shared self-test profile's sqlite (locked/readonly flakes) and state accumulating across runs
- `MUDLET_TEST_FAILURE_MARKER` isolates the shared `/tmp/busted-tests-failed` marker; new `ConfigDirOverrideTest` (11 cases) locks the resolution table in

#### Motivation for adding to Mudlet
Proper XDG platform behavior on Linux, and hermetic parallel test runs - proven by A/B: two simultaneous suites sharing one config dir reproduce the sqlite flakes, isolated dirs run both green (679/0/0 each).

#### Other info (issues closed, discussion etc)

**Test case:** `export XDG_CONFIG_HOME=/tmp/x && mkdir -p /tmp/x/mudlet` then launch - Mudlet uses `/tmp/x/mudlet`; unset it - Mudlet uses `~/.config/mudlet` as before; run two busted suites simultaneously with distinct pre-created XDG dirs - both green.


Assisted-by: Claude:claude-opus-4-8
