### PR TITLE
fix: memory leak when perm* functions receive invalid Lua code

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3323,6 +3323,24 @@ std::pair<bool, QString> TLuaInterpreter::validateLuaCodeParam(int index)
 }
 
 // No documentation available in wiki - internal function
+// Validates the Lua code argument at `index`; on success returns false. On
+// failure it formats "<functionName>: bad argument #<index> (<reason>)" onto
+// the Lua stack and returns true, expecting the caller to raise it with
+// `return lua_error(L)` on the next line. Raising here would longjmp past this
+// function's QString destructor and leak its buffer, so the message is copied
+// into the Lua-owned stack string while the QString is alive and the QString is
+// then released by this function's normal return, before the caller raises.
+bool TLuaInterpreter::reportInvalidLuaCodeParam(lua_State* L, const char* functionName, const int index)
+{
+    auto [isValid, errorMessage] = validateLuaCodeParam(index);
+    if (isValid) {
+        return false;
+    }
+    lua_pushfstring(L, "%s: bad argument #%d (%s)", functionName, index, errorMessage.toUtf8().constData());
+    return true;
+}
+
+// No documentation available in wiki - internal function
 // returns pair where first is bool stating true the given Lua code is valid, false otherwise
 // second is empty if code is valid, error message if not valid
 std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString& code)

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -861,6 +861,7 @@ private:
     void logEventError(const QString& event, const QString& error);
     std::pair<bool, QString> validLuaCode(const QString& code);
     std::pair<bool, QString> validateLuaCodeParam(int index);
+    bool reportInvalidLuaCodeParam(lua_State* L, const char* functionName, const int index);
     QByteArray encodeBytes(const char*);
     void setMatches(lua_State*);
     void setupLanguageData();

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1099,8 +1099,7 @@ int TLuaInterpreter::permAlias(lua_State* L)
     const QString regex = getVerifiedString(L, __func__, 3, "regexp pattern");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
-        lua_pushfstring(L, "permAlias: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permAlias", 4)) {
         return lua_error(L);
     }
 
@@ -1121,8 +1120,7 @@ int TLuaInterpreter::permPromptTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     const QString triggerName = getVerifiedString(L, __func__, 1, "trigger name");
     const QString parentName = getVerifiedString(L, __func__, 2, "parent trigger name");
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(3); !validationResult) {
-        lua_pushfstring(L, "permPromptTrigger: bad argument #%d (%s)", 3, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permPromptTrigger", 3)) {
         return lua_error(L);
     }
     const QString luaFunction = lua_tostring(L, 3);
@@ -1159,8 +1157,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
-        lua_pushfstring(L, "permRegexTrigger: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permRegexTrigger", 4)) {
         return lua_error(L);
     }
 
@@ -1197,8 +1194,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
-        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permBeginOfLineStringTrigger", 4)) {
         return lua_error(L);
     }
 
@@ -1234,8 +1230,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
-        lua_pushfstring(L, "permSubstringTrigger: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permSubstringTrigger", 4)) {
         return lua_error(L);
     }
 
@@ -1271,8 +1266,7 @@ int TLuaInterpreter::permExactMatchTrigger(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
-        lua_pushfstring(L, "permExactMatchTrigger: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permExactMatchTrigger", 4)) {
         return lua_error(L);
     }
 
@@ -1293,8 +1287,7 @@ int TLuaInterpreter::permScript(lua_State* L)
     const QString parent = getVerifiedString(L, __func__, 2, "script parent name");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(3); !validationResult) {
-        lua_pushfstring(L, "permScript: bad argument #%d (%s)", 3, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permScript", 3)) {
         return lua_error(L);
     }
     const QString luaCode{lua_tostring(L, 3)};
@@ -1315,8 +1308,7 @@ int TLuaInterpreter::permTimer(lua_State* L)
     const double time = getVerifiedDouble(L, __func__, 3, "time in seconds");
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(4); !validationResult) {
-        lua_pushfstring(L, "permTimer: bad argument #%d (%s)", 4, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permTimer", 4)) {
         return lua_error(L);
     }
     const QString luaCode{lua_tostring(L, 4)};
@@ -1345,8 +1337,7 @@ int TLuaInterpreter::permKey(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(++argIndex); !validationResult) {
-        lua_pushfstring(L, "permKey: bad argument #%d (%s)", argIndex, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "permKey", ++argIndex)) {
         return lua_error(L);
     }
 
@@ -1685,8 +1676,7 @@ int TLuaInterpreter::setScript(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    if (auto [validationResult, validationMessage] = pLuaInterpreter->validateLuaCodeParam(2); !validationResult) {
-        lua_pushfstring(L, "setScript: bad argument #%d (%s)", 2, validationMessage.toUtf8().constData());
+    if (pLuaInterpreter->reportInvalidLuaCodeParam(L, "setScript", 2)) {
         return lua_error(L);
     }
     const QString luaCode{lua_tostring(L, 2)};

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -231,9 +231,12 @@ describe("Alias processing", function()
     describe("permAlias argument validation", function()
 
         it("errors when the lua code (argument 4) is not a string", function()
-            assert.has_error(function()
+            local ok, err = pcall(function()
                 permAlias("SpecPermAliasBad", "", "^whatever$", 999)
             end)
+            assert.is_false(ok, "invalid lua code should error")
+            assert.is_truthy(tostring(err):find("permAlias", 1, true),
+                "the error should name permAlias, got: " .. tostring(err))
         end)
 
         it("errors when the regex pattern (argument 3) is missing", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- lua_error() longjmps past C++ destructors, stranding the validation-message QString from validLuaCode() - a latent leak in 10 call sites (permAlias, permKey, permTimer, permScript, setScript, all perm*Trigger variants)
- New TLuaInterpreter::reportInvalidLuaCodeParam() pushes the error message onto the Lua stack while the QString is still alive, then callers raise; output is byte-for-byte identical

#### Motivation for adding to Mudlet
This is the 512-byte QArrayData leak currently failing the leak-detection CI job on every open PR - the new #9532 specs exercise the invalid-code path and LSan enforcement (#9481) rightly makes it fatal.

#### Other info (issues closed, discussion etc)
Root-caused with full stacks (fast_unwind_on_malloc=0): QString::append in validLuaCode -> validateLuaCodeParam -> permAlias/permKey, 2x256 bytes matching CI exactly. Pre-#9532 development doesn't trigger it (path unexercised, bug still present). Verified: 3x full busted suite under LSan enforcement = zero leak output, 826/0/0 each; functional tests 21/21. Note: #9535's separate 29KB QNetworkRequest leak is a different site and still needs its own fix.

**Test case:** ASan/LSan build, run the busted suite - leak-detection passes; permAlias("x","","^y$",999) still errors with the identical message.

Awaiting build/test by a maintainer; squash-merge with:
Assisted-by: Claude:claude-opus-4-8
(Signed-off-by to be added at squash after testing)