### PR TITLE
infrastructure: survive xorg.freedesktop.org certificate expiry in CI

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -222,7 +222,15 @@ jobs:
         # Download and extract xcb-util-cursor 0.1.5
         # This version fixes the off-by-one heap buffer overflow in _XcursorThemeInherits
         # that causes PTB builds to crash with AddressSanitizer
-        wget -q --connect-timeout=10 --read-timeout=30 --tries=3 --waitretry=5 https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz
+        # Fall back to the xcb project's dist host: xorg.freedesktop.org served an
+        # expired TLS certificate on 2026-07-28, breaking every CI run
+        for url in \
+          https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz \
+          https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.5.tar.xz; do
+          wget -q --connect-timeout=10 --read-timeout=30 --tries=3 --waitretry=5 -O xcb-util-cursor-0.1.5.tar.xz "$url" && break
+        done || echo "all xcb-util-cursor mirrors failed" >&2
+        # Checksum from https://lists.x.org/archives/xorg-announce/2023-October/003428.html
+        echo "0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57  xcb-util-cursor-0.1.5.tar.xz" | sha256sum -c
         tar xf xcb-util-cursor-0.1.5.tar.xz
         cd xcb-util-cursor-0.1.5
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -228,7 +228,15 @@ jobs:
         # Download and extract xcb-util-cursor 0.1.5
         # This version fixes the off-by-one heap buffer overflow in _XcursorThemeInherits
         # that causes PTB builds to crash with AddressSanitizer
-        wget -q --connect-timeout=10 --read-timeout=30 --tries=3 --waitretry=5 https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz
+        # Fall back to the xcb project's dist host: xorg.freedesktop.org served an
+        # expired TLS certificate on 2026-07-28, breaking every CI run
+        for url in \
+          https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz \
+          https://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.5.tar.xz; do
+          wget -q --connect-timeout=10 --read-timeout=30 --tries=3 --waitretry=5 -O xcb-util-cursor-0.1.5.tar.xz "$url" && break
+        done || echo "all xcb-util-cursor mirrors failed" >&2
+        # Checksum from https://lists.x.org/archives/xorg-announce/2023-October/003428.html
+        echo "0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57  xcb-util-cursor-0.1.5.tar.xz" | sha256sum -c
         tar xf xcb-util-cursor-0.1.5.tar.xz
         cd xcb-util-cursor-0.1.5
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The "(Linux) Build xcb-util-cursor" step now tries the canonical xorg.freedesktop.org first, then falls back to xcb.freedesktop.org/dist (valid cert, byte-identical tarball)
- New sha256 integrity check (verified against the xorg-announce release email) makes any mirror trustworthy and hard-fails corrupt downloads

#### Motivation for adding to Mudlet
xorg.freedesktop.org's TLS cert expired 2026-07-28 11:20 UTC (verified via openssl: notAfter=Jul 28 11:20:31 2026), deterministically failing all three Ubuntu CI jobs on every PR since - reruns cannot clear it, and www/ftp.x.org 301-redirect back to the broken vhost.

#### Other info (issues closed, discussion etc)
Verified across 4 PRs' job logs (identical wget exit 5 = SSL failure) and reproduced standalone. Canonical-first ordering self-heals once upstream renews. Open PRs will need a merge-up after this lands.

**Test case:** the exact step body run locally under bash -e: canonical fails fast, fallback downloads, checksum passes, tarball extracts (~1.5s); corrupting the file fails the checksum; all-mirrors-down exits 1 with a clear marker.

Awaiting build/test by a maintainer; squash-merge with:
Assisted-by: Claude:claude-fable-5
(Signed-off-by to be added at squash after testing)