### PR TITLE
Fix six command line and console bugs

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1679,7 +1679,7 @@ void TConsole::setCmdVisible(bool isVisible)
         mpCommandLine->setFont(font());
         // put this CommandLine in the mainConsoles SubCommandLineMap
         // name is the console name
-        mpHost->mpConsole->mSubCommandLineMap[mConsoleName] = mpCommandLine;
+        mpHost->mpConsole->registerSubCommandLine(mConsoleName, mpCommandLine);
         layoutLayer2->addWidget(mpCommandLine);
     }
     if (mType == MainConsole) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2802,15 +2802,19 @@ int TLuaInterpreter::getEpoch(lua_State* L)
 int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // The mandatory text is last, but with no arguments at all that would be
+    // index 0 - not a valid Lua stack index, and Lua 5.1 hands back the first
+    // free slot for it rather than complaining:
+    const int textIndex = qMax(n, 1);
     const char* name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    if (!checkStringArg(L, __func__, n, "suggestion text")) {
+    if (!checkStringArg(L, __func__, textIndex, "suggestion text")) {
         return lua_error(L);
     }
     auto pN = COMMANDLINE(L, QString{name});
-    pN->addBlacklist(QString{lua_tostring(L, n)});
+    pN->addBlacklist(QString{lua_tostring(L, textIndex)});
     return 0;
 }
 
@@ -2818,15 +2822,17 @@ int TLuaInterpreter::addCmdLineBlacklist(lua_State* L)
 int TLuaInterpreter::removeCmdLineBlacklist(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // See addCmdLineBlacklist() on why the index is clamped:
+    const int textIndex = qMax(n, 1);
     const char* name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    if (!checkStringArg(L, __func__, n, "suggestion text")) {
+    if (!checkStringArg(L, __func__, textIndex, "suggestion text")) {
         return lua_error(L);
     }
     auto pN = COMMANDLINE(L, QString{name});
-    pN->removeBlacklist(QString{lua_tostring(L, n)});
+    pN->removeBlacklist(QString{lua_tostring(L, textIndex)});
     return 0;
 }
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -203,11 +203,15 @@ static bool timerDelayFits(const double time)
 int TLuaInterpreter::addCmdLineSuggestion(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // The mandatory text is last, but with no arguments at all that would be
+    // index 0 - not a valid Lua stack index, and Lua 5.1 hands back the first
+    // free slot for it rather than complaining:
+    const int textIndex = qMax(n, 1);
     const char* name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    const QString text = getVerifiedString(L, __func__, n, "suggestion text");
+    const QString text = getVerifiedString(L, __func__, textIndex, "suggestion text");
     auto pN = COMMANDLINE(L, QString{name});
     pN->addSuggestion(text);
     return 0;
@@ -242,12 +246,14 @@ int TLuaInterpreter::adjustStopWatch(lua_State* L)
 int TLuaInterpreter::appendCmdLine(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // See addCmdLineSuggestion() on why the index is clamped:
+    const int textIndex = qMax(n, 1);
     const char* name = "main";
 
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    const QString text = getVerifiedString(L, __func__, n, "text to set on command line");
+    const QString text = getVerifiedString(L, __func__, textIndex, "text to set on command line");
     auto pN = COMMANDLINE(L, QString{name});
 
     const QString curText = pN->toPlainText();
@@ -357,11 +363,13 @@ int TLuaInterpreter::deleteStopWatch(lua_State* L)
 int TLuaInterpreter::removeCmdLineSuggestion(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // See addCmdLineSuggestion() on why the index is clamped:
+    const int textIndex = qMax(n, 1);
     const char* name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    const QString text = getVerifiedString(L, __func__, n, "suggestion text");
+    const QString text = getVerifiedString(L, __func__, textIndex, "suggestion text");
     auto pN = COMMANDLINE(L, QString{name});
     pN->removeSuggestion(text);
     return 0;
@@ -1473,11 +1481,13 @@ int TLuaInterpreter::permKey(lua_State* L)
 int TLuaInterpreter::printCmdLine(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // See addCmdLineSuggestion() on why the index is clamped:
+    const int textIndex = qMax(n, 1);
     const char* name = "main";
     if (n > 1) {
         name = CMDLINE_NAME(L, 1);
     }
-    const QString text = getVerifiedString(L, __func__, n, "text to set on command line");
+    const QString text = getVerifiedString(L, __func__, textIndex, "text to set on command line");
 
     auto pN = COMMANDLINE(L, QString{name});
     pN->setPlainText(text);

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2477,6 +2477,7 @@ int TLuaInterpreter::selectCmdLineText(lua_State* L)
     }
     auto commandline = COMMANDLINE(L, name);
     commandline->selectAll();
+    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -2972,15 +2973,19 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L)
 int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
 {
     const int n = lua_gettop(L);
+    // The mandatory stylesheet is last, but with no arguments at all that would
+    // be index 0 - not a valid Lua stack index, and Lua 5.1 hands back the first
+    // free slot for it rather than complaining:
+    const int styleSheetIndex = qMax(n, 1);
     if (n > 1 && !checkStringArg(L, __func__, 1, "command line name", true)) {
         return lua_error(L);
     }
-    if (!checkStringArg(L, __func__, n, "StyleSheet")) {
+    if (!checkStringArg(L, __func__, styleSheetIndex, "StyleSheet")) {
         return lua_error(L);
     }
 
     const QString name = (n > 1) ? QString{lua_tostring(L, 1)} : qsl("main");
-    const QString styleSheet{lua_tostring(L, n)};
+    const QString styleSheet{lua_tostring(L, styleSheetIndex)};
     const Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -87,11 +87,17 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 
 TMainConsole::~TMainConsole()
 {
-    // The registered command lines are descendants of this console, so they are
-    // destroyed by ~QWidget below - which is well after mSubCommandLineMap itself
-    // has gone. Drop the destroyed() handlers registerSubCommandLine() set up
-    // before they can be run against the dead map.
-    for (auto commandLine : std::as_const(mSubCommandLineMap)) {
+    // There is one window in which a command line's destroyed() handler is unsafe:
+    // after this console's members - mSubCommandLineMap among them - have been
+    // destroyed, but before ~QObject severs incoming connections. The only command
+    // lines that can be destroyed inside it are the ones QWidget::~QWidget deletes,
+    // i.e. this console's own children, so sweeping those is enough. Command lines
+    // created into a user window belong to a TDockWidget reparented onto the main
+    // window instead, and can only die after ~QObject has already dropped the
+    // connection. Children rather than map entries, because deleteCommandLine() and
+    // resetMainConsole() drop the entry while the widget lives on until its
+    // deferred delete is delivered.
+    for (auto commandLine : findChildren<TCommandLine*>()) {
         disconnect(commandLine, &QObject::destroyed, this, nullptr);
     }
     mSubCommandLineMap.clear();
@@ -529,11 +535,10 @@ void TMainConsole::resetMainConsole()
         itDockWidget.remove();
     }
 
-    QMutableMapIterator<QString, TCommandLine*> itCommandLine(mSubCommandLineMap);
-    while (itCommandLine.hasNext()) {
-        itCommandLine.next();
-        itCommandLine.value()->deleteLater();
-        itCommandLine.remove();
+    const QList<TCommandLine*> commandLines = mSubCommandLineMap.values();
+    for (auto commandLine : commandLines) {
+        deregisterSubCommandLine(commandLine);
+        commandLine->deleteLater();
     }
 
     // Remaining SubConsole/Buffer entries (UserWindow ones were already removed above)
@@ -748,8 +753,12 @@ std::pair<bool, QString> TMainConsole::deleteCommandLine(const QString& name)
         return {false, QLatin1String("a command line cannot have an empty string as its name")};
     }
 
-    auto pCmdLine = mSubCommandLineMap.take(name);
+    auto pCmdLine = mSubCommandLineMap.value(name);
     if (pCmdLine) {
+        // Deregister rather than just take() the entry: the widget outlives this
+        // call until its deferred delete is delivered, and its destroyed() handler
+        // must not be left armed for a console that may be gone by then.
+        deregisterSubCommandLine(pCmdLine);
         // Using deleteLater() rather than delete as it seems a safer option
         // given that this item is likely to be linked to some events and
         // suchlike:
@@ -980,6 +989,10 @@ std::pair<bool, QString> TMainConsole::createCommandLine(const QString& windowna
 
 void TMainConsole::registerSubCommandLine(const QString& name, TCommandLine* pCommandLine)
 {
+    if (auto pDisplaced = mSubCommandLineMap.value(name); pDisplaced && pDisplaced != pCommandLine) {
+        // Would otherwise be left connected but unreachable by name
+        deregisterSubCommandLine(pDisplaced);
+    }
     mSubCommandLineMap[name] = pCommandLine;
 
     // A TCommandLine is always a child widget of something else - the miniconsole
@@ -989,11 +1002,19 @@ void TMainConsole::registerSubCommandLine(const QString& name, TCommandLine* pCo
     // every later lookup of the name reads freed memory; TConsole::setFont() walks
     // the whole map, so even changing the display font in Preferences hits it.
     connect(pCommandLine, &QObject::destroyed, this, [this, pCommandLine]() {
-        // Erase by value rather than by name: a replacement command line may have
-        // been registered under the same name in the meantime and must be kept.
-        mSubCommandLineMap.removeIf([pCommandLine](const auto& it) {
-            return it.value() == pCommandLine;
-        });
+        deregisterSubCommandLine(pCommandLine);
+    });
+}
+
+void TMainConsole::deregisterSubCommandLine(TCommandLine* pCommandLine)
+{
+    // This is the only destroyed() connection made from a command line to this
+    // console, so severing all of them is severing just that one.
+    disconnect(pCommandLine, &QObject::destroyed, this, nullptr);
+    // Erase by value rather than by name: a replacement command line may have been
+    // registered under the same name in the meantime and must be left in place.
+    mSubCommandLineMap.removeIf([pCommandLine](const auto& it) {
+        return it.value() == pCommandLine;
     });
 }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -87,6 +87,15 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 
 TMainConsole::~TMainConsole()
 {
+    // The registered command lines are descendants of this console, so they are
+    // destroyed by ~QWidget below - which is well after mSubCommandLineMap itself
+    // has gone. Drop the destroyed() handlers registerSubCommandLine() set up
+    // before they can be run against the dead map.
+    for (auto commandLine : std::as_const(mSubCommandLineMap)) {
+        disconnect(commandLine, &QObject::destroyed, this, nullptr);
+    }
+    mSubCommandLineMap.clear();
+
     // Neither is a child of this console: the map dock is reparented onto the main
     // window by addDockWidget(), and the unpacking dialog is parentless. So neither
     // dies with the console automatically.
@@ -960,13 +969,32 @@ std::pair<bool, QString> TMainConsole::createCommandLine(const QString& windowna
         } else {
             pN = new TCommandLine(mpHost, name, TCommandLine::SubCommandLine, this, mpMainFrame);
         }
-        mSubCommandLineMap[name] = pN;
+        registerSubCommandLine(name, pN);
         pN->resize(width, height);
         pN->move(x, y);
         pN->show();
         return {true, QString()};
     }
     return {false, QLatin1String("couldn't create commandLine")};
+}
+
+void TMainConsole::registerSubCommandLine(const QString& name, TCommandLine* pCommandLine)
+{
+    mSubCommandLineMap[name] = pCommandLine;
+
+    // A TCommandLine is always a child widget of something else - the miniconsole
+    // it is embedded in, or the user window / scroll box it was created into - so
+    // it can be destroyed without deleteCommandLine() ever being called, and this
+    // map does not hold QPointers. Without this the entry outlives the widget and
+    // every later lookup of the name reads freed memory; TConsole::setFont() walks
+    // the whole map, so even changing the display font in Preferences hits it.
+    connect(pCommandLine, &QObject::destroyed, this, [this, pCommandLine]() {
+        // Erase by value rather than by name: a replacement command line may have
+        // been registered under the same name in the meantime and must be kept.
+        mSubCommandLineMap.removeIf([pCommandLine](const auto& it) {
+            return it.value() == pCommandLine;
+        });
+    });
 }
 
 std::pair<bool, QString> TMainConsole::createTextBox(const QString& windowname, const QString& name, int x, int y, int width, int height)

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -77,6 +77,7 @@ public:
     TLabel* createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
     std::pair<bool, QString> createMapper(const QString& windowname, int, int, int, int);
     std::pair<bool, QString> createCommandLine(const QString& windowname, const QString& name, int, int, int, int);
+    void registerSubCommandLine(const QString& name, TCommandLine* pCommandLine);
     std::pair<bool, QString> createTextBox(const QString& windowname, const QString& name, int, int, int, int);
     QSize getUserWindowSize(const QString& windowname) const;
     std::pair<bool, QString> setCmdLineStyleSheet(const QString& name, const QString& styleSheet);

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -78,6 +78,7 @@ public:
     std::pair<bool, QString> createMapper(const QString& windowname, int, int, int, int);
     std::pair<bool, QString> createCommandLine(const QString& windowname, const QString& name, int, int, int, int);
     void registerSubCommandLine(const QString& name, TCommandLine* pCommandLine);
+    void deregisterSubCommandLine(TCommandLine* pCommandLine);
     std::pair<bool, QString> createTextBox(const QString& windowname, const QString& name, int, int, int, int);
     QSize getUserWindowSize(const QString& windowname) const;
     std::pair<bool, QString> setCmdLineStyleSheet(const QString& name, const QString& styleSheet);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2205,7 +2205,10 @@ function suffix(what, func, fgc, bgc, window)
   window = window or "main"
   func = insertFuncs[func] or func or insertText
   local length = utf8.len(getCurrentLine(window))
-  moveCursor(window, length - 1, getLineNumber(window))
+  moveCursor(window, length, getLineNumber(window))
+  -- fg()/bg() also repaint whatever is selected in the window, so drop any
+  -- live selection first - only the text being added is meant to be coloured
+  deselect(window)
   if fgc then fg(window,fgc) end
   if bgc then bg(window,bgc) end
   func(window,what)
@@ -2227,6 +2230,8 @@ function prefix(what, func, fgc, bgc, window)
   window = window or "main"
   func = insertFuncs[func] or func or insertText
   moveCursor(window, 0, getLineNumber(window))
+  -- see suffix() - colouring must not leak onto the current selection
+  deselect(window)
   if fgc then fg(window,fgc) end
   if bgc then bg(window,bgc) end
   func(window,what)
@@ -2240,7 +2245,7 @@ end
 function moveCursorUp(window, lines, keep_horizontal)
   if type(window) ~= "string" then lines, window, keep_horizontal = window, "main", lines end
   lines = tonumber(lines) or 1
-  if not type(keep_horizontal) == "boolean" then keep_horizontal = false end
+  if type(keep_horizontal) ~= "boolean" then keep_horizontal = false end
   local curLine = getLineNumber(window)
   if not curLine then return nil, "window does not exist" end
   local x = 0
@@ -2255,7 +2260,7 @@ end
 function moveCursorDown(window, lines, keep_horizontal)
   if type(window) ~= "string" then lines, window, keep_horizontal = window, "main", lines end
   lines = tonumber(lines) or 1
-  if not type(keep_horizontal) == "boolean" then keep_horizontal = false end
+  if type(keep_horizontal) ~= "boolean" then keep_horizontal = false end
   local curLine = getLineNumber(window)
   if not curLine then return nil, "window does not exist" end
   local x = 0
@@ -2669,9 +2674,10 @@ end
 function scrollUp(window, lines)
   if type(window) ~= "string" then window, lines = "main", window end
   lines = tonumber(lines) or 1
-  local numLines = getLastLineNumber(window)
-  if not numLines then return nil, "window does not exist" end
+  -- getScroll() is what actually answers nil for an unknown window;
+  -- getLastLineNumber() answers -1, so guarding on it never fires
   local curScroll = getScroll(window)
+  if not curScroll then return nil, "window does not exist" end
   scrollTo(window, math.max(curScroll - lines, 0))
 end
 
@@ -2681,10 +2687,10 @@ end
 function scrollDown(window, lines)
   if type(window) ~= "string" then window, lines = "main", window end
   lines = tonumber(lines) or 1
-  local numLines = getLastLineNumber(window)
-  if not numLines then return nil, "window does not exist" end
+  -- see scrollUp() on why the guard is on getScroll() rather than on the line count
   local curScroll = getScroll(window)
-  scrollTo(window, math.min(curScroll + lines, numLines))
+  if not curScroll then return nil, "window does not exist" end
+  scrollTo(window, math.min(curScroll + lines, getLastLineNumber(window)))
 end
 
 --[[

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2690,6 +2690,7 @@ function scrollDown(window, lines)
   -- see scrollUp() on why the guard is on getScroll() rather than on the line count
   local curScroll = getScroll(window)
   if not curScroll then return nil, "window does not exist" end
+  -- getScroll() having answered means the window exists, so this cannot fail
   scrollTo(window, math.min(curScroll + lines, getLastLineNumber(window)))
 end
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -2000,6 +2000,22 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.are_not.same(color_table["red"], getTextFormat(windowName).foreground)
     end)
 
+    it("Should not repaint the background of the current selection either", function()
+      selectSection(windowName, 0, 6)
+      prefix("[", nil, nil, "blue", windowName)
+      selectSection(windowName, 1, 6)
+      assert.are_not.same(color_table["blue"], getTextFormat(windowName).background)
+    end)
+
+    it("Should suffix onto an empty line", function()
+      clearWindow(windowName)
+      moveCursor(windowName, 0, 0)
+      echo(windowName, "\n")
+      moveCursor(windowName, 0, 0)
+      suffix("added", nil, nil, nil, windowName)
+      assert.equals("added", currentLine())
+    end)
+
     it("Should still colour what it adds when something is selected", function()
       selectSection(windowName, 0, 6)
       prefix("[", nil, "red", nil, windowName)
@@ -2059,6 +2075,14 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       moveCursor(windowName, 2, 1)
       moveCursorUp(windowName, 1, "yes")
       assert.equals(0, getColumnNumber(windowName))
+    end)
+
+    -- pairs with the assertion above: without this, "coerced to false" and
+    -- "keep_horizontal ignored entirely" would look the same for moveCursorUp
+    it("Should let moveCursorUp keep the column when asked with a boolean", function()
+      moveCursor(windowName, 2, 1)
+      moveCursorUp(windowName, 1, true)
+      assert.equals(2, getColumnNumber(windowName))
     end)
   end)
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -1961,6 +1961,51 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.has_error(function() prefix(5) end)
       assert.has_error(function() suffix(5) end)
     end)
+
+    -- A line that has been finished off with a newline is the ordinary trigger
+    -- case, and the only one where landing a column short is visible: on the
+    -- unfinished line the block above uses, an insert past the last character
+    -- is appended either way.
+    local function completedLine()
+      clearWindow(windowName)
+      moveCursor(windowName, 0, 0)
+      echo(windowName, "PROBE has a TARGET word\n")
+      moveCursor(windowName, 0, 0)
+    end
+
+    it("Should put text after the last character of a completed line", function()
+      completedLine()
+      suffix(" SUF", nil, nil, nil, windowName)
+      assert.equals("PROBE has a TARGET word SUF", currentLine())
+    end)
+
+    it("Should put text after the last character of a completed line when colouring it", function()
+      completedLine()
+      suffix(" SUF", nil, "red", nil, windowName)
+      assert.equals("PROBE has a TARGET word SUF", currentLine())
+    end)
+
+    it("Should not recolour the current selection when prefixing", function()
+      selectSection(windowName, 0, 6)
+      prefix("[", nil, "red", nil, windowName)
+      -- "middle" now starts one column along, and must have kept its colour
+      selectSection(windowName, 1, 6)
+      assert.are_not.same(color_table["red"], getTextFormat(windowName).foreground)
+    end)
+
+    it("Should not recolour the current selection when suffixing", function()
+      selectSection(windowName, 0, 6)
+      suffix("]", nil, "red", nil, windowName)
+      selectSection(windowName, 0, 6)
+      assert.are_not.same(color_table["red"], getTextFormat(windowName).foreground)
+    end)
+
+    it("Should still colour what it adds when something is selected", function()
+      selectSection(windowName, 0, 6)
+      prefix("[", nil, "red", nil, windowName)
+      selectSection(windowName, 0, 1)
+      assert.are.same(color_table["red"], getTextFormat(windowName).foreground)
+    end)
   end)
 
   describe("Tests the functionality of moveCursorDown", function()
@@ -2005,6 +2050,15 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       local ok, err = moveCursorDown("guiUtilsNoSuchWindow", 1)
       assert.is_nil(ok)
       assert.equals("window does not exist", err)
+    end)
+
+    it("Should treat a non-boolean keep_horizontal as false", function()
+      moveCursor(windowName, 2, 0)
+      moveCursorDown(windowName, 1, "yes")
+      assert.equals(0, getColumnNumber(windowName))
+      moveCursor(windowName, 2, 1)
+      moveCursorUp(windowName, 1, "yes")
+      assert.equals(0, getColumnNumber(windowName))
     end)
   end)
 
@@ -2154,10 +2208,6 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
 
     it("Should report an unknown window rather than raising", function()
-      -- BUG: the guard reads getLastLineNumber, which answers -1 rather than
-      -- nil for a window it does not know, so the documented nil + message
-      -- never happens and getScroll's nil blows up in the arithmetic below it
-      pending("scrollUp/scrollDown raise on an unknown window - see the Wave 3d report")
       local ok, err = scrollUp("guiUtilsNoSuchWindow", 1)
       assert.is_nil(ok)
       assert.equals("window does not exist", err)

--- a/src/mudlet-lua/tests/GeyserCommandLine_spec.lua
+++ b/src/mudlet-lua/tests/GeyserCommandLine_spec.lua
@@ -112,12 +112,17 @@ describe("Tests functionality of Geyser.CommandLine", function()
     end)
   end)
 
-  -- Two things are in the way. The selection itself has no getter; and
-  -- selectCmdLineText (TLuaInterpreterUI.cpp) declares one return value without
-  -- pushing one, so it hands back whatever was left on the Lua stack - the
-  -- window name it was passed - rather than a result. Asserting either of those
-  -- as they stand would freeze the defect in place.
-  pending("Geyser.CommandLine:selectText selects every character - the selection is not readable from Lua and needs a getCmdLineSelection getter, and selectCmdLineText returns the window name instead of a result")
+  describe("Geyser.CommandLine:selectText", function()
+    it("reports success", function()
+      local commandLine = track(Geyser.CommandLine:new({name = "gclSelect", x = 0, y = 0, width = 100, height = 30}))
+      commandLine:print("select me")
+      assert.is_true(commandLine:selectText())
+      -- selecting must not disturb what is typed
+      assert.are.equal("select me", commandLine:getText())
+    end)
+  end)
+
+  pending("Geyser.CommandLine:selectText selects every character - the selection itself is not readable from Lua and needs a getCmdLineSelection getter")
 
   describe("Geyser.CommandLine:setStyleSheet", function()
     it("reuses the remembered stylesheet when called without one", function()

--- a/src/mudlet-lua/tests/GeyserMiniConsole_spec.lua
+++ b/src/mudlet-lua/tests/GeyserMiniConsole_spec.lua
@@ -240,10 +240,6 @@ describe("Tests functionality of Geyser.MiniConsole", function()
     end)
 
     it("selectCmdLinetext reports success after selecting the typed text", function()
-      -- BUG: the C++ selectCmdLineText declares one return value but pushes
-      -- nothing, so Lua hands back whatever was left on the stack - here the
-      -- window name that was passed in
-      pending("selectCmdLineText returns a stack leftover, not a result - see the Wave 3d report")
       console:printCmd("select me")
       assert.is_true(console:selectCmdLinetext())
     end)

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -4517,6 +4517,17 @@ describe("Command line argument handling", function()
     assert.are.equal("kept text", getCmdLine())
   end)
 
+  it("setCmdLineStyleSheet with no arguments does not apply unrelated stack data", function()
+    local functionName = "setCmdLineStyleSheet"
+    setCmdLineStyleSheet("color: rgb(12,34,56);")
+    pcall(function()
+      leaveOnStack("cmdArgHandlingLeftover")
+      _G[functionName]()
+    end)
+    assert.are.equal("color: rgb(12,34,56);", getCmdLineStyleSheet())
+    setCmdLineStyleSheet("")
+  end)
+
   describe("selectCmdLineText", function()
     it("returns true for the main command line", function()
       printCmdLine("select me")

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -4453,3 +4453,88 @@ describe("Widget state getters", function()
     end)
   end)
 end)
+
+-- https://wiki.mudlet.org/w/Manual:UI_Functions
+describe("Command line argument handling", function()
+  local cmdLine = "cmdArgHandlingLine"
+
+  setup(function()
+    createCommandLine(cmdLine, 10, 10, 150, 30)
+  end)
+
+  teardown(function()
+    deleteCommandLine(cmdLine)
+    clearCmdLine()
+  end)
+
+  -- These seven take an optional leading window name and used to locate their
+  -- mandatory string at lua_gettop(L). Called with no arguments at all that is
+  -- index 0, which Lua 5.1 resolves to the first free stack slot instead of
+  -- rejecting - so the type check ran against whatever an earlier call had left
+  -- there, and a leftover string made the call quietly succeed on it.
+  local zeroArgumentFunctions = {
+    "addCmdLineSuggestion",
+    "appendCmdLine",
+    "removeCmdLineSuggestion",
+    "printCmdLine",
+    "setCmdLineStyleSheet",
+    "addCmdLineBlacklist",
+    "removeCmdLineBlacklist",
+  }
+
+  -- leaves its argument in the stack slot the next call in the same function
+  -- body starts from, which is exactly the slot index 0 used to resolve to
+  local function leaveOnStack() end
+
+  for _, functionName in ipairs(zeroArgumentFunctions) do
+    it(functionName .. " reports its missing argument as #1", function()
+      local ok, err = pcall(function()
+        leaveOnStack("cmdArgHandlingLeftover")
+        _G[functionName]()
+      end)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("bad argument #1", 1, true))
+    end)
+  end
+
+  it("printCmdLine with no arguments does not print unrelated stack data", function()
+    local functionName = "printCmdLine"
+    printCmdLine("kept text")
+    pcall(function()
+      leaveOnStack("cmdArgHandlingLeftover")
+      _G[functionName]()
+    end)
+    assert.are.equal("kept text", getCmdLine())
+  end)
+
+  it("appendCmdLine with no arguments does not append unrelated stack data", function()
+    local functionName = "appendCmdLine"
+    printCmdLine("kept text")
+    pcall(function()
+      leaveOnStack("cmdArgHandlingLeftover")
+      _G[functionName]()
+    end)
+    assert.are.equal("kept text", getCmdLine())
+  end)
+
+  describe("selectCmdLineText", function()
+    it("returns true for the main command line", function()
+      printCmdLine("select me")
+      assert.is_true(selectCmdLineText())
+      -- selecting must not disturb what is typed
+      assert.are.equal("select me", getCmdLine())
+    end)
+
+    it("returns true for a named command line", function()
+      printCmdLine(cmdLine, "select me too")
+      assert.is_true(selectCmdLineText(cmdLine))
+      assert.are.equal("select me too", getCmdLine(cmdLine))
+    end)
+
+    it("returns nil and a message naming an unknown command line", function()
+      local ok, err = selectCmdLineText("cmdArgHandlingNoSuchLine")
+      assert.is_nil(ok)
+      assert.is_truthy(tostring(err):find("cmdArgHandlingNoSuchLine", 1, true))
+    end)
+  end)
+end)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(FUNCTIONAL_TEST_SOURCES
     ResetProfileTest.cpp
     TOscTest.cpp
     TUserWindowTest.cpp
+    SubCommandLineLifetimeTest.cpp
     TriggerEditorTest.cpp
     TFeedTriggersRecursionTest.cpp
     TriggerSameLineMatchTest.cpp

--- a/test/functional_tests/SubCommandLineLifetimeTest.cpp
+++ b/test/functional_tests/SubCommandLineLifetimeTest.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2026 by the Mudlet developers                           *
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -13,7 +13,7 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
- *   Free Software Foundation, Inc.,                                        *
+ *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 

--- a/test/functional_tests/SubCommandLineLifetimeTest.cpp
+++ b/test/functional_tests/SubCommandLineLifetimeTest.cpp
@@ -192,6 +192,12 @@ private slots:
         runDeferredDeletes();
 
         QVERIFY2(!console->mSubCommandLineMap.contains(cmdLineName), "stale command line entry left behind after deleting the scroll box that owned it");
+
+        // Observable consequence: the name is free again.
+        auto [recreated, recreateMsg] = console->createCommandLine(QString(), cmdLineName, 0, 0, 100, 30);
+        QVERIFY2(recreated, qPrintable(recreateMsg));
+        console->deleteCommandLine(cmdLineName);
+        runDeferredDeletes();
     }
 
     // Route 3: createCommandLine() into a user window, then deleteMiniConsole()
@@ -213,6 +219,11 @@ private slots:
         runDeferredDeletes();
 
         QVERIFY2(!console->mSubCommandLineMap.contains(cmdLineName), "stale command line entry left behind after deleting the user window that owned it");
+
+        auto [recreated, recreateMsg] = console->createCommandLine(QString(), cmdLineName, 0, 0, 100, 30);
+        QVERIFY2(recreated, qPrintable(recreateMsg));
+        console->deleteCommandLine(cmdLineName);
+        runDeferredDeletes();
     }
 
     // deleteCommandLine() must not leave the entry behind either - it takes the
@@ -262,6 +273,51 @@ private slots:
         QVERIFY2(fontSet, qPrintable(fontMsg));
 
         QVERIFY2(!console->mSubCommandLineMap.contains(name), "stale command line entry survived into the setFont() walk");
+
+        auto [recreated, recreateMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(recreated, qPrintable(recreateMsg));
+        console->deleteCommandLine(name);
+        runDeferredDeletes();
+    }
+
+    // Erasure has to be by value, not by name: a replacement registered under the
+    // same name before the old widget's deferred delete has run must survive it.
+    void test_recreatingBeforeTheDeferredDeleteKeepsTheNewCommandLine()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString name = qsl("reusedCmdLineName");
+
+        auto [created, createMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(created, qPrintable(createMsg));
+        auto [deleted, deleteMsg] = console->deleteCommandLine(name);
+        QVERIFY2(deleted, qPrintable(deleteMsg));
+
+        // Deliberately no event loop turn here - the old widget is still alive.
+        auto [recreated, recreateMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(recreated, qPrintable(recreateMsg));
+        TCommandLine* replacement = console->mSubCommandLineMap.value(name);
+        QVERIFY(replacement);
+
+        runDeferredDeletes();
+
+        QVERIFY2(console->mSubCommandLineMap.value(name) == replacement, "the old command line's deregistration took the replacement with it");
+        console->deleteCommandLine(name);
+        runDeferredDeletes();
+    }
+
+    // Kept last on purpose: it leaves a registered command line behind, so that
+    // cleanupTestCase()'s teardown destroys the console with one still in its
+    // widget tree. ~TMainConsole has to drop its destroyed() handler first - that
+    // handler runs from ~QWidget, which is after the console's own members,
+    // mSubCommandLineMap included, have already been destroyed.
+    void test_destroyingTheConsoleWithALiveCommandLineIsSafe()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString name = qsl("outlivesTheConsole");
+
+        auto [created, createMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(created, qPrintable(createMsg));
+        QVERIFY(console->mSubCommandLineMap.contains(name));
     }
 };
 

--- a/test/functional_tests/SubCommandLineLifetimeTest.cpp
+++ b/test/functional_tests/SubCommandLineLifetimeTest.cpp
@@ -1,0 +1,284 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by the Mudlet developers                           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                        *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Regression test for a dangling TCommandLine* left behind in
+ * TMainConsole::mSubCommandLineMap when the widget that owns the command line
+ * is deleted.
+ *
+ * A TCommandLine is always a child widget of some other widget (the miniconsole
+ * it is embedded in, or the user window / scroll box it was created into), so
+ * Qt's parent-child ownership frees it along with that parent. The map entry
+ * registered in TConsole::setCmdVisible() / TMainConsole::createCommandLine()
+ * survived, leaving a non-null pointer to freed memory that every later lookup
+ * of that name dereferenced.
+ *
+ * The last test here is the one that needs no Lua at all: TConsole::setFont()
+ * walks the whole map and calls console() on every entry, and that walk is
+ * reached from Host::setDisplayFont(), i.e. from changing the display font in
+ * Preferences.
+ *
+ * Bootstrap mirrors the other functional tests (e.g. TUserWindowTest).
+ */
+
+#include <QSignalSpy>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TCommandLine.h"
+#include "TConsole.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForSubCommandLineTest();
+
+class SubCommandLineLifetimeTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "SubCommandLine-Test-Host";
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    const QString mLocalhost = "localhost";
+
+    // The free happens through deleteLater(), so it only lands once control
+    // returns to the event loop - which is exactly what makes the stale entry
+    // point at freed memory rather than at a doomed but still live widget.
+    void runDeferredDeletes()
+    {
+        QTest::qWait(50ms);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        QCoreApplication::processEvents();
+    }
+
+private slots:
+    // Start mudlet and create a profile once for all tests.
+    void initTestCase()
+    {
+        initializeQRCResourcesForSubCommandLineTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        QDir(path).removeRecursively();
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(500)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        QDir(path).removeRecursively();
+        delete mudlet::self();
+    }
+
+    void init()
+    {
+        QVERIFY(mpHost);
+        QVERIFY(mpHost->mpConsole);
+    }
+
+    // Route 1: enableCommandLine() on a miniconsole, then deleteMiniConsole().
+    // The command line is a child of the miniconsole, so the miniconsole's
+    // destruction frees it.
+    void test_miniConsoleCommandLineDeregistersWhenConsoleDeleted()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString name = qsl("doomedMiniConsole");
+
+        TConsole* miniConsole = console->createMiniConsole(QString(), name, 0, 0, 300, 100);
+        QVERIFY2(miniConsole, "could not create the miniconsole");
+        miniConsole->setCmdVisible(true); // what Lua enableCommandLine(name) does
+        QVERIFY2(console->mSubCommandLineMap.contains(name), "command line not registered after enabling it");
+
+        auto [deleted, deleteMsg] = console->deleteMiniConsole(name);
+        QVERIFY2(deleted, qPrintable(deleteMsg));
+        runDeferredDeletes();
+
+        QVERIFY2(!console->mSubCommandLineMap.contains(name), "stale command line entry left behind after deleting the miniconsole that owned it");
+
+        // The observable non-crashing symptom of the stale entry: the name still
+        // looks taken, so a fresh command line of that name cannot be made.
+        auto [created, createMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(created, qPrintable(createMsg));
+        console->deleteCommandLine(name);
+        runDeferredDeletes();
+    }
+
+    // Route 2: createCommandLine() into a scroll box, then deleteScrollBox().
+    void test_scrollBoxCommandLineDeregistersWhenScrollBoxDeleted()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString scrollBoxName = qsl("doomedScrollBox");
+        const QString cmdLineName = qsl("scrollBoxCmdLine");
+
+        QVERIFY2(console->createScrollBox(QString(), scrollBoxName, 0, 0, 300, 200), "could not create the scroll box");
+        auto [created, createMsg] = console->createCommandLine(scrollBoxName, cmdLineName, 0, 0, 100, 30);
+        QVERIFY2(created, qPrintable(createMsg));
+        QVERIFY(console->mSubCommandLineMap.contains(cmdLineName));
+
+        auto [deleted, deleteMsg] = console->deleteScrollBox(scrollBoxName);
+        QVERIFY2(deleted, qPrintable(deleteMsg));
+        runDeferredDeletes();
+
+        QVERIFY2(!console->mSubCommandLineMap.contains(cmdLineName), "stale command line entry left behind after deleting the scroll box that owned it");
+    }
+
+    // Route 3: createCommandLine() into a user window, then deleteMiniConsole()
+    // on that user window - the dock owns the command line's parent widget.
+    void test_userWindowCommandLineDeregistersWhenWindowDeleted()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString windowName = qsl("doomedUserWindow");
+        const QString cmdLineName = qsl("userWindowCmdLine");
+
+        auto [opened, openMsg] = mpHost->openWindow(windowName, /*loadLayout=*/false, /*autoDock=*/true, qsl("l"));
+        QVERIFY2(opened, qPrintable(openMsg));
+        auto [created, createMsg] = console->createCommandLine(windowName, cmdLineName, 0, 0, 100, 30);
+        QVERIFY2(created, qPrintable(createMsg));
+        QVERIFY(console->mSubCommandLineMap.contains(cmdLineName));
+
+        auto [deleted, deleteMsg] = console->deleteMiniConsole(windowName);
+        QVERIFY2(deleted, qPrintable(deleteMsg));
+        runDeferredDeletes();
+
+        QVERIFY2(!console->mSubCommandLineMap.contains(cmdLineName), "stale command line entry left behind after deleting the user window that owned it");
+    }
+
+    // deleteCommandLine() must not leave the entry behind either - it takes the
+    // entry itself, so the destructor has to cope with the name already gone.
+    void test_deleteCommandLineDeregisters()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString name = qsl("explicitlyDeletedCmdLine");
+
+        auto [created, createMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(created, qPrintable(createMsg));
+        auto [deleted, deleteMsg] = console->deleteCommandLine(name);
+        QVERIFY2(deleted, qPrintable(deleteMsg));
+        runDeferredDeletes();
+
+        QVERIFY2(!console->mSubCommandLineMap.contains(name), "command line entry left behind after deleteCommandLine()");
+
+        // Recreating under the same name must work.
+        auto [recreated, recreateMsg] = console->createCommandLine(QString(), name, 0, 0, 100, 30);
+        QVERIFY2(recreated, qPrintable(recreateMsg));
+        console->deleteCommandLine(name);
+        runDeferredDeletes();
+    }
+
+    // The no-Lua route: changing the display font in Preferences ends up in
+    // Host::setDisplayFont() -> TConsole::setFont(), which walks the whole
+    // mSubCommandLineMap and calls console() on every entry. With a stale entry
+    // present that is a read of freed memory (a clean heap-use-after-free under
+    // AddressSanitizer). Kept last so the cheaper assertions above report first.
+    void test_changingDisplayFontAfterDeletedWindowIsSafe()
+    {
+        TMainConsole* console = mpHost->mpConsole;
+        const QString name = qsl("fontWalkMiniConsole");
+
+        TConsole* miniConsole = console->createMiniConsole(QString(), name, 0, 0, 300, 100);
+        QVERIFY2(miniConsole, "could not create the miniconsole");
+        miniConsole->setCmdVisible(true);
+        QVERIFY(console->mSubCommandLineMap.contains(name));
+
+        auto [deleted, deleteMsg] = console->deleteMiniConsole(name);
+        QVERIFY2(deleted, qPrintable(deleteMsg));
+        runDeferredDeletes();
+
+        QFont changedFont = mpHost->getDisplayFont();
+        changedFont.setPointSize(changedFont.pointSize() == 12 ? 14 : 12);
+        auto [fontSet, fontMsg] = mpHost->setDisplayFont(changedFont);
+        QVERIFY2(fontSet, qPrintable(fontMsg));
+
+        QVERIFY2(!console->mSubCommandLineMap.contains(name), "stale command line entry survived into the setFont() walk");
+    }
+};
+
+void initializeQRCResourcesForSubCommandLineTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "SubCommandLineLifetimeTest.moc"
+QTEST_MAIN(SubCommandLineLifetimeTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Deleting the window that owns a command line no longer leaves a dangling `TCommandLine*` behind in `mSubCommandLineMap`. A new `TMainConsole::registerSubCommandLine()` is the single place that map is written, and it hooks `destroyed()` so the entry goes when the widget does.
- Seven command line Lua functions located their mandatory string at `lua_gettop(L)`, which is index `0` when they are called with no arguments - not a valid Lua stack index, so they silently operated on whatever an earlier call had left on the stack. The index is now clamped, and `selectCmdLineText` pushes a real result instead of handing back a stack leftover.
- `scrollUp`/`scrollDown` report an unknown window instead of raising, and `prefix()`/`suffix()` only colour the text they add - `suffix()` also puts it after the last character of the line rather than before it.

#### Motivation for adding to Mudlet

The dangling pointer is the serious one. The command line is a child widget of the miniconsole, user window or scroll box it lives in, so Qt frees it along with that parent while the map entry survives. `TConsole::setFont()` walks the whole map, and that walk is reached from `Host::setDisplayFont()` - so once any package has created and then deleted a window carrying a command line, simply changing the display font, its size or its antialiasing in Settings reads freed memory. No Lua is involved, and most dereferences land in Qt's text internals, so crashes from this are likely being filed as unrelated Qt text-layout bugs.

The rest are Lua API correctness: calls that quietly act on unrelated data, a return value that is really the C function object, a guard that never fires, and colour and insert positions that land on the wrong text.

#### Other info (issues closed, discussion etc)

Closes #9643, closes #9647, closes #9651, closes #9652, closes #9661, closes #9674

`selectCmdLineText` now returns `true`; its wiki entry needs updating to match.

**Test case:** with the fix reverted, the new `SubCommandLineLifetimeTest` fails three assertions and then aborts on an AddressSanitizer heap-use-after-free in `TCommandLine::console()` from `TConsole::setFont()`, and 17 of the 20 new and un-pended Lua specs fail too. With it, busted is 2246/0 twice over and ctest is 72/72 serially.

Assisted-by: Claude:claude-opus-5