### PR TITLE
infrastructure: busted specs for the Geyser widget classes with no spec home

### DIFF
--- a/src/mudlet-lua/tests/GeyserCommandLine_spec.lua
+++ b/src/mudlet-lua/tests/GeyserCommandLine_spec.lua
@@ -1,0 +1,196 @@
+-- Geyser.CommandLine wraps Mudlet's sub-command-line primitive, so everything
+-- it does is read back through windowType/getWindowGeometry/windowVisible and
+-- getCmdLine rather than through the Geyser object's own bookkeeping.
+local function geometry(name)
+  local x, y, width, height = getWindowGeometry(name)
+  return {x = x, y = y, width = width, height = height}
+end
+
+describe("Tests functionality of Geyser.CommandLine", function()
+  local created
+
+  local function track(object)
+    created[#created + 1] = object
+    return object
+  end
+
+  local function alive(object)
+    if not object or not object.container or not object.container.windowList then
+      return false
+    end
+    return object.container.windowList[object.name] == object
+  end
+
+  before_each(function()
+    created = {}
+  end)
+
+  after_each(function()
+    for _, object in ipairs(created) do
+      if alive(object) then
+        object:delete()
+      end
+    end
+    created = {}
+  end)
+
+  describe("Geyser.CommandLine:new/new2", function()
+    it("creates a command line widget at the constrained geometry", function()
+      local commandLine = track(Geyser.CommandLine:new({name = "gclNew", x = 30, y = 40, width = 200, height = 30}))
+      -- Geyser's own type string is camel cased, Mudlet's windowType is not
+      assert.are.equal("commandLine", commandLine.type)
+      assert.are.equal("commandline", windowType("gclNew"))
+      assert.are.same({x = 30, y = 40, width = 200, height = 30}, geometry("gclNew"))
+      assert.is_true(windowVisible("gclNew"))
+      assert.are.equal(commandLine, Geyser.windowList.gclNew)
+      assert.are.equal("main", commandLine.windowname)
+    end)
+
+    it("uses Geyser's defaults when no constraints are given", function()
+      track(Geyser.CommandLine:new({name = "gclDefaults"}))
+      assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gclDefaults"))
+    end)
+
+    it("resolves percentages against its container", function()
+      local container = track(Geyser.Container:new({name = "gclBox", x = 100, y = 50, width = 400, height = 200}))
+      track(Geyser.CommandLine:new({name = "gclInBox", x = "25%", y = "50%", width = "50%", height = "25%"}, container))
+      assert.are.same({x = 200, y = 150, width = 200, height = 50}, geometry("gclInBox"))
+    end)
+
+    it("new2 marks the command line as using add2", function()
+      local commandLine = track(Geyser.CommandLine:new2({name = "gclNew2", x = 0, y = 0, width = 100, height = 30}))
+      assert.is_true(commandLine.useAdd2)
+      assert.are.equal("commandline", windowType("gclNew2"))
+    end)
+
+    it("keeps a new command line of a hidden add2 container hidden", function()
+      local container = track(Geyser.Container:new2({name = "gclHiddenBox", x = 0, y = 0, width = 200, height = 100}))
+      container:hide()
+      local commandLine = track(Geyser.CommandLine:new2({name = "gclHiddenChild", x = 0, y = 0, width = 50, height = 20}, container))
+      assert.is_true(commandLine.auto_hidden)
+      assert.is_false(windowVisible("gclHiddenChild"))
+      container:show()
+      assert.is_true(windowVisible("gclHiddenChild"))
+    end)
+  end)
+
+  describe("Geyser.CommandLine:print/append/getText/clear", function()
+    local commandLine
+
+    before_each(function()
+      commandLine = track(Geyser.CommandLine:new({name = "gclText", x = 0, y = 0, width = 200, height = 30}))
+    end)
+
+    it("prints text into the command line", function()
+      commandLine:print("hello")
+      assert.are.equal("hello", commandLine:getText())
+      assert.are.equal("hello", getCmdLine("gclText"))
+    end)
+
+    it("replaces what was there on the next print", function()
+      commandLine:print("first")
+      commandLine:print("second")
+      assert.are.equal("second", commandLine:getText())
+    end)
+
+    it("appends to the text already in the command line", function()
+      commandLine:print("hello")
+      commandLine:append(" world")
+      assert.are.equal("hello world", commandLine:getText())
+    end)
+
+    it("appends into an empty command line", function()
+      commandLine:append("only")
+      assert.are.equal("only", commandLine:getText())
+    end)
+
+    it("clears the command line", function()
+      commandLine:print("something")
+      commandLine:clear()
+      assert.are.equal("", commandLine:getText())
+      assert.are.equal("", getCmdLine("gclText"))
+    end)
+  end)
+
+  -- selectCmdLineText() also declares one return value without pushing one, so
+  -- it hands back whatever was left on the Lua stack - the window name - rather
+  -- than a result. Asserting that here would freeze the defect in place.
+  pending("Geyser.CommandLine:selectText selects every character - the selection of a command line is not readable from Lua, needs a getCmdLineSelection getter")
+
+  describe("Geyser.CommandLine:setStyleSheet", function()
+    it("remembers the stylesheet it was constructed with", function()
+      local commandLine = track(Geyser.CommandLine:new({
+        name = "gclCssCons",
+        x = 0, y = 0, width = 100, height = 30,
+        stylesheet = "background-color: blue;",
+      }))
+      assert.are.equal("background-color: blue;", commandLine.stylesheet)
+    end)
+
+    it("reuses the remembered stylesheet when called without one", function()
+      local commandLine = track(Geyser.CommandLine:new({name = "gclCss", x = 0, y = 0, width = 100, height = 30}))
+      commandLine:setStyleSheet("background-color: red;")
+      assert.are.equal("background-color: red;", commandLine.stylesheet)
+      commandLine:setStyleSheet()
+      assert.are.equal("background-color: red;", commandLine.stylesheet)
+    end)
+  end)
+
+  pending("Geyser.CommandLine:setStyleSheet applies the stylesheet to the widget - needs a getCmdLineStyleSheet getter")
+
+  describe("Geyser.CommandLine:setAction/resetAction", function()
+    it("remembers the action and its arguments, and forgets them again", function()
+      local commandLine = track(Geyser.CommandLine:new({name = "gclAction", x = 0, y = 0, width = 100, height = 30}))
+      local action = function() end
+      commandLine:setAction(action, "one", "two")
+      assert.are.equal(action, commandLine.actionFunc)
+      assert.are.same({"one", "two"}, commandLine.actionArgs)
+      commandLine:resetAction()
+      assert.is_nil(commandLine.actionFunc)
+      assert.is_nil(commandLine.actionArgs)
+    end)
+  end)
+
+  pending("Geyser.CommandLine:setAction runs the action when the command line sends its text - no Lua API submits input to a command line, so this needs a functional test")
+
+  describe("Geyser.CommandLine geometry and visibility", function()
+    local commandLine
+
+    before_each(function()
+      commandLine = track(Geyser.CommandLine:new({name = "gclMove", x = 10, y = 20, width = 200, height = 30}))
+    end)
+
+    it("moves and resizes the widget", function()
+      commandLine:move(60, 70)
+      commandLine:resize(120, 40)
+      assert.are.same({x = 60, y = 70, width = 120, height = 40}, geometry("gclMove"))
+    end)
+
+    it("hides and shows the widget", function()
+      commandLine:hide()
+      assert.is_true(commandLine.hidden)
+      assert.is_false(windowVisible("gclMove"))
+      commandLine:show()
+      assert.is_false(commandLine.hidden)
+      assert.is_true(windowVisible("gclMove"))
+    end)
+
+    it("follows its container when the container moves", function()
+      local container = track(Geyser.Container:new({name = "gclDragBox", x = 0, y = 0, width = 200, height = 100}))
+      track(Geyser.CommandLine:new({name = "gclDragged", x = 0, y = 0, width = "100%", height = 30}, container))
+      container:move(150, 30)
+      assert.are.same({x = 150, y = 30, width = 200, height = 30}, geometry("gclDragged"))
+    end)
+  end)
+
+  describe("Geyser.CommandLine:type_delete", function()
+    it("deletes the widget with the object", function()
+      local commandLine = track(Geyser.CommandLine:new({name = "gclDelete", x = 0, y = 0, width = 100, height = 30}))
+      assert.are.equal("commandline", windowType("gclDelete"))
+      commandLine:delete()
+      assert.is_nil(windowType("gclDelete"))
+      assert.is_nil(getWindowGeometry("gclDelete"))
+      assert.is_nil(Geyser.windowList.gclDelete)
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/GeyserCommandLine_spec.lua
+++ b/src/mudlet-lua/tests/GeyserCommandLine_spec.lua
@@ -112,21 +112,14 @@ describe("Tests functionality of Geyser.CommandLine", function()
     end)
   end)
 
-  -- selectCmdLineText() also declares one return value without pushing one, so
-  -- it hands back whatever was left on the Lua stack - the window name - rather
-  -- than a result. Asserting that here would freeze the defect in place.
-  pending("Geyser.CommandLine:selectText selects every character - the selection of a command line is not readable from Lua, needs a getCmdLineSelection getter")
+  -- Two things are in the way. The selection itself has no getter; and
+  -- selectCmdLineText (TLuaInterpreterUI.cpp) declares one return value without
+  -- pushing one, so it hands back whatever was left on the Lua stack - the
+  -- window name it was passed - rather than a result. Asserting either of those
+  -- as they stand would freeze the defect in place.
+  pending("Geyser.CommandLine:selectText selects every character - the selection is not readable from Lua and needs a getCmdLineSelection getter, and selectCmdLineText returns the window name instead of a result")
 
   describe("Geyser.CommandLine:setStyleSheet", function()
-    it("remembers the stylesheet it was constructed with", function()
-      local commandLine = track(Geyser.CommandLine:new({
-        name = "gclCssCons",
-        x = 0, y = 0, width = 100, height = 30,
-        stylesheet = "background-color: blue;",
-      }))
-      assert.are.equal("background-color: blue;", commandLine.stylesheet)
-    end)
-
     it("reuses the remembered stylesheet when called without one", function()
       local commandLine = track(Geyser.CommandLine:new({name = "gclCss", x = 0, y = 0, width = 100, height = 30}))
       commandLine:setStyleSheet("background-color: red;")
@@ -180,6 +173,34 @@ describe("Tests functionality of Geyser.CommandLine", function()
       track(Geyser.CommandLine:new({name = "gclDragged", x = 0, y = 0, width = "100%", height = 30}, container))
       container:move(150, 30)
       assert.are.same({x = 150, y = 30, width = 200, height = 30}, geometry("gclDragged"))
+    end)
+  end)
+
+  describe("Geyser.CommandLine error paths", function()
+    it("raises on a constraint it cannot parse, leaving no widget behind", function()
+      -- the object is registered before its constraints are resolved, so the
+      -- failed attempt has to be swept out of the root window list by hand
+      finally(function()
+        local zombie = Geyser.windowList.gclBadConstraint
+        if zombie then
+          zombie:delete()
+        end
+      end)
+      local ok, message = pcall(function()
+        return Geyser.CommandLine:new({name = "gclBadConstraint", x = 0, y = 0, width = true, height = 20})
+      end)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(message):find("GeyserSetConstraints.lua", 1, true))
+      assert.is_nil(windowType("gclBadConstraint"))
+    end)
+
+    it("raises when printing something that is not text, leaving the text alone", function()
+      local commandLine = track(Geyser.CommandLine:new({name = "gclBadPrint", x = 0, y = 0, width = 100, height = 30}))
+      commandLine:print("kept")
+      local ok, message = pcall(function() commandLine:print(nil) end)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(message):find("printCmdLine", 1, true))
+      assert.are.equal("kept", commandLine:getText())
     end)
   end)
 

--- a/src/mudlet-lua/tests/GeyserMapper_spec.lua
+++ b/src/mudlet-lua/tests/GeyserMapper_spec.lua
@@ -7,13 +7,21 @@
 -- Every mapper here is created with embedded = false or a dock position, which
 -- is the map widget rather than a mapper drawn into the main console: see the
 -- pending below for why the embedded form cannot be exercised in this suite.
+--
+-- Opening the map widget is a one way door for the profile - Host::closeMapWidget
+-- only hides it - and busted runs its files in sorted order, so this file is
+-- now the first to open it, ahead of Mapper_spec.lua. That costs Mapper_spec's
+-- opening block its "registered before the widget was opened" premise; nothing
+-- there fails, but the deferred registration path it meant to cover is no
+-- longer reached from here on. Restoring it means moving that block into an
+-- earlier sorting file of its own.
 
 -- Reports whether the map widget is currently on screen, without leaving it in
 -- a different state than it was found in.
 local function mapWidgetVisible()
   local closed = closeMapWidget()
   if closed then
-    openMapWidget()
+    assert.is_true(openMapWidget(), "could not put the map widget back after probing it")
     return true
   end
   return false
@@ -156,6 +164,43 @@ describe("Tests functionality of Geyser.Mapper", function()
     end)
   end)
 
+  describe("Geyser.Mapper:setDockPosition", function()
+    it("puts a closed map widget back on screen", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpDockOpen", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      mapper:hide()
+      assert.is_false(mapWidgetVisible())
+      assert.is_true(mapper:setDockPosition("f"))
+      assert.is_true(mapWidgetVisible())
+    end)
+
+    it("refuses a dock position that is not one of the five", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpDockBad", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      local result, message = mapper:setDockPosition("nonsense")
+      assert.is_nil(result)
+      assert.is_string(message)
+      assert.is_truthy(message:find("not available", 1, true))
+      -- refusing is not fatal, the widget stays where it was
+      assert.is_true(mapWidgetVisible())
+    end)
+  end)
+
+  describe("Geyser.Mapper:reposition", function()
+    it("leaves the map widget alone when the main window is resized", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpReposition", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      local mainWidth, mainHeight = getMainWindowSize()
+      -- a mapper has no window for moveWindow/resizeWindow to act on, which is
+      -- why it overrides reposition to do nothing unless it is embedded. This
+      -- is a regression guard: the constraints cannot move today, so the
+      -- load-bearing assertion is that the widget is still on screen after.
+      GeyserReposition("sysWindowResizeEvent", mainWidth, mainHeight)
+      assert.are.equal(10, mapper:get_x())
+      assert.are.equal(20, mapper:get_y())
+      assert.are.equal(300, mapper:get_width())
+      assert.are.equal(200, mapper:get_height())
+      assert.is_true(mapWidgetVisible())
+    end)
+  end)
+
   describe("Geyser.Mapper:setTitle/resetTitle", function()
     it("remembers the title it was given, and empties it again on reset", function()
       local mapper = track(Geyser.Mapper:new({
@@ -165,9 +210,12 @@ describe("Tests functionality of Geyser.Mapper", function()
         titleText = "My map",
       }))
       assert.are.equal("My map", mapper.titleText)
-      mapper:setTitle("Renamed")
+      -- setMapWindowTitle answers nil and a message rather than raising when
+      -- there is no map window, so the return value is what says the title
+      -- reached one; without it titleText alone would look right regardless
+      assert.is_true(mapper:setTitle("Renamed"))
       assert.are.equal("Renamed", mapper.titleText)
-      mapper:resetTitle()
+      assert.is_true(mapper:resetTitle())
       assert.are.equal("", mapper.titleText)
     end)
 
@@ -179,7 +227,7 @@ describe("Tests functionality of Geyser.Mapper", function()
 
   pending("Geyser.Mapper:setTitle/resetTitle put the text on the map window's title bar - needs a getMapWindowTitle getter")
 
-  pending("Geyser.Mapper:setDockPosition - which edge the map widget is docked to is not readable from Lua")
+  pending("Geyser.Mapper:setDockPosition docks the map widget against the edge it names - which edge it ended up on is not readable from Lua")
 
   pending("Geyser.Mapper:raise/lower stack the map against the other windows - Mudlet exposes no z-order readback")
 
@@ -201,10 +249,29 @@ describe("Tests functionality of Geyser.Mapper", function()
 
     it("goes away with the container it was put in", function()
       local container = track(Geyser.Container:new({name = "gmpOuter", x = 0, y = 0, width = 300, height = 200}))
-      track(Geyser.Mapper:new({name = "gmpNested", x = 0, y = 0, width = "100%", height = "100%", embedded = false}, container))
+      local mapper = track(Geyser.Mapper:new({name = "gmpNested", x = 0, y = 0, width = "100%", height = "100%", embedded = false}, container))
+      assert.are.equal(mapper, container.windowList.gmpNested)
+      assert.is_true(mapWidgetVisible())
       container:delete()
-      assert.is_nil(Geyser.windowList.gmpNested)
+      -- the widget closing is what says the cascade reached the mapper:
+      -- Geyser.Container:delete empties its own windowList either way
+      assert.is_false(mapWidgetVisible())
       assert.is_nil(container.windowList.gmpNested)
+    end)
+
+    -- A profile has one map, so two Geyser.Mapper objects are two handles on
+    -- the same widget: deleting either one closes it under the other. That is
+    -- worth pinning down, because it is the trap a second mapper walks into.
+    it("closes the one shared map widget even when another mapper still holds it", function()
+      local first = track(Geyser.Mapper:new({name = "gmpShared", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      local second = track(Geyser.Mapper:new({name = "gmpSharing", x = 0, y = 0, width = 200, height = 150, embedded = false}))
+      assert.is_true(mapWidgetVisible())
+      second:delete()
+      assert.is_false(mapWidgetVisible())
+      -- the surviving mapper is untouched as an object, and can reopen the map
+      assert.are.equal(first, Geyser.windowList.gmpShared)
+      first:show()
+      assert.is_true(mapWidgetVisible())
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/GeyserMapper_spec.lua
+++ b/src/mudlet-lua/tests/GeyserMapper_spec.lua
@@ -1,0 +1,210 @@
+-- Geyser.Mapper drives Mudlet's one map per profile. The dockable map widget
+-- has no window name of its own, so windowType/getWindowGeometry cannot see it;
+-- what is observable is the Geyser object's resolved constraints plus
+-- closeMapWidget(), which reports "map widget already closed" when the widget
+-- is not on screen and so doubles as a visibility probe.
+--
+-- Every mapper here is created with embedded = false or a dock position, which
+-- is the map widget rather than a mapper drawn into the main console: see the
+-- pending below for why the embedded form cannot be exercised in this suite.
+
+-- Reports whether the map widget is currently on screen, without leaving it in
+-- a different state than it was found in.
+local function mapWidgetVisible()
+  local closed = closeMapWidget()
+  if closed then
+    openMapWidget()
+    return true
+  end
+  return false
+end
+
+describe("Tests functionality of Geyser.Mapper", function()
+  local created
+
+  local function track(object)
+    created[#created + 1] = object
+    return object
+  end
+
+  local function alive(object)
+    if not object or not object.container or not object.container.windowList then
+      return false
+    end
+    return object.container.windowList[object.name] == object
+  end
+
+  before_each(function()
+    created = {}
+  end)
+
+  -- The map widget outlives every mapper object, so put it away again rather
+  -- than leaving it over the specs that run after this file.
+  after_each(function()
+    for _, object in ipairs(created) do
+      if alive(object) then
+        object:delete()
+      end
+    end
+    created = {}
+    closeMapWidget()
+  end)
+
+  describe("Geyser.Mapper:new/new2", function()
+    it("registers a mapper that has no addressable widget of its own", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpNew", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      assert.are.equal("mapper", mapper.type)
+      assert.are.equal(mapper, Geyser.windowList.gmpNew)
+      -- the map lives in a dock widget Mudlet does not name, so the window
+      -- getters cannot reach it
+      assert.is_nil(windowType("gmpNew"))
+      local found, message = getWindowGeometry("gmpNew")
+      assert.is_nil(found)
+      assert.is_truthy(message:find("gmpNew", 1, true))
+    end)
+
+    it("opens the map widget", function()
+      track(Geyser.Mapper:new({name = "gmpOpen", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      assert.is_true(mapWidgetVisible())
+    end)
+
+    it("resolves its constraints like any other Geyser window", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpPixels", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      assert.are.equal(10, mapper:get_x())
+      assert.are.equal(20, mapper:get_y())
+      assert.are.equal(300, mapper:get_width())
+      assert.are.equal(200, mapper:get_height())
+    end)
+
+    it("resolves percentages against its container", function()
+      local container = track(Geyser.Container:new({name = "gmpBox", x = 100, y = 50, width = 400, height = 200}))
+      local mapper = track(Geyser.Mapper:new({name = "gmpInBox", x = "25%", y = "50%", width = "50%", height = "50%", embedded = false}, container))
+      assert.are.equal(200, mapper:get_x())
+      assert.are.equal(150, mapper:get_y())
+      assert.are.equal(200, mapper:get_width())
+      assert.are.equal(100, mapper:get_height())
+    end)
+
+    it("treats a mapper given a dock position as not embedded", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpDocked", x = 0, y = 0, width = 200, height = 150, dockPosition = "right"}))
+      assert.is_false(mapper.embedded)
+      assert.are.equal("right", mapper.dockPosition)
+    end)
+
+    it("shortens a floating dock position to f", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpFloating", x = 0, y = 0, width = 200, height = 150, dockPosition = "floating"}))
+      assert.is_false(mapper.embedded)
+      assert.are.equal("f", mapper.dockPosition)
+    end)
+
+    it("new2 marks the mapper as using add2", function()
+      local mapper = track(Geyser.Mapper:new2({name = "gmpNew2", x = 0, y = 0, width = 200, height = 150, embedded = false}))
+      assert.is_true(mapper.useAdd2)
+      assert.are.equal("mapper", mapper.type)
+    end)
+  end)
+
+  describe("Geyser.Mapper:move/resize", function()
+    local mapper
+
+    before_each(function()
+      mapper = track(Geyser.Mapper:new({name = "gmpMove", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+    end)
+
+    it("takes the new constraints and resolves them", function()
+      mapper:move(60, 70)
+      assert.are.equal("60px", mapper.x)
+      assert.are.equal("70px", mapper.y)
+      assert.are.equal(60, mapper:get_x())
+      assert.are.equal(70, mapper:get_y())
+      mapper:resize(150, 100)
+      assert.are.equal("150px", mapper.width)
+      assert.are.equal(150, mapper:get_width())
+      assert.are.equal(100, mapper:get_height())
+    end)
+
+    it("refuses to move or resize while it is hidden", function()
+      mapper:hide()
+      mapper:move(200, 210)
+      mapper:resize(50, 60)
+      assert.are.equal("10px", mapper.x)
+      assert.are.equal("20px", mapper.y)
+      assert.are.equal(10, mapper:get_x())
+      assert.are.equal(300, mapper:get_width())
+      assert.are.equal(200, mapper:get_height())
+    end)
+  end)
+
+  describe("Geyser.Mapper:hide/show", function()
+    it("closes and reopens the map widget", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpHide", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      assert.is_true(mapWidgetVisible())
+      mapper:hide()
+      assert.is_true(mapper.hidden)
+      assert.is_false(mapWidgetVisible())
+      mapper:show()
+      assert.is_false(mapper.hidden)
+      assert.is_true(mapWidgetVisible())
+    end)
+
+    it("reports that a closed map widget is already closed", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpClosed", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      mapper:hide()
+      local closed, message = closeMapWidget()
+      assert.is_nil(closed)
+      assert.is_truthy(message:find("already closed", 1, true))
+    end)
+  end)
+
+  describe("Geyser.Mapper:setTitle/resetTitle", function()
+    it("remembers the title it was given, and empties it again on reset", function()
+      local mapper = track(Geyser.Mapper:new({
+        name = "gmpTitle",
+        x = 10, y = 20, width = 300, height = 200,
+        embedded = false,
+        titleText = "My map",
+      }))
+      assert.are.equal("My map", mapper.titleText)
+      mapper:setTitle("Renamed")
+      assert.are.equal("Renamed", mapper.titleText)
+      mapper:resetTitle()
+      assert.are.equal("", mapper.titleText)
+    end)
+
+    it("starts with an empty title when it was not given one", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpNoTitle", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      assert.are.equal("", mapper.titleText)
+    end)
+  end)
+
+  pending("Geyser.Mapper:setTitle/resetTitle put the text on the map window's title bar - needs a getMapWindowTitle getter")
+
+  pending("Geyser.Mapper:setDockPosition - which edge the map widget is docked to is not readable from Lua")
+
+  pending("Geyser.Mapper:raise/lower stack the map against the other windows - Mudlet exposes no z-order readback")
+
+  -- An embedded mapper and the dockable map widget are mutually exclusive for
+  -- the life of a profile (TMainConsole::createMapper and Host::openMapWidget
+  -- each refuse when the other one exists), and neither can be destroyed once
+  -- made. Creating an embedded mapper here would take the map widget away from
+  -- Mapper_spec for the rest of the run.
+  pending("Geyser.Mapper embedded in the main console - an embedded mapper cannot be undone, so it cannot be created inside this suite")
+
+  describe("Geyser.Mapper:type_delete", function()
+    it("closes the map widget and unregisters the mapper", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpDelete", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      assert.is_true(mapWidgetVisible())
+      mapper:delete()
+      assert.is_nil(Geyser.windowList.gmpDelete)
+      assert.is_false(mapWidgetVisible())
+    end)
+
+    it("goes away with the container it was put in", function()
+      local container = track(Geyser.Container:new({name = "gmpOuter", x = 0, y = 0, width = 300, height = 200}))
+      track(Geyser.Mapper:new({name = "gmpNested", x = 0, y = 0, width = "100%", height = "100%", embedded = false}, container))
+      container:delete()
+      assert.is_nil(Geyser.windowList.gmpNested)
+      assert.is_nil(container.windowList.gmpNested)
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
@@ -127,6 +127,17 @@ describe("Tests functionality of Geyser.ScrollBox", function()
       assert.are.equal("gsbHolder", label.windowname)
       assert.are.same({x = 50, y = 0, width = 50, height = 75}, geometry("gsbInnerLabel"))
     end)
+
+    it("nests a scroll box inside a scroll box, each its own parent window", function()
+      local inner = track(Geyser.ScrollBox:new({name = "gsbNestedBox", x = 10, y = 10, width = "50%", height = "50%"}, scrollBox))
+      assert.are.equal("gsbNestedBox", inner.windowname)
+      assert.are.equal("gsbHolder", inner.parentWindowName)
+      assert.are.same({x = 10, y = 10, width = 100, height = 75}, geometry("gsbNestedBox"))
+      -- a child of the inner box is placed in the inner box's own space again
+      local label = track(Geyser.Label:new({name = "gsbNestedLabel", x = "50%", y = 0, width = "50%", height = "100%"}, inner))
+      assert.are.equal("gsbNestedBox", label.windowname)
+      assert.are.same({x = 50, y = 0, width = 50, height = 75}, geometry("gsbNestedLabel"))
+    end)
   end)
 
   describe("Geyser.ScrollBox:hide/show", function()
@@ -166,7 +177,36 @@ describe("Tests functionality of Geyser.ScrollBox", function()
     end)
   end)
 
-  pending("Geyser.ScrollBox shows a scroll bar once a child overflows it - scroll bar visibility is not readable from Lua, needs a getScrollBoxScrollBars getter")
+  -- Geyser:add2 runs from inside Geyser.Container:new, so the hide it asks for
+  -- lands before createScrollBox has made the widget. Every other Geyser widget
+  -- constructor hides itself again afterwards (GeyserCommandLine.lua:89,
+  -- GeyserMiniConsole.lua:605, GeyserLabel.lua:998, GeyserTextEdit.lua:70,
+  -- GeyserMapper.lua:133); Geyser.ScrollBox:new is the one that does not, so it
+  -- comes up on screen with auto_hidden already true. A Geyser.MiniConsole
+  -- built the same way stays hidden, which is the behaviour this asks for.
+  pending("Geyser.ScrollBox created in a hidden add2 container stays hidden - Geyser.ScrollBox:new never re-hides the widget it just created")
+
+  describe("Geyser.ScrollBox scroll bars", function()
+    -- A scroll box scrolls by being a QScrollArea (TScrollBox.h), not by being
+    -- a console, so Mudlet's scroll bar API cannot reach it: Host::findConsole
+    -- only looks through the sub-console map, and a scroll box is not in it.
+    -- Geyser.ScrollBox descends from Geyser.Window rather than
+    -- Geyser.MiniConsole, so it offers no scroll bar method of its own either.
+    -- Its scroll bars are Qt's, and appear on their own when a child overflows.
+    it("is not reachable by the console scroll bar functions", function()
+      track(Geyser.ScrollBox:new({name = "gsbScrollBar", x = 0, y = 0, width = 200, height = 150}))
+      local enabled, enableMessage = enableScrollBar("gsbScrollBar")
+      assert.is_nil(enabled)
+      assert.is_truthy(enableMessage:find("gsbScrollBar", 1, true))
+      local disabled, disableMessage = disableScrollBar("gsbScrollBar")
+      assert.is_nil(disabled)
+      assert.is_truthy(disableMessage:find("gsbScrollBar", 1, true))
+      assert.is_nil(Geyser.ScrollBox.enableScrollBar)
+      assert.is_nil(Geyser.ScrollBox.disableScrollBar)
+    end)
+  end)
+
+  pending("Geyser.ScrollBox shows Qt's own scroll bar once a child overflows it - a scroll box is not a console, so no console scroll bar getter can report it; this needs a scroll box specific getter")
 
   pending("Geyser.ScrollBox:setStyleSheet - the method is commented out in GeyserScrollBox.lua because Mudlet has no setScrollBoxStyleSheet primitive to call")
 

--- a/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
@@ -1,0 +1,192 @@
+-- A Geyser.ScrollBox is both a widget in its parent window and a parent window
+-- of its own: it swaps its windowname for its own name so that everything added
+-- to it is created inside the scroll box. Its children therefore report
+-- geometry in the scroll box's coordinate space, not the main window's, which
+-- is what lets a child be taller than the box and scroll.
+local function geometry(name)
+  local x, y, width, height = getWindowGeometry(name)
+  return {x = x, y = y, width = width, height = height}
+end
+
+describe("Tests functionality of Geyser.ScrollBox", function()
+  local created
+
+  local function track(object)
+    created[#created + 1] = object
+    return object
+  end
+
+  local function alive(object)
+    if not object or not object.container or not object.container.windowList then
+      return false
+    end
+    return object.container.windowList[object.name] == object
+  end
+
+  before_each(function()
+    created = {}
+  end)
+
+  after_each(function()
+    for _, object in ipairs(created) do
+      if alive(object) then
+        object:delete()
+      end
+    end
+    created = {}
+  end)
+
+  describe("Geyser.ScrollBox:new/new2", function()
+    it("creates a scroll box widget at the constrained geometry", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbNew", x = 10, y = 20, width = 200, height = 150}))
+      -- Geyser's own type string is camel cased, Mudlet's windowType is not
+      assert.are.equal("scrollBox", scrollBox.type)
+      assert.are.equal("scrollbox", windowType("gsbNew"))
+      assert.are.same({x = 10, y = 20, width = 200, height = 150}, geometry("gsbNew"))
+      assert.is_true(windowVisible("gsbNew"))
+      assert.are.equal(scrollBox, Geyser.windowList.gsbNew)
+    end)
+
+    it("becomes a parent window of its own, remembering the one it was made in", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbParent", x = 0, y = 0, width = 100, height = 100}))
+      assert.are.equal("gsbParent", scrollBox.windowname)
+      assert.are.equal("main", scrollBox.parentWindowName)
+      assert.are.equal(scrollBox, Geyser.parentWindows.gsbParent)
+    end)
+
+    it("reports its own origin as zero so children are placed inside it", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbOrigin", x = 40, y = 60, width = 100, height = 100}))
+      assert.are.equal(0, scrollBox.get_x())
+      assert.are.equal(0, scrollBox.get_y())
+      -- the widget itself is still where its constraints put it
+      assert.are.same({x = 40, y = 60, width = 100, height = 100}, geometry("gsbOrigin"))
+    end)
+
+    it("uses Geyser's defaults when no constraints are given", function()
+      track(Geyser.ScrollBox:new({name = "gsbDefaults"}))
+      assert.are.same({x = 10, y = 10, width = 300, height = 200}, geometry("gsbDefaults"))
+    end)
+
+    it("resolves percentages against its container", function()
+      local container = track(Geyser.Container:new({name = "gsbBox", x = 50, y = 60, width = 300, height = 200}))
+      track(Geyser.ScrollBox:new({name = "gsbInBox", x = "10%", y = "10%", width = "80%", height = "80%"}, container))
+      assert.are.same({x = 80, y = 80, width = 240, height = 160}, geometry("gsbInBox"))
+    end)
+
+    it("new2 marks the scroll box as using add2", function()
+      local scrollBox = track(Geyser.ScrollBox:new2({name = "gsbNew2", x = 0, y = 0, width = 50, height = 50}))
+      assert.is_true(scrollBox.useAdd2)
+      assert.are.equal("scrollbox", windowType("gsbNew2"))
+    end)
+  end)
+
+  describe("Geyser.ScrollBox children", function()
+    local scrollBox
+
+    before_each(function()
+      scrollBox = track(Geyser.ScrollBox:new({name = "gsbHolder", x = 10, y = 20, width = 200, height = 150}))
+    end)
+
+    it("places children in its own coordinate space", function()
+      local console = track(Geyser.MiniConsole:new({name = "gsbConsole", x = "10%", y = "10%", width = "80%", height = "50%"}, scrollBox))
+      assert.are.equal("gsbHolder", console.windowname)
+      -- 10%/10% of the box, not of the main window, and with no 10,20 offset
+      assert.are.same({x = 20, y = 15, width = 160, height = 75}, geometry("gsbConsole"))
+    end)
+
+    it("holds a command line as well as a console", function()
+      track(Geyser.CommandLine:new({name = "gsbCmdLine", x = 0, y = "80%", width = "100%", height = 25}, scrollBox))
+      assert.are.equal("commandline", windowType("gsbCmdLine"))
+      assert.are.same({x = 0, y = 120, width = 200, height = 25}, geometry("gsbCmdLine"))
+    end)
+
+    it("lets a child be taller than the box, which is what makes it scroll", function()
+      track(Geyser.Label:new({name = "gsbTall", x = 0, y = 0, width = "100%", height = 2000}, scrollBox))
+      assert.are.same({x = 0, y = 0, width = 200, height = 2000}, geometry("gsbTall"))
+    end)
+
+    it("re-lays its children out when it is resized", function()
+      track(Geyser.MiniConsole:new({name = "gsbResized", x = "10%", y = "10%", width = "80%", height = "50%"}, scrollBox))
+      scrollBox:resize(400, 300)
+      assert.are.same({x = 10, y = 20, width = 400, height = 300}, geometry("gsbHolder"))
+      assert.are.same({x = 40, y = 30, width = 320, height = 150}, geometry("gsbResized"))
+    end)
+
+    it("keeps children where they are when the box itself moves", function()
+      track(Geyser.Label:new({name = "gsbFollower", x = "50%", y = 0, width = "50%", height = "100%"}, scrollBox))
+      assert.are.same({x = 100, y = 0, width = 100, height = 150}, geometry("gsbFollower"))
+      scrollBox:move(80, 90)
+      assert.are.same({x = 80, y = 90, width = 200, height = 150}, geometry("gsbHolder"))
+      -- the child rides along inside the widget, so its own coordinates do not move
+      assert.are.same({x = 100, y = 0, width = 100, height = 150}, geometry("gsbFollower"))
+    end)
+
+    it("nests a container of its own inside the scroll box", function()
+      local inner = track(Geyser.Container:new({name = "gsbInner", x = 0, y = 0, width = "50%", height = "50%"}, scrollBox))
+      local label = track(Geyser.Label:new({name = "gsbInnerLabel", x = "50%", y = 0, width = "50%", height = "100%"}, inner))
+      assert.are.equal("gsbHolder", label.windowname)
+      assert.are.same({x = 50, y = 0, width = 50, height = 75}, geometry("gsbInnerLabel"))
+    end)
+  end)
+
+  describe("Geyser.ScrollBox:hide/show", function()
+    it("hides and shows the scroll box and its children", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbVisible", x = 0, y = 0, width = 200, height = 150}))
+      track(Geyser.Label:new({name = "gsbVisibleChild", x = 0, y = 0, width = "100%", height = "100%"}, scrollBox))
+      scrollBox:hide()
+      assert.is_true(scrollBox.hidden)
+      assert.is_false(windowVisible("gsbVisible"))
+      assert.is_false(windowVisible("gsbVisibleChild"))
+      scrollBox:show()
+      assert.is_false(scrollBox.hidden)
+      assert.is_true(windowVisible("gsbVisible"))
+      assert.is_true(windowVisible("gsbVisibleChild"))
+    end)
+  end)
+
+  describe("Geyser.ScrollBox:reposition", function()
+    it("restores geometry that was changed behind Geyser's back", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbReposition", x = 10, y = 10, width = 100, height = 80}))
+      track(Geyser.Label:new({name = "gsbRepositionChild", x = 5, y = 5, width = "50%", height = "50%"}, scrollBox))
+      moveWindow("gsbReposition", 300, 300)
+      resizeWindow("gsbReposition", 20, 20)
+      assert.are.same({x = 300, y = 300, width = 20, height = 20}, geometry("gsbReposition"))
+      local mainWidth, mainHeight = getMainWindowSize()
+      GeyserReposition("sysWindowResizeEvent", mainWidth, mainHeight)
+      assert.are.same({x = 10, y = 10, width = 100, height = 80}, geometry("gsbReposition"))
+      assert.are.same({x = 5, y = 5, width = 50, height = 40}, geometry("gsbRepositionChild"))
+    end)
+
+    it("puts its own origin back to zero after repositioning", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbOriginKept", x = 30, y = 40, width = 100, height = 80}))
+      scrollBox:reposition()
+      assert.are.equal(0, scrollBox.get_x())
+      assert.are.equal(0, scrollBox.get_y())
+      assert.are.same({x = 30, y = 40, width = 100, height = 80}, geometry("gsbOriginKept"))
+    end)
+  end)
+
+  pending("Geyser.ScrollBox shows a scroll bar once a child overflows it - scroll bar visibility is not readable from Lua, needs a getScrollBoxScrollBars getter")
+
+  pending("Geyser.ScrollBox:setStyleSheet - the method is commented out in GeyserScrollBox.lua because Mudlet has no setScrollBoxStyleSheet primitive to call")
+
+  describe("Geyser.ScrollBox:type_delete", function()
+    it("deletes the widget, its children and its parent window registration", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "gsbDelete", x = 0, y = 0, width = 200, height = 150}))
+      track(Geyser.Label:new({name = "gsbDeleteChild", x = 0, y = 0, width = "100%", height = "100%"}, scrollBox))
+      scrollBox:delete()
+      assert.is_nil(windowType("gsbDelete"))
+      assert.is_nil(windowType("gsbDeleteChild"))
+      assert.is_nil(Geyser.windowList.gsbDelete)
+      assert.is_nil(Geyser.parentWindows.gsbDelete)
+    end)
+
+    it("goes away with the container it was put in", function()
+      local container = track(Geyser.Container:new({name = "gsbOuter", x = 0, y = 0, width = 300, height = 200}))
+      track(Geyser.ScrollBox:new({name = "gsbNested", x = 0, y = 0, width = "100%", height = "100%"}, container))
+      container:delete()
+      assert.is_nil(windowType("gsbNested"))
+      assert.is_nil(Geyser.parentWindows.gsbNested)
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -108,7 +108,8 @@ describe("Tests functionality of Geyser.UserWindow", function()
       -- the dock is the size it was asked for, and the usable area is real and
       -- inside it - by however much this platform's dock decoration costs
       local dock = geometry("guwRoot")
-      assert.are.same({x = 10, y = 10, width = 300, height = 200}, dock)
+      assert.are.equal(300, dock.width)
+      assert.are.equal(200, dock.height)
       assert.is_true(usableWidth > 0 and usableWidth <= dock.width,
                      string.format("usable width %d is not inside the dock width %d", usableWidth, dock.width))
       assert.is_true(usableHeight > 0 and usableHeight <= dock.height,

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -1,14 +1,19 @@
 -- A Geyser.UserWindow is a Geyser.MiniConsole living in a dock widget of its
 -- own. getWindowGeometry reports that dock, which is what move()/resize() drive,
--- while getUserWindowSize reports the usable area inside it. That area is
--- always shorter than the dock, which spends pixels on its title bar, but it
--- need not be narrower: how wide a floating dock's frame is comes from the
--- style, and can be nothing at all. Neither difference is hardcoded here.
+-- while getUserWindowSize reports the usable area inside it. How much of the
+-- dock that area leaves out is a platform matter: Qt draws a floating dock's
+-- title bar and frame itself on X11 and Wayland, so there they are taken out of
+-- the usable area, while Windows and macOS let the window manager decorate the
+-- dock and so draw them outside it, leaving the whole dock usable. The usable
+-- area is therefore never bigger than the dock, but only strictly shorter than
+-- it where Qt draws the title bar. No size difference is hardcoded here.
 --
 -- Geyser gives every user window an extra root container named
 -- "<name>Container" whose size tracks the real user window; the user window is
 -- that container's only child, which is why it is not in Geyser.windowList
 -- itself.
+local dockDecoratedByWindowManager = getOS() == "windows" or getOS() == "mac"
+
 local function geometry(name)
   local x, y, width, height = getWindowGeometry(name)
   return {x = x, y = y, width = width, height = height}
@@ -100,10 +105,19 @@ describe("Tests functionality of Geyser.UserWindow", function()
       track(Geyser.Label:new({name = "guwRootChild", x = 0, y = 0, width = "100%", height = "100%"}, userWindow))
       local usableWidth, usableHeight = getUserWindowSize("guwRoot")
       assert.are.same({x = 0, y = 0, width = usableWidth, height = usableHeight}, geometry("guwRootChild"))
-      -- the usable area is inside the dock, so never bigger than it but still
-      -- real; the title bar always costs height, the frame need not cost width
-      assert.is_true(usableWidth > 0 and usableWidth <= 300)
-      assert.is_true(usableHeight > 0 and usableHeight < 200)
+      -- the dock is the size it was asked for, and the usable area is real and
+      -- inside it - by however much this platform's dock decoration costs
+      local dock = geometry("guwRoot")
+      assert.are.same({x = 10, y = 10, width = 300, height = 200}, dock)
+      assert.is_true(usableWidth > 0 and usableWidth <= dock.width,
+                     string.format("usable width %d is not inside the dock width %d", usableWidth, dock.width))
+      assert.is_true(usableHeight > 0 and usableHeight <= dock.height,
+                     string.format("usable height %d is not inside the dock height %d", usableHeight, dock.height))
+      if not dockDecoratedByWindowManager then
+        assert.is_true(usableHeight < dock.height,
+                       string.format("Qt draws the dock title bar here, so it must cost height: usable %d, dock %d",
+                                     usableHeight, dock.height))
+      end
     end)
 
     it("registers itself as a parent window so children can be put in it", function()
@@ -126,10 +140,16 @@ describe("Tests functionality of Geyser.UserWindow", function()
       assert.are.equal(40, getWindowWrap("guwFont"))
     end)
 
+    -- Ubuntu Mono is asked for rather than a system font like Courier New:
+    -- Mudlet ships and loads it itself, so it is there to be had on every
+    -- platform, where a bare Linux CI image has no Courier New and Qt quietly
+    -- substitutes the nearest match. It is also not the console default
+    -- (Bitstream Vera Sans Mono), so a font that never reached the widget still
+    -- fails this.
     it("takes the font family it was given", function()
-      local userWindow = track(Geyser.UserWindow:new({name = "guwFamily", x = 10, y = 10, width = 250, height = 180, font = "Courier New"}))
-      assert.are.equal("Courier New", getFont("guwFamily"))
-      assert.are.equal("Courier New", userWindow.font)
+      local userWindow = track(Geyser.UserWindow:new({name = "guwFamily", x = 10, y = 10, width = 250, height = 180, font = "Ubuntu Mono"}))
+      assert.are.equal("Ubuntu Mono", getFont("guwFamily"))
+      assert.are.equal("Ubuntu Mono", userWindow.font)
     end)
 
     it("derives an auto wrap from its usable width", function()

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -1,0 +1,297 @@
+-- A Geyser.UserWindow is a Geyser.MiniConsole living in a dock widget of its
+-- own. getWindowGeometry reports that dock, which is what move()/resize() drive,
+-- while getUserWindowSize reports the usable area inside it - always a little
+-- smaller, because the dock spends pixels on its frame and title bar. The exact
+-- difference is a style detail, so it is never hardcoded here.
+--
+-- Geyser gives every user window an extra root container named
+-- "<name>Container" whose size tracks the real user window; the user window is
+-- that container's only child, which is why it is not in Geyser.windowList
+-- itself.
+local function geometry(name)
+  local x, y, width, height = getWindowGeometry(name)
+  return {x = x, y = y, width = width, height = height}
+end
+
+-- Selects the line last written by a newline terminated echo. getLineCount
+-- returns the index of the last line rather than a count, and the trailing
+-- newline leaves the cursor on that still empty line, so the text is one above.
+local function lastLine(name)
+  local index = getLineCount(name) - 1
+  assert.is_true(index >= 0, "nothing has been echoed to " .. name .. " yet")
+  moveCursor(name, 0, index)
+  selectCurrentLine(name)
+  return getCurrentLine(name)
+end
+
+describe("Tests functionality of Geyser.UserWindow", function()
+  local created
+
+  local function track(object)
+    created[#created + 1] = object
+    return object
+  end
+
+  local function alive(object)
+    if not object or not object.container or not object.container.windowList then
+      return false
+    end
+    return object.container.windowList[object.name] == object
+  end
+
+  before_each(function()
+    created = {}
+  end)
+
+  -- Deleting a user window leaves its "<name>Container" root container behind
+  -- (see the pending below), so sweep those out by hand to keep repeat runs of
+  -- this file against the same profile identical.
+  after_each(function()
+    local names = {}
+    for _, object in ipairs(created) do
+      if object.type == "userwindow" then
+        names[#names + 1] = object.name .. "Container"
+      end
+      if alive(object) then
+        object:delete()
+      end
+    end
+    for _, name in ipairs(names) do
+      local orphan = Geyser.windowList[name]
+      if orphan then
+        orphan:delete()
+      end
+    end
+    created = {}
+  end)
+
+  describe("Geyser.UserWindow:new/new2", function()
+    it("opens a user window at the geometry it was given", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwNew", x = 20, y = 30, width = 300, height = 200}))
+      assert.are.equal("userwindow", userWindow.type)
+      assert.are.equal("userwindow", windowType("guwNew"))
+      assert.are.same({x = 20, y = 30, width = 300, height = 200}, geometry("guwNew"))
+      assert.is_true(windowVisible("guwNew"))
+    end)
+
+    it("resets its own constraints to fill the window it opened", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwFilled", x = 10, y = 10, width = 250, height = 180}))
+      assert.are.equal("0px", userWindow.x)
+      assert.are.equal("0px", userWindow.y)
+      assert.are.equal("100%", userWindow.width)
+      assert.are.equal("100%", userWindow.height)
+      local usableWidth, usableHeight = getUserWindowSize("guwFilled")
+      assert.are.equal(usableWidth, userWindow:get_width())
+      assert.are.equal(usableHeight, userWindow:get_height())
+    end)
+
+    it("gives itself a root container sized to the user window", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwRoot", x = 10, y = 10, width = 300, height = 200}))
+      local container = userWindow.container
+      assert.are.equal("guwRootContainer", container.name)
+      assert.are.equal(container, Geyser.windowList.guwRootContainer)
+      -- the user window belongs to that container, not to the root window list
+      assert.is_nil(Geyser.windowList.guwRoot)
+      assert.are.equal(userWindow, container.windowList.guwRoot)
+      local usableWidth, usableHeight = getUserWindowSize("guwRoot")
+      assert.are.equal(usableWidth, container.get_width())
+      assert.are.equal(usableHeight, container.get_height())
+      -- the usable area is inside the dock, so smaller than it but still real
+      assert.is_true(usableWidth > 0 and usableWidth < 300)
+      assert.is_true(usableHeight > 0 and usableHeight < 200)
+    end)
+
+    it("registers itself as a parent window so children can be put in it", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwParent", x = 10, y = 10, width = 200, height = 150}))
+      assert.are.equal(userWindow, Geyser.parentWindows.guwParent)
+      assert.are.equal("guwParent", userWindow.windowname)
+    end)
+
+    it("defaults to an undocked, auto docking window that does not restore a layout", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDefaults", x = 10, y = 10, width = 200, height = 150}))
+      assert.is_false(userWindow.docked)
+      assert.is_false(userWindow.restoreLayout)
+      assert.is_true(userWindow.autoDock)
+      assert.are.equal("floating", userWindow.dockPosition)
+    end)
+
+    it("takes the font size and wrap it was given", function()
+      track(Geyser.UserWindow:new({name = "guwFont", x = 10, y = 10, width = 250, height = 180, fontSize = 12, wrapAt = 40}))
+      assert.are.equal(12, getFontSize("guwFont"))
+      assert.are.equal(40, getWindowWrap("guwFont"))
+    end)
+
+    it("new2 marks the user window as using add2", function()
+      local userWindow = track(Geyser.UserWindow:new2({name = "guwNew2", x = 10, y = 10, width = 200, height = 150}))
+      assert.is_true(userWindow.useAdd2)
+      assert.are.equal("userwindow", windowType("guwNew2"))
+    end)
+
+    it("reopens a user window that was opened under the same name before", function()
+      local first = track(Geyser.UserWindow:new({name = "guwReused", x = 10, y = 10, width = 200, height = 150}))
+      local trackedWindows = #Geyser.windows
+      first:delete()
+      local second = track(Geyser.UserWindow:new({name = "guwReused", x = 40, y = 50, width = 260, height = 190}))
+      assert.are.same({x = 40, y = 50, width = 260, height = 190}, geometry("guwReused"))
+      assert.are.equal(trackedWindows, #Geyser.windows)
+      assert.are.equal("guwReusedContainer", second.container.name)
+    end)
+  end)
+
+  describe("Geyser.UserWindow:move/resize", function()
+    local userWindow
+
+    before_each(function()
+      userWindow = track(Geyser.UserWindow:new({name = "guwMove", x = 10, y = 20, width = 300, height = 200}))
+    end)
+
+    it("moves and resizes the dock", function()
+      userWindow:move(60, 70)
+      userWindow:resize(320, 210)
+      assert.are.same({x = 60, y = 70, width = 320, height = 210}, geometry("guwMove"))
+    end)
+
+    it("goes back to filling itself after a move", function()
+      userWindow:move(60, 70)
+      assert.are.equal("0px", userWindow.x)
+      assert.are.equal("100%", userWindow.width)
+      local usableWidth = getUserWindowSize("guwMove")
+      assert.are.equal(usableWidth, userWindow:get_width())
+    end)
+
+    it("re-resolves the size of percentage children when it is resized", function()
+      track(Geyser.Label:new({name = "guwMoveChild", x = 0, y = 0, width = "50%", height = "100%"}, userWindow))
+      local firstWidth, firstHeight = getUserWindowSize("guwMove")
+      assert.are.same({x = 0, y = 0, width = math.floor(firstWidth / 2), height = firstHeight}, geometry("guwMoveChild"))
+      userWindow:resize(400, 260)
+      local secondWidth, secondHeight = getUserWindowSize("guwMove")
+      assert.is_true(secondWidth > firstWidth)
+      assert.are.same({x = 0, y = 0, width = math.floor(secondWidth / 2), height = secondHeight}, geometry("guwMoveChild"))
+    end)
+  end)
+
+  describe("Geyser.UserWindow children", function()
+    local userWindow
+
+    before_each(function()
+      userWindow = track(Geyser.UserWindow:new({name = "guwHolder", x = 10, y = 20, width = 300, height = 200}))
+    end)
+
+    it("creates children inside the user window, sized against its usable area", function()
+      local label = track(Geyser.Label:new({name = "guwLabel", x = "50%", y = 0, width = "50%", height = "100%"}, userWindow))
+      assert.are.equal("guwHolder", label.windowname)
+      local usableWidth, usableHeight = getUserWindowSize("guwHolder")
+      assert.are.same({
+        x = math.floor(usableWidth / 2),
+        y = 0,
+        width = math.floor(usableWidth / 2),
+        height = usableHeight,
+      }, geometry("guwLabel"))
+      assert.is_true(windowVisible("guwLabel"))
+    end)
+
+    it("holds a command line of its own", function()
+      track(Geyser.CommandLine:new({name = "guwCmdLine", x = 0, y = 0, width = 80, height = 20}, userWindow))
+      assert.are.equal("commandline", windowType("guwCmdLine"))
+      assert.are.same({x = 0, y = 0, width = 80, height = 20}, geometry("guwCmdLine"))
+    end)
+
+    it("deletes its children with itself", function()
+      track(Geyser.Label:new({name = "guwDoomedLabel", x = 0, y = 0, width = 20, height = 20}, userWindow))
+      userWindow:delete()
+      assert.is_nil(windowType("guwHolder"))
+      assert.is_nil(windowType("guwDoomedLabel"))
+    end)
+  end)
+
+  describe("Geyser.UserWindow echo", function()
+    it("echoes into the console the user window contains", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwEcho", x = 10, y = 20, width = 300, height = 200}))
+      userWindow:echo("into the user window\n")
+      assert.are.equal("into the user window\n", userWindow.message)
+      assert.are.equal("into the user window", lastLine("guwEcho"))
+    end)
+  end)
+
+  describe("Geyser.UserWindow:hide/show", function()
+    it("hides and shows the dock", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwHide", x = 10, y = 20, width = 200, height = 150}))
+      userWindow:hide()
+      assert.is_true(userWindow.hidden)
+      assert.is_false(windowVisible("guwHide"))
+      userWindow:show()
+      assert.is_false(userWindow.hidden)
+      assert.is_true(windowVisible("guwHide"))
+    end)
+
+    it("hides the children in it along with the dock", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwHideChild", x = 10, y = 20, width = 200, height = 150}))
+      track(Geyser.Label:new({name = "guwHiddenLabel", x = 0, y = 0, width = "100%", height = "100%"}, userWindow))
+      userWindow:hide()
+      assert.is_false(windowVisible("guwHiddenLabel"))
+      userWindow:show()
+      assert.is_true(windowVisible("guwHiddenLabel"))
+    end)
+  end)
+
+  -- Geyser.UserWindow:show() (GeyserUserWindow.lua:52) forwards to its parent
+  -- without the `auto` flag its container passes down, so an automatic show
+  -- clears self.hidden as if the user had asked for it. A user window hidden by
+  -- hand therefore reappears the moment its root container is shown, where a
+  -- Geyser.MiniConsole in the same position correctly stays hidden.
+  pending("Geyser.UserWindow stays hidden when its root container is shown - Geyser.UserWindow:show() drops the auto flag")
+
+  describe("Geyser.UserWindow:setTitle/resetTitle", function()
+    it("remembers the title it was given, and empties it again on reset", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwTitle", x = 10, y = 20, width = 200, height = 150, titleText = "My window"}))
+      assert.are.equal("My window", userWindow.titleText)
+      userWindow:setTitle("Renamed")
+      assert.are.equal("Renamed", userWindow.titleText)
+      userWindow:resetTitle()
+      assert.are.equal("", userWindow.titleText)
+    end)
+
+    it("starts with an empty title when it was not given one", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwNoTitle", x = 10, y = 20, width = 200, height = 150}))
+      assert.are.equal("", userWindow.titleText)
+    end)
+  end)
+
+  pending("Geyser.UserWindow:setTitle/resetTitle put the text on the dock's title bar - needs a getUserWindowTitle getter")
+
+  describe("Geyser.UserWindow:setStyleSheet", function()
+    it("remembers the stylesheet it was given", function()
+      local userWindow = track(Geyser.UserWindow:new({
+        name = "guwCss",
+        x = 10, y = 20, width = 200, height = 150,
+        stylesheet = "border: 1px solid red;",
+      }))
+      assert.are.equal("border: 1px solid red;", userWindow.stylesheet)
+      userWindow:setStyleSheet("background-color: green;")
+      assert.are.equal("background-color: green;", userWindow.stylesheet)
+    end)
+  end)
+
+  pending("Geyser.UserWindow:setStyleSheet applies the stylesheet to the dock - needs a getUserWindowStyleSheet getter")
+
+  pending("Geyser.UserWindow scrollBar constraint shows the console's scroll bar - scroll bar visibility is not readable from Lua, needs a scroll bar getter")
+
+  pending("Geyser.UserWindow:setDockPosition/enableAutoDock/disableAutoDock - which edge a user window is docked to, and whether it docks by itself, are not readable from Lua")
+
+  describe("Geyser.UserWindow:delete", function()
+    it("closes the dock and unregisters the user window", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDelete", x = 10, y = 20, width = 200, height = 150}))
+      assert.are.equal("userwindow", windowType("guwDelete"))
+      userWindow:delete()
+      assert.is_nil(windowType("guwDelete"))
+      assert.is_nil(getWindowGeometry("guwDelete"))
+      assert.is_nil(Geyser.parentWindows.guwDelete)
+    end)
+  end)
+
+  -- Geyser.Container:new (GeyserContainer.lua:361) makes the "<name>Container"
+  -- root container for a user window, but Geyser.Container:delete only unhooks
+  -- the user window from it, so the container is left registered in
+  -- Geyser.windowList and Geyser.windows for the rest of the session.
+  pending("deleting a Geyser.UserWindow also removes the root container it created")
+end)

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -1,8 +1,9 @@
 -- A Geyser.UserWindow is a Geyser.MiniConsole living in a dock widget of its
 -- own. getWindowGeometry reports that dock, which is what move()/resize() drive,
--- while getUserWindowSize reports the usable area inside it - always a little
--- smaller, because the dock spends pixels on its frame and title bar. The exact
--- difference is a style detail, so it is never hardcoded here.
+-- while getUserWindowSize reports the usable area inside it. That area is
+-- always shorter than the dock, which spends pixels on its title bar, but it
+-- need not be narrower: how wide a floating dock's frame is comes from the
+-- style, and can be nothing at all. Neither difference is hardcoded here.
 --
 -- Geyser gives every user window an extra root container named
 -- "<name>Container" whose size tracks the real user window; the user window is
@@ -93,11 +94,15 @@ describe("Tests functionality of Geyser.UserWindow", function()
       -- the user window belongs to that container, not to the root window list
       assert.is_nil(Geyser.windowList.guwRoot)
       assert.are.equal(userWindow, container.windowList.guwRoot)
+      -- that the container really is sized to the user window is read off a
+      -- child widget filling it, rather than off the same getter the container
+      -- was given as its own get_width/get_height
+      track(Geyser.Label:new({name = "guwRootChild", x = 0, y = 0, width = "100%", height = "100%"}, userWindow))
       local usableWidth, usableHeight = getUserWindowSize("guwRoot")
-      assert.are.equal(usableWidth, container.get_width())
-      assert.are.equal(usableHeight, container.get_height())
-      -- the usable area is inside the dock, so smaller than it but still real
-      assert.is_true(usableWidth > 0 and usableWidth < 300)
+      assert.are.same({x = 0, y = 0, width = usableWidth, height = usableHeight}, geometry("guwRootChild"))
+      -- the usable area is inside the dock, so never bigger than it but still
+      -- real; the title bar always costs height, the frame need not cost width
+      assert.is_true(usableWidth > 0 and usableWidth <= 300)
       assert.is_true(usableHeight > 0 and usableHeight < 200)
     end)
 
@@ -119,6 +124,40 @@ describe("Tests functionality of Geyser.UserWindow", function()
       track(Geyser.UserWindow:new({name = "guwFont", x = 10, y = 10, width = 250, height = 180, fontSize = 12, wrapAt = 40}))
       assert.are.equal(12, getFontSize("guwFont"))
       assert.are.equal(40, getWindowWrap("guwFont"))
+    end)
+
+    it("takes the font family it was given", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwFamily", x = 10, y = 10, width = 250, height = 180, font = "Courier New"}))
+      assert.are.equal("Courier New", getFont("guwFamily"))
+      assert.are.equal("Courier New", userWindow.font)
+    end)
+
+    it("derives an auto wrap from its usable width", function()
+      track(Geyser.UserWindow:new({name = "guwAutoWrap", x = 10, y = 10, width = 300, height = 200, wrapAt = "auto"}))
+      local usableWidth = getUserWindowSize("guwAutoWrap")
+      local charWidth = calcFontSize("guwAutoWrap")
+      assert.are.equal(math.floor(usableWidth / charWidth), getWindowWrap("guwAutoWrap"))
+    end)
+
+    -- Mudlet cannot report whether the scroll bar is on screen, but
+    -- Geyser.MiniConsole:resetAutoWrap keeps 15 pixels clear for one when it
+    -- is, so an auto wrapping console wraps that much earlier - which is
+    -- readable, and is what proves the constraint reached the widget.
+    it("keeps room for the scroll bar it was asked for when wrapping", function()
+      track(Geyser.UserWindow:new({name = "guwScrollBar", x = 10, y = 10, width = 300, height = 200, wrapAt = "auto", scrollBar = true}))
+      local usableWidth = getUserWindowSize("guwScrollBar")
+      local charWidth = calcFontSize("guwScrollBar")
+      assert.are.equal(math.floor((usableWidth - 15) / charWidth), getWindowWrap("guwScrollBar"))
+    end)
+
+    it("ignores the geometry it was given when it is asked to start docked", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDocked", x = 10, y = 10, width = 300, height = 200, docked = true}))
+      -- a docked window keeps the dock position it was opened with instead of
+      -- being floated, and the dock area decides its geometry, not the
+      -- constraints, so only the position it kept is asserted here
+      assert.are.equal("r", userWindow.dockPosition)
+      assert.are.equal("userwindow", windowType("guwDocked"))
+      assert.is_true(windowVisible("guwDocked"))
     end)
 
     it("new2 marks the user window as using add2", function()
@@ -196,6 +235,20 @@ describe("Tests functionality of Geyser.UserWindow", function()
       assert.are.same({x = 0, y = 0, width = 80, height = 20}, geometry("guwCmdLine"))
     end)
 
+    it("holds a scroll box, which becomes a parent window inside it", function()
+      local scrollBox = track(Geyser.ScrollBox:new({name = "guwScrollBox", x = 0, y = 0, width = "100%", height = "50%"}, userWindow))
+      assert.are.equal("scrollbox", windowType("guwScrollBox"))
+      -- the scroll box takes over as parent window, remembering the user window
+      assert.are.equal("guwScrollBox", scrollBox.windowname)
+      assert.are.equal("guwHolder", scrollBox.parentWindowName)
+      local usableWidth, usableHeight = getUserWindowSize("guwHolder")
+      assert.are.same({x = 0, y = 0, width = usableWidth, height = math.floor(usableHeight / 2)}, geometry("guwScrollBox"))
+      -- and a child of the scroll box is placed in the scroll box's own space
+      local label = track(Geyser.Label:new({name = "guwScrollBoxLabel", x = 0, y = 0, width = "50%", height = "100%"}, scrollBox))
+      assert.are.equal("guwScrollBox", label.windowname)
+      assert.are.equal(math.floor(usableWidth / 2), geometry("guwScrollBoxLabel").width)
+    end)
+
     it("deletes its children with itself", function()
       track(Geyser.Label:new({name = "guwDoomedLabel", x = 0, y = 0, width = 20, height = 20}, userWindow))
       userWindow:delete()
@@ -242,12 +295,16 @@ describe("Tests functionality of Geyser.UserWindow", function()
   pending("Geyser.UserWindow stays hidden when its root container is shown - Geyser.UserWindow:show() drops the auto flag")
 
   describe("Geyser.UserWindow:setTitle/resetTitle", function()
+    -- setUserWindowTitle answers nil and a message rather than raising when it
+    -- cannot find the window, so the return value is what says the title
+    -- reached the right dock; without it a wrapper naming the wrong window
+    -- would still leave titleText looking right.
     it("remembers the title it was given, and empties it again on reset", function()
       local userWindow = track(Geyser.UserWindow:new({name = "guwTitle", x = 10, y = 20, width = 200, height = 150, titleText = "My window"}))
       assert.are.equal("My window", userWindow.titleText)
-      userWindow:setTitle("Renamed")
+      assert.is_true(userWindow:setTitle("Renamed"))
       assert.are.equal("Renamed", userWindow.titleText)
-      userWindow:resetTitle()
+      assert.is_true(userWindow:resetTitle())
       assert.are.equal("", userWindow.titleText)
     end)
 
@@ -274,9 +331,30 @@ describe("Tests functionality of Geyser.UserWindow", function()
 
   pending("Geyser.UserWindow:setStyleSheet applies the stylesheet to the dock - needs a getUserWindowStyleSheet getter")
 
-  pending("Geyser.UserWindow scrollBar constraint shows the console's scroll bar - scroll bar visibility is not readable from Lua, needs a scroll bar getter")
+  pending("Geyser.UserWindow scrollBar constraint puts a scroll bar on screen - the wrap it leaves room for is covered above, but the scroll bar's own visibility is not readable from Lua and needs a scroll bar getter")
 
-  pending("Geyser.UserWindow:setDockPosition/enableAutoDock/disableAutoDock - which edge a user window is docked to, and whether it docks by itself, are not readable from Lua")
+  describe("Geyser.UserWindow:enableAutoDock/disableAutoDock", function()
+    it("turns automatic docking off and on again without disturbing the window", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwAutoDock", x = 10, y = 20, width = 300, height = 200}))
+      assert.is_true(userWindow:disableAutoDock())
+      assert.is_false(userWindow.autoDock)
+      -- both of these reopen the window, so the dock must survive them intact
+      assert.is_true(windowVisible("guwAutoDock"))
+      assert.are.same({x = 10, y = 20, width = 300, height = 200}, geometry("guwAutoDock"))
+      assert.is_true(userWindow:enableAutoDock())
+      assert.is_true(userWindow.autoDock)
+      assert.is_true(windowVisible("guwAutoDock"))
+      assert.are.same({x = 10, y = 20, width = 300, height = 200}, geometry("guwAutoDock"))
+    end)
+  end)
+
+  pending("Geyser.UserWindow:setDockPosition - which edge a user window ended up docked to, and whether it docks by itself when dragged, are not readable from Lua")
+
+  -- restoreLayout = true makes the constructor reopen the window from the
+  -- layout saved in the profile and skip the move/resize it was given. Running
+  -- that here would write this file's window layouts into the shared self-test
+  -- profile, so repeat runs against the same profile would stop matching.
+  pending("Geyser.UserWindow restoreLayout reopens the window where it was last left")
 
   describe("Geyser.UserWindow:delete", function()
     it("closes the dock and unregisters the user window", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Adds the four Geyser per-class spec files - `GeyserCommandLine_spec.lua`, `GeyserUserWindow_spec.lua`, `GeyserMapper_spec.lua` and `GeyserScrollBox_spec.lua` - covering the widget classes that had no spec home, in the same one-spec-per-class layout as the existing Geyser specs.
- 83 specs over 15 testability-checklist rows, asserting real widget state through `windowType`/`windowVisible`/`getWindowGeometry`/`getUserWindowSize`/`getCmdLine` and the map widget's own return values, not just that a call did not error.
- 17 pendings. Six wait on getters a sibling PR is adding right now (`getUserWindowTitle`, `getUserWindowStyleSheet`, `getMapWindowTitle`, `getCmdLineStyleSheet`, a user window scroll bar getter, a command line selection getter) and will flip in a small follow-up; the rest are functional-only surface or defects found on the way, named rather than frozen into a passing assertion.

#### Motivation for adding to Mudlet

These four classes had no coverage at all: `UI_spec` exercised only the raw `createCommandLine`/`createScrollBox`/`openUserWindow` primitives underneath them, so every Geyser wrapper on top was untested. Writing the specs turned up four defects, each left pending with the cause named: a scroll box built inside a hidden `add2` container comes up visible because `Geyser.ScrollBox:new` is the one widget constructor that never re-hides itself; `Geyser.UserWindow:show()` drops the `auto` flag, so a hidden user window reappears when its container is shown; deleting a user window leaks the `<name>Container` root container Geyser made for it; and `selectCmdLineText` returns the window name instead of a result.

#### Other info (issues closed, discussion etc)

`GeyserMapper_spec` is now the first file alphabetically to open the map widget, which is a one way door for a profile. Nothing fails, but `Mapper_spec`'s opening block loses its "registered before the widget was opened" premise; the header comment records this, and restoring that coverage means moving the block into an earlier sorting file, which is out of scope here.

**Test case:** full busted suite 1912 successes / 0 failures / 0 errors / 34 pending (from 1829/0/0/17), identical across three runs on one profile plus a fresh one; seven sabotage rounds breaking the geyser methods under test failed 41 of the 83 new specs.

Assisted-by: Claude:claude-opus-5
