### PR TITLE
Fix eight Geyser layout and container bugs

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -332,7 +332,11 @@ function setGaugeWindow(windowName, gaugeName, x, y, show)
   windowName = windowName or "main"
   x = x or 0
   y = y or 0
-  show = show or true
+  -- `show or true` would turn an explicit false into true, since false is the
+  -- one value the `x or default` idiom cannot carry
+  if show == nil then
+    show = true
+  end
   assert(gaugesTable[gaugeName], "setGaugeWindow: no such gauge exists.")
   setWindow(windowName, gaugeName .. "_back", x, y, show)
   setWindow(windowName, gaugeName .. "_front", x, y, show)

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -409,6 +409,14 @@ end
 function Adjustable.Container:attachToBorder(border)
     if self.attached then self:detach() end
     Adjustable.Container.Attached[border] = Adjustable.Container.Attached[border] or {}
+    -- the registry is keyed by name, so a still live container of the same name
+    -- has to be taken off the border properly instead of being dropped from it:
+    -- it would otherwise go on believing it is attached while nothing reserves
+    -- a border for it, and its own detach() would then delete our entry
+    local superseded = Adjustable.Container.Attached[border][self.name]
+    if superseded and superseded ~= self then
+        superseded:detach()
+    end
     Adjustable.Container.Attached[border][self.name] = self
     self.attached = border
     self:adjustBorder()
@@ -419,8 +427,11 @@ end
 --- detaches the given container
 -- this means the mudlet main window border will be reset
 function Adjustable.Container:detach()
-    if Adjustable.Container.Attached and Adjustable.Container.Attached[self.attached] then
-        Adjustable.Container.Attached[self.attached][self.name] = nil
+    -- a container of the same name may have taken over the registration, so
+    -- only unregister while it is still ours - the same guard type_delete uses
+    local attachedTo = Adjustable.Container.Attached and Adjustable.Container.Attached[self.attached]
+    if attachedTo and attachedTo[self.name] == self then
+        attachedTo[self.name] = nil
     end
     self.borderSize = nil
     self:resetBorder(self.attached)

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -372,6 +372,9 @@ function Geyser.Container:new(cons, container)
             local w, h = getUserWindowSize(me.windowname)
             return h
         end
+        -- so the user window can take this container with it when it is deleted
+        -- without having to guess at the container by its name
+        me.rootContainer = container
     end
   end
 

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -39,17 +39,34 @@ local function pixelLength(token)
   return tonumber(number)
 end
 
--- Finds the value of a CSS declaration. The property has to start a word of
--- its own, or "qproperty-margin" would be read as a margin.
--- @param css The CSS string to search
--- @param property The property name, as a Lua pattern
--- @return the value with its trailing whitespace removed, or nil
+-- Takes CSS comments out, so a commented out declaration is not read as a live
+-- one.
+-- @param css The CSS string to clean
+-- @return the string without its comments
+local function withoutComments(css)
+  return (css:gsub("/%*.-%*/", ""))
+end
+
+-- Finds the value of a CSS declaration. The property has to start a word of its
+-- own, or "qproperty-margin" would be read as a margin, and the value ends at a
+-- block brace as well as at a semicolon, so an unterminated
+-- "QLabel { margin: 4px }" does not carry the brace into the value.
+-- Only the first declaration of a property is read, so a stylesheet that sets
+-- one twice, or sets one inside a state block such as ":hover", is read from
+-- whichever comes first rather than by the CSS cascade.
+-- @param css The CSS string to search, with its comments already taken out
+-- @param property The property name
+-- @return the value, lower cased and trimmed, or nil
 local function cssValue(css, property)
-  local value = css:match("%f[%w%-]" .. property .. "%s*:%s*([^;]+)")
+  local value = css:match("%f[%w%-]" .. property:gsub("%-", "%%-") .. "%s*:%s*([^;{}]+)")
   if not value then
     return nil
   end
-  return value:match("^(.-)%s*$")
+  -- "!important" marks the declaration's priority and is not part of its value.
+  -- Lower casing lets an upper case unit be read and costs nothing else: every
+  -- part of these values that is kept is a number or a unit.
+  value = value:lower():gsub("!%s*important", "")
+  return value:match("^%s*(.-)%s*$")
 end
 
 -- Reads a one to four value CSS box shorthand into its four sides.
@@ -95,24 +112,45 @@ end
 
 --- Helper function to extract spacing values (margin/border/padding) from CSS
 -- Shorthands are read first and longhands over the top of them, so
--- "margin: 5px; margin-left: 20px" gives 20 on the left and 5 elsewhere.
+-- "margin: 5px; margin-left: 20px" gives 20 on the left and 5 elsewhere. This
+-- is not the CSS cascade: a longhand wins over a shorthand whichever order they
+-- are written in.
 -- @param css The CSS string to parse
 -- @param property The property name to extract ("margin", "border" or "padding")
 -- @return left, right, top, bottom spacing values in pixels, 0 for each side
---         the stylesheet says nothing measurable about
+--         the stylesheet says nothing measurable about, and the text of the
+--         first declaration that held a length with no pixel reading
 local function extractCSSSpacing(css, property)
   if not css then return 0, 0, 0, 0 end
+  css = withoutComments(css)
   local spacing = {top = 0, right = 0, bottom = 0, left = 0}
   local border = property == "border"
+  local unreadable
+
+  -- Reads one declaration. reportsUnreadable says whether a value the reader
+  -- could make nothing of is worth telling the user about: it is for a length,
+  -- and it is not for a border shorthand, where "border: none" legitimately
+  -- names no width at all.
+  local function read(declaration, reader, reportsUnreadable)
+    local value = cssValue(css, declaration)
+    if not value then
+      return nil
+    end
+    local first, right, bottom, left = reader(value)
+    if not first and reportsUnreadable then
+      unreadable = unreadable or (declaration .. ": " .. value)
+    end
+    return first, right, bottom, left
+  end
 
   if border then
-    local width = borderWidth(cssValue(css, "border"))
+    local width = read("border", borderWidth, false)
     if width then
       spacing.top, spacing.right, spacing.bottom, spacing.left = width, width, width, width
     end
   end
 
-  local top, right, bottom, left = boxShorthand(cssValue(css, border and "border%-width" or property))
+  local top, right, bottom, left = read(border and "border-width" or property, boxShorthand, true)
   if top then
     spacing.top, spacing.right, spacing.bottom, spacing.left = top, right, bottom, left
   end
@@ -120,16 +158,16 @@ local function extractCSSSpacing(css, property)
   for _, side in ipairs({"top", "right", "bottom", "left"}) do
     local length
     if border then
-      length = borderWidth(cssValue(css, "border%-" .. side)) or pixelLength(cssValue(css, "border%-" .. side .. "%-width") or "")
+      length = read("border-" .. side, borderWidth, false) or read("border-" .. side .. "-width", pixelLength, true)
     else
-      length = pixelLength(cssValue(css, property .. "%-" .. side) or "")
+      length = read(property .. "-" .. side, pixelLength, true)
     end
     if length then
       spacing[side] = length
     end
   end
 
-  return spacing.left, spacing.right, spacing.top, spacing.bottom
+  return spacing.left, spacing.right, spacing.top, spacing.bottom, unreadable
 end
 
 --- Sets the gauge amount.
@@ -173,14 +211,26 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
   local leftOffset, rightOffset, topOffset, bottomOffset = 0, 0, 0, 0
   
   if self.backCSS then
-    local ml, mr, mt, mb = extractCSSSpacing(self.backCSS, "margin")
-    local bl, br, bt, bb = extractCSSSpacing(self.backCSS, "border")
-    local pl, pr, pt, pb = extractCSSSpacing(self.backCSS, "padding")
-    
+    local ml, mr, mt, mb, marginUnreadable = extractCSSSpacing(self.backCSS, "margin")
+    local bl, br, bt, bb, borderUnreadable = extractCSSSpacing(self.backCSS, "border")
+    local pl, pr, pt, pb, paddingUnreadable = extractCSSSpacing(self.backCSS, "padding")
+
     leftOffset = ml + bl + pl
     rightOffset = mr + br + pr
     topOffset = mt + bt + pt
     bottomOffset = mb + bb + pb
+
+    -- Qt still applies a spacing Geyser cannot measure, so the fill bar ends up
+    -- laid out against the wrong box and spills past the gauge's frame. Say so
+    -- rather than leave it looking like a Geyser bug - latched, because setValue
+    -- runs on every prompt.
+    local unreadable = marginUnreadable or borderUnreadable or paddingUnreadable
+    if unreadable and not self.warnedUnreadableCSS then
+      self.warnedUnreadableCSS = true
+      debugc(string.format(
+        "Geyser.Gauge: gauge '%s' has a stylesheet spacing Geyser cannot measure in pixels (%s), so it is left out of the fill bar's position - use px or unitless lengths",
+        self.name, unreadable))
+    end
   end
   
   -- Update gauge in the requested orientation
@@ -224,7 +274,7 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
     local gaugeValue = self.value
     self.front:move(
       function() return leftOffset + math.floor((self.back.get_width() - totalBackOffset) * (1 - gaugeValue / 100) + 0.5) end,
-      topOffset .. "px"
+      function() return topOffset end
     )
     self.front:resize(
       function() return math.floor((self.back.get_width() - totalBackOffset) * (gaugeValue / 100) + 0.5) end,
@@ -349,6 +399,7 @@ function Geyser.Gauge:setStyleSheet(css, cssback, cssText)
   self.frontCSS = css
   self.backCSS = cssback or css
   self.textCSS = cssText
+  self.warnedUnreadableCSS = nil
   
   -- Apply back stylesheet normally (this has margins/borders/padding)
   self.back:setStyleSheet(self.backCSS)
@@ -358,10 +409,13 @@ function Geyser.Gauge:setStyleSheet(css, cssback, cssText)
   -- the trailing semicolon is optional: the last declaration in a stylesheet
   -- usually carries none, and a margin left on the front label is applied on
   -- top of the offset already worked out from the back label, doubling it.
-  -- The frontier keeps qproperty-margin, which is not a margin, out of it.
+  -- The frontier keeps qproperty-margin, which is not a margin, out of it, and
+  -- the excluded braces and star stop a declaration that carries no semicolon
+  -- from eating the end of its block or of a comment, which would leave Qt an
+  -- unparseable sheet and the front label with no styling at all.
   local frontCSSStripped = css
   if frontCSSStripped then
-    frontCSSStripped = frontCSSStripped:gsub("%s*%f[%w%-]margin[^;]*;?", "")
+    frontCSSStripped = frontCSSStripped:gsub("%s*%f[%w%-]margin[^;{}%*]*;?", "")
   end
   self.front:setStyleSheet(frontCSSStripped)
   

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -21,50 +21,115 @@ Geyser.Gauge = Geyser.Container:new({
   strict = false,
   orientation = "horizontal" })
 
---- Helper function to extract spacing values (margin/border/padding) from CSS
--- @param css The CSS string to parse
--- @param property The property name to extract (e.g., "margin", "border", "padding")
--- @return left, right, top, bottom spacing values in pixels, or 0 if not found
-local function extractCSSSpacing(css, property)
-  if not css then return 0, 0, 0, 0 end
-  
-  -- Look for the property (e.g., "margin: 10px 30px;")
-  local pattern = property .. "%s*:%s*([^;]+)"
-  local value = css:match(pattern)
-  
-  if not value then return 0, 0, 0, 0 end
-  
-  -- Parse the values - CSS can have 1-4 values
-  local values = {}
-  for num in value:gmatch("(%d+%.?%d*)px") do
-    table.insert(values, tonumber(num))
+-- Reads one CSS token as a length in pixels. Qt reads a bare number as pixels
+-- and a negative length is meaningful, so both are taken; a unit that has no
+-- pixel value without knowing the font or the parent - em, %, pt - has none to
+-- give here, and neither has a keyword such as "solid".
+-- @param token The token to read
+-- @return the length in pixels, or nil if the token is not a pixel length
+local function pixelLength(token)
+  local number, unit = token:match("^([+-]?%d*%.?%d+)(.*)$")
+  if not number then
+    return nil
   end
-  
-  -- Handle border specially - extract width from "border: 2px solid color"
-  if property == "border" and #values == 0 then
-    local borderWidth = value:match("(%d+%.?%d*)px")
-    if borderWidth then
-      values = {tonumber(borderWidth)}
+  unit = unit:lower()
+  if unit ~= "" and unit ~= "px" then
+    return nil
+  end
+  return tonumber(number)
+end
+
+-- Finds the value of a CSS declaration. The property has to start a word of
+-- its own, or "qproperty-margin" would be read as a margin.
+-- @param css The CSS string to search
+-- @param property The property name, as a Lua pattern
+-- @return the value with its trailing whitespace removed, or nil
+local function cssValue(css, property)
+  local value = css:match("%f[%w%-]" .. property .. "%s*:%s*([^;]+)")
+  if not value then
+    return nil
+  end
+  return value:match("^(.-)%s*$")
+end
+
+-- Reads a one to four value CSS box shorthand into its four sides.
+-- @param value The declaration value, or nil
+-- @return top, right, bottom, left, or nil if any part of the value is not a
+--         pixel length: half a shorthand is worse than none, because the
+--         lengths that are left would be read in the wrong positions
+local function boxShorthand(value)
+  if not value then
+    return nil
+  end
+  local lengths = {}
+  for token in value:gmatch("%S+") do
+    local length = pixelLength(token)
+    if not length then
+      return nil
+    end
+    lengths[#lengths + 1] = length
+  end
+  if #lengths == 0 or #lengths > 4 then
+    return nil
+  end
+  local top, right = lengths[1], lengths[2] or lengths[1]
+  return top, right, lengths[3] or top, lengths[4] or right
+end
+
+-- Reads the width out of a CSS border shorthand such as "2px solid red", where
+-- only the first length is a width and the rest describes the line.
+-- @param value The declaration value, or nil
+-- @return the width in pixels, or nil
+local function borderWidth(value)
+  if not value then
+    return nil
+  end
+  for token in value:gmatch("%S+") do
+    local length = pixelLength(token)
+    if length then
+      return length
     end
   end
-  
-  if #values == 0 then
-    return 0, 0, 0, 0
-  elseif #values == 1 then
-    -- All sides same
-    return values[1], values[1], values[1], values[1]
-  elseif #values == 2 then
-    -- top/bottom, left/right
-    return values[2], values[2], values[1], values[1]
-  elseif #values == 3 then
-    -- top, left/right, bottom
-    return values[2], values[2], values[1], values[3]
-  elseif #values == 4 then
-    -- top, right, bottom, left
-    return values[4], values[2], values[1], values[3]
-  else
-    return 0, 0, 0, 0
+  return nil
+end
+
+--- Helper function to extract spacing values (margin/border/padding) from CSS
+-- Shorthands are read first and longhands over the top of them, so
+-- "margin: 5px; margin-left: 20px" gives 20 on the left and 5 elsewhere.
+-- @param css The CSS string to parse
+-- @param property The property name to extract ("margin", "border" or "padding")
+-- @return left, right, top, bottom spacing values in pixels, 0 for each side
+--         the stylesheet says nothing measurable about
+local function extractCSSSpacing(css, property)
+  if not css then return 0, 0, 0, 0 end
+  local spacing = {top = 0, right = 0, bottom = 0, left = 0}
+  local border = property == "border"
+
+  if border then
+    local width = borderWidth(cssValue(css, "border"))
+    if width then
+      spacing.top, spacing.right, spacing.bottom, spacing.left = width, width, width, width
+    end
   end
+
+  local top, right, bottom, left = boxShorthand(cssValue(css, border and "border%-width" or property))
+  if top then
+    spacing.top, spacing.right, spacing.bottom, spacing.left = top, right, bottom, left
+  end
+
+  for _, side in ipairs({"top", "right", "bottom", "left"}) do
+    local length
+    if border then
+      length = borderWidth(cssValue(css, "border%-" .. side)) or pixelLength(cssValue(css, "border%-" .. side .. "%-width") or "")
+    else
+      length = pixelLength(cssValue(css, property .. "%-" .. side) or "")
+    end
+    if length then
+      spacing[side] = length
+    end
+  end
+
+  return spacing.left, spacing.right, spacing.top, spacing.bottom
 end
 
 --- Sets the gauge amount.
@@ -122,10 +187,13 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
   -- Note: We use function-based constraints for dynamic sizing that accounts for margins
   -- The front label can have its own borders and padding (margins are stripped in setStyleSheet)
   -- Qt applies border/padding outside the widget's content area, so we don't need to compensate for them
-  
+  -- The offsets are given as functions rather than as "<n>px": a negative pixel
+  -- constraint is measured from the opposite edge, which is not what a negative
+  -- margin asks for
+
   if self.orientation == "horizontal" then
     -- Position the front label inside the back's content area
-    self.front:move(leftOffset .. "px", topOffset .. "px")
+    self.front:move(function() return leftOffset end, function() return topOffset end)
     -- For width: we want value% of the CONTENT width (back label's content area)
     -- Content width = back_label_width - leftOffset - rightOffset
     local totalBackOffset = leftOffset + rightOffset
@@ -141,7 +209,7 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
     local totalBackOffset = topOffset + bottomOffset
     local gaugeValue = self.value
     self.front:move(
-      leftOffset .. "px",
+      function() return leftOffset end,
       function() return topOffset + math.floor((self.back.get_height() - totalBackOffset) * (1 - gaugeValue / 100) + 0.5) end
     )
     self.front:resize(
@@ -163,7 +231,7 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
       function() return math.floor(self.back.get_height() - topOffset - bottomOffset + 0.5) end
     )
   else -- batty (top to bottom)
-    self.front:move(leftOffset .. "px", topOffset .. "px")
+    self.front:move(function() return leftOffset end, function() return topOffset end)
     local totalBackOffset = topOffset + bottomOffset
     local gaugeValue = self.value
     self.front:resize(
@@ -287,9 +355,13 @@ function Geyser.Gauge:setStyleSheet(css, cssback, cssText)
   
   -- For the front label, strip ONLY margins (borders and padding are safe and allow styling)
   -- Margins on the front label cause positioning issues, but borders/padding are fine
+  -- the trailing semicolon is optional: the last declaration in a stylesheet
+  -- usually carries none, and a margin left on the front label is applied on
+  -- top of the offset already worked out from the back label, doubling it.
+  -- The frontier keeps qproperty-margin, which is not a margin, out of it.
   local frontCSSStripped = css
   if frontCSSStripped then
-    frontCSSStripped = frontCSSStripped:gsub("%s*margin[^;]*;", "")
+    frontCSSStripped = frontCSSStripped:gsub("%s*%f[%w%-]margin[^;]*;?", "")
   end
   self.front:setStyleSheet(frontCSSStripped)
   

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -38,8 +38,17 @@ function Geyser.HBox:add2 (window, cons, passAdd2, exclude)
   organizeOrDefer(self)
 end
 
+-- The base remove only edits the bookkeeping, so without this the survivors
+-- keep the geometry that was worked out for the old child count and the box is
+-- left with a hole. Every removal path - delete, changeContainer, adding a
+-- child to another container - comes through here.
+function Geyser.HBox:remove (window)
+  Geyser.remove(self, window)
+  organizeOrDefer(self)
+end
+
 --- Responsible for organizing the elements inside the HBox
--- Called when a new element is added
+-- Called when an element is added or removed
 function Geyser.HBox:organize()
   local self_height = self:get_height()
   local self_width = self:get_width()

--- a/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
@@ -51,6 +51,13 @@ function Geyser.ScrollBox:new (cons, container)
     
     createScrollBox(me.windowname, me.name, me:get_x(), me:get_y(), me:get_width(), me:get_height())
 
+    -- add2 asks a new widget to hide itself from inside Geyser.Container:new,
+    -- which runs before there is a widget to hide, so the hide has to be made
+    -- good here - as every other Geyser widget constructor does
+    if me.hidden or me.auto_hidden then
+        hideWindow(me.name)
+    end
+
     --ScrollBox needs a special windowname handling as it by itself is a "window"
     --the given windowname will be saved to the parentWindowName variable
     me.parentWindowName = me.windowname

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -49,8 +49,10 @@ function Geyser.UserWindow:resetWindow()
 end
 
 --Override show to keep the dimensions of the UserWindow
-function Geyser.UserWindow:show()
-  self.Parent.show(self)
+--@param auto passed on by a container showing its children, and used by the
+--            base class to pick which of the two hidden flags to clear
+function Geyser.UserWindow:show(auto)
+  self.Parent.show(self, auto)
 end
 
 --- Your UserWindow will be docked at position (pos):
@@ -94,6 +96,21 @@ function Geyser.UserWindow:setStyleSheet(css)
   self.stylesheet = css
 end
 
+--- Deletes the UserWindow, along with the root container Geyser made for it
+function Geyser.UserWindow:type_delete()
+  local root = self.container
+  Geyser.MiniConsole.type_delete(self)
+  -- Geyser.Container:new gives every user window a "<name>Container" root
+  -- container. Left behind it is not inert: its get_width/get_height ask
+  -- getUserWindowSize for a window that is gone, which answers with the main
+  -- window's size, so the orphan claims all of it in every layout pass.
+  -- Unregistering it rather than calling delete() on it keeps this safe when
+  -- the user window is being deleted by that very container.
+  if root and root.container and root.name == self.name .. "Container" and table.is_empty(root.windowList) then
+    root.container:remove(root)
+  end
+end
+
 Geyser.UserWindow.Parent = Geyser.Window
 
 --- Geyser UserWindow constructor
@@ -128,6 +145,11 @@ function Geyser.UserWindow:new(cons)
 
   if me.restoreLayout then
     openUserWindow(me.name, me.restoreLayout, me.autoDock)
+  elseif me.docked == false then
+    -- this window is floated a few lines further down anyway, and docking it
+    -- first takes the dock's size off the main window straight away - which is
+    -- what the percentage constraints below would then be resolved against
+    openUserWindow(me.name, me.restoreLayout, me.autoDock, "floating")
   else
     openUserWindow(me.name, me.restoreLayout, me.autoDock, me.dockPosition)
   end

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -98,7 +98,7 @@ end
 
 --- Deletes the UserWindow, along with the root container Geyser made for it
 function Geyser.UserWindow:type_delete()
-  local root = self.container
+  local root = self.rootContainer
   Geyser.MiniConsole.type_delete(self)
   -- Geyser.Container:new gives every user window a "<name>Container" root
   -- container. Left behind it is not inert: its get_width/get_height ask
@@ -106,8 +106,17 @@ function Geyser.UserWindow:type_delete()
   -- window's size, so the orphan claims all of it in every layout pass.
   -- Unregistering it rather than calling delete() on it keeps this safe when
   -- the user window is being deleted by that very container.
-  if root and root.container and root.name == self.name .. "Container" and table.is_empty(root.windowList) then
+  if not root or not root.container then
+    return
+  end
+  if table.is_empty(root.windowList) then
     root.container:remove(root)
+  else
+    -- anything else put in the root container by hand is still using it, so it
+    -- has to stay - but it measures a user window that is about to be gone
+    debugc(string.format(
+      "Geyser.UserWindow: the root container of '%s' still holds other objects, so it is being left in place - it will report the main window's size from now on, because the user window it measured has been deleted",
+      self.name))
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -39,8 +39,17 @@ function Geyser.VBox:add2 (window, cons, passAdd2, exclude)
   organizeOrDefer(self)
 end
 
+-- The base remove only edits the bookkeeping, so without this the survivors
+-- keep the geometry that was worked out for the old child count and the box is
+-- left with a hole. Every removal path - delete, changeContainer, adding a
+-- child to another container - comes through here.
+function Geyser.VBox:remove (window)
+  Geyser.remove(self, window)
+  organizeOrDefer(self)
+end
+
 --- Responsible for organizing the elements inside the VBox
--- Called when a new element is added
+-- Called when an element is added or removed
 function Geyser.VBox:organize()
   local self_height = self:get_height()
   local self_width = self:get_width()

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -1460,11 +1460,16 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       end)
 
       it("Should keep the gauge hidden when show is passed as false", function()
-        -- BUG: setGaugeWindow does `show = show or true`, so an explicit false
-        -- is turned into true and the gauge is shown anyway
-        pending("setGaugeWindow cannot be told not to show the gauge - see the Wave 3d report")
         setGaugeWindow(userWindow, gaugeName, 0, 0, false)
         assert.is_false(windowVisible(gaugeName .. "_back"))
+        assert.is_false(windowVisible(gaugeName .. "_front"))
+        assert.is_false(windowVisible(gaugeName .. "_text"))
+      end)
+
+      it("Should still show the gauge when show is left out", function()
+        hideGauge(gaugeName)
+        setGaugeWindow(userWindow, gaugeName, 0, 0)
+        assert.is_true(windowVisible(gaugeName .. "_back"))
       end)
     end)
   end)

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -357,4 +357,82 @@ describe("Tests functionality of Adjustable.Container", function()
       other:delete()
     end)
   end)
+
+  -- Adjustable.Container.Attached is keyed by container name, so two live
+  -- containers sharing a name land on the same key. resetBorder/adjustBorder
+  -- walk those entries to work out how much border to reserve, so a container
+  -- that is still attached but no longer registered loses its reservation and
+  -- the main console is drawn underneath it.
+  describe("Tests the functionality of Adjustable.Container:attachToBorder/detach", function()
+    local containers
+    local borderBefore
+
+    local function make(name, width)
+      local container = Adjustable.Container:new({
+        name = name,
+        x = 0, y = 0, width = width, height = 100,
+        autoLoad = false,
+        autoSave = false,
+      })
+      containers[#containers + 1] = container
+      return container
+    end
+
+    before_each(function()
+      containers = {}
+      borderBefore = getBorderLeft()
+    end)
+
+    after_each(function()
+      for index = #containers, 1, -1 do
+        local container = containers[index]
+        if container.attached then
+          container:detach()
+        end
+        if Geyser.windowList[container.name] == container then
+          container:delete()
+        end
+      end
+      containers = {}
+      setBorderLeft(borderBefore)
+    end)
+
+    it("reserves a border while attached and gives it back on detach", function()
+      local container = make("gasAttachPlain", 200)
+      container:attachToBorder("left")
+      assert.are.equal("left", container.attached)
+      assert.are.equal(container.borderSize, getBorderLeft())
+      assert.are.equal(container, Adjustable.Container.Attached.left.gasAttachPlain)
+      container:detach()
+      assert.is_false(container.attached)
+      assert.is_nil(Adjustable.Container.Attached.left.gasAttachPlain)
+      assert.are.equal(0, getBorderLeft())
+    end)
+
+    it("detaches a same named container it takes the registration from", function()
+      local first = make("gasAttachName", 200)
+      local second = make("gasAttachName", 400)
+      first:attachToBorder("left")
+      assert.are.equal(first.borderSize, getBorderLeft())
+      second:attachToBorder("left")
+      assert.are.equal(second, Adjustable.Container.Attached.left.gasAttachName)
+      assert.are.equal(second.borderSize, getBorderLeft())
+      -- the superseded container must not be left believing it is attached
+      -- while nothing reserves a border for it any more
+      assert.is_false(first.attached)
+      assert.is_nil(first.borderSize)
+    end)
+
+    it("leaves a same named container's reservation alone when a superseded one detaches", function()
+      local first = make("gasDetachName", 200)
+      local second = make("gasDetachName", 400)
+      first:attachToBorder("left")
+      second:attachToBorder("left")
+      local reserved = getBorderLeft()
+      first:detach()
+      assert.are.equal(second, Adjustable.Container.Attached.left.gasDetachName)
+      assert.are.equal("left", second.attached)
+      assert.are.equal(reserved, getBorderLeft())
+    end)
+  end)
 end)

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -383,18 +383,23 @@ describe("Tests functionality of Adjustable.Container", function()
       borderBefore = getBorderLeft()
     end)
 
+    -- Deliberately same named containers share their children's names too, so
+    -- the one that still holds the registration is deleted first and takes the
+    -- widgets with it; the superseded one is then deleted for its own event
+    -- handlers and bookkeeping, which nothing else would clear.
     after_each(function()
       for index = #containers, 1, -1 do
         local container = containers[index]
         if container.attached then
           container:detach()
         end
-        if Geyser.windowList[container.name] == container then
-          container:delete()
-        end
+        container:delete()
       end
       containers = {}
       setBorderLeft(borderBefore)
+      assert.is_nil(Adjustable.Container.Attached.left.gasAttachPlain)
+      assert.is_nil(Adjustable.Container.Attached.left.gasAttachName)
+      assert.is_nil(Adjustable.Container.Attached.left.gasDetachName)
     end)
 
     it("reserves a border while attached and gives it back on detach", function()

--- a/src/mudlet-lua/tests/GeyserGauge_spec.lua
+++ b/src/mudlet-lua/tests/GeyserGauge_spec.lua
@@ -194,6 +194,69 @@ describe("Tests functionality of Geyser.Gauge", function()
       assert.are.same({x = 6, y = 4, width = 188, height = 88}, geometry("ggsThreePadding_front"))
     end)
 
+    -- A unitless zero is the ordinary way to write "no margin on this axis".
+    -- Counting only the px tokens dropped it, so what is left reads as a
+    -- shorter shorthand and every component shifts.
+    it("counts a unitless zero as a margin value", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsZero", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 0 10px;", "margin: 0 10px;")
+      assert.are.same({x = 10, y = 0, width = 180, height = 100}, geometry("ggsZero_front"))
+    end)
+
+    it("counts a unitless zero in a four value margin", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsZeroFour", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 10px 0 10px 0;", "margin: 10px 0 10px 0;")
+      assert.are.same({x = 0, y = 10, width = 200, height = 80}, geometry("ggsZeroFour_front"))
+    end)
+
+    it("keeps the sign of a negative margin", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsNegative", x = 20, y = 20, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: -5px;", "margin: -5px;")
+      assert.are.same({x = 15, y = 15, width = 210, height = 110}, geometry("ggsNegative_front"))
+    end)
+
+    it("reads a margin longhand", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsLonghand", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin-left: 10px;", "margin-left: 10px;")
+      assert.are.same({x = 10, y = 0, width = 190, height = 100}, geometry("ggsLonghand_front"))
+    end)
+
+    it("lets a margin longhand override the shorthand it follows", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsOverride", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 5px; margin-left: 20px;", "margin: 5px; margin-left: 20px;")
+      assert.are.same({x = 20, y = 5, width = 175, height = 90}, geometry("ggsOverride_front"))
+    end)
+
+    it("reads a border-width longhand", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsBorderWidth", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("border-width: 2px;", "border-width: 2px;")
+      assert.are.same({x = 2, y = 2, width = 196, height = 96}, geometry("ggsBorderWidth_front"))
+    end)
+
+    it("reads an upper case px unit", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsUpperCase", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 10PX;", "margin: 10PX;")
+      assert.are.same({x = 10, y = 10, width = 180, height = 80}, geometry("ggsUpperCase_front"))
+    end)
+
+    -- em and % cannot be turned into pixels here, so the whole declaration is
+    -- left alone rather than half of it being read as zero
+    it("leaves a margin it cannot measure in pixels alone", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsEm", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 1em;", "margin: 1em;")
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("ggsEm_front"))
+      gauge:setStyleSheet("margin: 5% 10px;", "margin: 5% 10px;")
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("ggsEm_front"))
+    end)
+
+    -- qproperty-margin is a Qt property, not a margin, and used to be picked up
+    -- by the unanchored property pattern
+    it("does not read qproperty-margin as a margin", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsQProperty", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("qproperty-margin: 5px;", "qproperty-margin: 5px;")
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("ggsQProperty_front"))
+    end)
+
     it("reads a four value margin as top, right, bottom, left", function()
       local gauge = track(Geyser.Gauge:new({name = "ggsFourValue", x = 0, y = 0, width = 200, height = 100}))
       gauge:setStyleSheet("margin: 1px 2px 3px 4px;", "margin: 1px 2px 3px 4px;")
@@ -226,6 +289,16 @@ describe("Tests functionality of Geyser.Gauge", function()
       assert.is_truthy(getLabelStyleSheet("ggsCss_front"):find("background-color: red;", 1, true))
       assert.is_truthy(getLabelStyleSheet("ggsCss_back"):find("margin: 5px;", 1, true))
       assert.are.equal("margin: 5px; background-color: blue;", gauge.backCSS)
+    end)
+
+    -- the last declaration in a stylesheet carries no semicolon, and a margin
+    -- left on the front label is applied on top of the offset computed from the
+    -- back label, doubling it
+    it("strips a margin that carries no trailing semicolon", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsNoSemicolon", x = 0, y = 0, width = 200, height = 40}))
+      gauge:setStyleSheet("background-color: red; margin: 5px", "margin: 5px;")
+      assert.is_nil(getLabelStyleSheet("ggsNoSemicolon_front"):find("margin", 1, true))
+      assert.are.same({x = 5, y = 5, width = 190, height = 30}, geometry("ggsNoSemicolon_front"))
     end)
 
     it("uses the front stylesheet for the back when only one is given", function()

--- a/src/mudlet-lua/tests/GeyserGauge_spec.lua
+++ b/src/mudlet-lua/tests/GeyserGauge_spec.lua
@@ -250,11 +250,117 @@ describe("Tests functionality of Geyser.Gauge", function()
     end)
 
     -- qproperty-margin is a Qt property, not a margin, and used to be picked up
-    -- by the unanchored property pattern
+    -- by the unanchored property pattern - both when working out the offset and
+    -- when stripping margins off the front label, where it left "qproperty-"
+    -- behind and Qt threw the whole sheet out
     it("does not read qproperty-margin as a margin", function()
       local gauge = track(Geyser.Gauge:new({name = "ggsQProperty", x = 0, y = 0, width = 200, height = 100}))
-      gauge:setStyleSheet("qproperty-margin: 5px;", "qproperty-margin: 5px;")
+      gauge:setStyleSheet("qproperty-margin: 5px; color: red;", "qproperty-margin: 5px;")
       assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("ggsQProperty_front"))
+      assert.is_truthy(getLabelStyleSheet("ggsQProperty_front"):find("qproperty-margin: 5px;", 1, true))
+    end)
+
+    -- Qt takes !important on a declaration; it marks priority and is not one of
+    -- the box's sides
+    it("reads a margin that carries !important", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsImportant", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 10px !important;", "margin: 10px !important;")
+      assert.are.same({x = 10, y = 10, width = 180, height = 80}, geometry("ggsImportant_front"))
+      gauge:setStyleSheet("margin-left: 10px !important;", "margin-left: 10px !important;")
+      assert.are.same({x = 10, y = 0, width = 190, height = 100}, geometry("ggsImportant_front"))
+    end)
+
+    -- a declaration written inside a selector block usually carries no
+    -- semicolon, and the closing brace is neither part of the value nor
+    -- something the front label's margin strip may swallow
+    it("reads a margin inside a selector block without wrecking the sheet", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsBlock", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("QLabel { background-color: red; margin: 4px }", "QLabel { background-color: blue; margin: 4px }")
+      assert.are.same({x = 4, y = 4, width = 192, height = 92}, geometry("ggsBlock_front"))
+      local front = getLabelStyleSheet("ggsBlock_front")
+      assert.is_nil(front:find("margin", 1, true))
+      assert.is_truthy(front:find("background-color: red;", 1, true))
+      assert.is_truthy(front:find("}", 1, true))
+    end)
+
+    it("does not read a commented out margin, and leaves the comment whole", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsComment", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("background-color: red; /* margin: 20px */ padding: 3px;", "background-color: blue; /* margin: 20px */ padding: 3px;")
+      assert.are.same({x = 3, y = 3, width = 194, height = 94}, geometry("ggsComment_front"))
+      local front = getLabelStyleSheet("ggsComment_front")
+      assert.is_truthy(front:find("background-color: red;", 1, true))
+      assert.is_nil(front:find("20px", 1, true))
+      -- whatever is left of the comment, it must still be closed
+      assert.are.equal(select(2, front:gsub("/%*", "")), select(2, front:gsub("%*/", "")))
+    end)
+
+    it("reads a length written without a leading digit", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsLeadingDot", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: .5px;", "margin: .5px;")
+      -- .5px used to match the "5px" inside it and inset the gauge tenfold; half
+      -- a pixel each side comes off the size and rounds away on the position
+      assert.are.same({x = 0, y = 0, width = 199, height = 99}, geometry("ggsLeadingDot_front"))
+    end)
+
+    it("reads border longhands", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsBorderLong", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("border-top: 3px solid red;", "border-top: 3px solid red;")
+      assert.are.same({x = 0, y = 3, width = 200, height = 97}, geometry("ggsBorderLong_front"))
+      gauge:setStyleSheet("border-left-width: 4px;", "border-left-width: 4px;")
+      assert.are.same({x = 4, y = 0, width = 196, height = 100}, geometry("ggsBorderLong_front"))
+      gauge:setStyleSheet("border-width: 1px 2px 3px 4px;", "border-width: 1px 2px 3px 4px;")
+      assert.are.same({x = 4, y = 1, width = 194, height = 96}, geometry("ggsBorderLong_front"))
+    end)
+
+    it("reads a padding longhand", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsPaddingLong", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("padding-bottom: 7px;", "padding-bottom: 7px;")
+      assert.are.same({x = 0, y = 0, width = 200, height = 93}, geometry("ggsPaddingLong_front"))
+    end)
+
+    -- the offsets reach the front label through a different branch per
+    -- orientation, and a negative one has to stay negative in each
+    it("keeps a negative margin in every orientation", function()
+      local expected = {
+        vertical = {x = 15, y = 15, width = 210, height = 110},
+        goofy = {x = 15, y = 15, width = 210, height = 110},
+        batty = {x = 15, y = 15, width = 210, height = 110},
+      }
+      for orientation, geometryWanted in pairs(expected) do
+        local name = "ggsNegative" .. orientation
+        local gauge = track(Geyser.Gauge:new({name = name, x = 20, y = 20, width = 200, height = 100, orientation = orientation}))
+        gauge:setStyleSheet("margin: -5px;", "margin: -5px;")
+        gauge:setValue(100)
+        assert.are.same(geometryWanted, geometry(name .. "_front"), orientation .. " gauge")
+      end
+    end)
+
+    -- Qt applies a spacing Geyser cannot measure, so the fill bar is laid out
+    -- against the wrong box: that has to be said rather than left looking like
+    -- a Geyser bug
+    it("says so when it cannot measure a spacing in pixels", function()
+      local debugMessage = spy.on(_G, "debugc")
+      finally(function() debugMessage:revert() end)
+      local gauge = track(Geyser.Gauge:new({name = "ggsUnreadable", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 1em;", "margin: 1em;")
+      assert.spy(debugMessage).was.called()
+      local said = debugMessage.calls[#debugMessage.calls].vals[1]
+      assert.is_truthy(said:find("ggsUnreadable", 1, true))
+      assert.is_truthy(said:find("margin: 1em", 1, true))
+      -- and it is latched, so a gauge updated every prompt does not flood
+      local saidOnce = #debugMessage.calls
+      gauge:setValue(50)
+      gauge:setValue(75)
+      assert.are.equal(saidOnce, #debugMessage.calls)
+    end)
+
+    it("says nothing about an ordinary borderless stylesheet", function()
+      local debugMessage = spy.on(_G, "debugc")
+      finally(function() debugMessage:revert() end)
+      local gauge = track(Geyser.Gauge:new({name = "ggsQuiet", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("border: none; background-color: red; margin: 0;", "border: none; background-color: blue; margin: 0;")
+      assert.spy(debugMessage).was_not.called()
+      assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("ggsQuiet_front"))
     end)
 
     it("reads a four value margin as top, right, bottom, left", function()

--- a/src/mudlet-lua/tests/GeyserHBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserHBox_spec.lua
@@ -150,20 +150,32 @@ describe("Tests functionality of Geyser.HBox", function()
       assert.are.same({x = 0, y = 0, width = 600, height = 50}, geometry("ghbShrinkA"))
     end)
 
+    -- an emptied box has no children to divide its width between, and organize()
+    -- still has to come through that without raising
     it("survives losing its last child", function()
-      box:remove(box.windowList.ghbShrinkA)
-      box:remove(box.windowList.ghbShrinkB)
+      assert.has_no.errors(function()
+        box:remove(box.windowList.ghbShrinkA)
+        box:remove(box.windowList.ghbShrinkB)
+      end)
       assert.are.same({}, box.windows)
     end)
 
     it("holds the layout back while updates are deferred", function()
       local third = track(Geyser.Label:new({name = "ghbShrinkDeferred"}, box))
+      local widthOfThree = geometry("ghbShrinkA").width
       box.defer_updates = true
       third:delete()
-      assert.are.equal(199, geometry("ghbShrinkA").width)
+      assert.are.equal(widthOfThree, geometry("ghbShrinkA").width)
       box.defer_updates = false
       box:reposition()
       assert.are.equal(300, geometry("ghbShrinkA").width)
+    end)
+
+    it("deletes a box that still holds children", function()
+      assert.has_no.errors(function() box:delete() end)
+      assert.is_nil(getWindowGeometry("ghbShrinkA"))
+      assert.is_nil(getWindowGeometry("ghbShrinkB"))
+      assert.is_nil(Geyser.windowList.ghbShrink)
     end)
   end)
 

--- a/src/mudlet-lua/tests/GeyserHBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserHBox_spec.lua
@@ -116,6 +116,57 @@ describe("Tests functionality of Geyser.HBox", function()
     end)
   end)
 
+  -- The box lays itself out when a child arrives, and has to do the same when
+  -- one leaves: without it the survivors keep the geometry computed for the old
+  -- child count and the box is left with a permanent hole. contains_fixed is
+  -- false for a box of plain labels, so reposition() does not heal it either.
+  describe("Geyser.HBox:remove", function()
+    local box
+
+    before_each(function()
+      box = track(Geyser.HBox:new({name = "ghbShrink", x = 0, y = 0, width = 600, height = 50}))
+      track(Geyser.Label:new({name = "ghbShrinkA"}, box))
+      track(Geyser.Label:new({name = "ghbShrinkB"}, box))
+    end)
+
+    it("re-splits the row when a child is deleted", function()
+      local third = track(Geyser.Label:new({name = "ghbShrinkC"}, box))
+      third:delete()
+      assert.are.same({"ghbShrinkA", "ghbShrinkB"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 300, height = 50}, geometry("ghbShrinkA"))
+      assert.are.same({x = 300, y = 0, width = 300, height = 50}, geometry("ghbShrinkB"))
+    end)
+
+    it("re-splits the row when a child is removed by hand", function()
+      box:remove(box.windowList.ghbShrinkB)
+      assert.are.same({"ghbShrinkA"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 600, height = 50}, geometry("ghbShrinkA"))
+    end)
+
+    it("re-splits the row a child left for another container", function()
+      local elsewhere = track(Geyser.Container:new({name = "ghbElsewhere", x = 0, y = 100, width = 100, height = 100}))
+      box.windowList.ghbShrinkB:changeContainer(elsewhere)
+      assert.are.same({"ghbShrinkA"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 600, height = 50}, geometry("ghbShrinkA"))
+    end)
+
+    it("survives losing its last child", function()
+      box:remove(box.windowList.ghbShrinkA)
+      box:remove(box.windowList.ghbShrinkB)
+      assert.are.same({}, box.windows)
+    end)
+
+    it("holds the layout back while updates are deferred", function()
+      local third = track(Geyser.Label:new({name = "ghbShrinkDeferred"}, box))
+      box.defer_updates = true
+      third:delete()
+      assert.are.equal(199, geometry("ghbShrinkA").width)
+      box.defer_updates = false
+      box:reposition()
+      assert.are.equal(300, geometry("ghbShrinkA").width)
+    end)
+  end)
+
   describe("Geyser.HBox:reposition", function()
     local box
 

--- a/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
@@ -178,13 +178,40 @@ describe("Tests functionality of Geyser.ScrollBox", function()
   end)
 
   -- Geyser:add2 runs from inside Geyser.Container:new, so the hide it asks for
-  -- lands before createScrollBox has made the widget. Every other Geyser widget
-  -- constructor hides itself again afterwards (GeyserCommandLine.lua:89,
-  -- GeyserMiniConsole.lua:605, GeyserLabel.lua:998, GeyserTextEdit.lua:70,
-  -- GeyserMapper.lua:133); Geyser.ScrollBox:new is the one that does not, so it
-  -- comes up on screen with auto_hidden already true. A Geyser.MiniConsole
-  -- built the same way stays hidden, which is the behaviour this asks for.
-  pending("Geyser.ScrollBox created in a hidden add2 container stays hidden - Geyser.ScrollBox:new never re-hides the widget it just created")
+  -- lands before createScrollBox has made the widget. Every Geyser widget
+  -- constructor therefore hides itself again afterwards
+  -- (GeyserCommandLine.lua:89, GeyserMiniConsole.lua:605, GeyserLabel.lua:998,
+  -- GeyserTextEdit.lua:70, GeyserMapper.lua:133), and a Geyser.MiniConsole
+  -- built the same way is the reference behaviour asserted alongside.
+  describe("Geyser.ScrollBox created in a hidden container", function()
+    it("stays off screen, and comes back when the container is shown", function()
+      local parent = track(Geyser.Container:new2({name = "gsbHiddenParent", x = 0, y = 0, width = 300, height = 200}))
+      parent:hide()
+      local scrollBox = track(Geyser.ScrollBox:new2({name = "gsbBornHidden", x = 0, y = 0, width = "100%", height = "50%"}, parent))
+      local console = track(Geyser.MiniConsole:new2({name = "gsbBornHiddenConsole", x = 0, y = "50%", width = "100%", height = "50%"}, parent))
+      assert.is_true(scrollBox.auto_hidden)
+      assert.is_true(console.auto_hidden)
+      assert.is_false(windowVisible("gsbBornHiddenConsole"))
+      assert.is_false(windowVisible("gsbBornHidden"))
+      parent:show()
+      assert.is_true(windowVisible("gsbBornHidden"))
+      assert.is_true(windowVisible("gsbBornHiddenConsole"))
+    end)
+
+    -- a scroll box that came up on screen while its bookkeeping said hidden
+    -- could not be taken off it again: Geyser.Container:hide skips hide_impl
+    -- for anything that already believes itself hidden, so neither an explicit
+    -- hide nor another parent:hide() reached it
+    it("can be taken off screen by hand without being shown first", function()
+      local parent = track(Geyser.Container:new2({name = "gsbHideParent", x = 0, y = 0, width = 300, height = 200}))
+      parent:hide()
+      local scrollBox = track(Geyser.ScrollBox:new2({name = "gsbHideByHand", x = 0, y = 0, width = "100%", height = "100%"}, parent))
+      scrollBox:hide()
+      assert.is_false(windowVisible("gsbHideByHand"))
+      parent:hide()
+      assert.is_false(windowVisible("gsbHideByHand"))
+    end)
+  end)
 
   describe("Geyser.ScrollBox scroll bars", function()
     -- A scroll box scrolls by being a QScrollArea (TScrollBox.h), not by being

--- a/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserScrollBox_spec.lua
@@ -211,6 +211,15 @@ describe("Tests functionality of Geyser.ScrollBox", function()
       parent:hide()
       assert.is_false(windowVisible("gsbHideByHand"))
     end)
+
+    -- add2 carries a hidden constraint through as well as an inherited one
+    it("stays off screen when it was asked to start hidden", function()
+      local scrollBox = track(Geyser.ScrollBox:new2({name = "gsbBornHiddenFlag", x = 0, y = 0, width = 100, height = 100, hidden = true}))
+      assert.is_true(scrollBox.hidden)
+      assert.is_false(windowVisible("gsbBornHiddenFlag"))
+      scrollBox:show()
+      assert.is_true(windowVisible("gsbBornHiddenFlag"))
+    end)
   end)
 
   describe("Geyser.ScrollBox scroll bars", function()

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -191,8 +191,12 @@ describe("Tests functionality of Geyser.UserWindow", function()
     it("still docks a window that was asked to start docked", function()
       local openWindow = spy.on(_G, "openUserWindow")
       finally(function() openWindow:revert() end)
-      track(Geyser.UserWindow:new({name = "guwStaysDocked", x = 10, y = 10, width = 300, height = 200, docked = true, dockPosition = "left"}))
+      local userWindow = track(Geyser.UserWindow:new({name = "guwStaysDocked", x = 10, y = 10, width = 300, height = 200, docked = true, dockPosition = "left"}))
       assert.spy(openWindow).was.called_with("guwStaysDocked", false, true, "left")
+      -- a docked window keeps the position it was opened with, where a floated
+      -- one has its dockPosition rewritten to "floating"
+      assert.are.equal("left", userWindow.dockPosition)
+      assert.is_true(windowVisible("guwStaysDocked"))
     end)
 
     it("new2 marks the user window as using add2", function()
@@ -445,10 +449,35 @@ describe("Tests functionality of Geyser.UserWindow", function()
       assert.are.equal(trackedWindows, #Geyser.windows)
     end)
 
-    -- a root container still holding the user window has to be left alone: the
-    -- user window is deleted through its own container in the ordinary
-    -- container:delete() cascade, and that container is still in use
-    it("keeps the root container while the user window is still in it", function()
+    -- anything else the user put in the root container is still using it, so it
+    -- has to survive the user window being deleted out of it
+    it("leaves a root container that still holds something else", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwRootShared", x = 10, y = 20, width = 200, height = 150}))
+      local root = userWindow.container
+      local lodger = track(Geyser.Label:new({name = "guwRootLodger", x = 0, y = 0, width = 20, height = 20}, root))
+      userWindow:delete()
+      assert.are.equal(root, Geyser.windowList.guwRootSharedContainer)
+      assert.are.equal(lodger, root.windowList.guwRootLodger)
+      root:delete()
+      assert.is_nil(Geyser.windowList.guwRootSharedContainer)
+    end)
+
+    -- a user window moved out of the root container Geyser made for it still
+    -- has to take that container with it, and the container is no longer the
+    -- one the user window reports as its own
+    it("removes the root container even after the user window was moved out of it", function()
+      local elsewhere = track(Geyser.Container:new({name = "guwNewHome", x = 0, y = 0, width = 200, height = 200}))
+      local userWindow = track(Geyser.UserWindow:new({name = "guwMovedOut", x = 10, y = 20, width = 200, height = 150}))
+      userWindow:changeContainer(elsewhere)
+      assert.are.equal(elsewhere, userWindow.container)
+      userWindow:delete()
+      assert.is_nil(Geyser.windowList.guwMovedOutContainer)
+    end)
+
+    -- deleting the root container deletes the user window inside it, which
+    -- reaches back for the root container it is being deleted by, so that
+    -- cascade has to come apart cleanly rather than recursing
+    it("comes apart cleanly when the root container is the one deleted", function()
       local userWindow = track(Geyser.UserWindow:new({name = "guwRootKept", x = 10, y = 20, width = 200, height = 150}))
       local root = userWindow.container
       track(Geyser.Label:new({name = "guwRootKeptLabel", x = 0, y = 0, width = 20, height = 20}, userWindow))

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -49,23 +49,10 @@ describe("Tests functionality of Geyser.UserWindow", function()
     created = {}
   end)
 
-  -- Deleting a user window leaves its "<name>Container" root container behind
-  -- (see the pending below), so sweep those out by hand to keep repeat runs of
-  -- this file against the same profile identical.
   after_each(function()
-    local names = {}
     for _, object in ipairs(created) do
-      if object.type == "userwindow" then
-        names[#names + 1] = object.name .. "Container"
-      end
       if alive(object) then
         object:delete()
-      end
-    end
-    for _, name in ipairs(names) do
-      local orphan = Geyser.windowList[name]
-      if orphan then
-        orphan:delete()
       end
     end
     created = {}
@@ -179,6 +166,33 @@ describe("Tests functionality of Geyser.UserWindow", function()
       assert.are.equal("r", userWindow.dockPosition)
       assert.are.equal("userwindow", windowType("guwDocked"))
       assert.is_true(windowVisible("guwDocked"))
+    end)
+
+    -- A window that is about to be floated must not be docked on the way there:
+    -- docking takes the dock's size off the main window, and the percentage
+    -- constraints the constructor resolves straight afterwards are measured
+    -- against the main window. Which dock position was asked for is what says
+    -- so; how much the main window shrinks by, and when, is Qt's business and
+    -- is not the same on every platform.
+    it("opens a window it is going to float as floating, not docked first", function()
+      local openWindow = spy.on(_G, "openUserWindow")
+      finally(function() openWindow:revert() end)
+      local mainWidth, mainHeight = getMainWindowSize()
+      track(Geyser.UserWindow:new({name = "guwPercent", x = "25%", y = "10%", width = "30%", height = "30%"}))
+      assert.spy(openWindow).was.called_with("guwPercent", false, true, "floating")
+      assert.are.same({
+        x = math.floor(mainWidth * 0.25),
+        y = math.floor(mainHeight * 0.1),
+        width = math.floor(mainWidth * 0.3),
+        height = math.floor(mainHeight * 0.3),
+      }, geometry("guwPercent"))
+    end)
+
+    it("still docks a window that was asked to start docked", function()
+      local openWindow = spy.on(_G, "openUserWindow")
+      finally(function() openWindow:revert() end)
+      track(Geyser.UserWindow:new({name = "guwStaysDocked", x = 10, y = 10, width = 300, height = 200, docked = true, dockPosition = "left"}))
+      assert.spy(openWindow).was.called_with("guwStaysDocked", false, true, "left")
     end)
 
     it("new2 marks the user window as using add2", function()
@@ -308,12 +322,31 @@ describe("Tests functionality of Geyser.UserWindow", function()
     end)
   end)
 
-  -- Geyser.UserWindow:show() (GeyserUserWindow.lua:52) forwards to its parent
-  -- without the `auto` flag its container passes down, so an automatic show
-  -- clears self.hidden as if the user had asked for it. A user window hidden by
-  -- hand therefore reappears the moment its root container is shown, where a
-  -- Geyser.MiniConsole in the same position correctly stays hidden.
-  pending("Geyser.UserWindow stays hidden when its root container is shown - Geyser.UserWindow:show() drops the auto flag")
+  -- Geyser.UserWindow:show() forwards to its parent, and has to pass on the
+  -- `auto` flag its container hands down: the base class picks which of the two
+  -- hidden bits to clear from it. Without the flag an automatic show clears
+  -- self.hidden as if the user had asked for it, and never clears auto_hidden.
+  describe("Geyser.UserWindow show cascade", function()
+    it("stays hidden when its root container is shown after a hand hide", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwHandHidden", x = 10, y = 20, width = 200, height = 150}))
+      userWindow:hide()
+      assert.is_true(userWindow.hidden)
+      assert.is_false(windowVisible("guwHandHidden"))
+      userWindow.container:show()
+      assert.is_true(userWindow.hidden)
+      assert.is_false(windowVisible("guwHandHidden"))
+    end)
+
+    it("comes back when the container that hid it is shown again", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwAutoHidden", x = 10, y = 20, width = 200, height = 150}))
+      userWindow.container:hide()
+      assert.is_true(userWindow.auto_hidden)
+      assert.is_false(windowVisible("guwAutoHidden"))
+      userWindow.container:show()
+      assert.is_false(userWindow.auto_hidden)
+      assert.is_true(windowVisible("guwAutoHidden"))
+    end)
+  end)
 
   describe("Geyser.UserWindow:setTitle/resetTitle", function()
     -- setUserWindowTitle answers nil and a message rather than raising when it
@@ -388,9 +421,42 @@ describe("Tests functionality of Geyser.UserWindow", function()
     end)
   end)
 
-  -- Geyser.Container:new (GeyserContainer.lua:361) makes the "<name>Container"
-  -- root container for a user window, but Geyser.Container:delete only unhooks
-  -- the user window from it, so the container is left registered in
-  -- Geyser.windowList and Geyser.windows for the rest of the session.
-  pending("deleting a Geyser.UserWindow also removes the root container it created")
+  -- Geyser.Container:new makes the "<name>Container" root container for a user
+  -- window. An orphaned one is not inert: its get_width/get_height ask
+  -- getUserWindowSize for a window that is gone, which falls back to the main
+  -- window size, so every leftover claims the whole main window in every
+  -- layout pass.
+  describe("Geyser.UserWindow root container cleanup", function()
+    it("removes the root container it created", function()
+      local trackedWindows = #Geyser.windows
+      local userWindow = track(Geyser.UserWindow:new({name = "guwRootGone", x = 10, y = 20, width = 200, height = 150}))
+      assert.are.equal(userWindow.container, Geyser.windowList.guwRootGoneContainer)
+      userWindow:delete()
+      assert.is_nil(Geyser.windowList.guwRootGoneContainer)
+      assert.is_nil(table.index_of(Geyser.windows, "guwRootGoneContainer"))
+      assert.are.equal(trackedWindows, #Geyser.windows)
+    end)
+
+    it("leaves nothing behind over repeated create and delete cycles", function()
+      local trackedWindows = #Geyser.windows
+      for index = 1, 5 do
+        Geyser.UserWindow:new({name = "guwCycle" .. index, x = 10, y = 20, width = 200, height = 150}):delete()
+      end
+      assert.are.equal(trackedWindows, #Geyser.windows)
+    end)
+
+    -- a root container still holding the user window has to be left alone: the
+    -- user window is deleted through its own container in the ordinary
+    -- container:delete() cascade, and that container is still in use
+    it("keeps the root container while the user window is still in it", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwRootKept", x = 10, y = 20, width = 200, height = 150}))
+      local root = userWindow.container
+      track(Geyser.Label:new({name = "guwRootKeptLabel", x = 0, y = 0, width = 20, height = 20}, userWindow))
+      assert.are.equal(root, Geyser.windowList.guwRootKeptContainer)
+      root:delete()
+      assert.is_nil(Geyser.windowList.guwRootKeptContainer)
+      assert.is_nil(windowType("guwRootKept"))
+      assert.is_nil(windowType("guwRootKeptLabel"))
+    end)
+  end)
 end)

--- a/src/mudlet-lua/tests/GeyserVBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserVBox_spec.lua
@@ -128,6 +128,47 @@ describe("Tests functionality of Geyser.VBox", function()
     end)
   end)
 
+  -- The box lays itself out when a child arrives, and has to do the same when
+  -- one leaves: without it the survivors keep the geometry computed for the old
+  -- child count and the box is left with a permanent hole. contains_fixed is
+  -- false for a box of plain labels, so reposition() does not heal it either.
+  describe("Geyser.VBox:remove", function()
+    local box
+
+    before_each(function()
+      box = track(Geyser.VBox:new({name = "gvbShrink", x = 0, y = 0, width = 50, height = 600}))
+      track(Geyser.Label:new({name = "gvbShrinkA"}, box))
+      track(Geyser.Label:new({name = "gvbShrinkB"}, box))
+    end)
+
+    it("re-stacks the column when a child is deleted", function()
+      local third = track(Geyser.Label:new({name = "gvbShrinkC"}, box))
+      third:delete()
+      assert.are.same({"gvbShrinkA", "gvbShrinkB"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 50, height = 300}, geometry("gvbShrinkA"))
+      assert.are.same({x = 0, y = 300, width = 50, height = 300}, geometry("gvbShrinkB"))
+    end)
+
+    it("re-stacks the column when a child is removed by hand", function()
+      box:remove(box.windowList.gvbShrinkB)
+      assert.are.same({"gvbShrinkA"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 50, height = 600}, geometry("gvbShrinkA"))
+    end)
+
+    it("re-stacks the column a child left for another container", function()
+      local elsewhere = track(Geyser.Container:new({name = "gvbElsewhere", x = 100, y = 0, width = 100, height = 100}))
+      box.windowList.gvbShrinkB:changeContainer(elsewhere)
+      assert.are.same({"gvbShrinkA"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 50, height = 600}, geometry("gvbShrinkA"))
+    end)
+
+    it("survives losing its last child", function()
+      box:remove(box.windowList.gvbShrinkA)
+      box:remove(box.windowList.gvbShrinkB)
+      assert.are.same({}, box.windows)
+    end)
+  end)
+
   describe("Geyser.VBox:reposition", function()
     local box
 

--- a/src/mudlet-lua/tests/GeyserVBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserVBox_spec.lua
@@ -162,10 +162,32 @@ describe("Tests functionality of Geyser.VBox", function()
       assert.are.same({x = 0, y = 0, width = 50, height = 600}, geometry("gvbShrinkA"))
     end)
 
+    -- an emptied box has no children to divide its height between, and
+    -- organize() still has to come through that without raising
     it("survives losing its last child", function()
-      box:remove(box.windowList.gvbShrinkA)
-      box:remove(box.windowList.gvbShrinkB)
+      assert.has_no.errors(function()
+        box:remove(box.windowList.gvbShrinkA)
+        box:remove(box.windowList.gvbShrinkB)
+      end)
       assert.are.same({}, box.windows)
+    end)
+
+    it("holds the layout back while updates are deferred", function()
+      local third = track(Geyser.Label:new({name = "gvbShrinkDeferred"}, box))
+      local heightOfThree = geometry("gvbShrinkA").height
+      box.defer_updates = true
+      third:delete()
+      assert.are.equal(heightOfThree, geometry("gvbShrinkA").height)
+      box.defer_updates = false
+      box:reposition()
+      assert.are.equal(300, geometry("gvbShrinkA").height)
+    end)
+
+    it("deletes a box that still holds children", function()
+      assert.has_no.errors(function() box:delete() end)
+      assert.is_nil(getWindowGeometry("gvbShrinkA"))
+      assert.is_nil(getWindowGeometry("gvbShrinkB"))
+      assert.is_nil(Geyser.windowList.gvbShrink)
     end)
   end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- **Layout**: `HBox`/`VBox` lay themselves out again when a child leaves (delete, `remove`, `changeContainer`); a `ScrollBox` made inside a hidden container stays hidden instead of coming up on screen unhideable; `Geyser.UserWindow:show()` passes the `auto` flag on, so a container-hidden user window can be shown again.
- **Lifetime and identity**: deleting a `Geyser.UserWindow` takes the `<name>Container` root container Geyser made for it, which otherwise answers every layout pass with the main window's size; `Adjustable.Container`'s border registry no longer lets two same-named containers silently clobber each other's reservation; a user window that is going to float is no longer docked first, so its percentage constraints are measured against the whole main window.
- **Gauge CSS**: `setGaugeWindow` honours `show = false`; the spacing parser reads unitless zeros, negative lengths, `!important`, longhands like `margin-left` and `border-width`, and upper case `PX`, stops at block braces and comments, no longer mistakes `qproperty-margin` for a margin, and says through `debugc` when a spacing has no pixel reading.

#### Motivation for adding to Mudlet

Each of these leaves a Geyser UI visibly wrong with no way for a script to put it right: a box with a permanent hole in it, a scroll box that cannot be hidden, a user window stuck off screen for the session, a gauge whose fill bar looks empty or broken, and orphaned containers that claim 100% x 100% in every layout pass.

#### Other info (issues closed, discussion etc)

Closes #9642 - setGaugeWindow ignores show = false and always shows the gauge
Closes #9656 - Geyser gauge CSS spacing parser ignores unitless zeros, negative values and longhand properties
Closes #9657 - Geyser HBox/VBox never re-organize when a child is removed
Closes #9658 - Adjustable.Container:detach() unregisters by name, so same-named containers clobber each other
Closes #9666 - Geyser.ScrollBox created in a hidden container comes up on screen and cannot be hidden
Closes #9667 - Geyser.UserWindow:show() drops the auto flag, so a user window can get stuck hidden for good
Closes #9668 - Deleting a Geyser.UserWindow leaks the <name>Container root container Geyser made for it
Closes #9669 - Geyser.UserWindow percentage constraints are measured against a main window its own dock just shrank

Test case: `Geyser.HBox:new{name="b",x=0,y=0,width=600,height=50}` with three labels, then delete one - the survivors now split the box instead of leaving the last third empty.

47 new busted specs across seven spec files, each proven to fail without its fix; the full suite runs 2269 passing, 0 failures.

Assisted-by: Claude:claude-opus-5
