### PR TITLE
infrastructure: document un-suppressible <unknown module> CI leak flakes

### DIFF
--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -15,6 +15,13 @@
 # Qt modules) - a suppression matches if ANY frame does, so those can hide
 # genuine Mudlet leaks too.
 #
+# A leak: line can only match a frame that still resolves to a module path or a
+# symbol name. Leaks reported as "<unknown module>" with no symbols cannot be
+# matched by any leak: line: the allocating library was dlclose()d (or the code
+# was JITed) before LeakSanitizer runs at exit, so there is no name left to
+# compare against. Those have to be handled at their source, not here - see the
+# GPU driver note below for the recurring example.
+#
 # See: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
 
 # ==============================================================================
@@ -25,6 +32,18 @@
 leak:libcuda.so
 leak:nvidia
 leak:_dri.so
+
+# leak:_dri.so above can only match when the driver is still mapped at process
+# exit, where LeakSanitizer runs its check. Mesa dlopen()s a DRI driver on first
+# GL use and dlclose()s it when the last GL context - e.g. the 3D map view's
+# QOpenGLWidget - is torn down. A driver-init allocation that leaks and is then
+# unloaded before exit is reported as "<unknown module>" (the .so is gone by the
+# time LeakSanitizer runs), so NO leak: line can match it. On the CI leak job
+# (Ubuntu 22.04) this recurs as a small (~240 byte) realloc+calloc leak during
+# mudlet teardown and flakes across unrelated PRs; it does not reproduce on newer
+# Mesa. Do not try to silence it with a leak: line here (there is no name to
+# match) - keep the GL context from being created/destroyed under the sanitizer
+# test-side instead, as PR #9534 did for the show3dMapView test.
 
 # ==============================================================================
 # Fontconfig library leaks


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Comment-only change to `asan-suppressions.txt` (the LeakSanitizer list used by the `ubuntu / gcc / lua tests + leak detection` CI job). It adds two documentation notes and changes **no** functional `leak:` line:

1. A general note in the header: a `leak:` line can only match a frame that still resolves to a module path or a symbol name, so a leak reported as `<unknown module>` (the allocating library was `dlclose()`d, or the code was JITed, before LeakSanitizer runs at exit) cannot be matched by any `leak:` line.
2. A specific note under the GPU-driver section: the recurring `~240 byte` realloc+calloc leak that flakes the leak job across unrelated PRs is a Mesa DRI driver **teardown** leak of exactly this `<unknown module>` kind, and must be handled test-side (as PR #9534 did for the `show3dMapView` test), not with an ineffective `leak:` line.

#### Motivation for adding to Mudlet

I looked into whether the recurring `lua tests + leak detection` flakes could be durably fixed by extending the suppression list. After pulling the actual leak stacks from the recent failing runs and reproducing the busted leak recipe locally under ASan, the honest finding is that **none of the observed recurring third-party leaks can be safely added as a `leak:` line**:

- **Mesa DRI driver teardown leak (the recurring cross-PR flake).** 128-byte `realloc` + 2x 56-byte `calloc` = 240 bytes, all `<unknown module>` with zero symbols. Byte-for-byte identical across #9534 (pre-fix) and #9550, with matching sub-offsets under ASLR - i.e. the same `dlclose()`d `.so`. Because the module is gone before LeakSanitizer runs at exit, no `leak:` line can match it; the existing `leak:_dri.so` only fires while the driver is still mapped. PR #9534 correctly handled this test-side.
- **`QNetworkRequest` / `QUrl` / `QHttp2Configuration` leaks (#9535, #9551).** These symbolize to `libQt6Network`, but they originate from Mudlet's own binary frames (the PIE main executable) - they are genuine Mudlet-owned ownership leaks being fixed in those PRs. Suppressing `libQt6Network` would permanently hide real Mudlet network leaks, so they are deliberately left alone.

So rather than add speculative lines that match nothing (or dangerous ones that hide real bugs), this PR records the reasoning in the file itself, so the next person who hits an `<unknown module>` leak does not waste time adding a `leak:swrast_dri.so`-style line and instead handles it at the source.

Durable alternatives for the Mesa flake, not done here because they cannot be verified without the CI (jammy) toolchain / a local repro and carry behaviour-change risk: keep handling it test-side per #9534, or add a leak-job workflow env that keeps the driver resident / avoids the incidental GL context so the leak becomes nameable. 

#### Other info (issues closed, discussion etc)

- The suppression file is embedded at compile time (`LsanSuppressions.h.in` -> `__lsan_default_suppressions()` in `src/main.cpp`) **and** passed at runtime via `LSAN_OPTIONS` in the leak job; LeakSanitizer merges both (verified locally: with an empty runtime file the embedded defaults still fired).
- Verified locally: built with `-DUSE_SANITIZER=address` and ran the busted leak recipe (`AUTORUN_BUSTED_TESTS`, `detect_leaks=1`, `exitcode=1`, clean HOME, under Xvfb). Suite passes 1104/0/0 with no leak; the comment change embeds and compiles cleanly. The Mesa `<unknown module>` leak does not reproduce on newer Mesa (25.2), consistent with it being a jammy-toolchain flake - so the Mesa claims are reasoned from the CI logs, not locally reproduced.
- No functional suppression line was added or changed; this is documentation to prevent ineffective/dangerous suppressions.
