### PR TITLE
fix: package lifecycle - queued save outliving the profile, unremovable archives, module priority

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -412,6 +412,8 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         }
     });
     connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTemps);
+    mDeferredSaveTimer.setSingleShot(true);
+    connect(&mDeferredSaveTimer, &QTimer::timeout, this, &Host::slot_saveProfileAfterPackageChange);
     connect(this, &Host::signal_forceMXPProcessorOnChanged, this, [this](bool enabled) {
         if (enabled) {
             if (!mMxpProcessor.isEnabled()) {
@@ -448,6 +450,11 @@ Host::~Host()
 {
     // Mark the host as closing down to prevent keybinding processing during destruction
     mIsClosingDown = true;
+
+    // closeChildren() normally does this, but a Host whose console has already
+    // gone never gets there - and a package save left to fire from a Host that
+    // is being taken apart runs against freed members (#9653):
+    mDeferredSaveTimer.stop();
 
     // This needs to be cleared here while the Host object is still valid,
     // otherwise it'll be cleared when the Host object is being destroyed,
@@ -514,6 +521,14 @@ bool Host::requestClose()
 void Host::closeChildren()
 {
     mIsClosingDown = true;
+    // Drop the profile save a package install/uninstall put off: the close path
+    // has already saved the profile with that change in it (or the user declined
+    // to save at all), and a save that outlives the profile runs on a destroyed
+    // Host (#9653).
+    if (mDeferredSaveTimer.isActive()) {
+        qDebug().nospace().noquote() << "Host::closeChildren() INFO - dropping the profile save that a package change owed \"" << getName() << "\": the close saves the profile itself.";
+        mDeferredSaveTimer.stop();
+    }
     const auto hostToolBarMap = getActionUnit()->getToolBarList();
     // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
     mTelnet.terminateConnection();
@@ -1846,6 +1861,30 @@ void Host::slot_purgeTemps()
     mScriptUnit.doCleanup();
 }
 
+// The profile save that installPackage()/uninstallPackage() put off to the next
+// event loop pass - see mDeferredSaveTimer.
+void Host::slot_saveProfileAfterPackageChange()
+{
+    if (currentlySavingProfile()) {
+        // saveProfile() would refuse outright, and this is the only save the
+        // package change has coming: ask again once the one in flight is out of
+        // the way rather than leaving the change unwritten until something else
+        // happens to save. The profile close stops this timer, so the retries
+        // cannot outlive the profile.
+        mDeferredSaveTimer.start(100ms);
+        return;
+    }
+    // If a package's own script uninstalled it mid-compile (from a script
+    // reached outside the compileAll()/editor/raiseEvent flush points, e.g. a
+    // permScript() run from an alias or key), the script deletes were deferred
+    // and are still registered. Flush them now, at depth 0, before saving so
+    // the save below does not serialize the just-uninstalled scripts back in:
+    mScriptUnit.doCleanup();
+    if (auto [ok, filename, error] = saveProfile(); !ok) {
+        qWarning() << qsl("Host::slot_saveProfileAfterPackageChange() WARNING - couldn't save '%1' to '%2' because: %3").arg(getName(), filename, error);
+    }
+}
+
 void Host::registerEventHandler(const QString& name, TScript* pScript)
 {
     if (mEventHandlerMap.contains(name)) {
@@ -2152,12 +2191,14 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
         QStringList _filterList;
         _filterList << qsl("*.xml") << qsl("*.trigger");
         const QFileInfoList entries = _dir.entryInfoList(_filterList, QDir::Files);
+        bool registeredFromArchive = false;
         for (auto& entry : entries) {
             file2.setFileName(entry.absoluteFilePath());
             if (!file2.open(QFile::ReadOnly | QFile::Text)) {
                 qWarning() << "Host: failed to open file for reading:" << entry.absoluteFilePath() << file2.errorString();
                 continue;
             }
+            registeredFromArchive = true;
             XMLimport reader(this);
             if (thing != enums::PackageModuleType::Package) {
                 QStringList moduleEntry;
@@ -2178,6 +2219,31 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
                 }
             }
             file2.close();
+        }
+
+        // Registering the package is this loop's job, so an archive that holds no
+        // package XML that could be read is not installed anywhere: it would be
+        // missing from getPackages()/getModules(), uninstallPackage() would refuse
+        // it, and the folder it was just unpacked into would stay in the profile
+        // for good (#9654). Take that folder away again and say so. Asking the
+        // loop whether it registered anything, rather than asking
+        // mInstalledPackages/mInstalledModules afterwards, is what makes this hold
+        // for a module whose name is already in mInstalledModules on the way in
+        // (profile loading, and installModule() over a stale entry, both do that).
+        if (!registeredFromArchive) {
+            // Only ever remove a folder of this package's own. The package name
+            // can come out empty (a file called ".mpackage") or be whatever an
+            // untrusted archive's config.lua says (".." above), in which case
+            // _dir is the profile itself or the folder holding every profile -
+            // and removeDir() takes everything below what it is given.
+            const QString profileHome = QDir(mudlet::getMudletPath(enums::profileHomePath, getName())).absolutePath();
+            const QString unpackedPath = _dir.absolutePath();
+            if (unpackedPath.startsWith(profileHome + QLatin1Char('/'))) {
+                removeDir(unpackedPath, unpackedPath);
+            } else {
+                qWarning() << "Host::installPackage() WARNING - not removing" << unpackedPath << "for the refused package" << packageName << "as it is not a folder inside the profile" << profileHome;
+            }
+            return {false, qsl("no package found in %1 - no Mudlet package file in it could be read").arg(fileName)};
         }
     } else {
         file2.setFileName(fileName);
@@ -2223,7 +2289,15 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     // Defer raising install events until the next event loop iteration
     // This ensures all package installation is complete (including variable loading)
     // before event handlers execute, preventing Lua state corruption
-    QTimer::singleShot(0ms, this, [this, thing, packageName, fileName]() {
+    QTimer::singleShot(0ms, this, [this, guard = QPointer<Host>(this), thing, packageName, fileName]() {
+        // The queued call can still be delivered once this Host has been
+        // destroyed - the profile save queued the same way was #9653 - and the
+        // isClosingDown() check below would then be read off freed memory. The
+        // guard lives in the queued call rather than in the Host, so it is safe
+        // to ask and is null by then:
+        if (!guard) {
+            return;
+        }
         // Don't raise events if Host is shutting down to avoid handlers executing during teardown
         if (isClosingDown()) {
             return;
@@ -2277,9 +2351,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     // Save profile to ensure modules persist and appear in module manager
     if (thing != enums::PackageModuleType::Package) {
         // Use a timer to save profile after module installation completes
-        QTimer::singleShot(100ms, this, [this]() {
-            saveProfile();
-        });
+        mDeferredSaveTimer.start(100ms);
     }
 
     return {true, QString()};
@@ -2442,24 +2514,9 @@ bool Host::uninstallPackage(const QString& packageName, enums::PackageModuleType
     const QString dest = mudlet::getMudletPath(enums::profilePackagePath, getName(), packageName);
     removeDir(dest, dest);
 
-    // ensure only one timer is running in case multiple modules are uninstalled at once
-    if (!mSaveTimer.has_value() || !mSaveTimer.value()) {
-        mSaveTimer = true;
-        // save the profile on the next Qt main loop cycle in order for the asyncronous save mechanism
-        // not to try to write to disk a package/module that just got uninstalled and removed from memory
-        QTimer::singleShot(0ms, this, [this]() {
-            mSaveTimer = false;
-            // If a package's own script uninstalled it mid-compile (from a script
-            // reached outside the compileAll()/editor/raiseEvent flush points, e.g. a
-            // permScript() run from an alias or key), the script deletes were deferred
-            // and are still registered. Flush them now, at depth 0, before saving so
-            // the save below does not serialize the just-uninstalled scripts back in:
-            mScriptUnit.doCleanup();
-            if (auto [ok, filename, error] = saveProfile(); !ok) {
-                qDebug() << qsl("Host::uninstallPackage: Couldn't save '%1' to '%2' because: %3").arg(getName(), filename, error);
-            }
-        });
-    }
+    // save the profile on the next Qt main loop cycle in order for the asyncronous save mechanism
+    // not to try to write to disk a package/module that just got uninstalled and removed from memory
+    mDeferredSaveTimer.start(0ms);
 
     //NOW we reset if we're uninstalling a module
     if (mpEditorDialog && thing == enums::PackageModuleType::ModuleFromScript) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2134,10 +2134,17 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
         // home directory for the PROFILE
         const QDir _tmpDir(_home);
         // directory to store the expanded archive file contents
+        // Noted before it is made: the only folder this install may ever delete
+        // again is one it made itself. The package name is the archive's own file
+        // name, and then whatever its config.lua says, so it can just as well name
+        // a folder of the profile's that was already here ("map", "log",
+        // "current") - see the refusal further down.
+        const bool destinationAlreadyExisted = QDir(_dest).exists();
         const bool mkpathSuccessful = _tmpDir.mkpath(_dest);
         if (!mkpathSuccessful) {
             return {false, qsl("could not create destination folder")};
         }
+        QString folderThisInstallMade = destinationAlreadyExisted ? QString() : QDir(_dest).absolutePath();
 
         // Skip the unpacking dialog for modules created from UI, and for
         // script-initiated installs (passed via quiet) to avoid stealing
@@ -2185,7 +2192,13 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
             }
             // continuing, so update the folder name on disk
             const QString newpath(qsl("%1/%2").arg(_home, packageName));
-            _dir.rename(_dir.absolutePath(), newpath);
+            // A rename onto a folder that is already there fails, and then the
+            // folder this install made is still at its old name while _dir goes
+            // on to the folder that was already here - which is not ours to
+            // delete, whatever the archive would like.
+            if (_dir.rename(_dir.absolutePath(), newpath) && !folderThisInstallMade.isEmpty()) {
+                folderThisInstallMade = QDir(newpath).absolutePath();
+            }
             _dir = QDir(newpath);
         }
         QStringList _filterList;
@@ -2231,17 +2244,17 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
         // for a module whose name is already in mInstalledModules on the way in
         // (profile loading, and installModule() over a stale entry, both do that).
         if (!registeredFromArchive) {
-            // Only ever remove a folder of this package's own. The package name
-            // can come out empty (a file called ".mpackage") or be whatever an
-            // untrusted archive's config.lua says (".." above), in which case
-            // _dir is the profile itself or the folder holding every profile -
-            // and removeDir() takes everything below what it is given.
+            // Only ever remove the folder this install made, and only if it is
+            // inside the profile: the package name can come out empty (a file
+            // called ".mpackage"), name a folder of the user's ("map"), or be
+            // whatever an untrusted archive's config.lua says (".." - the folder
+            // holding every profile), and removeDir() takes everything below what
+            // it is given.
             const QString profileHome = QDir(mudlet::getMudletPath(enums::profileHomePath, getName())).absolutePath();
-            const QString unpackedPath = _dir.absolutePath();
-            if (unpackedPath.startsWith(profileHome + QLatin1Char('/'))) {
-                removeDir(unpackedPath, unpackedPath);
+            if (!folderThisInstallMade.isEmpty() && folderThisInstallMade.startsWith(profileHome + QLatin1Char('/'))) {
+                removeDir(folderThisInstallMade, folderThisInstallMade);
             } else {
-                qWarning() << "Host::installPackage() WARNING - not removing" << unpackedPath << "for the refused package" << packageName << "as it is not a folder inside the profile" << profileHome;
+                qWarning() << "Host::installPackage() WARNING - refused" << fileName << "as package" << packageName << "but leaving" << _dir.absolutePath() << "alone: this install did not make it";
             }
             return {false, qsl("no package found in %1 - no Mudlet package file in it could be read").arg(fileName)};
         }

--- a/src/Host.h
+++ b/src/Host.h
@@ -351,6 +351,9 @@ public:
     QString readProfileIniData(const QString& item);
     void xmlSaved(const QString& xmlName);
     bool currentlySavingProfile();
+    // Whether a package install or uninstall still owes the profile a save - see
+    // mDeferredSaveTimer.
+    bool hasPendingProfileSave() const { return mDeferredSaveTimer.isActive(); }
     void processDiscordGMCP(const QString& packageMessage, const QString& data);
     void waitForProfileSave();
     void clearDiscordData();
@@ -888,6 +891,7 @@ signals:
 
 private slots:
     void slot_purgeTemps();
+    void slot_saveProfileAfterPackageChange();
 
 private:
     void setBorders(const QMargins);
@@ -954,8 +958,15 @@ private:
     ActionUnit mActionUnit;
     KeyUnit mKeyUnit;
     GifTracker mGifTracker;
-    // ensures that only one saveProfile call is active when multiple modules are being uninstalled in one go
-    std::optional<bool> mSaveTimer;
+    // The profile save that a package/module install or uninstall owes is put off
+    // to the next event loop pass, so that the asynchronous save mechanism is not
+    // asked to write out something that was just taken out of memory. Restarting
+    // this timer also folds a batch of installs/uninstalls into a single save.
+    // It has to be a member timer rather than a QTimer::singleShot(): a call
+    // queued on the Host is still delivered after the Host has been destroyed,
+    // and the save then reads freed members - closeChildren() and ~Host() stop
+    // this one instead (#9653).
+    QTimer mDeferredSaveTimer;
 
     QFile mErrorLogFile;
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1340,12 +1340,15 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
 {
     const QString moduleName = getVerifiedString(L, __func__, 1, "module name");
     Host& host = getHostFromLua(L);
-    if (host.mModulePriorities.contains(moduleName)) {
-        const int priority = host.mModulePriorities[moduleName];
-        lua_pushnumber(L, priority);
-        return 1;
+    // Installing a module does not seed mModulePriorities, so whether the module
+    // exists has to be asked of mInstalledModules - the same list
+    // setModulePriority() checks. A module nobody has set a priority on has the
+    // default of 0 that the module manager and the saved profile use (#9655).
+    if (!host.mInstalledModules.contains(moduleName)) {
+        return warnArgumentValue(L, __func__, "module doesn't exist");
     }
-    return warnArgumentValue(L, __func__, "module doesn't exist");
+    lua_pushnumber(L, host.mModulePriorities.value(moduleName));
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setModulePriority

--- a/src/mudlet-lua/tests/Package_spec.lua
+++ b/src/mudlet-lua/tests/Package_spec.lua
@@ -713,14 +713,18 @@ describe("Tests the module accessors", function()
     -- alone), so once one has been set for this module the default this spec is
     -- about can never be observed again.
     it("reports the default priority of a freshly installed module", function()
-      -- BUG: a module nobody has called setModulePriority() on has no entry in
-      -- the priority map, so getModulePriority() answers nil and "module
-      -- doesn't exist" for a module that plainly does exist. The module manager
-      -- reads the same map with operator[] and so shows 0, which is what this
-      -- should return. Left pending rather than pinning the wrong answer.
-      pending("getModulePriority() reports an installed module as non-existent until a priority is set")
-
+      requireWorkingInstalls()
+      -- Installing a module seeds no priority for it, so this is the default the
+      -- module manager displays and the profile exporter writes out, rather than
+      -- the "module doesn't exist" that reading the priority map as an existence
+      -- check used to answer here.
       assert.equals(0, getModulePriority(moduleName))
+    end)
+
+    it("returns nil+msg for a module that is not installed", function()
+      local ok, err = getModulePriority("mudlet-spec-never-installed")
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "module doesn't exist"), tostring(err))
     end)
   end)
 
@@ -866,6 +870,19 @@ describe("Tests the functionality of reloadModule", function()
   end)
 end)
 
+-- Runs once the block above has uninstalled the module it shares, which is what
+-- this is about - it installs nothing of its own.
+describe("Tests reading the priority of a module that has been uninstalled", function()
+  it("stops answering for it, even though the priority it was given is remembered", function()
+    assert.is_false(moduleInstalled(moduleName), "the module accessor specs left their module installed")
+    -- Uninstalling leaves the module's entry in the priority map behind, so
+    -- reading that map is not a way to tell whether the module is there.
+    local ok, err = getModulePriority(moduleName)
+    assert.is_nil(ok)
+    assert.is_true(contains(err, "module doesn't exist"), tostring(err))
+  end)
+end)
+
 describe("Tests a package that uninstalls itself", function()
   -- Regression #9557: a package whose event handler uninstalls its own package
   -- used to free the TScript objects that Host::raiseEvent() was still
@@ -928,22 +945,28 @@ end)
 
 describe("Tests installing an archive with nothing in it for Mudlet", function()
   it("refuses an archive that holds neither a config.lua nor a package XML", function()
-    -- BUG: such an archive is unpacked into the profile and answered with true,
-    -- but nothing is registered: it is missing from getPackages(), so
-    -- uninstallPackage() will not take it and the unpacked folder stays in the
-    -- profile for good. Left pending rather than pinning a success that
-    -- installs nothing and cannot be undone.
-    pending("installPackage() answers true for an archive with no package in it, and leaves it unremovable")
-    -- uninstallPackage() will not take a package it never registered, so the
-    -- unpacked folder has to go by hand
+    requireWorkingInstalls()
+    -- Nothing in such an archive registers the package, so answering true would
+    -- leave a name that getPackages() does not list, that uninstallPackage()
+    -- refuses, and a folder in the profile that only a file manager can take
+    -- away. If the refusal ever regresses, this puts the folder back by hand.
     defer(function()
-      os.remove(getMudletHomeDir() .. "/mudlet-spec-emptyarchive/readme.txt")
-      lfs.rmdir(getMudletHomeDir() .. "/mudlet-spec-emptyarchive")
+      if fileExists(getMudletHomeDir() .. "/mudlet-spec-emptyarchive") then
+        os.remove(getMudletHomeDir() .. "/mudlet-spec-emptyarchive/readme.txt")
+        lfs.rmdir(getMudletHomeDir() .. "/mudlet-spec-emptyarchive")
+      end
     end)
+
+    -- an install asked for while a save is running is postponed and answered
+    -- with a bare true, which would read here as the refusal not happening
+    assert.is_true(waitForProfileSaveToPass(), "a profile save was still running")
 
     local ok, err = installPackage(fixtureDirectory .. "/mudlet-spec-emptyarchive.mpackage")
     assert.is_nil(ok)
-    assert.is_string(err)
+    -- the message matters: "could not unzip package" here would mean the fixture
+    -- has rotted and the spec is passing for the wrong reason
+    assert.is_true(contains(err, "no package found in"), tostring(err))
+    assert.is_false(packageInstalled("mudlet-spec-emptyarchive"))
     assert.is_false(fileExists(getMudletHomeDir() .. "/mudlet-spec-emptyarchive"))
   end)
 end)
@@ -977,8 +1000,7 @@ describe("The package specs clean up after themselves", function()
     end
 
     -- Let the profile save that the last uninstall queued run while the profile
-    -- is still up: it dereferences the profile when it fires, and Mudlet may be
-    -- shutting down by the time it would otherwise get its turn.
+    -- is still up, rather than leaving it to be stopped by the profile close.
     pumpEventLoop(1500)
   end)
 end)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2423,8 +2423,8 @@ void mudlet::slot_timerFires()
         // on the stack (a timer script uninstalling its own package). Doing it
         // here - after the last use of pTT - keeps the window in which the
         // "uninstalled" timers linger down to this event loop iteration, before
-        // the profile save that Host::uninstallPackage() queues with a 0ms
-        // single-shot can serialize them back into the profile:
+        // the profile save that Host::uninstallPackage() queues for the next
+        // event loop pass can serialize them back into the profile:
         pHost->getTimerUnit()->doCleanup();
 
         // Okay now we've found it we are done:

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(FUNCTIONAL_TEST_SOURCES
     ProfileRoundTripTest.cpp
     ProfileLoadTempFileTest.cpp
     PackageSelfUninstallTest.cpp
+    PackageUninstallSaveTeardownTest.cpp
     MapRoundTripTest.cpp
     MapProgressDialogSeamTest.cpp
     UndoServerWrapTest.cpp

--- a/test/functional_tests/HostWidgetDecouplingTest.cpp
+++ b/test/functional_tests/HostWidgetDecouplingTest.cpp
@@ -35,6 +35,8 @@
 #include <QLabel>
 #include <QTemporaryDir>
 
+#include <zip.h>
+
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();
@@ -218,8 +220,9 @@ private slots:
 
         QTemporaryDir packageDir;
         QVERIFY2(packageDir.isValid(), "Could not create a temporary directory for the test package.");
-        const QString packagePath = packageDir.filePath(qsl("HostWidgetDecouplingPackage.zip"));
-        QVERIFY2(writeEmptyZipArchive(packagePath), "Could not write the test package archive.");
+        const QString packageName = qsl("HostWidgetDecouplingPackage");
+        const QString packagePath = packageDir.filePath(qsl("%1.zip").arg(packageName));
+        QVERIFY2(writePackageArchive(packagePath, packageName), "Could not write the test package archive.");
 
         // installPackage() postpones the whole install (and so emits nothing) if a
         // profile save is still in flight from loading the profile.
@@ -323,20 +326,32 @@ private slots:
         }
     }
 
-    // Utility function producing the smallest valid zip archive there is: a lone
-    // end-of-central-directory record holding no entries. installPackage() only
-    // has to find a real archive to unpack for the dialog wiring to be exercised;
-    // what is inside it is beside the point here.
-    bool writeEmptyZipArchive(const QString& path)
+    // Utility function producing the smallest package archive that installs: a
+    // zip holding one Mudlet package XML with nothing in it. An archive with no
+    // package XML at all is refused (it would install nowhere and could never be
+    // uninstalled), so the dialog wiring this test is about needs a real one.
+    bool writePackageArchive(const QString& path, const QString& packageName)
     {
-        static const char endOfCentralDirectoryRecord[22] = {'P', 'K', '\x05', '\x06'};
-        QFile archive(path);
-        if (!archive.open(QIODevice::WriteOnly)) {
+        static const char packageXml[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                         "<!DOCTYPE MudletPackage>\n"
+                                         "<MudletPackage version=\"1.001\">\n"
+                                         "<TriggerPackage /><TimerPackage /><AliasPackage /><ActionPackage />\n"
+                                         "<ScriptPackage /><KeyPackage /><VariablePackage><HiddenVariables /></VariablePackage>\n"
+                                         "</MudletPackage>\n";
+
+        int errorCode = 0;
+        zip* archive = zip_open(path.toUtf8().constData(), ZIP_CREATE | ZIP_TRUNCATE, &errorCode);
+        if (!archive) {
             return false;
         }
-        const bool written = archive.write(endOfCentralDirectoryRecord, sizeof(endOfCentralDirectoryRecord)) == static_cast<qint64>(sizeof(endOfCentralDirectoryRecord));
-        archive.close();
-        return written;
+        // sizeof - 1 to leave the terminating null out of the archived file
+        zip_source* source = zip_source_buffer(archive, packageXml, sizeof(packageXml) - 1, 0);
+        if (!source || zip_file_add(archive, qsl("%1.xml").arg(packageName).toUtf8().constData(), source, ZIP_FL_ENC_UTF_8) < 0) {
+            zip_source_free(source);
+            zip_discard(archive);
+            return false;
+        }
+        return zip_close(archive) == 0;
     }
 
     // Utility function

--- a/test/functional_tests/PackageUninstallSaveTeardownTest.cpp
+++ b/test/functional_tests/PackageUninstallSaveTeardownTest.cpp
@@ -1,0 +1,313 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Regression test for the profile save that uninstalling a package puts off to
+ * the next event loop pass outliving the profile (#9653).
+ *
+ * Uninstalling a package cannot save the profile there and then - the
+ * asynchronous save mechanism would be handed a package that has just been
+ * taken out of memory - so the save is deferred. Closing Mudlet right after an
+ * uninstall then destroys the Host while that save is still owed, and the save
+ * ran anyway: against a freed Host, reading its writer map. Under
+ * AddressSanitizer that is a heap-use-after-free at
+ * Host::pendingXmlSaveFutures(); in a release build it is a crash or silent
+ * memory corruption on the way out, i.e. a "Mudlet crashed when I closed it"
+ * report.
+ *
+ * The two tests here pin both halves of what the fix has to hold true: the
+ * deferred save still happens for a profile that stays up, and nothing of it is
+ * left to run once the profile has been closed and its Host destroyed. The
+ * report itself needs the whole application to shut down (the queued call is
+ * delivered by the event loop pass after mudlet::closeEvent() has returned),
+ * which is what the busted package specs arrange; what this file adds is the
+ * contract the fix rests on, and a sanitizer run over the uninstall/close/
+ * destroy/pump sequence itself.
+ *
+ * Run with: ctest -R PackageUninstallSaveTeardownTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QTemporaryDir>
+#include <chrono>
+#include <zip.h>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForPackageUninstallSaveTeardownTest();
+
+class PackageUninstallSaveTeardownTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("PackageUninstallSaveTeardown-Test");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort; // the stub's actual ephemeral port, assigned in initTestCase()
+    // The refusal test below installs an archive that names itself ".." - that
+    // has to happen nowhere near the developer's own profiles.
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+
+    static void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    static QStringList savedProfileFiles(const QString& profileName) { return QDir(mudlet::getMudletPath(enums::profileXmlFilesPath, profileName)).entryList(QStringList{qsl("*.xml")}, QDir::Files); }
+
+    // Whether needle appears in the profile that was saved last - what actually
+    // landed on disk, rather than what a save signal says was attempted.
+    static bool lastSavedProfileContains(const QString& profileName, const QString& needle)
+    {
+        const QDir directory(mudlet::getMudletPath(enums::profileXmlFilesPath, profileName));
+        const QStringList saved = directory.entryList(QStringList{qsl("*.xml")}, QDir::Files, QDir::Name);
+        if (saved.isEmpty()) {
+            return false;
+        }
+        QFile file(directory.absoluteFilePath(saved.last()));
+        if (!file.open(QFile::ReadOnly | QFile::Text)) {
+            return false;
+        }
+        return QString::fromUtf8(file.readAll()).contains(needle);
+    }
+
+    // Utility function to manually start a profile like a user would do via the GUI
+    void startProfile(const QString& profileName, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0ms, qApp, [profileName, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), profileName);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+    }
+
+    // The package itself is beside the point here - what matters is that
+    // uninstallPackage() has something to take away, and so owes the profile a
+    // save afterwards.
+    void uninstallPackageOwingASave(const QString& packageName)
+    {
+        mpHost->waitForProfileSave();
+        mpHost->mInstalledPackages << packageName;
+        QVERIFY2(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package), "The package could not be uninstalled");
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "The package is still installed");
+        QVERIFY2(mpHost->hasPendingProfileSave(), "Uninstalling a package left the profile no save to do");
+    }
+
+    // Writes an archive holding nothing but a config.lua that names the package,
+    // i.e. one installPackage() unpacks and then refuses, having registered
+    // nothing from it.
+    static bool writeConfigOnlyArchive(const QString& path, const QString& declaredName)
+    {
+        const QByteArray config = qsl("mpackage = \"%1\"\n").arg(declaredName).toUtf8();
+        int errorCode = 0;
+        zip* archive = zip_open(path.toUtf8().constData(), ZIP_CREATE | ZIP_TRUNCATE, &errorCode);
+        if (!archive) {
+            return false;
+        }
+        zip_source* source = zip_source_buffer(archive, config.constData(), config.size(), 0);
+        if (!source || zip_file_add(archive, "config.lua", source, ZIP_FL_ENC_UTF_8) < 0) {
+            zip_source_free(source);
+            zip_discard(archive);
+            return false;
+        }
+        return zip_close(archive) == 0;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForPackageUninstallSaveTeardownTest();
+
+        // Keep the test hermetic: point the config dir resolution at a temporary
+        // directory instead of the user's real profiles - one of the tests below
+        // drives an archive that tries to have the profiles folder deleted.
+        QVERIFY(mConfigDir.isValid());
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        startProfile(mProfileName, mLocalhost, mPort);
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mProfileName);
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // The save is deferred, not dropped: a profile that stays up has to end up
+    // with the uninstall written out. Without this the test below could be
+    // passed by never saving at all.
+    void test_deferredSaveRunsWhileTheProfileIsUp()
+    {
+        QSignalSpy saveSpy(mpHost, &Host::profileSaveStarted);
+        uninstallPackageOwingASave(qsl("uninstall-save-deferred"));
+        QCOMPARE(saveSpy.count(), 0); // the point of the deferral: not saved on the spot
+
+        QTRY_VERIFY_WITH_TIMEOUT(saveSpy.count() >= 1, 5000);
+        mpHost->waitForProfileSave();
+    }
+
+    // A batch of uninstalls owes the profile one save between them, not one
+    // each: restarting the timer is what the old "only one timer is running"
+    // flag did, and a profile save is expensive enough that the package specs
+    // are shaped around how many of them a run does.
+    void test_aBatchOfUninstallsOwesOneSave()
+    {
+        QSignalSpy saveSpy(mpHost, &Host::profileSaveStarted);
+        uninstallPackageOwingASave(qsl("uninstall-save-batch-one"));
+        // no pumping in between, so all three land in the same event loop pass
+        mpHost->mInstalledPackages << qsl("uninstall-save-batch-two") << qsl("uninstall-save-batch-three");
+        QVERIFY(mpHost->uninstallPackage(qsl("uninstall-save-batch-two"), enums::PackageModuleType::Package));
+        QVERIFY(mpHost->uninstallPackage(qsl("uninstall-save-batch-three"), enums::PackageModuleType::Package));
+
+        QTRY_VERIFY_WITH_TIMEOUT(saveSpy.count() >= 1, 5000);
+        mpHost->waitForProfileSave();
+        QCOMPARE(saveSpy.count(), 1);
+    }
+
+    // Refusing an archive that installed nothing takes the folder it unpacked
+    // away again (#9654) - and nothing else. The package name can be whatever an
+    // untrusted archive's config.lua says, and ".." names the folder that holds
+    // every profile the user has.
+    void test_refusingAnArchiveOnlyRemovesItsOwnFolder()
+    {
+        QTemporaryDir archiveDir;
+        QVERIFY2(archiveDir.isValid(), "Could not create a temporary directory for the test archive");
+        const QString archivePath = archiveDir.filePath(qsl("uninstall-save-escape.mpackage"));
+        QVERIFY2(writeConfigOnlyArchive(archivePath, qsl("..")), "Could not write the test archive");
+
+        mpHost->waitForProfileSave(); // an install during a save is postponed and answered with a bare true
+        const QString profileHome = mudlet::getMudletPath(enums::profileHomePath, mProfileName);
+        const QString profilesDirectory = QFileInfo(profileHome).absolutePath();
+
+        auto [ok, message] = mpHost->installPackage(archivePath, enums::PackageModuleType::Package, true);
+        QVERIFY2(!ok, "An archive holding no package was installed");
+        QVERIFY2(QDir(profilesDirectory).exists(), "Refusing the archive took the folder holding every profile with it");
+        QVERIFY2(QDir(profileHome).exists(), "Refusing the archive took the profile with it");
+        QVERIFY2(!savedProfileFiles(mProfileName).isEmpty(), "Refusing the archive took the saved profile with it");
+    }
+
+    // ...and closing the profile straight after an uninstall must leave nothing
+    // of that save behind: it would run on a destroyed Host.
+    void test_deferredSaveDoesNotOutliveTheProfile()
+    {
+        const QString packageName = qsl("uninstall-save-teardown");
+        QSignalSpy saveSpy(mpHost, &Host::profileSaveStarted);
+        uninstallPackageOwingASave(packageName);
+
+        // The close path Mudlet takes when the application is closed
+        // (mudlet::closeEvent): forceClose() keeps TMainConsole::closeEvent()
+        // from asking whether to save, which would block on a modal dialog.
+        // deleteHost() is the step of the mudlet::closeHost() that follows which
+        // destroys the Host - the rest of it is tab and dock bookkeeping, and is
+        // private to mudlet.
+        mpHost->forceClose();
+        QVERIFY2(mpHost->requestClose(), "Closing the profile was refused");
+        QVERIFY2(!mpHost->hasPendingProfileSave(), "Closing the profile left a package save still owed");
+        // Dropping that save is only right because the uninstall reached the disk
+        // on the way out - by the close's own save, or by the deferred one going
+        // first. Assert the profile that was written, not that a save was tried:
+        QVERIFY2(saveSpy.count() >= 1, "Closing the profile after an uninstall saved it nowhere");
+        QVERIFY2(!lastSavedProfileContains(mProfileName, packageName), "The saved profile still carries the uninstalled package");
+        mpHost = nullptr;
+        mudlet::self()->getHostManager().deleteHost(mProfileName);
+
+        // Nothing the uninstall queued may reach the destroyed Host now. Under
+        // AddressSanitizer a queued save that does reach it aborts the run here;
+        // without the sanitizer, the save it writes is what gives it away.
+        const QStringList savedBefore = savedProfileFiles(mProfileName);
+        QTest::qWait(500ms);
+        QCOMPARE(savedProfileFiles(mProfileName), savedBefore);
+    }
+};
+
+void initializeQRCResourcesForPackageUninstallSaveTeardownTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "PackageUninstallSaveTeardownTest.moc"
+QTEST_MAIN(PackageUninstallSaveTeardownTest)

--- a/test/functional_tests/PackageUninstallSaveTeardownTest.cpp
+++ b/test/functional_tests/PackageUninstallSaveTeardownTest.cpp
@@ -50,6 +50,7 @@
 #include <zip.h>
 
 #include "Host.h"
+#include "AliasUnit.h"
 #include "HostManager.h"
 #include "MudletInstanceCoordinator.h"
 #include "TelnetServerStub.h"
@@ -150,25 +151,28 @@ private:
         QVERIFY2(mpHost->hasPendingProfileSave(), "Uninstalling a package left the profile no save to do");
     }
 
-    // Writes an archive holding nothing but a config.lua that names the package,
-    // i.e. one installPackage() unpacks and then refuses, having registered
-    // nothing from it.
-    static bool writeConfigOnlyArchive(const QString& path, const QString& declaredName)
+    // Writes an archive holding one file, i.e. one installPackage() unpacks and
+    // then refuses, having registered nothing from it.
+    static bool writeArchive(const QString& path, const QString& entryName, const QByteArray& contents)
     {
-        const QByteArray config = qsl("mpackage = \"%1\"\n").arg(declaredName).toUtf8();
         int errorCode = 0;
         zip* archive = zip_open(path.toUtf8().constData(), ZIP_CREATE | ZIP_TRUNCATE, &errorCode);
         if (!archive) {
             return false;
         }
-        zip_source* source = zip_source_buffer(archive, config.constData(), config.size(), 0);
-        if (!source || zip_file_add(archive, "config.lua", source, ZIP_FL_ENC_UTF_8) < 0) {
+        zip_source* source = zip_source_buffer(archive, contents.constData(), contents.size(), 0);
+        if (!source || zip_file_add(archive, entryName.toUtf8().constData(), source, ZIP_FL_ENC_UTF_8) < 0) {
             zip_source_free(source);
             zip_discard(archive);
             return false;
         }
         return zip_close(archive) == 0;
     }
+
+    // ...specifically one whose config.lua renames the package to declaredName.
+    static bool writeConfigOnlyArchive(const QString& path, const QString& declaredName) { return writeArchive(path, qsl("config.lua"), qsl("mpackage = \"%1\"\n").arg(declaredName).toUtf8()); }
+
+    QString profileFilePath(const QString& relativePath) const { return qsl("%1/%2").arg(mudlet::getMudletPath(enums::profileHomePath, mProfileName), relativePath); }
 
 private slots:
     void initTestCase()
@@ -258,6 +262,92 @@ private slots:
         QVERIFY2(QDir(profilesDirectory).exists(), "Refusing the archive took the folder holding every profile with it");
         QVERIFY2(QDir(profileHome).exists(), "Refusing the archive took the profile with it");
         QVERIFY2(!savedProfileFiles(mProfileName).isEmpty(), "Refusing the archive took the saved profile with it");
+    }
+
+    // ...and it may only remove a folder it made itself. The package name is the
+    // archive's own file name, and then whatever its config.lua says, so it can
+    // just as well be "map" - the folder the profile keeps the user's maps in.
+    void test_refusingAnArchiveLeavesFoldersItDidNotMake()
+    {
+        const QString mapFolder = profileFilePath(qsl("map"));
+        const QString mapFile = qsl("%1/spec-map.dat").arg(mapFolder);
+        QVERIFY2(QDir().mkpath(mapFolder), "Could not create the map folder the profile would have");
+        QFile map(mapFile);
+        QVERIFY2(map.open(QFile::WriteOnly), "Could not write the map file this test is about");
+        map.write("map data that was here before any package was installed");
+        map.close();
+
+        QTemporaryDir archiveDir;
+        QVERIFY2(archiveDir.isValid(), "Could not create a temporary directory for the test archives");
+        mpHost->waitForProfileSave(); // an install during a save is postponed and answered with a bare true
+
+        // named through config.lua, from an archive called something harmless
+        const QString viaConfig = archiveDir.filePath(qsl("uninstall-save-mapgrab.mpackage"));
+        QVERIFY2(writeConfigOnlyArchive(viaConfig, qsl("map")), "Could not write the test archive");
+        auto [configOk, configMessage] = mpHost->installPackage(viaConfig, enums::PackageModuleType::Package, true);
+        QVERIFY2(!configOk, "An archive holding no package was installed");
+        QVERIFY2(QFile::exists(mapFile), "Refusing the archive took the profile's map folder with it");
+        // the folder the install did make is this one, and it does have to go
+        QVERIFY2(!QDir(profileFilePath(qsl("uninstall-save-mapgrab"))).exists(), "Refusing the archive left the folder it unpacked behind");
+
+        // ...and the same through the archive's file name alone, no config.lua
+        mpHost->waitForProfileSave();
+        const QString viaFileName = archiveDir.filePath(qsl("map.mpackage"));
+        QVERIFY2(writeArchive(viaFileName, qsl("readme.txt"), QByteArray("no package in here")), "Could not write the test archive");
+        auto [fileNameOk, fileNameMessage] = mpHost->installPackage(viaFileName, enums::PackageModuleType::Package, true);
+        QVERIFY2(!fileNameOk, "An archive holding no package was installed");
+        QVERIFY2(QFile::exists(mapFile), "Refusing the archive took the profile's map folder with it");
+    }
+
+    // The refusal is about archives nothing could be read out of, not about
+    // archives whose XML turns out to be no good - those are a different case,
+    // and one this deliberately leaves alone.
+    void test_anArchiveWithABadXmlIsStillARemovablePackage()
+    {
+        QTemporaryDir archiveDir;
+        QVERIFY2(archiveDir.isValid(), "Could not create a temporary directory for the test archives");
+
+        // 1. well-formed XML that is not a Mudlet package at all. XMLimport only
+        //    reports the XML reader's own errors, so the import of this one
+        //    SUCCEEDS - checking the import result would not refuse it either.
+        mpHost->waitForProfileSave();
+        const QString notAPackage = archiveDir.filePath(qsl("spec-notapackage.mpackage"));
+        QVERIFY2(writeArchive(notAPackage, qsl("spec-notapackage.xml"), QByteArray("<?xml version=\"1.0\"?>\n<something-else/>\n")), "Could not write the test archive");
+        auto [notAPackageOk, notAPackageMessage] = mpHost->installPackage(notAPackage, enums::PackageModuleType::Package, true);
+        QVERIFY2(notAPackageOk, qPrintable(notAPackageMessage));
+        QVERIFY2(mpHost->mInstalledPackages.contains(qsl("spec-notapackage")), "The package was not registered");
+        mpHost->waitForProfileSave(); // installing a package saves, and an uninstall during a save is refused
+        QVERIFY2(mpHost->uninstallPackage(qsl("spec-notapackage"), enums::PackageModuleType::Package), "The package could not be uninstalled");
+        QVERIFY2(!QDir(profileFilePath(qsl("spec-notapackage"))).exists(), "Uninstalling left the package folder behind");
+
+        // 2. XML the reader does fail on, after it has already read items out of
+        //    it. The import answers false, but the alias it created is in the
+        //    profile - refusing the archive here would delete the folder and
+        //    strand what was imported, and the package is registered either way,
+        //    so it is listed and can be uninstalled. That is what #9654 was about.
+        mpHost->waitForProfileSave();
+        const QString truncated = archiveDir.filePath(qsl("spec-truncatedxml.mpackage"));
+        const QByteArray truncatedXml = QByteArray("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                                   "<!DOCTYPE MudletPackage>\n"
+                                                   "<MudletPackage version=\"1.001\">\n"
+                                                   "<AliasPackage>\n"
+                                                   "<Alias isActive=\"yes\" isFolder=\"no\">\n"
+                                                   "<name>spec-truncatedxml alias</name>\n"
+                                                   "<script>send(\"hello\")</script>\n"
+                                                   "<command></command>\n"
+                                                   "<packageName></packageName>\n"
+                                                   "<regex>^spec-truncatedxml$</regex>\n"
+                                                   "</Alias>\n"
+                                                   "</AliasPackage>\n"
+                                                   "<ActionPackage");
+        QVERIFY2(writeArchive(truncated, qsl("spec-truncatedxml.xml"), truncatedXml), "Could not write the test archive");
+        auto [truncatedOk, truncatedMessage] = mpHost->installPackage(truncated, enums::PackageModuleType::Package, true);
+        QVERIFY2(truncatedOk, qPrintable(truncatedMessage));
+        QVERIFY2(mpHost->getAliasUnit()->findFirstAlias(qsl("spec-truncatedxml alias")), "The alias read before the XML gave out was not created");
+        QVERIFY2(mpHost->mInstalledPackages.contains(qsl("spec-truncatedxml")), "The package was not registered");
+        mpHost->waitForProfileSave();
+        QVERIFY2(mpHost->uninstallPackage(qsl("spec-truncatedxml"), enums::PackageModuleType::Package), "The package could not be uninstalled");
+        QVERIFY2(!QDir(profileFilePath(qsl("spec-truncatedxml"))).exists(), "Uninstalling left the package folder behind");
     }
 
     // ...and closing the profile straight after an uninstall must leave nothing


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The profile save that installing or uninstalling a package owes is now held in a member `QTimer` that the profile close and `~Host()` stop, instead of a `QTimer::singleShot()` queued on the `Host`: that call was still delivered after `HostManager::deleteHost()` had destroyed the profile, and `Host::saveProfile()` then read freed members.
- `installPackage()` refuses an archive it could read no package out of and takes the folder it unpacked back off disk - but only a folder inside the profile, since the name can be whatever an untrusted `config.lua` says. It answered `true` for such an archive before, leaving something registered nowhere that could never be uninstalled.
- `getModulePriority()` asks `mInstalledModules` whether the module exists, the same list `setModulePriority()` uses, and reports the default priority of 0 for one nobody has prioritised yet.

#### Motivation for adding to Mudlet

Uninstall a package, close Mudlet, and the queued save runs against the destroyed profile - a heap use-after-free on the way out, which is what a "Mudlet crashed when I closed it" report looks like. Reproduced under AddressSanitizer, clean afterwards. The other two are smaller but user-visible: picking the wrong zip in the package manager reported success and left a folder behind that nothing could remove, and a script could not tell "module not installed" from "installed, never prioritised".

#### Other info (issues closed, discussion etc)

Closes #9653, closes #9654, closes #9655.

Test case: `installPackage("something.mpackage")`, `uninstallPackage("something")`, then close Mudlet straight away - it exits cleanly; `installPackage()` on a zip with no package XML in it now answers `nil` plus a message and leaves nothing behind; `getModulePriority()` on a freshly installed module answers `0`.

The package lifecycle specs carried the last two as `pending()`; both are flipped to real specs, and a new `PackageUninstallSaveTeardownTest` covers the save deferral, its coalescing, the profile close, and that a refused archive can only take its own folder with it.

Assisted-by: Claude:claude-opus-5
