### PR TITLE
fix: Windows auto-update failing on a release binary with no checksum

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -191,55 +191,49 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: assets/
 
-      - name: Verify release assets
+      # A download that fails leaves the release short of a platform, so surface it
+      # rather than letting continue-on-error hide it
+      - name: Report asset download failures
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
         env:
-          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+          LINUX_MACOS_OUTCOME: ${{ steps.download-linux-macos.outcome }}
+          WINDOWS_OUTCOME: ${{ steps.download-windows.outcome }}
         run: |
-          mkdir -p assets/
-          echo "Downloaded assets:"
-          find assets/ -type f | sort
-
-          MISSING=()
-          if ! find assets/ -name '*.AppImage.tar' -type f | grep -q .; then
-            MISSING+=("Linux (.AppImage.tar)")
+          if [[ "${LINUX_MACOS_OUTCOME}" == "failure" ]]; then
+            echo "::warning::Downloading the Linux/macOS release assets failed - they will be missing from this release"
           fi
-          if ! find assets/ -name '*.dmg' -type f | grep -q .; then
-            MISSING+=("macOS (.dmg)")
-          fi
-          if ! find assets/ -name '*.exe' -type f | grep -q .; then
-            MISSING+=("Windows (.exe)")
+          if [[ "${WINDOWS_OUTCOME}" == "failure" ]]; then
+            echo "::warning::Downloading the Windows release assets failed - it will be missing from this release"
           fi
 
-          if [[ ${#MISSING[@]} -gt 0 ]]; then
-            echo "::warning::Missing release assets for: ${MISSING[*]}"
-          fi
+      - name: Verify release assets
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        run: bash CI/prepare-release-assets.sh assets/ "${{ steps.release-type.outputs.tag }}" "${{ steps.release-type.outputs.type }}"
 
-          # Stable releases must have all platforms; PTB tolerates partial
-          if [[ "${RELEASE_TYPE}" == "release" && ${#MISSING[@]} -gt 0 ]]; then
-            echo "::error::Stable release is missing assets for: ${MISSING[*]}"
-            exit 1
+      # The release may already carry assets from the other build workflow's run of
+      # this job, so its SHA256SUMS.txt has to be merged rather than overwritten
+      - name: Fetch published SHA256SUMS.txt
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p published/
+          if ! gh release view "${RELEASE_TAG}" &>/dev/null; then
+            echo "Release ${RELEASE_TAG} does not exist yet - no checksums to merge"
+            exit 0
           fi
-
-          if [[ ${#MISSING[@]} -eq 3 ]]; then
-            echo "::error::No release assets found for any platform"
-            exit 1
+          if gh release download "${RELEASE_TAG}" --pattern SHA256SUMS.txt --dir published/; then
+            echo "Already published on ${RELEASE_TAG}:"
+            cat published/SHA256SUMS.txt
+          else
+            echo "::warning::${RELEASE_TAG} exists but has no SHA256SUMS.txt to merge"
           fi
 
       # Assemble SHA256SUMS.txt from per-platform .sha256 sidecar files
       - name: Assemble SHA256SUMS.txt
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        run: |
-          mapfile -t SHA_FILES < <(find assets/ -name '*.sha256' -type f)
-
-          if [[ ${#SHA_FILES[@]} -eq 0 ]]; then
-            echo "::error::No .sha256 checksum files found in assets/"
-            exit 1
-          fi
-
-          cat "${SHA_FILES[@]}" > assets/SHA256SUMS.txt
-          echo "Generated SHA256SUMS.txt (${#SHA_FILES[@]} entries):"
-          cat assets/SHA256SUMS.txt
+        run: bash CI/assemble-release-checksums.sh assets/ published/SHA256SUMS.txt
 
       - name: Generate changelog
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
@@ -364,6 +358,13 @@ jobs:
           echo "Files to upload:"
           printf '%s\n' "${FILES[@]}"
 
+          # Guard against publishing a binary SHA256SUMS.txt does not cover: the
+          # release ends up holding what is already on it plus what we upload now
+          : > final-assets.txt
+          gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' >> final-assets.txt 2>/dev/null || true
+          printf '%s\n' "${FILES[@]}" | xargs -n 1 basename >> final-assets.txt
+          bash CI/verify-release-checksums.sh assets/SHA256SUMS.txt final-assets.txt
+
           if gh release view "${RELEASE_TAG}" &>/dev/null; then
             echo "Release ${RELEASE_TAG} already exists - uploading any missing assets"
             gh release upload "${RELEASE_TAG}" "${FILES[@]}" --clobber
@@ -381,6 +382,21 @@ jobs:
             gh release create "${ARGS[@]}" "${FILES[@]}" \
               || gh release upload "${RELEASE_TAG}" "${FILES[@]}" --clobber
           fi
+
+      # Confirm against the live release, not just the files we meant to upload
+      - name: Verify published release checksums
+        if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
+        env:
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rm -rf published-final/
+          mkdir -p published-final/
+          gh release download "${RELEASE_TAG}" --pattern SHA256SUMS.txt --dir published-final/
+          gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' > published-final/assets.txt
+          echo "Published assets:"
+          cat published-final/assets.txt
+          bash CI/verify-release-checksums.sh published-final/SHA256SUMS.txt published-final/assets.txt
 
       # Generate and upload Sparkle appcast XML for macOS updates
       - name: Add SSH agent for appcast upload

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -80,6 +80,16 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
+      # workflow_run always runs this file from the default branch, while the
+      # checkout above is the commit that was built - which may predate the release
+      # scripts below. Take them from the same ref as this workflow file.
+      - uses: actions/checkout@v7
+        if: steps.check.outputs.ready == 'true'
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: release-scripts
+          fetch-depth: 1
+
       - uses: leafo/gh-actions-lua@v13
         if: steps.check.outputs.ready == 'true'
         with:
@@ -206,9 +216,12 @@ jobs:
             echo "::warning::Downloading the Windows release assets failed - it will be missing from this release"
           fi
 
-      - name: Verify release assets
+      - name: Prepare release assets
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        run: bash CI/prepare-release-assets.sh assets/ "${{ steps.release-type.outputs.tag }}" "${{ steps.release-type.outputs.type }}"
+        env:
+          RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+        run: bash release-scripts/CI/prepare-release-assets.sh assets/ "${RELEASE_TAG}" "${RELEASE_TYPE}"
 
       # The release may already carry assets from the other build workflow's run of
       # this job, so its SHA256SUMS.txt has to be merged rather than overwritten
@@ -219,21 +232,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p published/
-          if ! gh release view "${RELEASE_TAG}" &>/dev/null; then
-            echo "Release ${RELEASE_TAG} does not exist yet - no checksums to merge"
-            exit 0
+          if ! gh release view "${RELEASE_TAG}" 2> view-error.txt; then
+            if grep -qi 'release not found' view-error.txt; then
+              echo "Release ${RELEASE_TAG} does not exist yet - no checksums to merge"
+              exit 0
+            fi
+            cat view-error.txt
+            echo "::error::Could not read release ${RELEASE_TAG} - refusing to rebuild its checksums from a partial view"
+            exit 1
           fi
           if gh release download "${RELEASE_TAG}" --pattern SHA256SUMS.txt --dir published/; then
             echo "Already published on ${RELEASE_TAG}:"
             cat published/SHA256SUMS.txt
           else
-            echo "::warning::${RELEASE_TAG} exists but has no SHA256SUMS.txt to merge"
+            echo "::warning::${RELEASE_TAG} exists but its SHA256SUMS.txt could not be downloaded - any entry only it covers will be lost"
           fi
 
       # Assemble SHA256SUMS.txt from per-platform .sha256 sidecar files
       - name: Assemble SHA256SUMS.txt
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
-        run: bash CI/assemble-release-checksums.sh assets/ published/SHA256SUMS.txt
+        run: bash release-scripts/CI/assemble-release-checksums.sh assets/ published/SHA256SUMS.txt
 
       - name: Generate changelog
         if: steps.release-type.outputs.type == 'release' || steps.release-type.outputs.type == 'ptb'
@@ -346,28 +364,43 @@ jobs:
           TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Collect release files and combined checksums (exclude per-platform .sha256 sidecars)
-          mapfile -t FILES < <(find assets/ -type f \
-            \( -name '*.AppImage.tar' -o -name '*.exe' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \))
+          # Everything in assets/ except the per-platform sidecars, which only feed
+          # SHA256SUMS.txt. Not a list of binary suffixes: a new asset type must not
+          # be able to reach the release without the checksum gate below seeing it.
+          mapfile -t BINARIES < <(find assets/ -type f ! -name '*.sha256' ! -name 'SHA256SUMS.txt')
 
-          if [[ ${#FILES[@]} -eq 0 ]]; then
+          if [[ ${#BINARIES[@]} -eq 0 ]]; then
             echo "::error::No release files found to upload"
             exit 1
           fi
 
           echo "Files to upload:"
-          printf '%s\n' "${FILES[@]}"
+          printf '%s\n' assets/SHA256SUMS.txt "${BINARIES[@]}"
 
           # Guard against publishing a binary SHA256SUMS.txt does not cover: the
           # release ends up holding what is already on it plus what we upload now
           : > final-assets.txt
-          gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' >> final-assets.txt 2>/dev/null || true
-          printf '%s\n' "${FILES[@]}" | xargs -n 1 basename >> final-assets.txt
-          bash CI/verify-release-checksums.sh assets/SHA256SUMS.txt final-assets.txt
+          if gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' >> final-assets.txt 2> view-error.txt; then
+            RELEASE_EXISTS=yes
+          elif grep -qi 'release not found' view-error.txt; then
+            RELEASE_EXISTS=no
+          else
+            cat view-error.txt
+            echo "::error::Could not list the assets already published on ${RELEASE_TAG} - refusing to publish without checking checksum coverage"
+            exit 1
+          fi
+          basename -a -- "${BINARIES[@]}" >> final-assets.txt
 
-          if gh release view "${RELEASE_TAG}" &>/dev/null; then
+          echo "Assets the release will hold afterwards:"
+          sort -u final-assets.txt
+          bash release-scripts/CI/verify-release-checksums.sh assets/SHA256SUMS.txt final-assets.txt assets/
+
+          # SHA256SUMS.txt first: it is a superset of the old and new binaries, so if
+          # the upload dies partway the release is never left holding an uncovered one
+          if [[ "${RELEASE_EXISTS}" == "yes" ]]; then
             echo "Release ${RELEASE_TAG} already exists - uploading any missing assets"
-            gh release upload "${RELEASE_TAG}" "${FILES[@]}" --clobber
+            gh release upload "${RELEASE_TAG}" assets/SHA256SUMS.txt --clobber
+            gh release upload "${RELEASE_TAG}" "${BINARIES[@]}" --clobber
           else
             ARGS=(
               "${RELEASE_TAG}"
@@ -379,8 +412,9 @@ jobs:
               ARGS+=(--prerelease --target "${TARGET_SHA}")
             fi
 
-            gh release create "${ARGS[@]}" "${FILES[@]}" \
-              || gh release upload "${RELEASE_TAG}" "${FILES[@]}" --clobber
+            gh release create "${ARGS[@]}" assets/SHA256SUMS.txt \
+              || gh release upload "${RELEASE_TAG}" assets/SHA256SUMS.txt --clobber
+            gh release upload "${RELEASE_TAG}" "${BINARIES[@]}" --clobber
           fi
 
       # Confirm against the live release, not just the files we meant to upload
@@ -390,13 +424,26 @@ jobs:
           RELEASE_TAG: ${{ steps.release-type.outputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          rm -rf published-final/
-          mkdir -p published-final/
-          gh release download "${RELEASE_TAG}" --pattern SHA256SUMS.txt --dir published-final/
-          gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' > published-final/assets.txt
+          # A freshly uploaded asset is not always immediately readable, so retry
+          # rather than declaring a good release broken
+          for attempt in 1 2 3 4 5; do
+            rm -rf published-final/
+            mkdir -p published-final/
+            if gh release download "${RELEASE_TAG}" --pattern SHA256SUMS.txt --dir published-final/ \
+              && gh release view "${RELEASE_TAG}" --json assets --jq '.assets[].name' > published-final/assets.txt; then
+              break
+            fi
+            if [[ "${attempt}" -eq 5 ]]; then
+              echo "::error::Could not read back the published ${RELEASE_TAG} assets to verify them"
+              exit 1
+            fi
+            echo "Attempt ${attempt} could not read the published release yet - retrying"
+            sleep 10
+          done
+
           echo "Published assets:"
           cat published-final/assets.txt
-          bash CI/verify-release-checksums.sh published-final/SHA256SUMS.txt published-final/assets.txt
+          bash release-scripts/CI/verify-release-checksums.sh published-final/SHA256SUMS.txt published-final/assets.txt
 
       # Generate and upload Sparkle appcast XML for macOS updates
       - name: Add SSH agent for appcast upload

--- a/CI/assemble-release-checksums.sh
+++ b/CI/assemble-release-checksums.sh
@@ -6,11 +6,15 @@
 # workflow and uploads with --clobber. A run that sees fewer platforms than an
 # earlier run - or a re-run of one platform whose binary is named differently -
 # used to regenerate SHA256SUMS.txt from its own subset of sidecars and overwrite
-# the complete file, while the binaries from the earlier run stayed published.
-# That left release binaries with no checksum line, which Mudlet's updater rejects
-# with "Could not verify the integrity of the download". Entries are keyed by
-# filename and the freshly built sidecars win, so the published file only ever
-# gains coverage.
+# the complete file, while the binaries from the earlier run stayed published. That
+# left release binaries with no checksum line, which the updater's download path
+# refuses to install (see Feed::findChecksum and UpdateDialog::startDownload).
+# Entries are keyed by filename and the freshly built sidecars win, so the
+# published file only ever gains coverage.
+#
+# This is a read-modify-write of a file shared by both platform triggers; it is
+# only safe because create-github-release.yml serialises them with a `concurrency`
+# group keyed on the build's head_sha.
 #
 # Usage: assemble-release-checksums.sh <assets-dir> [published-sums-file]
 
@@ -21,7 +25,12 @@ PUBLISHED_SUMS="${2:-}"
 
 OUTPUT="${ASSETS_DIR%/}/SHA256SUMS.txt"
 
-mapfile -t SHA_FILES < <(find "${ASSETS_DIR}" -name '*.sha256' -type f | sort)
+# no mapfile: macOS ships bash 3.2, and test/ci/release-checksums-test.sh runs
+# these scripts under ctest there
+SHA_FILES=()
+while IFS= read -r sha_file; do
+  SHA_FILES+=("${sha_file}")
+done < <(find "${ASSETS_DIR}" -name '*.sha256' -type f | sort)
 
 if [[ ${#SHA_FILES[@]} -eq 0 ]]; then
   echo "::error::No .sha256 checksum files found in ${ASSETS_DIR}"
@@ -31,35 +40,88 @@ fi
 RECORDS="$(mktemp)"
 trap 'rm -f "${RECORDS}"' EXIT
 
-# Emits "<filename>\t<priority>\t<line>" for every checksum line on stdin, so the
-# lines can be deduplicated by filename with the lowest priority winning.
+# Appends "<filename>\t<priority>\t<hash>\t<binary marker>" to ${RECORDS} for
+# every checksum line on stdin, so the lines can be deduplicated by filename with
+# the lowest priority number winning. The output line is rebuilt from these fields
+# rather than carried through verbatim, because a checksum line may itself contain
+# a tab and would then be truncated by the tab-delimited dedupe.
 collect() {
   local priority="$1"
-  local line hash filename
+  local source_label="$2"
+  local line
   while IFS= read -r line || [[ -n "${line}" ]]; do
-    # sha256sum writes "<hash>  <name>" in text mode and "<hash> *<name>" in binary mode
-    if [[ ! "${line}" =~ ^([0-9a-fA-F]{64})[[:space:]]+\*?(.+)$ ]]; then
+    line="${line%$'\r'}"
+    if [[ -z "${line}" ]]; then
       continue
     fi
-    hash="${BASH_REMATCH[1]}"
-    filename="${BASH_REMATCH[2]}"
-    printf '%s\t%s\t%s\n' "${filename}" "${priority}" "${line}" >> "${RECORDS}"
+    # sha256sum writes "<hash>  <name>" in text mode and "<hash> *<name>" in
+    # binary mode; MSYS2's defaults to binary, so the Windows entry uses " *"
+    if [[ ! "${line}" =~ ^([0-9a-fA-F]{64})[[:space:]]+(\*?)(.+)$ ]]; then
+      echo "::warning::Ignoring unparseable checksum line from ${source_label}: ${line}"
+      continue
+    fi
+    printf '%s\t%s\t%s\t%s\n' "${BASH_REMATCH[3]}" "${priority}" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" >> "${RECORDS}"
   done
+}
+
+record_count() {
+  wc -l < "${RECORDS}" | tr -d ' '
 }
 
 if [[ -n "${PUBLISHED_SUMS}" && -f "${PUBLISHED_SUMS}" ]]; then
   echo "Merging over the SHA256SUMS.txt already published on the release"
-  collect 2 < "${PUBLISHED_SUMS}"
+  collect 2 "the published SHA256SUMS.txt" < "${PUBLISHED_SUMS}"
 fi
 
-cat "${SHA_FILES[@]}" | collect 1
+# one sidecar at a time: concatenating them would join two records whenever a
+# sidecar lacks a trailing newline
+for sha_file in "${SHA_FILES[@]}"; do
+  before="$(record_count)"
+  sidecar_name="$(basename "${sha_file}")"
+  collect 1 "${sidecar_name}" < "${sha_file}"
+  if [[ "$(record_count)" -eq "${before}" ]]; then
+    echo "::error::${sha_file} contributed no checksum entry, so the binary it describes would be published uncovered"
+    exit 1
+  fi
+done
 
 if [[ ! -s "${RECORDS}" ]]; then
   echo "::error::No valid checksum lines found in ${SHA_FILES[*]} ${PUBLISHED_SUMS}"
   exit 1
 fi
 
-sort -t $'\t' -k1,1 -k2,2n "${RECORDS}" | awk -F '\t' '!seen[$1]++ { print $3 }' > "${OUTPUT}"
+# First record per filename wins after sorting by filename then priority, so a
+# freshly built sidecar (1) beats an already published entry (2). Two different
+# hashes for one filename at the winning priority mean the inputs disagree, which
+# must not be resolved by picking one arbitrarily.
+if ! sort -t $'\t' -k1,1 -k2,2n "${RECORDS}" | awk -F '\t' '
+{
+  filename = $1; priority = $2 + 0; hash = $3; marker = $4
+  if (!(filename in winningPriority)) {
+    winningPriority[filename] = priority
+    winningHash[filename] = hash
+    winningMarker[filename] = marker
+    order[++count] = filename
+  } else if (priority == winningPriority[filename] && hash != winningHash[filename]) {
+    conflicting[filename] = 1
+  }
+}
+END {
+  failed = 0
+  for (i = 1; i <= count; i++) {
+    filename = order[i]
+    if (filename in conflicting) {
+      printf "::error::Conflicting checksums for %s - refusing to guess which is current\n", filename > "/dev/stderr"
+      failed = 1
+      continue
+    }
+    separator = (winningMarker[filename] == "*") ? " *" : "  "
+    printf "%s%s%s\n", winningHash[filename], separator, filename
+  }
+  exit failed
+}' > "${OUTPUT}"; then
+  exit 1
+fi
 
-echo "Generated SHA256SUMS.txt ($(wc -l < "${OUTPUT}") entries):"
+echo "Generated SHA256SUMS.txt ($(wc -l < "${OUTPUT}" | tr -d ' ') entries):"
 cat "${OUTPUT}"

--- a/CI/assemble-release-checksums.sh
+++ b/CI/assemble-release-checksums.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Assembles SHA256SUMS.txt for a GitHub Release from the per-platform .sha256
+# sidecar files, merged over the SHA256SUMS.txt already published on the release.
+#
+# Merging matters because create-github-release.yml runs once per platform build
+# workflow and uploads with --clobber. A run that sees fewer platforms than an
+# earlier run - or a re-run of one platform whose binary is named differently -
+# used to regenerate SHA256SUMS.txt from its own subset of sidecars and overwrite
+# the complete file, while the binaries from the earlier run stayed published.
+# That left release binaries with no checksum line, which Mudlet's updater rejects
+# with "Could not verify the integrity of the download". Entries are keyed by
+# filename and the freshly built sidecars win, so the published file only ever
+# gains coverage.
+#
+# Usage: assemble-release-checksums.sh <assets-dir> [published-sums-file]
+
+set -euo pipefail
+
+ASSETS_DIR="${1:?assets directory required}"
+PUBLISHED_SUMS="${2:-}"
+
+OUTPUT="${ASSETS_DIR%/}/SHA256SUMS.txt"
+
+mapfile -t SHA_FILES < <(find "${ASSETS_DIR}" -name '*.sha256' -type f | sort)
+
+if [[ ${#SHA_FILES[@]} -eq 0 ]]; then
+  echo "::error::No .sha256 checksum files found in ${ASSETS_DIR}"
+  exit 1
+fi
+
+RECORDS="$(mktemp)"
+trap 'rm -f "${RECORDS}"' EXIT
+
+# Emits "<filename>\t<priority>\t<line>" for every checksum line on stdin, so the
+# lines can be deduplicated by filename with the lowest priority winning.
+collect() {
+  local priority="$1"
+  local line hash filename
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    # sha256sum writes "<hash>  <name>" in text mode and "<hash> *<name>" in binary mode
+    if [[ ! "${line}" =~ ^([0-9a-fA-F]{64})[[:space:]]+\*?(.+)$ ]]; then
+      continue
+    fi
+    hash="${BASH_REMATCH[1]}"
+    filename="${BASH_REMATCH[2]}"
+    printf '%s\t%s\t%s\n' "${filename}" "${priority}" "${line}" >> "${RECORDS}"
+  done
+}
+
+if [[ -n "${PUBLISHED_SUMS}" && -f "${PUBLISHED_SUMS}" ]]; then
+  echo "Merging over the SHA256SUMS.txt already published on the release"
+  collect 2 < "${PUBLISHED_SUMS}"
+fi
+
+cat "${SHA_FILES[@]}" | collect 1
+
+if [[ ! -s "${RECORDS}" ]]; then
+  echo "::error::No valid checksum lines found in ${SHA_FILES[*]} ${PUBLISHED_SUMS}"
+  exit 1
+fi
+
+sort -t $'\t' -k1,1 -k2,2n "${RECORDS}" | awk -F '\t' '!seen[$1]++ { print $3 }' > "${OUTPUT}"
+
+echo "Generated SHA256SUMS.txt ($(wc -l < "${OUTPUT}") entries):"
+cat "${OUTPUT}"

--- a/CI/prepare-release-assets.sh
+++ b/CI/prepare-release-assets.sh
@@ -2,15 +2,21 @@
 # Validates the assets downloaded from the platform build runs before they are
 # published to a GitHub Release, and sets aside any that do not belong.
 #
-# Release assets are named "<release tag>[<rebuild counter>]-<platform>.<ext>",
-# because both the tag and the filenames are built from the same
-# VERSION/MUDLET_VERSION_BUILD/BUILD_COMMIT triple. The two platform build
-# workflows can be re-run independently, and a re-run restamps the PTB build date
-# and appends a rebuild counter - so its artifacts carry a different tag prefix.
-# create-github-release.yml always picks the newest successful run per platform,
-# so a re-run of one platform can pair its artifacts with another platform's
-# older artifacts. Publishing those would put a binary from build B into the
-# release for build A, whose in-app version does not match the release tag.
+# A PTB tag is "Mudlet-<VERSION><-ptb-DATE>-<COMMIT>" and its asset filenames are
+# built from the same values, so they share that prefix; a stable release tag is
+# the pushed git tag, which spells "Mudlet-<VERSION>" and so shares the prefix
+# too. Anything else came from a different build: the two platform build workflows
+# can be re-run independently, a re-run recomputes the PTB date and so carries a
+# newer prefix than the tag, and create-github-release.yml always pairs the newest
+# successful run of each platform. Publishing such a file would put a binary from
+# build B into the release for build A, whose in-app version does not match the
+# release tag - and would leave the release holding a binary that no SHA256SUMS.txt
+# line can cover, because its checksum sidecar belongs to the other build.
+#
+# Setting an asset aside does not remove anything already published: a binary from
+# another build that an earlier run uploaded stays on the release, and stays
+# covered because assemble-release-checksums.sh merges its published entry
+# forward.
 #
 # Usage: prepare-release-assets.sh <assets-dir> <release-tag> <release-type>
 
@@ -20,30 +26,33 @@ ASSETS_DIR="${1:?assets directory required}"
 RELEASE_TAG="${2:?release tag required}"
 RELEASE_TYPE="${3:?release type required}"
 
-# Suffixes of files published as release assets, as opposed to the .sha256
-# sidecars that only feed SHA256SUMS.txt
-readonly BINARY_SUFFIXES=('.AppImage.tar' '.dmg' '.exe')
-
 mkdir -p "${ASSETS_DIR}"
 
 echo "Downloaded assets:"
 find "${ASSETS_DIR}" -type f | sort
 
+# Everything published alongside the binaries, rather than a list of binary
+# suffixes: an unrecognised suffix has to be treated as a binary that needs
+# checking, or adding an asset type would silently exempt it
 is_release_binary() {
   local name="$1"
-  local suffix
-  for suffix in "${BINARY_SUFFIXES[@]}"; do
-    if [[ "${name}" == *"${suffix}" ]]; then
-      return 0
-    fi
-  done
-  return 1
+  [[ "${name}" != "SHA256SUMS.txt" && "${name}" != *.sha256 ]]
+}
+
+# Whether any file matching the pattern exists. `find | grep -q .` would be
+# simpler but exits non-zero under `set -o pipefail` when find is still writing as
+# grep leaves, which would report a present asset as missing.
+have_asset() {
+  [[ -n "$(find "${ASSETS_DIR}" -name "$1" -type f -print -quit)" ]]
 }
 
 # Set aside assets belonging to a different build. A .sha256 sidecar is judged by
 # the binary it describes, so a rejected binary takes its sidecar with it.
+# CI/set-build-info.sh lowercases VERSION while a git tag keeps its case, so the
+# prefix has to be compared case-insensitively.
 REJECTED_DIR="${ASSETS_DIR%/}-rejected"
 REJECTED=()
+shopt -s nocasematch
 while IFS= read -r asset_path; do
   asset_name="$(basename "${asset_path}")"
   binary_name="${asset_name%.sha256}"
@@ -57,19 +66,23 @@ while IFS= read -r asset_path; do
   mv "${asset_path}" "${REJECTED_DIR}/"
   REJECTED+=("${asset_name}")
 done < <(find "${ASSETS_DIR}" -type f | sort)
+shopt -u nocasematch
 
 if [[ ${#REJECTED[@]} -gt 0 ]]; then
   echo "::warning::Ignoring ${#REJECTED[@]} asset(s) from a different build than ${RELEASE_TAG}: ${REJECTED[*]}"
 fi
 
 MISSING=()
-if ! find "${ASSETS_DIR}" -name '*.AppImage.tar' -type f | grep -q .; then
+if ! have_asset '*.AppImage.tar'; then
   MISSING+=("Linux (.AppImage.tar)")
 fi
-if ! find "${ASSETS_DIR}" -name '*.dmg' -type f | grep -q .; then
-  MISSING+=("macOS (.dmg)")
+if ! have_asset '*-arm64.dmg'; then
+  MISSING+=("macOS (arm64 .dmg)")
 fi
-if ! find "${ASSETS_DIR}" -name '*.exe' -type f | grep -q .; then
+if ! have_asset '*-x86_64.dmg'; then
+  MISSING+=("macOS (x86_64 .dmg)")
+fi
+if ! have_asset '*.exe'; then
   MISSING+=("Windows (.exe)")
 fi
 
@@ -83,7 +96,7 @@ if [[ "${RELEASE_TYPE}" == "release" && ${#MISSING[@]} -gt 0 ]]; then
   exit 1
 fi
 
-if [[ ${#MISSING[@]} -eq 3 ]]; then
+if ! have_asset '*.AppImage.tar' && ! have_asset '*.dmg' && ! have_asset '*.exe'; then
   echo "::error::No release assets found for any platform"
   exit 1
 fi

--- a/CI/prepare-release-assets.sh
+++ b/CI/prepare-release-assets.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Validates the assets downloaded from the platform build runs before they are
+# published to a GitHub Release, and sets aside any that do not belong.
+#
+# Release assets are named "<release tag>[<rebuild counter>]-<platform>.<ext>",
+# because both the tag and the filenames are built from the same
+# VERSION/MUDLET_VERSION_BUILD/BUILD_COMMIT triple. The two platform build
+# workflows can be re-run independently, and a re-run restamps the PTB build date
+# and appends a rebuild counter - so its artifacts carry a different tag prefix.
+# create-github-release.yml always picks the newest successful run per platform,
+# so a re-run of one platform can pair its artifacts with another platform's
+# older artifacts. Publishing those would put a binary from build B into the
+# release for build A, whose in-app version does not match the release tag.
+#
+# Usage: prepare-release-assets.sh <assets-dir> <release-tag> <release-type>
+
+set -euo pipefail
+
+ASSETS_DIR="${1:?assets directory required}"
+RELEASE_TAG="${2:?release tag required}"
+RELEASE_TYPE="${3:?release type required}"
+
+# Suffixes of files published as release assets, as opposed to the .sha256
+# sidecars that only feed SHA256SUMS.txt
+readonly BINARY_SUFFIXES=('.AppImage.tar' '.dmg' '.exe')
+
+mkdir -p "${ASSETS_DIR}"
+
+echo "Downloaded assets:"
+find "${ASSETS_DIR}" -type f | sort
+
+is_release_binary() {
+  local name="$1"
+  local suffix
+  for suffix in "${BINARY_SUFFIXES[@]}"; do
+    if [[ "${name}" == *"${suffix}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Set aside assets belonging to a different build. A .sha256 sidecar is judged by
+# the binary it describes, so a rejected binary takes its sidecar with it.
+REJECTED_DIR="${ASSETS_DIR%/}-rejected"
+REJECTED=()
+while IFS= read -r asset_path; do
+  asset_name="$(basename "${asset_path}")"
+  binary_name="${asset_name%.sha256}"
+  if ! is_release_binary "${binary_name}"; then
+    continue
+  fi
+  if [[ "${binary_name}" == "${RELEASE_TAG}"* ]]; then
+    continue
+  fi
+  mkdir -p "${REJECTED_DIR}"
+  mv "${asset_path}" "${REJECTED_DIR}/"
+  REJECTED+=("${asset_name}")
+done < <(find "${ASSETS_DIR}" -type f | sort)
+
+if [[ ${#REJECTED[@]} -gt 0 ]]; then
+  echo "::warning::Ignoring ${#REJECTED[@]} asset(s) from a different build than ${RELEASE_TAG}: ${REJECTED[*]}"
+fi
+
+MISSING=()
+if ! find "${ASSETS_DIR}" -name '*.AppImage.tar' -type f | grep -q .; then
+  MISSING+=("Linux (.AppImage.tar)")
+fi
+if ! find "${ASSETS_DIR}" -name '*.dmg' -type f | grep -q .; then
+  MISSING+=("macOS (.dmg)")
+fi
+if ! find "${ASSETS_DIR}" -name '*.exe' -type f | grep -q .; then
+  MISSING+=("Windows (.exe)")
+fi
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "::warning::Missing release assets for: ${MISSING[*]}"
+fi
+
+# Stable releases must have all platforms; PTB tolerates partial
+if [[ "${RELEASE_TYPE}" == "release" && ${#MISSING[@]} -gt 0 ]]; then
+  echo "::error::Stable release is missing assets for: ${MISSING[*]}"
+  exit 1
+fi
+
+if [[ ${#MISSING[@]} -eq 3 ]]; then
+  echo "::error::No release assets found for any platform"
+  exit 1
+fi
+
+echo "Assets to publish for ${RELEASE_TAG}:"
+find "${ASSETS_DIR}" -type f | sort

--- a/CI/verify-release-checksums.sh
+++ b/CI/verify-release-checksums.sh
@@ -1,63 +1,107 @@
 #!/bin/bash
-# Fails if any release binary lacks a SHA256SUMS.txt entry.
+# Fails if any release binary lacks a SHA256SUMS.txt entry, or if a binary we still
+# have on disk does not hash to the value listed for it.
 #
-# Mudlet's updater refuses to install a download it cannot verify, so a release
-# binary without a checksum line is not installable - see
+# The updater's download path refuses a download it cannot verify (see
+# UpdateDialog::startDownload, which passes requireChecksums), so a release binary
+# without a checksum line cannot be installed through the update dialog - see
 # assemble-release-checksums.sh for how that used to happen. This is the gate that
 # keeps it from being published.
 #
-# Usage: verify-release-checksums.sh <sums-file> <asset-names-file>
+# The check covers assets already on the release, not just the ones being uploaded,
+# because those are what a user's updater will see. A release that is *already*
+# missing a checksum therefore fails every later run of the publishing job and
+# cannot be repaired by re-running it: the sidecar for an older run's binary is no
+# longer downloadable, so the stale asset has to be deleted from the release (or
+# its platform build re-run) by hand.
+#
+# Usage: verify-release-checksums.sh <sums-file> <asset-names-file> [assets-dir]
 #   asset-names-file lists one asset filename per line: every release binary among
-#   them must have an entry in sums-file.
+#     them must have an entry in sums-file.
+#   assets-dir, when given, is searched for each of those binaries, and any that is
+#     found has its actual SHA256 compared against the listed one.
 
 set -euo pipefail
 
 SUMS_FILE="${1:?SHA256SUMS.txt path required}"
 ASSET_NAMES_FILE="${2:?asset names file required}"
-
-readonly BINARY_SUFFIXES=('.AppImage.tar' '.dmg' '.exe')
+ASSETS_DIR="${3:-}"
 
 if [[ ! -f "${SUMS_FILE}" ]]; then
   echo "::error::${SUMS_FILE} does not exist - cannot verify release checksum coverage"
   exit 1
 fi
 
+# Everything published alongside the binaries, rather than a list of binary
+# suffixes: an unrecognised suffix has to be treated as a binary that needs
+# checking, or adding an asset type would silently exempt it
 is_release_binary() {
   local name="$1"
-  local suffix
-  for suffix in "${BINARY_SUFFIXES[@]}"; do
-    if [[ "${name}" == *"${suffix}" ]]; then
-      return 0
-    fi
-  done
-  return 1
+  [[ "${name}" != "SHA256SUMS.txt" && "${name}" != *.sha256 ]]
 }
 
-# Filenames covered by the checksum file, one per line
+sha256_of() {
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
+# "<filename>\t<hash>" for every entry in the checksum file
 COVERED="$(mktemp)"
 trap 'rm -f "${COVERED}"' EXIT
 while IFS= read -r line || [[ -n "${line}" ]]; do
+  line="${line%$'\r'}"
   if [[ "${line}" =~ ^([0-9a-fA-F]{64})[[:space:]]+\*?(.+)$ ]]; then
-    printf '%s\n' "${BASH_REMATCH[2]}" >> "${COVERED}"
+    printf '%s\t%s\n' "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}" >> "${COVERED}"
   fi
 done < "${SUMS_FILE}"
 
+if [[ ! -s "${COVERED}" ]]; then
+  echo "::error::${SUMS_FILE} contains no usable checksum entries - it is empty or was not downloaded correctly"
+  exit 1
+fi
+
 UNCOVERED=()
+MISMATCHED=()
 CHECKED=0
 while IFS= read -r asset_name || [[ -n "${asset_name}" ]]; do
+  asset_name="${asset_name%$'\r'}"
   if [[ -z "${asset_name}" ]] || ! is_release_binary "${asset_name}"; then
     continue
   fi
   CHECKED=$((CHECKED + 1))
-  if ! grep -qxF "${asset_name}" "${COVERED}"; then
+
+  expected="$(awk -F '\t' -v name="${asset_name}" '$1 == name { print $2; exit }' "${COVERED}")"
+  if [[ -z "${expected}" ]]; then
     UNCOVERED+=("${asset_name}")
+    continue
+  fi
+
+  if [[ -z "${ASSETS_DIR}" ]]; then
+    continue
+  fi
+  asset_path="$(find "${ASSETS_DIR}" -name "${asset_name}" -type f -print -quit 2> /dev/null || true)"
+  if [[ -z "${asset_path}" ]]; then
+    continue
+  fi
+  actual="$(sha256_of "${asset_path}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    MISMATCHED+=("${asset_name} (listed ${expected}, actual ${actual})")
   fi
 done < "${ASSET_NAMES_FILE}"
 
 if [[ ${#UNCOVERED[@]} -gt 0 ]]; then
   echo "::error::${#UNCOVERED[@]} release binary/binaries have no SHA256SUMS.txt entry, so Mudlet's updater cannot install them: ${UNCOVERED[*]}"
+  echo "Delete the stale asset from the release, or re-run the platform build that produced it, then re-run this job."
   echo "SHA256SUMS.txt covers:"
-  sort "${COVERED}"
+  cut -f 1 "${COVERED}" | sort
+  exit 1
+fi
+
+if [[ ${#MISMATCHED[@]} -gt 0 ]]; then
+  echo "::error::${#MISMATCHED[@]} release binary/binaries do not match their SHA256SUMS.txt entry, so Mudlet's updater would reject the download: ${MISMATCHED[*]}"
   exit 1
 fi
 

--- a/CI/verify-release-checksums.sh
+++ b/CI/verify-release-checksums.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Fails if any release binary lacks a SHA256SUMS.txt entry.
+#
+# Mudlet's updater refuses to install a download it cannot verify, so a release
+# binary without a checksum line is not installable - see
+# assemble-release-checksums.sh for how that used to happen. This is the gate that
+# keeps it from being published.
+#
+# Usage: verify-release-checksums.sh <sums-file> <asset-names-file>
+#   asset-names-file lists one asset filename per line: every release binary among
+#   them must have an entry in sums-file.
+
+set -euo pipefail
+
+SUMS_FILE="${1:?SHA256SUMS.txt path required}"
+ASSET_NAMES_FILE="${2:?asset names file required}"
+
+readonly BINARY_SUFFIXES=('.AppImage.tar' '.dmg' '.exe')
+
+if [[ ! -f "${SUMS_FILE}" ]]; then
+  echo "::error::${SUMS_FILE} does not exist - cannot verify release checksum coverage"
+  exit 1
+fi
+
+is_release_binary() {
+  local name="$1"
+  local suffix
+  for suffix in "${BINARY_SUFFIXES[@]}"; do
+    if [[ "${name}" == *"${suffix}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Filenames covered by the checksum file, one per line
+COVERED="$(mktemp)"
+trap 'rm -f "${COVERED}"' EXIT
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  if [[ "${line}" =~ ^([0-9a-fA-F]{64})[[:space:]]+\*?(.+)$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[2]}" >> "${COVERED}"
+  fi
+done < "${SUMS_FILE}"
+
+UNCOVERED=()
+CHECKED=0
+while IFS= read -r asset_name || [[ -n "${asset_name}" ]]; do
+  if [[ -z "${asset_name}" ]] || ! is_release_binary "${asset_name}"; then
+    continue
+  fi
+  CHECKED=$((CHECKED + 1))
+  if ! grep -qxF "${asset_name}" "${COVERED}"; then
+    UNCOVERED+=("${asset_name}")
+  fi
+done < "${ASSET_NAMES_FILE}"
+
+if [[ ${#UNCOVERED[@]} -gt 0 ]]; then
+  echo "::error::${#UNCOVERED[@]} release binary/binaries have no SHA256SUMS.txt entry, so Mudlet's updater cannot install them: ${UNCOVERED[*]}"
+  echo "SHA256SUMS.txt covers:"
+  sort "${COVERED}"
+  exit 1
+fi
+
+if [[ ${CHECKED} -eq 0 ]]; then
+  echo "::error::No release binaries found to verify - expected at least one"
+  exit 1
+fi
+
+echo "All ${CHECKED} release binary/binaries have a SHA256SUMS.txt entry"

--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -159,11 +159,41 @@ void Feed::downloadRelease(const Release& release, bool requireChecksums)
     if (checksumsUrl.isValid() && !checksumsUrl.isEmpty()) {
         fetchChecksums(checksumsUrl);
     } else if (requireChecksums) {
-        //: Error shown when a manual update cannot be verified as safe to install
-        emit downloadError(tr("Could not verify the integrity of the download. Please try again later."));
+        qWarning() << "Release" << release.getVersion() << "publishes no checksums - refusing to install an unverifiable download";
+        //: Error shown when the release publishes no checksums at all, so the download cannot be verified as safe to install
+        emit downloadError(tr("This update does not publish the checksums needed to verify it. Please try again later, or download it from https://www.mudlet.org/download/"));
     } else {
         makeDownloadRequest(downloadUrl);
     }
+}
+
+QString Feed::findChecksum(const QString& checksumData, const QString& downloadFilename)
+{
+    if (downloadFilename.isEmpty()) {
+        return QString();
+    }
+
+    // SHA256 hex digest is 64 characters; search for separator after that
+    static const QRegularExpression separatorRx(qsl("[\\s*]+"));
+    static const QRegularExpression hexRx(qsl("^[0-9a-fA-F]{64}$"));
+
+    const QStringList lines = checksumData.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const auto& line : lines) {
+        // Format: "hash  filename" or "hash *filename"
+        const int separatorPos = line.indexOf(separatorRx, 64);
+        if (separatorPos <= 0) {
+            continue;
+        }
+        const QString hash = line.left(separatorPos).trimmed();
+        if (!hexRx.match(hash).hasMatch()) {
+            continue;
+        }
+        const QString filename = line.mid(separatorPos).trimmed().remove(QLatin1Char('*'));
+        if (filename.contains(downloadFilename, Qt::CaseInsensitive)) {
+            return hash;
+        }
+    }
+    return QString();
 }
 
 void Feed::fetchChecksums(const QUrl& checksumsUrl)
@@ -177,45 +207,26 @@ void Feed::fetchChecksums(const QUrl& checksumsUrl)
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         if (reply->error() != QNetworkReply::NoError) {
             if (mRequireChecksums) {
+                qWarning() << "Failed to fetch checksums:" << reply->errorString() << "- refusing to install an unverifiable download";
                 reply->deleteLater();
-                //: Error shown when a manual update cannot be verified as safe to install
-                emit downloadError(tr("Could not verify the integrity of the download. Please try again later."));
+                //: Error shown when the checksums needed to verify the update could not be downloaded
+                emit downloadError(tr("Could not download the checksums needed to verify this update. Please try again later."));
                 return;
             }
             qWarning() << "Failed to fetch checksums:" << reply->errorString() << "- download will proceed without integrity verification";
         } else {
-            const QString checksumData = QString::fromUtf8(reply->readAll());
-            const QStringList lines = checksumData.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-            // SHA256 hex digest is 64 characters; search for separator after that
-            static const QRegularExpression separatorRx(qsl("[\\s*]+"));
-            static const QRegularExpression hexRx(qsl("^[0-9a-fA-F]{64}$"));
-            for (const auto& line : lines) {
-                // Format: "hash  filename" or "hash *filename"
-                const int separatorPos = line.indexOf(separatorRx, 64);
-                if (separatorPos <= 0) {
-                    continue;
-                }
-                const QString hash = line.left(separatorPos).trimmed();
-                if (!hexRx.match(hash).hasMatch()) {
-                    continue;
-                }
-                const QString filename = line.mid(separatorPos).trimmed().remove(QLatin1Char('*'));
-
-                // Match against the download URL filename
-                const QString downloadFilename = mCurrentDownload.getDownloadUrl().fileName();
-                if (!downloadFilename.isEmpty() && filename.contains(downloadFilename, Qt::CaseInsensitive)) {
-                    mCurrentDownload.setDownloadSHA256(hash);
-                    break;
-                }
-            }
+            const QString downloadFilename = mCurrentDownload.getDownloadUrl().fileName();
+            mCurrentDownload.setDownloadSHA256(findChecksum(QString::fromUtf8(reply->readAll()), downloadFilename));
             if (mCurrentDownload.getDownloadSHA256().isEmpty()) {
                 if (mRequireChecksums) {
+                    qWarning() << "Checksum file downloaded but it has no entry for" << downloadFilename << "- refusing to install an unverifiable download";
                     reply->deleteLater();
-                    //: Error shown when a manual update cannot be verified as safe to install
-                    emit downloadError(tr("Could not verify the integrity of the download. Please try again later."));
+                    //: Error shown when the release publishes checksums but none of them cover this platform's download
+                    emit downloadError(
+                            tr("This update is missing a checksum for your platform, so it cannot be verified. Please try again later, or download it from https://www.mudlet.org/download/"));
                     return;
                 }
-                qCritical() << "Checksum file downloaded but no matching hash found for" << mCurrentDownload.getDownloadUrl().fileName() << "- download will proceed without integrity verification";
+                qCritical() << "Checksum file downloaded but no matching hash found for" << downloadFilename << "- download will proceed without integrity verification";
             }
         }
         reply->deleteLater();

--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -163,12 +163,16 @@ void Feed::downloadRelease(const Release& release, bool requireChecksums)
         //: Error shown when the release publishes no checksums at all, so the download cannot be verified as safe to install
         emit downloadError(tr("This update does not publish the checksums needed to verify it. Please try again later, or download it from https://www.mudlet.org/download/"));
     } else {
+        qCritical() << "Release" << release.getVersion() << "publishes no checksums - download will proceed without integrity verification";
         makeDownloadRequest(downloadUrl);
     }
 }
 
-QString Feed::findChecksum(const QString& checksumData, const QString& downloadFilename)
+QString Feed::findChecksum(const QString& checksumData, const QString& downloadFilename, int* entriesParsed)
 {
+    if (entriesParsed) {
+        *entriesParsed = 0;
+    }
     if (downloadFilename.isEmpty()) {
         return QString();
     }
@@ -177,6 +181,7 @@ QString Feed::findChecksum(const QString& checksumData, const QString& downloadF
     static const QRegularExpression separatorRx(qsl("[\\s*]+"));
     static const QRegularExpression hexRx(qsl("^[0-9a-fA-F]{64}$"));
 
+    QString match;
     const QStringList lines = checksumData.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
     for (const auto& line : lines) {
         // Format: "hash  filename" or "hash *filename"
@@ -188,12 +193,19 @@ QString Feed::findChecksum(const QString& checksumData, const QString& downloadF
         if (!hexRx.match(hash).hasMatch()) {
             continue;
         }
+        if (entriesParsed) {
+            ++*entriesParsed;
+        }
+        // Compare the whole name, not a substring of it: SHA256SUMS.txt accumulates
+        // entries across builds, so a longer name that happens to contain this one
+        // would otherwise hand back the wrong hash. The generators write bare
+        // basenames, but tolerate a path in case one ever stops.
         const QString filename = line.mid(separatorPos).trimmed().remove(QLatin1Char('*'));
-        if (filename.contains(downloadFilename, Qt::CaseInsensitive)) {
-            return hash;
+        if (match.isEmpty() && filename.section(QLatin1Char('/'), -1).compare(downloadFilename, Qt::CaseInsensitive) == 0) {
+            match = hash;
         }
     }
-    return QString();
+    return match;
 }
 
 void Feed::fetchChecksums(const QUrl& checksumsUrl)
@@ -216,17 +228,27 @@ void Feed::fetchChecksums(const QUrl& checksumsUrl)
             qWarning() << "Failed to fetch checksums:" << reply->errorString() << "- download will proceed without integrity verification";
         } else {
             const QString downloadFilename = mCurrentDownload.getDownloadUrl().fileName();
-            mCurrentDownload.setDownloadSHA256(findChecksum(QString::fromUtf8(reply->readAll()), downloadFilename));
+            const QByteArray checksumData = reply->readAll();
+            int entriesParsed = 0;
+            mCurrentDownload.setDownloadSHA256(findChecksum(QString::fromUtf8(checksumData), downloadFilename, &entriesParsed));
             if (mCurrentDownload.getDownloadSHA256().isEmpty()) {
+                qWarning() << "Checksum file has no entry for" << downloadFilename << "- parsed" << entriesParsed << "entries from" << checksumData.size() << "bytes";
                 if (mRequireChecksums) {
-                    qWarning() << "Checksum file downloaded but it has no entry for" << downloadFilename << "- refusing to install an unverifiable download";
                     reply->deleteLater();
-                    //: Error shown when the release publishes checksums but none of them cover this platform's download
-                    emit downloadError(
-                            tr("This update is missing a checksum for your platform, so it cannot be verified. Please try again later, or download it from https://www.mudlet.org/download/"));
+                    if (entriesParsed == 0) {
+                        // Nothing parsed means the payload was not a checksum file at
+                        // all - a truncated transfer, or an error page served as 200 -
+                        // rather than a release that forgot one platform
+                        //: Error shown when the checksum file for the update was downloaded but could not be read
+                        emit downloadError(tr("The checksums for this update could not be read, so it cannot be verified. Please try again later."));
+                    } else {
+                        //: Error shown when the release publishes checksums but none of them cover this platform's download
+                        emit downloadError(
+                                tr("This update is missing a checksum for your platform, so it cannot be verified. Please try again later, or download it from https://www.mudlet.org/download/"));
+                    }
                     return;
                 }
-                qCritical() << "Checksum file downloaded but no matching hash found for" << downloadFilename << "- download will proceed without integrity verification";
+                qCritical() << "Proceeding without integrity verification for" << downloadFilename;
             }
         }
         reply->deleteLater();

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -48,6 +48,10 @@ public:
     void load();
     void downloadRelease(const Release& release, bool requireChecksums = false);
 
+    // Returns the SHA256 for downloadFilename from sha256sum-style output, or an
+    // empty string when no line covers it
+    static QString findChecksum(const QString& checksumData, const QString& downloadFilename);
+
     QList<Release> getUpdates(const Release& currentRelease) const;
     QList<Release> getReleases() const;
     QString getDownloadFilePath() const;

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -48,9 +48,12 @@ public:
     void load();
     void downloadRelease(const Release& release, bool requireChecksums = false);
 
-    // Returns the SHA256 for downloadFilename from sha256sum-style output, or an
-    // empty string when no line covers it
-    static QString findChecksum(const QString& checksumData, const QString& downloadFilename);
+    // Returns the SHA256 that sha256sum-style output lists for downloadFilename,
+    // comparing the whole filename case-insensitively, or an empty string when no
+    // line covers it. entriesParsed, when given, receives the number of well-formed
+    // lines seen, which tells "this release forgot my platform" apart from "that was
+    // not a checksum file".
+    static QString findChecksum(const QString& checksumData, const QString& downloadFilename, int* entriesParsed = nullptr);
 
     QList<Release> getUpdates(const Release& currentRelease) const;
     QList<Release> getReleases() const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT WIN32)
     include(${CMAKE_SOURCE_DIR}/src/cmake/EnableSanitizers.cmake)
 endif()
 
-find_package(Qt6 6.8.2 REQUIRED COMPONENTS Test)
+find_package(Qt6 6.8.2 REQUIRED COMPONENTS Test Network Widgets)
 
 set(UNIT_TESTS
     TEntityResolverTest
@@ -61,5 +61,28 @@ add_test(NAME CMakeListsConsistencyTest COMMAND $<TARGET_FILE:CMakeListsConsiste
 set_tests_properties(CMakeListsConsistencyTest PROPERTIES
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
 )
+
+# Pairing of a release's assets with its SHA256SUMS.txt. Built from the updater
+# sources rather than linked against the Mudlet library, because the library only
+# contains them when configured with USE_UPDATER.
+add_executable(UpdaterChecksumTest
+    UpdaterChecksumTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/Feed.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/Release.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/SemVer.cpp
+)
+target_link_libraries(UpdaterChecksumTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
+add_test(NAME UpdaterChecksumTest COMMAND $<TARGET_FILE:UpdaterChecksumTest>)
+set_tests_properties(UpdaterChecksumTest PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
+)
+
+# Checks the release-publishing scripts that keep SHA256SUMS.txt covering every
+# release binary - a binary without an entry is one the updater refuses to install
+if(NOT WIN32)
+    add_test(NAME ReleaseChecksumsTest
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/ci/release-checksums-test.sh
+    )
+endif()
 
 add_subdirectory(functional_tests)

--- a/test/UpdaterChecksumTest.cpp
+++ b/test/UpdaterChecksumTest.cpp
@@ -1,0 +1,190 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "../src/updater/Feed.h"
+#include "../src/updater/Release.h"
+
+#include <QtTest/QtTest>
+
+#include <QJsonArray>
+#include <QJsonObject>
+
+/*
+ * Covers the pairing of a release's assets with its SHA256SUMS.txt, which is what
+ * decides whether an update can be installed at all.
+ *
+ * Windows auto-update broke on the 2026-08-01 PTB: the release carried five
+ * binaries but a SHA256SUMS.txt covering only four, and the uncovered one was the
+ * .exe the Windows updater picks. Feed refuses to install a download it cannot
+ * verify, so users got "Could not verify the integrity of the download" and no
+ * update. The data below is that release's real asset list and checksum file.
+ *
+ * The publishing side of the fix - never overwriting SHA256SUMS.txt with a file
+ * that covers fewer binaries - is covered by test/ci/release-checksums-test.sh.
+ */
+
+namespace {
+const auto tag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137");
+const auto windowsAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-windows-64.exe");
+const auto linuxAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-linux-x64.AppImage.tar");
+const auto arm64Asset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-arm64.dmg");
+const auto x86_64Asset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-x86_64.dmg");
+// A re-run of the Windows build restamped the date and appended a rebuild counter
+const auto rebuiltWindowsAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-02-dfdcb137rebuild2-windows-64.exe");
+
+const auto windowsHash = QStringLiteral("72dba076741a245a994b553b1cf88dba5d7f5bb07f0d6887ecd58361402764e1");
+const auto linuxHash = QStringLiteral("72a239146b07fc3b94f9e96955d2d6d52a6f0f40c8a5b7ee314b0bf875a55611");
+const auto arm64Hash = QStringLiteral("7a7a75723e15a3443c4e8937fe2a85cee90b9dc8938e1e0580887e5c5e1fabbb");
+const auto x86_64Hash = QStringLiteral("d2426d7f799b619b0bfcb1e51e373f776288f77584bc9f08a79cc288cc58278c");
+const auto rebuiltWindowsHash = QStringLiteral("9b3895247937d37f645dd31e7ded739e3126ccad6bfa4188cdd3b78f735c2f6f");
+
+// Exactly what the 2026-08-01 PTB shipped: the .exe on the release is absent and a
+// different build's .exe is listed in its place
+QString publishedChecksums()
+{
+    return QStringLiteral("%1  %2\n%3  %4\n%5 *%6\n%7  %8\n").arg(linuxHash, linuxAsset, x86_64Hash, x86_64Asset, rebuiltWindowsHash, rebuiltWindowsAsset, arm64Hash, arm64Asset);
+}
+
+// What the release should have shipped, and does once the publishing scripts merge
+// instead of overwrite
+QString mergedChecksums()
+{
+    return publishedChecksums() + QStringLiteral("%1 *%2\n").arg(windowsHash, windowsAsset);
+}
+
+// The 2026-08-01 PTB's assets, in the order the GitHub releases API returns them
+QJsonObject releaseJson()
+{
+    const QStringList assetNames{arm64Asset, linuxAsset, windowsAsset, x86_64Asset, rebuiltWindowsAsset, QStringLiteral("SHA256SUMS.txt")};
+
+    QJsonArray assets;
+    for (const auto& name : assetNames) {
+        QJsonObject asset;
+        asset.insert(QStringLiteral("name"), name);
+        asset.insert(QStringLiteral("browser_download_url"), QStringLiteral("https://github.com/Mudlet/Mudlet/releases/download/%1/%2").arg(tag, name));
+        asset.insert(QStringLiteral("size"), 137252032);
+        assets.append(asset);
+    }
+
+    QJsonObject release;
+    release.insert(QStringLiteral("tag_name"), tag);
+    release.insert(QStringLiteral("published_at"), QStringLiteral("2026-07-31T18:22:33Z"));
+    release.insert(QStringLiteral("prerelease"), true);
+    release.insert(QStringLiteral("draft"), false);
+    release.insert(QStringLiteral("assets"), assets);
+    return release;
+}
+} // namespace
+
+class UpdaterChecksumTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void windowsDownloadIsThePlatformExe();
+    void publishedChecksumsDoNotCoverTheWindowsDownload();
+    void mergedChecksumsCoverTheWindowsDownload();
+    void everyOtherPlatformWasAlreadyCovered();
+    void binaryAndTextModeLinesBothParse();
+    void anotherBuildsEntryDoesNotCoverThisDownload();
+    void malformedLinesAreIgnored();
+    void emptyInputsYieldNoChecksum();
+};
+
+// The updater picks the first asset matching its platform, so this is the file
+// whose checksum has to be present
+void UpdaterChecksumTest::windowsDownloadIsThePlatformExe()
+{
+    const dblsqd::Release release(releaseJson(), QStringLiteral("win"), QStringLiteral("x86_64"));
+
+    QCOMPARE(release.getDownloadUrl().fileName(), windowsAsset);
+    QCOMPARE(release.getChecksumsUrl().fileName(), QStringLiteral("SHA256SUMS.txt"));
+}
+
+// The regression: this is why Windows auto-update failed
+void UpdaterChecksumTest::publishedChecksumsDoNotCoverTheWindowsDownload()
+{
+    const dblsqd::Release release(releaseJson(), QStringLiteral("win"), QStringLiteral("x86_64"));
+
+    QVERIFY(dblsqd::Feed::findChecksum(publishedChecksums(), release.getDownloadUrl().fileName()).isEmpty());
+}
+
+void UpdaterChecksumTest::mergedChecksumsCoverTheWindowsDownload()
+{
+    const dblsqd::Release release(releaseJson(), QStringLiteral("win"), QStringLiteral("x86_64"));
+
+    QCOMPARE(dblsqd::Feed::findChecksum(mergedChecksums(), release.getDownloadUrl().fileName()), windowsHash);
+}
+
+void UpdaterChecksumTest::everyOtherPlatformWasAlreadyCovered()
+{
+    const dblsqd::Release linuxRelease(releaseJson(), QStringLiteral("linux"), QStringLiteral("x86_64"));
+    QCOMPARE(linuxRelease.getDownloadUrl().fileName(), linuxAsset);
+    QCOMPARE(dblsqd::Feed::findChecksum(publishedChecksums(), linuxRelease.getDownloadUrl().fileName()), linuxHash);
+
+    const dblsqd::Release intelMacRelease(releaseJson(), QStringLiteral("mac"), QStringLiteral("x86_64"));
+    QCOMPARE(intelMacRelease.getDownloadUrl().fileName(), x86_64Asset);
+    QCOMPARE(dblsqd::Feed::findChecksum(publishedChecksums(), intelMacRelease.getDownloadUrl().fileName()), x86_64Hash);
+
+    const dblsqd::Release appleSiliconRelease(releaseJson(), QStringLiteral("mac"), QStringLiteral("arm64"));
+    QCOMPARE(appleSiliconRelease.getDownloadUrl().fileName(), arm64Asset);
+    QCOMPARE(dblsqd::Feed::findChecksum(publishedChecksums(), appleSiliconRelease.getDownloadUrl().fileName()), arm64Hash);
+}
+
+// sha256sum writes two spaces in text mode and " *" in binary mode; the Windows
+// build produces the latter
+void UpdaterChecksumTest::binaryAndTextModeLinesBothParse()
+{
+    QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1 *%2").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
+    QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1  %2").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
+    QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1\t%2").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
+    // trailing CR from a file written on Windows must not become part of the name
+    QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1 *%2\r\n").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
+}
+
+// The rebuilt installer's entry must not be accepted for a different file, or the
+// updater would check the download against the wrong hash
+void UpdaterChecksumTest::anotherBuildsEntryDoesNotCoverThisDownload()
+{
+    const QString rebuiltOnly = QStringLiteral("%1 *%2\n").arg(rebuiltWindowsHash, rebuiltWindowsAsset);
+
+    QVERIFY(dblsqd::Feed::findChecksum(rebuiltOnly, windowsAsset).isEmpty());
+    QCOMPARE(dblsqd::Feed::findChecksum(rebuiltOnly, rebuiltWindowsAsset), rebuiltWindowsHash);
+}
+
+void UpdaterChecksumTest::malformedLinesAreIgnored()
+{
+    // too short, non-hex, and no separator respectively, then the real entry
+    const QString data = QStringLiteral("abc123  %1\n"
+                                        "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz  %1\n"
+                                        "%2\n"
+                                        "%3 *%1\n")
+                                 .arg(windowsAsset, windowsHash, windowsHash);
+
+    QCOMPARE(dblsqd::Feed::findChecksum(data, windowsAsset), windowsHash);
+}
+
+void UpdaterChecksumTest::emptyInputsYieldNoChecksum()
+{
+    QVERIFY(dblsqd::Feed::findChecksum(QString(), windowsAsset).isEmpty());
+    QVERIFY(dblsqd::Feed::findChecksum(mergedChecksums(), QString()).isEmpty());
+}
+
+#include "UpdaterChecksumTest.moc"
+QTEST_MAIN(UpdaterChecksumTest)

--- a/test/UpdaterChecksumTest.cpp
+++ b/test/UpdaterChecksumTest.cpp
@@ -44,21 +44,21 @@ const auto tag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137");
 const auto windowsAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-windows-64.exe");
 const auto linuxAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-linux-x64.AppImage.tar");
 const auto arm64Asset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-arm64.dmg");
-const auto x86_64Asset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-x86_64.dmg");
+const auto intelMacAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-x86_64.dmg");
 // A re-run of the Windows build restamped the date and appended a rebuild counter
 const auto rebuiltWindowsAsset = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-02-dfdcb137rebuild2-windows-64.exe");
 
 const auto windowsHash = QStringLiteral("72dba076741a245a994b553b1cf88dba5d7f5bb07f0d6887ecd58361402764e1");
 const auto linuxHash = QStringLiteral("72a239146b07fc3b94f9e96955d2d6d52a6f0f40c8a5b7ee314b0bf875a55611");
 const auto arm64Hash = QStringLiteral("7a7a75723e15a3443c4e8937fe2a85cee90b9dc8938e1e0580887e5c5e1fabbb");
-const auto x86_64Hash = QStringLiteral("d2426d7f799b619b0bfcb1e51e373f776288f77584bc9f08a79cc288cc58278c");
+const auto intelMacHash = QStringLiteral("d2426d7f799b619b0bfcb1e51e373f776288f77584bc9f08a79cc288cc58278c");
 const auto rebuiltWindowsHash = QStringLiteral("9b3895247937d37f645dd31e7ded739e3126ccad6bfa4188cdd3b78f735c2f6f");
 
 // Exactly what the 2026-08-01 PTB shipped: the .exe on the release is absent and a
 // different build's .exe is listed in its place
 QString publishedChecksums()
 {
-    return QStringLiteral("%1  %2\n%3  %4\n%5 *%6\n%7  %8\n").arg(linuxHash, linuxAsset, x86_64Hash, x86_64Asset, rebuiltWindowsHash, rebuiltWindowsAsset, arm64Hash, arm64Asset);
+    return QStringLiteral("%1  %2\n%3  %4\n%5 *%6\n%7  %8\n").arg(linuxHash, linuxAsset, intelMacHash, intelMacAsset, rebuiltWindowsHash, rebuiltWindowsAsset, arm64Hash, arm64Asset);
 }
 
 // What the release should have shipped, and does once the publishing scripts merge
@@ -68,10 +68,13 @@ QString mergedChecksums()
     return publishedChecksums() + QStringLiteral("%1 *%2\n").arg(windowsHash, windowsAsset);
 }
 
-// The 2026-08-01 PTB's assets, in the order the GitHub releases API returns them
+// The 2026-08-01 PTB's assets, in the order the GitHub releases API returns them -
+// which is what decided the bug: had the API listed the rebuilt .exe first, the
+// updater would have chosen the one that *was* covered. published_at and size are
+// filler, only the tag and the asset names and order are the release's real values.
 QJsonObject releaseJson()
 {
-    const QStringList assetNames{arm64Asset, linuxAsset, windowsAsset, x86_64Asset, rebuiltWindowsAsset, QStringLiteral("SHA256SUMS.txt")};
+    const QStringList assetNames{arm64Asset, linuxAsset, windowsAsset, intelMacAsset, rebuiltWindowsAsset, QStringLiteral("SHA256SUMS.txt")};
 
     QJsonArray assets;
     for (const auto& name : assetNames) {
@@ -103,8 +106,11 @@ private slots:
     void everyOtherPlatformWasAlreadyCovered();
     void binaryAndTextModeLinesBothParse();
     void anotherBuildsEntryDoesNotCoverThisDownload();
+    void aLongerNameContainingThisOneDoesNotCoverIt();
+    void aPathPrefixedEntryStillCoversTheDownload();
     void malformedLinesAreIgnored();
     void emptyInputsYieldNoChecksum();
+    void entriesParsedTellsAnUnreadableFileFromAMissingEntry();
 };
 
 // The updater picks the first asset matching its platform, so this is the file
@@ -139,8 +145,8 @@ void UpdaterChecksumTest::everyOtherPlatformWasAlreadyCovered()
     QCOMPARE(dblsqd::Feed::findChecksum(publishedChecksums(), linuxRelease.getDownloadUrl().fileName()), linuxHash);
 
     const dblsqd::Release intelMacRelease(releaseJson(), QStringLiteral("mac"), QStringLiteral("x86_64"));
-    QCOMPARE(intelMacRelease.getDownloadUrl().fileName(), x86_64Asset);
-    QCOMPARE(dblsqd::Feed::findChecksum(publishedChecksums(), intelMacRelease.getDownloadUrl().fileName()), x86_64Hash);
+    QCOMPARE(intelMacRelease.getDownloadUrl().fileName(), intelMacAsset);
+    QCOMPARE(dblsqd::Feed::findChecksum(publishedChecksums(), intelMacRelease.getDownloadUrl().fileName()), intelMacHash);
 
     const dblsqd::Release appleSiliconRelease(releaseJson(), QStringLiteral("mac"), QStringLiteral("arm64"));
     QCOMPARE(appleSiliconRelease.getDownloadUrl().fileName(), arm64Asset);
@@ -168,6 +174,23 @@ void UpdaterChecksumTest::anotherBuildsEntryDoesNotCoverThisDownload()
     QCOMPARE(dblsqd::Feed::findChecksum(rebuiltOnly, rebuiltWindowsAsset), rebuiltWindowsHash);
 }
 
+// SHA256SUMS.txt accumulates entries across builds, so a name that merely contains
+// the download's name must not hand back its hash - the updater would then reject a
+// perfectly good download as corrupt
+void UpdaterChecksumTest::aLongerNameContainingThisOneDoesNotCoverIt()
+{
+    const QString longerName = QStringLiteral("old-%1").arg(windowsAsset);
+
+    QVERIFY(dblsqd::Feed::findChecksum(QStringLiteral("%1 *%2\n").arg(rebuiltWindowsHash, longerName), windowsAsset).isEmpty());
+    QVERIFY(dblsqd::Feed::findChecksum(QStringLiteral("%1  %2.sha256\n").arg(rebuiltWindowsHash, windowsAsset), windowsAsset).isEmpty());
+    QVERIFY(dblsqd::Feed::findChecksum(QStringLiteral("%1  %2.tar\n").arg(rebuiltWindowsHash, linuxAsset), linuxAsset).isEmpty());
+}
+
+void UpdaterChecksumTest::aPathPrefixedEntryStillCoversTheDownload()
+{
+    QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1 *upload/%2\n").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
+}
+
 void UpdaterChecksumTest::malformedLinesAreIgnored()
 {
     // too short, non-hex, and no separator respectively, then the real entry
@@ -184,6 +207,23 @@ void UpdaterChecksumTest::emptyInputsYieldNoChecksum()
 {
     QVERIFY(dblsqd::Feed::findChecksum(QString(), windowsAsset).isEmpty());
     QVERIFY(dblsqd::Feed::findChecksum(mergedChecksums(), QString()).isEmpty());
+}
+
+// A release that forgot one platform and a payload that was never a checksum file
+// both yield no hash, but they need different messages
+void UpdaterChecksumTest::entriesParsedTellsAnUnreadableFileFromAMissingEntry()
+{
+    int entriesParsed = -1;
+    QVERIFY(dblsqd::Feed::findChecksum(publishedChecksums(), windowsAsset, &entriesParsed).isEmpty());
+    QCOMPARE(entriesParsed, 4);
+
+    entriesParsed = -1;
+    QVERIFY(dblsqd::Feed::findChecksum(QStringLiteral("<html><body>503 Service Unavailable</body></html>"), windowsAsset, &entriesParsed).isEmpty());
+    QCOMPARE(entriesParsed, 0);
+
+    entriesParsed = -1;
+    QCOMPARE(dblsqd::Feed::findChecksum(mergedChecksums(), windowsAsset, &entriesParsed), windowsHash);
+    QCOMPARE(entriesParsed, 5);
 }
 
 #include "UpdaterChecksumTest.moc"

--- a/test/ci/release-checksums-test.sh
+++ b/test/ci/release-checksums-test.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# Tests the release checksum scripts against the asset sets that made Windows
+# auto-update fail with "Could not verify the integrity of the download".
+#
+# The failure: the 2026-08-01 PTB ended up with five binaries but a
+# SHA256SUMS.txt covering only four. The uncovered one was
+# Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-windows-64.exe - the very file the
+# updater downloads on Windows - so it refused to install anything. Hashes and
+# filenames below are the real ones from that release and from the
+# create-github-release runs that produced it.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CI_DIR="$(cd "${SCRIPT_DIR}/../../CI" && pwd)"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+FAILURES=0
+CURRENT_TEST=""
+
+readonly TAG='Mudlet-4.22.0-ptb-2026-08-01-dfdcb137'
+readonly LINUX_ASSET="${TAG}-linux-x64.AppImage.tar"
+readonly ARM64_ASSET="${TAG}-arm64.dmg"
+readonly X86_64_ASSET="${TAG}-x86_64.dmg"
+readonly WINDOWS_ASSET="${TAG}-windows-64.exe"
+# A Windows re-run restamps the build date and appends a rebuild counter, so its
+# installer is published under a name that does not belong to ${TAG}
+readonly REBUILD_WINDOWS_ASSET='Mudlet-4.22.0-ptb-2026-08-02-dfdcb137rebuild2-windows-64.exe'
+
+readonly LINUX_HASH='72a239146b07fc3b94f9e96955d2d6d52a6f0f40c8a5b7ee314b0bf875a55611'
+readonly ARM64_HASH='7a7a75723e15a3443c4e8937fe2a85cee90b9dc8938e1e0580887e5c5e1fabbb'
+readonly X86_64_HASH='d2426d7f799b619b0bfcb1e51e373f776288f77584bc9f08a79cc288cc58278c'
+readonly WINDOWS_HASH='72dba076741a245a994b553b1cf88dba5d7f5bb07f0d6887ecd58361402764e1'
+readonly REBUILD_WINDOWS_HASH='9b3895247937d37f645dd31e7ded739e3126ccad6bfa4188cdd3b78f735c2f6f'
+
+start_test() {
+  CURRENT_TEST="$1"
+  echo "=== ${CURRENT_TEST}"
+}
+
+fail() {
+  echo "    FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "    ok: $*"
+}
+
+assert_contains() {
+  local file="$1" needle="$2"
+  if grep -qF -- "${needle}" "${file}"; then
+    pass "${file##*/} contains ${needle}"
+  else
+    fail "${file##*/} is missing ${needle}"
+    echo "--- ${file} ---" >&2
+    cat "${file}" >&2
+  fi
+}
+
+assert_absent() {
+  local file="$1" needle="$2"
+  if grep -qF -- "${needle}" "${file}"; then
+    fail "${file##*/} unexpectedly contains ${needle}"
+  else
+    pass "${file##*/} does not contain ${needle}"
+  fi
+}
+
+assert_line_count() {
+  local file="$1" expected="$2" actual
+  actual="$(wc -l < "${file}" | tr -d ' ')"
+  if [[ "${actual}" == "${expected}" ]]; then
+    pass "${file##*/} has ${expected} entries"
+  else
+    fail "${file##*/} has ${actual} entries, expected ${expected}"
+    cat "${file}" >&2
+  fi
+}
+
+# Creates a case directory with an assets/ subdirectory holding placeholder
+# binaries and their .sha256 sidecars. Arguments are "name:hash" pairs.
+make_assets() {
+  local case_dir="$1"
+  shift
+  mkdir -p "${case_dir}/assets"
+  local pair name hash
+  for pair in "$@"; do
+    name="${pair%%:*}"
+    hash="${pair##*:}"
+    echo "placeholder for ${name}" > "${case_dir}/assets/${name}"
+    printf '%s *%s\n' "${hash}" "${name}" > "${case_dir}/assets/${name}.sha256"
+  done
+}
+
+published_sums_from_the_complete_run() {
+  # What run 30687252829 published: all four platforms of ${TAG}
+  cat <<EOF
+${LINUX_HASH}  ${LINUX_ASSET}
+${X86_64_HASH}  ${X86_64_ASSET}
+${ARM64_HASH}  ${ARM64_ASSET}
+${WINDOWS_HASH} *${WINDOWS_ASSET}
+EOF
+}
+
+#-----------------------------------------------------------------------------
+start_test "the run that broke the 2026-08-01 PTB now keeps every binary covered"
+# Run 30734870982 downloaded the Linux/macOS artifacts of ${TAG} but, because it
+# picks the newest successful Windows run, the Windows installer of a later
+# rebuild. It regenerated SHA256SUMS.txt from those four sidecars and clobbered
+# the published file, dropping the entry for the ${WINDOWS_ASSET} that stayed on
+# the release.
+CASE="${WORK_DIR}/clobber"
+make_assets "${CASE}" \
+  "${REBUILD_WINDOWS_ASSET}:${REBUILD_WINDOWS_HASH}" \
+  "${LINUX_ASSET}:${LINUX_HASH}" \
+  "${ARM64_ASSET}:${ARM64_HASH}" \
+  "${X86_64_ASSET}:${X86_64_HASH}"
+published_sums_from_the_complete_run > "${CASE}/published-SHA256SUMS.txt"
+
+if ! bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${TAG}" ptb > "${CASE}/prepare.log" 2>&1; then
+  fail "prepare-release-assets.sh exited non-zero"
+  cat "${CASE}/prepare.log" >&2
+else
+  pass "prepare-release-assets.sh succeeded"
+fi
+assert_contains "${CASE}/prepare.log" "::warning::Ignoring 2 asset(s) from a different build"
+if [[ -e "${CASE}/assets/${REBUILD_WINDOWS_ASSET}" ]]; then
+  fail "the other build's installer was left in assets/"
+else
+  pass "the other build's installer was set aside"
+fi
+
+if ! bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "${CASE}/published-SHA256SUMS.txt" > "${CASE}/assemble.log" 2>&1; then
+  fail "assemble-release-checksums.sh exited non-zero"
+  cat "${CASE}/assemble.log" >&2
+else
+  pass "assemble-release-checksums.sh succeeded"
+fi
+SUMS="${CASE}/assets/SHA256SUMS.txt"
+# The regression: without merging, this file lost the ${WINDOWS_ASSET} entry
+assert_contains "${SUMS}" "${WINDOWS_HASH}"
+assert_contains "${SUMS}" "${WINDOWS_ASSET}"
+assert_contains "${SUMS}" "${LINUX_ASSET}"
+assert_contains "${SUMS}" "${ARM64_ASSET}"
+assert_contains "${SUMS}" "${X86_64_ASSET}"
+assert_absent "${SUMS}" "${REBUILD_WINDOWS_ASSET}"
+assert_line_count "${SUMS}" 4
+
+# The release afterwards holds what was already published plus what we upload
+cat > "${CASE}/final-assets.txt" <<EOF
+${ARM64_ASSET}
+${LINUX_ASSET}
+${WINDOWS_ASSET}
+${X86_64_ASSET}
+SHA256SUMS.txt
+EOF
+if bash "${CI_DIR}/verify-release-checksums.sh" "${SUMS}" "${CASE}/final-assets.txt" > "${CASE}/verify.log" 2>&1; then
+  pass "verify-release-checksums.sh accepts the merged release"
+else
+  fail "verify-release-checksums.sh rejected a fully covered release"
+  cat "${CASE}/verify.log" >&2
+fi
+
+#-----------------------------------------------------------------------------
+start_test "an uncovered release binary is rejected"
+# The exact state the 2026-08-01 PTB shipped in: SHA256SUMS.txt regenerated from
+# one run's sidecars while an earlier run's Windows installer stayed published
+CASE="${WORK_DIR}/uncovered"
+mkdir -p "${CASE}"
+cat > "${CASE}/SHA256SUMS.txt" <<EOF
+${LINUX_HASH}  ${LINUX_ASSET}
+${X86_64_HASH}  ${X86_64_ASSET}
+${REBUILD_WINDOWS_HASH} *${REBUILD_WINDOWS_ASSET}
+${ARM64_HASH}  ${ARM64_ASSET}
+EOF
+cat > "${CASE}/assets.txt" <<EOF
+${ARM64_ASSET}
+${LINUX_ASSET}
+${WINDOWS_ASSET}
+${X86_64_ASSET}
+${REBUILD_WINDOWS_ASSET}
+SHA256SUMS.txt
+EOF
+if bash "${CI_DIR}/verify-release-checksums.sh" "${CASE}/SHA256SUMS.txt" "${CASE}/assets.txt" > "${CASE}/verify.log" 2>&1; then
+  fail "verify-release-checksums.sh accepted a release whose Windows installer has no checksum"
+  cat "${CASE}/verify.log" >&2
+else
+  pass "verify-release-checksums.sh rejected the release"
+fi
+assert_contains "${CASE}/verify.log" "${WINDOWS_ASSET}"
+assert_contains "${CASE}/verify.log" "::error::"
+
+#-----------------------------------------------------------------------------
+start_test "a Windows-only PTB is published with its one checksum"
+# The 2026-08-03 PTB: the Linux/macOS build had not succeeded, so only the
+# Windows installer was available. Partial PTBs are allowed, but the installer
+# still has to be covered.
+CASE="${WORK_DIR}/windows-only"
+WINDOWS_ONLY_TAG='Mudlet-4.22.0-ptb-2026-08-03-3474cb58'
+WINDOWS_ONLY_ASSET="${WINDOWS_ONLY_TAG}-windows-64.exe"
+make_assets "${CASE}" \
+  "${WINDOWS_ONLY_ASSET}:c22435c7ff0d36a5dbe5936bcfbbc173f656c2c33583dccbf17a7ad4ade3e350"
+if bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${WINDOWS_ONLY_TAG}" ptb > "${CASE}/prepare.log" 2>&1; then
+  pass "prepare-release-assets.sh allows a partial PTB"
+else
+  fail "prepare-release-assets.sh rejected a partial PTB"
+  cat "${CASE}/prepare.log" >&2
+fi
+assert_contains "${CASE}/prepare.log" "::warning::Missing release assets for: Linux (.AppImage.tar) macOS (.dmg)"
+bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "" > "${CASE}/assemble.log" 2>&1
+assert_line_count "${CASE}/assets/SHA256SUMS.txt" 1
+printf '%s\nSHA256SUMS.txt\n' "${WINDOWS_ONLY_ASSET}" > "${CASE}/assets.txt"
+if bash "${CI_DIR}/verify-release-checksums.sh" "${CASE}/assets/SHA256SUMS.txt" "${CASE}/assets.txt" > "${CASE}/verify.log" 2>&1; then
+  pass "the Windows-only PTB passes verification"
+else
+  fail "the Windows-only PTB was rejected"
+  cat "${CASE}/verify.log" >&2
+fi
+
+#-----------------------------------------------------------------------------
+start_test "a stable release missing a platform is rejected"
+CASE="${WORK_DIR}/partial-stable"
+STABLE_TAG='Mudlet-4.22.0'
+make_assets "${CASE}" \
+  "${STABLE_TAG}-windows-64-installer.exe:c22435c7ff0d36a5dbe5936bcfbbc173f656c2c33583dccbf17a7ad4ade3e350"
+if bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${STABLE_TAG}" release > "${CASE}/prepare.log" 2>&1; then
+  fail "prepare-release-assets.sh published an incomplete stable release"
+else
+  pass "prepare-release-assets.sh rejected the incomplete stable release"
+fi
+assert_contains "${CASE}/prepare.log" "::error::Stable release is missing assets for:"
+
+#-----------------------------------------------------------------------------
+start_test "a rebuild counter on this build's own assets is kept"
+# A re-run of both platforms tags itself with the rebuild counter too, so the
+# counter alone must not make an asset look foreign
+CASE="${WORK_DIR}/own-rebuild"
+REBUILD_TAG='Mudlet-4.22.0-ptb-2026-08-02-dfdcb137'
+make_assets "${CASE}" \
+  "${REBUILD_TAG}rebuild2-windows-64.exe:${REBUILD_WINDOWS_HASH}" \
+  "${REBUILD_TAG}-linux-x64.AppImage.tar:${LINUX_HASH}" \
+  "${REBUILD_TAG}-arm64.dmg:${ARM64_HASH}"
+if bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${REBUILD_TAG}" ptb > "${CASE}/prepare.log" 2>&1; then
+  pass "prepare-release-assets.sh succeeded"
+else
+  fail "prepare-release-assets.sh exited non-zero"
+  cat "${CASE}/prepare.log" >&2
+fi
+assert_absent "${CASE}/prepare.log" "::warning::Ignoring"
+if [[ -e "${CASE}/assets/${REBUILD_TAG}rebuild2-windows-64.exe" ]]; then
+  pass "this build's own rebuilt installer was kept"
+else
+  fail "this build's own rebuilt installer was set aside"
+fi
+
+#-----------------------------------------------------------------------------
+start_test "merging keeps the freshly built hash when a filename repeats"
+CASE="${WORK_DIR}/rebuilt-same-name"
+make_assets "${CASE}" "${WINDOWS_ASSET}:${REBUILD_WINDOWS_HASH}"
+printf '%s *%s\n' "${WINDOWS_HASH}" "${WINDOWS_ASSET}" > "${CASE}/published-SHA256SUMS.txt"
+bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "${CASE}/published-SHA256SUMS.txt" > "${CASE}/assemble.log" 2>&1
+assert_line_count "${CASE}/assets/SHA256SUMS.txt" 1
+assert_contains "${CASE}/assets/SHA256SUMS.txt" "${REBUILD_WINDOWS_HASH}"
+assert_absent "${CASE}/assets/SHA256SUMS.txt" "${WINDOWS_HASH}"
+
+#-----------------------------------------------------------------------------
+start_test "no sidecars at all is an error"
+CASE="${WORK_DIR}/no-sidecars"
+mkdir -p "${CASE}/assets"
+if bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "" > "${CASE}/assemble.log" 2>&1; then
+  fail "assemble-release-checksums.sh accepted an empty assets directory"
+else
+  pass "assemble-release-checksums.sh rejected an empty assets directory"
+fi
+assert_contains "${CASE}/assemble.log" "::error::No .sha256 checksum files found"
+
+#-----------------------------------------------------------------------------
+echo
+if [[ ${FAILURES} -gt 0 ]]; then
+  echo "${FAILURES} check(s) FAILED"
+  exit 1
+fi
+echo "All checks passed"

--- a/test/ci/release-checksums-test.sh
+++ b/test/ci/release-checksums-test.sh
@@ -5,9 +5,10 @@
 # The failure: the 2026-08-01 PTB ended up with five binaries but a
 # SHA256SUMS.txt covering only four. The uncovered one was
 # Mudlet-4.22.0-ptb-2026-08-01-dfdcb137-windows-64.exe - the very file the
-# updater downloads on Windows - so it refused to install anything. Hashes and
-# filenames below are the real ones from that release and from the
-# create-github-release runs that produced it.
+# updater downloads on Windows - so it refused to install anything.
+#
+# The 2026-08-01 and 2026-08-03 filenames and hashes below are the real published
+# ones; the stable-release and rebuild-counter cases further down are synthetic.
 
 set -uo pipefail
 
@@ -23,15 +24,15 @@ CURRENT_TEST=""
 readonly TAG='Mudlet-4.22.0-ptb-2026-08-01-dfdcb137'
 readonly LINUX_ASSET="${TAG}-linux-x64.AppImage.tar"
 readonly ARM64_ASSET="${TAG}-arm64.dmg"
-readonly X86_64_ASSET="${TAG}-x86_64.dmg"
+readonly INTEL_MAC_ASSET="${TAG}-x86_64.dmg"
 readonly WINDOWS_ASSET="${TAG}-windows-64.exe"
-# A Windows re-run restamps the build date and appends a rebuild counter, so its
-# installer is published under a name that does not belong to ${TAG}
+# Only the Windows build appends a rebuild counter (CI/deploy-mudlet-for-windows.sh);
+# a re-run also restamps the PTB date, which is what changes the tag prefix
 readonly REBUILD_WINDOWS_ASSET='Mudlet-4.22.0-ptb-2026-08-02-dfdcb137rebuild2-windows-64.exe'
 
 readonly LINUX_HASH='72a239146b07fc3b94f9e96955d2d6d52a6f0f40c8a5b7ee314b0bf875a55611'
 readonly ARM64_HASH='7a7a75723e15a3443c4e8937fe2a85cee90b9dc8938e1e0580887e5c5e1fabbb'
-readonly X86_64_HASH='d2426d7f799b619b0bfcb1e51e373f776288f77584bc9f08a79cc288cc58278c'
+readonly INTEL_MAC_HASH='d2426d7f799b619b0bfcb1e51e373f776288f77584bc9f08a79cc288cc58278c'
 readonly WINDOWS_HASH='72dba076741a245a994b553b1cf88dba5d7f5bb07f0d6887ecd58361402764e1'
 readonly REBUILD_WINDOWS_HASH='9b3895247937d37f645dd31e7ded739e3126ccad6bfa4188cdd3b78f735c2f6f'
 
@@ -62,6 +63,10 @@ assert_contains() {
 
 assert_absent() {
   local file="$1" needle="$2"
+  if [[ ! -s "${file}" ]]; then
+    fail "${file##*/} is empty or missing, so 'does not contain' proves nothing"
+    return
+  fi
   if grep -qF -- "${needle}" "${file}"; then
     fail "${file##*/} unexpectedly contains ${needle}"
   else
@@ -80,8 +85,44 @@ assert_line_count() {
   fi
 }
 
+run_prepare() {
+  local case_dir="$1" tag="$2" type="$3"
+  bash "${CI_DIR}/prepare-release-assets.sh" "${case_dir}/assets" "${tag}" "${type}" > "${case_dir}/prepare.log" 2>&1
+}
+
+run_assemble() {
+  local case_dir="$1" published="$2"
+  bash "${CI_DIR}/assemble-release-checksums.sh" "${case_dir}/assets" "${published}" > "${case_dir}/assemble.log" 2>&1
+}
+
+run_verify() {
+  local case_dir="$1"
+  shift
+  bash "${CI_DIR}/verify-release-checksums.sh" "$@" > "${case_dir}/verify.log" 2>&1
+}
+
+expect_ok() {
+  local what="$1" case_dir="$2" log="$3"
+  if [[ "$4" -eq 0 ]]; then
+    pass "${what} succeeded"
+  else
+    fail "${what} exited non-zero"
+    cat "${case_dir}/${log}" >&2
+  fi
+}
+
+expect_failure() {
+  local what="$1" status="$2"
+  if [[ "${status}" -ne 0 ]]; then
+    pass "${what} rejected it"
+  else
+    fail "${what} accepted it"
+  fi
+}
+
 # Creates a case directory with an assets/ subdirectory holding placeholder
-# binaries and their .sha256 sidecars. Arguments are "name:hash" pairs.
+# binaries and their .sha256 sidecars. Arguments are "name:hash" pairs; a hash of
+# "real" is computed from the placeholder's actual bytes.
 make_assets() {
   local case_dir="$1"
   shift
@@ -91,6 +132,9 @@ make_assets() {
     name="${pair%%:*}"
     hash="${pair##*:}"
     echo "placeholder for ${name}" > "${case_dir}/assets/${name}"
+    if [[ "${hash}" == "real" ]]; then
+      hash="$(sha256sum "${case_dir}/assets/${name}" | cut -d ' ' -f 1)"
+    fi
     printf '%s *%s\n' "${hash}" "${name}" > "${case_dir}/assets/${name}.sha256"
   done
 }
@@ -99,7 +143,7 @@ published_sums_from_the_complete_run() {
   # What run 30687252829 published: all four platforms of ${TAG}
   cat <<EOF
 ${LINUX_HASH}  ${LINUX_ASSET}
-${X86_64_HASH}  ${X86_64_ASSET}
+${INTEL_MAC_HASH}  ${INTEL_MAC_ASSET}
 ${ARM64_HASH}  ${ARM64_ASSET}
 ${WINDOWS_HASH} *${WINDOWS_ASSET}
 EOF
@@ -107,25 +151,21 @@ EOF
 
 #-----------------------------------------------------------------------------
 start_test "the run that broke the 2026-08-01 PTB now keeps every binary covered"
-# Run 30734870982 downloaded the Linux/macOS artifacts of ${TAG} but, because it
-# picks the newest successful Windows run, the Windows installer of a later
-# rebuild. It regenerated SHA256SUMS.txt from those four sidecars and clobbered
-# the published file, dropping the entry for the ${WINDOWS_ASSET} that stayed on
-# the release.
+# The 2026-08-02 run downloaded the Linux/macOS artifacts of ${TAG} but, because
+# create-github-release.yml picks the newest successful run of each platform, the
+# Windows installer of a later rebuild. It regenerated SHA256SUMS.txt from those
+# four sidecars and clobbered the published file, dropping the entry for the
+# ${WINDOWS_ASSET} that stayed on the release.
 CASE="${WORK_DIR}/clobber"
 make_assets "${CASE}" \
   "${REBUILD_WINDOWS_ASSET}:${REBUILD_WINDOWS_HASH}" \
   "${LINUX_ASSET}:${LINUX_HASH}" \
   "${ARM64_ASSET}:${ARM64_HASH}" \
-  "${X86_64_ASSET}:${X86_64_HASH}"
+  "${INTEL_MAC_ASSET}:${INTEL_MAC_HASH}"
 published_sums_from_the_complete_run > "${CASE}/published-SHA256SUMS.txt"
 
-if ! bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${TAG}" ptb > "${CASE}/prepare.log" 2>&1; then
-  fail "prepare-release-assets.sh exited non-zero"
-  cat "${CASE}/prepare.log" >&2
-else
-  pass "prepare-release-assets.sh succeeded"
-fi
+run_prepare "${CASE}" "${TAG}" ptb
+expect_ok "prepare-release-assets.sh" "${CASE}" prepare.log $?
 assert_contains "${CASE}/prepare.log" "::warning::Ignoring 2 asset(s) from a different build"
 if [[ -e "${CASE}/assets/${REBUILD_WINDOWS_ASSET}" ]]; then
   fail "the other build's installer was left in assets/"
@@ -133,19 +173,15 @@ else
   pass "the other build's installer was set aside"
 fi
 
-if ! bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "${CASE}/published-SHA256SUMS.txt" > "${CASE}/assemble.log" 2>&1; then
-  fail "assemble-release-checksums.sh exited non-zero"
-  cat "${CASE}/assemble.log" >&2
-else
-  pass "assemble-release-checksums.sh succeeded"
-fi
+run_assemble "${CASE}" "${CASE}/published-SHA256SUMS.txt"
+expect_ok "assemble-release-checksums.sh" "${CASE}" assemble.log $?
 SUMS="${CASE}/assets/SHA256SUMS.txt"
 # The regression: without merging, this file lost the ${WINDOWS_ASSET} entry
 assert_contains "${SUMS}" "${WINDOWS_HASH}"
 assert_contains "${SUMS}" "${WINDOWS_ASSET}"
 assert_contains "${SUMS}" "${LINUX_ASSET}"
 assert_contains "${SUMS}" "${ARM64_ASSET}"
-assert_contains "${SUMS}" "${X86_64_ASSET}"
+assert_contains "${SUMS}" "${INTEL_MAC_ASSET}"
 assert_absent "${SUMS}" "${REBUILD_WINDOWS_ASSET}"
 assert_line_count "${SUMS}" 4
 
@@ -154,15 +190,11 @@ cat > "${CASE}/final-assets.txt" <<EOF
 ${ARM64_ASSET}
 ${LINUX_ASSET}
 ${WINDOWS_ASSET}
-${X86_64_ASSET}
+${INTEL_MAC_ASSET}
 SHA256SUMS.txt
 EOF
-if bash "${CI_DIR}/verify-release-checksums.sh" "${SUMS}" "${CASE}/final-assets.txt" > "${CASE}/verify.log" 2>&1; then
-  pass "verify-release-checksums.sh accepts the merged release"
-else
-  fail "verify-release-checksums.sh rejected a fully covered release"
-  cat "${CASE}/verify.log" >&2
-fi
+run_verify "${CASE}" "${SUMS}" "${CASE}/final-assets.txt"
+expect_ok "verify-release-checksums.sh" "${CASE}" verify.log $?
 
 #-----------------------------------------------------------------------------
 start_test "an uncovered release binary is rejected"
@@ -172,7 +204,7 @@ CASE="${WORK_DIR}/uncovered"
 mkdir -p "${CASE}"
 cat > "${CASE}/SHA256SUMS.txt" <<EOF
 ${LINUX_HASH}  ${LINUX_ASSET}
-${X86_64_HASH}  ${X86_64_ASSET}
+${INTEL_MAC_HASH}  ${INTEL_MAC_ASSET}
 ${REBUILD_WINDOWS_HASH} *${REBUILD_WINDOWS_ASSET}
 ${ARM64_HASH}  ${ARM64_ASSET}
 EOF
@@ -180,18 +212,35 @@ cat > "${CASE}/assets.txt" <<EOF
 ${ARM64_ASSET}
 ${LINUX_ASSET}
 ${WINDOWS_ASSET}
-${X86_64_ASSET}
+${INTEL_MAC_ASSET}
 ${REBUILD_WINDOWS_ASSET}
 SHA256SUMS.txt
 EOF
-if bash "${CI_DIR}/verify-release-checksums.sh" "${CASE}/SHA256SUMS.txt" "${CASE}/assets.txt" > "${CASE}/verify.log" 2>&1; then
-  fail "verify-release-checksums.sh accepted a release whose Windows installer has no checksum"
-  cat "${CASE}/verify.log" >&2
-else
-  pass "verify-release-checksums.sh rejected the release"
-fi
+run_verify "${CASE}" "${CASE}/SHA256SUMS.txt" "${CASE}/assets.txt"
+expect_failure "verify-release-checksums.sh" $?
 assert_contains "${CASE}/verify.log" "${WINDOWS_ASSET}"
 assert_contains "${CASE}/verify.log" "::error::"
+# a blocked release cannot be repaired by re-running, so say what to do
+assert_contains "${CASE}/verify.log" "Delete the stale asset from the release"
+
+#-----------------------------------------------------------------------------
+start_test "a binary whose bytes do not match its entry is rejected"
+# The Windows job recomputes the sidecar after signing changes the bytes
+# (build-mudlet-win.yml); if that ever stops happening, coverage alone would not
+# notice and every user's updater would report a corrupt download
+CASE="${WORK_DIR}/mismatch"
+make_assets "${CASE}" "${WINDOWS_ASSET}:real"
+run_assemble "${CASE}" ""
+expect_ok "assemble-release-checksums.sh" "${CASE}" assemble.log $?
+printf '%s\nSHA256SUMS.txt\n' "${WINDOWS_ASSET}" > "${CASE}/assets.txt"
+
+run_verify "${CASE}" "${CASE}/assets/SHA256SUMS.txt" "${CASE}/assets.txt" "${CASE}/assets"
+expect_ok "verify-release-checksums.sh on matching bytes" "${CASE}" verify.log $?
+
+echo "tampered" > "${CASE}/assets/${WINDOWS_ASSET}"
+run_verify "${CASE}" "${CASE}/assets/SHA256SUMS.txt" "${CASE}/assets.txt" "${CASE}/assets"
+expect_failure "verify-release-checksums.sh on altered bytes" $?
+assert_contains "${CASE}/verify.log" "do not match their SHA256SUMS.txt entry"
 
 #-----------------------------------------------------------------------------
 start_test "a Windows-only PTB is published with its one checksum"
@@ -203,22 +252,17 @@ WINDOWS_ONLY_TAG='Mudlet-4.22.0-ptb-2026-08-03-3474cb58'
 WINDOWS_ONLY_ASSET="${WINDOWS_ONLY_TAG}-windows-64.exe"
 make_assets "${CASE}" \
   "${WINDOWS_ONLY_ASSET}:c22435c7ff0d36a5dbe5936bcfbbc173f656c2c33583dccbf17a7ad4ade3e350"
-if bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${WINDOWS_ONLY_TAG}" ptb > "${CASE}/prepare.log" 2>&1; then
-  pass "prepare-release-assets.sh allows a partial PTB"
-else
-  fail "prepare-release-assets.sh rejected a partial PTB"
-  cat "${CASE}/prepare.log" >&2
-fi
-assert_contains "${CASE}/prepare.log" "::warning::Missing release assets for: Linux (.AppImage.tar) macOS (.dmg)"
-bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "" > "${CASE}/assemble.log" 2>&1
+run_prepare "${CASE}" "${WINDOWS_ONLY_TAG}" ptb
+expect_ok "prepare-release-assets.sh on a partial PTB" "${CASE}" prepare.log $?
+assert_contains "${CASE}/prepare.log" "::warning::Missing release assets for: Linux (.AppImage.tar) macOS (arm64 .dmg) macOS (x86_64 .dmg)"
+# the workflow always passes published/SHA256SUMS.txt, which does not exist on a
+# release's first run
+run_assemble "${CASE}" "${CASE}/does-not-exist-SHA256SUMS.txt"
+expect_ok "assemble-release-checksums.sh with no published file" "${CASE}" assemble.log $?
 assert_line_count "${CASE}/assets/SHA256SUMS.txt" 1
 printf '%s\nSHA256SUMS.txt\n' "${WINDOWS_ONLY_ASSET}" > "${CASE}/assets.txt"
-if bash "${CI_DIR}/verify-release-checksums.sh" "${CASE}/assets/SHA256SUMS.txt" "${CASE}/assets.txt" > "${CASE}/verify.log" 2>&1; then
-  pass "the Windows-only PTB passes verification"
-else
-  fail "the Windows-only PTB was rejected"
-  cat "${CASE}/verify.log" >&2
-fi
+run_verify "${CASE}" "${CASE}/assets/SHA256SUMS.txt" "${CASE}/assets.txt"
+expect_ok "verify-release-checksums.sh on the Windows-only PTB" "${CASE}" verify.log $?
 
 #-----------------------------------------------------------------------------
 start_test "a stable release missing a platform is rejected"
@@ -226,29 +270,23 @@ CASE="${WORK_DIR}/partial-stable"
 STABLE_TAG='Mudlet-4.22.0'
 make_assets "${CASE}" \
   "${STABLE_TAG}-windows-64-installer.exe:c22435c7ff0d36a5dbe5936bcfbbc173f656c2c33583dccbf17a7ad4ade3e350"
-if bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${STABLE_TAG}" release > "${CASE}/prepare.log" 2>&1; then
-  fail "prepare-release-assets.sh published an incomplete stable release"
-else
-  pass "prepare-release-assets.sh rejected the incomplete stable release"
-fi
+run_prepare "${CASE}" "${STABLE_TAG}" release
+expect_failure "prepare-release-assets.sh on an incomplete stable release" $?
 assert_contains "${CASE}/prepare.log" "::error::Stable release is missing assets for:"
 
 #-----------------------------------------------------------------------------
-start_test "a rebuild counter on this build's own assets is kept"
-# A re-run of both platforms tags itself with the rebuild counter too, so the
-# counter alone must not make an asset look foreign
+start_test "a rebuild counter on this build's own installer is kept"
+# When the tag comes from the Windows re-run itself, the counter is part of that
+# build's own filename and must not make the installer look foreign
 CASE="${WORK_DIR}/own-rebuild"
 REBUILD_TAG='Mudlet-4.22.0-ptb-2026-08-02-dfdcb137'
 make_assets "${CASE}" \
   "${REBUILD_TAG}rebuild2-windows-64.exe:${REBUILD_WINDOWS_HASH}" \
   "${REBUILD_TAG}-linux-x64.AppImage.tar:${LINUX_HASH}" \
-  "${REBUILD_TAG}-arm64.dmg:${ARM64_HASH}"
-if bash "${CI_DIR}/prepare-release-assets.sh" "${CASE}/assets" "${REBUILD_TAG}" ptb > "${CASE}/prepare.log" 2>&1; then
-  pass "prepare-release-assets.sh succeeded"
-else
-  fail "prepare-release-assets.sh exited non-zero"
-  cat "${CASE}/prepare.log" >&2
-fi
+  "${REBUILD_TAG}-arm64.dmg:${ARM64_HASH}" \
+  "${REBUILD_TAG}-x86_64.dmg:${INTEL_MAC_HASH}"
+run_prepare "${CASE}" "${REBUILD_TAG}" ptb
+expect_ok "prepare-release-assets.sh" "${CASE}" prepare.log $?
 assert_absent "${CASE}/prepare.log" "::warning::Ignoring"
 if [[ -e "${CASE}/assets/${REBUILD_TAG}rebuild2-windows-64.exe" ]]; then
   pass "this build's own rebuilt installer was kept"
@@ -257,24 +295,97 @@ else
 fi
 
 #-----------------------------------------------------------------------------
+start_test "assets are matched to the tag case-insensitively"
+# CI/set-build-info.sh lowercases VERSION, while a pushed git tag keeps its case
+CASE="${WORK_DIR}/tag-case"
+MIXED_CASE_TAG='Mudlet-4.23.0-RC1'
+make_assets "${CASE}" \
+  "mudlet-4.23.0-rc1-windows-64-installer.exe:${WINDOWS_HASH}" \
+  "mudlet-4.23.0-rc1-linux-x64.AppImage.tar:${LINUX_HASH}" \
+  "mudlet-4.23.0-rc1-arm64.dmg:${ARM64_HASH}" \
+  "mudlet-4.23.0-rc1-x86_64.dmg:${INTEL_MAC_HASH}"
+run_prepare "${CASE}" "${MIXED_CASE_TAG}" release
+expect_ok "prepare-release-assets.sh on a mixed-case tag" "${CASE}" prepare.log $?
+assert_absent "${CASE}/prepare.log" "::warning::Ignoring"
+
+#-----------------------------------------------------------------------------
 start_test "merging keeps the freshly built hash when a filename repeats"
 CASE="${WORK_DIR}/rebuilt-same-name"
 make_assets "${CASE}" "${WINDOWS_ASSET}:${REBUILD_WINDOWS_HASH}"
 printf '%s *%s\n' "${WINDOWS_HASH}" "${WINDOWS_ASSET}" > "${CASE}/published-SHA256SUMS.txt"
-bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "${CASE}/published-SHA256SUMS.txt" > "${CASE}/assemble.log" 2>&1
+run_assemble "${CASE}" "${CASE}/published-SHA256SUMS.txt"
+expect_ok "assemble-release-checksums.sh" "${CASE}" assemble.log $?
 assert_line_count "${CASE}/assets/SHA256SUMS.txt" 1
 assert_contains "${CASE}/assets/SHA256SUMS.txt" "${REBUILD_WINDOWS_HASH}"
 assert_absent "${CASE}/assets/SHA256SUMS.txt" "${WINDOWS_HASH}"
 
 #-----------------------------------------------------------------------------
+start_test "two different hashes for one filename are not resolved by guessing"
+CASE="${WORK_DIR}/conflict"
+mkdir -p "${CASE}/assets"
+printf '%s *%s\n%s *%s\n' "${WINDOWS_HASH}" "${WINDOWS_ASSET}" "${REBUILD_WINDOWS_HASH}" "${WINDOWS_ASSET}" \
+  > "${CASE}/published-SHA256SUMS.txt"
+make_assets "${CASE}" "${LINUX_ASSET}:${LINUX_HASH}"
+run_assemble "${CASE}" "${CASE}/published-SHA256SUMS.txt"
+expect_failure "assemble-release-checksums.sh on conflicting entries" $?
+assert_contains "${CASE}/assemble.log" "::error::Conflicting checksums for ${WINDOWS_ASSET}"
+
+#-----------------------------------------------------------------------------
+start_test "checksum lines survive tabs, CRLF and a missing trailing newline"
+# None of our generators produce these, but each used to turn a cosmetic quirk into
+# a release that could not be published
+CASE="${WORK_DIR}/odd-formatting"
+mkdir -p "${CASE}/assets"
+printf '%s\t%s' "${WINDOWS_HASH}" "${WINDOWS_ASSET}" > "${CASE}/assets/${WINDOWS_ASSET}.sha256"
+printf '%s *%s\r\n' "${LINUX_HASH}" "${LINUX_ASSET}" > "${CASE}/assets/${LINUX_ASSET}.sha256"
+printf '%s  %s' "${ARM64_HASH}" "${ARM64_ASSET}" > "${CASE}/assets/${ARM64_ASSET}.sha256"
+run_assemble "${CASE}" ""
+expect_ok "assemble-release-checksums.sh on oddly formatted sidecars" "${CASE}" assemble.log $?
+assert_line_count "${CASE}/assets/SHA256SUMS.txt" 3
+assert_contains "${CASE}/assets/SHA256SUMS.txt" "${WINDOWS_HASH}  ${WINDOWS_ASSET}"
+assert_contains "${CASE}/assets/SHA256SUMS.txt" "${LINUX_HASH} *${LINUX_ASSET}"
+assert_contains "${CASE}/assets/SHA256SUMS.txt" "${ARM64_HASH}  ${ARM64_ASSET}"
+printf '%s\n%s\n%s\nSHA256SUMS.txt\n' "${WINDOWS_ASSET}" "${LINUX_ASSET}" "${ARM64_ASSET}" > "${CASE}/assets.txt"
+run_verify "${CASE}" "${CASE}/assets/SHA256SUMS.txt" "${CASE}/assets.txt"
+expect_ok "verify-release-checksums.sh on the merged file" "${CASE}" verify.log $?
+
+#-----------------------------------------------------------------------------
+start_test "a sidecar that contributes nothing is an error"
+CASE="${WORK_DIR}/empty-sidecar"
+mkdir -p "${CASE}/assets"
+echo "placeholder" > "${CASE}/assets/${WINDOWS_ASSET}"
+: > "${CASE}/assets/${WINDOWS_ASSET}.sha256"
+run_assemble "${CASE}" ""
+expect_failure "assemble-release-checksums.sh on an empty sidecar" $?
+assert_contains "${CASE}/assemble.log" "contributed no checksum entry"
+
+#-----------------------------------------------------------------------------
+start_test "an unreadable checksum file is reported as such, not as missing entries"
+CASE="${WORK_DIR}/unreadable-sums"
+mkdir -p "${CASE}"
+echo "<html>503 Service Unavailable</html>" > "${CASE}/SHA256SUMS.txt"
+printf '%s\nSHA256SUMS.txt\n' "${WINDOWS_ASSET}" > "${CASE}/assets.txt"
+run_verify "${CASE}" "${CASE}/SHA256SUMS.txt" "${CASE}/assets.txt"
+expect_failure "verify-release-checksums.sh on an unreadable checksum file" $?
+assert_contains "${CASE}/verify.log" "contains no usable checksum entries"
+
+#-----------------------------------------------------------------------------
+start_test "an unrecognised asset type still has to be covered"
+# The gate must not exempt a file just because its suffix is new
+CASE="${WORK_DIR}/new-asset-type"
+mkdir -p "${CASE}"
+printf '%s *%s\n' "${WINDOWS_HASH}" "${WINDOWS_ASSET}" > "${CASE}/SHA256SUMS.txt"
+printf '%s\nMudlet-4.22.0-linux-x64-portable.tar.gz\nSHA256SUMS.txt\n' "${WINDOWS_ASSET}" > "${CASE}/assets.txt"
+run_verify "${CASE}" "${CASE}/SHA256SUMS.txt" "${CASE}/assets.txt"
+expect_failure "verify-release-checksums.sh on an uncovered new asset type" $?
+assert_contains "${CASE}/verify.log" "Mudlet-4.22.0-linux-x64-portable.tar.gz"
+
+#-----------------------------------------------------------------------------
 start_test "no sidecars at all is an error"
 CASE="${WORK_DIR}/no-sidecars"
 mkdir -p "${CASE}/assets"
-if bash "${CI_DIR}/assemble-release-checksums.sh" "${CASE}/assets" "" > "${CASE}/assemble.log" 2>&1; then
-  fail "assemble-release-checksums.sh accepted an empty assets directory"
-else
-  pass "assemble-release-checksums.sh rejected an empty assets directory"
-fi
+run_assemble "${CASE}" ""
+expect_failure "assemble-release-checksums.sh on an empty assets directory" $?
 assert_contains "${CASE}/assemble.log" "::error::No .sha256 checksum files found"
 
 #-----------------------------------------------------------------------------

--- a/test/ci/release-checksums-test.sh
+++ b/test/ci/release-checksums-test.sh
@@ -120,6 +120,15 @@ expect_failure() {
   fi
 }
 
+# macOS has shasum rather than coreutils' sha256sum
+sha256_of() {
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  else
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  fi
+}
+
 # Creates a case directory with an assets/ subdirectory holding placeholder
 # binaries and their .sha256 sidecars. Arguments are "name:hash" pairs; a hash of
 # "real" is computed from the placeholder's actual bytes.
@@ -133,7 +142,7 @@ make_assets() {
     hash="${pair##*:}"
     echo "placeholder for ${name}" > "${case_dir}/assets/${name}"
     if [[ "${hash}" == "real" ]]; then
-      hash="$(sha256sum "${case_dir}/assets/${name}" | cut -d ' ' -f 1)"
+      hash="$(sha256_of "${case_dir}/assets/${name}")"
     fi
     printf '%s *%s\n' "${hash}" "${name}" > "${case_dir}/assets/${name}.sha256"
   done


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Never publish a release binary without a matching `SHA256SUMS.txt` entry: merge over the already-published file instead of overwriting it, set aside assets belonging to a different build than the release tag, and gate the upload on every binary having an entry that matches its bytes.
- Say which check failed in the updater - missing checksums, undownloadable checksums, no entry for this platform, unreadable checksum file - instead of one message for all of them.
- Add `UpdaterChecksumTest` and `ReleaseChecksumsTest`; both fail if the fix is reverted.

#### Motivation for adding to Mudlet

Windows auto-update failed with "Could not verify the integrity of the download", so PTB users could not update at all. `create-github-release.yml` runs once per platform build workflow and uploads with `--clobber`, so the 2026-08-02 run regenerated `SHA256SUMS.txt` from its own subset of sidecars and overwrote the complete file while the earlier `.exe` stayed published. The updater was right to refuse it.

#### Other info (issues closed, discussion etc)

Test case: `ctest -R 'UpdaterChecksumTest|ReleaseChecksumsTest'`.

Verified on a Windows 11 VM against a scratch release reproducing the exact layout: before, the Download Error dialog; after replacing only `SHA256SUMS.txt` with what the new script produces, the installer downloaded, verified and staged.

`requireChecksums` is unchanged - nothing accepts an unverified download that did not before.

Not fixed here: PTBs ship Windows-only when the scheduled Linux/macOS build is still queued, which is why the 2026-08-03 PTB has one asset.

Assisted-by: Claude:claude-opus-5
