### PR TITLE
fix: eight Geyser widget bugs found by the new geometry specs

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -60,8 +60,10 @@ end
 -- @param format A format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, 's' - strikethrough,  '##' - font size.  For example, "cb18" specifies center bold 18pt font be used.  Order doesn't matter.
 function Adjustable.Container:setTitle(text, color, format)
     self.titleFormat = format or self.titleFormat or "l"
-    self.titleText = text or self.titleText or string.format("%s - Adjustable Container")
-    self.titleTxtColor = color or self.titleTxtColor or "green"
+    self.titleText = text or self.titleText or string.format("%s - Adjustable Container", self.name)
+    -- the fallback is only reached once resetTitle() has cleared the colour, so
+    -- it has to be the constructor's default for a reset to restore it
+    self.titleTxtColor = color or self.titleTxtColor or "grey"
     if self.locked and (self.connectedContainers or self.lockStyle == "standard" or self.lockStyle == "border" or self.lockStyle == "full") then
         return
     end
@@ -857,6 +859,81 @@ function Adjustable.Container:reposition()
     )
 end
 
+-- internal function: a container recreated under the same name builds its labels
+-- with the same widget names, so deleting the stale object must not take the live
+-- container's widgets with it
+-- @param label the label to delete if it is still the registered one
+local function deleteIfStillRegistered(label)
+    -- ask the container the label was added to: menu labels of a container that
+    -- lives in a user window are registered there, not in Geyser.windowList
+    local windowList = label and label.delete and label.container and label.container.windowList
+    if windowList and windowList[label.name] == label then
+        label:delete()
+    end
+end
+
+-- internal function to delete the "More..." labels doNestShow adds to a menu that
+-- does not fit on screen. They are kept in Geyser.Label.scrollV/scrollH, keyed by
+-- the menu they scroll, rather than in the menu's own MenuLabels.
+-- @param label the menu label whose scroll labels are to be deleted
+local function deleteScrollLabels(label)
+    for _, cache in pairs({vertical = Geyser.Label.scrollV, horizontal = Geyser.Label.scrollH}) do
+        local scrollLabels = cache[label]
+        if scrollLabels then
+            cache[label] = nil
+            for _, scrollLabel in ipairs(scrollLabels) do
+                deleteIfStillRegistered(scrollLabel)
+            end
+        end
+    end
+end
+
+-- internal function to delete the labels of a right click menu and of all its submenus.
+-- Menu labels are created as top level Geyser objects rather than as children of
+-- the menu they belong to, so Geyser.Container:delete()'s cascade never reaches them.
+-- @param menu the menu label whose MenuLabels are to be deleted
+local function deleteMenuLabels(menu)
+    if not menu or not menu.MenuLabels then
+        return
+    end
+    local menuLabels = menu.MenuLabels
+    menu.MenuLabels = {}
+    deleteScrollLabels(menu)
+    for _, label in pairs(menuLabels) do
+        deleteMenuLabels(label)
+        deleteIfStillRegistered(label)
+    end
+end
+
+-- internal function called by Geyser.Container:delete() to clean up what the
+-- delete cascade cannot reach: the right click menu labels, the event handlers
+-- that keep firing on a deleted container, and the container's entries in
+-- Adjustable.Container's own bookkeeping
+function Adjustable.Container:type_delete()
+    deleteMenuLabels(self.adjLabel and self.adjLabel.rightClickMenu)
+    -- detach() also kills the resize handler and drops the container out of
+    -- Adjustable.Container.Attached, which otherwise keeps reserving a border
+    if self.attached then
+        self:detach()
+    end
+    self:disconnect()
+    -- not disableAutoSave(), which kills an already nil handler and errors
+    if self.autoSaveHandler then
+        killAnonymousEventHandler(self.autoSaveHandler)
+        self.autoSaveHandler = nil
+    end
+    self.autoSave = false
+    -- a container recreated under the same name has taken over the registration,
+    -- so only unregister while it is still ours
+    if Adjustable.Container.all[self.name] == self then
+        Adjustable.Container.all[self.name] = nil
+        local index = table.index_of(Adjustable.Container.all_windows, self.name)
+        if index then
+            table.remove(Adjustable.Container.all_windows, index)
+        end
+    end
+end
+
 --- deletes the file where your saved settings are stored
 -- @param dir defines directory where the saved file is in [optional]
 -- @see Adjustable.Container:save
@@ -1040,7 +1117,7 @@ end
 --@param cons.attLabel.txt  text of the "attached menu" item
 --@param cons.lockStylesLabel.txt  text of the "lockstyle menu" item
 --@param cons.customItemsLabel.txt  text of the "custom menu" item
---@param[opt="green"] cons.titleTxtColor  color of the title text
+--@param[opt="grey"] cons.titleTxtColor  color of the title text
 --@param cons.titleText  title text
 --@param cons.titleFormat  a format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, 's' - strikethrough,  '##' - font size.
 --@param[opt="standard"] cons.lockStyle  choose lockstyle at creation. possible integrated lockstyle are: "standard", "border", "light" and "full"

--- a/src/mudlet-lua/lua/geyser/GeyserButton.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserButton.lua
@@ -52,7 +52,12 @@ function Geyser.Button:new(cons, container)
   local me = self.parent:new(cons, container)
   setmetatable(me, self)
   me:setClickCallback(function() me:press() end)
-  me:setState(me.state)
+  -- an unusable state constraint would otherwise leave the button holding it
+  -- and never painted, since setState returns before drawing anything
+  if not me:setState(me.state) then
+    me.state = "up"
+    me:setState("up")
+  end
   me:resize() -- to pick up the Geyser.Button default size rather than Geyser.Label's
   return me
 end
@@ -70,6 +75,9 @@ function Geyser.Button:setState(state)
   if state ~= "up" and state ~= "down" then
     return nil, f"bad argument #1 value (state must be one of 'up' or 'down', got {state})"
   end
+  if state == "down" and not self.twoState then
+    return nil, "cannot set a single state button's state to 'down', only 'up'"
+  end
   self.state = state
   if state == "up" then
     self:echo(self.msg)
@@ -85,9 +93,6 @@ function Geyser.Button:setState(state)
     self:setToolTip(self.tooltip, self.toolTipDuration)
     return true
   end
-  if not self.twoState then
-    return nil, "cannot set a single state button's state to 'down', only 'up'"
-  end
   self:echo(self.downMsg)
   if self.downStyle then
     if type(self.downStyle) == "table" then
@@ -99,6 +104,9 @@ function Geyser.Button:setState(state)
     self.parent.setColor(self, self.downColor)
   end
   self:setToolTip(self.downTooltip, self.toolTipDuration)
+  -- both branches report success, otherwise a legitimate 'down' is
+  -- indistinguishable from the refusals above
+  return true
 end
 
 --- Handles clicking the button. If the button is twoState, also handles switching the button's state

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -56,6 +56,9 @@ local function extractCSSSpacing(css, property)
   elseif #values == 2 then
     -- top/bottom, left/right
     return values[2], values[2], values[1], values[1]
+  elseif #values == 3 then
+    -- top, left/right, bottom
+    return values[2], values[2], values[1], values[3]
   elseif #values == 4 then
     -- top, right, bottom, left
     return values[4], values[2], values[1], values[3]
@@ -70,9 +73,24 @@ end
 --        used to set the gauge.
 -- @param maxValue Maximum numeric value.  Optionally nil, see above.
 -- @param text The text to display on the gauge, it is optional.
+-- @return true, or nil and a message if maxValue has no reading to give
 function Geyser.Gauge:setValue (currentValue, maxValue, text)
   assert(type(currentValue) == "number", string.format("bad argument #1 type (currentValue as number expected, got %s!)", type(currentValue)))
   assert(maxValue == nil or type(maxValue) == "number", string.format("bad argument #2 type (optional maxValue as number expected, got %s!)", type(maxValue)))
+  -- A zero, negative or NaN maximum has no sensible reading: dividing by it leaves
+  -- the gauge on an infinite or negative value that sticks until the next good
+  -- call. Games do report these while a stat is still unknown, so refuse the
+  -- reading and leave the gauge as it was rather than aborting the caller.
+  if maxValue ~= nil and not (maxValue > 0) then
+    local message = string.format("Geyser.Gauge:setValue: bad argument #2 value (maxValue must be a positive number, got %s!) - gauge '%s' was left as it was", tostring(maxValue), self.name)
+    -- latched, because a game that reports a bad maximum reports it every prompt
+    if not self.warnedBadMaxValue then
+      self.warnedBadMaxValue = true
+      debugc(message)
+    end
+    return nil, message
+  end
+  self.warnedBadMaxValue = nil
   -- Use sensible defaults for missing parameters.
   if currentValue < 0 then
     currentValue = 0
@@ -157,6 +175,7 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
   if text then
     self.text:echo(text)
   end
+  return true
 end
 
 --- Sets the gauge color.

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -8,6 +8,18 @@ Geyser.HBox = Geyser.Container:new({
   name = "HBoxClass"
 })
 
+-- Internal function: lays the box out, or remembers that it still has to be laid
+-- out when updates are being deferred, so that the reposition end_update() runs
+-- picks the work up again
+-- @param box the HBox to organize
+local function organizeOrDefer(box)
+  if box.defer_updates then
+    box.pending_organize = true
+  else
+    box:organize()
+  end
+end
+
 function Geyser.HBox:add (window, cons)
   -- VBox/HBox have their own add function therefore passing off add2 should be possible without
   -- overwriting their add functions
@@ -16,9 +28,14 @@ function Geyser.HBox:add (window, cons)
   else
     Geyser.add(self, window, cons)
   end
-  if not self.defer_updates then
-    self:organize()
-  end
+  organizeOrDefer(self)
+end
+
+-- add2 has to be overridden as well, otherwise children created with new2 reach
+-- Geyser.add2 directly and the box never lays them out
+function Geyser.HBox:add2 (window, cons, passAdd2, exclude)
+  Geyser.add2(self, window, cons, passAdd2, exclude)
+  organizeOrDefer(self)
 end
 
 --- Responsible for organizing the elements inside the HBox
@@ -61,8 +78,13 @@ end
 
 function Geyser.HBox:reposition()
   Geyser.Container.reposition(self)
-  if self.contains_fixed then
+  -- contains_fixed prevents gaps when items have fixed size and is deliberately
+  -- not deferred, pending_organize
+  -- flushes a layout that was skipped while updates were deferred. Clearing it
+  -- only after organize() keeps the work queued if organize() throws.
+  if self.contains_fixed or (self.pending_organize and not self.defer_updates) then
     self:organize()
+    self.pending_organize = nil
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserReposition.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserReposition.lua
@@ -5,16 +5,39 @@
 
 --- Responds to sysWindowResizeEvent and causes all windows managed
 -- by Geyser to update their sizes and positions.
--- @param event a sysWindowResizeEvent or sysUserWindowResizeEvent event
+-- Called without an event by Geyser:reposition(), which is how Geyser:end_update()
+-- applies the layout it deferred; that call is meant for every window Geyser owns.
+-- @param event a sysWindowResizeEvent or sysUserWindowResizeEvent event, or nil to reposition everything
 -- @param w the new width
 -- @param h the new height
 -- @param arg additional arguments
 function GeyserReposition(event, w, h, arg)
-  for _, window in pairs(Geyser.windowList) do
-    if event == "sysUserWindowResizeEvent" and window.type == "userwindow" and arg.."Container" == window.name then
-      window:reposition()
-    elseif event == "sysWindowResizeEvent" and window.type ~= "userwindow" then 
-      window:reposition()
+  if event ~= nil and event ~= "sysWindowResizeEvent" and event ~= "sysUserWindowResizeEvent" then
+    -- otherwise a mistyped event name is indistinguishable from a no-op
+    debugc(string.format("GeyserReposition: ignoring the unknown event '%s'", tostring(event)))
+    return
+  end
+  if event == "sysUserWindowResizeEvent" and not arg then
+    debugc("GeyserReposition: sysUserWindowResizeEvent needs the name of the user window that was resized")
+    return
+  end
+  -- repositioning raises events, and a handler that creates or deletes a top
+  -- level window would be mutating windowList mid-traversal, so work off a
+  -- snapshot of the names and re-check each one is still there
+  local names = {}
+  for name in pairs(Geyser.windowList) do
+    names[#names + 1] = name
+  end
+  for _, name in ipairs(names) do
+    local window = Geyser.windowList[name]
+    if window then
+      if event == nil then
+        window:reposition()
+      elseif event == "sysUserWindowResizeEvent" and window.type == "userwindow" and arg.."Container" == window.name then
+        window:reposition()
+      elseif event == "sysWindowResizeEvent" and window.type ~= "userwindow" then
+        window:reposition()
+      end
     end
   end
 end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -8,6 +8,18 @@ Geyser.VBox = Geyser.Container:new({
   name = "VBoxClass"
 })
 
+-- Internal function: lays the box out, or remembers that it still has to be laid
+-- out when updates are being deferred, so that the reposition end_update() runs
+-- picks the work up again
+-- @param box the VBox to organize
+local function organizeOrDefer(box)
+  if box.defer_updates then
+    box.pending_organize = true
+  else
+    box:organize()
+  end
+end
+
 function Geyser.VBox:add (window, cons)
   -- VBox/HBox have their own add function therefore passing off add2 should be possible without
   -- overwriting their add functions
@@ -16,10 +28,15 @@ function Geyser.VBox:add (window, cons)
   else
     Geyser.add(self, window, cons)
   end
-  
-  if not self.defer_updates then
-    self:organize()
-  end
+
+  organizeOrDefer(self)
+end
+
+-- add2 has to be overridden as well, otherwise children created with new2 reach
+-- Geyser.add2 directly and the box never lays them out
+function Geyser.VBox:add2 (window, cons, passAdd2, exclude)
+  Geyser.add2(self, window, cons, passAdd2, exclude)
+  organizeOrDefer(self)
 end
 
 --- Responsible for organizing the elements inside the VBox
@@ -62,8 +79,13 @@ end
 
 function Geyser.VBox:reposition()
   Geyser.Container.reposition(self)
-  if self.contains_fixed then -- prevent gaps when items have fixed size
+  -- contains_fixed prevents gaps when items have fixed size and is deliberately
+  -- not deferred, pending_organize
+  -- flushes a layout that was skipped while updates were deferred. Clearing it
+  -- only after organize() keeps the work queued if organize() throws.
+  if self.contains_fixed or (self.pending_organize and not self.defer_updates) then
     self:organize()
+    self.pending_organize = nil
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserWindow.lua
@@ -26,7 +26,7 @@ Geyser.Window = Geyser.Container:new({
 --- Prints a message to the window
 -- @param message The message to print. Can contain html formatting.
 function Geyser.Window:echo(message)
-  self.message = message
+  self.message = message or self.message
   echo(self.name, self.message)
 end
 
@@ -34,21 +34,24 @@ end
 -- @param message The message to print. Uses color formatting information -
 -- a message of "<red>Hi" would make 'Hi' red.
 function Geyser.Window:cecho(message)
-  self.message = message or self.message cecho(self.name, self.message)
+  self.message = message or self.message
+  cecho(self.name, self.message)
 end
 
 --- Prints a message to the window.
 -- @param message The message to print. Uses color formatting information -
 -- a message of "<255,0,0>Hi" would make 'Hi' red.
 function Geyser.Window:decho(message)
-  self.message = message or self.message decho(self.name, self.message)
+  self.message = message or self.message
+  decho(self.name, self.message)
 end
 
 --- Prints a message to the window.
 -- @param message The message to print. Uses color formatting information -
 -- a message of "|cff0000Hi" would make 'Hi' red.
 function Geyser.Window:hecho(message)
-  self.message = message or self.message hecho(self.name, self.message)
+  self.message = message or self.message
+  hecho(self.name, self.message)
 end
 
 --- Get the window's foreground color.

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -16,10 +16,12 @@ describe("Tests functionality of Adjustable.Container", function()
     end)
 
     after_each(function()
-      -- Clean up the container after each test
-      if testContainer then
-        testContainer:hide()
+      -- deleting rather than hiding keeps the container, its right click menu
+      -- and the submenu addConnectMenu builds out of every later spec file
+      if testContainer and Geyser.windowList.testAdjustableContainer == testContainer then
+        testContainer:delete()
       end
+      testContainer = nil
     end)
 
     it("should successfully add connect menu on first call", function()
@@ -107,7 +109,7 @@ describe("Tests functionality of Adjustable.Container", function()
       assert.equals(10, ac.padding)
       assert.equals("standard", ac.lockStyle)
 
-      ac:hide()
+      ac:delete()
     end)
   end)
 
@@ -115,13 +117,32 @@ describe("Tests functionality of Adjustable.Container", function()
   -- container builds rather than on its bookkeeping alone.
   describe("Adjustable.Container widget state", function()
     local container
+    local topLevelBefore
 
     local function geometry(name)
       local x, y, width, height = getWindowGeometry(name)
       return {x = x, y = y, width = width, height = height}
     end
 
+    -- Every top level Geyser object registered since this spec's container was
+    -- built. Snapshotting rather than matching on the container's name catches
+    -- leaks whatever they are called, such as the menu's "More..." labels.
+    local function newTopLevelObjects()
+      local new = {}
+      for name in pairs(Geyser.windowList) do
+        if not topLevelBefore[name] then
+          new[#new + 1] = name
+        end
+      end
+      table.sort(new)
+      return new
+    end
+
     before_each(function()
+      topLevelBefore = {}
+      for name in pairs(Geyser.windowList) do
+        topLevelBefore[name] = true
+      end
       container = Adjustable.Container:new({
         name = "gasContainer",
         x = 20,
@@ -134,21 +155,17 @@ describe("Tests functionality of Adjustable.Container", function()
     end)
 
     after_each(function()
+      -- a delete that throws must not skip the sweep below, or it strands the
+      -- container and its menu labels for the rest of the suite
+      local deleted, deleteError = true, nil
       if container and Geyser.windowList.gasContainer == container then
-        container:delete()
+        deleted, deleteError = pcall(function() container:delete() end)
       end
       container = nil
-      -- Deleting an Adjustable.Container does not take its right click menu
-      -- labels with it: they are registered as top level Geyser objects, so
-      -- the cascade never reaches them. Sweep them by name, and unregister
-      -- the container from Adjustable's own bookkeeping, so nothing of this
-      -- spec is left behind for the rest of the suite.
-      local leftovers = {}
-      for name in pairs(Geyser.windowList) do
-        if name:find("^gasContainer") then
-          leftovers[#leftovers + 1] = name
-        end
-      end
+      -- the whole suite shares one Lua state, so anything left registered here
+      -- would follow later spec files around: sweep it, but report it rather
+      -- than quietly repairing a delete that stopped cleaning up after itself
+      local leftovers = newTopLevelObjects()
       for _, name in ipairs(leftovers) do
         local object = Geyser.windowList[name]
         if object then
@@ -160,6 +177,12 @@ describe("Tests functionality of Adjustable.Container", function()
       if index then
         table.remove(Adjustable.Container.all_windows, index)
       end
+      -- the delete throwing is the root cause, so report it ahead of the leak
+      -- it would have caused
+      if not deleted then
+        error(deleteError)
+      end
+      assert.are.same({}, leftovers)
     end)
 
     it("puts its backdrop label over the container's geometry", function()
@@ -240,13 +263,98 @@ describe("Tests functionality of Adjustable.Container", function()
       assert.are.same({x = 20, y = 30, width = 200, height = 200}, geometry("gasContaineradjLabel"))
     end)
 
+    it("titles itself after its name again after resetTitle", function()
+      container:setTitle("My Title", "red", "c")
+      container:resetTitle()
+      assert.are.equal("gasContainer - Adjustable Container", container.titleText)
+      -- back to what the constructor produced, colour and alignment included
+      assert.are.equal("grey", container.titleTxtColor)
+      assert.are.equal("l", container.titleFormat)
+      local text = getLabelText("gasContaineradjLabel")
+      assert.is_truthy(text:find("gasContainer - Adjustable Container", 1, true))
+      assert.is_truthy(text:find("color: " .. Geyser.Color.hex("grey"), 1, true))
+    end)
+
     it("deletes the container and its backdrop label", function()
-      -- the right click menu labels it created are not part of the cascade,
-      -- so they are swept by name in after_each instead
       container:delete()
       assert.is_nil(getWindowGeometry("gasContaineradjLabel"))
       assert.is_nil(getWindowGeometry("gasContainerexitLabel"))
       assert.is_nil(Geyser.windowList.gasContainer)
+    end)
+
+    it("takes its right click menu labels and its registration with it", function()
+      -- menu labels are registered as top level Geyser objects rather than as
+      -- children of the menu, so only the container's own delete reaches them
+      local menuLabelName = container.lockLabel.name
+      local lockStyleLabelName = container.adjLabel:findMenuElement("lockStylesLabel.standard").name
+      assert.is_not_nil(Geyser.windowList[menuLabelName])
+      assert.is_not_nil(Geyser.windowList[lockStyleLabelName])
+      container:delete()
+      -- listed by name: a leaked Geyser object prints as the whole widget tree
+      assert.are.same({}, newTopLevelObjects())
+      assert.is_nil(getWindowGeometry(menuLabelName))
+      assert.is_nil(getWindowGeometry(lockStyleLabelName))
+      assert.is_nil(Adjustable.Container.all.gasContainer)
+      assert.is_nil(table.index_of(Adjustable.Container.all_windows, "gasContainer"))
+    end)
+
+    it("takes the menu labels of a container inside a user window with it", function()
+      -- menu labels of a container in a user window are registered in that
+      -- window's list rather than in Geyser.windowList
+      local userWindow = Geyser.UserWindow:new({name = "gasUserWindow", x = 0, y = 0, width = 300, height = 300})
+      finally(function()
+        -- a user window gets a root container of its own, which is what has to
+        -- go for the window and everything in it to be cleaned up
+        local root = Geyser.windowList.gasUserWindowContainer
+        if root then
+          root:delete()
+        end
+      end)
+      local inWindow = Adjustable.Container:new({
+        name = "gasInUserWindow",
+        x = 0, y = 0, width = 100, height = 100,
+        autoLoad = false,
+        autoSave = false,
+      }, userWindow)
+      local menuLabelName = inWindow.lockLabel.name
+      assert.is_not_nil(getWindowGeometry(menuLabelName))
+      inWindow:delete()
+      assert.is_nil(getWindowGeometry(menuLabelName))
+    end)
+
+    it("takes its autosave handler with it", function()
+      local saving = Adjustable.Container:new({
+        name = "gasSavingContainer",
+        x = 0, y = 0, width = 100, height = 100,
+        autoLoad = false,
+      })
+      assert.is_not_nil(saving.autoSaveHandler)
+      saving:delete()
+      -- left registered, the handler would write a deleted container's geometry
+      -- back out at exit, over whatever took its name in the meantime
+      assert.is_nil(saving.autoSaveHandler)
+      assert.is_false(saving.autoSave)
+    end)
+
+    it("leaves another adjustable container's registration alone", function()
+      local other = Adjustable.Container:new({
+        name = "gasOtherContainer",
+        x = 0, y = 0, width = 100, height = 100,
+        autoLoad = false,
+        autoSave = false,
+      })
+      finally(function()
+        if Geyser.windowList.gasOtherContainer == other then
+          other:delete()
+        end
+      end)
+      local otherMenuLabelName = other.lockLabel.name
+      container:delete()
+      assert.are.equal(other, Adjustable.Container.all.gasOtherContainer)
+      assert.is_not_nil(table.index_of(Adjustable.Container.all_windows, "gasOtherContainer"))
+      assert.are.equal(other.lockLabel, Geyser.windowList[otherMenuLabelName])
+      assert.is_not_nil(getWindowGeometry(otherMenuLabelName))
+      other:delete()
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/GeyserButton_spec.lua
+++ b/src/mudlet-lua/tests/GeyserButton_spec.lua
@@ -222,11 +222,47 @@ describe("Tests functionality of Geyser.Button", function()
       local result, message = button:setState("down")
       assert.is_nil(result)
       assert.are.equal("cannot set a single state button's state to 'down', only 'up'", message)
-      -- the refusal happens before anything is drawn, so the button still
-      -- shows its up message. button.state is deliberately not asserted here:
-      -- setState writes it before the refusal, which is a Geyser bug to fix
-      -- rather than a contract to pin down.
+      -- the refusal happens before anything is written, so neither the stored
+      -- state nor the drawn message move
+      assert.are.equal("up", button.state)
       assert.is_truthy(getLabelText("gbsSingleState"):find("up text", 1, true))
+    end)
+
+    it('keeps clicking a refused single state button on its up command', function()
+      local clicks, downs = 0, 0
+      local button = track(Geyser.Button:new({
+        name = "gbsRefusedPress",
+        x = 0, y = 0, width = 60, height = 20,
+        clickFunction = function() clicks = clicks + 1 end,
+        downFunction = function() downs = downs + 1 end,
+      }))
+      button:setState("down")
+      button:press()
+      assert.are.equal(1, clicks)
+      assert.are.equal(0, downs)
+      assert.are.equal("up", button.state)
+    end)
+
+    it('reports success for both states of a two state button', function()
+      local button = track(Geyser.Button:new({
+        name = "gbsStateResult",
+        x = 0, y = 0, width = 60, height = 20,
+        twoState = true,
+      }))
+      -- a legitimate 'down' has to be distinguishable from a refusal
+      assert.is_true(button:setState("down"))
+      assert.is_true(button:setState("up"))
+    end)
+
+    it('will not start a single state button in the down state', function()
+      local button = track(Geyser.Button:new({
+        name = "gbsDownConstraint",
+        x = 0, y = 0, width = 60, height = 20,
+        msg = "up text",
+        state = "down",
+      }))
+      assert.are.equal("up", button.state)
+      assert.is_truthy(getLabelText("gbsDownConstraint"):find("up text", 1, true))
     end)
 
     it('rejects a state that is not a string or not a known state', function()

--- a/src/mudlet-lua/tests/GeyserContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserContainer_spec.lua
@@ -593,20 +593,73 @@ describe("Tests functionality of Geyser.Container", function()
       -- the children keep their own constraints instead of being stacked
       assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gcsDeferredA"))
       assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gcsDeferredB"))
+      -- end_update applies the layout that was held back, without the caller
+      -- having to organize the box itself
       box:end_update()
       assert.is_false(box.defer_updates)
-      box:organize()
       assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("gcsDeferredA"))
       assert.are.same({x = 0, y = 100, width = 200, height = 100}, geometry("gcsDeferredB"))
     end)
 
-    it("does nothing when Geyser:reposition is called outside a resize event", function()
-      -- Geyser:reposition hands GeyserReposition no event, and GeyserReposition
-      -- only acts on the two resize events, so this is a no-op by construction
-      track(Geyser.Label:new({name = "gcsRepositionNoop", x = 10, y = 10, width = 100, height = 50}))
-      moveWindow("gcsRepositionNoop", 300, 300)
+    it("holds back the layout of an hbox while its updates are deferred", function()
+      local box = track(Geyser.HBox:new({name = "gcsDeferredH", x = 0, y = 0, width = 200, height = 200}))
+      box:begin_update()
+      finally(function() box.defer_updates = false end)
+      track(Geyser.Label:new({name = "gcsDeferredHA"}, box))
+      track(Geyser.Label:new({name = "gcsDeferredHB"}, box))
+      assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gcsDeferredHA"))
+      box:end_update()
+      assert.are.same({x = 0, y = 0, width = 100, height = 200}, geometry("gcsDeferredHA"))
+      assert.are.same({x = 100, y = 0, width = 100, height = 200}, geometry("gcsDeferredHB"))
+    end)
+
+    it("holds back the layout of a new2 box, which fills through add2", function()
+      local box = track(Geyser.VBox:new2({name = "gcsDeferred2", x = 0, y = 0, width = 200, height = 200}))
+      box:begin_update()
+      finally(function() box.defer_updates = false end)
+      track(Geyser.Label:new2({name = "gcsDeferred2A"}, box))
+      track(Geyser.Label:new2({name = "gcsDeferred2B"}, box))
+      assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gcsDeferred2A"))
+      box:end_update()
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("gcsDeferred2A"))
+      assert.are.same({x = 0, y = 100, width = 200, height = 100}, geometry("gcsDeferred2B"))
+    end)
+
+    it("keeps holding the layout back when the box itself is moved", function()
+      -- move() repositions, and reposition is what flushes the deferred layout,
+      -- so it must not undo the deferral it was asked for
+      local box = track(Geyser.VBox:new({name = "gcsDeferredMove", x = 0, y = 0, width = 200, height = 200}))
+      box:begin_update()
+      finally(function() box.defer_updates = false end)
+      track(Geyser.Label:new({name = "gcsDeferredMoveA"}, box))
+      track(Geyser.Label:new({name = "gcsDeferredMoveB"}, box))
+      box:move(0, 0)
+      assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gcsDeferredMoveA"))
+      box:end_update()
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("gcsDeferredMoveA"))
+    end)
+
+    it("lays a box out that was filled during a deferral of the root window", function()
+      -- leaving the flag set would stop every later spec repositioning
+      finally(function() Geyser.defer_updates = false end)
+      local box = track(Geyser.VBox:new({name = "gcsRootDeferred", x = 0, y = 0, width = 200, height = 200}))
+      Geyser:begin_update()
+      track(Geyser.Label:new({name = "gcsRootDeferredA"}, box))
+      track(Geyser.Label:new({name = "gcsRootDeferredB"}, box))
+      Geyser:end_update()
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("gcsRootDeferredA"))
+      assert.are.same({x = 0, y = 100, width = 200, height = 100}, geometry("gcsRootDeferredB"))
+    end)
+
+    it("repositions every window when Geyser:reposition is called directly", function()
+      -- Geyser:reposition hands GeyserReposition no event, which is how
+      -- end_update flushes what was deferred, so it applies to everything
+      -- a leaked deferral would make this a no-op for a reason of its own
+      assert.is_false(Geyser.defer_updates)
+      track(Geyser.Label:new({name = "gcsRepositionDirect", x = 10, y = 10, width = 100, height = 50}))
+      moveWindow("gcsRepositionDirect", 300, 300)
       Geyser:reposition()
-      assert.are.equal(300, geometry("gcsRepositionNoop").x)
+      assert.are.same({x = 10, y = 10, width = 100, height = 50}, geometry("gcsRepositionDirect"))
     end)
 
     it("lays a box out as its children arrive when updates are not deferred", function()

--- a/src/mudlet-lua/tests/GeyserGauge_spec.lua
+++ b/src/mudlet-lua/tests/GeyserGauge_spec.lua
@@ -128,6 +128,23 @@ describe("Tests functionality of Geyser.Gauge", function()
       assert.is_false(ok)
       assert.is_truthy(tostring(message):find("maxValue as number expected, got string", 1, true))
     end)
+
+    it("refuses a maximum that is not positive instead of going infinite", function()
+      gauge:setValue(25)
+      -- a zero maximum used to leave value at inf, a negative one at a negative
+      -- value, and both stuck until the next good call
+      for _, bad in ipairs({0, -10, 0 / 0}) do
+        local result, message = gauge:setValue(5, bad)
+        assert.is_nil(result)
+        assert.is_not_nil(message)
+        assert.is_truthy(message:find("maxValue must be a positive number", 1, true))
+      end
+      -- refusing is not fatal, and leaves the gauge on the value it already had
+      assert.are.equal(25, gauge.value)
+      assert.are.equal(50, geometry("ggsValue_front").width)
+      -- a good reading has to be distinguishable from those refusals
+      assert.is_true(gauge:setValue(50, 100))
+    end)
   end)
 
   describe("Geyser.Gauge orientations", function()
@@ -163,6 +180,18 @@ describe("Tests functionality of Geyser.Gauge", function()
       local gauge = track(Geyser.Gauge:new({name = "ggsTwoValue", x = 0, y = 0, width = 200, height = 100}))
       gauge:setStyleSheet("margin: 10px 30px;", "margin: 10px 30px;")
       assert.are.same({x = 30, y = 10, width = 140, height = 80}, geometry("ggsTwoValue_front"))
+    end)
+
+    it("reads a three value margin as top, horizontal, bottom", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsThreeValue", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 10px 20px 30px;", "margin: 10px 20px 30px;")
+      assert.are.same({x = 20, y = 10, width = 160, height = 60}, geometry("ggsThreeValue_front"))
+    end)
+
+    it("reads a three value padding the same way as a margin", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsThreePadding", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("padding: 4px 6px 8px;", "padding: 4px 6px 8px;")
+      assert.are.same({x = 6, y = 4, width = 188, height = 88}, geometry("ggsThreePadding_front"))
     end)
 
     it("reads a four value margin as top, right, bottom, left", function()

--- a/src/mudlet-lua/tests/GeyserHBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserHBox_spec.lua
@@ -42,13 +42,19 @@ describe("Tests functionality of Geyser.HBox", function()
       assert.is_nil(getWindowGeometry("ghbNew"))
     end)
 
-    -- children of a new2 box are not laid out at all: HBox overrides add but
-    -- not add2, so organize() is never reached. Left unspecified rather than
-    -- pinned, since the layout is what a caller of new2 is asking for.
     it("new2 marks the box as using add2", function()
       local box = track(Geyser.HBox:new2({name = "ghbNew2", x = 0, y = 0, width = 100, height = 100}))
       assert.is_true(box.useAdd2)
       assert.are.equal("hbox", box.type)
+    end)
+
+    it("lines the children of a new2 box up the same way new does", function()
+      local box = track(Geyser.HBox:new2({name = "ghbNew2Layout", x = 0, y = 0, width = 200, height = 100}))
+      -- the children arrive through add2 rather than add
+      track(Geyser.Label:new2({name = "ghbNew2A", x = 10, y = 10, width = 300, height = 200}, box))
+      track(Geyser.Label:new2({name = "ghbNew2B", x = 10, y = 10, width = 300, height = 200}, box))
+      assert.are.same({x = 0, y = 0, width = 100, height = 100}, geometry("ghbNew2A"))
+      assert.are.same({x = 100, y = 0, width = 100, height = 100}, geometry("ghbNew2B"))
     end)
   end)
 

--- a/src/mudlet-lua/tests/GeyserVBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserVBox_spec.lua
@@ -43,13 +43,31 @@ describe("Tests functionality of Geyser.VBox", function()
       assert.is_nil(getWindowGeometry("gvbNew"))
     end)
 
-    -- children of a new2 box are not laid out at all: VBox overrides add but
-    -- not add2, so organize() is never reached. Left unspecified rather than
-    -- pinned, since the layout is what a caller of new2 is asking for.
     it("new2 marks the box as using add2", function()
       local box = track(Geyser.VBox:new2({name = "gvbNew2", x = 0, y = 0, width = 100, height = 100}))
       assert.is_true(box.useAdd2)
       assert.are.equal("VBox", box.type)
+    end)
+
+    it("stacks the children of a new2 box the same way new does", function()
+      local box = track(Geyser.VBox:new2({name = "gvbNew2Layout", x = 0, y = 0, width = 200, height = 200}))
+      -- the children arrive through add2 rather than add
+      track(Geyser.Label:new2({name = "gvbNew2A", x = 10, y = 10, width = 300, height = 200}, box))
+      track(Geyser.Label:new2({name = "gvbNew2B", x = 10, y = 10, width = 300, height = 200}, box))
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("gvbNew2A"))
+      assert.are.same({x = 0, y = 100, width = 200, height = 100}, geometry("gvbNew2B"))
+    end)
+
+    it("lays out a new2 box nested in another new2 box", function()
+      local outer = track(Geyser.HBox:new2({name = "gvbNestedOuter", x = 0, y = 0, width = 200, height = 200}))
+      local inner = track(Geyser.VBox:new2({name = "gvbNestedInner"}, outer))
+      track(Geyser.Label:new2({name = "gvbNestedSibling"}, outer))
+      track(Geyser.Label:new2({name = "gvbNestedA"}, inner))
+      track(Geyser.Label:new2({name = "gvbNestedB"}, inner))
+      -- the inner box takes half the outer one, and splits it between its own two
+      assert.are.same({x = 0, y = 0, width = 100, height = 100}, geometry("gvbNestedA"))
+      assert.are.same({x = 0, y = 100, width = 100, height = 100}, geometry("gvbNestedB"))
+      assert.are.same({x = 100, y = 0, width = 100, height = 200}, geometry("gvbNestedSibling"))
     end)
   end)
 

--- a/src/mudlet-lua/tests/GeyserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserWindow_spec.lua
@@ -93,6 +93,16 @@ describe("Tests functionality of Geyser.Window", function()
       assert.are.equal("remembered\n", console.message)
       assert.are.equal("remembered", lastLine("gwsConsole"))
     end)
+
+    it("echo without a message redisplays the stored one instead of wiping it", function()
+      console:echo("kept\n")
+      local lines = getLineCount("gwsConsole")
+      console:echo()
+      assert.are.equal("kept\n", console.message)
+      -- the line count pins that it was written again, not merely left alone
+      assert.are.equal(lines + 1, getLineCount("gwsConsole"))
+      assert.are.equal("kept", lastLine("gwsConsole"))
+    end)
   end)
 
   describe("Geyser.Window:getFgColor/getBgColor/setBgColor/setFgColor", function()


### PR DESCRIPTION
Wave 2 of the Geyser specs (#9571) documented eight widget bugs rather than pinning correct behaviour. This fixes all eight and flips those specs to assert the fixed contract.

- **The eight:** `Adjustable.Container:resetTitle()` no longer throws; deleting an `Adjustable.Container` now takes its right click menu labels, its autosave/resize handlers and its `all`/`all_windows` entries with it; `Geyser.Button:setState("down")` refuses on a single-state button *before* writing the state; `VBox`/`HBox` override `add2`, so `new2` children get laid out; `Geyser:end_update()` actually applies the deferred layout; gauges honour the 3-value CSS margin/border/padding shorthand; `Gauge:setValue(n, 0)` is refused instead of producing `inf`; and `Geyser.Window:echo()` with no argument redisplays the stored message instead of wiping it.
- **Three contract calls the issues left open.** `setValue` refuses any non-positive or NaN maximum by returning `nil` + a message and leaving the gauge as it was, rather than raising - games do report a zero maximum while a stat is still unknown, and raising would abort the rest of the caller's handler; it says so once in the debug console so a frozen gauge is not a mystery. `resetTitle()` restores the constructor's grey rather than `setTitle`'s otherwise unreachable green default. And `GeyserReposition(nil)`, which is how `Geyser:reposition()` calls it, now means "reposition everything", so a package calling `Geyser:reposition()` after a manual `moveWindow` on a Geyser-managed widget will see it snap back.
- `end_update` needed two halves: the eventless `GeyserReposition` above, plus a `pending_organize` flag so a box remembers the `organize()` it skipped while deferred.

Stacked on #9571 - review that one first; this retargets to `development` automatically once it merges.

Fixes #9582
Fixes #9583
Fixes #9584
Fixes #9585
Fixes #9586
Fixes #9587
Fixes #9588
Fixes #9589

**Test case:** busted suite 1549 successes / 0 failures / 0 errors / 2 pending (pre-existing HTTP-fixture skips), green twice; reverting just the Lua fixes and keeping the flipped specs gives 20 failures + 16 errors covering all eight issues.

Assisted-by: Claude:claude-opus-5
