### PR TITLE
infrastructure: run the HTTP fixture server on Windows CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# CI/http-fixtures/ is served byte for byte to the networking specs, which
+# assert the exact bodies that come back, so a Windows checkout must not turn
+# its newlines into CRLF.
+CI/http-fixtures/** -text

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -113,11 +113,13 @@ jobs:
         QT_FORCE_STDERR_LOGGING: 1
 
     - name: (Windows) Run Lua tests
-      timeout-minutes: 1
+      timeout-minutes: 2
       shell: msys2 {0}
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
+        MUDLET_TEST_REQUIRE_TTS_MOCK: 1
+        MUDLET_TEST_REQUIRE_HTTP_FIXTURE: 1
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
@@ -125,6 +127,39 @@ jobs:
         export LUA_PATH
         LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
         export LUA_CPATH
+
+        # Linux and macOS start the fixture HTTP server in a step of their own,
+        # but each msys2 step here is its own shell and a process backgrounded
+        # in one is not guaranteed to still be around in the next, so start the
+        # server in the very shell that runs the tests and stop it on the way
+        # out. Paths are handed over in mixed form (C:/...) because bash and
+        # the native Windows python both understand that.
+        temp_dir="$(cygpath -m "${RUNNER_TEMP}")"
+        port_file="${temp_dir}/mudlet-http-fixture-port"
+        fixture_log="${temp_dir}/http-fixture-server.log"
+        rm -f "${port_file}"
+        python_bin=python3
+        command -v "${python_bin}" > /dev/null 2>&1 || python_bin=python
+        MUDLET_TEST_HTTP_PORT_FILE="${port_file}" "${python_bin}" "$GITHUB_WORKSPACE/CI/http-fixture-server.py" > "${fixture_log}" 2>&1 &
+        fixture_pid=$!
+        trap 'kill "${fixture_pid}" > /dev/null 2>&1 || true' EXIT
+        for _ in $(seq 1 100); do
+          [ -s "${port_file}" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${port_file}" ]; then
+          echo "fixture HTTP server failed to start" >&2
+          cat "${fixture_log}" 2>/dev/null || true
+          exit 1
+        fi
+        MUDLET_TEST_HTTP_PORT="$(cat "${port_file}")"
+        export MUDLET_TEST_HTTP_PORT
+        if ! curl -fsS "http://127.0.0.1:${MUDLET_TEST_HTTP_PORT}/fixture.txt" > /dev/null; then
+          echo "fixture HTTP server is not serving fixtures" >&2
+          cat "${fixture_log}" 2>/dev/null || true
+          exit 1
+        fi
+        echo "fixture HTTP server ready on 127.0.0.1:${MUDLET_TEST_HTTP_PORT}"
 
         $GITHUB_WORKSPACE/build-$MSYSTEM/release/mudlet.exe --profile "Mudlet self-test"
 

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -142,21 +142,24 @@ jobs:
         command -v "${python_bin}" > /dev/null 2>&1 || python_bin=python
         MUDLET_TEST_HTTP_PORT_FILE="${port_file}" "${python_bin}" "$GITHUB_WORKSPACE/CI/http-fixture-server.py" > "${fixture_log}" 2>&1 &
         fixture_pid=$!
-        trap 'kill "${fixture_pid}" > /dev/null 2>&1 || true' EXIT
+        # Disowned so that stopping it is not reported as a job crash, and -9
+        # because a plain SIGTERM does not reach a native Windows process from
+        # msys2. The server's log is one line when all is well, so print it
+        # either way rather than only where trouble is expected.
+        disown "${fixture_pid}" 2>/dev/null || true
+        trap 'kill -9 "${fixture_pid}" > /dev/null 2>&1 || true; cat "${fixture_log}" 2>/dev/null || true' EXIT
         for _ in $(seq 1 100); do
           [ -s "${port_file}" ] && break
           sleep 0.1
         done
         if [ ! -s "${port_file}" ]; then
           echo "fixture HTTP server failed to start" >&2
-          cat "${fixture_log}" 2>/dev/null || true
           exit 1
         fi
         MUDLET_TEST_HTTP_PORT="$(cat "${port_file}")"
         export MUDLET_TEST_HTTP_PORT
-        if ! curl -fsS "http://127.0.0.1:${MUDLET_TEST_HTTP_PORT}/fixture.txt" > /dev/null; then
+        if ! curl -fsS --max-time 10 "http://127.0.0.1:${MUDLET_TEST_HTTP_PORT}/fixture.txt" > /dev/null; then
           echo "fixture HTTP server is not serving fixtures" >&2
-          cat "${fixture_log}" 2>/dev/null || true
           exit 1
         fi
         echo "fixture HTTP server ready on 127.0.0.1:${MUDLET_TEST_HTTP_PORT}"

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -148,21 +148,24 @@ jobs:
         command -v "${python_bin}" > /dev/null 2>&1 || python_bin=python
         MUDLET_TEST_HTTP_PORT_FILE="${port_file}" "${python_bin}" "$GITHUB_WORKSPACE/CI/http-fixture-server.py" > "${fixture_log}" 2>&1 &
         fixture_pid=$!
-        trap 'kill "${fixture_pid}" > /dev/null 2>&1 || true' EXIT
+        # Disowned so that stopping it is not reported as a job crash, and -9
+        # because a plain SIGTERM does not reach a native Windows process from
+        # msys2. The server's log is one line when all is well, so print it
+        # either way rather than only where trouble is expected.
+        disown "${fixture_pid}" 2>/dev/null || true
+        trap 'kill -9 "${fixture_pid}" > /dev/null 2>&1 || true; cat "${fixture_log}" 2>/dev/null || true' EXIT
         for _ in $(seq 1 100); do
           [ -s "${port_file}" ] && break
           sleep 0.1
         done
         if [ ! -s "${port_file}" ]; then
           echo "fixture HTTP server failed to start" >&2
-          cat "${fixture_log}" 2>/dev/null || true
           exit 1
         fi
         MUDLET_TEST_HTTP_PORT="$(cat "${port_file}")"
         export MUDLET_TEST_HTTP_PORT
-        if ! curl -fsS "http://127.0.0.1:${MUDLET_TEST_HTTP_PORT}/fixture.txt" > /dev/null; then
+        if ! curl -fsS --max-time 10 "http://127.0.0.1:${MUDLET_TEST_HTTP_PORT}/fixture.txt" > /dev/null; then
           echo "fixture HTTP server is not serving fixtures" >&2
-          cat "${fixture_log}" 2>/dev/null || true
           exit 1
         fi
         echo "fixture HTTP server ready on 127.0.0.1:${MUDLET_TEST_HTTP_PORT}"

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -119,11 +119,13 @@ jobs:
         QT_FORCE_STDERR_LOGGING: 1
 
     - name: (Windows) Run Lua tests
-      timeout-minutes: 1
+      timeout-minutes: 2
       shell: msys2 {0}
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
+        MUDLET_TEST_REQUIRE_TTS_MOCK: 1
+        MUDLET_TEST_REQUIRE_HTTP_FIXTURE: 1
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
@@ -131,6 +133,39 @@ jobs:
         export LUA_PATH
         LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
         export LUA_CPATH
+
+        # Linux and macOS start the fixture HTTP server in a step of their own,
+        # but each msys2 step here is its own shell and a process backgrounded
+        # in one is not guaranteed to still be around in the next, so start the
+        # server in the very shell that runs the tests and stop it on the way
+        # out. Paths are handed over in mixed form (C:/...) because bash and
+        # the native Windows python both understand that.
+        temp_dir="$(cygpath -m "${RUNNER_TEMP}")"
+        port_file="${temp_dir}/mudlet-http-fixture-port"
+        fixture_log="${temp_dir}/http-fixture-server.log"
+        rm -f "${port_file}"
+        python_bin=python3
+        command -v "${python_bin}" > /dev/null 2>&1 || python_bin=python
+        MUDLET_TEST_HTTP_PORT_FILE="${port_file}" "${python_bin}" "$GITHUB_WORKSPACE/CI/http-fixture-server.py" > "${fixture_log}" 2>&1 &
+        fixture_pid=$!
+        trap 'kill "${fixture_pid}" > /dev/null 2>&1 || true' EXIT
+        for _ in $(seq 1 100); do
+          [ -s "${port_file}" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${port_file}" ]; then
+          echo "fixture HTTP server failed to start" >&2
+          cat "${fixture_log}" 2>/dev/null || true
+          exit 1
+        fi
+        MUDLET_TEST_HTTP_PORT="$(cat "${port_file}")"
+        export MUDLET_TEST_HTTP_PORT
+        if ! curl -fsS "http://127.0.0.1:${MUDLET_TEST_HTTP_PORT}/fixture.txt" > /dev/null; then
+          echo "fixture HTTP server is not serving fixtures" >&2
+          cat "${fixture_log}" 2>/dev/null || true
+          exit 1
+        fi
+        echo "fixture HTTP server ready on 127.0.0.1:${MUDLET_TEST_HTTP_PORT}"
 
         $GITHUB_WORKSPACE/build-$MSYSTEM/release/mudlet.exe --profile "Mudlet self-test"
 

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -19,7 +19,9 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 2.3.0    Switch from MINGW64 to CLANG64 
+# Version: 2.4.0    Add Python, needed by the fixture HTTP server the Lua
+#                   tests run against
+#          2.3.0    Switch from MINGW64 to CLANG64
 #          2.2.0    Add CMake package for CMake-based builds
 #          2.1.0    Remove MINGW32 since upstream no longer supports it
 #          2.0.0    Rework to build on an MSYS2 MINGW64 Github workflow
@@ -128,6 +130,7 @@ while true; do
     "${MINGW_PACKAGE_PREFIX}-ninja" \
     "${MINGW_PACKAGE_PREFIX}-assimp" \
     "${MINGW_PACKAGE_PREFIX}-curl" \
+    "${MINGW_PACKAGE_PREFIX}-python" \
     "${MINGW_PACKAGE_PREFIX}-uasm" \
     "${MINGW_PACKAGE_PREFIX}-cmake" \
     "${MINGW_PACKAGE_PREFIX}-jq"; then


### PR DESCRIPTION
The 17 HTTP effect specs from #9573 only run where the fixture HTTP server runs, and today that is Linux and macOS - on Windows they pend, so the getHTTP/postHTTP/downloadFile family goes untested on the platform most Mudlet users are on.

- start `CI/http-fixture-server.py` in the Windows job and hand its ephemeral port to Mudlet as `MUDLET_TEST_HTTP_PORT`, the same handoff Linux and macOS use. It starts inside the test step rather than in a step of its own, because each msys2 step is a fresh shell and a process backgrounded in one is not guaranteed to still be there in the next
- set `MUDLET_TEST_REQUIRE_HTTP_FIXTURE=1` and `MUDLET_TEST_REQUIRE_TTS_MOCK=1` there, so a fixture or a mock TTS engine that goes missing fails the job instead of quietly pending the specs
- pin the fixtures to LF: Windows checks out with `core.autocrlf` on, which served the fixture as 32 bytes where the specs expect 31. Python is now declared in the Windows SDK script too, rather than arriving as a dependency of meson

Stacked on #9573, where the specs themselves live; the base retargets to development once that merges.

**Test case:** this PR's own Windows CI - `1356 successes / 0 failures / 0 errors / 2 pending` where it read `1339 successes / 0 failures / 0 errors / 19 pending` before, the 2 left over being the documented TTS bugs #9590 and #9591.

Assisted-by: Claude:claude-opus-5
