### PR TITLE
fix: setTextFormat leak, createLabel return convention, windowType scrollbox

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4938,6 +4938,10 @@ std::optional<QString> Host::windowType(const QString& name) const
         }
     }
 
+    if (mpConsole->mScrollBoxMap.contains(name)) {
+        return {qsl("scrollbox")};
+    }
+
     if (mpConsole->mSubCommandLineMap.contains(name)) {
         return {qsl("commandline")};
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1387,7 +1387,10 @@ int TLuaInterpreter::getMudletInfo(lua_State* L)
 }
 
 // Internal Function createLabel in an UserWindow
-int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowName, const QString& labelName)
+// The names arrive as the Lua-owned strings still anchored at stack indexes 1 and
+// 2 rather than as QStrings: every check below can raise, and lua_error() longjmps
+// past C++ destructors, so the QStrings are only built once nothing else can raise
+int TLuaInterpreter::createLabelUserWindow(lua_State* L, const char* windowName, const char* labelName)
 {
     const int n = lua_gettop(L);
     const int x = getVerifiedInt(L, "createLabel", 3, "label x-coordinate");
@@ -1420,7 +1423,7 @@ int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowNa
     }
 
     Host& host = getHostFromLua(L);
-    if (auto [success, message] = host.createLabel(windowName, labelName, x, y, width, height, fillBackground, clickthrough); !success) {
+    if (auto [success, message] = host.createLabel(QString{windowName}, QString{labelName}, x, y, width, height, fillBackground, clickthrough); !success) {
         // We should, perhaps be returning a nil here but the published API
         // says the function returns true or false and we cannot change that now
         return warnArgumentValue(L, "createLabel", message, true);
@@ -1431,9 +1434,9 @@ int TLuaInterpreter::createLabelUserWindow(lua_State* L, const QString& windowNa
 }
 
 // Internal Function create Label in MainWindow
-int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelName)
+// See createLabelUserWindow() for why the name is not a QString
+int TLuaInterpreter::createLabelMainWindow(lua_State* L, const char* labelName)
 {
-    const QString windowName = QLatin1String("main");
     const int n = lua_gettop(L);
     const int x = getVerifiedInt(L, "createLabel", 2, "label x-coordinate");
     const int y = getVerifiedInt(L, "createLabel", 3, "label y-coordinate");
@@ -1465,7 +1468,7 @@ int TLuaInterpreter::createLabelMainWindow(lua_State* L, const QString& labelNam
     }
 
     Host& host = getHostFromLua(L);
-    if (auto [success, message] = host.createLabel(windowName, labelName, x, y, width, height, fillBackground, clickthrough); !success) {
+    if (auto [success, message] = host.createLabel(qsl("main"), QString{labelName}, x, y, width, height, fillBackground, clickthrough); !success) {
         // We should, perhaps be returning a nil here but the published API
         // says the function returns true or false and we cannot change that now
         return warnArgumentValue(L, "createLabel", message, true);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -446,8 +446,8 @@ public:
     static int createMiniConsole(lua_State*);
     static int createScrollBox(lua_State*);
     static int createLabel(lua_State*);
-    static int createLabelMainWindow(lua_State*, const QString& labelName);
-    static int createLabelUserWindow(lua_State*, const QString& windowName, const QString& labelName);
+    static int createLabelMainWindow(lua_State*, const char* labelName);
+    static int createLabelUserWindow(lua_State*, const char* windowName, const char* labelName);
     static int deleteLabel(lua_State*);
     static int deleteMiniConsole(lua_State*);
     static int deleteCommandLine(lua_State*);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -59,6 +59,7 @@
 #include "glwidget_integration.h"
 #endif
 
+#include <array>
 #include <limits>
 #include <math.h>
 
@@ -352,26 +353,19 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createLabel
 int TLuaInterpreter::createLabel(lua_State* L)
 {
-    QString labelName;
-    QString windowName = QLatin1String("main");
-
     if (lua_type(L, 1) != LUA_TSTRING) {
         lua_pushfstring(L, "createLabel: bad argument #1 type (label or parent window name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    if ((lua_type(L, 1) == LUA_TSTRING) && (lua_type(L, 2) == LUA_TSTRING)) {
-        windowName = lua_tostring(L, 1);
-        labelName = lua_tostring(L, 2);
-        createLabelUserWindow(L, windowName, labelName);
-    } else if ((lua_type(L, 1) == LUA_TSTRING) && (lua_type(L, 2) == LUA_TNUMBER)) {
-        labelName = lua_tostring(L, 1);
-        createLabelMainWindow(L, labelName);
-    } else {
-        lua_pushfstring(L, "createLabel: bad argument #2 type (label name as string or label x-coordinate as number expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
+    if (lua_type(L, 2) == LUA_TSTRING) {
+        return createLabelUserWindow(L, lua_tostring(L, 1), lua_tostring(L, 2));
+    }
+    if (lua_type(L, 2) == LUA_TNUMBER) {
+        return createLabelMainWindow(L, lua_tostring(L, 1));
     }
 
-    return 1;
+    lua_pushfstring(L, "createLabel: bad argument #2 type (label name as string or label x-coordinate as number expected, got %s!)", luaL_typename(L, 2));
+    return lua_error(L);
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMiniConsole
@@ -3303,9 +3297,16 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
 
     const int n = lua_gettop(L);
 
-    const QString windowName{WINDOW_NAME(L, 1)};
+    // Every argument check below can raise a Lua error, and lua_error() longjmps
+    // past C++ destructors - so nothing holding heap memory may be alive while they
+    // run: the window name stays the Lua-owned string anchored at stack index 1 and
+    // the colour components a plain array until the last check has passed. The
+    // blinkMode QString further down is exempt only because it holds a
+    // QStringLiteral until after the last raise; give it a computed default and the
+    // leak comes back
+    const char* windowNameCString = WINDOW_NAME(L, 1);
 
-    QVector<int> colorComponents(6); // 0-2 RGB background, 3-5 RGB foreground
+    std::array<int, 6> colorComponents{}; // 0-2 RGB background, 3-5 RGB foreground
     colorComponents[0] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 2, "red background color component"), 255.0));
     colorComponents[1] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 3, "green background color component"), 255.0));
     colorComponents[2] = qRound(qBound(0.0, getVerifiedDouble(L, __func__, 4, "blue background color component"), 255.0));
@@ -3406,8 +3407,8 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
                                         | (reverse ? TChar::Reverse : TChar::None) | (strikeout ? TChar::StrikeOut : TChar::None) | (underline ? TChar::Underline : TChar::None)
                                         | (fastBlink ? TChar::FastBlink : (slowBlink ? TChar::Blink : TChar::None));
 
-    if (!host.mpConsole->setTextFormat(
-                windowName, QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)), QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)), flags)) {
+    const QString windowName{windowNameCString};
+    if (!host.mpConsole->setTextFormat(windowName, QColor(colorComponents[3], colorComponents[4], colorComponents[5]), QColor(colorComponents[0], colorComponents[1], colorComponents[2]), flags)) {
         return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName), true);
     }
 
@@ -3752,7 +3753,7 @@ int TLuaInterpreter::windowType(lua_State* L)
     }
 
     lua_pushnil(L);
-    lua_pushfstring(L, "'%s' is not a known label, any type of console, nor command line", windowName.toUtf8().constData());
+    lua_pushfstring(L, "'%s' is not a known label, any type of console, command line, text edit, nor scroll box", windowName.toUtf8().constData());
     return 2;
 }
 

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -133,11 +133,22 @@ describe("Tests UI functions", function()
       assert.are.equal(windowType("fake commandline"), nil)
     end)
 
+    it("Should identify a scroll box", function()
+      createScrollBox("testscrollbox", 0,0,100,100)
+
+      assert.are.equal(windowType("testscrollbox"), "scrollbox")
+    end)
+
+    it("Should not identify a non-existing scroll box", function()
+      assert.are.equal(windowType("fake scrollbox"), nil)
+    end)
+
     teardown(function()
       deleteLabel("testlabel")
       hideWindow("testuserwindow")
       hideWindow("testminiconsole")
       disableCommandLine("testcommandline")
+      deleteScrollBox("testscrollbox")
     end)
   end)
 
@@ -2841,8 +2852,7 @@ describe("Window and label state", function()
       assert.are.equal("miniconsole", windowType(console))
       assert.are.equal("commandline", windowType(cmdLine))
       assert.are.equal("textedit", windowType(textEdit))
-      -- windowType is deliberately not asserted for the scroll box: it has no
-      -- scroll box branch, so it reports a live scroll box as unknown
+      assert.are.equal("scrollbox", windowType(scrollBox))
     end)
 
     it("openUserWindow reports the window as a userwindow and is repeatable", function()
@@ -2856,6 +2866,37 @@ describe("Window and label state", function()
       local ok, err = openUserWindow(label)
       assert.is_nil(ok)
       assert.are.equal(("label with the name '%s' already exists"):format(label), err)
+    end)
+
+    it("createLabel on an existing name returns false and a message", function()
+      local ok, err = createLabel(label, 41, 51, 61, 71, 1)
+      assert.is_false(ok)
+      assert.are.equal(("label '%s' already exists"):format(label), err)
+      -- the parented form reports the same way
+      local childOk, childErr = createLabel(userWindow, childLabel, 4, 5, 30, 20, 1)
+      assert.is_false(childOk)
+      assert.are.equal(("label '%s' already exists"):format(childLabel), childErr)
+      -- unlike createMiniConsole/createScrollBox a refused createLabel must leave
+      -- the existing labels alone rather than moving and resizing them
+      assert.are.same({11, 22, 133, 44}, {getWindowGeometry(label)})
+      assert.are.same({5, 6, 40, 20}, {getWindowGeometry(childLabel)})
+    end)
+
+    it("createLabel on a name taken by a miniconsole returns false and a message", function()
+      local ok, err = createLabel(console, 1, 2, 3, 4, 1)
+      assert.is_false(ok)
+      assert.are.equal(("a miniconsole/userwindow with the name '%s' already exists"):format(console), err)
+    end)
+
+    it("createLabel hard-errors on a non-number coordinate", function()
+      -- a string second argument selects the parented form, so the two forms
+      -- report the same argument number for different coordinates
+      local mainOk, mainErr = pcall(createLabel, name("wlsBadCoordLabel"), 0, "here", 40, 40, 1)
+      assert.is_false(mainOk)
+      assert.is_truthy(mainErr:find("createLabel: bad argument #3 type (label y-coordinate", 1, true))
+      local childOk, childErr = pcall(createLabel, userWindow, name("wlsBadCoordChild"), "here", 0, 40, 40, 1)
+      assert.is_false(childOk)
+      assert.is_truthy(childErr:find("createLabel: bad argument #3 type (label x-coordinate", 1, true))
     end)
 
     it("createMiniConsole on an existing name moves and resizes it instead", function()
@@ -3810,9 +3851,33 @@ describe("Window and label state", function()
       assert.is_true(format.italic)
     end)
 
-    -- setTextFormat's argument-type errors are deliberately not covered: the
-    -- lua_error() they raise longjmps past the destructor of the QVector the
-    -- function builds first, so exercising them leaks and fails the leak check
+    -- these four cover setTextFormat's raising paths, which used to leak the
+    -- objects the function built before validating (issue #9576) - they assert the
+    -- messages, the leak checker asserts the rest
+
+    it("hard-errors on a non-number colour component", function()
+      local ok, err = pcall(setTextFormat, console, "red", 0, 0, 0, 0, 0, false, false, false)
+      assert.is_false(ok)
+      assert.is_truthy(err:find("setTextFormat: bad argument #2 type", 1, true))
+    end)
+
+    it("hard-errors on a non-boolean attribute", function()
+      local ok, err = pcall(setTextFormat, console, 0, 0, 0, 0, 0, 0, "yes", false, false)
+      assert.is_false(ok)
+      assert.is_truthy(err:find("setTextFormat: bad argument #8 type", 1, true))
+    end)
+
+    it("hard-errors on a non-boolean optional attribute", function()
+      local ok, err = pcall(setTextFormat, console, 0, 0, 0, 0, 0, 0, false, false, false, "yes")
+      assert.is_false(ok)
+      assert.is_truthy(err:find("setTextFormat: bad argument #11 type", 1, true))
+    end)
+
+    it("hard-errors on a blink mode that is not a string", function()
+      local ok, err = pcall(setTextFormat, console, 0, 0, 0, 0, 0, 0, false, false, false, false, false, false, {})
+      assert.is_false(ok)
+      assert.is_truthy(err:find("setTextFormat: bad argument #14 type", 1, true))
+    end)
 
     it("returns false and a message for an unknown window", function()
       -- unlike most of the UI API this one reports false rather than nil


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `setTextFormat` built a `QVector<int>` and a `QString` before validating its arguments, so every `lua_error()` on the type paths longjmped past their destructors; `createLabel`'s two helpers held `QString`s across the same kind of raise. Both now build owning objects only once nothing else can raise.
- `createLabel` discarded its helpers' return count and always returned 1, so a failed call handed Lua only the message string - truthy, so `if not createLabel(...)` could never see the failure. It now returns the documented `false` + message.
- `windowType` gained a scroll box branch, and its not-found message now names every type it actually checks.

#### Motivation for adding to Mudlet
All three turned up while writing #9570's specs; the leak was blocking spec coverage of `setTextFormat`'s error paths outright, so those specs are enabled here too.

Fixes #9576
Fixes #9577
Fixes #9578

#### Other info (issues closed, discussion etc)
Stacked on #9570 - based on `specs-ui-geometry`, so review that one first; GitHub retargets this to `development` when #9570 merges. Note for package authors: `createLabel` (and its `createButton` alias) now returns 2 values on failure where it returned 1.

**Test case:** busted suite 1458/0/0 twice, LSan clean; against the unfixed binary the same specs give 1454/4 failures (scroll box reports nil, `createLabel` returns the message string where `false` is expected) plus `160 byte(s) leaked in 4 allocation(s)` from `TLuaInterpreter::setTextFormat`.

Assisted-by: Claude:claude-opus-5
