### PR TITLE
fix: four Lua API corrections - colours, room name offsets, map window state and printTable

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3471,16 +3471,36 @@ void Host::setBufferSearchOptions(const TConsole::SearchOptions optionsState)
     mBufferSearchOptions = optionsState;
 }
 
+// The single answer to "does this profile have a map widget on screen right
+// now" - null both for a profile that has never opened one and for one that put
+// it away again, which a script cannot tell apart and does not need to.
+//
+// isHidden() rather than a flag of our own, because the dock gets hidden by
+// paths that would never think to update one: its own title bar close button,
+// mudlet::slot_showMapperDialog() handing the map over to a main window dock,
+// and QMainWindow::restoreState() replaying a saved layout. It is also not
+// !isVisible(), which would additionally answer "no map widget" whenever the
+// main window itself is hidden, e.g. minimised to the system tray.
+QDockWidget* Host::mapWidget() const
+{
+    if (!mpConsole || !mpConsole->mpDockableMapWidget || mpConsole->mpDockableMapWidget->isHidden()) {
+        return nullptr;
+    }
+
+    return mpConsole->mpDockableMapWidget;
+}
+
 std::pair<bool, QString> Host::setMapperTitle(const QString& title)
 {
-    if (!mpConsole || !mpConsole->mpDockableMapWidget) {
-        return {false, "no floating/dockable type map window found"};
+    auto pM = mapWidget();
+    if (!pM) {
+        return {false, qsl("no floating/dockable type map window found")};
     }
 
     if (title.isEmpty()) {
-        mpConsole->mpDockableMapWidget->setWindowTitle(tr("Map - %1").arg(mHostName));
+        pM->setWindowTitle(tr("Map - %1").arg(mHostName));
     } else {
-        mpConsole->mpDockableMapWidget->setWindowTitle(title);
+        pM->setWindowTitle(title);
     }
 
     return {true, QString()};
@@ -3488,11 +3508,12 @@ std::pair<bool, QString> Host::setMapperTitle(const QString& title)
 
 std::optional<QString> Host::getMapperTitle() const
 {
-    if (!mpConsole || !mpConsole->mpDockableMapWidget) {
+    auto pM = mapWidget();
+    if (!pM) {
         return {};
     }
 
-    return {mpConsole->mpDockableMapWidget->windowTitle()};
+    return {pM->windowTitle()};
 }
 
 std::pair<int, QString> Host::createMapView(int areaId)
@@ -4200,7 +4221,7 @@ std::pair<bool, QString> Host::setWindow(const QString& windowname, const QStrin
 std::pair<bool, QString> Host::openMapWidget(const QString& area, int x, int y, int width, int height)
 {
     if (!mpConsole) {
-        return {false, QString()};
+        return {false, qsl("no console for this profile - it may be closing")};
     }
 
     auto pM = mpConsole->mpDockableMapWidget;
@@ -4265,28 +4286,29 @@ std::pair<bool, QString> Host::openMapWidget(const QString& area, int x, int y, 
 // while a floating dock's geometry() reports the client area instead.
 std::optional<QRect> Host::mapWidgetGeometry() const
 {
-    if (!mpConsole || !mpConsole->mpDockableMapWidget) {
+    auto pM = mapWidget();
+    if (!pM) {
         return {};
     }
 
-    auto pM = mpConsole->mpDockableMapWidget;
     return {QRect(pM->pos(), pM->size())};
 }
 
 std::pair<bool, QString> Host::closeMapWidget()
 {
     if (!mpConsole) {
-        return {false, QString()};
+        return {false, qsl("no console for this profile - it may be closing")};
     }
 
-    auto pM = mpConsole->mpDockableMapWidget;
-    if (!pM) {
+    // Test the raw pointer first so that a profile which never made a map widget
+    // is told apart from one that has put its widget away.
+    if (!mpConsole->mpDockableMapWidget) {
         return {false, qsl("no map widget found to close")};
     }
-    if (!pM->isVisible()) {
+    if (!mapWidget()) {
         return {false, qsl("map widget already closed")};
     }
-    pM->hide();
+    mpConsole->mpDockableMapWidget->hide();
     return {true, QString()};
 }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -57,6 +57,7 @@
 #include "TMxpProcessor.h"
 #include "TMxpFrameManager.h"
 
+class QDockWidget;
 class QJsonObject;
 class QKeyEvent;
 
@@ -396,6 +397,7 @@ public:
     void setBufferSearchOptions(const TConsole::SearchOptions);
     std::pair<bool, QString> setMapperTitle(const QString&);
     std::optional<QString> getMapperTitle() const;
+    QDockWidget* mapWidget() const;
 
     // Multiple map views support
     std::pair<int, QString> createMapView(int areaId = 0);

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -149,6 +149,9 @@ public:
     bool mLogToLogFile = false;
     QPointer<QProgressDialog> mpPackageDownloadProgressDialog;
     QPointer<QProgressDialog> mpMapProgressDialog;
+    // Outlives Host::closeMapWidget(), which only hides it, so this being
+    // non-null says the profile has made a map widget at some point, not that it
+    // has one on screen - see Host::mapWidget() for the latter.
     QPointer<QDockWidget> mpDockableMapWidget;
     QPointer<QDialog> mpUnpackingDialog;
 

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -413,22 +413,21 @@ end
 
 --- Pads a hex number to ensure a minimum of 2 digits.
 ---
---- @usage Following command will returns "F0".
+--- @usage Following command will return "0F".
 ---   <pre>
 ---   PadHexNum("F")
 ---   </pre>
 function PadHexNum(incString)
   assert(type(incString) == 'string', 'PadHexNum: bad argument #1 type (expected string, got '..type(incString)..'!)')
-  local l_Return = incString
-  if tonumber(incString, 16) < 16 then
-    if tonumber(incString, 16) < 10 then
-      l_Return = "0" .. l_Return
-    elseif tonumber(incString, 16) > 10 then
-      l_Return = l_Return .. "0"
-    end
+  assert(tonumber(incString, 16) ~= nil, 'PadHexNum: bad argument #1 value (hex number as string expected, got "'..incString..'"!)')
+
+  -- the pad goes on the front, and it is the width that decides whether one is
+  -- needed: "00" is already two digits wide even though its value is below 16
+  if #incString < 2 then
+    return "0" .. incString
   end
 
-  return l_Return
+  return incString
 end
 
 
@@ -2380,7 +2379,12 @@ function getRoomNameOffset(room)
   local d = getRoomUserData(room, "room.ui_nameOffset")
   if d == nil or d == "" then return 0,0 end
   local split = {}
-  for w in string.gfind(d, '[%.%d]+') do split[#split+1] = tonumber(w) end
+  -- the minus has to be part of the match: T2DMap parses the same user data with
+  -- QString::toDouble(), so a negative offset the renderer honours must read
+  -- back negative here too. This still only scrapes numbers out of the string,
+  -- so malformed user data reads back as a plausible pair the renderer will not
+  -- draw - unchanged by the sign fix
+  for w in string.gfind(d, '%-?[%.%d]+') do split[#split+1] = tonumber(w) end
   if #split == 1 then return 0,split[1] end
   if #split >= 2 then return split[1],split[2] end
   return 0,0

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -50,9 +50,10 @@ end
 ---
 --- @see display
 function printTable( map )
+  assert(type(map) == 'table', 'printTable: bad argument #1 type (table expected, got '..type(map)..'!)')
   echo("-------------------------------------------------------\n");
   for k, v in pairs( map ) do
-    echo( "key=" .. k .. " value=" .. v .. "\n" )
+    echo( "key=" .. tostring(k) .. " value=" .. tostring(v) .. "\n" )
   end
   echo("-------------------------------------------------------\n");
 end
@@ -60,7 +61,9 @@ end
 
 
 -- NOT LUADOC
--- This is supporting function for printTable().
+-- Prints a single key/value pair into the main console at the cursor. Named as
+-- a helper for printTable(), but printTable() has never called it and formats
+-- its own lines; kept because it is reachable from scripts.
 function __printTable( k, v )
   insertText("\nkey = " .. tostring(k) .. " value = " .. tostring( v )  )
 end
@@ -135,9 +138,10 @@ end
 --- @see display
 --- @see printTable
 function listPrint( map )
+  assert(type(map) == 'table', 'listPrint: bad argument #1 type (table expected, got '..type(map)..'!)')
   echo("-------------------------------------------------------\n");
   for k, v in ipairs( map ) do
-    echo( k .. ". ) " .. v .. "\n" );
+    echo( k .. ". ) " .. tostring(v) .. "\n" );
   end
   echo("-------------------------------------------------------\n");
 end

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -59,9 +59,14 @@ function Geyser.Mapper:show_impl()
     createMapper(self.windowname, self:get_x(), self:get_y(), self:get_width(), self:get_height())
   else
     openMapWidget()
-    -- setMapWindowTitle only reaches a map window that is on screen, so a title
-    -- set while this mapper was hidden has to be applied now instead
-    if self.titleText and self.titleText ~= "" then
+    -- A title only reaches a map window that is on screen, so one this mapper
+    -- set while it was hidden has to be applied now instead. Only one that did
+    -- not land: an unconditional apply here would overwrite a title set through
+    -- setMapWindowTitle() directly every time any mapper is shown. An empty
+    -- titleText is a reset rather than "no title", which is why this tracks
+    -- whether the call failed instead of whether the text is empty.
+    if self.titlePending then
+      self.titlePending = false
       setMapWindowTitle(self.titleText)
     end
   end
@@ -84,12 +89,18 @@ end
 
 function Geyser.Mapper:setTitle(text)
   self.titleText = text
-  return setMapWindowTitle(text)
+  local applied, message = setMapWindowTitle(text)
+  self.titlePending = not applied
+  return applied, message
 end
 
 function Geyser.Mapper:resetTitle()
   self.titleText = ""
-  return resetMapWindowTitle()
+  -- resetMapWindowTitle() is setMapWindowTitle(""), so show_impl applying
+  -- titleText covers a reset as well
+  local applied, message = resetMapWindowTitle()
+  self.titlePending = not applied
+  return applied, message
 end
 
 -- Overridden constructor

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -59,6 +59,11 @@ function Geyser.Mapper:show_impl()
     createMapper(self.windowname, self:get_x(), self:get_y(), self:get_width(), self:get_height())
   else
     openMapWidget()
+    -- setMapWindowTitle only reaches a map window that is on screen, so a title
+    -- set while this mapper was hidden has to be applied now instead
+    if self.titleText and self.titleText ~= "" then
+      setMapWindowTitle(self.titleText)
+    end
   end
 end
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -1079,20 +1079,36 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.equals("FF", PadHexNum("FF"))
       assert.equals("0A", PadHexNum("0A"))
       assert.equals("10", PadHexNum("10"))
+      -- "00" is worth its own assertion: its value is below sixteen, so a pad
+      -- driven by value rather than by width grows it to three digits
+      assert.equals("00", PadHexNum("00"))
     end)
 
     it("Should error when not given a string", function()
       assert.has_error(function() PadHexNum(15) end)
     end)
 
+    it("Should error when the string is not a hex number", function()
+      -- the message matters: the old code reached the same outcome by accident,
+      -- comparing a nil tonumber() result against a number
+      assert.has_error(function() PadHexNum("zz") end,
+        'PadHexNum: bad argument #1 value (hex number as string expected, got "zz"!)')
+      assert.has_error(function() PadHexNum("") end,
+        'PadHexNum: bad argument #1 value (hex number as string expected, got ""!)')
+    end)
+
     it("Should zero-pad single hex digits above nine as well", function()
-      -- BUG: for values 11..15 the zero is appended instead of prepended, so
-      -- PadHexNum("B") is "B0" (176) rather than "0B" (11); the value 10 hits
-      -- neither branch and comes back as the unpadded, single character "A"
-      pending("PadHexNum pads on the wrong side above nine - see the Wave 3d report")
       assert.equals("0A", PadHexNum("A"))
       assert.equals("0B", PadHexNum("B"))
       assert.equals("0F", PadHexNum("F"))
+    end)
+
+    it("Should pad every single digit to the same width", function()
+      for value = 0, 15 do
+        local padded = PadHexNum(string.format("%X", value))
+        assert.equals(2, #padded)
+        assert.equals(value, tonumber(padded, 16))
+      end
     end)
   end)
 
@@ -1114,11 +1130,27 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
 
     it("Should produce six hex digits for every component below sixteen", function()
-      -- BUG: RGB2Hex inherits PadHexNum's wrong-side padding, so a component
-      -- of 11 becomes "B0" (176) and one of 10 contributes a single "A",
-      -- yielding the malformed five character string "AB00C" here
-      pending("RGB2Hex mis-encodes components below sixteen - see the Wave 3d report")
       assert.equals("0A0B0C", RGB2Hex(10, 11, 12))
+      assert.equals("0A0A0A", RGB2Hex(10, 10, 10))
+    end)
+
+    it("Should encode a small component as its own value, not a shifted one", function()
+      -- the damaging case: a well formed six digit string that names the wrong
+      -- colour, so nothing downstream can notice. 11 must not become 0xB0 (176)
+      assert.equals("C80B0C", RGB2Hex(200, 11, 12))
+      assert.equals("FF0000", RGB2Hex(255, 0, 0))
+    end)
+
+    -- in 0-255 only: RGB2Hex range-checks nothing, so an out of range component
+    -- still produces a longer string. That is a separate defect from the padding
+    it("Should return six hex digits for every component value in 0-255", function()
+      for _, component in ipairs({0, 1, 9, 10, 15, 16, 17, 128, 255}) do
+        local hex = RGB2Hex(component, component, component)
+        assert.equals(6, #hex)
+        for position = 1, 5, 2 do
+          assert.equals(component, tonumber(hex:sub(position, position + 1), 16))
+        end
+      end
     end)
   end)
 
@@ -1355,6 +1387,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       it("Should accept an r, g, b triple", function()
         setGaugeText(gaugeName, "hurt", 0, 128, 255)
         assert.equals([[<font color="#0080FF">hurt</font>]], gaugesTable[gaugeName].text)
+      end)
+
+      it("Should emit a six digit colour for components below sixteen", function()
+        setGaugeText(gaugeName, "dim", 10, 11, 12)
+        assert.equals([[<font color="#0A0B0C">dim</font>]], gaugesTable[gaugeName].text)
       end)
 
       it("Should clear the caption when no text is given", function()

--- a/src/mudlet-lua/tests/GeyserMapper_spec.lua
+++ b/src/mudlet-lua/tests/GeyserMapper_spec.lua
@@ -230,6 +230,37 @@ describe("Tests functionality of Geyser.Mapper", function()
       assert.are.equal("Named while hidden", getMapWindowTitle())
     end)
 
+    it("applies a reset that was made while the mapper was hidden", function()
+      local mapper = track(Geyser.Mapper:new({
+        name = "gmpHiddenReset",
+        x = 10, y = 20, width = 300, height = 200,
+        embedded = false,
+        titleText = "Named before hiding",
+      }))
+      mapper:hide()
+      assert.is_nil(mapper:resetTitle())
+      assert.are.equal("", mapper.titleText)
+      mapper:show()
+      -- an empty titleText is a reset, not "no title to apply", so the map
+      -- window has to come back with its generated default rather than the
+      -- title it carried before the hide
+      local title = getMapWindowTitle()
+      assert.is_truthy(title:find(getProfileName(), 1, true))
+      assert.are_not.equal("Named before hiding", title)
+    end)
+
+    it("does not overwrite a directly set title when a mapper is shown", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpNoClobber", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      mapper:hide()
+      openMapWidget()
+      assert.is_true(setMapWindowTitle("Set without Geyser"))
+      mapper:show()
+      -- this mapper never had a title of its own, so showing it has nothing to
+      -- reapply and must leave the map window titled as it was found
+      assert.are.equal("Set without Geyser", getMapWindowTitle())
+      resetMapWindowTitle()
+    end)
+
     it("starts with an empty title when it was not given one", function()
       local mapper = track(Geyser.Mapper:new({name = "gmpNoTitle", x = 10, y = 20, width = 300, height = 200, embedded = false}))
       assert.are.equal("", mapper.titleText)

--- a/src/mudlet-lua/tests/GeyserMapper_spec.lua
+++ b/src/mudlet-lua/tests/GeyserMapper_spec.lua
@@ -8,13 +8,14 @@
 -- is the map widget rather than a mapper drawn into the main console: see the
 -- pending below for why the embedded form cannot be exercised in this suite.
 --
--- Opening the map widget is a one way door for the profile - Host::closeMapWidget
--- only hides it - and busted runs its files in sorted order, so this file is
--- now the first to open it, ahead of Mapper_spec.lua. That costs Mapper_spec's
--- opening block its "registered before the widget was opened" premise; nothing
--- there fails, but the deferred registration path it meant to cover is no
--- longer reached from here on. Restoring it means moving that block into an
--- earlier sorting file of its own.
+-- Host::closeMapWidget() hides the dock widget and records the close, so the map
+-- window functions answer as they do for a profile that never opened one; what
+-- it does not do is destroy the dock. busted runs its files in sorted order, so
+-- this file opens the widget ahead of Mapper_spec.lua and its opening block
+-- therefore keeps its "there is no map widget" premise but loses its "registered
+-- before the widget was opened" one. Nothing there fails, but the deferred
+-- registration path that block meant to cover is no longer reached from here on.
+-- Restoring it means moving it into an earlier sorting file of its own.
 
 -- Reports whether the map widget is currently on screen, without leaving it in
 -- a different state than it was found in.
@@ -217,6 +218,16 @@ describe("Tests functionality of Geyser.Mapper", function()
       assert.are.equal("Renamed", mapper.titleText)
       assert.is_true(mapper:resetTitle())
       assert.are.equal("", mapper.titleText)
+    end)
+
+    it("applies a title that was set while the mapper was hidden", function()
+      local mapper = track(Geyser.Mapper:new({name = "gmpHiddenTitle", x = 10, y = 20, width = 300, height = 200, embedded = false}))
+      mapper:hide()
+      -- the map widget is off screen, so setMapWindowTitle has nothing to retitle
+      assert.is_nil(mapper:setTitle("Named while hidden"))
+      assert.are.equal("Named while hidden", mapper.titleText)
+      mapper:show()
+      assert.are.equal("Named while hidden", getMapWindowTitle())
     end)
 
     it("starts with an empty title when it was not given one", function()

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -27,24 +27,20 @@ describe("Tests map events and menus before the map widget is opened", function(
     assert.is_nil(getMapMenus()["PreWidgetMenu"])
   end)
 
-  -- nothing can destroy the map widget again once it exists, so a second
-  -- runTests in the same session inherits one and these two have nothing left
-  -- to observe
+  -- the dock widget itself outlives closeMapWidget(), but a closed one answers
+  -- the map window functions exactly as a never-opened profile does, so these
+  -- two reach the same branch whether or not an earlier file opened it
   it("should report that there is no map widget to read a title from", function()
+    closeMapWidget()
     local title, err = getMapWindowTitle()
-    if title then
-      pending("the map widget is already open in this session")
-      return
-    end
+    assert.is_nil(title)
     assert.are.equal("no floating/dockable type map window found", err)
   end)
 
   it("should report that there is no map widget to read a geometry from", function()
+    closeMapWidget()
     local x, err = getMapWidgetGeometry()
-    if x then
-      pending("the map widget is already open in this session")
-      return
-    end
+    assert.is_nil(x)
     assert.are.equal("no floating/dockable type map window found", err)
   end)
 
@@ -1460,12 +1456,31 @@ describe("Tests mapper functions against a shared fixture", function()
     end)
 
     it("getRoomNameOffset keeps the sign of a negative shift", function()
-      -- BUG: setRoomNameOffset stores the offset as "x y", but
-      -- getRoomNameOffset reads it back with the pattern '[%.%d]+', which
-      -- cannot match a minus sign, so every negative shift comes back positive
-      pending("getRoomNameOffset drops the sign of a stored offset - see the Wave 3d report")
       setRoomNameOffset(rSandA, -3, -4)
+      assert.are.equal("-3 -4", getRoomUserData(rSandA, "room.ui_nameOffset"))
       assert.are.same({-3, -4}, {getRoomNameOffset(rSandA)})
+    end)
+
+    it("getRoomNameOffset keeps the sign of a mixed pair", function()
+      setRoomNameOffset(rSandA, -3, 4)
+      assert.are.same({-3, 4}, {getRoomNameOffset(rSandA)})
+      setRoomNameOffset(rSandA, 3, -4)
+      assert.are.same({3, -4}, {getRoomNameOffset(rSandA)})
+    end)
+
+    it("getRoomNameOffset keeps the sign of a lone negative y shift", function()
+      -- x == 0 makes setRoomNameOffset store the y shift on its own, which is
+      -- the one-value branch of the reader
+      setRoomNameOffset(rSandA, 0, -5)
+      assert.are.equal("-5", getRoomUserData(rSandA, "room.ui_nameOffset"))
+      assert.are.same({0, -5}, {getRoomNameOffset(rSandA)})
+    end)
+
+    it("getRoomNameOffset keeps the sign of a fractional offset", function()
+      -- T2DMap reads the same user data with QString::toDouble(), so the Lua
+      -- getter has to accept everything the renderer does
+      setRoomUserData(rSandA, "room.ui_nameOffset", "-1.5 -2.5")
+      assert.are.same({-1.5, -2.5}, {getRoomNameOffset(rSandA)})
     end)
   end)
 
@@ -1802,6 +1817,103 @@ describe("Tests mapper functions against a shared fixture", function()
     end)
   end)
 
+end)
+
+-- closeMapWidget() has to leave the profile in a state that is distinguishable
+-- from "the map widget is open", or every map window function keeps answering
+-- for a widget the script just put away.
+--
+-- The map dock has no window name, so windowVisible() cannot reach it and these
+-- specs read the state through the map window functions instead. That works
+-- because Host::mapWidget() derives its answer from the dock's own hidden
+-- state: drop the hide() out of Host::closeMapWidget() and the two specs below
+-- that assert the closed answers fail.
+describe("Tests the open and closed states of the map widget", function()
+  setup(function()
+    assert.is_true(openMapWidget())
+  end)
+
+  teardown(function()
+    -- back to a right-docked, open widget: the position loop below leaves it
+    -- docked at the bottom otherwise, which shrinks the main console for
+    -- everything that runs after this file
+    openMapWidget("r")
+    resetMapWindowTitle()
+  end)
+
+  before_each(function()
+    openMapWidget()
+  end)
+
+  -- companion guard rather than a guard for the bug: closeMapWidget() reported
+  -- "already closed" before this was fixed too. It is here so that a fix which
+  -- stopped distinguishing the two calls would be caught.
+  it("reports the widget as closed once, and as already closed after that", function()
+    assert.is_true(closeMapWidget())
+    local closed, message = closeMapWidget()
+    assert.is_nil(closed)
+    assert.are.equal("map widget already closed", message)
+  end)
+
+  it("stops setMapWindowTitle from retitling a widget that was closed", function()
+    assert.is_true(setMapWindowTitle("still open"))
+    assert.is_true(closeMapWidget())
+    local set, message = setMapWindowTitle("closed already")
+    assert.is_nil(set)
+    assert.are.equal("no floating/dockable type map window found", message)
+  end)
+
+  it("makes the map window getters agree with setMapWindowTitle", function()
+    assert.is_true(closeMapWidget())
+    local title, titleMessage = getMapWindowTitle()
+    assert.is_nil(title)
+    local x, geometryMessage = getMapWidgetGeometry()
+    assert.is_nil(x)
+    -- same wording from all three, so a script can test one and trust the rest
+    assert.are.equal("no floating/dockable type map window found", titleMessage)
+    assert.are.equal("no floating/dockable type map window found", geometryMessage)
+  end)
+
+  it("hands the widget back on reopen", function()
+    setMapWindowTitle("before the close")
+    assert.is_true(closeMapWidget())
+    assert.is_true(openMapWidget())
+    -- the same dock comes back rather than a fresh one, so its title survives
+    assert.are.equal("before the close", getMapWindowTitle())
+    assert.are.equal(4, select("#", getMapWidgetGeometry()))
+    assert.is_true(setMapWindowTitle("after the reopen"))
+    assert.are.equal("after the reopen", getMapWindowTitle())
+  end)
+
+  it("reopens from every docking position", function()
+    for _, position in ipairs({"f", "l", "r", "t", "b"}) do
+      assert.is_true(closeMapWidget())
+      assert.is_true(openMapWidget(position), "could not reopen the map widget at " .. position)
+      assert.is_string(getMapWindowTitle())
+    end
+  end)
+
+  -- moveMapWidget/resizeMapWidget are openMapWidget in disguise, so they reopen
+  -- a closed widget rather than failing the way the getters do. Pinned because
+  -- it is the one place where the map functions do not agree about the state.
+  it("lets moveMapWidget and resizeMapWidget reopen a closed widget", function()
+    assert.is_true(closeMapWidget())
+    resizeMapWidget(640, 480)
+    local _, _, width, height = getMapWidgetGeometry()
+    assert.are.same({640, 480}, {width, height})
+
+    assert.is_true(closeMapWidget())
+    moveMapWidget(120, 130)
+    assert.are.equal(4, select("#", getMapWidgetGeometry()))
+  end)
+
+  -- Neither of these can be reached from Lua, so they are recorded rather than
+  -- covered: the dock's own title bar close button and mudlet's map toolbar
+  -- button both hide the same dock, and Host::mapWidget() reads the dock's
+  -- hidden state so that it follows them without either having to know.
+  pending("the map dock's title bar close button leaves the map window functions reporting no map window - needs GUI automation")
+
+  pending("the map toolbar button handing the map to a main window dock leaves the map window functions reporting no map window - needs GUI automation")
 end)
 
 -- deleteMap wipes the whole map, so it lives in its own block that runs after

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -105,9 +105,8 @@ describe("Tests TableUtils.lua functions", function()
     end)
   end)
 
-  -- __printTable is an internal helper of printTable and is not tested directly;
-  -- printTable, listPrint, listAdd and listRemove are covered near the end of
-  -- this file.
+  -- printTable, listPrint, __printTable, listAdd and listRemove are covered
+  -- near the end of this file.
 
   describe("Tests the functionality of table.size", function()
 
@@ -952,6 +951,41 @@ describe("Tests TableUtils.lua functions", function()
       assert.spy(echo).was.called_with("key=alpha value=one\n")
       assert.spy(echo).was.called_with("key=beta value=two\n")
     end)
+
+    it("should render a value that is neither a string nor a number", function()
+      local echo = spy.on(_G, "echo")
+      finally(function() echo:revert() end)
+      local nested = {}
+      printTable({ flag = true, nested = nested, fn = print })
+      assert.spy(echo).was.called(5)
+      assert.spy(echo).was.called_with("key=flag value=true\n")
+      assert.spy(echo).was.called_with("key=nested value=" .. tostring(nested) .. "\n")
+      assert.spy(echo).was.called_with("key=fn value=" .. tostring(print) .. "\n")
+    end)
+
+    it("should render a key that is neither a string nor a number", function()
+      local echo = spy.on(_G, "echo")
+      finally(function() echo:revert() end)
+      local key = {}
+      printTable({ [key] = "one", [true] = "two" })
+      assert.spy(echo).was.called(4)
+      assert.spy(echo).was.called_with("key=" .. tostring(key) .. " value=one\n")
+      assert.spy(echo).was.called_with("key=true value=two\n")
+    end)
+
+    it("should not raise on a table of mixed value types", function()
+      local echo = spy.on(_G, "echo")
+      finally(function() echo:revert() end)
+      assert.has_no.errors(function() printTable({ 1, "two", true, {}, print }) end)
+      assert.has_no.errors(function() printTable({}) end)
+    end)
+
+    it("should name itself when it is not given a table", function()
+      assert.has_error(function() printTable(nil) end,
+        'printTable: bad argument #1 type (table expected, got nil!)')
+      assert.has_error(function() listPrint("not a table") end,
+        'listPrint: bad argument #1 type (table expected, got string!)')
+    end)
   end)
 
   describe("Tests the contract of listPrint", function()
@@ -963,6 +997,16 @@ describe("Tests TableUtils.lua functions", function()
       assert.spy(echo).was.called(4)
       assert.spy(echo).was.called_with("1. ) first\n")
       assert.spy(echo).was.called_with("2. ) second\n")
+    end)
+
+    it("should render entries that are neither strings nor numbers", function()
+      local echo = spy.on(_G, "echo")
+      finally(function() echo:revert() end)
+      local nested = {}
+      listPrint({ true, nested })
+      assert.spy(echo).was.called(4)
+      assert.spy(echo).was.called_with("1. ) true\n")
+      assert.spy(echo).was.called_with("2. ) " .. tostring(nested) .. "\n")
     end)
   end)
 

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -4389,8 +4389,7 @@ describe("Widget state getters", function()
   end)
 
   -- The "no map widget" error path for these two is covered in Mapper_spec,
-  -- which runs first and whose opening spec is the only point in the session
-  -- where the widget does not exist yet.
+  -- which runs first and reaches it by closing the widget.
   describe("map widget getters", function()
     setup(function()
       assert.is_true(openMapWidget())


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `PadHexNum()` prepends its zero and pads by width rather than by value, so `RGB2Hex()` stops mangling any colour component below 16 and `setGaugeText()` stops emitting a broken `<font color>`. The worst case was silent: `RGB2Hex(200, 11, 12)` returned the well-formed but wrong `C8B0C0`, painting (200, 176, 192) instead of (200, 11, 12).
- `getRoomNameOffset()` matches a leading minus, so a negative offset reads back negative - the map renderer already draws it that way.
- The map window functions now answer for the map widget that is actually on screen. `setMapWindowTitle()`, `getMapWindowTitle()` and `getMapWidgetGeometry()` report `no floating/dockable type map window found` after `closeMapWidget()` instead of acting on a widget the script put away. They go through a new `Host::mapWidget()`, which reads the dock's own hidden state, so the dock's close button and the map toolbar button move it too. Reopening is unaffected: the dock is still only hidden, so its title and geometry survive.
- `printTable()` and `listPrint()` `tostring()` their keys and values instead of raising `attempt to concatenate` on a table, boolean or function, and now name themselves when handed a non-table.

#### Motivation for adding to Mudlet

All four fail quietly: a wrong-but-valid colour string, an offset that comes back with the wrong sign, a map window function that reports success against a widget that is not on screen, and a debug printer that errors on exactly the tables you would want to inspect.

#### Other info (issues closed, discussion etc)

Closes #9641, closes #9644, closes #9662, closes #9663.

- #9641 PadHexNum pads hex digits on the wrong side, so RGB2Hex mangles any colour component below 16
- #9644 getRoomNameOffset drops the minus sign, so negative room name offsets read back positive
- #9662 closeMapWidget() only hides the map widget, so open and closed cannot be told apart
- #9663 printTable() errors on any table holding a value that is not a string or number

Test case: `lua print(RGB2Hex(200, 11, 12))` prints `C80B0C`, not `C8B0C0`.

`__printTable()` is kept (#9663 "printTable() errors on any table holding a value that is not a string or number" asked for a decision): it is a reachable global with its own specs, and wiring it into `printTable()` would change `printTable()`'s output format. Its inaccurate "supporting function for printTable()" comment is corrected instead.

`Geyser.Mapper:show()` now reapplies a title that was set while the mapper was hidden, which the map widget change would otherwise have dropped.

Specs added to `GUIUtils_spec`, `TableUtils_spec`, `Mapper_spec` and `GeyserMapper_spec`; the four `pending()` guards that recorded these bugs are gone. All of the new assertions fail on development and pass here.

Before and after for #9662 "closeMapWidget() only hides the map widget, so open and closed cannot be told apart":

https://github.com/user-attachments/assets/1bf72811-4f79-492f-b449-9013f13984a8

Assisted-by: Claude:claude-opus-5