### PR TITLE
fix: killTrigger and killAlias report failure when the item is already dead

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -385,6 +385,14 @@ bool AliasUnit::killAlias(const QString& name)
             if (!alias->isTemporary()) {
                 return false;
             }
+            // An already killed alias is only unlinked from this list once
+            // doCleanup() gets to free it, which cannot happen while an alias
+            // script is on the call stack - so until then it is still findable by
+            // name. Killing it a second time achieves nothing and must be reported
+            // as the failure it is:
+            if (mCleanupSet.contains(alias)) {
+                return false;
+            }
             alias->setIsActive(false);
             markCleanup(alias);
             return true;

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -233,6 +233,14 @@ bool KeyUnit::killKey(QString& name)
             if (!pChild->isTemporary()) {
                 return false;
             }
+            // An already killed key is only unlinked from this list once
+            // doCleanup() gets to free it, which cannot happen while a key script
+            // is on the call stack - so until then it is still findable by name.
+            // Killing it a second time achieves nothing and must be reported as
+            // the failure it is:
+            if (mCleanupSet.contains(pChild)) {
+                return false;
+            }
             pChild->setIsActive(false);
             markCleanup(pChild);
             return true;

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -458,16 +458,31 @@ void TriggerUnit::setTriggerStayOpen(const QString& name, int lines)
 
 bool TriggerUnit::killTrigger(const QString& name)
 {
-    auto it = mLookupTable.constFind(name);
-    while (it != mLookupTable.cend() && it.key() == name) {
+    // equal_range visits every same-named trigger; constFind() + (++it) can
+    // start mid-run and skip duplicates on some QMultiMap implementations
+    const auto [begin, end] = mLookupTable.equal_range(name);
+    for (auto it = begin; it != end; ++it) {
         TTrigger* pT = it.value();
-        if (pT->isTemporary()) //this function is only defined for tempTriggers, permanent objects cannot be removed
-        {
-            // there can only be a single tempTrigger by this name and this function ignores non-tempTriggers by definition
-            markCleanup(pT);
-            return true;
+        if (!pT->isTemporary()) {
+            // this function is only defined for tempTriggers, permanent objects cannot be removed
+            continue;
         }
-        it++;
+        // An already killed trigger is only unlinked from the lookup table once
+        // doCleanup() gets to free it, which cannot happen while a trigger script
+        // is on the call stack - so until then it is still findable by name.
+        // tempComplexRegexTrigger() replaces a temporary trigger under the name it
+        // was given, so a corpse and a live trigger can share one: keep looking
+        // rather than report a kill that would achieve nothing.
+        if (mCleanupSet.contains(pT)) {
+            continue;
+        }
+        // Deactivating matters as much as queueing the delete: the trigger stays
+        // in the list processDataStream() is walking until that deferred cleanup,
+        // and a killed trigger must no more fire on the rest of the line than a
+        // disabled one does
+        pT->setIsActive(false);
+        markCleanup(pT);
+        return true;
     }
     return false;
 }

--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -539,10 +539,15 @@ if false then
 
 
 
-  --- Deletes an alias with the given name. If several aliases have this name, they'll all be deleted.
+  --- Deletes a tempAlias. Use the alias ID returned by tempAlias() as the name parameter.
+  --- This function returns true on success and false if the alias has already been killed
+  --- or is not a temporary alias. Note that non-temporary aliases that you have set up in
+  --- the GUI cannot be deleted with this function. Use disableAlias() to turn them on or off.
   ---
   --- @see killTimer
   --- @see killTrigger
+  ---
+  --- @return true or false
   function killAlias(name)
   end
 
@@ -563,6 +568,10 @@ if false then
 
 
   --- Deletes a tempTrigger according to trigger ID. ID is a string value, not a number.
+  --- This function returns true on success and false if the trigger has already been killed
+  --- (or has used up its last firing) or is not a temporary trigger. Note that non-temporary
+  --- triggers that you have set up in the GUI cannot be deleted with this function.
+  --- Use disableTrigger() to turn them on or off.
   ---
   --- @see killAlias
   --- @see killTimer

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -270,6 +270,37 @@ describe("Alias processing", function()
             assert.is_false(killAlias("no_such_alias_name"), "killing a missing alias should return false")
         end)
 
+        it("killAlias returns false the second time, as the alias is already dead", function()
+            local id = tempAlias("^spec_double_kill_alias$", [[]])
+            assert.is_true(killAlias(id), "killing a live temporary alias should report success")
+            -- the alias is still present here: only the deferred cleanup frees it, so
+            -- the second kill really is being told about a corpse it can find
+            assert.are.equal(1, exists(id, "alias"), "the killed alias is still present until cleanup runs")
+            assert.are.equal(0, isActive(id, "alias"), "a killed alias is no longer active")
+            assert.is_false(killAlias(id),
+                "killing an already killed alias achieves nothing and has to say so")
+            -- an incoming line runs every unit's deferred cleanup, which is what
+            -- finally frees the alias; the answer has to be the same after it
+            feedTriggers("\nspec_alias_kill_flush\n")
+            assert.are.equal(0, exists(id, "alias"), "the alias should be gone after kill and cleanup")
+            assert.is_false(killAlias(id), "a freed alias cannot be killed either")
+        end)
+
+        it("killAlias returns false the second time inside the alias's own script", function()
+            _G.AliasSpec = {}
+            local id
+            id = tempAlias("^spec_self_kill_alias$", function()
+                _G.AliasSpec.killed = killAlias(id)
+                _G.AliasSpec.killedAgain = killAlias(id)
+            end)
+            expandAlias("spec_self_kill_alias")
+            assert.is_not_nil(_G.AliasSpec.killed, "the alias should have matched and run")
+            assert.is_true(_G.AliasSpec.killed,
+                "killAlias should report success from inside the alias's own script")
+            assert.is_false(_G.AliasSpec.killedAgain,
+                "killing the same alias twice from its own script must fail the second time")
+        end)
+
         it("killAlias returns false for a permanent alias (they cannot be killed)", function()
             local id = permAlias("SpecPermAliasKill", "", "^spec_perm_kill$", [[]])
             assert.is_true(id > 0)

--- a/src/mudlet-lua/tests/KeyBinds_spec.lua
+++ b/src/mudlet-lua/tests/KeyBinds_spec.lua
@@ -186,6 +186,24 @@ describe("Tests keybind-related functions", function()
       assert.is_false(killKey("no_such_key_name"), "killing a missing key should return false")
     end)
 
+    it("killKey returns false the second time, as the key is already dead", function()
+      local id = tempKey(mudlet.key.F11, [[echo("x")]])
+      assert.is_true(killKey(id), "killing a live temporary key should report success")
+      -- the key is still present here: only the deferred cleanup frees it, so the
+      -- second kill really is being told about a corpse it can find
+      assert.are.equal(1, exists(id, "keybind"), "the killed key is still present until cleanup runs")
+      assert.are.equal(0, isActive(id, "keybind"), "a killed key is no longer active")
+      assert.is_false(killKey(id),
+        "killing an already killed key achieves nothing and has to say so")
+      -- an incoming line runs every unit's deferred cleanup, which is what finally
+      -- frees the key; the answer has to be the same after it. A key press cannot be
+      -- synthesised headlessly, so there is no in-callback double kill to pin here -
+      -- KeyUnit's depth and cleanup machinery matches AliasUnit's, whose spec has one
+      feedTriggers("\nspec_key_kill_flush\n")
+      assert.are.equal(0, exists(id, "keybind"), "the key should be gone after kill and cleanup")
+      assert.is_false(killKey(id), "a freed key cannot be killed either")
+    end)
+
     it("killKey returns false for a permanent key (they cannot be killed)", function()
       local id = permKey("SpecPermKeyKill", "", mudlet.key.F12, [[echo("x")]])
       assert.is_true(id > 0)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -713,6 +713,77 @@ describe("Trigger processing", function()
             assert.is_false(killTrigger("no_such_trigger_name"))
         end)
 
+        it("killTrigger returns false the second time, as the trigger is already dead", function()
+            local id = tempRegexTrigger("^double_kill_probe$", [[]])
+            assert.is_true(killTrigger(id), "killing a live temporary trigger should report success")
+            -- the trigger is still present here: only the deferred cleanup frees it,
+            -- so the second kill really is being told about a corpse it can find
+            assert.is_equal(1, exists(id, "trigger"), "the killed trigger is still present until cleanup runs")
+            assert.is_equal(0, isActive(id, "trigger"), "a killed trigger is no longer active")
+            assert.is_false(killTrigger(id),
+                "killing an already killed trigger achieves nothing and has to say so")
+            -- a fed line runs that cleanup, and the answer has to be the same after it
+            feedTriggers("\ndouble_kill_flush\n")
+            assert.is_equal(0, exists(id, "trigger"), "the trigger should be gone after kill and cleanup")
+            assert.is_false(killTrigger(id), "a freed trigger cannot be killed either")
+        end)
+
+        it("a trigger killed earlier in a line's pass does not fire on that line", function()
+            _G.TrigSpec = {count = 0, witness = 0}
+            -- the killer is created first, so the trigger unit reaches it first and
+            -- its victim is still in the list this pass is walking; only the cleanup
+            -- at the end of the line frees the victim. The witness is created last so
+            -- that it proves the pass really did carry on past the killer
+            local victimId
+            local killerId = tempRegexTrigger("^kill_stops_firing$", function()
+                _G.TrigSpec.killed = killTrigger(victimId)
+            end)
+            victimId = tempRegexTrigger("^kill_stops_firing$", function()
+                _G.TrigSpec.count = _G.TrigSpec.count + 1
+            end)
+            local witnessId = tempRegexTrigger("^kill_stops_firing$", function()
+                _G.TrigSpec.witness = _G.TrigSpec.witness + 1
+            end)
+            feedTriggers("\nkill_stops_firing\n")
+            killTrigger(killerId)
+            killTrigger(witnessId)
+            assert.is_true(_G.TrigSpec.killed, "the first trigger should have killed the second")
+            assert.is_equal(1, _G.TrigSpec.witness, "the line should still reach triggers behind the killer")
+            assert.is_equal(0, _G.TrigSpec.count,
+                "a killed trigger must no more fire on the rest of the line than a disabled one does")
+        end)
+
+        it("killTrigger returns false for a trigger that has used up its last firing", function()
+            -- an expiring trigger queues itself for the same deferred cleanup a killed
+            -- one does, so it is just as dead - as killTimer reports for a one-shot
+            -- timer that has already fired
+            _G.TrigSpec = {}
+            local expiringId = tempRegexTrigger("^expiry_kill_probe$", [[]], 1)
+            local killerId = tempRegexTrigger("^expiry_kill_probe$", function()
+                _G.TrigSpec.killedExpired = killTrigger(expiringId)
+            end)
+            feedTriggers("\nexpiry_kill_probe\n")
+            killTrigger(killerId)
+            assert.is_not_nil(_G.TrigSpec.killedExpired, "the killing trigger should have fired")
+            assert.is_false(_G.TrigSpec.killedExpired,
+                "a trigger that just used up its last firing cannot be killed again")
+        end)
+
+        it("killTrigger returns false the second time inside the trigger's own script", function()
+            _G.TrigSpec = {}
+            local id
+            id = tempRegexTrigger("^self_kill_probe$", function()
+                _G.TrigSpec.killed = killTrigger(id)
+                _G.TrigSpec.killedAgain = killTrigger(id)
+            end)
+            feedTriggers("\nself_kill_probe\n")
+            assert.is_not_nil(_G.TrigSpec.killed, "the trigger should have fired")
+            assert.is_true(_G.TrigSpec.killed,
+                "killTrigger should report success from inside the trigger's own script")
+            assert.is_false(_G.TrigSpec.killedAgain,
+                "killing the same trigger twice from its own script must fail the second time")
+        end)
+
         it("exists rejects an invalid item type", function()
             local ok, err = exists(1, "notarealtype")
             assert.is_nil(ok)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `killTrigger()`, `killAlias()` and `killKey()` return `false` for an already dead item, using the same cleanup-set membership predicate `killTimer()` does (answers the same way at cleanup depth 0 and from inside a script). `killKey()` was not named in the original review but had the identical defect. As with timers, a temporary trigger that has used up its last firing is dead and reports so.
- `killTrigger()` now deactivates the trigger it kills, as `killAlias()` and `killKey()` already did - until cleanup runs, the corpse is still in the list the current line's pass is walking, so a trigger killed by an earlier trigger on the same line went on to fire. Its lookup walk also moves to `equal_range()` (as `enableTrigger()` did in #9366) and skips a corpse instead of giving up on the name.
- Specs added to the existing kill coverage in `Trigger_spec`, `Alias_spec` and `KeyBinds_spec`, including the in-callback double kill the `killTimer` specs pinned. (A key press cannot be synthesised headlessly, so keys have no in-callback counterpart.)

#### Motivation for adding to Mudlet
`killTimer()` learned to report an already dead timer in #9597 (fixing #9581), and review flagged that its siblings share the defect: a killed temporary item is only unlinked once the deferred `doCleanup()` frees it, which cannot happen while a script of that unit is on the call stack, so the corpse stayed findable and a second kill claimed success.

#### Other info (issues closed, discussion etc)
Follows the contract and predicate established in #9597/#9581; the `equal_range()` walk mirrors #9366.
**Test case:** busted suite 1827 successes / 0 failures / 0 errors / 17 pending (HTTP fixture), twice; the 7 new specs all fail against the unfixed binary (1820/7) - the second kill returning `true`, a killed trigger still reported active and still firing.

Assisted-by: Claude:claude-opus-5