### PR TITLE
Fix temporary trigger/alias/key/timer cleanup evicting same-named items

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -89,6 +89,9 @@ void AliasUnit::uninstall(const QString& packageName)
         return;
     }
     for (auto& alias : uninstallList) {
+        // in case the alias was also queued for the markCleanup()/doCleanup()
+        // path - deleting it here would otherwise leave a dangling pointer there:
+        mCleanupSet.remove(alias);
         delete alias;
     }
     uninstallList.clear();
@@ -177,11 +180,12 @@ void AliasUnit::removeAliasRootNode(TAlias* pT)
     if (!pT) {
         return;
     }
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->mName, pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // Names are not unique - the lookup table is a QMultiMap - so drop this one
+    // alias' entry rather than every entry filed under the name. The
+    // single-argument remove() used to be taken for temporary aliases, which
+    // evicted live same-named aliases and left them unreachable by name for the
+    // rest of the session
+    mLookupTable.remove(pT->getName(), pT);
     mAliasMap.remove(pT->getID());
     mAliasRootNodeList.remove(pT);
 }
@@ -257,11 +261,8 @@ void AliasUnit::removeAlias(TAlias* pT)
     if (!pT) {
         return;
     }
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->mName, pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // see removeAliasRootNode(): one entry, not every same-named one
+    mLookupTable.remove(pT->getName(), pT);
 
     mAliasMap.remove(pT->getID());
 }
@@ -441,17 +442,20 @@ void AliasUnit::doCleanup()
         return;
     }
 
+    QSet<TAlias*> deletedAliases;
     QMutableSetIterator<TAlias*> itAlias(mCleanupSet);
     while (itAlias.hasNext()) {
         auto pAlias = itAlias.next();
         itAlias.remove();
+        deletedAliases.insert(pAlias);
         delete pAlias;
     }
     // Flush the deletes uninstall() deferred (#9337). uninstallList is ordered
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
-    // set guards a node queued twice by re-entrant uninstalls.
-    QSet<TAlias*> deletedAliases;
+    // set guards a node queued twice by re-entrant uninstalls and is shared with
+    // the mCleanupSet loop above so an object that somehow ended up in both
+    // containers cannot be freed twice.
     for (auto alias : uninstallList) {
         if (!deletedAliases.contains(alias)) {
             deletedAliases.insert(alias);

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -381,23 +381,27 @@ bool AliasUnit::disableAlias(const QString& name)
 bool AliasUnit::killAlias(const QString& name)
 {
     for (auto alias : mAliasRootNodeList) {
-        if (alias->getName() == name) {
-            // only temporary Aliases can be killed
-            if (!alias->isTemporary()) {
-                return false;
-            }
-            // An already killed alias is only unlinked from this list once
-            // doCleanup() gets to free it, which cannot happen while an alias
-            // script is on the call stack - so until then it is still findable by
-            // name. Killing it a second time achieves nothing and must be reported
-            // as the failure it is:
-            if (mCleanupSet.contains(alias)) {
-                return false;
-            }
-            alias->setIsActive(false);
-            markCleanup(alias);
-            return true;
+        if (alias->getName() != name) {
+            continue;
         }
+        // Names are not unique, so keep looking rather than give up on the first
+        // same-named alias that cannot be killed - a permanent alias loaded from
+        // the profile precedes this session's temporaries in this list, and
+        // reporting a failure over it would strand a killable alias
+        if (!alias->isTemporary()) {
+            // only temporary Aliases can be killed
+            continue;
+        }
+        // An already killed alias is only unlinked from this list once doCleanup()
+        // gets to free it, which cannot happen while an alias script is on the
+        // call stack - so until then it is still findable by name. Killing it a
+        // second time achieves nothing:
+        if (mCleanupSet.contains(alias)) {
+            continue;
+        }
+        alias->setIsActive(false);
+        markCleanup(alias);
+        return true;
     }
     return false;
 }
@@ -454,8 +458,10 @@ void AliasUnit::doCleanup()
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
     // set guards a node queued twice by re-entrant uninstalls and is shared with
-    // the mCleanupSet loop above so an object that somehow ended up in both
-    // containers cannot be freed twice.
+    // the mCleanupSet loop above so an object that ended up in both containers is
+    // freed once. It matches on pointer identity only: a node freed indirectly, as
+    // a child of a queued parent, is not in the set (not reachable today - only
+    // temporary root nodes are ever queued, and those have no children).
     for (auto alias : uninstallList) {
         if (!deletedAliases.contains(alias)) {
             deletedAliases.insert(alias);

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -231,23 +231,27 @@ bool KeyUnit::disableKey(const QString& name)
 bool KeyUnit::killKey(QString& name)
 {
     for (auto pChild : mKeyRootNodeList) {
-        if (pChild->getName() == name) {
-            // only temporary Keys can be killed
-            if (!pChild->isTemporary()) {
-                return false;
-            }
-            // An already killed key is only unlinked from this list once
-            // doCleanup() gets to free it, which cannot happen while a key script
-            // is on the call stack - so until then it is still findable by name.
-            // Killing it a second time achieves nothing and must be reported as
-            // the failure it is:
-            if (mCleanupSet.contains(pChild)) {
-                return false;
-            }
-            pChild->setIsActive(false);
-            markCleanup(pChild);
-            return true;
+        if (pChild->getName() != name) {
+            continue;
         }
+        // Names are not unique, so keep looking rather than give up on the first
+        // same-named key that cannot be killed - a permanent key loaded from the
+        // profile precedes this session's temporaries in this list, and reporting
+        // a failure over it would strand a killable key
+        if (!pChild->isTemporary()) {
+            // only temporary Keys can be killed
+            continue;
+        }
+        // An already killed key is only unlinked from this list once doCleanup()
+        // gets to free it, which cannot happen while a key script is on the call
+        // stack - so until then it is still findable by name. Killing it a second
+        // time achieves nothing:
+        if (mCleanupSet.contains(pChild)) {
+            continue;
+        }
+        pChild->setIsActive(false);
+        markCleanup(pChild);
+        return true;
     }
     return false;
 }
@@ -490,8 +494,10 @@ void KeyUnit::doCleanup()
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
     // set guards a node queued twice by re-entrant uninstalls and is shared with
-    // the mCleanupSet loop above so an object that somehow ended up in both
-    // containers cannot be freed twice.
+    // the mCleanupSet loop above so an object that ended up in both containers is
+    // freed once. It matches on pointer identity only: a node freed indirectly, as
+    // a child of a queued parent, is not in the set (not reachable today - only
+    // temporary root nodes are ever queued, and those have no children).
     for (auto key : uninstallList) {
         if (!deletedKeys.contains(key)) {
             deletedKeys.insert(key);

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -98,6 +98,9 @@ void KeyUnit::uninstall(const QString& packageName)
         return;
     }
     for (auto& key : uninstallList) {
+        // in case the key was also queued for the markCleanup()/doCleanup()
+        // path - deleting it here would otherwise leave a dangling pointer there:
+        mCleanupSet.remove(key);
         delete key;
     }
     uninstallList.clear();
@@ -324,11 +327,12 @@ void KeyUnit::removeKeyRootNode(TKey* pT)
     if (!pT) {
         return;
     }
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->getName(), pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // Names are not unique - the lookup table is a QMultiMap - so drop this one
+    // key's entry rather than every entry filed under the name. The
+    // single-argument remove() used to be taken for temporary keys, which evicted
+    // live same-named keys and left them unreachable by name for the rest of the
+    // session
+    mLookupTable.remove(pT->getName(), pT);
     mKeyMap.remove(pT->getID());
     mKeyRootNodeList.remove(pT);
 }
@@ -390,11 +394,8 @@ void KeyUnit::removeKey(TKey* pT)
     if (!pT) {
         return;
     }
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->getName(), pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // see removeKeyRootNode(): one entry, not every same-named one
+    mLookupTable.remove(pT->getName(), pT);
     mKeyMap.remove(pT->getID());
 }
 
@@ -477,17 +478,20 @@ void KeyUnit::doCleanup()
         return;
     }
 
+    QSet<TKey*> deletedKeys;
     QMutableSetIterator<TKey*> itKey(mCleanupSet);
     while (itKey.hasNext()) {
         auto pKey = itKey.next();
         itKey.remove();
+        deletedKeys.insert(pKey);
         delete pKey;
     }
     // Flush the deletes uninstall() deferred (#9337). uninstallList is ordered
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
-    // set guards a node queued twice by re-entrant uninstalls.
-    QSet<TKey*> deletedKeys;
+    // set guards a node queued twice by re-entrant uninstalls and is shared with
+    // the mCleanupSet loop above so an object that somehow ended up in both
+    // containers cannot be freed twice.
     for (auto key : uninstallList) {
         if (!deletedKeys.contains(key)) {
             deletedKeys.insert(key);

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1102,9 +1102,11 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                 // pass ends, so an expired trigger that is still active would fire
                 // again from any pass that re-enters in the meantime (a later
                 // trigger's script calling feedTriggers(), most commonly).
-                // Deactivate first, as the line-trigger path above and
-                // TriggerUnit::killTrigger() both do.
-                deactivate();
+                // setIsActive(false) rather than deactivate(), matching
+                // TriggerUnit::killTrigger(): it also clears the user-active state,
+                // so an enableTrigger() before the deferred free cannot resurrect a
+                // trigger that has already spent its last fire.
+                setIsActive(false);
                 mpHost->getTriggerUnit()->markCleanup(this);
 
                 if (mudlet::smDebugMode) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1098,6 +1098,13 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
             mExpiryCount--;
 
             if (mExpiryCount == 0) {
+                // The delete is deferred until the outermost processDataStream()
+                // pass ends, so an expired trigger that is still active would fire
+                // again from any pass that re-enters in the meantime (a later
+                // trigger's script calling feedTriggers(), most commonly).
+                // Deactivate first, as the line-trigger path above and
+                // TriggerUnit::killTrigger() both do.
+                deactivate();
                 mpHost->getTriggerUnit()->markCleanup(this);
 
                 if (mudlet::smDebugMode) {

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -392,23 +392,27 @@ std::vector<int> TimerUnit::findItems(const QString& name, const bool exactMatch
 bool TimerUnit::killTimer(const QString& name)
 {
     for (auto timer : mTimerRootNodeList) {
-        if (timer->getName() == name) {
-            // only temporary timers can be killed
-            if (!timer->isTemporary()) {
-                return false;
-            }
-            // An already killed timer is only unlinked from this list once
-            // doCleanup() gets to free it, which cannot happen while a timer
-            // script is on the call stack - so until then it is still findable
-            // by name. Killing it a second time achieves nothing and must be
-            // reported as the failure it is:
-            if (mCleanupSet.contains(timer)) {
-                return false;
-            }
-            timer->killTimer();
-            markCleanup(timer);
-            return true;
+        if (timer->getName() != name) {
+            continue;
         }
+        // Names are not unique, so keep looking rather than give up on the first
+        // same-named timer that cannot be killed - a permanent timer loaded from
+        // the profile precedes this session's temporaries in this list, and
+        // reporting a failure over it would strand a killable timer
+        if (!timer->isTemporary()) {
+            // only temporary timers can be killed
+            continue;
+        }
+        // An already killed timer is only unlinked from this list once doCleanup()
+        // gets to free it, which cannot happen while a timer script is on the call
+        // stack - so until then it is still findable by name. Killing it a second
+        // time achieves nothing:
+        if (mCleanupSet.contains(timer)) {
+            continue;
+        }
+        timer->killTimer();
+        markCleanup(timer);
+        return true;
     }
     return false;
 }
@@ -458,8 +462,10 @@ void TimerUnit::doCleanup()
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
     // set guards a node queued twice by re-entrant uninstalls and is shared with
-    // the mCleanupSet loop above so an object that somehow ended up in both
-    // containers cannot be freed twice.
+    // the mCleanupSet loop above so an object that ended up in both containers is
+    // freed once. It matches on pointer identity only: a node freed indirectly, as
+    // a child of a queued parent, is not in the set (not reachable today - only
+    // temporary root nodes are ever queued, and those have no children).
     for (auto timer : uninstallList) {
         if (!deletedTimers.contains(timer)) {
             deletedTimers.insert(timer);

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -210,13 +210,13 @@ void TimerUnit::_removeTimerRootNode(TTimer* pT)
     if (!pT) {
         return;
     }
-    // temp timers do not need to check for names referring to multiple different
-    // objects as names=ID -> much faster tempTimer creation
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->mName, pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // Names are not unique - the lookup table is a QMultiMap - so drop this one
+    // timer's entry rather than every entry filed under the name. The
+    // single-argument remove() used to be taken for temporary timers on the
+    // grounds that their name is their id, but a permanent timer named after
+    // that id was evicted with it and left unreachable by name for the rest of
+    // the session
+    mLookupTable.remove(pT->getName(), pT);
     mTimerMap.remove(pT->getID());
     mTimerRootNodeList.remove(pT);
 }
@@ -296,13 +296,8 @@ void TimerUnit::_removeTimer(TTimer* pT)
         return;
     }
 
-    // temp timers do not need to check for names referring to multiple different
-    // objects as names=ID -> much faster tempTimer creation
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->mName, pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // see _removeTimerRootNode(): one entry, not every same-named one
+    mLookupTable.remove(pT->getName(), pT);
     mTimerMap.remove(pT->getID());
 }
 

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -90,6 +90,7 @@ public:
 
     QMultiMap<QString, TTimer*> mLookupTable;
     QList<TTimer*> uninstallList;
+    QSet<TTimer*> mCleanupSet;
 
     // This will contain all the QTimers associated with the TTimer instances
     // it is needed so that should mpHost be renamed we can update them to have
@@ -114,7 +115,6 @@ private:
     std::list<TTimer*> mTimerRootNodeList;
     int mMaxID = 0;
     bool mModuleMember = false;
-    QSet<TTimer*> mCleanupSet;
     // > 0 whilst a TTimer::execute() is on the call stack; uninstall() and
     // doCleanup() must not delete timers then - see the note above the class:
     int mProcessingDepth = 0;

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -543,8 +543,10 @@ void TriggerUnit::doCleanup()
     // children-before-parents and each ~Tree unlinks from its parent, so deleting
     // children first empties the parent's child list (no double free); the seen
     // set guards a node queued twice by re-entrant uninstalls and is shared with
-    // the mCleanupSet loop above so an object that somehow ended up in both
-    // containers cannot be freed twice.
+    // the mCleanupSet loop above so an object that ended up in both containers is
+    // freed once. It matches on pointer identity only: a node freed indirectly, as
+    // a child of a queued parent, is not in the set (not reachable today - only
+    // temporary root nodes are ever queued, and those have no children).
     for (auto trigger : uninstallList) {
         if (!deletedTriggers.contains(trigger)) {
             deletedTriggers.insert(trigger);

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -194,11 +194,13 @@ void TriggerUnit::removeTriggerRootNode(TTrigger* pT)
     if (!pT) {
         return;
     }
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->mName, pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // Names are not unique - the lookup table is a QMultiMap - so drop this one
+    // trigger's entry rather than every entry filed under the name. The
+    // single-argument remove() used to be taken for temporary triggers, which
+    // evicted live same-named triggers and left them unreachable by name for the
+    // rest of the session (tempComplexRegexTrigger() takes a user-supplied name,
+    // so a collision needs no coincidence)
+    mLookupTable.remove(pT->getName(), pT);
     mTriggerMap.remove(pT->getID());
     mTriggerRootNodeList.remove(pT);
     // A node can be removed and deleted mid-pass without going through the
@@ -274,11 +276,8 @@ void TriggerUnit::removeTrigger(TTrigger* pT)
     if (!pT) {
         return;
     }
-    if (!pT->isTemporary()) {
-        mLookupTable.remove(pT->mName, pT);
-    } else {
-        mLookupTable.remove(pT->getName());
-    }
+    // see removeTriggerRootNode(): one entry, not every same-named one
+    mLookupTable.remove(pT->getName(), pT);
 
     mTriggerMap.remove(pT->getID());
 }

--- a/src/mudlet-lua/lua/IDManager.lua
+++ b/src/mudlet-lua/lua/IDManager.lua
@@ -93,7 +93,12 @@ function IDMgr:stopAllTimers()
 end
 
 function IDMgr:stopAllTriggers()
-  return self:stopAll("triggers")
+  -- named triggers live in two stores - registerNamedTrigger() fills "triggers"
+  -- and registerNamedRegexTrigger() fills "regexTriggers" - so stopping them all
+  -- has to walk both, exactly as deleteAllTriggers() does
+  local regex = self:stopAll("regexTriggers")
+  local substring = self:stopAll("triggers")
+  return regex and substring
 end
 
 function IDMgr:deleteAllEvents()
@@ -175,7 +180,7 @@ end
 function IDMgr:emergencyStop()
   self:stopAll("events")
   self:stopAll("timers")
-  self:stopAll("triggers")
+  self:stopAllTriggers()
   return true
 end
 

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -326,5 +326,22 @@ describe("Alias processing", function()
             killAlias(id)
         end)
 
+        it("freeing a temporary alias leaves a same-named permanent one reachable", function()
+            -- tempAlias names its alias after its id, so a permanent alias called
+            -- after that number shares the name - and the name lookup table holds
+            -- several aliases per name
+            local tempId = tempAlias("^spec_evicted_temp$", [[]])
+            local sharedName = tostring(tempId)
+            assert.is_true(permAlias(sharedName, "", "^spec_evicted_perm$", [[]]) > 0)
+            assert.are.equal(2, exists(sharedName, "alias"))
+
+            assert.is_true(killAlias(tempId), "the temporary alias is the one that can be killed")
+            -- an incoming line runs every unit's deferred cleanup, which frees it
+            feedTriggers("\nspec_alias_eviction_flush\n")
+
+            assert.are.equal(1, exists(sharedName, "alias"), "only the temporary alias should leave the lookup table")
+            assert.is_true(enableAlias(sharedName), "the permanent alias must still be reachable by name")
+        end)
+
     end)
 end)

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -332,15 +332,35 @@ describe("Alias processing", function()
             -- several aliases per name
             local tempId = tempAlias("^spec_evicted_temp$", [[]])
             local sharedName = tostring(tempId)
+            -- permanent aliases cannot be deleted from Lua, so earlier local runs
+            -- can leave same-named ones behind: work from a relative baseline
+            local before = exists(sharedName, "alias")
             assert.is_true(permAlias(sharedName, "", "^spec_evicted_perm$", [[]]) > 0)
-            assert.are.equal(2, exists(sharedName, "alias"))
+            finally(function() disableAlias(sharedName) end)
+            assert.are.equal(before + 1, exists(sharedName, "alias"))
 
             assert.is_true(killAlias(tempId), "the temporary alias is the one that can be killed")
             -- an incoming line runs every unit's deferred cleanup, which frees it
             feedTriggers("\nspec_alias_eviction_flush\n")
 
-            assert.are.equal(1, exists(sharedName, "alias"), "only the temporary alias should leave the lookup table")
+            assert.are.equal(before, exists(sharedName, "alias"), "only the temporary alias should leave the lookup table")
             assert.is_true(enableAlias(sharedName), "the permanent alias must still be reachable by name")
+        end)
+
+        it("killAlias finds a temporary alias behind a same-named permanent one", function()
+            -- killAlias walks the root node list in creation order, so a permanent
+            -- alias restored from the profile sits in front of this session's
+            -- temporaries: it must be scanned past, not reported as a failure
+            local seed = tempAlias("^spec_kill_order_seed$", [[]])
+            killAlias(seed)
+            -- permAlias itself takes seed + 1, so the next temporary takes seed + 2
+            local sharedName = tostring(seed + 2)
+            assert.is_true(permAlias(sharedName, "", "^spec_kill_order_perm$", [[]]) > 0)
+            finally(function() disableAlias(sharedName) end)
+
+            local tempId = tempAlias("^spec_kill_order_temp$", [[]])
+            assert.are.equal(seed + 2, tempId, "ids should still be handed out in sequence")
+            assert.is_true(killAlias(tempId), "killAlias must scan past the permanent alias")
         end)
 
     end)

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -517,10 +517,6 @@ describe("Tests the functionality of IDMgr", function()
     end)
 
     it("Should stop regex named triggers too", function()
-      -- BUG: stopAllNamedTriggers reaches IDMgr:stopAllTriggers, which only
-      -- walks the substring store; regex named triggers keep firing. Compare
-      -- deleteAllNamedTriggers, which clears both stores.
-      pending("stopAllNamedTriggers ignores regex named triggers - see the Wave 3d report")
       _G.StopAllTrigFire = 0
       registerNamedRegexTrigger(user, "re", "^stop_all_re$", function() _G.StopAllTrigFire = _G.StopAllTrigFire + 1 end)
       feedTriggers("\nstop_all_re\n")
@@ -692,12 +688,13 @@ describe("Tests the functionality of IDMgr", function()
       end)
 
       it("Should stop regex triggers as well", function()
-        -- BUG: stopAllTriggers only calls stopAll("triggers"), so entries in
-        -- the regexTriggers store keep their live handlerID and keep firing
-        pending("IDMgr:stopAllTriggers ignores the regex store - see the Wave 3d report")
+        mgr:registerTrigger("sub", "private_mgr_stopall_sub", function() end)
         mgr:registerRegexTrigger("re", "^private_mgr_stopall_re$", function() end)
-        mgr:stopAllTriggers()
+        assert.is_true(mgr:stopAllTriggers())
         assert.is_equal(-1, mgr.regexTriggers["re"].handlerID)
+        -- the substring store must not regress while the regex one is added
+        assert.is_equal(-1, mgr.triggers["sub"].handlerID)
+        assert.are.same({"re", "sub"}, mgr:getTriggers())
       end)
     end)
 
@@ -718,12 +715,11 @@ describe("Tests the functionality of IDMgr", function()
       end)
 
       it("Should stop regex triggers too", function()
-        -- BUG: emergencyStop shares IDMgr:stopAllTriggers' blind spot and never
-        -- touches the regexTriggers store, so those triggers survive it
-        pending("IDMgr:emergencyStop leaves regex triggers running - see the Wave 3d report")
         mgr:registerRegexTrigger("re", "^private_mgr_emergency_re$", function() end)
-        mgr:emergencyStop()
+        assert.is_true(mgr:emergencyStop())
         assert.is_equal(-1, mgr.regexTriggers["re"].handlerID)
+        -- stopped, not deleted, so it can still be resumed
+        assert.are.same({"re"}, mgr:getTriggers())
       end)
     end)
   end)

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -523,10 +523,26 @@ describe("Tests the functionality of IDMgr", function()
       assert.is_true(_G.StopAllTrigFire >= 1)
 
       stopAllNamedTriggers(user)
+      -- killTrigger deactivates synchronously, so not one more fire is allowed
+      local atStop = _G.StopAllTrigFire
       feedTriggers("\nstop_all_re\n")
-      local afterFlush = _G.StopAllTrigFire
       feedTriggers("\nstop_all_re\n")
-      assert.is_equal(afterFlush, _G.StopAllTrigFire, "a stopped regex named trigger must not keep firing")
+      assert.is_equal(atStop, _G.StopAllTrigFire, "a stopped regex named trigger must not keep firing")
+      -- stopped, not deleted
+      assert.are.same({"re"}, getNamedTriggers(user))
+    end)
+
+    it("Should let a stopped regex named trigger be resumed", function()
+      _G.StopAllTrigFire = 0
+      registerNamedRegexTrigger(user, "re", "^stop_all_resume_re$", function() _G.StopAllTrigFire = _G.StopAllTrigFire + 1 end)
+      stopAllNamedTriggers(user)
+      local atStop = _G.StopAllTrigFire
+      feedTriggers("\nstop_all_resume_re\n")
+      assert.is_equal(atStop, _G.StopAllTrigFire, "the regex named trigger should be stopped")
+
+      assert.is_true(resumeNamedTrigger(user, "re"), "a stopped regex named trigger must be resumable")
+      feedTriggers("\nstop_all_resume_re\n")
+      assert.is_true(_G.StopAllTrigFire > atStop, "the resumed regex named trigger should fire again")
     end)
 
     it("Should raise an error if the userName is missing or wrong type", function()

--- a/src/mudlet-lua/tests/KeyBinds_spec.lua
+++ b/src/mudlet-lua/tests/KeyBinds_spec.lua
@@ -258,15 +258,35 @@ describe("Tests keybind-related functions", function()
       -- name
       local tempId = tempKey(mudlet.key.F11, [[echo("x")]])
       local sharedName = tostring(tempId)
+      -- permanent keys cannot be deleted from Lua, so earlier local runs can leave
+      -- same-named ones behind: work from a relative baseline
+      local before = exists(sharedName, "keybind")
       assert.is_true(permKey(sharedName, "", mudlet.key.F12, [[echo("x")]]) > 0)
-      assert.are.equal(2, exists(sharedName, "keybind"))
+      finally(function() disableKey(sharedName) end)
+      assert.are.equal(before + 1, exists(sharedName, "keybind"))
 
       assert.is_true(killKey(tempId), "the temporary key is the one that can be killed")
       -- an incoming line runs every unit's deferred cleanup, which frees it
       feedTriggers("\nspec_key_eviction_flush\n")
 
-      assert.are.equal(1, exists(sharedName, "keybind"), "only the temporary key should leave the lookup table")
+      assert.are.equal(before, exists(sharedName, "keybind"), "only the temporary key should leave the lookup table")
       assert.is_true(enableKey(sharedName), "the permanent key must still be reachable by name")
+    end)
+
+    it("killKey finds a temporary key behind a same-named permanent one", function()
+      -- killKey walks the root node list in creation order, so a permanent key
+      -- restored from the profile sits in front of this session's temporaries: it
+      -- must be scanned past, not reported as a failure
+      local seed = tempKey(mudlet.key.F9, [[echo("x")]])
+      killKey(seed)
+      -- permKey itself takes seed + 1, so the next temporary takes seed + 2
+      local sharedName = tostring(seed + 2)
+      assert.is_true(permKey(sharedName, "", mudlet.key.F10, [[echo("x")]]) > 0)
+      finally(function() disableKey(sharedName) end)
+
+      local tempId = tempKey(mudlet.key.F11, [[echo("x")]])
+      assert.are.equal(seed + 2, tempId, "ids should still be handed out in sequence")
+      assert.is_true(killKey(tempId), "killKey must scan past the permanent key")
     end)
 
   end)

--- a/src/mudlet-lua/tests/KeyBinds_spec.lua
+++ b/src/mudlet-lua/tests/KeyBinds_spec.lua
@@ -252,6 +252,23 @@ describe("Tests keybind-related functions", function()
       assert.are.equal(exists("SpecDupKeys", "keybind"), isActive("SpecDupKeys", "keybind"), "enabling by name must reactivate every duplicate")
     end)
 
+    it("freeing a temporary key leaves a same-named permanent one reachable", function()
+      -- tempKey names its key after its id, so a permanent key called after that
+      -- number shares the name - and the name lookup table holds several keys per
+      -- name
+      local tempId = tempKey(mudlet.key.F11, [[echo("x")]])
+      local sharedName = tostring(tempId)
+      assert.is_true(permKey(sharedName, "", mudlet.key.F12, [[echo("x")]]) > 0)
+      assert.are.equal(2, exists(sharedName, "keybind"))
+
+      assert.is_true(killKey(tempId), "the temporary key is the one that can be killed")
+      -- an incoming line runs every unit's deferred cleanup, which frees it
+      feedTriggers("\nspec_key_eviction_flush\n")
+
+      assert.are.equal(1, exists(sharedName, "keybind"), "only the temporary key should leave the lookup table")
+      assert.is_true(enableKey(sharedName), "the permanent key must still be reachable by name")
+    end)
+
   end)
 
 end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -934,4 +934,61 @@ describe("Trigger processing", function()
         end)
 
     end)
+
+    -- The delete of an expired or killed trigger is deferred until the outermost
+    -- processDataStream() pass ends, so everything between the queueing and the
+    -- free has to behave as if the trigger were already gone.
+    describe("deferred deletion", function()
+
+        it("does not let an expired trigger fire again from a nested feed", function()
+            local fires = 0
+            -- expireAfter = 1, so this must fire exactly once no matter how many
+            -- lines reach it
+            tempRegexTrigger("^expiry_reentry$", function() fires = fires + 1 end, 1)
+
+            local nestedFed = false
+            local reentrantId = tempRegexTrigger("^expiry_reentry$", function()
+                if not nestedFed then
+                    nestedFed = true
+                    -- re-enters trigger processing while the expired trigger is
+                    -- still queued for deletion
+                    feedTriggers("\nexpiry_reentry\n")
+                end
+            end)
+            finally(function() killTrigger(reentrantId) end)
+
+            feedTriggers("\nexpiry_reentry\n")
+
+            assert.is_true(nestedFed, "the re-entrant trigger should have fed a nested line")
+            assert.are.equal(1, fires, "a trigger with expireAfter = 1 must not fire a second time")
+        end)
+
+        it("keeps a same-named permanent trigger in the lookup table", function()
+            local name = "Spec Name Eviction"
+            _G.NameEvictionSpec = 0
+            finally(function()
+                disableTrigger(name)
+                _G.NameEvictionSpec = nil
+            end)
+
+            -- permanent triggers cannot be deleted from Lua, so earlier local runs
+            -- leave same-named ones behind: work from a relative baseline
+            assert.is_true(permRegexTrigger(name, "", {"^name_eviction_perm$"}, [[_G.NameEvictionSpec = (_G.NameEvictionSpec or 0) + 1]]) > 0)
+            local permanents = exists(name, "trigger")
+            assert.is_true(permanents >= 1)
+
+            -- tempComplexRegexTrigger is the one temporary-trigger API that takes a
+            -- user-supplied name, so sharing one with a permanent trigger is easy
+            tempComplexRegexTrigger(name, "^name_eviction_temp$", [[]], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            assert.are.equal(permanents + 1, exists(name, "trigger"))
+
+            killTrigger(name) -- only the temporary one can be killed
+            feedTriggers("\nname_eviction_perm\n") -- the pass ends, flushing the deferred delete
+
+            assert.are.equal(permanents, exists(name, "trigger"), "only the temporary trigger should leave the lookup table")
+            assert.is_true(_G.NameEvictionSpec >= 1, "the permanent trigger should still fire")
+            assert.is_true(disableTrigger(name), "the permanent trigger must still be reachable by name")
+        end)
+
+    end)
 end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -963,6 +963,31 @@ describe("Trigger processing", function()
             assert.are.equal(1, fires, "a trigger with expireAfter = 1 must not fire a second time")
         end)
 
+        it("does not let an expiring trigger fire again from its own nested feed", function()
+            -- A separate defect from the one above, found while fixing it: the
+            -- expiry count is decremented at the end of match(), after execute()
+            -- has run, so a trigger whose own script re-feeds the matching line is
+            -- still at its old count and still active when the nested pass reaches
+            -- it. Fixing that means moving the expiry accounting ahead of
+            -- execute(), which also has to keep the "return true to extend the
+            -- expiry" contract working - out of scope for the deactivate() fix.
+            pending("expiry is accounted after execute(), so a self-refeeding trigger overshoots expireAfter")
+            local fires = 0
+            local nestedFed = false
+            tempRegexTrigger("^self_expiry_reentry$", function()
+                fires = fires + 1
+                if not nestedFed then
+                    nestedFed = true
+                    feedTriggers("\nself_expiry_reentry\n")
+                end
+            end, 1)
+
+            feedTriggers("\nself_expiry_reentry\n")
+
+            assert.is_true(nestedFed)
+            assert.are.equal(1, fires, "a trigger with expireAfter = 1 must not fire a second time")
+        end)
+
         it("keeps a same-named permanent trigger in the lookup table", function()
             local name = "Spec Name Eviction"
             _G.NameEvictionSpec = 0
@@ -978,7 +1003,10 @@ describe("Trigger processing", function()
             assert.is_true(permanents >= 1)
 
             -- tempComplexRegexTrigger is the one temporary-trigger API that takes a
-            -- user-supplied name, so sharing one with a permanent trigger is easy
+            -- user-supplied name, so sharing one with a permanent trigger is easy.
+            -- Note it copies the pattern list of the trigger it finds under that
+            -- name, so this temporary also carries ^name_eviction_perm$ - harmless
+            -- here, since it is killed before anything is fed
             tempComplexRegexTrigger(name, "^name_eviction_temp$", [[]], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             assert.are.equal(permanents + 1, exists(name, "trigger"))
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TDiscordModeTest.cpp
     MainConsoleSelectionTest.cpp
     EnableDisableByNameTest.cpp
+    UnitDeferredDeleteTest.cpp
     ColorTriggerFilterChildTest.cpp
     GMCPCharLoginTest.cpp
     InsertTextCapTest.cpp

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -1,0 +1,416 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * TriggerUnit, AliasUnit, KeyUnit and TimerUnit each defer the deletion of an
+ * item until no script is on the call stack. Two properties of that machinery
+ * are checked here for all four units:
+ *
+ * - freeing a temporary item must unlink only that item from the by-name lookup
+ *   table, not every item filed under the same name (#9649). The lookup table is
+ *   a QMultiMap and names are not unique
+ * - the two deferred-delete containers, mCleanupSet and uninstallList, must never
+ *   free the same object twice, whichever order it lands in them (#9650)
+ *
+ * The timer and key halves of #9649 cannot be reached from the busted Lua suite -
+ * that runs inside a tempTimer, so TimerUnit's cleanup stays deferred for the
+ * whole run - which is why they live here. The trigger and alias halves are
+ * covered from Lua as well, in Trigger_spec.lua and Alias_spec.lua.
+ *
+ * Run with: ctest -R UnitDeferredDeleteTest -V
+ */
+
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "AliasUnit.h"
+#include "Host.h"
+#include "KeyUnit.h"
+#include "MudletInstanceCoordinator.h"
+#include "TAlias.h"
+#include "TKey.h"
+#include "TLuaInterpreter.h"
+#include "TTimer.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "TimerUnit.h"
+#include "TriggerUnit.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForUnitDeferredDeleteTest();
+
+class UnitDeferredDeleteTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "UnitDeferredDelete-Test";
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    const QString mLocalhost = "localhost";
+    const QString mPackageName = "unit deferred delete package";
+
+    // QMultiMap::count() is a qsizetype; narrow it so QCOMPARE reports a plain
+    // number against the int literals below
+    static int lookupCount(qsizetype count) { return static_cast<int>(count); }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForUnitDeferredDeleteTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+
+        startProfile(mHostname, mLocalhost, mPort);
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    // #9649: temporary items are named after their id, so a permanent item called
+    // after that number shares the name. tempComplexRegexTrigger() makes the
+    // trigger case even easier - it takes a user-supplied name - and that variant
+    // is covered from Lua in Trigger_spec.lua.
+    void test_triggerLookupKeepsSameNamedPermanent()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const int tempId = mpHost->mLuaInterpreter.startTempTrigger(qsl("lookup_evict_trigger_temp"), QString());
+        QVERIFY(tempId > 0);
+        const QString sharedName = QString::number(tempId);
+
+        const QStringList permPatterns{qsl("lookup_evict_trigger_perm")};
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermSubstringTrigger(sharedName, QString(), permPatterns, QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTrigger(sharedName), "the temporary trigger should be the one killed");
+        unit->doCleanup();
+
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 1);
+        QCOMPARE(unit->mLookupTable.value(sharedName), unit->getTrigger(permId));
+        QVERIFY2(unit->enableTrigger(sharedName), "the permanent trigger must still be reachable by name");
+    }
+
+    void test_aliasLookupKeepsSameNamedPermanent()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        const int tempId = mpHost->mLuaInterpreter.startTempAlias(qsl("^lookup_evict_alias$"), QString());
+        QVERIFY(tempId > 0);
+        const QString sharedName = QString::number(tempId);
+
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermAlias(sharedName, QString(), qsl("^lookup_evict_alias_perm$"), QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killAlias(sharedName), "the temporary alias should be the one killed");
+        unit->doCleanup();
+
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 1);
+        QCOMPARE(unit->mLookupTable.value(sharedName), unit->getAlias(permId));
+        QVERIFY2(unit->enableAlias(sharedName), "the permanent alias must still be reachable by name");
+    }
+
+    void test_timerLookupKeepsSameNamedPermanent()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [tempId, tempMessage] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(tempId > 0, qPrintable(tempMessage));
+        const QString sharedName = QString::number(tempId);
+
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermTimer(sharedName, QString(), 60.0, QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTimer(sharedName), "the temporary timer should be the one killed");
+        unit->doCleanup();
+
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 1);
+        QCOMPARE(unit->mLookupTable.value(sharedName), unit->getTimer(permId));
+        QVERIFY2(unit->enableTimer(sharedName), "the permanent timer must still be reachable by name");
+    }
+
+    void test_keyLookupKeepsSameNamedPermanent()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        int tempModifier = Qt::NoModifier;
+        int tempKeyCode = Qt::Key_F5;
+        const int tempId = mpHost->mLuaInterpreter.startTempKey(tempModifier, tempKeyCode, emptyScript);
+        QVERIFY(tempId > 0);
+        QString sharedName = QString::number(tempId);
+
+        QString parent;
+        int permModifier = Qt::NoModifier;
+        int permKeyCode = Qt::Key_F6;
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermKey(sharedName, parent, permKeyCode, permModifier, emptyScript);
+        QVERIFY2(permId > 0, qPrintable(message));
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killKey(sharedName), "the temporary key should be the one killed");
+        unit->doCleanup();
+
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 1);
+        QCOMPARE(unit->mLookupTable.value(sharedName), unit->getKey(permId));
+        QVERIFY2(unit->enableKey(sharedName), "the permanent key must still be reachable by name");
+    }
+
+    // #9650: an item can be queued in mCleanupSet and in uninstallList at the same
+    // time (uninstall() at a non-zero processing depth leaves its items in
+    // uninstallList, and a script can then kill one of them). doCleanup() has to
+    // free such an item exactly once. Both containers are populated directly here
+    // because no current Lua path produces the overlap.
+    void test_triggerDeferredDeleteContainersStayDisjoint()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const int id = mpHost->mLuaInterpreter.startTempTrigger(qsl("double_free_trigger"), QString(), -1);
+        QVERIFY(id > 0);
+        auto* pTrigger = unit->getTrigger(id);
+        QVERIFY(pTrigger);
+
+        unit->uninstallList.append(pTrigger);
+        unit->markCleanup(pTrigger);
+        unit->doCleanup();
+
+        QVERIFY(unit->mCleanupSet.isEmpty());
+        QVERIFY(unit->uninstallList.isEmpty());
+        QVERIFY2(!unit->getTrigger(id), "the trigger should have been freed exactly once");
+    }
+
+    // #9650: uninstall() at depth 0 deletes straight away, so it also has to drop
+    // the item from mCleanupSet - otherwise the next doCleanup() frees a dangling
+    // pointer.
+    void test_triggerUninstallAtDepthZeroClearsCleanupSet()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const int id = mpHost->mLuaInterpreter.startTempTrigger(qsl("uninstall_trigger"), QString(), -1);
+        QVERIFY(id > 0);
+        auto* pTrigger = unit->getTrigger(id);
+        QVERIFY(pTrigger);
+        pTrigger->mPackageName = mPackageName;
+
+        unit->markCleanup(pTrigger);
+        unit->uninstall(mPackageName);
+
+        // pointer comparison only - pTrigger is freed by now
+        QVERIFY2(!unit->mCleanupSet.contains(pTrigger), "uninstall() must take the trigger it freed out of the cleanup set");
+        unit->doCleanup();
+        QVERIFY2(!unit->getTrigger(id), "the trigger should have been freed exactly once");
+    }
+
+    void test_aliasDeferredDeleteContainersStayDisjoint()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        const int id = mpHost->mLuaInterpreter.startTempAlias(qsl("^double_free_alias$"), QString());
+        QVERIFY(id > 0);
+        auto* pAlias = unit->getAlias(id);
+        QVERIFY(pAlias);
+
+        unit->uninstallList.append(pAlias);
+        unit->markCleanup(pAlias);
+        unit->doCleanup();
+
+        QVERIFY(unit->mCleanupSet.isEmpty());
+        QVERIFY(unit->uninstallList.isEmpty());
+        QVERIFY2(!unit->getAlias(id), "the alias should have been freed exactly once");
+    }
+
+    void test_aliasUninstallAtDepthZeroClearsCleanupSet()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        const int id = mpHost->mLuaInterpreter.startTempAlias(qsl("^uninstall_alias$"), QString());
+        QVERIFY(id > 0);
+        auto* pAlias = unit->getAlias(id);
+        QVERIFY(pAlias);
+        pAlias->mPackageName = mPackageName;
+
+        unit->markCleanup(pAlias);
+        unit->uninstall(mPackageName);
+
+        QVERIFY2(!unit->mCleanupSet.contains(pAlias), "uninstall() must take the alias it freed out of the cleanup set");
+        unit->doCleanup();
+        QVERIFY2(!unit->getAlias(id), "the alias should have been freed exactly once");
+    }
+
+    void test_timerDeferredDeleteContainersStayDisjoint()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [id, message] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(id > 0, qPrintable(message));
+        auto* pTimer = unit->getTimer(id);
+        QVERIFY(pTimer);
+
+        unit->uninstallList.append(pTimer);
+        unit->markCleanup(pTimer);
+        // a second free would abort here; TimerUnit keeps mCleanupSet private, so
+        // there is no post-condition to read back beyond the timer being gone
+        unit->doCleanup();
+
+        QVERIFY(unit->uninstallList.isEmpty());
+        QVERIFY2(!unit->getTimer(id), "the timer should have been freed exactly once");
+    }
+
+    void test_timerUninstallAtDepthZeroClearsCleanupSet()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [id, message] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(id > 0, qPrintable(message));
+        auto* pTimer = unit->getTimer(id);
+        QVERIFY(pTimer);
+        pTimer->mPackageName = mPackageName;
+
+        unit->markCleanup(pTimer);
+        unit->uninstall(mPackageName);
+
+        // doCleanup() would free the pointer uninstall() left behind a second time
+        unit->doCleanup();
+        QVERIFY2(!unit->getTimer(id), "the timer should have been freed exactly once");
+    }
+
+    void test_keyDeferredDeleteContainersStayDisjoint()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        int modifier = Qt::NoModifier;
+        int keyCode = Qt::Key_F10;
+        const int id = mpHost->mLuaInterpreter.startTempKey(modifier, keyCode, emptyScript);
+        QVERIFY(id > 0);
+        auto* pKey = unit->getKey(id);
+        QVERIFY(pKey);
+
+        unit->uninstallList.append(pKey);
+        unit->markCleanup(pKey);
+        unit->doCleanup();
+
+        QVERIFY(unit->mCleanupSet.isEmpty());
+        QVERIFY(unit->uninstallList.isEmpty());
+        QVERIFY2(!unit->getKey(id), "the key should have been freed exactly once");
+    }
+
+    void test_keyUninstallAtDepthZeroClearsCleanupSet()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        int modifier = Qt::NoModifier;
+        int keyCode = Qt::Key_F11;
+        const int id = mpHost->mLuaInterpreter.startTempKey(modifier, keyCode, emptyScript);
+        QVERIFY(id > 0);
+        auto* pKey = unit->getKey(id);
+        QVERIFY(pKey);
+        pKey->mPackageName = mPackageName;
+
+        unit->markCleanup(pKey);
+        unit->uninstall(mPackageName);
+
+        QVERIFY2(!unit->mCleanupSet.contains(pKey), "uninstall() must take the key it freed out of the cleanup set");
+        unit->doCleanup();
+        QVERIFY2(!unit->getKey(id), "the key should have been freed exactly once");
+    }
+
+    // Helpers (reused from the ResetProfileTest pattern)
+
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(500)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForUnitDeferredDeleteTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "UnitDeferredDeleteTest.moc"
+QTEST_MAIN(UnitDeferredDeleteTest)

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -25,13 +25,25 @@
  * - freeing a temporary item must unlink only that item from the by-name lookup
  *   table, not every item filed under the same name (#9649). The lookup table is
  *   a QMultiMap and names are not unique
+ * - killing by name must keep scanning past same-named items it cannot kill,
+ *   rather than report failure over the first one (#9649)
  * - the two deferred-delete containers, mCleanupSet and uninstallList, must never
  *   free the same object twice, whichever order it lands in them (#9650)
  *
- * The timer and key halves of #9649 cannot be reached from the busted Lua suite -
- * that runs inside a tempTimer, so TimerUnit's cleanup stays deferred for the
- * whole run - which is why they live here. The trigger and alias halves are
- * covered from Lua as well, in Trigger_spec.lua and Alias_spec.lua.
+ * The timer half of #9649 cannot be reached from the busted Lua suite - that runs
+ * inside a tempTimer, so TimerUnit's cleanup stays deferred for the whole run -
+ * which is why it lives here. The trigger, alias and key halves are covered from
+ * Lua as well, in Trigger_spec.lua, Alias_spec.lua and KeyBinds_spec.lua.
+ *
+ * Note on the ...ContainersStayDisjoint cases: a regression there is a double
+ * free, which has no post-condition to read back - the assertions below hold
+ * either way and the run aborts instead. That is a real signal because the
+ * functional tests always build with the address sanitizer on non-Windows
+ * (test/functional_tests/CMakeLists.txt includes EnableSanitizers.cmake, whose
+ * USE_SANITIZER defaults to "address"), but it does mean these four cases carry
+ * no weight in a build with sanitizers switched off. The trigger and timer
+ * variants are pure regression guards: those two units already had the guards on
+ * development, and only AliasUnit and KeyUnit gain them here.
  *
  * Run with: ctest -R UnitDeferredDeleteTest -V
  */
@@ -196,11 +208,136 @@ private slots:
         QVERIFY2(unit->enableKey(sharedName), "the permanent key must still be reachable by name");
     }
 
+    // #9649, the kill-by-name half: killX(name) walks the root node list, which
+    // holds items in creation order, so a permanent item restored from the profile
+    // at startup precedes this session's temporaries. Giving up on the first
+    // same-named item that cannot be killed strands the killable one and reports a
+    // bare false. Each case below renames a freshly created permanent item to the
+    // id the next temporary will take, which is exactly the collision a saved
+    // profile produces; the QCOMPARE on the temporary's id makes the test fail
+    // loudly rather than silently stop testing anything if ids stop being handed
+    // out in sequence.
+    void test_triggerKillByNameScansPastPermanent()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const QStringList permPatterns{qsl("kill_order_trigger_perm")};
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("kill order placeholder"), QString(), permPatterns, QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        const QString sharedName = QString::number(permId + 1);
+        unit->getTrigger(permId)->setName(sharedName);
+
+        const int tempId = mpHost->mLuaInterpreter.startTempTrigger(qsl("kill_order_trigger_temp"), QString());
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTrigger(sharedName), "killTrigger must scan past the permanent trigger to the temporary one");
+        unit->doCleanup();
+        QVERIFY2(!unit->getTrigger(tempId), "the temporary trigger should have been freed");
+        QVERIFY(unit->getTrigger(permId));
+    }
+
+    void test_aliasKillByNameScansPastPermanent()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermAlias(qsl("kill order placeholder"), QString(), qsl("^kill_order_alias_perm$"), QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        const QString sharedName = QString::number(permId + 1);
+        unit->getAlias(permId)->setName(sharedName);
+
+        const int tempId = mpHost->mLuaInterpreter.startTempAlias(qsl("^kill_order_alias_temp$"), QString());
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killAlias(sharedName), "killAlias must scan past the permanent alias to the temporary one");
+        unit->doCleanup();
+        QVERIFY2(!unit->getAlias(tempId), "the temporary alias should have been freed");
+        QVERIFY(unit->getAlias(permId));
+    }
+
+    void test_timerKillByNameScansPastPermanent()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermTimer(qsl("kill order placeholder"), QString(), 60.0, QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        const QString sharedName = QString::number(permId + 1);
+        unit->getTimer(permId)->setName(sharedName);
+
+        auto [tempId, tempMessage] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(tempId > 0, qPrintable(tempMessage));
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTimer(sharedName), "killTimer must scan past the permanent timer to the temporary one");
+        unit->doCleanup();
+        QVERIFY2(!unit->getTimer(tempId), "the temporary timer should have been freed");
+        QVERIFY(unit->getTimer(permId));
+    }
+
+    void test_keyKillByNameScansPastPermanent()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        QString parent;
+        QString placeholder = qsl("kill order placeholder");
+        int permModifier = Qt::NoModifier;
+        int permKeyCode = Qt::Key_F7;
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermKey(placeholder, parent, permKeyCode, permModifier, emptyScript);
+        QVERIFY2(permId > 0, qPrintable(message));
+        QString sharedName = QString::number(permId + 1);
+        unit->getKey(permId)->setName(sharedName);
+
+        int tempModifier = Qt::NoModifier;
+        int tempKeyCode = Qt::Key_F8;
+        const int tempId = mpHost->mLuaInterpreter.startTempKey(tempModifier, tempKeyCode, emptyScript);
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killKey(sharedName), "killKey must scan past the permanent key to the temporary one");
+        unit->doCleanup();
+        QVERIFY2(!unit->getKey(tempId), "the temporary key should have been freed");
+        QVERIFY(unit->getKey(permId));
+    }
+
+    // #9649 again, on the non-root removal path: a temporary child goes through
+    // removeTrigger() rather than removeTriggerRootNode(), and both got the same
+    // exact-match fix.
+    void test_temporaryChildTriggerLeavesSameNamedSiblingAlone()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const QStringList parentPatterns{qsl("child_evict_parent")};
+        auto [parentId, message] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("Child Eviction Parent"), QString(), parentPatterns, QString());
+        QVERIFY2(parentId > 0, qPrintable(message));
+        auto* pParent = unit->getTrigger(parentId);
+        QVERIFY(pParent);
+
+        const QString sharedName = qsl("Child Eviction Shared");
+        const QStringList childPatterns{qsl("child_evict_perm")};
+        auto [permChildId, childMessage] = mpHost->mLuaInterpreter.startPermSubstringTrigger(sharedName, qsl("Child Eviction Parent"), childPatterns, QString());
+        QVERIFY2(permChildId > 0, qPrintable(childMessage));
+
+        auto* pTempChild = new TTrigger(pParent, mpHost);
+        pTempChild->setRegexCodeList(QStringList{qsl("child_evict_temp")}, QList<int>{REGEX_SUBSTRING});
+        pTempChild->setIsFolder(false);
+        pTempChild->setIsActive(true);
+        pTempChild->setTemporary(true);
+        pTempChild->registerTrigger();
+        pTempChild->setName(sharedName);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTrigger(sharedName), "the temporary child should be the one killed");
+        unit->doCleanup();
+
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 1);
+        QCOMPARE(unit->mLookupTable.value(sharedName), unit->getTrigger(permChildId));
+    }
+
     // #9650: an item can be queued in mCleanupSet and in uninstallList at the same
-    // time (uninstall() at a non-zero processing depth leaves its items in
-    // uninstallList, and a script can then kill one of them). doCleanup() has to
-    // free such an item exactly once. Both containers are populated directly here
-    // because no current Lua path produces the overlap.
+    // time - uninstall() at a non-zero processing depth leaves its items in
+    // uninstallList and drops them from mCleanupSet, and a script killing one of
+    // them afterwards puts it back. doCleanup() has to free such an item exactly
+    // once. Both containers are populated directly here because reaching the
+    // overlap from Lua needs a package-owned temporary item, which no current
+    // import path produces.
     void test_triggerDeferredDeleteContainersStayDisjoint()
     {
         auto* unit = mpHost->getTriggerUnit();
@@ -233,8 +370,9 @@ private slots:
         unit->markCleanup(pTrigger);
         unit->uninstall(mPackageName);
 
-        // pointer comparison only - pTrigger is freed by now
-        QVERIFY2(!unit->mCleanupSet.contains(pTrigger), "uninstall() must take the trigger it freed out of the cleanup set");
+        // pTrigger is freed by now, so read the set's size rather than look the
+        // dangling pointer up in it
+        QVERIFY2(unit->mCleanupSet.isEmpty(), "uninstall() must take the trigger it freed out of the cleanup set");
         unit->doCleanup();
         QVERIFY2(!unit->getTrigger(id), "the trigger should have been freed exactly once");
     }
@@ -268,7 +406,7 @@ private slots:
         unit->markCleanup(pAlias);
         unit->uninstall(mPackageName);
 
-        QVERIFY2(!unit->mCleanupSet.contains(pAlias), "uninstall() must take the alias it freed out of the cleanup set");
+        QVERIFY2(unit->mCleanupSet.isEmpty(), "uninstall() must take the alias it freed out of the cleanup set");
         unit->doCleanup();
         QVERIFY2(!unit->getAlias(id), "the alias should have been freed exactly once");
     }
@@ -283,10 +421,9 @@ private slots:
 
         unit->uninstallList.append(pTimer);
         unit->markCleanup(pTimer);
-        // a second free would abort here; TimerUnit keeps mCleanupSet private, so
-        // there is no post-condition to read back beyond the timer being gone
         unit->doCleanup();
 
+        QVERIFY(unit->mCleanupSet.isEmpty());
         QVERIFY(unit->uninstallList.isEmpty());
         QVERIFY2(!unit->getTimer(id), "the timer should have been freed exactly once");
     }
@@ -303,7 +440,7 @@ private slots:
         unit->markCleanup(pTimer);
         unit->uninstall(mPackageName);
 
-        // doCleanup() would free the pointer uninstall() left behind a second time
+        QVERIFY2(unit->mCleanupSet.isEmpty(), "uninstall() must take the timer it freed out of the cleanup set");
         unit->doCleanup();
         QVERIFY2(!unit->getTimer(id), "the timer should have been freed exactly once");
     }
@@ -343,7 +480,7 @@ private slots:
         unit->markCleanup(pKey);
         unit->uninstall(mPackageName);
 
-        QVERIFY2(!unit->mCleanupSet.contains(pKey), "uninstall() must take the key it freed out of the cleanup set");
+        QVERIFY2(unit->mCleanupSet.isEmpty(), "uninstall() must take the key it freed out of the cleanup set");
         unit->doCleanup();
         QVERIFY2(!unit->getKey(id), "the key should have been freed exactly once");
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- An expired trigger is deactivated before it is queued for deletion, so a nested `feedTriggers()` pass cannot fire it again while the deferred delete is still pending.
- Deleting a temporary trigger, alias, key or timer unlinks only that item from the by-name lookup table instead of every item filed under the same name, and `killAlias()`/`killKey()`/`killTimer()` scan past a same-named item they cannot kill rather than report failure over it.
- `AliasUnit` and `KeyUnit` gain the double-free guards `TriggerUnit` and `TimerUnit` already had; `stopAllNamedTriggers()` and `IDMgr:emergencyStop()` now stop named regex triggers too.

#### Motivation for adding to Mudlet

The four lookup tables are `QMultiMap`s, so names are not unique, but the temporary-item branch used the single-argument `remove(key)` and evicted live same-named items with it: a permanent trigger could stay alive yet become invisible to `enableTrigger()`, `killTrigger()` and `exists()` for the rest of the session. The kill-by-name asymmetry is the same defect one level up - a permanent item restored from the profile precedes this session's temporaries in the root node list, so it stranded the temporary behind it.

#### Other info (issues closed, discussion etc)

Closes #9646, closes #9648, closes #9649, closes #9650

Test case: `permRegexTrigger("Health", "", {"^permanent$"}, [[echo("permanent fired\n")]])`, then `tempComplexRegexTrigger("Health", "^temp$", [[]], 0,0,0,0,0,0,0,0,0,0)`, `killTrigger("Health")` and `feedTriggers("permanent\n")` - `exists("Health", "trigger")` still finds the permanent trigger.

New coverage: `test/functional_tests/UnitDeferredDeleteTest.cpp` (17 cases across all four units) plus additions to `Trigger_spec.lua`, `Alias_spec.lua`, `KeyBinds_spec.lua` and `IDManager_spec.lua`, three of which were `pending()` markers for these bugs.

Review turned up an adjacent defect deliberately **not** fixed here: expiry is accounted for after `execute()` runs, so a trigger whose *own* script re-feeds the matching line overshoots its `expireAfter`. Fixing that means moving the expiry accounting ahead of `execute()` while keeping the "return true to extend" contract, so it is left for a follow-up and recorded as a `pending()` spec in `Trigger_spec.lua`.

Assisted-by: Claude:claude-opus-5
