### PR TITLE
infrastructure: Discord effect specs against a fake Discord IPC server

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -520,9 +520,40 @@ jobs:
         echo "MUDLET_TEST_HTTP_PORT=${port}" >> "${GITHUB_ENV}"
         echo "fixture HTTP server ready on 127.0.0.1:${port}"
 
+    - name: (Linux) Start fake Discord IPC server for Lua tests
+      if: matrix.run_tests == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        # A short runtime directory of its own: the whole discord-ipc-0 socket
+        # path has to fit into sockaddr_un's 108 character sun_path, and
+        # runner.temp does not leave room for it.
+        runtime_dir="$(mktemp -d /tmp/mdxdg-XXXX)"
+        ready_file="${{runner.temp}}/mudlet-discord-fixture-ready"
+        rm -f "${ready_file}"
+        nohup python3 "${{github.workspace}}/CI/discord-ipc-fixture.py" \
+          --runtime-dir "${runtime_dir}" \
+          --capture-file "${{runner.temp}}/mudlet-discord-frames.jsonl" \
+          --ready-file "${ready_file}" > "${{runner.temp}}/discord-ipc-fixture.log" 2>&1 &
+        for _ in $(seq 1 50); do
+          [ -s "${ready_file}" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${ready_file}" ] || [ ! -S "${runtime_dir}/discord-ipc-0" ]; then
+          echo "fake Discord IPC server failed to start" >&2
+          cat "${{runner.temp}}/discord-ipc-fixture.log" 2>/dev/null || true
+          exit 1
+        fi
+        cat "${ready_file}" >> "${GITHUB_ENV}"
+        # Prepended rather than replacing: the Qt install action puts Qt's own
+        # libraries on this path.
+        echo "MUDLET_TEST_DISCORD_LIB_PATH=${{github.workspace}}/3rdparty/discord/rpc/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
+        echo "fake Discord IPC server ready in ${runtime_dir}"
+
     - name: (Linux) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'Linux'
-      timeout-minutes: 1
+      # Longer than the other platforms': this leg also drives the real
+      # discord-rpc library, whose reconnects happen in wall-clock time.
+      timeout-minutes: 3
       run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror
       env:
         AUTORUN_BUSTED_TESTS: 'true'
@@ -534,6 +565,12 @@ jobs:
         # environment quirk. macOS runners start no player at all, so the gate
         # stays off there.
         MUDLET_TEST_REQUIRE_MEDIA: 1
+        # The fake Discord IPC server's socket lives in this runtime directory,
+        # and the bundled discord-rpc library is only reachable through this
+        # library path - without both the Discord specs have nothing to talk to.
+        MUDLET_TEST_REQUIRE_DISCORD: 1
+        XDG_RUNTIME_DIR: ${{env.MUDLET_TEST_DISCORD_RUNTIME_DIR}}
+        LD_LIBRARY_PATH: ${{env.MUDLET_TEST_DISCORD_LIB_PATH}}
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}
@@ -553,6 +590,15 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: detect_leaks=0
+
+    - name: (Linux) Show the captured Discord frames on failure
+      if: failure() && matrix.run_tests == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "--- fake Discord IPC server log ---"
+        cat "${{runner.temp}}/discord-ipc-fixture.log" 2>/dev/null || true
+        echo "--- frames it captured ---"
+        cat "${{runner.temp}}/mudlet-discord-frames.jsonl" 2>/dev/null || true
 
     - name: Passed Lua tests
       if: matrix.run_tests == 'true'

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -571,6 +571,13 @@ jobs:
         MUDLET_TEST_REQUIRE_DISCORD: 1
         XDG_RUNTIME_DIR: ${{env.MUDLET_TEST_DISCORD_RUNTIME_DIR}}
         LD_LIBRARY_PATH: ${{env.MUDLET_TEST_DISCORD_LIB_PATH}}
+        # The session bus socket lives in the runtime directory replaced above,
+        # so Qt's D-Bus platform theme can no longer find it and would fall back
+        # to spawning dbus-launch. Point it at nothing instead: libdbus leaks
+        # the buffer it reads the autolaunch reply into (1032 bytes, reported
+        # against this job by LeakSanitizer with no Mudlet frames in the stack),
+        # and no spec needs a session bus.
+        DBUS_SESSION_BUS_ADDRESS: 'disabled:'
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -536,9 +536,40 @@ jobs:
         echo "MUDLET_TEST_HTTP_PORT=${port}" >> "${GITHUB_ENV}"
         echo "fixture HTTP server ready on 127.0.0.1:${port}"
 
+    - name: (Linux) Start fake Discord IPC server for Lua tests
+      if: matrix.run_tests == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        # A short runtime directory of its own: the whole discord-ipc-0 socket
+        # path has to fit into sockaddr_un's 108 character sun_path, and
+        # runner.temp does not leave room for it.
+        runtime_dir="$(mktemp -d /tmp/mdxdg-XXXX)"
+        ready_file="${{runner.temp}}/mudlet-discord-fixture-ready"
+        rm -f "${ready_file}"
+        nohup python3 "${{github.workspace}}/CI/discord-ipc-fixture.py" \
+          --runtime-dir "${runtime_dir}" \
+          --capture-file "${{runner.temp}}/mudlet-discord-frames.jsonl" \
+          --ready-file "${ready_file}" > "${{runner.temp}}/discord-ipc-fixture.log" 2>&1 &
+        for _ in $(seq 1 50); do
+          [ -s "${ready_file}" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${ready_file}" ] || [ ! -S "${runtime_dir}/discord-ipc-0" ]; then
+          echo "fake Discord IPC server failed to start" >&2
+          cat "${{runner.temp}}/discord-ipc-fixture.log" 2>/dev/null || true
+          exit 1
+        fi
+        cat "${ready_file}" >> "${GITHUB_ENV}"
+        # Prepended rather than replacing: the Qt install action puts Qt's own
+        # libraries on this path.
+        echo "MUDLET_TEST_DISCORD_LIB_PATH=${{github.workspace}}/3rdparty/discord/rpc/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
+        echo "fake Discord IPC server ready in ${runtime_dir}"
+
     - name: (Linux) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'Linux'
-      timeout-minutes: 1
+      # Longer than the other platforms': this leg also drives the real
+      # discord-rpc library, whose reconnects happen in wall-clock time.
+      timeout-minutes: 3
       run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror
       env:
         AUTORUN_BUSTED_TESTS: 'true'
@@ -550,6 +581,12 @@ jobs:
         # environment quirk. macOS runners start no player at all, so the gate
         # stays off there.
         MUDLET_TEST_REQUIRE_MEDIA: 1
+        # The fake Discord IPC server's socket lives in this runtime directory,
+        # and the bundled discord-rpc library is only reachable through this
+        # library path - without both the Discord specs have nothing to talk to.
+        MUDLET_TEST_REQUIRE_DISCORD: 1
+        XDG_RUNTIME_DIR: ${{env.MUDLET_TEST_DISCORD_RUNTIME_DIR}}
+        LD_LIBRARY_PATH: ${{env.MUDLET_TEST_DISCORD_LIB_PATH}}
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}
@@ -569,6 +606,15 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: detect_leaks=0
+
+    - name: (Linux) Show the captured Discord frames on failure
+      if: failure() && matrix.run_tests == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "--- fake Discord IPC server log ---"
+        cat "${{runner.temp}}/discord-ipc-fixture.log" 2>/dev/null || true
+        echo "--- frames it captured ---"
+        cat "${{runner.temp}}/mudlet-discord-frames.jsonl" 2>/dev/null || true
 
     - name: Passed Lua tests
       if: matrix.run_tests == 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -587,6 +587,13 @@ jobs:
         MUDLET_TEST_REQUIRE_DISCORD: 1
         XDG_RUNTIME_DIR: ${{env.MUDLET_TEST_DISCORD_RUNTIME_DIR}}
         LD_LIBRARY_PATH: ${{env.MUDLET_TEST_DISCORD_LIB_PATH}}
+        # The session bus socket lives in the runtime directory replaced above,
+        # so Qt's D-Bus platform theme can no longer find it and would fall back
+        # to spawning dbus-launch. Point it at nothing instead: libdbus leaks
+        # the buffer it reads the autolaunch reply into (1032 bytes, reported
+        # against this job by LeakSanitizer with no Mudlet frames in the stack),
+        # and no spec needs a session bus.
+        DBUS_SESSION_BUS_ADDRESS: 'disabled:'
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
         ASAN_OPTIONS: ${{ matrix.enable_asan == 'true' && 'detect_leaks=1' || '' }}

--- a/CI/discord-ipc-fixture.py
+++ b/CI/discord-ipc-fixture.py
@@ -17,8 +17,8 @@ Wire framing: [opcode:uint32 LE][length:uint32 LE][json payload]
 
 Capture file format: one JSON object per line,
   {"op": <opcode>, "payload": <parsed frame> | {"raw": "<undecodable text>"}}
-Records are appended with a single O_APPEND write so a spec reading the file
-concurrently never sees a half-written line.
+Records are appended under a lock to an O_APPEND descriptor so a spec reading
+the file concurrently never sees a half-written or spliced line.
 
 The C++ equivalent used by TDiscordModeTest is
 test/functional_tests/DiscordIpcServerStub.cpp - keep the two in step.
@@ -83,6 +83,7 @@ def ready_payload(username):
 class CaptureLog:
     def __init__(self, path):
         self._fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        self._lock = threading.Lock()
 
     def append(self, opcode, payload_bytes):
         try:
@@ -90,10 +91,14 @@ class CaptureLog:
         except (UnicodeDecodeError, ValueError):
             payload = {"raw": payload_bytes.decode("utf-8", "replace")}
         line = (json.dumps({"op": opcode, "payload": payload}, sort_keys=True) + "\n").encode("utf-8")
-        # os.write() may write less than it was given; a short write here would
-        # splice two records into one line and the reading spec would drop both.
-        while line:
-            line = line[os.write(self._fd, line):]
+        # os.write() may write less than it was given, and discord-rpc's
+        # reconnects overlap connections, so two serve_connection() threads can
+        # be here at once. Without the lock one record's remainder could land
+        # after another record's first write, splicing both into one malformed
+        # line that framesAfter() would silently drop.
+        with self._lock:
+            while line:
+                line = line[os.write(self._fd, line):]
 
 
 def frame(opcode, payload_bytes):

--- a/CI/discord-ipc-fixture.py
+++ b/CI/discord-ipc-fixture.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Fake Discord IPC server for Mudlet's Lua self-tests.
+
+Speaks enough of the discord-rpc wire protocol that the bundled
+libdiscord-rpc library believes a Discord client is running, reports a
+logged-in user, and accepts rich presence updates. Every frame the library
+sends is appended to a capture file so the Lua specs can assert on the
+SET_ACTIVITY payload that actually reached "Discord", rather than on the
+return value of the setter that produced it.
+
+Wire framing: [opcode:uint32 LE][length:uint32 LE][json payload]
+  opcode 0 = HANDSHAKE (client -> server)
+  opcode 1 = FRAME     (both directions)
+  opcode 2 = CLOSE
+  opcode 3 = PING
+  opcode 4 = PONG
+
+Capture file format: one JSON object per line,
+  {"op": <opcode>, "payload": <parsed frame> | {"raw": "<undecodable text>"}}
+Records are appended with a single O_APPEND write so a spec reading the file
+concurrently never sees a half-written line.
+
+The C++ equivalent used by TDiscordModeTest is
+test/functional_tests/DiscordIpcServerStub.cpp - keep the two in step.
+
+Usage:
+  discord-ipc-fixture.py --ready-file <path> [--runtime-dir <dir>]
+                         [--capture-file <path>] [--username <name>]
+
+It prints (and, with --ready-file, writes) shell-style KEY=VALUE lines naming
+the runtime directory and capture file once it is listening. Point
+XDG_RUNTIME_DIR at the former before Mudlet starts: discord-rpc's reconnect
+backoff is process-global and survives Discord_Shutdown, so a server that only
+appears after the first failed connection attempt can cost up to ~120s.
+"""
+
+import argparse
+import json
+import os
+import socket
+import struct
+import sys
+import tempfile
+import threading
+
+SOCKET_FILE_NAME = "discord-ipc-0"
+
+OP_HANDSHAKE = 0
+OP_FRAME = 1
+OP_CLOSE = 2
+OP_PING = 3
+OP_PONG = 4
+
+# discord-rpc's own send buffer is 16KB, so anything near this is nonsense:
+MAXIMUM_FRAME_BYTES = 1024 * 1024
+
+
+def ready_payload(username):
+    return {
+        "cmd": "DISPATCH",
+        "evt": "READY",
+        "data": {
+            "v": 1,
+            "config": {
+                "cdn_host": "cdn.discordapp.com",
+                "api_endpoint": "//discord.com/api",
+                "environment": "production",
+            },
+            "user": {
+                "id": "111111111111111111",
+                "username": username,
+                "discriminator": "0",
+                "global_name": username,
+                "avatar": None,
+                "bot": False,
+                "flags": 0,
+                "premium_type": 0,
+            },
+        },
+    }
+
+
+class CaptureLog:
+    def __init__(self, path):
+        self._fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+
+    def append(self, opcode, payload_bytes):
+        try:
+            payload = json.loads(payload_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError):
+            payload = {"raw": payload_bytes.decode("utf-8", "replace")}
+        line = (json.dumps({"op": opcode, "payload": payload}, sort_keys=True) + "\n").encode("utf-8")
+        # os.write() may write less than it was given; a short write here would
+        # splice two records into one line and the reading spec would drop both.
+        while line:
+            line = line[os.write(self._fd, line):]
+
+
+def frame(opcode, payload_bytes):
+    return struct.pack("<II", opcode, len(payload_bytes)) + payload_bytes
+
+
+def read_exact(conn, count):
+    buf = b""
+    while len(buf) < count:
+        chunk = conn.recv(count - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def serve_connection(conn, capture, username):
+    # discord-rpc drops the socket without a CLOSE frame when it shuts down or
+    # switches application ID, so an aborted connection is routine here.
+    with conn:
+        try:
+            while True:
+                header = read_exact(conn, 8)
+                if not header:
+                    return
+                opcode, length = struct.unpack("<II", header)
+                if length > MAXIMUM_FRAME_BYTES:
+                    # A desynchronised stream would otherwise have us block on a
+                    # length that never arrives, with the specs polling a capture
+                    # file that has quietly stopped growing.
+                    sys.stdout.write("discord-ipc-fixture: refusing a %d byte frame, closing the connection\n" % length)
+                    sys.stdout.flush()
+                    return
+                payload = read_exact(conn, length) if length else b""
+                if payload is None:
+                    return
+                capture.append(opcode, payload)
+                if opcode == OP_HANDSHAKE:
+                    conn.sendall(frame(OP_FRAME, json.dumps(ready_payload(username)).encode("utf-8")))
+                elif opcode == OP_PING:
+                    conn.sendall(frame(OP_PONG, payload))
+                elif opcode == OP_CLOSE:
+                    return
+                # opcode 1 (FRAME, e.g. SET_ACTIVITY) needs no reply - the real
+                # Discord client answers it, but discord-rpc ignores the answer.
+        except OSError as error:
+            sys.stdout.write("discord-ipc-fixture: connection ended: %s\n" % error)
+            sys.stdout.flush()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fake Discord IPC server for Mudlet's Lua self-tests")
+    parser.add_argument("--runtime-dir", help="directory to create the discord-ipc-0 socket in (default: a fresh short temporary directory)")
+    parser.add_argument("--capture-file", help="file to append captured frames to (default: discord-frames.jsonl inside the runtime directory)")
+    parser.add_argument("--username", default="MudletSelfTest", help="username the READY dispatch reports as logged in")
+    parser.add_argument("--ready-file", help="file to write the KEY=VALUE handover lines to once listening")
+    args = parser.parse_args()
+
+    runtime_dir = args.runtime_dir
+    if runtime_dir:
+        os.makedirs(runtime_dir, exist_ok=True)
+        # Qt refuses to use an XDG_RUNTIME_DIR that anyone else can read, and
+        # falls back with a warning:
+        os.chmod(runtime_dir, 0o700)
+    else:
+        # Deliberately short: sizeof(sockaddr_un::sun_path) is 108 on Linux and
+        # 104 on macOS, and the whole socket path has to fit.
+        runtime_dir = tempfile.mkdtemp(prefix="mdxdg-")
+
+    socket_path = os.path.join(runtime_dir, SOCKET_FILE_NAME)
+    if len(socket_path) >= 100:
+        sys.stderr.write("discord-ipc-fixture: socket path %s is too long for AF_UNIX\n" % socket_path)
+        return 1
+
+    capture_file = args.capture_file or os.path.join(runtime_dir, "discord-frames.jsonl")
+    # Truncate any capture left over from an earlier run so the specs never see
+    # frames from a previous suite:
+    with open(capture_file, "w"):
+        pass
+    capture = CaptureLog(capture_file)
+
+    if os.path.exists(socket_path):
+        os.unlink(socket_path)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(8)
+
+    handover = "MUDLET_TEST_DISCORD_RUNTIME_DIR=%s\nMUDLET_TEST_DISCORD_CAPTURE_FILE=%s\n" % (runtime_dir, capture_file)
+    if args.ready_file:
+        with open(args.ready_file, "w") as handle:
+            handle.write(handover)
+    sys.stdout.write(handover)
+    sys.stdout.write("discord-ipc-fixture: listening on %s as Discord user %s\n" % (socket_path, args.username))
+    sys.stdout.flush()
+
+    while True:
+        try:
+            conn, _ = server.accept()
+        except OSError as error:
+            # Staying up matters: every spec still to run would otherwise wait
+            # out its timeout against a capture file nobody is writing to.
+            sys.stdout.write("discord-ipc-fixture: accept failed: %s\n" % error)
+            sys.stdout.flush()
+            continue
+        threading.Thread(target=serve_connection, args=(conn, capture, args.username), daemon=True).start()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mudlet-lua/tests/Discord_spec.lua
+++ b/src/mudlet-lua/tests/Discord_spec.lua
@@ -1,0 +1,767 @@
+-- Specs for the Discord rich-presence Lua API.
+--
+-- Networking_spec.lua covers the availability contract - every gated function
+-- returning the same denial while the discord-rpc library cannot be loaded.
+-- These specs need the opposite arrangement: a Discord client to talk to.
+-- CI/discord-ipc-fixture.py is one, a fake Discord IPC server that completes
+-- the genuine discord-rpc handshake, reports a logged-in user, and appends
+-- every frame the library sends it to the capture file named by
+-- MUDLET_TEST_DISCORD_CAPTURE_FILE. That capture is what is asserted on here:
+-- the SET_ACTIVITY payload that actually reached "Discord", rather than the
+-- return value of the setter that produced it. Nothing is mocked - the real
+-- libdiscord-rpc does the talking, over a real socket.
+--
+-- To run them locally, start the fixture first:
+--   python3 CI/discord-ipc-fixture.py --runtime-dir "$(mktemp -d /tmp/mdxdg-XXXX)" \
+--       --capture-file /tmp/discord-frames.jsonl --ready-file /tmp/discord-ready &
+-- then start Mudlet with XDG_RUNTIME_DIR set to that runtime directory,
+-- MUDLET_TEST_DISCORD_CAPTURE_FILE to that capture file, and LD_LIBRARY_PATH
+-- including 3rdparty/discord/rpc/lib so the bundled library can be found.
+--
+-- The fixture has to be listening BEFORE Mudlet starts. discord-rpc's
+-- reconnect backoff is process-global, survives Discord_Shutdown and gates
+-- even the READY read, so a server that only appears after the first failed
+-- attempt costs up to a couple of minutes instead of the ~1s a cold start
+-- takes.
+
+local capturePath = os.getenv("MUDLET_TEST_DISCORD_CAPTURE_FILE")
+-- A developer's local run without the fixture pends the whole family; CI sets
+-- MUDLET_TEST_REQUIRE_DISCORD so that a workflow which stops starting the
+-- fixture, or an image where the library cannot be loaded, fails instead of
+-- quietly skipping everything.
+local requireDiscord = os.getenv("MUDLET_TEST_REQUIRE_DISCORD")
+
+-- Mudlet's own Discord application, from Discord::mMudletApplicationId
+local mudletApplicationId = "450571881909583884"
+-- MidMUD's, one of the registered test applications listed in src/discord.cpp
+local otherApplicationId = "460618737712889858"
+
+local function contains(haystack, needle)
+  return type(haystack) == "string" and haystack:find(needle, 1, true) ~= nil
+end
+
+-- Asserts that calling fn raises a Lua error whose message contains needle.
+-- Matching the message rather than merely "did it error?" proves the call
+-- reached its own argument validation: an unregistered function would raise a
+-- different "attempt to call" error.
+local function assertArgError(fn, needle)
+  local ok, err = pcall(fn)
+  assert.is_false(ok)
+  assert.is_true(contains(err, needle), tostring(err))
+end
+
+-- Every frame the fake Discord client has recorded so far, oldest first, still
+-- as JSON text. Only whole lines are taken: the fixture appends one JSON
+-- object per line in a single write, so an unterminated tail can only be a
+-- record still being written.
+local function capturedLines()
+  local handle = io.open(capturePath, "rb")
+  if not handle then
+    return {}
+  end
+  local body = handle:read("*a")
+  handle:close()
+  local lines = {}
+  for line in body:gmatch("[^\n]+\n") do
+    lines[#lines + 1] = line
+  end
+  return lines
+end
+
+local function frameCount()
+  return #capturedLines()
+end
+
+-- The frames recorded after `mark`, as {op = <opcode>, payload = <frame>}.
+-- Decoding from `mark` rather than from the start of the file is what keeps
+-- the polling below cheap as the capture grows over a suite run.
+local function framesAfter(mark)
+  local lines = capturedLines()
+  local frames = {}
+  for index = mark + 1, #lines do
+    local decoded = select(2, pcall(yajl.to_value, lines[index]))
+    if type(decoded) == "table" then
+      frames[#frames + 1] = decoded
+    end
+  end
+  return frames
+end
+
+-- Hands control back to Mudlet's event loop for a moment. The frames arrive on
+-- discord-rpc's own IO thread and are written by the fixture process, so the
+-- specs can only see them while Mudlet is idle.
+local function pumpEventLoop(milliseconds)
+  tempTimer(milliseconds / 1000, function() raiseEvent("bustedDiscordTick") end)
+  waitForEvent("bustedDiscordTick", milliseconds + 1000)
+end
+
+-- The rich presence of the first SET_ACTIVITY recorded after `mark` that
+-- `accept` is satisfied with. Every new frame is offered to `accept`, not just
+-- the newest one, so an update that lands while waiting cannot make the
+-- expectation unsatisfiable. On timeout the most recent frame seen is returned
+-- instead, so a spec whose expectation is never met reports what Discord
+-- really received rather than a bare timeout.
+local function waitForActivity(mark, accept, timeoutMilliseconds)
+  timeoutMilliseconds = timeoutMilliseconds or 5000
+  local waited = 0
+  local latest
+  while true do
+    for _, frame in ipairs(framesAfter(mark)) do
+      if frame.op == 1 and type(frame.payload) == "table" and frame.payload.cmd == "SET_ACTIVITY" then
+        latest = frame.payload.args.activity
+        if latest and (not accept or accept(latest)) then
+          return latest
+        end
+      end
+    end
+    if waited >= timeoutMilliseconds then
+      return latest
+    end
+    -- A frame normally lands within a few milliseconds of the setter, so poll
+    -- finely: over the whole file this is the difference between adding a
+    -- couple of seconds to the suite and adding ten.
+    pumpEventLoop(10)
+    waited = waited + 10
+  end
+end
+
+-- Runs `action` and returns the rich presence Discord received because of it.
+local function activityFrom(action, accept, timeoutMilliseconds)
+  local mark = frameCount()
+  action()
+  local activity = waitForActivity(mark, accept, timeoutMilliseconds)
+  assert.is_table(activity, "no SET_ACTIVITY frame reached the fake Discord client in time")
+  -- Fail here, on the whole payload, rather than leaving the spec's own
+  -- assertions to index a field that never arrived and report a nil error.
+  if accept and not accept(activity) then
+    assert.is_true(false, "the presence Discord received is not the one expected: " .. tostring(select(2, pcall(yajl.to_string, activity))))
+  end
+  return activity
+end
+
+-- How many presence updates have reached the fake Discord client. Counting
+-- SET_ACTIVITY frames rather than all of them keeps an unrelated handshake or
+-- subscription from being mistaken for a presence update.
+local function activityFrameCount()
+  local count = 0
+  for _, frame in ipairs(framesAfter(0)) do
+    if frame.op == 1 and type(frame.payload) == "table" and frame.payload.cmd == "SET_ACTIVITY" then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+-- The application IDs of the handshakes recorded after `mark`, waited for
+-- until at least one arrives. Changing the application ID makes discord-rpc
+-- tear its connection down and hand the new ID over in a fresh handshake,
+-- which is the only externally visible proof that the switch took effect.
+local function waitForHandshakes(mark, timeoutMilliseconds)
+  local waited = 0
+  while true do
+    local applicationIds = {}
+    for _, frame in ipairs(framesAfter(mark)) do
+      if frame.op == 0 then
+        applicationIds[#applicationIds + 1] = frame.payload.client_id
+      end
+    end
+    if #applicationIds > 0 or waited >= (timeoutMilliseconds or 20000) then
+      return applicationIds
+    end
+    pumpEventLoop(50)
+    waited = waited + 50
+  end
+end
+
+local function discordApiAvailable()
+  -- A read-access getter: nil plus a message means the API is gated off, any
+  -- string means the library is loaded and Discord is enabled for this profile.
+  return getDiscordState() ~= nil
+end
+
+-- Established lazily by connectedToFakeDiscord(): discord-rpc opens its
+-- connection on the first presence update and only sends once the READY
+-- dispatch has arrived, so the first frame of a run takes about a second while
+-- every later one lands within ~50ms.
+local connectionProbe
+-- Latched once a reset stops coming back, so that a fixture which dies partway
+-- through fails the rest of the file at once instead of spending every
+-- remaining spec's timeout on a connection that is not going to answer.
+local connectionLost = false
+
+-- What resetDiscordData() puts on the wire: everything cleared but the Mudlet
+-- logo, which is not profile data. Recognising it exactly is what lets the
+-- reset below double as a drain - once that frame has been seen, no frame from
+-- an earlier spec can still be in flight.
+local function emptyPresence(activity)
+  return type(activity.assets) == "table" and activity.assets.large_image == "mudlet" and activity.assets.large_text == nil
+         and activity.assets.small_image == nil and activity.assets.small_text == nil and activity.details == nil
+         and activity.state == nil and activity.party == nil and activity.timestamps == nil
+end
+
+-- Clears the presence and waits for the frame that proves it arrived, which is
+-- also the whole of the connection probe on the first call.
+local function resetPresence(timeoutMilliseconds)
+  local mark = frameCount()
+  resetDiscordData()
+  local activity = waitForActivity(mark, emptyPresence, timeoutMilliseconds)
+  -- Re-checked, because waitForActivity() hands back the last frame it saw
+  -- when it times out rather than nothing at all.
+  return type(activity) == "table" and emptyPresence(activity)
+end
+
+local function connectedToFakeDiscord()
+  if connectionProbe == nil then
+    connectionProbe = resetPresence(20000)
+  end
+  return connectionProbe
+end
+
+-- Every spec below starts here. Returns false when there is no fake Discord
+-- client to talk to, and otherwise leaves the presence empty so that the frame
+-- the spec's own call produces is unambiguous. The reset is re-checked every
+-- time rather than trusting the first probe: a fixture that dies mid-run would
+-- otherwise let the remaining specs pass without asserting anything.
+local function readyForDiscord()
+  local reason
+  if not capturePath then
+    reason = "MUDLET_TEST_DISCORD_CAPTURE_FILE is not set (fake Discord IPC server not running)"
+  elseif not discordApiAvailable() then
+    reason = "the Discord API is unavailable (discord-rpc could not be loaded, or Discord is disabled for this profile)"
+  elseif not connectedToFakeDiscord() then
+    reason = "no presence update reached the fake Discord IPC server"
+  elseif connectionLost then
+    reason = "the fake Discord IPC server did not see the cleared presence resetDiscordData() should have sent"
+  elseif not resetPresence(8000) then
+    connectionLost = true
+    reason = "the fake Discord IPC server did not see the cleared presence resetDiscordData() should have sent"
+  end
+  if reason then
+    if requireDiscord then
+      assert.is_true(false, "MUDLET_TEST_REQUIRE_DISCORD is set but " .. reason)
+    end
+    pending(reason)
+    return false
+  end
+  return true
+end
+
+describe("Discord presence reaches Discord", function()
+  it("completes the IPC handshake with Mudlet's own application ID", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- The first handshake of the run, which is the one Mudlet's own presence
+    -- opened before any spec asked for a different application.
+    assert.equals(mudletApplicationId, waitForHandshakes(0)[1])
+  end)
+
+  it("reports that the default Mudlet application ID is in use", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(usingMudletsDiscordID())
+  end)
+
+  it("sends the Mudlet logo as the large icon when the profile sets none", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordState("no icon of its own") end)
+    assert.equals("mudlet", activity.assets.large_image)
+  end)
+
+  it("leaves every read-access function callable while Discord is available", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- The mirror of Networking_spec.lua's availability contract: those specs
+    -- prove one shared denial while the API is gated off, this one proves the
+    -- same set is reachable once it is not.
+    local readers = {
+      "getDiscordDetail", "getDiscordLargeIcon", "getDiscordLargeIconText",
+      "getDiscordParty", "getDiscordSmallIcon", "getDiscordSmallIconText",
+      "getDiscordState", "getDiscordTimeStamps", "usingMudletsDiscordID",
+    }
+    for _, name in ipairs(readers) do
+      assert.is_not_nil(_G[name](), name .. " should be reachable while Discord is available")
+    end
+  end)
+end)
+
+describe("setDiscordDetail", function()
+  it("sends the detail text to Discord", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordDetail("Exploring the fixture") end,
+                                  function(seen) return seen.details == "Exploring the fixture" end)
+    assert.equals("Exploring the fixture", activity.details)
+  end)
+
+  it("reports the detail text it sent", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordDetail("Hunting in the woods"))
+    assert.equals("Hunting in the woods", getDiscordDetail())
+  end)
+
+  it("substitutes a placeholder for an empty detail text", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- The placeholder is tr("via Mudlet"), so a localised Mudlet sends a
+    -- different string; what matters is that something took the empty text's
+    -- place and that it is what the getter reports.
+    local activity = activityFrom(function() setDiscordDetail("") end,
+                                  function(seen) return seen.details ~= nil end)
+    assert.is_true(#activity.details > 1)
+    assert.equals(getDiscordDetail(), activity.details)
+  end)
+
+  it("refuses a one character detail text and leaves the presence alone", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- Waited for, so that the frame count below can only move if the rejected
+    -- call produced one of its own.
+    activityFrom(function() setDiscordDetail("still here") end,
+                 function(seen) return seen.details == "still here" end)
+    local presenceUpdates = activityFrameCount()
+    local ok, message = setDiscordDetail("x")
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "text of length 1 not allowed by Discord"))
+    assert.equals("still here", getDiscordDetail())
+    -- A rejected setter must not reach Discord at all, so no further presence
+    -- update is expected - unlike everywhere else, seeing one here is the
+    -- failure.
+    pumpEventLoop(500)
+    assert.equals(presenceUpdates, activityFrameCount())
+  end)
+
+  it("sends a detail text containing a percent sequence unchanged", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- What reaches Discord is fine; it is only the getter that mangles this,
+    -- which the pending spec at the end of this file covers. Reading it back
+    -- here would be the thing that misbehaves, so this one stops at the wire.
+    local activity = activityFrom(function() setDiscordDetail("Level %d Mage") end,
+                                  function(seen) return seen.details ~= nil end)
+    assert.equals("Level %d Mage", activity.details)
+  end)
+
+  it("raises a Lua error when the detail text is not a string", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- Only reachable with the API available: the availability gate is checked
+    -- before any argument is, so Networking_spec.lua cannot get this far.
+    assertArgError(function() setDiscordDetail({}) end, "setDiscordDetail: bad argument #1")
+  end)
+
+  it("truncates a detail text that overflows Discord's 128 byte field", function()
+    if not readyForDiscord() then
+      return
+    end
+    local overlong = string.rep("a", 200)
+    local activity = activityFrom(function() setDiscordDetail(overlong) end,
+                                  function(seen) return seen.details ~= nil end)
+    assert.equals(127, #activity.details)
+    assert.equals(string.rep("a", 127), activity.details)
+    -- Only what Discord is sent is truncated; Mudlet keeps the whole string.
+    assert.equals(overlong, getDiscordDetail())
+  end)
+end)
+
+describe("setDiscordState", function()
+  it("sends the state text to Discord", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordState("Level 50 Mage") end,
+                                  function(seen) return seen.state == "Level 50 Mage" end)
+    assert.equals("Level 50 Mage", activity.state)
+  end)
+
+  it("reports the state text it sent", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordState("In combat"))
+    assert.equals("In combat", getDiscordState())
+  end)
+
+  it("omits the state field entirely when the state text is empty", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- Empty fields are sent as JSON absences, not as "", so Discord hides the
+    -- line rather than showing a blank one.
+    local activity = activityFrom(function() setDiscordState("") end)
+    assert.is_nil(activity.state)
+  end)
+
+  it("refuses a one character state text", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordState("holding"))
+    local ok, message = setDiscordState("x")
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "text of length 1 not allowed by Discord"))
+    assert.equals("holding", getDiscordState())
+  end)
+end)
+
+describe("setDiscordGame", function()
+  it("sets both the detail text and the large icon from the game name", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordGame("WoTMUD") end,
+                                  function(seen) return seen.details ~= nil and seen.assets.large_image == "wotmud" end)
+    -- The detail text is tr("Playing %1"), so only the interpolated game name
+    -- is the same on a localised Mudlet.
+    assert.is_true(contains(activity.details, "WoTMUD"))
+    assert.equals("wotmud", activity.assets.large_image)
+  end)
+end)
+
+describe("setDiscordLargeIcon and setDiscordSmallIcon", function()
+  it("lower-cases the large icon key on the way to Discord", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- Discord asset keys are lower case, so Mudlet folds whatever it is given.
+    local activity = activityFrom(function() setDiscordLargeIcon("Achaea") end,
+                                  function(seen) return seen.assets.large_image ~= "mudlet" end)
+    assert.equals("achaea", activity.assets.large_image)
+    assert.equals("achaea", getDiscordLargeIcon())
+  end)
+
+  it("sends the large icon's tooltip text", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordLargeIconText("Achaea, Dreams of Divine Lands") end,
+                                  function(seen) return seen.assets.large_text ~= nil end)
+    assert.equals("Achaea, Dreams of Divine Lands", activity.assets.large_text)
+    assert.equals("Achaea, Dreams of Divine Lands", getDiscordLargeIconText())
+  end)
+
+  it("lower-cases the small icon key on the way to Discord", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordSmallIcon("Shield") end,
+                                  function(seen) return seen.assets.small_image ~= nil end)
+    assert.equals("shield", activity.assets.small_image)
+    assert.equals("shield", getDiscordSmallIcon())
+  end)
+
+  it("sends the small icon's tooltip text", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordSmallIconText("Guardian") end,
+                                  function(seen) return seen.assets.small_text ~= nil end)
+    assert.equals("Guardian", activity.assets.small_text)
+    assert.equals("Guardian", getDiscordSmallIconText())
+  end)
+
+  it("refuses a one character large icon text", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordLargeIconText("unchanged"))
+    local ok, message = setDiscordLargeIconText("x")
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "text of length 1 not allowed by Discord"))
+    assert.equals("unchanged", getDiscordLargeIconText())
+  end)
+
+  it("refuses a one character small icon text", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordSmallIconText("unchanged"))
+    local ok, message = setDiscordSmallIconText("x")
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "text of length 1 not allowed by Discord"))
+    assert.equals("unchanged", getDiscordSmallIconText())
+  end)
+end)
+
+describe("setDiscordElapsedStartTime and setDiscordRemainingEndTime", function()
+  it("sends an elapsed start time and no end time", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordElapsedStartTime(1700000000) end,
+                                  function(seen) return seen.timestamps ~= nil end)
+    assert.equals(1700000000, activity.timestamps.start)
+    assert.is_nil(activity.timestamps["end"])
+  end)
+
+  it("replaces an elapsed start time with a remaining end time", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- The two are mutually exclusive: Discord shows either "elapsed" or
+    -- "remaining", so setting one has to clear the other.
+    assert.is_true(setDiscordElapsedStartTime(1700000000))
+    local activity = activityFrom(function() setDiscordRemainingEndTime(1900000000) end,
+                                  function(seen) return seen.timestamps and seen.timestamps["end"] ~= nil end)
+    assert.equals(1900000000, activity.timestamps["end"])
+    assert.is_nil(activity.timestamps.start)
+  end)
+
+  it("reports the timestamps it sent", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordElapsedStartTime(1700000000))
+    local startTime, endTime = getDiscordTimeStamps()
+    assert.equals(1700000000, startTime)
+    assert.equals(0, endTime)
+
+    assert.is_true(setDiscordRemainingEndTime(1900000000))
+    startTime, endTime = getDiscordTimeStamps()
+    assert.equals(0, startTime)
+    assert.equals(1900000000, endTime)
+  end)
+
+  it("drops the timestamps entirely when given zero", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- Waited for, not just called: the spec below asserts on the first frame
+    -- that follows, so this one's has to have landed already.
+    activityFrom(function() setDiscordElapsedStartTime(1700000000) end,
+                 function(seen) return seen.timestamps ~= nil end)
+    local activity = activityFrom(function() setDiscordElapsedStartTime(0) end)
+    assert.is_nil(activity.timestamps)
+  end)
+
+  it("refuses a negative elapsed start time", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordElapsedStartTime(1700000000))
+    local ok, message = setDiscordElapsedStartTime(-1)
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "the timestamp must be zero"))
+    assert.equals(1700000000, (getDiscordTimeStamps()))
+  end)
+
+  it("refuses a negative remaining end time", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordRemainingEndTime(1900000000))
+    local ok, message = setDiscordRemainingEndTime(-1)
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "the timestamp must be zero"))
+    assert.equals(1900000000, select(2, getDiscordTimeStamps()))
+  end)
+end)
+
+describe("setDiscordParty", function()
+  it("sends the party size and maximum", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordParty(2, 5) end,
+                                  function(seen) return seen.party ~= nil end)
+    assert.same({2, 5}, activity.party.size)
+  end)
+
+  it("raises the maximum to the size when only a size is given", function()
+    if not readyForDiscord() then
+      return
+    end
+    local activity = activityFrom(function() setDiscordParty(3) end,
+                                  function(seen) return seen.party ~= nil end)
+    assert.same({3, 3}, activity.party.size)
+  end)
+
+  it("keeps an established maximum when only a smaller size is given", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordParty(2, 5))
+    local activity = activityFrom(function() setDiscordParty(1) end,
+                                  function(seen) return seen.party and seen.party.size[1] == 1 end)
+    assert.same({1, 5}, activity.party.size)
+  end)
+
+  it("removes the party from the presence when the maximum is zero", function()
+    if not readyForDiscord() then
+      return
+    end
+    activityFrom(function() setDiscordParty(2, 5) end, function(seen) return seen.party ~= nil end)
+    local activity = activityFrom(function() setDiscordParty(0, 0) end)
+    assert.is_nil(activity.party)
+  end)
+
+  it("reports the party it sent", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordParty(4, 8))
+    local size, maximum = getDiscordParty()
+    assert.equals(4, size)
+    assert.equals(8, maximum)
+  end)
+
+  it("refuses a negative party size", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordParty(2, 5))
+    local ok, message = setDiscordParty(-1)
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "the current party size must be zero or more"))
+    assert.equals(2, (getDiscordParty()))
+  end)
+
+  it("refuses a negative party maximum", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordParty(2, 5))
+    local ok, message = setDiscordParty(3, -1)
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "the optional party maximum size"))
+    -- Both, so that a rejected call falling through to the size-only overload
+    -- would be caught rather than looking unchanged.
+    local size, maximum = getDiscordParty()
+    assert.equals(2, size)
+    assert.equals(5, maximum)
+  end)
+
+  it("raises a Lua error when the party size is not a number", function()
+    if not readyForDiscord() then
+      return
+    end
+    assertArgError(function() setDiscordParty("a few") end, "setDiscordParty: bad argument #1")
+  end)
+end)
+
+describe("resetDiscordData", function()
+  it("clears every presence field it had set", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordDetail("Exploring the forest"))
+    assert.is_true(setDiscordState("Level 50 Mage"))
+    assert.is_true(setDiscordLargeIcon("achaea"))
+    assert.is_true(setDiscordLargeIconText("Achaea"))
+    assert.is_true(setDiscordSmallIcon("shield"))
+    assert.is_true(setDiscordSmallIconText("Guardian"))
+    assert.is_true(setDiscordParty(2, 5))
+    assert.is_true(setDiscordElapsedStartTime(1700000000))
+
+    local activity = activityFrom(function() resetDiscordData() end,
+                                  function(seen) return seen.details == nil end)
+    assert.is_nil(activity.details)
+    assert.is_nil(activity.state)
+    assert.is_nil(activity.party)
+    assert.is_nil(activity.timestamps)
+    assert.is_nil(activity.assets.large_text)
+    assert.is_nil(activity.assets.small_image)
+    assert.is_nil(activity.assets.small_text)
+    -- The Mudlet logo is not profile data, so it comes back with the reset
+    -- presence rather than being cleared by it.
+    assert.equals("mudlet", activity.assets.large_image)
+  end)
+
+  it("clears what the getters report", function()
+    if not readyForDiscord() then
+      return
+    end
+    assert.is_true(setDiscordDetail("Exploring the forest"))
+    assert.is_true(setDiscordSmallIconText("Guardian"))
+    assert.is_true(setDiscordParty(2, 5))
+    assert.is_true(setDiscordElapsedStartTime(1700000000))
+
+    assert.is_true(resetDiscordData())
+
+    assert.equals("", getDiscordDetail())
+    assert.equals("", getDiscordState())
+    assert.equals("", getDiscordLargeIcon())
+    assert.equals("", getDiscordSmallIconText())
+    assert.equals(0, (getDiscordParty()))
+    assert.equals(0, (getDiscordTimeStamps()))
+  end)
+end)
+
+describe("setDiscordApplicationID", function()
+  it("reconnects to Discord under the new application ID and back again", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- Should an assertion below leave the other application in place, the
+    -- following spec would open with a reconnect it does not expect.
+    finally(function() setDiscordApplicationID() end)
+
+    -- Both directions in one spec on purpose: each switch makes discord-rpc
+    -- drop its socket and hand the new ID over in a fresh handshake, which
+    -- costs about a second and a half of real reconnect time.
+    local mark = frameCount()
+    assert.is_true(setDiscordApplicationID(otherApplicationId))
+    assert.is_false(usingMudletsDiscordID())
+    -- The first handshake after the switch, rather than the whole list: a
+    -- connection attempt that had to be retried would add another.
+    assert.equals(otherApplicationId, waitForHandshakes(mark)[1])
+
+    mark = frameCount()
+    assert.is_true(setDiscordApplicationID())
+    assert.is_true(usingMudletsDiscordID())
+    assert.equals(mudletApplicationId, waitForHandshakes(mark)[1])
+  end)
+
+  it("treats an empty application ID as the request to go back to Mudlet's", function()
+    if not readyForDiscord() then
+      return
+    end
+    finally(function() setDiscordApplicationID() end)
+
+    local mark = frameCount()
+    assert.is_true(setDiscordApplicationID(otherApplicationId))
+    assert.equals(otherApplicationId, waitForHandshakes(mark)[1])
+
+    mark = frameCount()
+    assert.is_true(setDiscordApplicationID(""))
+    assert.is_true(usingMudletsDiscordID())
+    assert.equals(mudletApplicationId, waitForHandshakes(mark)[1])
+  end)
+
+  it("refuses an application ID that is not a number", function()
+    if not readyForDiscord() then
+      return
+    end
+    local ok, message = setDiscordApplicationID("not-an-id")
+    assert.is_nil(ok)
+    assert.is_true(contains(message, "can not be converted to the expected numeric Discord application ID"))
+    assert.is_true(usingMudletsDiscordID())
+  end)
+end)
+
+describe("known Discord API defects", function()
+  it("returns a detail text containing a percent sequence unchanged", function()
+    pending("getDiscordDetail() and the other five Discord getters pass the stored text to "
+            .. "lua_pushfstring() as its format string, so a detail of 'Level %d Mage' comes back "
+            .. "with a garbage number in place of the %d and a '%s' would dereference a pointer "
+            .. "that was never passed - fix TLuaInterpreterDiscord.cpp to push the string as data, "
+            .. "then unpend this")
+  end)
+
+  it("truncates an overlong detail text on a character boundary", function()
+    pending("localDiscordPresence cuts the text at 127 bytes without regard for UTF-8, so 64 "
+            .. "two-byte characters reach Discord as 63 characters plus half of one - the frame is "
+            .. "no longer valid UTF-8. Fix the truncation in discord.cpp, then unpend this")
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `CI/discord-ipc-fixture.py`: a fake Discord IPC server that completes the genuine discord-rpc handshake, reports a logged-in user, and appends every frame Mudlet's copy of libdiscord-rpc sends to a JSON-lines capture file. It is the Python counterpart of `DiscordIpcServerStub` (#9475).
- Both ubuntu workflows start the fixture before the Lua tests and put the bundled discord-rpc library on the load path, so ~20 Lua functions CI could never reach are exercised there for the first time. macOS is left alone: its test leg runs the unpackaged bundle, which has no `libdiscord-rpc.dylib` in it (only the installer copies one in), so the specs pend there as they do on Windows.

#### Motivation for adding to Mudlet

Discord rich presence was the largest block of Lua functions with no effect coverage at all - CI could not even load the library, so every one of them was only ever checked for the message it returns when denied. With a fake Discord client on the other end of the socket, the payloads themselves become assertable.

#### Other info (issues closed, discussion etc)

Two defects turned up while writing these and are left as `pending` specs rather than frozen in, each with a follow-up: the six Discord getters hand the stored text to `lua_pushfstring()` as its format string (`getDiscordDetail()` on `"Level %d Mage"` returns a garbage number, and a `%s` would dereference a pointer that was never passed - the text can come from the server over GMCP, so it is remotely reachable), fixed in the stacked #9660; and `localDiscordPresence` truncates at 127 bytes with no regard for UTF-8, putting an invalid frame on the wire, filed as #9634.

Loading the library in CI makes Networking_spec.lua's 22 Discord availability-contract rows pend by their own design ("on a machine where Discord is live these pend"); that denial path stays covered by `TDiscordModeTest`. Moving those rows into `Discord_spec.lua`, where the fixture can arrange both states, is a deliberate follow-up and not done here. The Linux Lua step's `timeout-minutes` goes 1 -> 3 because these specs wait out real discord-rpc reconnects.

**Test case:** full suite green twice with the fixture (1848 passed / 0 failed / 41 pending, 43 of those new) and once without it (1829 / 0 / 60, every Discord spec pending cleanly, no failures); leak detection clean under the CI leg's ASan settings; sabotaging six behaviours in `discord.cpp`/`TLuaInterpreterDiscord.cpp` failed 9 of the 41 active specs directly (22%), all reverted afterwards.

Assisted-by: Claude:claude-opus-5
