### PR TITLE
infrastructure: document the LSan tracer-crash CI flake

### DIFF
--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -44,6 +44,22 @@ leak:_dri.so
 # Mesa. Do not try to silence it with a leak: line here (there is no name to
 # match) - keep the GL context from being created/destroyed under the sanitizer
 # test-side instead, as PR #9534 did for the show3dMapView test.
+#
+# A second un-suppressible flake lives on the same CI job: LeakSanitizer's
+# stop-the-world tracer - the helper process that ptrace-attaches at exit to
+# scan memory for live pointers - itself segfaults while driver/X teardown is
+# still removing mappings under it. The job log then ends with
+#   Tracer caught signal 11: addr=0x... pc=0x... sp=0x...
+#   ==NNNNN==LeakSanitizer has encountered a fatal error.
+# right after "mudlet::~mudlet() INFO - uninstalling translation...", with no
+# leak report at all, and the busted summary line goes missing too (LSan's
+# Die() skips the stdio flush - the Lua tests themselves passed). Since
+# exitcode=1 the job fails. Suppressions filter leak *reports*, and this
+# aborts before reporting begins, so nothing in this file can help; it is
+# also unrelated to the change under test (the same faulting instruction was
+# observed on development-branch runs 26705214438 and 28641460889 and on PR
+# run 30744002320, at a rate of roughly 1 in 250-500 leak-job runs). If a
+# leak job fails with this signature, just re-run it.
 
 # ==============================================================================
 # Fontconfig library leaks

--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -47,8 +47,8 @@ leak:_dri.so
 #
 # A second un-suppressible flake lives on the same CI job: LeakSanitizer's
 # stop-the-world tracer - the helper process that ptrace-attaches at exit to
-# scan memory for live pointers - itself segfaults while driver/X teardown is
-# still removing mappings under it. The job log then ends with
+# scan memory for live pointers - itself segfaults during exit-time teardown,
+# apparently racing driver/X cleanup. The job log then ends with
 #   Tracer caught signal 11: addr=0x... pc=0x... sp=0x...
 #   ==NNNNN==LeakSanitizer has encountered a fatal error.
 # right after "mudlet::~mudlet() INFO - uninstalling translation...", with no


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Comment-only addition to `asan-suppressions.txt`, next to the existing `<unknown module>` Mesa flake note.
- Documents a rare CI flake: LeakSanitizer's stop-the-world tracer segfaults ("Tracer caught signal 11") during exit, aborting before any leak report - the job then fails on exitcode=1 with no actual leak found.
- No `leak:` line can fix it; seen on development runs 26705214438 / 28641460889 and PR run 30744002320, roughly 1 in 250-500 leak-job runs. Remedy is re-running the job.

#### Motivation for adding to Mudlet

So the next person who hits this failure doesn't have to re-derive that it's a flake and can just re-run the job.

#### Other info (issues closed, discussion etc)

Comment-only change - nothing to test.

Assisted-by: Claude:claude-fable-5