### PR TITLE
fix: compare() no longer rejects tables that hold false

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -575,9 +575,9 @@ function _comp(a, b)
     local a_size = 0
     for k, v in pairs(a) do
       a_size = a_size + 1
-      if not b[k] then
-        return false
-      end
+      -- A key missing from b is already caught by the _comp call below, whose
+      -- first check is a type comparison and so fails against nil. Testing
+      -- `not b[k]` here as well rejected a legitimate `false` value.
       if not _comp(v, b[k]) then
         return false
       end

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -441,6 +441,13 @@ describe("Tests Other.lua functions", function()
       assert.is_false(_comp(true,false))
     end)
 
+    it("compares tables holding false like tables holding any other value", function()
+      assert.is_true(_comp({ key = false }, { key = false }))
+      assert.is_false(_comp({ key = false }, { key = true }))
+      assert.is_false(_comp({ key = false }, {}))
+      assert.is_true(_comp({ outer = { inner = false } }, { outer = { inner = false } }))
+    end)
+
     it("returns true if table B has the same value for every key which table A contains.", function()
       local tableA = { "One", "Two" }
       local tableB = { "One", "Two" }


### PR DESCRIPTION
`compare()` reports two identical tables as different when they hold `false`.

```lua
compare({ key = false }, { key = false })   --> false    should be true
compare({ key = true },  { key = true })    --> true
compare({ key = 0 },     { key = 0 })       --> true     (0 is truthy in Lua)
```

Only `false` is affected, which is what makes it easy to miss.

## Cause

`_comp` checks whether a key exists in `b` with a truthiness test:

```lua
if not b[k] then
  return false
end
```

`b[k]` is `false` for a key that is present and holds `false`, so the comparison bails out
as though the key were missing.

`compare` is this function (`compare = _comp`), and `_comp` is also the engine behind
`table.intersection`, `table.n_intersection`, `table.complement` and
`table.n_complement`. All of them return wrong results for nested tables holding `false`:

```lua
table.complement({ k = { x = false } }, { k = { x = false } })
--> { k = { x = false } }    should be {} -- the tables are equal
```

## Fix

The three lines are removed rather than rewritten, because they were redundant as well as
wrong:

- **A key missing from `b`** is caught by the `_comp(v, b[k])` call immediately after.
  Its first check is `type(a) ~= type(b)`, which fails against `nil`.
- **`b` having extra keys** is caught by `a_size ~= table.size(b)` at the end of the loop,
  which is what #3423 added for exactly that case.

So no check is lost by deleting them. I have added a comment in their place recording why,
so the test does not get reintroduced later as a "missing" guard.

## Testing

I ran the patched `_comp` in a Lua interpreter:

```
{a=false} vs {a=false}   -> true    (was false)
{a=false} vs {a=true}    -> false
{a=false} vs {}          -> false   (missing key still rejected)
{a=1}     vs {a=1,b=2}   -> false   (extra key still rejected)
nested {k={x=false}}     -> true
{a=1}     vs {a="1"}     -> false   (type mismatch still rejected)
```

The existing `_comp` specs pass unchanged. One spec is added covering `false` at the top
level and nested, plus the missing-key case so the removed guard stays covered.

<sub>Written with AI assistance, declared in the commit trailer per `AGENTS.md`. I ran the
tests and reviewed the change before signing off.</sub>
