### PR TITLE
improve: credit seven more contributors in the About Mudlet dialog

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -177,6 +177,11 @@ void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
                         //: about:Leris
                         tr("Does a ton of work in making Mudlet, the website and the wiki accessible to you "
                            "regardless of the language you speak - and promoting our genre!")});
+    aboutMakers.append({true, qsl("Piotr Wilczynski"), QString(), qsl("Delwing"), qsl("delwing@gmail.com"),
+                        //: about:Delwing
+                        tr("Joined in 2020, reworking much of the 2D mapper and adding many Lua API features. "
+                           "Outside the client they build Mudlet Web, the documentation extract that powers "
+                           "autocompletion in code editors, and the tools that share Mudlet maps online.")});
     aboutMakers.append({false, qsl("Ahmed Charles"), QString(), qsl("ahmedcharles"), qsl("acharles@outlook.com"),
                         //: about:ahmedcharles
                         tr("Contributions to the Travis integration, CMake and Visual C++ build, "

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -182,6 +182,11 @@ void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
                         tr("Joined in 2020, reworking much of the 2D mapper and adding many Lua API features. "
                            "Outside the client they build Mudlet Web, the documentation extract that powers "
                            "autocompletion in code editors, and the tools that share Mudlet maps online.")});
+    aboutMakers.append({true, qsl("Zooka"), QString(), qsl("ZookaOnGit"), QString(),
+                        //: about:Zooka
+                        tr("Joined in 2023 and works across the whole client - script editor, preferences, package manager "
+                           "and mapper - along with many Lua API additions. Wrote the Mudlet Tutorial profile and "
+                           "maintains the Mudlet package repository.")});
     aboutMakers.append({false, qsl("Ahmed Charles"), QString(), qsl("ahmedcharles"), qsl("acharles@outlook.com"),
                         //: about:ahmedcharles
                         tr("Contributions to the Travis integration, CMake and Visual C++ build, "

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -216,6 +216,10 @@ void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
     aboutMakers.append({false, qsl("Erik Pettis"), qsl("Etomyutikos#9266"), qsl("Oneymus"), QString(),
                         //: about:Oneymus
                         tr("Developed the Vyzor GUI Manager for Mudlet.")});
+    aboutMakers.append({false, qsl("Harrison"), QString(), qsl("Harrison-Teeg"), qsl("harrison.martin@gmail.com"),
+                        //: about:Harrison
+                        tr("Brought the 3D mapper back to life with camera controls, lighting and proper geometry "
+                           "for z-squished rooms, and has fixed a number of console and command line annoyances.")});
     aboutMakers.append({false, qsl("ItsTheFae"), qsl("TheFae#9971"), qsl("Kae"), QString(),
                         //: about:TheFae
                         tr("Worked wonders in rejuvenating our Website in 2017 but who prefers a little anonymity - "
@@ -231,6 +235,10 @@ void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
     aboutMakers.append({false, qsl("John Dahlström"), QString(), QString(), qsl("email@johndahlstrom.se"),
                         //: about:John Dahlström
                         tr("Helped develop and debug the Lua API.")});
+    aboutMakers.append({false, qsl("John McKisson"), QString(), qsl("jmckisson"), qsl("john.mckisson@gmail.com"),
+                        //: about:John McKisson
+                        tr("Implemented MMCP, so Mudlet can join MudMaster chat networks, and has contributed "
+                           "a range of console and Lua API fixes.")});
     aboutMakers.append({false, qsl("Karsten Bock"), QString(), qsl("Beliaar"), QString(),
                         //: about:Beliaar
                         tr("Contributed several improvements and new features for Geyser.")});
@@ -240,6 +248,16 @@ void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
     aboutMakers.append({false, qsl("Maksym Grinenko"), QString(), QString(), qsl("maksym.grinenko@gmail.com"),
                         //: about:Maksym Grinenko
                         tr("Worked on the manual, forum help and helps with GUI design and documentation.")});
+    aboutMakers.append({false, qsl("Manuel Wegmann"), QString(), qsl("Edru2"), QString(),
+                        //: about:Edru2
+                        tr("Built much of the GUI toolkit you script with between 2020 and 2022: Adjustable Containers, "
+                           "Geyser's ScrollBox, animated labels and Geyser in UserWindows - plus the dark theme toggle "
+                           "and the Package Exporter rework.")});
+    aboutMakers.append({false, qsl("Mike Conley"), QString(), qsl("mpconley"), qsl("sousesider@gmail.com"),
+                        //: about:Mike Conley
+                        tr("Joined in 2018 and looks after nearly everything Mudlet plays or negotiates - MCMP media, "
+                           "sound and video, closed captioning, MXP, OSC 8 hyperlinks and text encodings - plus "
+                           "multi-window support with drag-and-drop tabs.")});
     aboutMakers.append({false, qsl("Stephen Hansen"), QString(), QString(), qsl("me+mudlet@ixokai.io"),
                         //: about:Stephen Hansen
                         tr("Developed a database Lua API that allows for far easier use of databases and one of the original OSX installers.")});
@@ -247,6 +265,10 @@ void dlgAboutDialog::setAboutTab(const QString& htmlHead) const
                         //: about:Thorsten Wilms
                         tr("Designed our beautiful logo, our splash screen, the about dialog, our website, several icons and badges. "
                            "Visit his homepage at <a href=\"http://thorwil.wordpress.com/\">thorwil.wordpress.com</a>.")});
+    aboutMakers.append({false, qsl("Tim Johnson"), QString(), qsl("atari2600tim"), QString(),
+                        //: about:Tim Johnson
+                        tr("Joined in 2020 and made Mudlet work far better with screen readers, alongside secure IRC "
+                           "connections, Discord improvements, and a batch of editor shortcuts and Lua configuration functions.")});
 
     QString aboutMudletBody("<p align=\"center\"><big><b>Credits:</b></big></p>");
     QVectorIterator<aboutMaker> iterateMakers(aboutMakers);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Adds seven contributors to the credits list in Help -> About Mudlet: Delwing, Zooka, Mike Conley, Edru2, Tim Johnson, Harrison and John McKisson
- Delwing and Zooka join the highlighted group; the rest slot into the alphabetical list below it
- Descriptions are sized in line with the existing entries

#### Motivation for adding to Mudlet
Several of Mudlet's most prolific contributors were entirely uncredited - between them they account for most of today's 2D mapper, the media/MXP/encoding stack, the Geyser GUI toolkit, the script editor and preferences, the 3D mapper revival, MMCP, and Mudlet's screen reader support. Delwing and Zooka also build and maintain Mudlet Web and the package repository respectively.

#### Other info (issues closed, discussion etc)
- Pronouns are not stated publicly for any of the seven, so the entries avoid gendered wording.
- Emails are only listed where the contributor commits publicly with a real address; those using GitHub noreply addresses are credited by handle alone.

**Test case:** Open Help -> About Mudlet and confirm the seven new entries render in place, with GitHub handle and email links coloured like the rest.

Assisted-by: Claude:claude-opus-5