### PR TITLE
improve: do not copy leading spaces in multi-line select

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2283,12 +2283,9 @@ QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTime
             textLines[0] = textLines.at(0).mid(startPos, endPos - startPos + 1);
         }
     } else {
-        // replace a number of QChars at the front with a corresponding
-        // number of spaces to push the first line to the right so it lines up
-        // with the following lines:
+        // trim characters off the front of the first line according to startPos:
         if (!textLines.at(0).isEmpty()) {
             textLines[0] = textLines.at(0).mid(startPos);
-            textLines[0] = QString(QChar::Space).repeated(startPos) % textLines.at(0);
         }
         // and chop off the required number of QChars from the end of the last
         // line:


### PR DESCRIPTION
Copying text from the main console no longer pads the first line with extra leading spaces when a multi-line selection starts in the middle of a line.

Previously, if you started a copy partway through a line (e.g. selecting "is a fat dog" out of "My dog is a fat \ndog") and the selection continued onto the next line, the pasted text would come out with the first line padded with blank spaces equal to the starting column offset e.g. pasting "       is a fat dog" instead of "is a fat dog".

This change removes that padding so copied text matches what was actually selected.
<img width="1152" height="892" alt="Screenshot 2026-07-29 at 8 40 11 AM" src="https://github.com/user-attachments/assets/e767b9aa-b416-4616-b1f8-1fed65794706" />


#### Motivation for adding to Mudlet

Constantly having to fix the copy/paste by removing unexpected whitespace

#### Other info (issues closed, discussion etc)

Closes: [#4956](https://github.com/Mudlet/Mudlet/issues/4956)

A companion Lua package, ["Aligned Copy"](https://github.com/Mudlet/mudlet-package-repository/pull/739), has been published to the Mudlet package repository for anyone who relied on the old column-aligned behaviour (e.g. for preserving indentation when copying ASCII maps/tables). It adds a separate, opt-in "Copy (aligned)" entry to the main console's right-click menu that reproduces the previous padding behaviour, so this fix removes the padding by default without removing the functionality for those who want it. 