### PR TITLE
fix: Mudlet freezing when a window is set to wrap too narrowly

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4987,7 +4987,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
             xPos = 0;
             continue;
         }
-        int nextBoundary = boundaryFinder.toNextBoundary();
+        const int nextBoundary = boundaryFinder.toNextBoundary();
         const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
         const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
         // Safety check: during destruction, mpHost might be null
@@ -5005,13 +5005,21 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
             const int firstNonIndentChar = firstChar + (needsIndent ? 0 : indentationHere);
             if (c == QChar::Space or lineBreakFinder.isAtBoundary() or lineBreakFinder.toPreviousBoundary() <= firstNonIndentChar) {
                 boundaryFinder.setPosition(indexOfChar);
-                output.append(WrapInfo(isNewline, needsIndent, firstChar, indexOfChar));
             } else {
                 indexOfChar = lineBreakFinder.position();
-                nextBoundary = lineBreakFinder.position();
-                boundaryFinder.setPosition(nextBoundary);
-                output.append(WrapInfo(isNewline, needsIndent, firstChar, indexOfChar));
+                boundaryFinder.setPosition(indexOfChar);
             }
+            if (indexOfChar <= firstChar) {
+                // no room for even one grapheme - either the wrap width is too
+                // narrow (or zero) or the indentation eats all of it. Breaking
+                // here would produce an empty segment and leave indexOfChar
+                // where it was, looping forever, so keep one grapheme on the
+                // line to guarantee the scan moves on
+                indexOfChar = (nextBoundary > firstChar) ? nextBoundary : firstChar + 1;
+                boundaryFinder.setPosition(indexOfChar);
+                totalWidth += charWidth;
+            }
+            output.append(WrapInfo(isNewline, needsIndent, firstChar, indexOfChar));
             isNewline = false;
             needsIndent = true;
             xPos = 0;

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3662,7 +3662,8 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     }
     console->setWrapAt(luaFrom);
     // only the main console's width belongs to the profile - it is what the
-    // preferences dialog shows and what NAWS reports to the game
+    // preferences dialog shows, what NEW-ENVIRON reports as WORD_WRAP and what
+    // caps the width NAWS reports to the game
     if (console->getType() == TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         const int priorWrapAt = host.mWrapAt;
@@ -3672,7 +3673,8 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
         }
         host.updateDisplayDimensions();
     }
-    return 0;
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapIndent

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -3654,10 +3654,16 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     }
     const int luaFrom = getVerifiedInt(L, __func__, s, "wrapAt");
     auto console = CONSOLE(L, QString{windowName});
+    if (luaFrom < 1) {
+        // a width of zero or less cannot hold a single character, so nothing
+        // could be displayed in such a window - the preferences dialog does not
+        // offer these values either
+        return warnArgumentValue(L, __func__, qsl("wrapAt must be greater than zero, got %1").arg(luaFrom));
+    }
     console->setWrapAt(luaFrom);
-    // only mirror values the preferences dialog itself accepts into the
-    // profile, otherwise an invalid width would reach NAWS and get saved
-    if (luaFrom >= 1 && console->getType() == TConsole::MainConsole) {
+    // only the main console's width belongs to the profile - it is what the
+    // preferences dialog shows and what NAWS reports to the game
+    if (console->getType() == TConsole::MainConsole) {
         Host& host = getHostFromLua(L);
         const int priorWrapAt = host.mWrapAt;
         host.mWrapAt = luaFrom;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1138,7 +1138,9 @@ void XMLimport::readHost(Host* pHost)
             } else if (name() == qsl("commandLineMinimumHeight")) {
                 pHost->commandLineMinimumHeight = readElementText().toInt();
             } else if (name() == qsl("wrapAt")) {
-                pHost->mWrapAt = readElementText().toInt();
+                // toInt() yields 0 for anything unparseable, and a profile that
+                // wraps at zero columns can show no text at all
+                pHost->mWrapAt = qMax(1, readElementText().toInt());
             } else if (name() == qsl("wrapIndentCount")) {
                 pHost->mWrapIndentCount = readElementText().toInt();
             } else if (name() == qsl("wrapHangingIndentCount")) {

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -614,6 +614,7 @@ function createConsole(windowName, consoleName, fontSize, charsPerLine, numberOf
   assert(type(consoleName) == 'string', 'createConsole: invalid type for consoleName (expected string, got '..type(consoleName)..'!)')
   assert(type(fontSize) == 'number', 'createConsole: invalid type for fontSize (expected number, got '..type(fontSize)..'!)')
   assert(type(charsPerLine) == 'number', 'createConsole: invalid type for charsPerLine (expected number, got '..type(charsPerLine)..'!)')
+  assert(charsPerLine >= 1, 'createConsole: charsPerLine must be 1 or more, got '..charsPerLine..'!')
   assert(type(numberOfLines) == 'number', 'createConsole: invalid type for numberOfLines (expected number, got '..type(numberOfLines)..'!)')
   assert(type(Xpos) == 'number', 'createConsole: invalid type for Xpos (expected number, got '..type(Xpos)..'!)')
   assert(type(Ypos) == 'number', 'createConsole: invalid type for Ypos (expected number, got '..type(Ypos)..'!)')

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -73,14 +73,20 @@ function Geyser.MiniConsole:getFont()
 end
 
 --- Sets the point at which text is wrapped in this miniconsole unless autoWrap is on
--- @param wrapAt The number of characters to start wrapping.
+-- @param wrapAt The number of characters to start wrapping. Must be 1 or more.
+-- @return true, or nil and an error message if the wrap was not applied.
 function Geyser.MiniConsole:setWrap (wrapAt)
   if self.autoWrap then return nil, "autoWrap is enabled in this MiniConsole and that overrides manual wrapping" end
 
-  if wrapAt then
-    self.wrapAt = wrapAt
+  -- only record the new wrap once Mudlet has accepted it, or a refused width
+  -- would be re-sent (and refused again) by every later call
+  local newWrap = wrapAt or self.wrapAt
+  local ok, err = setWindowWrap(self.name, newWrap)
+  if not ok then
+    return nil, err
   end
-  setWindowWrap(self.name, self.wrapAt)
+  self.wrapAt = newWrap
+  return true
 end
 
 function Geyser.MiniConsole:resetFormat()

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -431,7 +431,9 @@ function Geyser.MiniConsole:resetAutoWrap()
   if self.scrollBar then
     consoleWidth = consoleWidth - 15
   end
-  local charactersWidth = math.floor(consoleWidth / fontWidth)
+  -- a console narrower than one character (or one the scroll bar leaves no
+  -- room in) works out as zero columns, which is not a width to wrap at
+  local charactersWidth = math.max(1, math.floor(consoleWidth / fontWidth))
 
   self.wrapAt = charactersWidth
   setWindowWrap(self.name, self.wrapAt)

--- a/src/mudlet-lua/tests/GeyserMiniConsole_spec.lua
+++ b/src/mudlet-lua/tests/GeyserMiniConsole_spec.lua
@@ -130,6 +130,26 @@ describe("Tests functionality of Geyser.MiniConsole", function()
       assert.are.equal(17, getWindowWrap("gmcNoAutoWrap"))
     end)
 
+    -- a console too narrow for even one character works out as zero columns,
+    -- which Mudlet refuses (and which used to hang it, issue #9622)
+    it("never derives a wrap of less than one column", function()
+      local console = track(Geyser.MiniConsole:new({name = "gmcTinyAutoWrap", x = 0, y = 0, width = 4, height = 100, autoWrap = true}))
+      assert.are.equal(1, console.wrapAt)
+      assert.are.equal(1, getWindowWrap("gmcTinyAutoWrap"))
+    end)
+
+    it("passes on a refused wrap width instead of recording it", function()
+      local console = track(Geyser.MiniConsole:new({name = "gmcZeroWrap", x = 0, y = 0, width = 300, height = 100}))
+      console:setWrap(30)
+      local result, message = console:setWrap(0)
+      assert.is_nil(result)
+      assert.is_truthy(message:find("greater than zero", 1, true))
+      -- the refused width must not be remembered, or every later setWrap()
+      -- would re-send it and be refused as well
+      assert.are.equal(30, console.wrapAt)
+      assert.are.equal(30, getWindowWrap("gmcZeroWrap"))
+    end)
+
     it("reports that resetAutoWrap has nothing to do when auto wrap is off", function()
       local console = track(Geyser.MiniConsole:new({name = "gmcResetWrap", x = 0, y = 0, width = 300, height = 100}))
       local result, message = console:resetAutoWrap()

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -2325,7 +2325,17 @@ describe("Tests UI functions", function()
     end)
 
     it("setWindowWrap round-trips through getWindowWrap", function()
+      assert.is_true(setWindowWrap(win, 42))
+      assert.are.equal(42, getWindowWrap(win))
+    end)
+
+    -- a window zero columns wide can show nothing, and used to hang Mudlet
+    -- as soon as the next line was displayed in it (issue #9622)
+    it("setWindowWrap refuses a wrap width below one and keeps the old width", function()
       setWindowWrap(win, 42)
+      local ok, err = setWindowWrap(win, 0)
+      assert.is_nil(ok)
+      assert.is_truthy(err:find("greater than zero", 1, true))
       assert.are.equal(42, getWindowWrap(win))
     end)
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -120,6 +120,9 @@ set_tests_properties(ProfileRoundTripTest MapRoundTripTest MapProgressDialogSeam
 # HostWidgetDecouplingTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(HostWidgetDecouplingTest PROPERTIES TIMEOUT 300)
 
+# NarrowWindowWrapTest creates a fresh profile per test method, so it needs a longer timeout
+set_tests_properties(NarrowWindowWrapTest PROPERTIES TIMEOUT 300)
+
 # TDiscordModeTest drives the real discord-rpc library end-to-end. The library's
 # reconnect backoff is a process-global (60s ceiling) that the suite's
 # init/shutdown churn can inflate, so a fresh handshake can take a while (see

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(FUNCTIONAL_TEST_SOURCES
     MapRoundTripTest.cpp
     MapProgressDialogSeamTest.cpp
     UndoServerWrapTest.cpp
+    NarrowWindowWrapTest.cpp
     HostWidgetDecouplingTest.cpp
     ActionSelfUninstallTest.cpp
     DialogTeardownTest.cpp

--- a/test/functional_tests/NarrowWindowWrapTest.cpp
+++ b/test/functional_tests/NarrowWindowWrapTest.cpp
@@ -1,0 +1,272 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include <atomic>
+#include <functional>
+#include <thread>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResources();
+
+// A wrap width that cannot hold a single glyph - because it is zero, because
+// the glyph is wider than the width, or because the indentation uses the width
+// up - made TBuffer::getWrapInfo() break the line at the character it was
+// already sitting on, so the scan never advanced and Mudlet hung (#9622).
+// Everything here therefore runs under a watchdog: a regression is an endless
+// loop on the main thread, so no assertion after it would ever be reached.
+class NarrowWindowWrapTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = "Test-NarrowWrap";
+    QString mPort; // assigned the stub's actual loopback port in init()
+    const QString mLocalhost = "localhost";
+    const QString mMiniConsole = "wrapTest";
+    // U+6F22 U+5B57 - East Asian Wide, so two columns are needed per glyph
+    const QString mWideText = QString(QChar(0x6F22)) + QChar(0x5B57);
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        // Port 0 asks the OS for an ephemeral port so parallel test runs do
+        // not collide on a hardcoded one
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), "TelnetServerStub failed to bind a loopback port");
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+    }
+
+    // The report from #9622, at the level the Lua API no longer allows:
+    // TConsole::setWrapAt() is still reachable from C++, so the wrapping itself
+    // has to cope with a width of zero instead of spinning forever.
+    void test_zeroWrapWidthDoesNotHang()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        console->setWrapAt(0);
+
+        runWithWatchdog("echo at a wrap width of zero", [this]() {
+            runLua(qsl("echo('%1', 'abc def\\n')").arg(mMiniConsole));
+        });
+
+        // no width can hold a character, so every character ends up on a line of
+        // its own - but not one of them may be dropped or duplicated
+        QCOMPARE(joinedText(console), qsl("abcdef"));
+    }
+
+    // A width of one column with two-column glyphs is the same dead end, and
+    // unlike a width of zero it is a perfectly ordinary thing to ask for.
+    void test_wrapWidthNarrowerThanTheGlyphDoesNotHang()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        runLua(qsl("setWindowWrap('%1', 1)").arg(mMiniConsole));
+
+        runWithWatchdog("echo of a wide glyph at a wrap width of one", [this]() {
+            runLua(qsl("echo('%1', '%2\\n')").arg(mMiniConsole, mWideText));
+        });
+
+        QCOMPARE(joinedText(console), mWideText);
+    }
+
+    // Indentation is subtracted from the wrap width, so a legal width and a
+    // legal indent together can still leave less room than one glyph needs.
+    void test_indentEatingTheWrapWidthDoesNotHang()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        runLua(qsl("setWindowWrap('%1', 5)").arg(mMiniConsole));
+        // both, so that whichever of the two a line uses leaves a single column
+        runLua(qsl("setWindowWrapIndent('%1', 4)").arg(mMiniConsole));
+        runLua(qsl("setWindowWrapHangingIndent('%1', 4)").arg(mMiniConsole));
+
+        runWithWatchdog("echo of a wide glyph with the indent using up the wrap width", [this]() {
+            runLua(qsl("echo('%1', '%2\\n')").arg(mMiniConsole, mWideText));
+        });
+
+        QCOMPARE(joinedText(console), mWideText);
+    }
+
+    // Nothing can be shown in a window that is zero columns wide, so the Lua
+    // API turns such a width away rather than let it reach the wrapping.
+    void test_setWindowWrapRejectsWidthsBelowOne()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        runLua(qsl("setWindowWrap('%1', 40)").arg(mMiniConsole));
+
+        // under the watchdog as well: were the width to be accepted, the echo
+        // reporting the result would be the thing that hangs
+        runWithWatchdog("setWindowWrap() with a width of zero", [this]() {
+            runLua(qsl("local ok, err = setWindowWrap('%1', 0) echo('%1', 'RESULT:'..tostring(ok)..':'..tostring(err))").arg(mMiniConsole));
+        });
+
+        QCOMPARE(joinedText(console), qsl("RESULT:nil:wrapAtmustbegreaterthanzero,got0"));
+        // the rejected call must not have changed the width either
+        QCOMPARE(console->getWrapAt(), 40);
+    }
+
+    void cleanup()
+    {
+        const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+
+        // Tear down Mudlet (and with it the live cTelnet connection) before the
+        // stub server it is talking to, so the socket is closed from the client
+        // side rather than being yanked out from under an active connection.
+        delete mudlet::self();
+        delete mpServer;
+        mpServer = nullptr;
+        deleteDirectory(profilePath);
+    }
+
+private:
+    // Runs work on the main thread with a hard deadline: should the wrapping
+    // regress into an endless loop, kill the test process with a useful message
+    // rather than leave the whole ctest run to sit until its own timeout.
+    void runWithWatchdog(const char* what, const std::function<void()>& work, int timeoutSeconds = 10)
+    {
+        std::atomic_bool finished{false};
+        std::thread watchdog([&finished, what, timeoutSeconds]() {
+            for (int i = 0; i < timeoutSeconds * 10 && !finished.load(); ++i) {
+                QThread::msleep(100);
+            }
+            if (!finished.load()) {
+                qFatal("%s did not finish within %d seconds - the wrapping is stuck in a loop", what, timeoutSeconds);
+            }
+        });
+        work();
+        finished.store(true);
+        watchdog.join();
+    }
+
+    void runLua(const QString& script)
+    {
+        auto host = mudlet::self()->getActiveHost();
+        host->getLuaInterpreter()->compileAndExecuteScript(script);
+    }
+
+    // a miniconsole keeps the assertions free of the main console's connection
+    // messages, and wraps its text through exactly the same code
+    TConsole* createTestMiniConsole()
+    {
+        runLua(qsl("createMiniConsole('%1', 0, 0, 300, 300)").arg(mMiniConsole));
+        auto* console = mudlet::self()->getActiveHost()->mpConsole->mSubConsoleMap.value(mMiniConsole);
+        Q_ASSERT_X(console, "createTestMiniConsole", "the miniconsole the tests write into was not created");
+        return console;
+    }
+
+    void startProfile()
+    {
+        QTimer::singleShot(0, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy connectedSpy(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!connectedSpy.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    // everything in the console, with the whitespace that wrapping introduces
+    // at the break points removed, so wrapped and unwrapped text compare equal
+    static QString joinedText(TConsole* console)
+    {
+        QString text;
+        for (int i = 0, total = console->buffer.getLastLineNumber(); i <= total; ++i) {
+            text.append(console->buffer.line(i));
+        }
+        return text.remove(QChar::Space).remove(QChar::LineFeed);
+    }
+
+    void deleteProfileDirectory(const QString& profileName) { deleteDirectory(mudlet::getMudletPath(enums::profileHomePath, profileName)); }
+
+    void deleteDirectory(const QString& path)
+    {
+        QDir dir(path);
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+};
+
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "NarrowWindowWrapTest.moc"
+QTEST_MAIN(NarrowWindowWrapTest)

--- a/test/functional_tests/NarrowWindowWrapTest.cpp
+++ b/test/functional_tests/NarrowWindowWrapTest.cpp
@@ -43,8 +43,9 @@ void initializeQRCResources();
 // the glyph is wider than the width, or because the indentation uses the width
 // up - made TBuffer::getWrapInfo() break the line at the character it was
 // already sitting on, so the scan never advanced and Mudlet hung (#9622).
-// Everything here therefore runs under a watchdog: a regression is an endless
-// loop on the main thread, so no assertion after it would ever be reached.
+// Every step that can reach the wrapping therefore runs under a watchdog: a
+// regression is an endless loop on the main thread, so no assertion after it
+// would ever be reached.
 class NarrowWindowWrapTest : public QObject
 {
     Q_OBJECT
@@ -84,15 +85,34 @@ private slots:
     {
         startProfile();
         auto* console = createTestMiniConsole();
+        QVERIFY(console);
         console->setWrapAt(0);
 
         runWithWatchdog("echo at a wrap width of zero", [this]() {
-            runLua(qsl("echo('%1', 'abc def\\n')").arg(mMiniConsole));
+            runLua(qsl("echo('%1', 'abcdef\\n')").arg(mMiniConsole));
         });
 
-        // no width can hold a character, so every character ends up on a line of
-        // its own - but not one of them may be dropped or duplicated
+        // no width can hold a character, so every character ends up on a line
+        // of its own - and not one of them may be dropped or duplicated
+        QCOMPARE(nonEmptyLineCount(console), 6);
         QCOMPARE(joinedText(console), qsl("abcdef"));
+    }
+
+    // Newlines inside the echoed text take their own path through the wrapping
+    // scan, which has to keep its bookkeeping straight alongside the forced
+    // per-glyph breaks.
+    void test_embeddedNewlinesAtZeroWrapWidthDoNotHang()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        QVERIFY(console);
+        console->setWrapAt(0);
+
+        runWithWatchdog("echo of embedded newlines at a wrap width of zero", [this]() {
+            runLua(qsl("echo('%1', 'ab\\ncd\\n')").arg(mMiniConsole));
+        });
+
+        QCOMPARE(joinedText(console), qsl("abcd"));
     }
 
     // A width of one column with two-column glyphs is the same dead end, and
@@ -101,12 +121,14 @@ private slots:
     {
         startProfile();
         auto* console = createTestMiniConsole();
+        QVERIFY(console);
         runLua(qsl("setWindowWrap('%1', 1)").arg(mMiniConsole));
 
         runWithWatchdog("echo of a wide glyph at a wrap width of one", [this]() {
             runLua(qsl("echo('%1', '%2\\n')").arg(mMiniConsole, mWideText));
         });
 
+        QCOMPARE(nonEmptyLineCount(console), 2);
         QCOMPARE(joinedText(console), mWideText);
     }
 
@@ -116,6 +138,7 @@ private slots:
     {
         startProfile();
         auto* console = createTestMiniConsole();
+        QVERIFY(console);
         runLua(qsl("setWindowWrap('%1', 5)").arg(mMiniConsole));
         // both, so that whichever of the two a line uses leaves a single column
         runLua(qsl("setWindowWrapIndent('%1', 4)").arg(mMiniConsole));
@@ -125,7 +148,58 @@ private slots:
             runLua(qsl("echo('%1', '%2\\n')").arg(mMiniConsole, mWideText));
         });
 
-        QCOMPARE(joinedText(console), mWideText);
+        QCOMPARE(textIgnoringIndentation(console), mWideText);
+    }
+
+    // An indent at or beyond the wrap width is not range-checked anywhere.
+    // wrapLine() drops such an indent instead of leaving no room at all, and
+    // that is what keeps this case out of the trap the one above falls into.
+    void test_indentWiderThanTheWrapWidthDoesNotHang()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        QVERIFY(console);
+        runLua(qsl("setWindowWrap('%1', 5)").arg(mMiniConsole));
+        runLua(qsl("setWindowWrapIndent('%1', 10)").arg(mMiniConsole));
+        runLua(qsl("setWindowWrapHangingIndent('%1', 10)").arg(mMiniConsole));
+
+        runWithWatchdog("echo with an indent wider than the wrap width", [this]() {
+            runLua(qsl("echo('%1', '%2%2\\n')").arg(mMiniConsole, mWideText));
+        });
+
+        QCOMPARE(textIgnoringIndentation(console), mWideText + mWideText);
+    }
+
+    // insertText() wraps against the screen width and the profile's own indent
+    // rather than the console's, so it reaches the wrapping by a different
+    // route than echo() does.
+    void test_insertTextIntoTheMainConsoleDoesNotHang()
+    {
+        mpServer->setWelcomeMessage(qsl("HELLO\r\n"));
+        startProfile();
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY2(waitForMainConsoleText(qsl("HELLO")), "Welcome text never reached the buffer");
+
+        // leave a single column free of the screen width the insert wraps at -
+        // both indents, since only the first segment of a line uses the plain
+        // one and every segment after it uses the hanging one
+        const int indent = host->mScreenWidth - 1;
+        QVERIFY2(indent > 1, "the main console reported no usable screen width");
+        runLua(qsl("setWindowWrapIndent('main', %1)").arg(indent));
+        runLua(qsl("setWindowWrapHangingIndent('main', %1)").arg(indent));
+
+        // mid-line, so the insert goes through insertInLine() rather than the
+        // append path the cursor at the end of the buffer would take
+        const int welcomeLine = mainConsoleLineOf(qsl("HELLO"));
+        QVERIFY2(welcomeLine >= 0, "the welcome line went missing from the buffer");
+        QVERIFY2(host->mpConsole->moveCursor(2, welcomeLine), "could not position the user cursor mid-line");
+
+        runWithWatchdog("insertText of a wide glyph with the indent using up the screen width", [this, host]() {
+            // the newline is what makes the insert re-wrap the line it landed in
+            host->mpConsole->insertText(mWideText + QChar::LineFeed + mWideText);
+        });
+
+        QVERIFY2(mainConsoleContains(mWideText), "the inserted text did not survive wrapping");
     }
 
     // Nothing can be shown in a window that is zero columns wide, so the Lua
@@ -134,7 +208,9 @@ private slots:
     {
         startProfile();
         auto* console = createTestMiniConsole();
-        runLua(qsl("setWindowWrap('%1', 40)").arg(mMiniConsole));
+        QVERIFY(console);
+        // wide enough that the reported result is not itself wrapped
+        runLua(qsl("setWindowWrap('%1', 200)").arg(mMiniConsole));
 
         // under the watchdog as well: were the width to be accepted, the echo
         // reporting the result would be the thing that hangs
@@ -142,9 +218,42 @@ private slots:
             runLua(qsl("local ok, err = setWindowWrap('%1', 0) echo('%1', 'RESULT:'..tostring(ok)..':'..tostring(err))").arg(mMiniConsole));
         });
 
-        QCOMPARE(joinedText(console), qsl("RESULT:nil:wrapAtmustbegreaterthanzero,got0"));
+        const QString result = joinedText(console);
+        QVERIFY2(result.startsWith(qsl("RESULT:nil:")), qPrintable(qsl("setWindowWrap() did not refuse a wrap width of zero, it returned: %1").arg(result)));
+        QVERIFY2(result.contains(qsl("greater than zero")), qPrintable(qsl("the refusal did not say why: %1").arg(result)));
         // the rejected call must not have changed the width either
-        QCOMPARE(console->getWrapAt(), 40);
+        QCOMPARE(console->getWrapAt(), 200);
+    }
+
+    // An accepted width answers true, so that the usual `if not ok then` check
+    // does not read every successful call as a failure.
+    void test_setWindowWrapReportsSuccess()
+    {
+        startProfile();
+        auto* console = createTestMiniConsole();
+        QVERIFY(console);
+
+        runLua(qsl("local ok = setWindowWrap('%1', 200) echo('%1', 'RESULT:'..tostring(ok))").arg(mMiniConsole));
+
+        QCOMPARE(joinedText(console), qsl("RESULT:true"));
+        QCOMPARE(console->getWrapAt(), 200);
+    }
+
+    // The main console's width is mirrored into the profile and reported to the
+    // game, so a refused width must not reach either.
+    void test_rejectedMainConsoleWidthLeavesTheProfileUntouched()
+    {
+        startProfile();
+        auto* host = mudlet::self()->getActiveHost();
+        runLua(qsl("setWindowWrap(80)"));
+        QCOMPARE(host->mWrapAt, 80);
+
+        runWithWatchdog("setWindowWrap() with a width of zero on the main console", [this]() {
+            runLua(qsl("setWindowWrap(0)"));
+        });
+
+        QCOMPARE(host->mWrapAt, 80);
+        QCOMPARE(host->mpConsole->getWrapAt(), 80);
     }
 
     void cleanup()
@@ -191,9 +300,7 @@ private:
     TConsole* createTestMiniConsole()
     {
         runLua(qsl("createMiniConsole('%1', 0, 0, 300, 300)").arg(mMiniConsole));
-        auto* console = mudlet::self()->getActiveHost()->mpConsole->mSubConsoleMap.value(mMiniConsole);
-        Q_ASSERT_X(console, "createTestMiniConsole", "the miniconsole the tests write into was not created");
-        return console;
+        return mudlet::self()->getActiveHost()->mpConsole->mSubConsoleMap.value(mMiniConsole);
     }
 
     void startProfile()
@@ -231,15 +338,55 @@ private:
         }
     }
 
-    // everything in the console, with the whitespace that wrapping introduces
-    // at the break points removed, so wrapped and unwrapped text compare equal
+    // the buffer carries empty lines of its own (one is always kept ready for
+    // the next text), so only the lines with something in them are counted
+    static int nonEmptyLineCount(TConsole* console)
+    {
+        int count = 0;
+        for (int i = 0, total = console->buffer.getLastLineNumber(); i <= total; ++i) {
+            if (!console->buffer.line(i).isEmpty()) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    // every line of the console joined back together - the wrapping only breaks
+    // lines, so this has to come back out exactly as it went in
     static QString joinedText(TConsole* console)
     {
         QString text;
         for (int i = 0, total = console->buffer.getLastLineNumber(); i <= total; ++i) {
             text.append(console->buffer.line(i));
         }
-        return text.remove(QChar::Space).remove(QChar::LineFeed);
+        return text;
+    }
+
+    // as joinedText(), but with every space dropped, for the cases where the
+    // wrapping pads lines out with indentation. Spaces in the text itself are
+    // lost along with it, so these cases echo text that has none.
+    static QString textIgnoringIndentation(TConsole* console) { return joinedText(console).remove(QChar::Space); }
+
+    static int mainConsoleLineOf(const QString& text)
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        for (int i = 0, total = console->buffer.getLastLineNumber(); i <= total; ++i) {
+            if (console->buffer.line(i).contains(text)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    static bool mainConsoleContains(const QString& text) { return mainConsoleLineOf(text) >= 0; }
+
+    bool waitForMainConsoleText(const QString& text, int timeoutMs = 5000)
+    {
+        return QTest::qWaitFor(
+                [this, &text]() {
+                    return mainConsoleContains(text);
+                },
+                timeoutMs);
     }
 
     void deleteProfileDirectory(const QString& profileName) { deleteDirectory(mudlet::getMudletPath(enums::profileHomePath, profileName)); }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- line wrapping now always moves on: a width too narrow for a single glyph used to break the line at the character the scan was already on, looping forever on the main thread
- `setWindowWrap()` refuses widths below 1 (the range Preferences offers) and answers `true` when it accepts one; Geyser's `setWrap()` passes a refusal on and its autoWrap never derives 0 columns
- new `NarrowWindowWrapTest` (9 cases, 5 of them verified to hang without the fix) plus busted coverage of the Lua and Geyser contracts

#### Motivation for adding to Mudlet
`setWindowWrap(0)` froze Mudlet completely as soon as the next line was displayed, and so did an ordinary wrap width of 1 with East Asian text, or an indent that used the width up.

#### Other info (issues closed, discussion etc)
Fixes #9622

**Test case:** `lua setWindowWrap(0)` then `lua getWindowWrap()` - Mudlet used to freeze; now the first call reports "wrapAt must be greater than zero" and the client keeps running.

Assisted-by: Claude:claude-opus-5