### PR TITLE
fix: stop crashes while saving and profiles losing their triggers

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1808,6 +1808,9 @@ void Host::incomingStreamProcessor(const QString& data, int line)
     mTimerUnit.doCleanup();
     mTriggerUnit.doCleanup();
     mKeyUnit.doCleanup();
+    // ScriptUnit defers deletes too (a package script uninstalling its own package
+    // mid-compile or mid-event-dispatch), so flush it here alongside the others:
+    mScriptUnit.doCleanup();
 }
 
 // When Mudlet is running in online mode, deleted temp* objects are cleaned up in bulk
@@ -1819,6 +1822,7 @@ void Host::slot_purgeTemps()
     mTimerUnit.doCleanup();
     mTriggerUnit.doCleanup();
     mKeyUnit.doCleanup();
+    mScriptUnit.doCleanup();
 }
 
 void Host::registerEventHandler(const QString& name, TScript* pScript)
@@ -2446,6 +2450,12 @@ bool Host::uninstallPackage(const QString& packageName, enums::PackageModuleType
         // not to try to write to disk a package/module that just got uninstalled and removed from memory
         QTimer::singleShot(0ms, this, [this]() {
             mSaveTimer = false;
+            // If a package's own script uninstalled it mid-compile (from a script
+            // reached outside the compileAll()/editor/raiseEvent flush points, e.g. a
+            // permScript() run from an alias or key), the script deletes were deferred
+            // and are still registered. Flush them now, at depth 0, before saving so
+            // the save below does not serialize the just-uninstalled scripts back in:
+            mScriptUnit.doCleanup();
             if (auto [ok, filename, error] = saveProfile(); !ok) {
                 qDebug() << qsl("Host::uninstallPackage: Couldn't save '%1' to '%2' because: %3").arg(getName(), filename, error);
             }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -71,6 +71,7 @@
 #include <QNetworkProxy>
 #include <QRegularExpression>
 #include <QSaveFile>
+#include <QScopeGuard>
 #include <QSettings>
 #include <QTextStream>
 #include <zip.h>
@@ -644,15 +645,26 @@ void Host::writeModule(const QString& moduleName, const QString& filename)
     updateModuleZips(filename, moduleName);
 }
 
+// Main thread only: `writers` and each writer's `saveFutures` are mutated on the
+// main thread as profile saves start and finish, so the background module-sync
+// task must not read them - it gets a snapshot taken up front instead (see
+// saveProfile()). NB: saveModules()/writeModule() still touch `writers` from
+// that background task for profiles that use modules - a known remaining race
+// that needs module writing to move back to the main thread to fix properly.
+QVector<QFuture<bool>> Host::pendingXmlSaveFutures() const
+{
+    QVector<QFuture<bool>> futures;
+    for (const auto& writer : writers) {
+        futures += writer->saveFutures;
+    }
+    return futures;
+}
+
 void Host::waitForAsyncXmlSave()
 {
-    // writers and futures are copied to prevent deletion during for loop (which would mean crash)
-    auto myWriters = writers;
-    for (auto& writer : myWriters) {
-        auto myFutures = writer->saveFutures;
-        for (auto& future : myFutures) {
-            future.waitForFinished();
-        }
+    const auto futures = pendingXmlSaveFutures();
+    for (auto future : futures) {
+        future.waitForFinished();
     }
 }
 
@@ -1004,10 +1016,18 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     }
 
     auto watcher = new QFutureWatcher<void>;
-    mModuleFuture = QtConcurrent::run([=, this]() {
+    // Snapshot the pending XML save futures on the main thread: the background task
+    // below must not read `writers`/`saveFutures` itself as the main thread mutates
+    // them whenever a save starts or finishes - concurrently copying those containers
+    // from the pool thread is a data race that can corrupt the heap
+    const QVector<QFuture<bool>> xmlSaveFutures = pendingXmlSaveFutures();
+    const bool backupModules = saveName != qsl("autosave");
+    mModuleFuture = QtConcurrent::run([this, xmlSaveFutures, backupModules]() {
         // wait for the host xml to be ready before starting to sync modules
-        waitForAsyncXmlSave();
-        saveModules(saveName != qsl("autosave"));
+        for (auto future : xmlSaveFutures) {
+            future.waitForFinished();
+        }
+        saveModules(backupModules);
     });
     connect(watcher, &QFutureWatcher<void>::finished, this, [=, this]() {
         // reload, or queue module reload for when xml is ready
@@ -1845,6 +1865,18 @@ void Host::raiseEvent(const TEvent& pE)
     }
 
     static const QString star = qsl("*");
+
+    // A handler can uninstall its own package mid-dispatch (a common package
+    // auto-updater pattern): whilst this frame is on the stack
+    // ScriptUnit::uninstall() defers its deletes so neither the executing
+    // handler nor the other TScript pointers in the lists copied below get
+    // freed under us; the deferred deletes are flushed once the outermost
+    // dispatch finishes:
+    mScriptUnit.beginProcessing();
+    const auto processingGuard = qScopeGuard([this] {
+        mScriptUnit.endProcessing();
+        mScriptUnit.doCleanup();
+    });
 
     if (mEventHandlerMap.contains(pE.mArgumentList.at(0))) {
         QList<TScript*> scriptList = mEventHandlerMap.value(pE.mArgumentList.at(0));

--- a/src/Host.h
+++ b/src/Host.h
@@ -897,6 +897,7 @@ private:
     void removePackageInfo(const QString& packageName, const bool);
     static void createModuleBackup(const QString& filename, const QString& saveName);
     void writeModule(const QString& moduleName, const QString& filename);
+    QVector<QFuture<bool>> pendingXmlSaveFutures() const;
     void waitForAsyncXmlSave();
     void saveModules(bool backup = true);
     void updateModuleZips(const QString& zipName, const QString& moduleName);

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -79,8 +79,41 @@ void ScriptUnit::uninstall(const QString& packageName)
             uninstallList.append(rootScript);
         }
     }
+    // Re-entrant uninstall (#9337): a script's own event handler (e.g. a package
+    // auto-updater calling uninstallPackage()) is removing its package while
+    // Host::raiseEvent() is still dispatching to that script. Deleting now would
+    // be a use-after-free - both of the handler still executing and of the other
+    // TScript pointers in raiseEvent()'s copied handler list - so defer to
+    // doCleanup() at depth 0. Deactivating is enough to stop the handlers firing
+    // for the rest of the dispatch: TScript::callEventHandler() checks isActive().
+    if (mProcessingDepth > 0) {
+        for (auto script : uninstallList) {
+            script->setIsActive(false);
+        }
+        return;
+    }
     for (auto& script : uninstallList) {
         delete script;
+    }
+    uninstallList.clear();
+}
+
+// Flush the deletes uninstall() deferred (#9337). uninstallList is ordered
+// children-before-parents and each ~Tree unlinks from its parent, so deleting
+// children first empties the parent's child list (no double free); the seen
+// set guards a node queued twice by re-entrant uninstalls.
+void ScriptUnit::doCleanup()
+{
+    if (mProcessingDepth > 0) {
+        return;
+    }
+
+    QSet<TScript*> deletedScripts;
+    for (auto script : uninstallList) {
+        if (!deletedScripts.contains(script)) {
+            deletedScripts.insert(script);
+            delete script;
+        }
     }
     uninstallList.clear();
 }

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -79,23 +79,26 @@ void ScriptUnit::uninstall(const QString& packageName)
             uninstallList.append(rootScript);
         }
     }
-    // Re-entrant uninstall (#9337): a script's own event handler (e.g. a package
-    // auto-updater calling uninstallPackage()) is removing its package while
-    // Host::raiseEvent() is still dispatching to that script. Deleting now would
-    // be a use-after-free - both of the handler still executing and of the other
-    // TScript pointers in raiseEvent()'s copied handler list - so defer to
-    // doCleanup() at depth 0. Deactivating is enough to stop the handlers firing
-    // for the rest of the dispatch: TScript::callEventHandler() checks isActive().
+    // Re-entrant uninstall (#9337): a package's own script (e.g. a package
+    // auto-updater calling uninstallPackage()) is removing its package while one
+    // of that package's scripts is still on the call stack - either an event
+    // handler Host::raiseEvent() is dispatching to, or a top-level body
+    // TScript::compileScript() is compiling. Deleting now would be a use-after-free
+    // (of the script still executing, and of the other TScript pointers raiseEvent()
+    // or ScriptUnit::compileAll() is still iterating), so defer to doCleanup() at
+    // depth 0. Deactivating is enough to stop the handlers firing for the rest of
+    // the dispatch: TScript::callEventHandler() checks isActive().
     if (mProcessingDepth > 0) {
         for (auto script : uninstallList) {
             script->setIsActive(false);
         }
         return;
     }
-    for (auto& script : uninstallList) {
-        delete script;
-    }
-    uninstallList.clear();
+    // At depth 0 delete straight away, but go through doCleanup() rather than a bare
+    // loop: uninstallList is a member that a prior deferred uninstall may have left
+    // populated, so a second uninstall of the same still-registered package can queue
+    // the same pointers twice - doCleanup()'s seen set stops that double-freeing.
+    doCleanup();
 }
 
 // Flush the deletes uninstall() deferred (#9337). uninstallList is ordered
@@ -270,11 +273,22 @@ int ScriptUnit::getNewID()
 
 void ScriptUnit::compileAll(bool saveLoadingError)
 {
-    for (auto script : mScriptRootNodeList) {
+    // Iterate a snapshot of the root list: a script's top-level body, run by
+    // compile() below, can uninstall its own package (a package auto-updater
+    // pattern). uninstall() defers the actual delete whilst compileScript() is on
+    // the stack, so no node is unlinked mid-loop, but taking a copy keeps the
+    // iteration safe even against a body that adds or removes root scripts:
+    const std::vector<TScript*> rootNodes(mScriptRootNodeList.begin(), mScriptRootNodeList.end());
+    for (auto script : rootNodes) {
         if (script->isActive()) {
             script->compileAll(saveLoadingError);
         }
     }
+    // The loop is now done with the (possibly self-uninstalled) scripts, so flush
+    // the deletes uninstall() deferred - before the editor tree is rebuilt below and
+    // before returning to the event loop, where the 0ms save Host::uninstallPackage()
+    // queues would otherwise serialize the still-live "uninstalled" scripts back in:
+    doCleanup();
     if (mpHost->mpEditorDialog) {
         mpHost->mpEditorDialog->doCleanReset();
     }

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -44,15 +44,9 @@ public:
     explicit ScriptUnit(Host*);
     ~ScriptUnit();
 
-    std::list<TScript*> getScriptRootNodeList()
-    {
-        return mScriptRootNodeList;
-    }
+    std::list<TScript*> getScriptRootNodeList() { return mScriptRootNodeList; }
 
-    QMap<int, TScript*> getScriptList()
-    {
-        return mScriptMap;
-    }
+    QMap<int, TScript*> getScriptList() { return mScriptMap; }
 
     TScript* getScript(int id);
     void compileAll(bool saveLoadingError = false);
@@ -63,6 +57,17 @@ public:
     void stopAllTriggers();
     void uninstall(const QString&);
     void _uninstall(TScript* pChild, const QString& packageName);
+    // Tracks Host::raiseEvent() dispatch nesting so that uninstall() can defer
+    // deleting a package's scripts while one of their event handlers is still on
+    // the call stack (e.g. a handler calling uninstallPackage() on its own
+    // package) - deferred items are flushed by doCleanup() at depth 0:
+    void beginProcessing() { ++mProcessingDepth; }
+    void endProcessing()
+    {
+        --mProcessingDepth;
+        Q_ASSERT(mProcessingDepth >= 0);
+    }
+    void doCleanup();
     int getNewID();
     std::vector<int> findItems(const QString& name, const bool exactMatch = true, const bool caseSensitive = true);
     void resetStats();
@@ -84,6 +89,9 @@ private:
     QPointer<Host> mpHost;
     QMap<int, TScript*> mScriptMap;
     std::list<TScript*> mScriptRootNodeList;
+    // > 0 whilst Host::raiseEvent() is dispatching to event handlers; uninstall()
+    // and doCleanup() must not delete scripts then:
+    int mProcessingDepth = 0;
     int mMaxID = 0;
     int statsItemsTotal = 0;
     int statsTempItems = 0;

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -25,8 +25,11 @@
 
 
 #include "Host.h"
+#include "ScriptUnit.h"
 #include "TDebug.h"
 #include "mudlet.h"
+
+#include <QScopeGuard>
 
 TScript::TScript(TScript* parent, Host* pHost)
 : Tree<TScript>(parent)
@@ -120,6 +123,26 @@ bool TScript::setScript(const QString& script)
 
 bool TScript::compileScript(bool saveLoadingError)
 {
+    // Whilst this frame is on the stack ScriptUnit::uninstall() must defer deleting
+    // this profile's scripts: the top-level Lua body run below (the lua_pcall inside
+    // TLuaInterpreter::compile()) can uninstall its own package - a common package
+    // auto-updater pattern - and freeing this script mid-compile, or writing to it
+    // after compile() returns (see mNeedsToBeCompiled/mOK_code below and in
+    // setScript()), is a use-after-free. See ScriptUnit::mProcessingDepth.
+    ScriptUnit* pUnit = mpHost->getScriptUnit();
+    pUnit->beginProcessing();
+    // NB: deliberately decrement-only - do NOT add a doCleanup() call here. setScript()
+    // writes mOK_code AFTER this returns and ScriptUnit::compileAll()'s loop is still
+    // iterating the root list, so deleting `this` now would be a use-after-free. The
+    // deferred deletes are flushed at a safe point once the pointer is no longer in
+    // use: after ScriptUnit::compileAll()'s loop, at the end of the editor's
+    // saveScript(), in Host::raiseEvent()'s scope guard, and by the catch-all
+    // doCleanup() in Host::incomingStreamProcessor()/slot_purgeTemps() and the queued
+    // save in Host::uninstallPackage().
+    const auto processingGuard = qScopeGuard([pUnit] {
+        pUnit->endProcessing();
+    });
+
     QString error;
     if (mpHost->mLuaInterpreter.compile(mScript, error, QString("Script: ") + getName())) {
         mNeedsToBeCompiled = false;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -28,6 +28,8 @@
 #include "TDebug.h"
 #include "mudlet.h"
 
+#include <QScopeGuard>
+
 const char* TTimer::scmProperty_HostName = "HostName";
 const char* TTimer::scmProperty_TTimerId = "TTimerId";
 
@@ -202,6 +204,22 @@ void TTimer::execute()
         qWarning() << "TTimer::execute() called on destroyed timer - ID:" << mID << "Name:" << mName;
         return;
     }
+
+    // Whilst this frame is on the stack TimerUnit::uninstall() must defer deleting
+    // this profile's timers: the scripts run below can uninstall their own package
+    // (a common package auto-updater pattern) and freeing this timer mid-execute()
+    // is a use-after-free - see TimerUnit::mProcessingDepth:
+    TimerUnit* pUnit = mpHost->getTimerUnit();
+    pUnit->beginProcessing();
+    // NB: deliberately only decrements the depth - do NOT add a doCleanup() call
+    // here: it would delete `this` (and other deferred timers) while
+    // mudlet::slot_timerFires() still holds the pointer. Deferred deletes are
+    // flushed by slot_timerFires() itself once it is finished with the timer
+    // (and by the doCleanup() calls in Host::incomingStreamProcessor() and
+    // Host::slot_purgeTemps()):
+    const auto processingGuard = qScopeGuard([pUnit] {
+        pUnit->endProcessing();
+    });
 
     if (!isActive() || isFolder()) {
         mpQTimer->stop();

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -84,7 +84,21 @@ void TimerUnit::uninstall(const QString& packageName)
             uninstallList.append(rootTimer);
         }
     }
+    // Re-entrant uninstall (#9337): a timer's own script (e.g. a package
+    // auto-updater calling uninstallPackage()) is removing its package while
+    // TTimer::execute() is still on the call stack for that timer. Deleting now
+    // would be a use-after-free, so defer to doCleanup() at depth 0.
+    if (mProcessingDepth > 0) {
+        for (auto timer : uninstallList) {
+            timer->setIsActive(false);
+            mCleanupSet.remove(timer); // keep the two deferred-delete paths disjoint
+        }
+        return;
+    }
     for (auto& timer : uninstallList) {
+        // in case the timer was also queued for the markCleanup()/doCleanup()
+        // path - deleting it here would otherwise leave a dangling pointer there:
+        mCleanupSet.remove(timer);
         delete timer;
     }
     uninstallList.clear();
@@ -423,14 +437,33 @@ int TimerUnit::getNewID()
 
 void TimerUnit::doCleanup()
 {
+    if (mProcessingDepth > 0) {
+        return;
+    }
+
+    QSet<TTimer*> deletedTimers;
     QMutableSetIterator<TTimer*> itTimer(mCleanupSet);
     while (itTimer.hasNext()) {
         auto pTimer = itTimer.next();
         // It is important to take the item OUT of the set before you delete
         // (and thus invalidate this pointer to) it...!
         itTimer.remove();
+        deletedTimers.insert(pTimer);
         delete pTimer;
     }
+    // Flush the deletes uninstall() deferred (#9337). uninstallList is ordered
+    // children-before-parents and each ~Tree unlinks from its parent, so deleting
+    // children first empties the parent's child list (no double free); the seen
+    // set guards a node queued twice by re-entrant uninstalls and is shared with
+    // the mCleanupSet loop above so an object that somehow ended up in both
+    // containers cannot be freed twice.
+    for (auto timer : uninstallList) {
+        if (!deletedTimers.contains(timer)) {
+            deletedTimers.insert(timer);
+            delete timer;
+        }
+    }
+    uninstallList.clear();
 }
 
 void TimerUnit::markCleanup(TTimer* pT)

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -37,10 +37,15 @@ class Host;
 class TTimer;
 class QTimer;
 
-// Note: Unlike AliasUnit/TriggerUnit/KeyUnit, TimerUnit does not use mProcessingDepth
-// because timers execute via Qt's event loop (QTimer signals), not synchronous loops.
-// Protection against re-entrancy is provided by the guard in TTimer::execute() and
-// by re-verifying timer existence after execute() in mudlet::slot_timerFires().
+// Note: mProcessingDepth tracks TTimer::execute() nesting (via begin/endProcessing())
+// so that uninstall() can defer deletion of a package's timers while one of them is
+// still on the call stack - a timer script calling uninstallPackage() on its own
+// package would otherwise free the very TTimer execute() is running on. Deferred
+// items are flushed by doCleanup() once no timer script is executing - primarily
+// by mudlet::slot_timerFires() right after it finishes with the fired timer, so
+// the "uninstalled" objects do not outlive the event loop iteration. This
+// complements the guard in TTimer::execute() and the re-verification of timer
+// existence after execute() in mudlet::slot_timerFires().
 class TimerUnit
 {
     friend class XMLexport;
@@ -70,6 +75,12 @@ public:
     void reenableAllTriggers();
     void markCleanup(TTimer*);
     void doCleanup();
+    void beginProcessing() { ++mProcessingDepth; }
+    void endProcessing()
+    {
+        --mProcessingDepth;
+        Q_ASSERT(mProcessingDepth >= 0);
+    }
     std::tuple<QString, int, int, int> assembleReport();
     int getNewID();
     void uninstall(const QString&);
@@ -104,6 +115,9 @@ private:
     int mMaxID = 0;
     bool mModuleMember = false;
     QSet<TTimer*> mCleanupSet;
+    // > 0 whilst a TTimer::execute() is on the call stack; uninstall() and
+    // doCleanup() must not delete timers then - see the note above the class:
+    int mProcessingDepth = 0;
     int statsActiveItems = 0;
     int statsItemsTotal = 0;
     int statsTempItems = 0;

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -104,6 +104,9 @@ void TriggerUnit::uninstall(const QString& packageName)
         return;
     }
     for (auto& trigger : uninstallList) {
+        // in case the trigger was also queued for the markCleanup()/doCleanup()
+        // path - deleting it here would otherwise leave a dangling pointer there:
+        mCleanupSet.remove(trigger);
         delete trigger;
     }
     uninstallList.clear();
@@ -514,17 +517,20 @@ void TriggerUnit::doCleanup()
         return;
     }
 
+    QSet<TTrigger*> deletedTriggers;
     QMutableSetIterator<TTrigger*> itTrigger(mCleanupSet);
     while (itTrigger.hasNext()) {
         auto pTrigger = itTrigger.next();
         itTrigger.remove();
+        deletedTriggers.insert(pTrigger);
         delete pTrigger;
     }
     // Flush the deletes uninstall() deferred (#9337). uninstallList is ordered
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
-    // set guards a node queued twice by re-entrant uninstalls.
-    QSet<TTrigger*> deletedTriggers;
+    // set guards a node queued twice by re-entrant uninstalls and is shared with
+    // the mCleanupSet loop above so an object that somehow ended up in both
+    // containers cannot be freed twice.
     for (auto trigger : uninstallList) {
         if (!deletedTriggers.contains(trigger)) {
             deletedTriggers.insert(trigger);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1858,7 +1858,9 @@ void dlgConnectionProfiles::copyProfileSettingsOnly(const QString& oldname, cons
     const QDir oldProfiledir(mudlet::getMudletPath(enums::profileXmlFilesPath, oldname));
     const QDir newProfiledir(mudlet::getMudletPath(enums::profileXmlFilesPath, newname));
     newProfiledir.mkpath(newProfiledir.absolutePath());
-    QStringList entries = oldProfiledir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    // Only copy from a real profile save (*.xml): the newest file of any name could
+    // be a leftover QSaveFile temporary from an interrupted save (e.g. "....xml.AbCdEf")
+    QStringList entries = oldProfiledir.entryList(QStringList{qsl("*.xml")}, QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
     if (entries.empty()) {
         return;
     }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1191,7 +1191,9 @@ void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
 
     QDir dir(mudlet::getMudletPath(enums::profileXmlFilesPath, profile_name));
     dir.setSorting(QDir::Time);
-    const QStringList entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
+    // Only offer real profile saves (*.xml) as history entries; leftover QSaveFile
+    // temporaries from an interrupted save (e.g. "....xml.AbCdEf") must not be loadable
+    const QStringList entries = dir.entryList(QStringList{qsl("*.xml")}, QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
 
     for (const auto& entry : entries) {
         const QRegularExpression rx(qsl("(\\d+)\\-(\\d+)\\-(\\d+)#(\\d+)\\-(\\d+)\\-(\\d+).xml"));
@@ -1695,12 +1697,7 @@ void dlgConnectionProfiles::slot_copyProfile()
 
 dlgConnectionProfiles::CopiedProfileData dlgConnectionProfiles::captureProfileData() const
 {
-    return {host_name_entry->text(),
-            port_entry->text(),
-            port_ssl_tsl->isChecked() ? Qt::Checked : Qt::Unchecked,
-            login_entry->text(),
-            website_entry->text(),
-            mud_description_textedit->toPlainText()};
+    return {host_name_entry->text(), port_entry->text(), port_ssl_tsl->isChecked() ? Qt::Checked : Qt::Unchecked, login_entry->text(), website_entry->text(), mud_description_textedit->toPlainText()};
 }
 
 // Copying a default profile (one of the predefined games) has nothing to copy

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6722,6 +6722,13 @@ void dlgTriggerEditor::saveScript()
             mpTextUndoStack->clear();
         }
     }
+
+    // If pT's own body uninstalled its package during the compile above, the delete
+    // was deferred (see TScript::compileScript / ScriptUnit::uninstall). We are now
+    // done with pT, so flush it before returning to the event loop - otherwise the
+    // 0ms save uninstallPackage() queued would serialize the "uninstalled" script
+    // back into the profile:
+    mpHost->getScriptUnit()->doCleanup();
 }
 
 void dlgTriggerEditor::clearEditorNotification()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2400,6 +2400,14 @@ void mudlet::slot_timerFires()
             pTT->start();
         }
 
+        // Flush any deletes TimerUnit::uninstall() deferred whilst execute() was
+        // on the stack (a timer script uninstalling its own package). Doing it
+        // here - after the last use of pTT - keeps the window in which the
+        // "uninstalled" timers linger down to this event loop iteration, before
+        // the profile save that Host::uninstallPackage() queues with a 0ms
+        // single-shot can serialize them back into the profile:
+        pHost->getTimerUnit()->doCleanup();
+
         // Okay now we've found it we are done:
         return;
     }
@@ -6078,11 +6086,23 @@ Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, co
     const QString folder = getMudletPath(enums::profileXmlFilesPath, profile_name);
     QDir dir(folder);
     dir.setSorting(QDir::Time);
-    QStringList entries = dir.entryList(QDir::Files, QDir::Time);
+    // Only consider profile saves (*.xml): a crash during a save can leave behind
+    // an empty QSaveFile temporary (e.g. "2026-01-01#12-00-00.xml.AbCdEf") as the
+    // newest file, and loading that instead of the newest real save presents the
+    // profile with all of its triggers/scripts seemingly wiped out
+    QStringList entries = dir.entryList(QStringList{qsl("*.xml")}, QDir::Files, QDir::Time);
     // pre-install packages when loading this profile for the first time
     bool preInstallPackages = false;
     pHost->hideMudletsVariables();
-    if (entries.isEmpty()) {
+    // NB: an explicitly requested saveFileName is honored even when no *.xml
+    // is present - failing to open it then reports a proper load error rather
+    // than silently starting a fresh profile:
+    if (entries.isEmpty() && saveFileName.isEmpty()) {
+        if (!dir.entryList(QDir::Files | QDir::NoDotAndDotDot).isEmpty()) {
+            qWarning().nospace().noquote() << "mudlet::loadProfile(" << profile_name << ", ...) WARNING - profile directory \"" << folder
+                                           << "\" contains files but no completed (*.xml) save; treating the profile as new. An interrupted save may have left "
+                                              "a recoverable QSaveFile temporary behind.";
+        }
         preInstallPackages = true;
         pHost->mLoadedOk = true;
         pHost->mMapInfoContributors.insert(qsl("Short"));

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -23,6 +23,8 @@ set(FUNCTIONAL_TEST_SOURCES
     GMCPCharLoginTest.cpp
     LogRestartDuplicateLineTest.cpp
     ProfileRoundTripTest.cpp
+    ProfileLoadTempFileTest.cpp
+    PackageSelfUninstallTest.cpp
     MapRoundTripTest.cpp
     UndoServerWrapTest.cpp
 )

--- a/test/functional_tests/PackageSelfUninstallTest.cpp
+++ b/test/functional_tests/PackageSelfUninstallTest.cpp
@@ -1,0 +1,190 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Regression test for use-after-free when a package uninstalls itself from its
+ * own timer script or event-handler script (#9337 class, the remaining timer
+ * and script cases).
+ *
+ * Package auto-updaters commonly call uninstallPackage()+installPackage() on
+ * their own package from one of the package's own items. Since the
+ * *Unit::uninstall() methods started deleting items immediately (instead of
+ * just unregistering them), doing that from a timer deleted the very TTimer
+ * whose execute() was still on the call stack, and doing it from an event
+ * handler deleted TScript objects that Host::raiseEvent() was still iterating
+ * over - heap corruption either way. TriggerUnit/AliasUnit/KeyUnit gained a
+ * processing-depth deferral in #9383; this covers TimerUnit and ScriptUnit.
+ *
+ * Under AddressSanitizer the pre-fix code aborts with heap-use-after-free
+ * inside TTimer::execute() / Host::raiseEvent(); with the deferral in place
+ * both scenarios complete cleanly.
+ *
+ * Run with: ctest -R PackageSelfUninstallTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QTemporaryDir>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "ScriptUnit.h"
+#include "TEvent.h"
+#include "TScript.h"
+#include "TTimer.h"
+#include "TimerUnit.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForPackageSelfUninstallTest();
+
+class PackageSelfUninstallTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    const QString mProfileName = qsl("PackageSelfUninstall-Test");
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForPackageSelfUninstallTest();
+
+        // Keep the test hermetic: point the config dir resolution at a
+        // temporary directory instead of the user's real profiles.
+        QVERIFY(mConfigDir.isValid());
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QVERIFY2(mudlet::self()->getHostManager().addHost(mProfileName, QString(), QString(), QString()), "failed to create the Host");
+        mpHost = mudlet::self()->getHostManager().getHost(mProfileName);
+        QVERIFY(mpHost);
+        // A bare Host blocks script compilation until the full profile boot
+        // would normally clear this; the test's scripts need to compile:
+        mpHost->mBlockScriptCompile = false;
+        // NB: mLoadedOk is left false on purpose - the deferred saveProfile()
+        // that uninstallPackage() schedules then declines to run, which this
+        // console-less test Host could not service anyway.
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // A package's event-handler script uninstalls its own package while
+    // Host::raiseEvent() is mid-dispatch. The second handler in the same
+    // package is what the pre-fix code would have called through a freed
+    // TScript pointer.
+    void test_scriptEventHandlerSelfUninstall()
+    {
+        const QString packageName = qsl("selfuninstall-script");
+        mpHost->mInstalledPackages << packageName;
+
+        auto pUninstaller = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pUninstaller);
+        pUninstaller->mPackageName = packageName;
+        pUninstaller->setName(qsl("selfUninstallHandler"));
+        QVERIFY2(pUninstaller->setScript(qsl("function selfUninstallHandler(event)\n    uninstallPackage(\"%1\")\nend\n").arg(packageName)), "uninstaller handler script failed to compile");
+        pUninstaller->setEventHandlerList(QStringList{qsl("testSelfUninstallEvent")});
+        pUninstaller->setIsActive(true);
+
+        auto pBystander = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pBystander);
+        pBystander->mPackageName = packageName;
+        pBystander->setName(qsl("selfUninstallBystander"));
+        QVERIFY2(pBystander->setScript(qsl("function selfUninstallBystander(event)\nend\n")), "bystander handler script failed to compile");
+        pBystander->setEventHandlerList(QStringList{qsl("testSelfUninstallEvent")});
+        pBystander->setIsActive(true);
+
+        TEvent event{};
+        event.mArgumentList.append(qsl("testSelfUninstallEvent"));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        // Pre-fix this dispatch freed both TScripts under raiseEvent()'s feet:
+        mpHost->raiseEvent(event);
+
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "package was not uninstalled");
+        // The deferred deletes must have been flushed once the dispatch ended:
+        QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("selfUninstallHandler")).empty(), "uninstalled script is still registered");
+        QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("selfUninstallBystander")).empty(), "uninstalled script is still registered");
+    }
+
+    // A package's timer script uninstalls its own package while
+    // TTimer::execute() is still on the call stack for that timer. Pre-fix,
+    // execute() would resume on a freed `this`.
+    void test_timerScriptSelfUninstall()
+    {
+        const QString packageName = qsl("selfuninstall-timer");
+        mpHost->mInstalledPackages << packageName;
+
+        auto pTimer = new TTimer(qsl("selfUninstallTimer"), QTime(0, 0, 0, 250), mpHost);
+        mpHost->getTimerUnit()->registerTimer(pTimer);
+        pTimer->mPackageName = packageName;
+        QVERIFY2(pTimer->setScript(qsl("uninstallPackage(\"%1\")").arg(packageName)), "timer script failed to compile");
+        pTimer->setIsActive(true);
+        pTimer->enableTimer();
+
+        // Let the timer fire and take its package (and itself) down:
+        QTRY_VERIFY_WITH_TIMEOUT(!mpHost->mInstalledPackages.contains(packageName), 5000);
+
+        // Allow any queued activity (the declined deferred save, further timer
+        // ticks) to surface problems:
+        QTest::qWait(500);
+        // mudlet::slot_timerFires() flushes the deferred delete as soon as the
+        // uninstalling timer's execute() has finished, so by now the timer must
+        // be properly gone - not lingering deactivated where the next profile
+        // save would serialize it back in:
+        QVERIFY2(!mpHost->getTimerUnit()->findFirstTimer(qsl("selfUninstallTimer")), "uninstalled package timer is still registered");
+    }
+};
+
+void initializeQRCResourcesForPackageSelfUninstallTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "PackageSelfUninstallTest.moc"
+QTEST_MAIN(PackageSelfUninstallTest)

--- a/test/functional_tests/PackageSelfUninstallTest.cpp
+++ b/test/functional_tests/PackageSelfUninstallTest.cpp
@@ -26,14 +26,17 @@
  * their own package from one of the package's own items. Since the
  * *Unit::uninstall() methods started deleting items immediately (instead of
  * just unregistering them), doing that from a timer deleted the very TTimer
- * whose execute() was still on the call stack, and doing it from an event
- * handler deleted TScript objects that Host::raiseEvent() was still iterating
- * over - heap corruption either way. TriggerUnit/AliasUnit/KeyUnit gained a
- * processing-depth deferral in #9383; this covers TimerUnit and ScriptUnit.
+ * whose execute() was still on the call stack; doing it from an event handler
+ * deleted TScript objects that Host::raiseEvent() was still iterating over; and
+ * doing it from a script's top-level body deleted the very TScript that
+ * compileScript() was in the middle of compiling - heap corruption every way.
+ * TriggerUnit/AliasUnit/KeyUnit gained a processing-depth deferral in #9383;
+ * this covers TimerUnit and ScriptUnit (both the event-dispatch and the
+ * compile-time body paths).
  *
  * Under AddressSanitizer the pre-fix code aborts with heap-use-after-free
- * inside TTimer::execute() / Host::raiseEvent(); with the deferral in place
- * both scenarios complete cleanly.
+ * inside TTimer::execute() / Host::raiseEvent() / TScript::compileScript(); with
+ * the deferral in place all scenarios complete cleanly.
  *
  * Run with: ctest -R PackageSelfUninstallTest -V
  */
@@ -142,6 +145,85 @@ private slots:
         QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("selfUninstallBystander")).empty(), "uninstalled script is still registered");
     }
 
+    // A package script's TOP-LEVEL body (not an event handler) uninstalls its own
+    // package while it is being compiled - the path profile boot and reset take
+    // when they run "all the Lua code outside of functions" via ScriptUnit::compileAll().
+    // Pre-fix, ScriptUnit::uninstall() deleted the script immediately: compileScript()
+    // then wrote to the freed TScript (heap-use-after-free WRITE at TScript::compileScript),
+    // and compileAll()'s range-for walked onto the freed std::list node it had unlinked.
+    void test_scriptBodySelfUninstallOnCompile()
+    {
+        const QString packageName = qsl("selfuninstall-script-compile");
+        mpHost->mInstalledPackages << packageName;
+
+        // Defer compilation so the bodies run through compileAll() below rather than
+        // from setScript() here, mirroring how a freshly loaded package's scripts are
+        // compiled at profile boot (mudlet::loadProfile) and reset (Host::resetProfile_phase2):
+        mpHost->mBlockScriptCompile = true;
+
+        auto pUninstaller = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pUninstaller);
+        pUninstaller->mPackageName = packageName;
+        pUninstaller->setName(qsl("selfUninstallOnCompile"));
+        // A bare uninstallPackage() at the top level runs the moment the script is compiled:
+        pUninstaller->setScript(qsl("uninstallPackage(\"%1\")").arg(packageName));
+        pUninstaller->setIsActive(true);
+
+        // A second script in the same package, registered AFTER the uninstaller, is
+        // the node the pre-fix immediate delete unlinks from under compileAll()'s loop:
+        auto pBystander = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pBystander);
+        pBystander->mPackageName = packageName;
+        pBystander->setName(qsl("selfUninstallCompileBystander"));
+        pBystander->setScript(qsl("local noop = true\n"));
+        pBystander->setIsActive(true);
+
+        mpHost->mBlockScriptCompile = false;
+        // Pre-fix this trips heap-use-after-free; post-fix the delete is deferred until
+        // after the loop and then flushed by compileAll():
+        mpHost->getScriptUnit()->compileAll();
+
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "package was not uninstalled");
+        // The deferred deletes must have been flushed at the end of compileAll():
+        QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("selfUninstallOnCompile")).empty(), "uninstalled script is still registered");
+        QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("selfUninstallCompileBystander")).empty(), "uninstalled bystander script is still registered");
+    }
+
+    // A package script's top-level body uninstalls its own package from a plain
+    // setScript() compile - the path permScript()/setScript() take when invoked from
+    // an alias, key or the command line, none of which sit inside compileAll(), the
+    // editor's saveScript(), or raiseEvent(). Pre-fix this hit the same
+    // heap-use-after-free in compileScript() as the compileAll() case. The compile
+    // guard defers the delete here too; because this entry point has no synchronous
+    // flush of its own, the deferred script lingers (deactivated) until a catch-all
+    // flush - ScriptUnit::doCleanup() via Host::incomingStreamProcessor()/
+    // slot_purgeTemps(), or the doCleanup() Host::uninstallPackage()'s queued save runs
+    // - collects it, which must happen without leaking or double-freeing.
+    void test_scriptBodySelfUninstallFromSetScript()
+    {
+        const QString packageName = qsl("selfuninstall-script-setscript");
+        mpHost->mInstalledPackages << packageName;
+
+        auto pUninstaller = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pUninstaller);
+        pUninstaller->mPackageName = packageName;
+        pUninstaller->setName(qsl("selfUninstallFromSetScript"));
+        // mBlockScriptCompile is false, so setScript() compiles and runs the top-level
+        // body immediately - uninstallPackage() fires from inside compileScript():
+        pUninstaller->setScript(qsl("uninstallPackage(\"%1\")").arg(packageName));
+
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "package was not uninstalled");
+
+        // No synchronous flush point covers this entry, so the script is still
+        // registered (deferred, deactivated) right after setScript() returns:
+        QVERIFY2(!mpHost->getScriptUnit()->findItems(qsl("selfUninstallFromSetScript")).empty(), "self-uninstalling script should still be deferred, not yet deleted");
+
+        // The catch-all flush (as wired into incomingStreamProcessor()/slot_purgeTemps())
+        // must then collect it cleanly - no leak, no double-free:
+        mpHost->getScriptUnit()->doCleanup();
+        QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("selfUninstallFromSetScript")).empty(), "deferred uninstalled script was not flushed");
+    }
+
     // A package's timer script uninstalls its own package while
     // TTimer::execute() is still on the call stack for that timer. Pre-fix,
     // execute() would resume on a freed `this`.
@@ -153,7 +235,13 @@ private slots:
         auto pTimer = new TTimer(qsl("selfUninstallTimer"), QTime(0, 0, 0, 250), mpHost);
         mpHost->getTimerUnit()->registerTimer(pTimer);
         pTimer->mPackageName = packageName;
-        QVERIFY2(pTimer->setScript(qsl("uninstallPackage(\"%1\")").arg(packageName)), "timer script failed to compile");
+        // The trailing error() is what makes this a genuine regression test: after
+        // uninstallPackage() has (pre-fix) freed this timer, the error aborts the
+        // Lua call so it returns false, and TTimer::execute() then resumes past the
+        // call and reads the freed `this` at `mpQTimer->stop()` - the heap-use-after-free
+        // the deferral prevents. Without the error the call returns cleanly and
+        // execute() never touches `this` again, so the bug would go undetected.
+        QVERIFY2(pTimer->setScript(qsl("uninstallPackage(\"%1\")\nerror(\"boom\")").arg(packageName)), "timer script failed to compile");
         pTimer->setIsActive(true);
         pTimer->enableTimer();
 

--- a/test/functional_tests/ProfileLoadTempFileTest.cpp
+++ b/test/functional_tests/ProfileLoadTempFileTest.cpp
@@ -1,0 +1,193 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Regression test for profile data-loss after a crash during save.
+ *
+ * Profile saves go through QSaveFile: the data is written to a randomly named
+ * temporary next to the target ("<name>.xml.AbCdEf") which is renamed over the
+ * real file on commit. If Mudlet dies mid-save, that temporary is left behind,
+ * empty, as the NEWEST file in the profile's current/ directory.
+ *
+ * mudlet::loadProfile() used to load the newest file of ANY name from
+ * current/, so after such a crash it would "load" the empty leftover instead
+ * of the newest real save: the profile opened with its connection settings
+ * (stored in separate files) intact but every trigger/alias/script seemingly
+ * wiped out. This test crashes a save in effigy - by planting an empty
+ * QSaveFile-style leftover newer than a real save - and verifies the loader
+ * skips it and restores the real data.
+ *
+ * Run with: ctest -R ProfileLoadTempFileTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QTemporaryDir>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TTrigger.h"
+#include "TriggerUnit.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForProfileLoadTempFileTest();
+
+namespace {
+// A minimal but complete profile save holding one trigger - the "guts" whose
+// survival the test asserts:
+const QString scmTriggerName = qsl("synthetic data-loss canary");
+const QString scmProfileXml = qsl(R"(<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE MudletPackage>
+<MudletPackage version="1.001">
+<TriggerPackage>
+<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+<name>synthetic data-loss canary</name>
+<script>-- intentionally empty</script>
+<triggerType>0</triggerType>
+<conditonLineDelta>0</conditonLineDelta>
+<mStayOpen>0</mStayOpen>
+<mCommand></mCommand>
+<packageName></packageName>
+<mFgColor>#ff0000</mFgColor>
+<mBgColor>#ffff00</mBgColor>
+<mSoundFile></mSoundFile>
+<colorTriggerFgColor>#000000</colorTriggerFgColor>
+<colorTriggerBgColor>#000000</colorTriggerBgColor>
+<regexCodeList>
+<string>^synthetic pattern$</string>
+</regexCodeList>
+<regexCodePropertyList>
+<integer>1</integer>
+</regexCodePropertyList>
+</Trigger>
+</TriggerPackage>
+</MudletPackage>
+)");
+} // namespace
+
+class ProfileLoadTempFileTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    const QString mProfileName = qsl("ProfileLoadTempFile-Test");
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+
+    static bool setModificationTime(const QString& path, const QDateTime& when)
+    {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadWrite)) {
+            return false;
+        }
+        return file.setFileTime(when, QFileDevice::FileModificationTime);
+    }
+
+    // setupConfig() prefers a portable.txt marker over the XDG override; skip
+    // rather than report a baffling failure if one is present:
+    bool portableMarkerPresent() const
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForProfileLoadTempFileTest();
+
+        // Keep the test hermetic: point the config dir resolution at a
+        // temporary directory instead of the user's real profiles.
+        QVERIFY(mConfigDir.isValid());
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt marker present - config dir cannot be redirected for this test");
+        }
+        QVERIFY2(mudlet::getMudletPath(enums::profilesPath).startsWith(mConfigDir.path()), "test config dir redirection did not take effect");
+    }
+
+    void cleanupTestCase()
+    {
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_loaderSkipsLeftoverSaveTemporary()
+    {
+        // 1. A real save, holding one trigger:
+        const QString folder = mudlet::getMudletPath(enums::profileXmlFilesPath, mProfileName);
+        QVERIFY(QDir().mkpath(folder));
+        const QString xmlPath = qsl("%1/2020-01-01#00-00-00.xml").arg(folder);
+        {
+            QFile xmlFile(xmlPath);
+            QVERIFY(xmlFile.open(QIODevice::WriteOnly | QIODevice::Text));
+            QVERIFY(xmlFile.write(scmProfileXml.toUtf8()) > 0);
+        }
+
+        // 2. What a crash mid-save leaves behind: an empty QSaveFile temporary
+        //    that is the newest file in current/:
+        const QString leftoverPath = qsl("%1/2020-01-02#00-00-00.xml.AbCdEf").arg(folder);
+        {
+            QFile leftover(leftoverPath);
+            QVERIFY(leftover.open(QIODevice::WriteOnly));
+        }
+        const QDateTime now = QDateTime::currentDateTime();
+        QVERIFY(setModificationTime(xmlPath, now.addSecs(-3600)));
+        QVERIFY(setModificationTime(leftoverPath, now));
+
+        // 3. Load the profile through the production loader; it must pick the
+        //    real save, not the newer empty leftover:
+        Host* pHost = mudlet::self()->loadProfile(mProfileName, false);
+        QVERIFY(pHost);
+        QVERIFY2(pHost->mLoadedOk, "loader tried to load a leftover QSaveFile temporary instead of the newest real save");
+        QVERIFY2(pHost->getTriggerUnit()->findTrigger(scmTriggerName), "trigger from the real save is missing - the profile lost its data");
+    }
+};
+
+void initializeQRCResourcesForProfileLoadTempFileTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "ProfileLoadTempFileTest.moc"
+QTEST_MAIN(ProfileLoadTempFileTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Profile loading now only considers real `*.xml` saves: an empty QSaveFile temporary left behind by a crash during a save can no longer be loaded as "the profile", which made a profile open with its connection settings intact but every trigger/script seemingly gone. Affected profiles heal themselves on next load by falling back to the newest real save.
- Packages that uninstall themselves from their own timer script or event-handler script (a common auto-updater pattern) no longer free the very objects still executing: `TimerUnit`/`ScriptUnit` uninstall now defers deletion while `TTimer::execute()` / `Host::raiseEvent()` are on the call stack, completing the #9337/#9383 fix that already covered triggers/aliases/keys. Deferred timer deletes are flushed before the queued post-uninstall save runs, so removed items cannot be serialized back into the profile.
- `Host::saveProfile()`'s background module task no longer reads `writers`/`saveFutures` concurrently with the main thread (data race in the profile save path).

#### Motivation for adding to Mudlet
Fixes a real-world heap-corruption crash cluster (Sentry MUDLET-32 / MUDLET-2S / MUDLET-48: `STATUS_HEAP_CORRUPTION` on 4.21.0/4.21.1, frames touching lua51/Qt6Core/libpugixml, breadcrumbs showing package uninstall activity around saves) and the profile data loss it caused.

#### Other info (issues closed, discussion etc)
Root cause of the crashes: #9111 (in the 4.20.1 → 4.21.0 window) changed the `*Unit::uninstall()` methods from unregister-only to immediate `delete`. A package script calling `uninstallPackage()` on its own package then freed objects still on the call stack - use-after-free that poisons the heap, typically detected slightly later during the background save serialization (hence the pugixml/lua frames, aborts mid-save, and zero-byte `....xml.XXXXXX` QSaveFile leftovers in `current/`). #9383 fixed the trigger/alias/key cases; this completes timers and scripts, which reproduce under ASan on current development (heap-use-after-free in `Tree<TScript>::isActive()` / `TTimer::execute()`).

Data-loss mechanism (generic): a crash mid-save leaves a 0-byte QSaveFile temporary as the newest file in `current/`; `mudlet::loadProfile()` picked the newest file of any name, tried to load the empty temp, and the profile opened "gutted" (connection details live in separate files and survived). Verified end-to-end with affected profile data and covered by a synthetic regression test.

Both new functional tests fail on pre-fix code (`PackageSelfUninstallTest` trips ASan heap-use-after-free; `ProfileLoadTempFileTest` reproduces the data loss) and pass with the fix; full functional suite green (24/24).

Known remaining (pre-existing) issue documented in-code at `Host::pendingXmlSaveFutures()`: module writing still touches `writers` from the background task for profiles that use modules; fixing that properly means moving module serialization back to the main thread and deserves its own PR.

**Test case:**
1. Create a package containing a timer or event-handler script that calls `uninstallPackage()` on its own package, and let it fire - no crash, package cleanly removed, next save does not resurrect it.
2. Simulate an interrupted save: place an empty file named like `2026-01-01#12-00-00.xml.AbCdEf` in a profile's `current/` folder with the newest timestamp - the profile still loads the newest real save with all triggers intact, and the temporary no longer appears in Connect → Options → Profile history.
3. `ctest -R "ProfileLoadTempFileTest|PackageSelfUninstallTest"` in an ASan (default Debug) build.


Assisted-by: Claude:claude-fable-5
Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
