### PR TITLE
Infrastucture: ignore multiple build targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,7 @@ CMakeLists.txt.user
 
 #CLion
 .idea
-cmake-build-debug
-cmake-build-minsizerel
-cmake-build-release
-cmake-build-relwithdebinfo
+cmake-build-*/
 
 #VS Code
 .vscode/*.code-workspace


### PR DESCRIPTION
 so any local custom target is already excluded