### PR TITLE
fix: table.n_collect drops values that match an index

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -245,7 +245,11 @@ function table.n_collect(tbl, func)
   assert(func_type == "function", string.format("table.n_collect: bad argument #2 type (function to run against each item in tbl as function expected, got %s)", func_type))
   local matches = {}
   for key,value in pairs(tbl) do
-    if func(value) == true and not table.contains(matches, value) then
+    -- table.contains matches keys and nested values too, so a value equal to
+    -- an index already in `matches` looked like a duplicate. table.index_of
+    -- compares by value over ipairs, which is the semantics a list of unique
+    -- values needs, and is what the sibling table.n_matches already uses.
+    if func(value) == true and not table.index_of(matches, value) then
       table.insert(matches, value)
     end
   end

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -264,7 +264,18 @@ describe("Tests TableUtils.lua functions", function()
       local errfn = function()
         table.n_collect(tbl, func)
       end
-      assert.has_error(errfn, "table.n_collect: bad argument #2 type (function to run against each item in tbl as function expected, got string)") 
+      assert.has_error(errfn, "table.n_collect: bad argument #2 type (function to run against each item in tbl as function expected, got string)")
+    end)
+
+    it("should keep a value that is equal to an index already collected", function()
+      local actual = table.n_collect({ "a", 1 }, function() return true end)
+      table.sort(actual, function(a, b) return tostring(a) < tostring(b) end)
+      assert.are.same({ 1, "a" }, actual)
+    end)
+
+    it("should keep a value that also appears inside a nested table", function()
+      local actual = table.n_collect({ { "z" }, "z" }, function() return true end)
+      assert.are.equal(2, #actual)
     end)
   end)
 

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -276,6 +276,19 @@ describe("Tests TableUtils.lua functions", function()
     it("should keep a value that also appears inside a nested table", function()
       local actual = table.n_collect({ { "z" }, "z" }, function() return true end)
       assert.are.equal(2, #actual)
+      local nested, plain
+      for _, value in ipairs(actual) do
+        if type(value) == "table" then nested = value else plain = value end
+      end
+      assert.are.same({ "z" }, nested)
+      assert.are.equal("z", plain)
+    end)
+
+    it("should still drop real duplicates", function()
+      local actual = table.n_collect({ 5, "x", 5, "x" }, function() return true end)
+      assert.are.equal(2, #actual)
+      table.sort(actual, function(a, b) return tostring(a) < tostring(b) end)
+      assert.are.same({ 5, "x" }, actual)
     end)
   end)
 


### PR DESCRIPTION
`table.n_collect` silently drops values that passed the filter.

```lua
table.n_collect({ "a", 1 }, function() return true end)
--> { "a" }              should be { "a", 1 }

table.n_collect({ { "z" }, "z" }, function() return true end)
--> { { "z" } }          should be { { "z" }, "z" }
```

The predicate returns `true` for every element, so nothing should be filtered out. The
values disappear during deduplication.

## Cause

`n_collect` deduplicates with `table.contains`:

```lua
if func(value) == true and not table.contains(matches, value) then
```

`table.contains` matches a value against **keys** as well as values, and recurses into
nested tables. That is deliberate — `table._contains` has an explicit `elseif k == value`
branch — but it is the wrong predicate here.

`matches` is a list indexed `1..n`. Once `"a"` occupies index 1, `table.contains(matches, 1)`
is true because `1` is a key, so the value `1` looks like a duplicate and is discarded. The
nested case fails through the recursive branch instead.

## Fix

Use `table.index_of`, which walks with `ipairs` and compares by value — the semantics a
list of unique values needs.

Two things support this beyond it being correct:

- The sibling function `table.n_matches` already uses `table.index_of` for the same
  purpose, so this makes the pair consistent.
- In #6675 the key matching in `table.contains` was confirmed as intended, and
  `table.index_of` was named as the better route for callers that want value matching.
  This applies that decision rather than proposing a new one.

## Testing

I ran the patched file in a Lua interpreter:

```
n_collect({"a", 1})        -> 2 items    (was 1)
n_collect({{"z"}, "z"})    -> 2 items    (was 1)
n_collect({"a","a","b"})   -> 2 items    (dedup still works)
```

The five existing `n_collect` specs pass unchanged — none of them relies on key matching or
on the recursive branch. Two specs are added for the cases above.

<sub>Written with AI assistance, declared in the commit trailer per `AGENTS.md`. I ran the
tests and reviewed the change before signing off.</sub>
