### PR TITLE
Fix: don't replay a sign-in token the game already rejected

### DIFF
--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -626,17 +626,14 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
     QPointer<CredentialManager> credentialManager = new CredentialManager();
     const auto attemptGeneration = mAuthAttemptGeneration;
     // Capture the per-connection facts this recovery needs before awaiting the keychain: a
-    // Char.Login.Default arriving while the read is in flight - a server re-offering sign-in on this
-    // connection, or the next connection - resets mConn, and comparing against a cleared hash would
-    // mistake another instance's freshly rotated token for a dead one.
+    // Char.Login.Default arriving while the read is in flight resets mConn, and the callback would then
+    // have no hash to recognise the rejected token by and no account or provider to keep a resume hint
+    // from - silently downgrading the drop below into discarding the whole entry.
     const auto sentTokenHash = mConn.sentReconnectTokenHash;
     const auto retriedRotatedToken = mConn.retriedRotatedToken;
     const auto reconnectAccount = mConn.reconnectAccount;
     const auto accountProvider = mConn.accountProvider;
-    // Latch the rejection now, synchronously, rather than when the read returns: whichever
-    // Char.Login.Default comes next must not replay the token that was just rejected - Char.Login 2
-    // forbids replaying a token rejected on the same connection - and the store rewrite below has not
-    // necessarily landed by then.
+    // Latch synchronously rather than when the read returns; see mReconnectRejected's declaration.
     mReconnectRejected = true;
     credentialManager->retrievePassword(
             mpHost->getName(),
@@ -649,9 +646,8 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                     return;
                 }
                 // A newer sign-in attempt began while the read was in flight; it owns the connection now, so
-                // this recovery must not send anything or reconnect. The stored entry still has to be put
-                // right, though, so the decision below - rotated by another instance, or genuinely dead - is
-                // made either way, and only the parts that drive the connection are skipped.
+                // this recovery must not send anything or reconnect. It may still rewrite the stored entry,
+                // but only on positive evidence that the rejected token is the one stored - see the drop below.
                 const bool superseded = (attemptGeneration != mAuthAttemptGeneration);
                 // A read failure (locked/denied/timed-out keychain) is not "no token": log it so a dropped
                 // token that was actually unreadable can be told apart from a genuinely dead one. The recovery
@@ -660,8 +656,6 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                     qWarning().noquote() << "GMCP Char.Login - could not read the stored sign-in while recovering a rejected token:" << errorMessage;
                 }
 
-                // Whether this read positively saw the token this connection sent still stored. A superseded
-                // recovery may only rewrite the entry on that evidence - see the drop below.
                 bool rejectedTokenStillStored = false;
 
                 // Shared-store rotation check: if the stored token no longer hashes to what this connection
@@ -705,8 +699,9 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                                 sendReconnect(account, std::move(token));
                                 return;
                             }
-                            // Both branches above return, so reaching here means the stored token still
-                            // hashes to the one this connection sent: a genuinely dead token, not a rotation.
+                            // Both branches above return, so reaching here means the stored token is not a
+                            // rotation. That only counts as evidence the rejected token is still stored when
+                            // this connection recorded what it sent; with no hash there is nothing to match.
                             rejectedTokenStillStored = !sentTokenHash.isEmpty();
                         }
                         // Catch-all: scrub the parsed token on every path that did not move it into
@@ -729,6 +724,12 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                 // if that attempt never completes, the next connection's rejection runs this recovery again
                 // un-superseded and drops it then.
                 if (superseded && !rejectedTokenStillStored) {
+                    // Leaving the rejected token stored means re-arming the latch. The Char.Login.Default
+                    // that superseded this recovery already consumed it in attemptReconnect(), so without
+                    // this the *next* Char.Login.Default would be free to replay a token the server has
+                    // already rejected - the very thing this whole path exists to prevent. Costs at most one
+                    // extra resume on the connection after that.
+                    mReconnectRejected = true;
                     return;
                 }
                 // The token really is dead. Keep the account+provider resume hint (dropping only the token) so

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -660,6 +660,10 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                     qWarning().noquote() << "GMCP Char.Login - could not read the stored sign-in while recovering a rejected token:" << errorMessage;
                 }
 
+                // Whether this read positively saw the token this connection sent still stored. A superseded
+                // recovery may only rewrite the entry on that evidence - see the drop below.
+                bool rejectedTokenStillStored = false;
+
                 // Shared-store rotation check: if the stored token no longer hashes to what this connection
                 // sent, another running instance rotated it (single-use) - replay the fresh one once, rather
                 // than discarding its token. A rejection whose stored token still matches (a genuinely dead
@@ -701,6 +705,9 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                                 sendReconnect(account, std::move(token));
                                 return;
                             }
+                            // Both branches above return, so reaching here means the stored token still
+                            // hashes to the one this connection sent: a genuinely dead token, not a rotation.
+                            rejectedTokenStillStored = !sentTokenHash.isEmpty();
                         }
                         // Catch-all: scrub the parsed token on every path that did not move it into
                         // sendReconnect - including a stored entry with a token but an empty account - so a
@@ -713,6 +720,17 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                 // block above already cleared it.
                 SecureStringUtils::secureStringClear(value);
 
+                // A superseded recovery rewrites the entry only when this read positively saw the rejected
+                // token still stored. Without that evidence - a failed read, an entry that never parsed, or a
+                // second rejection after a rotation replay - the newer attempt may already have saved its own
+                // fresh token (its Char.Login.Token can land while this read is in flight), and a token-less
+                // rewrite here would erase it and force another browser sign-in. Leaving the entry alone is
+                // self-correcting instead: the latch keeps the newer attempt from replaying a dead token, and
+                // if that attempt never completes, the next connection's rejection runs this recovery again
+                // un-superseded and drops it then.
+                if (superseded && !rejectedTokenStillStored) {
+                    return;
+                }
                 // The token really is dead. Keep the account+provider resume hint (dropping only the token) so
                 // the next attempt restarts the same provider's browser sign-in with no menu. The captured
                 // account and provider are used rather than mConn's, which a newer Char.Login.Default may have

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -625,91 +625,125 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
     QPointer<Host> safeHost = mpHost;
     QPointer<CredentialManager> credentialManager = new CredentialManager();
     const auto attemptGeneration = mAuthAttemptGeneration;
-    credentialManager->retrievePassword(mpHost->getName(), qsl("reconnect"), [this, safeHost, credentialManager, attemptGeneration](bool success, QString value, const QString& errorMessage) {
-        if (credentialManager) {
-            credentialManager->deleteLater();
-        }
-        if (!safeHost) {
-            return;
-        }
-        if (attemptGeneration != mAuthAttemptGeneration) {
-            return;
-        }
-        // A read failure (locked/denied/timed-out keychain) is not "no token": log it so a dropped
-        // token that was actually unreadable can be told apart from a genuinely dead one. The recovery
-        // below still proceeds - a fresh sign-in is the safe outcome either way.
-        if (!success) {
-            qWarning().noquote() << "GMCP Char.Login - could not read the stored sign-in while recovering a rejected token:" << errorMessage;
-        }
+    // Capture the per-connection facts this recovery needs before awaiting the keychain: a
+    // Char.Login.Default arriving while the read is in flight - a server re-offering sign-in on this
+    // connection, or the next connection - resets mConn, and comparing against a cleared hash would
+    // mistake another instance's freshly rotated token for a dead one.
+    const auto sentTokenHash = mConn.sentReconnectTokenHash;
+    const auto retriedRotatedToken = mConn.retriedRotatedToken;
+    const auto reconnectAccount = mConn.reconnectAccount;
+    const auto accountProvider = mConn.accountProvider;
+    // Latch the rejection now, synchronously, rather than when the read returns: whichever
+    // Char.Login.Default comes next must not replay the token that was just rejected - Char.Login 2
+    // forbids replaying a token rejected on the same connection - and the store rewrite below has not
+    // necessarily landed by then.
+    mReconnectRejected = true;
+    credentialManager->retrievePassword(
+            mpHost->getName(),
+            qsl("reconnect"),
+            [this, safeHost, credentialManager, attemptGeneration, sentTokenHash, retriedRotatedToken, reconnectAccount, accountProvider](bool success, QString value, const QString& errorMessage) {
+                if (credentialManager) {
+                    credentialManager->deleteLater();
+                }
+                if (!safeHost) {
+                    return;
+                }
+                // A newer sign-in attempt began while the read was in flight; it owns the connection now, so
+                // this recovery must not send anything or reconnect. The stored entry still has to be put
+                // right, though, so the decision below - rotated by another instance, or genuinely dead - is
+                // made either way, and only the parts that drive the connection are skipped.
+                const bool superseded = (attemptGeneration != mAuthAttemptGeneration);
+                // A read failure (locked/denied/timed-out keychain) is not "no token": log it so a dropped
+                // token that was actually unreadable can be told apart from a genuinely dead one. The recovery
+                // below still proceeds - a fresh sign-in is the safe outcome either way.
+                if (!success) {
+                    qWarning().noquote() << "GMCP Char.Login - could not read the stored sign-in while recovering a rejected token:" << errorMessage;
+                }
 
-        // Shared-store rotation check: if the stored token no longer hashes to what this connection
-        // sent, another running instance rotated it (single-use) - replay the fresh one once, rather
-        // than discarding its token. A rejection whose stored token still matches (a genuinely dead
-        // token, or a non-rotation rejection) falls through to drop-and-re-sign-in below.
-        if (!mConn.retriedRotatedToken && success && !value.isEmpty()) {
-            // The stored JSON may hold a bearer token; parse from an owned buffer and scrub every owned
-            // copy - the QByteArray and the QString value (retrievePassword moved it in) - on all paths,
-            // including a corrupt entry that never parses.
-            QByteArray valueBytes = value.toUtf8();
-            const auto doc = QJsonDocument::fromJson(valueBytes);
-            SecureStringUtils::secureByteArrayClear(valueBytes);
-            SecureStringUtils::secureStringClear(value);
-            if (doc.isObject()) {
-                const auto account = doc.object()[qsl("account")].toString();
-                auto token = doc.object()[qsl("token")].toString();
-                if (!account.isEmpty() && !token.isEmpty()) {
-                    QByteArray tokenBytes = token.toUtf8();
-                    const QByteArray storedHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
-                    SecureStringUtils::secureByteArrayClear(tokenBytes);
-                    if (!mConn.sentReconnectTokenHash.isEmpty() && storedHash != mConn.sentReconnectTokenHash) {
+                // Shared-store rotation check: if the stored token no longer hashes to what this connection
+                // sent, another running instance rotated it (single-use) - replay the fresh one once, rather
+                // than discarding its token. A rejection whose stored token still matches (a genuinely dead
+                // token, or a non-rotation rejection) falls through to drop-and-re-sign-in below.
+                if (!retriedRotatedToken && success && !value.isEmpty()) {
+                    // The stored JSON may hold a bearer token; parse from an owned buffer and scrub every owned
+                    // copy - the QByteArray and the QString value (retrievePassword moved it in) - on all paths,
+                    // including a corrupt entry that never parses.
+                    QByteArray valueBytes = value.toUtf8();
+                    const auto doc = QJsonDocument::fromJson(valueBytes);
+                    SecureStringUtils::secureByteArrayClear(valueBytes);
+                    SecureStringUtils::secureStringClear(value);
+                    if (doc.isObject()) {
+                        const auto account = doc.object()[qsl("account")].toString();
+                        auto token = doc.object()[qsl("token")].toString();
+                        if (!account.isEmpty() && !token.isEmpty()) {
+                            QByteArray tokenBytes = token.toUtf8();
+                            const QByteArray storedHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
+                            SecureStringUtils::secureByteArrayClear(tokenBytes);
+                            if (!sentTokenHash.isEmpty() && storedHash != sentTokenHash) {
+                                if (superseded) {
+                                    // The newer attempt reads the store for itself, so leave the other
+                                    // instance's fresh token in place and let it decide.
+                                    SecureStringUtils::secureStringClear(token);
+                                    return;
+                                }
 #if defined(DEBUG_GMCP_AUTHENTICATION)
-                        qDebug() << "GMCP reconnect token was rotated by another instance; replaying the fresh token";
+                                qDebug() << "GMCP reconnect token was rotated by another instance; replaying the fresh token";
 #endif
-                        mConn.retriedRotatedToken = true;
-                        mConn.sentReconnectTokenHash = storedHash;
-                        mConn.reconnectingWithToken = true;
-                        mConn.awaitingReconnectResult = true;
-                        mConn.reconnectAccount = account;
-                        sendReconnect(account, std::move(token));
-                        return;
+                                mConn.retriedRotatedToken = true;
+                                mConn.sentReconnectTokenHash = storedHash;
+                                mConn.reconnectingWithToken = true;
+                                mConn.awaitingReconnectResult = true;
+                                mConn.reconnectAccount = account;
+                                // This attempt is replaying a live token rather than recovering from a dead
+                                // one, so release the latch: the next Char.Login.Default is an ordinary
+                                // sign-in again and may use a stored token.
+                                mReconnectRejected = false;
+                                sendReconnect(account, std::move(token));
+                                return;
+                            }
+                        }
+                        // Catch-all: scrub the parsed token on every path that did not move it into
+                        // sendReconnect - including a stored entry with a token but an empty account - so a
+                        // bearer secret is never dropped un-zeroed. Mirrors readStoredSignIn.
+                        SecureStringUtils::secureStringClear(token);
                     }
                 }
-                // Catch-all: scrub the parsed token on every path that did not move it into
-                // sendReconnect - including a stored entry with a token but an empty account - so a
-                // bearer secret is never dropped un-zeroed. Mirrors readStoredSignIn.
-                SecureStringUtils::secureStringClear(token);
-            }
-        }
-        // Scrub the retrieved store copy on the fall-through too: when the rotation block was skipped
-        // (a second rejection, or an empty read) value may still hold token JSON. Idempotent when the
-        // block above already cleared it.
-        SecureStringUtils::secureStringClear(value);
+                // Scrub the retrieved store copy on the fall-through too: when the rotation block was skipped
+                // (a second rejection, or an empty read) value may still hold token JSON. Idempotent when the
+                // block above already cleared it.
+                SecureStringUtils::secureStringClear(value);
 
-        // The token really is dead. Keep the account+provider resume hint (dropping only the token) so
-        // the next attempt restarts the same provider's browser sign-in with no menu, then reconnect:
-        // servers commonly drop the connection right after rejecting a reconnect, so the fresh sign-in
-        // needs a fresh, stable connection. mReconnectRejected makes that next connection read the entry
-        // without replaying a possibly not-yet-rewritten token.
-        dropTokenKeepResumeHint();
-        mReconnectRejected = true;
-        //: Shown when a saved password-less sign-in is no longer accepted; Mudlet reconnects so the user can sign in again.
-        mpHost->postMessage(tr("[ INFO ]  - Your saved sign-in has expired; reconnecting so you can sign in again."));
-        QTimer::singleShot(0ms, mpHost, [safeHost]() {
-            if (safeHost) {
-                safeHost->mTelnet.reconnect();
-            }
-        });
-    });
+                // The token really is dead. Keep the account+provider resume hint (dropping only the token) so
+                // the next attempt restarts the same provider's browser sign-in with no menu. The captured
+                // account and provider are used rather than mConn's, which a newer Char.Login.Default may have
+                // cleared - that would silently downgrade this to discarding the whole entry.
+                dropTokenKeepResumeHint(reconnectAccount, accountProvider);
+                if (superseded) {
+                    // A newer attempt is already driving the sign-in; it consumes the latch set above and
+                    // resumes (or hands off) without the dead token, so there is nothing left to do here.
+                    return;
+                }
+                // Reconnect: servers commonly drop the connection right after rejecting a reconnect, so the
+                // fresh sign-in needs a fresh, stable connection. The latch set above makes that next
+                // connection read the entry without replaying a possibly not-yet-rewritten token.
+                //: Shown when a saved password-less sign-in is no longer accepted; Mudlet reconnects so the user can sign in again.
+                mpHost->postMessage(tr("[ INFO ]  - Your saved sign-in has expired; reconnecting so you can sign in again."));
+                QTimer::singleShot(0ms, mpHost, [safeHost]() {
+                    if (safeHost) {
+                        safeHost->mTelnet.reconnect();
+                    }
+                });
+            });
 }
 
-void GMCPAuthenticator::dropTokenKeepResumeHint()
+void GMCPAuthenticator::dropTokenKeepResumeHint(const QString& account, const QString& provider)
 {
     // Without a remembered provider there is nothing to resume, so remove the whole entry.
-    if (mConn.reconnectAccount.isEmpty() || mConn.accountProvider.isEmpty()) {
+    if (account.isEmpty() || provider.isEmpty()) {
         discardReconnectToken();
         return;
     }
-    storeResumeHint(mConn.reconnectAccount, mConn.accountProvider);
+    storeResumeHint(account, provider);
 }
 
 // controller for GMCP authentication

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -82,7 +82,9 @@ private:
     // replayed once instead of destroyed. Only a genuinely dead token is dropped, keeping the
     // account+provider resume hint so the next sign-in needs no provider menu.
     void retryOrDropRejectedToken();
-    void dropTokenKeepResumeHint();
+    // Takes the account and provider explicitly: the caller captures them before its keychain read, so
+    // a Char.Login.Default arriving mid-read cannot clear mConn and turn this into a full discard.
+    void dropTokenKeepResumeHint(const QString& account, const QString& provider);
     // Rewrites the stored entry as {account, provider} with no token: enough to resume later, nothing
     // any longer a bearer secret.
     void storeResumeHint(const QString& account, const QString& provider);
@@ -144,11 +146,14 @@ private:
     };
     PerConnectionState mConn;
 
-    // Set when a reconnect token is rejected and we reconnect for a clean sign-in. Deliberately NOT part
-    // of mConn: it is a one-shot latch consumed by attemptReconnect() on the very next connection, so it
-    // must survive the per-connection reset that the reconnect it triggers performs. The saved token is
-    // cleared asynchronously, so this makes that next connection skip a token replay rather than racing
-    // the keychain rewrite and looping back into another rejected reconnect.
+    // Set when a reconnect token is rejected, before the keychain read that decides what to do about it.
+    // Deliberately NOT part of mConn: it is a one-shot latch consumed by attemptReconnect() on the next
+    // Char.Login.Default, so it must survive the per-connection reset that Default performs. The saved
+    // token is cleared asynchronously, so this makes the next attempt skip a token replay rather than
+    // racing the keychain rewrite and looping back into another rejected reconnect. That next Default
+    // usually arrives on the connection we reconnect to, but a server is also permitted to re-offer one
+    // on this connection instead, and Char.Login 2 forbids replaying a token rejected on it - hence
+    // latching synchronously at the rejection rather than when the read returns.
     bool mReconnectRejected = false;
     // Incremented on every per-connection auth reset (each Char.Login.Default). The asynchronous
     // reconnect-token keychain read captures the value current when it started and re-checks it in its

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -147,13 +147,18 @@ private:
     PerConnectionState mConn;
 
     // Set when a reconnect token is rejected, before the keychain read that decides what to do about it.
-    // Deliberately NOT part of mConn: it is a one-shot latch consumed by attemptReconnect() on the next
-    // Char.Login.Default, so it must survive the per-connection reset that Default performs. The saved
-    // token is cleared asynchronously, so this makes the next attempt skip a token replay rather than
-    // racing the keychain rewrite and looping back into another rejected reconnect. That next Default
-    // usually arrives on the connection we reconnect to, but a server is also permitted to re-offer one
-    // on this connection instead, and Char.Login 2 forbids replaying a token rejected on it - hence
-    // latching synchronously at the rejection rather than when the read returns.
+    // Deliberately NOT part of mConn: attemptReconnect() consumes it on the next Char.Login.Default, so it
+    // must survive the per-connection reset that Default performs. The saved token is cleared
+    // asynchronously, so this makes the next attempt skip a token replay rather than racing the keychain
+    // rewrite and looping back into another rejected reconnect. That next Default usually arrives on the
+    // connection we reconnect to, but a server is also permitted to re-offer one on this connection
+    // instead, and Char.Login 2 forbids replaying a token rejected on it - hence latching synchronously at
+    // the rejection rather than when the read returns.
+    //
+    // Consumed in one place (attemptReconnect()) but cleared or re-armed in two others, so audit all three
+    // together: retryOrDropRejectedToken() clears it when it replays a live rotated token, and re-arms it
+    // when a superseded recovery leaves the rejected token stored - by then the superseding Default has
+    // already consumed the latch, so without re-arming the Default after that could replay the dead token.
     bool mReconnectRejected = false;
     // Incremented on every per-connection auth reset (each Char.Login.Default). The asynchronous
     // reconnect-token keychain read captures the value current when it started and re-checks it in its

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -530,6 +530,41 @@ private slots:
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
     }
 
+    void testRotationReplayClearsTheRejectionLatch()
+    {
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+        const QString tokenJson = qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-A\"}");
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), tokenJson));
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "client did not replay the saved token");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-A"));
+
+        // Another instance rotates the token, so our replay of token-A is rejected and the client replays
+        // the fresh token-B rather than discarding it.
+        const QString rotatedJson = qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-B\"}");
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), rotatedJson));
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Reconnect token expired\"}"));
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "client did not replay the rotated token");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-B"));
+
+        // Replaying a rotated token is an ordinary sign-in, not a recovery from a dead one, so the
+        // rejection latch must have been released again: a following Char.Login.Default may replay the
+        // stored token. Were the latch left set, this would come back as the token-less resume form and
+        // the player would face a browser sign-in despite holding a good token.
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "the rejection latch leaked past the rotation replay");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-B"));
+        QCOMPARE(mpServer->countReceived(qsl("Char.Login.Credentials")), 0);
+    }
+
     void testCorruptStoredEntryFallsThroughToHandoff()
     {
         Host* host = connectAndNegotiate();
@@ -660,14 +695,18 @@ private slots:
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
     }
 
-    // NOTE: the stale-callback (mAuthAttemptGeneration) guard in readStoredSignIn/retryOrDropRejectedToken
-    // - which drops a reconnect-token keychain read whose connection was superseded by a newer
-    // Char.Login.Default before the async read resolved - is intentionally NOT covered here. It is not
-    // deterministically testable with the current harness: in test/portable mode CredentialManager reads
-    // credentials synchronously and inline (see CredentialManager::retrievePassword), so a read always
-    // completes before any superseding Char.Login.Default can arrive, and the guarded race never occurs.
-    // Exercising it would require an injectable, genuinely-asynchronous credential manager. Documented
-    // rather than covered by a test that would pass without ever reaching the guard.
+    // NOTE: the superseded-callback (mAuthAttemptGeneration) path in readStoredSignIn and
+    // retryOrDropRejectedToken - taken when a newer Char.Login.Default arrives before the reconnect-token
+    // keychain read resolves - is intentionally NOT covered here. It is not deterministically testable
+    // with the current harness: in test/portable mode CredentialManager reads credentials synchronously
+    // and inline (see CredentialManager::retrievePassword), so a read always completes before any
+    // superseding Char.Login.Default can arrive, and the race never occurs. Exercising it would require an
+    // injectable, genuinely-asynchronous credential manager.
+    //
+    // Worth the seam if anyone revisits this: in readStoredSignIn the path is a bare early return, but in
+    // retryOrDropRejectedToken it decides whether to rewrite the stored entry and whether to re-arm
+    // mReconnectRejected. Getting either wrong loses a player's freshly saved token or lets a rejected one
+    // be replayed, and neither failure is reachable by hand.
 
     // ---- Char.Login.Result --------------------------------------------------
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Latch the "this token was rejected" flag synchronously at the rejection, instead of when the asynchronous keychain read returns, so a `Char.Login.Default` arriving mid-read cannot replay the just-rejected token.
- Capture the per-connection facts the recovery needs (sent-token hash, rotation-retry flag, account, provider) before awaiting the read, so a `mConn` reset mid-read cannot corrupt the rotated-vs-dead decision or downgrade the resume hint into a full discard.
- Replace the stale-generation early return with a `superseded` flag: the stored entry is always put right, and only the parts that drive the connection are skipped.

#### Motivation for adding to Mudlet

This is in response to [questions](https://discord.com/channels/279748146316312576/1393998251786768384/1534048607051841597) from @RahjIII on the MUD/coding/MUDstandards thread on Discord.

The GMCP Char.Login 2 standard forbids a client from replaying a reconnect token that was rejected on the same connection, and in this race Mudlet did exactly that - then also left the dead token sitting in the keychain, so the next connection could loop on it.

#### Other info (issues closed, discussion etc)

Part of the Char.Login 2 authentication work in #9354.

The race needs a `Char.Login.Default` to arrive while the keychain read is in flight. That happens either when a server holds the connection open and re-offers sign-in after rejecting a token - behaviour the spec is being extended to permit - or, against a server that closes the connection instead, on the next connection after Mudlet's own recovery reconnect.

Out of scope, noted here because it turned up during testing: on the recovery reconnect the browser is not auto-opened, only the sign-in link is printed. That is the pre-existing `Host::userSentInputThisConnection()` guard in `GMCPAuthenticator::handleAuthUrl()`, which `cTelnet` clears on every new connection so a misbehaving server cannot pop a browser at an idle player. Since the recovery reconnect is client-initiated, the flag is false when `Char.Login.URL` arrives. Unchanged by this PR.

**Test case:** Sign in to a Char.Login 2 server (StickMUD) via OAuth so a reconnect token is saved; confirm a later connect signs in silently. Invalidate the token server-side (`logout everywhere` on StickMUD), then reconnect. Expect: "Your saved sign-in has expired; reconnecting so you can sign in again", a single reconnect, and the same provider's sign-in resumed with no provider menu - not a repeated expiry loop, and not a provider menu.