### PR TITLE
fix: stop the telnet reader writing a NUL past the data it was given

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -5050,17 +5050,11 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (3 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char out_buffer[BUFFER_SIZE + 10];
 
-    in_buffer[amount + 1] = '\0';
-
-    if (amount == -1) {
+    if (amount == -1 || amount == 0) {
         --mDecompressionRecursionDepth;
         return;
     }
-
-    if (amount == 0) {
-        --mDecompressionRecursionDepth;
-        return;
-    }
+    in_buffer[amount] = '\0';
 
     std::string cleandata;
     // Pre-allocate for worst case: decompressed data can be much larger than input

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -5050,10 +5050,16 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (3 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char out_buffer[BUFFER_SIZE + 10];
 
-    if (amount == -1 || amount == 0) {
+    // read() reports -1 on error and 0 when nothing was available; loopbackTest()
+    // narrows a qsizetype into this int, so treat every non-positive value the
+    // same rather than testing for -1 exactly. Terminating before this point is
+    // what wrote a NUL outside the caller's buffer - see issue #1065.
+    if (amount <= 0) {
         --mDecompressionRecursionDepth;
         return;
     }
+    // Restates the input contract for decompressBuffer() below, which may swap
+    // `buffer` over to out_buffer before the terminator is written again.
     in_buffer[amount] = '\0';
 
     std::string cleandata;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -167,9 +167,6 @@ const char NEW_ENVIRON_USERVAR = 3;
 class cTelnet : public QObject
 {
     Q_OBJECT
-    // Needs to call processSocketData() with a buffer it laid out itself, which
-    // the public loopbackTest() cannot express - see issue #1065.
-    friend class cTelnetBufferTest;
 
 public:
     Q_DISABLE_COPY(cTelnet)
@@ -327,6 +324,10 @@ private:
     // Lets the functional test drive the real download entry point and inspect
     // the in-flight reply, reproducing the dialog-swap cancellation cascade.
     friend class TelnetTlsPromptTest;
+
+    // Needs to call processSocketData() with a buffer it laid out itself, which
+    // the public loopbackTest() cannot express - see issue #1065.
+    friend class cTelnetBufferTest;
 
 #if defined(QT_NO_SSL)
     void abortLosingSocket(QTcpSocket* losingSocket);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -167,6 +167,9 @@ const char NEW_ENVIRON_USERVAR = 3;
 class cTelnet : public QObject
 {
     Q_OBJECT
+    // Needs to call processSocketData() with a buffer it laid out itself, which
+    // the public loopbackTest() cannot express - see issue #1065.
+    friend class cTelnetBufferTest;
 
 public:
     Q_DISABLE_COPY(cTelnet)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TelnetSgrDefaultColorTest.cpp
     TelnetTlsPromptTest.cpp
     TelnetBenchmark.cpp
+    cTelnetBufferTest.cpp
     DefaultGameDeleteTest.cpp
     ResetProfileTest.cpp
     TOscTest.cpp

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -271,8 +271,6 @@ private:
         return n;
     }
 
-    // loopbackTest() writes NUL bytes up to two past the data end, so the corpus
-    // is over-reserved in initTestCase().
     double feedCorpusBestPass(Host* host, int passes)
     {
         double best = std::numeric_limits<double>::max();
@@ -333,9 +331,6 @@ private slots:
         initializeQRCResources();
         mCorpus = generateCorpus(kCorpusLines, mCorpusLines);
         mCorpusBytes = mCorpus.size();
-        // loopbackTest() writes NUL bytes past the data end; reserve slack so that
-        // stays within the allocation.
-        mCorpus.reserve(mCorpus.size() + 16);
         // An invariant, emitted here so it is present regardless of which bench
         // slots run: the compare script rejects an ASan-vs-release comparison.
         emitMetric("build_asan", static_cast<qint64>(BENCH_BUILD_ASAN));
@@ -408,7 +403,6 @@ private slots:
         QVERIFY(sentinel->setScript(qsl("benchSentinelFired = true")));
         QVERIFY(sentinel->state());
         QByteArray probe{"__bench_sentinel__\r\n"};
-        probe.reserve(probe.size() + 16);
         host->mTelnet.loopbackTest(probe);
         QVERIFY2(host->getLuaInterpreter()->compileAndExecuteScript(qsl("assert(benchSentinelFired)")), "sentinel trigger did not fire - the trigger engine is not seeing pipeline data");
 

--- a/test/functional_tests/TelnetSubnegotiationTest.cpp
+++ b/test/functional_tests/TelnetSubnegotiationTest.cpp
@@ -88,10 +88,6 @@ private slots:
         data.append(TN_IAC);
         data.append(TN_SE);
         data.append("SUBNEG_RECOVERED\r\n");
-        // processSocketData() writes a NUL at in_buffer[size + 1], so give the
-        // backing buffer a little slack before handing it its data pointer.
-        data.reserve(data.size() + 16);
-
         host->mTelnet.loopbackTest(data);
 
         QVERIFY2(waitForBufferToContain("SUBNEG_RECOVERED"), "Ordinary text after an oversized subnegotiation was not displayed - recovery failed.");

--- a/test/functional_tests/TelnetTlsPromptTest.cpp
+++ b/test/functional_tests/TelnetTlsPromptTest.cpp
@@ -112,10 +112,6 @@ private slots:
         data.append(tlsPort);
         data.append(TN_IAC);
         data.append(TN_SE);
-        // processSocketData() writes a NUL at in_buffer[size + 1], so give the
-        // backing buffer a little slack before handing it its data pointer.
-        data.reserve(data.size() + 16);
-
         host->mTelnet.loopbackTest(data);
 
         // The signal is emitted synchronously inside loopbackTest(), so it has

--- a/test/functional_tests/TelnetTlsPromptTest.cpp
+++ b/test/functional_tests/TelnetTlsPromptTest.cpp
@@ -156,7 +156,6 @@ private slots:
         // Advertise a secure port so mMSSPTlsPort is populated (the handler is
         // detached, so nothing pops up).
         QByteArray advertise = msspTlsPayload("48000");
-        advertise.reserve(advertise.size() + 16);
         host->mTelnet.loopbackTest(advertise);
 
         // The user answers No; the reconnect that follows must complete.
@@ -172,7 +171,6 @@ private slots:
         // the user has declined (don't-ask-again is sticky for the session).
         QSignalSpy promptSpy(&host->mTelnet, &cTelnet::signal_promptTlsAvailable);
         QByteArray advertiseAgain = msspTlsPayload("48000");
-        advertiseAgain.reserve(advertiseAgain.size() + 16);
         host->mTelnet.loopbackTest(advertiseAgain);
         QCOMPARE(promptSpy.count(), 0);
 #endif
@@ -200,7 +198,6 @@ private slots:
 
         // Advertise the second stub's port as the secure port.
         QByteArray advertise = msspTlsPayload(QByteArray::number(securePort));
-        advertise.reserve(advertise.size() + 16);
         host->mTelnet.loopbackTest(advertise);
         QCOMPARE(host->mMSSPTlsPort, static_cast<int>(securePort));
 
@@ -239,7 +236,6 @@ private slots:
         QVERIFY(spy.isValid());
 
         QByteArray advertise = msspTlsPayload("48000");
-        advertise.reserve(advertise.size() + 16);
         host->mTelnet.loopbackTest(advertise);
         if (spy.isEmpty()) {
             QVERIFY2(spy.wait(2s), "cTelnet did not emit signal_promptTlsAvailable for the first advertisement.");
@@ -249,7 +245,6 @@ private slots:
         // Nobody has answered, so the prompt is still in flight: a repeated
         // advertisement (as a hostile server could spam) must be swallowed.
         QByteArray advertiseAgain = msspTlsPayload("48000");
-        advertiseAgain.reserve(advertiseAgain.size() + 16);
         host->mTelnet.loopbackTest(advertiseAgain);
         QCOMPARE(spy.count(), 1);
 #endif
@@ -273,7 +268,6 @@ private slots:
         // Advertise so the port is recorded and the latch is set, mirroring a
         // real pending prompt.
         QByteArray advertise = msspTlsPayload("48000");
-        advertise.reserve(advertise.size() + 16);
         host->mTelnet.loopbackTest(advertise);
 
         const int originalPort = host->getPort();
@@ -310,12 +304,10 @@ private slots:
         QSignalSpy bellSpy(&host->mTelnet, &cTelnet::signal_bell);
 
         QByteArray oneBell("\a");
-        oneBell.reserve(oneBell.size() + 16);
         host->mTelnet.loopbackTest(oneBell);
         QCOMPARE(bellSpy.count(), 1);
 
         QByteArray twoBells("\a\a");
-        twoBells.reserve(twoBells.size() + 16);
         host->mTelnet.loopbackTest(twoBells);
         QCOMPARE(bellSpy.count(), 3);
     }

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2026 by Mudlet Developers                               *
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -29,9 +29,13 @@
  * exactly to its contents - so the stray NUL landed one byte past the end of a
  * heap allocation.
  *
- * The discriminating test is nulTerminatorLandsAtTheDataEnd(): a sentinel is
- * planted at [amount + 1] and must still be there afterwards. It fails on the
- * unfixed code without needing a sanitizer.
+ * The discriminating tests are nulTerminatorLandsAtTheDataEnd(), its every-size
+ * sibling, and emptyAndErroredReadsLeaveTheBufferAlone(): a sentinel is planted
+ * at [amount + 1] and must still be there afterwards. Those fail on the unfixed
+ * code without needing a sanitizer, which matters because Windows CI builds
+ * without one. Note that the byte at [amount] is written by the later
+ * "buffer[datalen] = '\0'" too, so asserting on it only proves the call ran -
+ * the sentinel one byte further along is what catches the bug.
  *
  * Run with: ctest -R cTelnetBufferTest -V
  */
@@ -140,7 +144,13 @@ private slots:
         QVERIFY(mpHost);
         QVERIFY(mpHost->mpConsole);
         mpHost->mpConsole->buffer.clear();
+        // A leaked recursion level is permanent for the profile and eventually
+        // turns processSocketData() into a silent no-op, which would make the
+        // "nothing was written" assertions below pass for the wrong reason.
+        QCOMPARE(mpHost->mTelnet.mDecompressionRecursionDepth, 0);
     }
+
+    void cleanup() { QCOMPARE(mpHost->mTelnet.mDecompressionRecursionDepth, 0); }
 
     // The regression test for #1065. processSocketData() is handed `payloadSize`
     // bytes inside a buffer that has two spare bytes after them. It may write
@@ -173,29 +183,17 @@ private slots:
 
             mpHost->mTelnet.processSocketData(backing.data(), payloadSize, true);
 
+            // The terminator check proves the call actually ran, so the
+            // past-the-end check below cannot pass by the function bailing out.
+            QVERIFY2(backing.at(payloadSize) == '\0', qPrintable(qsl("processSocketData() did not terminate a %1 byte payload at all.").arg(payloadSize)));
             QVERIFY2(backing.at(payloadSize + 1) == scmPastTheEnd, qPrintable(qsl("processSocketData() wrote past the end of a %1 byte payload.").arg(payloadSize)));
         }
     }
 
-    // The heap shape that Lua's feedTelnet() actually produces: an allocation
-    // sized exactly to the data plus its terminator. Writing at [size + 1] runs
-    // off the end of it, which AddressSanitizer reports as a heap-buffer-overflow.
-    void exactlySizedHeapAllocationIsNotOverrun()
-    {
-        const QByteArray payload = QByteArrayLiteral("heap probe\r\n");
-        const auto size = static_cast<int>(payload.size());
-        auto buffer = std::make_unique<char[]>(size + 1); // +1 for the terminator, exactly as QByteArray allocates
-        std::memcpy(buffer.get(), payload.constData(), size);
-        buffer[size] = scmTerminatorSlot;
-
-        mpHost->mTelnet.processSocketData(buffer.get(), size, true);
-
-        QCOMPARE(buffer[size], '\0');
-    }
-
     // The production route from Lua: feedTelnet() -> loopbackTest() ->
-    // processSocketData(), with a QByteArray squeezed down to its contents so
-    // there is no slack to absorb a stray write.
+    // processSocketData(). loopbackTest() takes a non-const QByteArray and calls
+    // data(), which detaches, so the allocation shape is Qt's choice rather than
+    // ours - this is a "the pipeline still works" check, not a bounds check.
     void feedTelnetPathDisplaysItsDataIntact()
     {
         QByteArray payload = QByteArrayLiteral("BUFFER_TEST_MARKER\r\n");
@@ -212,20 +210,37 @@ private slots:
 
     // A closed or errored socket reports -1 and an empty read reports 0. Neither
     // may touch the caller's buffer, which for amount == 0 can legitimately have
-    // no writable byte at all.
+    // no writable byte at all. -2 stands in for the qsizetype narrowing in
+    // loopbackTest(), which can produce a negative that is not -1.
     void emptyAndErroredReadsLeaveTheBufferAlone()
     {
-        QByteArray backing(2, '\0');
-        backing[0] = scmTerminatorSlot;
-        backing[1] = scmPastTheEnd;
+        for (const int amount : {0, -1, -2}) {
+            QByteArray backing(2, '\0');
+            backing[0] = scmTerminatorSlot;
+            backing[1] = scmPastTheEnd;
 
-        mpHost->mTelnet.processSocketData(backing.data(), 0, true);
-        QCOMPARE(backing.at(0), scmTerminatorSlot);
-        QCOMPARE(backing.at(1), scmPastTheEnd);
+            mpHost->mTelnet.processSocketData(backing.data(), amount, true);
 
-        mpHost->mTelnet.processSocketData(backing.data(), -1, true);
-        QCOMPARE(backing.at(0), scmTerminatorSlot);
-        QCOMPARE(backing.at(1), scmPastTheEnd);
+            QVERIFY2(backing.at(0) == scmTerminatorSlot, qPrintable(qsl("processSocketData() wrote into the buffer for a read of %1.").arg(amount)));
+            QVERIFY2(backing.at(1) == scmPastTheEnd, qPrintable(qsl("processSocketData() wrote past the buffer for a read of %1.").arg(amount)));
+        }
+    }
+
+    // Declared last on purpose: on the unfixed code this trips AddressSanitizer,
+    // which aborts the process, so anything after it would never report. The
+    // sentinels give it teeth on Windows too, where CI builds without ASan.
+    void exactlySizedHeapAllocationIsNotOverrun()
+    {
+        const QByteArray payload = QByteArrayLiteral("heap probe\r\n");
+        const auto size = static_cast<int>(payload.size());
+        // Exactly the shape QByteArray allocates: the data plus its terminator.
+        auto buffer = std::make_unique<char[]>(size + 1);
+        std::memcpy(buffer.get(), payload.constData(), size);
+        buffer[size] = scmTerminatorSlot;
+
+        mpHost->mTelnet.processSocketData(buffer.get(), size, true);
+
+        QCOMPARE(buffer[size], '\0');
     }
 
     void cleanupTestCase()

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -1,0 +1,258 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Tests for the off-by-one write in cTelnet::processSocketData() -
+ * https://github.com/Mudlet/Mudlet/issues/1065
+ *
+ * processSocketData() used to terminate its input with
+ * "in_buffer[amount + 1] = '\0'", one byte further along than the data it was
+ * given. The socket path survived it because slot_socketReadyToBeRead() over-
+ * allocates its stack buffer, but the same function is also reached from Lua's
+ * feedTelnet() via cTelnet::loopbackTest(), which hands it a QByteArray sized
+ * exactly to its contents - so the stray NUL landed one byte past the end of a
+ * heap allocation.
+ *
+ * The discriminating test is nulTerminatorLandsAtTheDataEnd(): a sentinel is
+ * planted at [amount + 1] and must still be there afterwards. It fails on the
+ * unfixed code without needing a sanitizer.
+ *
+ * Run with: ctest -R cTelnetBufferTest -V
+ */
+
+#include <QtTest/QtTest>
+#include <chrono>
+#include <cstring>
+#include <memory>
+
+#include "MudletInstanceCoordinator.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForBufferTest();
+
+class cTelnetBufferTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("BufferTest-Host");
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    const QString mLocalhost = qsl("localhost");
+
+    // The byte processSocketData() is entitled to overwrite with its NUL, and
+    // the one immediately after it that it must leave alone.
+    static constexpr char scmTerminatorSlot = '\x7b';
+    static constexpr char scmPastTheEnd = '\x7c';
+
+    // True if any line in the main console buffer contains the given substring
+    bool bufferContains(const QString& text) const
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            if (console->buffer.line(i).contains(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForBufferTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        QDir(path).removeRecursively();
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(500)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void init()
+    {
+        QVERIFY(mpHost);
+        QVERIFY(mpHost->mpConsole);
+        mpHost->mpConsole->buffer.clear();
+    }
+
+    // The regression test for #1065. processSocketData() is handed `payloadSize`
+    // bytes inside a buffer that has two spare bytes after them. It may write
+    // its NUL over the first spare byte; the second must come back untouched.
+    void nulTerminatorLandsAtTheDataEnd()
+    {
+        constexpr int payloadSize = 8;
+        QByteArray backing(payloadSize + 2, '\0');
+        std::memset(backing.data(), 'A', payloadSize);
+        backing[payloadSize] = scmTerminatorSlot;
+        backing[payloadSize + 1] = scmPastTheEnd;
+
+        mpHost->mTelnet.processSocketData(backing.data(), payloadSize, true);
+
+        QCOMPARE(backing.at(payloadSize), '\0');
+        QVERIFY2(backing.at(payloadSize + 1) == scmPastTheEnd,
+                 "processSocketData() wrote its NUL terminator one byte past the data it was given "
+                 "- the off-by-one of issue #1065 is back.");
+    }
+
+    // The same off-by-one across the sizes a read can plausibly return, so a
+    // future rewrite cannot reintroduce it for only some lengths.
+    void nulTerminatorLandsAtTheDataEndAtEverySize()
+    {
+        for (const int payloadSize : {1, 2, 4, 8, 15, 16, 31, 32, 33, 63, 64, 1024}) {
+            QByteArray backing(payloadSize + 2, '\0');
+            std::memset(backing.data(), 'A', payloadSize);
+            backing[payloadSize] = scmTerminatorSlot;
+            backing[payloadSize + 1] = scmPastTheEnd;
+
+            mpHost->mTelnet.processSocketData(backing.data(), payloadSize, true);
+
+            QVERIFY2(backing.at(payloadSize + 1) == scmPastTheEnd, qPrintable(qsl("processSocketData() wrote past the end of a %1 byte payload.").arg(payloadSize)));
+        }
+    }
+
+    // The heap shape that Lua's feedTelnet() actually produces: an allocation
+    // sized exactly to the data plus its terminator. Writing at [size + 1] runs
+    // off the end of it, which AddressSanitizer reports as a heap-buffer-overflow.
+    void exactlySizedHeapAllocationIsNotOverrun()
+    {
+        const QByteArray payload = QByteArrayLiteral("heap probe\r\n");
+        const auto size = static_cast<int>(payload.size());
+        auto buffer = std::make_unique<char[]>(size + 1); // +1 for the terminator, exactly as QByteArray allocates
+        std::memcpy(buffer.get(), payload.constData(), size);
+        buffer[size] = scmTerminatorSlot;
+
+        mpHost->mTelnet.processSocketData(buffer.get(), size, true);
+
+        QCOMPARE(buffer[size], '\0');
+    }
+
+    // The production route from Lua: feedTelnet() -> loopbackTest() ->
+    // processSocketData(), with a QByteArray squeezed down to its contents so
+    // there is no slack to absorb a stray write.
+    void feedTelnetPathDisplaysItsDataIntact()
+    {
+        QByteArray payload = QByteArrayLiteral("BUFFER_TEST_MARKER\r\n");
+        payload.squeeze();
+
+        mpHost->mTelnet.loopbackTest(payload);
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return bufferContains(qsl("BUFFER_TEST_MARKER"));
+                         },
+                         QDeadlineTimer(5s)),
+                 "Text fed through loopbackTest() did not reach the console.");
+    }
+
+    // A closed or errored socket reports -1 and an empty read reports 0. Neither
+    // may touch the caller's buffer, which for amount == 0 can legitimately have
+    // no writable byte at all.
+    void emptyAndErroredReadsLeaveTheBufferAlone()
+    {
+        QByteArray backing(2, '\0');
+        backing[0] = scmTerminatorSlot;
+        backing[1] = scmPastTheEnd;
+
+        mpHost->mTelnet.processSocketData(backing.data(), 0, true);
+        QCOMPARE(backing.at(0), scmTerminatorSlot);
+        QCOMPARE(backing.at(1), scmPastTheEnd);
+
+        mpHost->mTelnet.processSocketData(backing.data(), -1, true);
+        QCOMPARE(backing.at(0), scmTerminatorSlot);
+        QCOMPARE(backing.at(1), scmPastTheEnd);
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        QDir(path).removeRecursively();
+        delete mudlet::self();
+    }
+};
+
+void initializeQRCResourcesForBufferTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "cTelnetBufferTest.moc"
+QTEST_MAIN(cTelnetBufferTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

* `cTelnet::processSocketData()` terminated its input at `in_buffer[amount + 1]`, one byte past the data it was given, and did so *before* checking the `-1`/`0` returns from `QIODevice::read()`. It now guards first, then terminates at `in_buffer[amount]`.
* The guard is `amount <= 0` rather than `== -1`, because `loopbackTest()` narrows a `qsizetype` into an `int` and can produce a negative that is not `-1`.
* Adds `cTelnetBufferTest` (5 slots) and drops the `reserve(size + 16)` slack that three existing telnet tests carried purely to absorb the stray write, which turns them into regression guards too.

#### Motivation for adding to Mudlet

The socket path survived this because `slot_socketReadyToBeRead()` over-allocates its stack buffer, but the same function is reached from Lua's `feedTelnet()` via `loopbackTest()`, which passes a `QByteArray` sized exactly to its contents - so the stray NUL landed one byte past a heap allocation. That is a real out-of-bounds write reachable from any script, and the workarounds already sitting in our test suite show it has been quietly worked around rather than fixed.

#### Other info (issues closed, discussion etc)

Closes #1065. Supersedes the closed #8438, which carried the same fix under 19 commits of unrelated history and had CI red on a faulty assertion in its own test.

**Test case:** reverting the `src/ctelnet.cpp` hunk makes 3 of the 5 new slots fail and AddressSanitizer report `heap-buffer-overflow ... in cTelnet::processSocketData(char*, int, bool)`; restoring it gives 7 passed / 0 failed, and the full suite is 72/72 serially.

One thing to flag for review: this adds `friend class cTelnetBufferTest;` to `cTelnet`, since `processSocketData()` is private and the public `loopbackTest()` cannot express a caller-laid-out buffer. It sits beside the existing `friend class TelnetTlsPromptTest;`, so there is precedent, but it is a test name in a shipped header and worth a second opinion.

Three review findings were deliberately left out of scope. The MCCP decompression path hit the same overflow, via the re-entry that passes `remainingData`/`remainingAmount` back into `processSocketData()` - the fix covers it, but nothing under `test/` exercises compression at all, so it is fixed-but-unguarded and a dedicated MCCP test belongs in its own PR. The other two are pre-existing and orthogonal: a read error (`amount == -1`) is still silent, because `slot_socketError()` has been commented out as unused since 2017; and `mDecompressionRecursionDepth` is hand-balanced across four decrements rather than held by a scope guard (verified balanced today, but fragile). Happy to do any of them as a follow-up.

Assisted-by: Claude:claude-opus-5
