### PR TITLE
fix: crash when opening settings on macOS

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -217,6 +217,10 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         checkbox_noAutomaticUpdates->setChecked(true);
         checkbox_noAutomaticUpdates->setDisabled(true);
         checkbox_noAutomaticUpdates->setToolTip(utils::richText(tr("Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet.")));
+    } else if (!pMudlet->pUpdater->ready()) {
+        // Nothing to show a setting for until the platform updater is set up,
+        // and a checkbox that silently does nothing is worse than no checkbox
+        groupBox_updates->hide();
     } else {
         checkbox_noAutomaticUpdates->setChecked(!pMudlet->pUpdater->updateAutomatically());
         // This is the extra connect(...) relating to settings' changes saved by

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -144,9 +144,25 @@ void Updater::checkUpdatesOnStart()
     mPeriodicCheck->start();
 }
 
+// Whether the platform updater is set up and can answer for itself. On macOS
+// that only happens in checkUpdatesOnStart(), so anything reaching the Updater
+// before then - the preferences dialog above all - has to ask first. Elsewhere
+// the automatic-update flag lives in QSettings and is readable straight away.
+bool Updater::ready() const
+{
+#if defined(Q_OS_MACOS)
+    return msparkleUpdater != nullptr;
+#else
+    return true;
+#endif
+}
+
 void Updater::setAutomaticUpdates(const bool state)
 {
 #if defined(Q_OS_MACOS)
+    if (!ready()) {
+        return;
+    }
     msparkleUpdater->setAutomaticallyDownloadsUpdates(state);
 #else
     dblsqd::UpdateDialog::enableAutoDownload(state, mSettings);
@@ -159,6 +175,9 @@ void Updater::setAutomaticUpdates(const bool state)
 bool Updater::updateAutomatically() const
 {
 #if defined(Q_OS_MACOS)
+    if (!ready()) {
+        return false;
+    }
     return msparkleUpdater->automaticallyDownloadsUpdates();
 #else
     return dblsqd::UpdateDialog::autoDownloadEnabled(true, mSettings);
@@ -168,6 +187,9 @@ bool Updater::updateAutomatically() const
 void Updater::manuallyCheckUpdates()
 {
 #if defined(Q_OS_MACOS)
+    if (!ready()) {
+        return;
+    }
     msparkleUpdater->checkForUpdates();
 #else
     if (mManualCheckInProgress) {

--- a/src/updater.h
+++ b/src/updater.h
@@ -58,6 +58,7 @@ public:
     void setAutomaticUpdates(bool state);
     bool updateAutomatically() const;
     bool shouldShowChangelog();
+    bool ready() const;
 
 private:
     std::unique_ptr<dblsqd::Feed> feed;
@@ -101,7 +102,9 @@ private:
 #elif defined(Q_OS_WINDOWS)
     QString mDownloadedInstallerPath;
 #elif defined(Q_OS_MACOS)
-    SparkleUpdater* msparkleUpdater;
+    // Only exists once checkUpdatesOnStart() has run - every use must cope with
+    // it still being null, see ready()
+    SparkleUpdater* msparkleUpdater = nullptr;
 #endif
 
 

--- a/test/functional_tests/DialogTeardownTest.cpp
+++ b/test/functional_tests/DialogTeardownTest.cpp
@@ -42,6 +42,7 @@
 
 #include <QKeySequenceEdit>
 #include <QLineEdit>
+#include <QScopeGuard>
 
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
@@ -51,6 +52,9 @@
 #include "dlgProfilePreferences.h"
 #include "dlgTriggerEditor.h"
 #include "mudlet.h"
+#if defined(INCLUDE_UPDATER)
+#include "updater.h"
+#endif
 
 using namespace std::chrono_literals;
 
@@ -244,6 +248,48 @@ private slots:
         delete preferences;
         QVERIFY2(mpHost->mpDlgProfilePreferences.isNull(), "Preferences dialog should have been destroyed");
         QCOMPARE(mpHost->getMMCPChatName(), chatNameBefore);
+    }
+
+    // Opening the preferences at all used to be enough to end the run: the
+    // dialog asks the updater whether it downloads updates by itself, which on
+    // macOS reaches into Sparkle - and Sparkle is only created by
+    // checkUpdatesOnStart(), which no test calls. Development builds skip that
+    // whole branch, so only PTB and release builds ever crashed and CI stayed
+    // green until the nightly PTB. DEV_UPDATER puts this build on the same path.
+    void test_preferencesOpensBeforeTheUpdaterIsSetUp()
+    {
+        qputenv("DEV_UPDATER", "1");
+        auto restoreEnvironment = qScopeGuard([]() {
+            qunsetenv("DEV_UPDATER");
+        });
+
+        mudlet::self()->showOptionsDialog(qsl("tab_specialOptions"), mpHost);
+        QTest::qWait(100ms);
+        auto* preferences = mpHost->mpDlgProfilePreferences.data();
+        QVERIFY2(preferences, "Preferences dialog was not created");
+
+#if defined(INCLUDE_UPDATER)
+        auto* updater = mudlet::self()->pUpdater;
+        QVERIFY2(updater, "An updater-enabled build has no updater");
+        // the dev-build branch disables the checkbox and touches no updater, so
+        // this is what says the test is on the crashing path at all
+        QVERIFY2(preferences->checkbox_noAutomaticUpdates->isEnabled(), "DEV_UPDATER no longer moves a development build onto the release update path - this test covers nothing now");
+        // isHidden() rather than isVisible(): the group box sits on a tab page,
+        // and only an explicit hide() should count here
+        QCOMPARE(preferences->groupBox_updates->isHidden(), !updater->ready());
+
+        if (!updater->ready()) {
+            // the accessors the dialog and the Help menu reach for have to be
+            // safe to call in this state, not merely avoidable
+            QVERIFY2(!updater->updateAutomatically(), "An updater with no platform updater claimed it auto-updates");
+            updater->setAutomaticUpdates(true);
+            updater->manuallyCheckUpdates();
+            QVERIFY2(!updater->updateAutomatically(), "An updater with no platform updater took a setting it cannot store");
+        }
+#endif
+
+        delete preferences;
+        QVERIFY2(mpHost->mpDlgProfilePreferences.isNull(), "Preferences dialog should have been destroyed");
     }
 
     // ...and through the editor, where the item name field is connected to


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- On macOS the `Updater` only creates its Sparkle wrapper in `checkUpdatesOnStart()`, but the preferences dialog asks it about automatic updates in its constructor - null dereference. All three Sparkle-backed accessors are now guarded by a new `Updater::ready()`.
- The preferences hide the updates group box while the platform updater isn't set up, rather than showing a checkbox that stores nothing.
- `DialogTeardownTest` gains a case that opens the preferences with `DEV_UPDATER` set, which is what puts a development build on the release-build update path where the crash lives.

#### Motivation for adding to Mudlet
Development builds skip the branch entirely, so the crash only appears in PTB and release builds - where opening settings is a normal thing to do.

#### Other info (issues closed, discussion etc)
It took out today's PTB: both macOS jobs segfaulted in `DialogTeardownTest`, which failed the Linux/macOS build workflow, so `create-github-release` never ran for it and [the release](https://github.com/Mudlet/Mudlet/releases/tag/Mudlet-4.22.0-ptb-2026-08-04-295b0002) got only the Windows installer - the Linux AppImage had built fine.

**Test case:** the macOS CI jobs here are the proof - they crash without this change. Locally: `ctest -R DialogTeardownTest`.

Assisted-by: Claude:claude-opus-5