### PR TITLE
fix: profile close during a map operation, Discord presence truncation, and interrupting ttsSpeak()

### DIFF
--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -59,6 +59,7 @@
 #include "glwidget_integration.h"
 #endif
 
+#include <chrono>
 #include <limits>
 #include <math.h>
 
@@ -67,6 +68,7 @@
 #include <QDesktopServices>
 #include <QFileInfo>
 #include <QMovie>
+#include <QTimer>
 #include <QVector>
 #ifdef QT_TEXTTOSPEECH_LIB
 #include <QTextToSpeech>
@@ -88,6 +90,9 @@ static bool speechStartAnnounced = false;
 // and the Ready that reports that has to be told apart from the engine going
 // idle - see ttsSpeak().
 static bool speechInterrupting = false;
+// How long an engine is given to start the utterance that interrupted another
+// before a Ready held back on its account is taken at face value after all.
+static constexpr std::chrono::milliseconds scmInterruptedSpeechGrace{250};
 
 static const QTextToSpeech::State TEXT_TO_SPEECH_ERROR_STATE = QTextToSpeech::State::Error;
 
@@ -148,12 +153,22 @@ int TLuaInterpreter::ttsSkip(lua_State* L)
 // No documentation available in wiki - internal function
 void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
 {
+    // ttsSpeak() announces an utterance itself when the engine was already
+    // speaking, because there is then no state edge to announce it. An engine
+    // that gets round to reporting the interruption afterwards ends up here
+    // with an edge back into Speaking for that same utterance, which would tell
+    // a script it started twice.
+    const bool alreadyAnnounced = (state == QTextToSpeech::State::Speaking && speechStartAnnounced);
+
     if (state != speechState) {
         speechState = state;
         TEvent event{};
         switch (state) {
         case QTextToSpeech::State::Paused:
             event.mArgumentList.append(QLatin1String("ttsSpeechPaused"));
+            // Resuming has always announced the utterance again, so let it:
+            // being paused is the end of what was announced before.
+            speechStartAnnounced = false;
             break;
         case QTextToSpeech::State::Speaking:
             event.mArgumentList.append(QLatin1String("ttsSpeechStarted"));
@@ -183,7 +198,9 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
             speechInterrupting = false;
         }
 
-        mudlet::self()->getHostManager().postInterHostEvent(NULL, event, true);
+        if (!alreadyAnnounced) {
+            mudlet::self()->getHostManager().postInterHostEvent(NULL, event, true);
+        }
     }
 
     if (state == QTextToSpeech::State::Ready && speechInterrupting) {
@@ -194,6 +211,17 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
         // utterance next, which clears this above.
         speechInterrupting = false;
         bSpeechQueueing = false;
+        // Unless it does not: an engine that rejects an utterance outright, or
+        // that replaces one without ever reporting a state change, leaves this
+        // as the last word on the matter, and a queue waiting on a Ready that
+        // is never coming waits forever. Look again once the engine has had its
+        // chance to start speaking - if it is still idle, that Ready did mean
+        // idle and the queue is free to go.
+        QTimer::singleShot(scmInterruptedSpeechGrace, qApp, []() {
+            if (!speechUnit.isNull() && speechUnit->state() == QTextToSpeech::State::Ready && !speechQueue.isEmpty()) {
+                TLuaInterpreter::ttsStateChanged(QTextToSpeech::State::Ready);
+            }
+        });
         return;
     }
 

--- a/src/TLuaInterpreterTextToSpeech.cpp
+++ b/src/TLuaInterpreterTextToSpeech.cpp
@@ -79,8 +79,30 @@ bool bSpeechBuilt;
 bool bSpeechQueueing;
 int speechState = QTextToSpeech::State::Ready;
 QString speechCurrent;
+// Whether a ttsSpeechStarted has been raised for what speechCurrent holds. The
+// events are raised off the engine's state edges, and an engine that is already
+// speaking has no edge to report when it is given something else to say.
+static bool speechStartAnnounced = false;
+// Set while the utterance ttsSpeak() last asked for was started over one that
+// was still being spoken. Every engine stops the running utterance inside say(),
+// and the Ready that reports that has to be told apart from the engine going
+// idle - see ttsSpeak().
+static bool speechInterrupting = false;
 
 static const QTextToSpeech::State TEXT_TO_SPEECH_ERROR_STATE = QTextToSpeech::State::Error;
+
+// ttsStateChanged() raises this same event whenever the engine reports a state
+// edge into Speaking; ttsSpeak() raises it through here for the utterance an
+// already-speaking engine starts without any such edge.
+static void raiseSpeechStartedEvent(const QString& text)
+{
+    TEvent event{};
+    event.mArgumentList.append(QLatin1String("ttsSpeechStarted"));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(text);
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mudlet::self()->getHostManager().postInterHostEvent(nullptr, event, true);
+}
 
 // No documentation available in wiki - internal function
 void TLuaInterpreter::ttsBuild()
@@ -114,6 +136,10 @@ int TLuaInterpreter::ttsSkip(lua_State* L)
     Q_UNUSED(L)
     TLuaInterpreter::ttsBuild();
 
+    // An explicit stop ends whatever is being spoken outright, so the Ready it
+    // produces is the engine going idle and must drain the queue as it always
+    // has - it is not the interruption ttsSpeak() has to defend against.
+    speechInterrupting = false;
     speechUnit->stop();
 
     return 0;
@@ -151,9 +177,24 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
         if (state == QTextToSpeech::Speaking) {
             event.mArgumentList.append(speechCurrent);
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            // The engine has taken up what it was last given, so ttsSpeak() has
+            // nothing left to announce and any interruption is over.
+            speechStartAnnounced = true;
+            speechInterrupting = false;
         }
 
         mudlet::self()->getHostManager().postInterHostEvent(NULL, event, true);
+    }
+
+    if (state == QTextToSpeech::State::Ready && speechInterrupting) {
+        // Not the engine falling idle but the utterance ttsSpeak() spoke over
+        // ending inside say(). Draining here would speak a queued line on top of
+        // the one the script has just asked for, and that one is then never
+        // heard at all (#9659). The engine reports Speaking for the requested
+        // utterance next, which clears this above.
+        speechInterrupting = false;
+        bSpeechQueueing = false;
+        return;
     }
 
     if (state != QTextToSpeech::State::Ready || speechQueue.empty()) {
@@ -166,6 +207,7 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
     // recorded before say() because the engine can switch to Speaking inside
     // that call, and this function reports speechCurrent with the event
     speechCurrent = textToSay;
+    speechStartAnnounced = false;
     speechUnit->say(textToSay);
 
     return;
@@ -379,6 +421,9 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
 
     if (speechQueue.size() == 1 && speechUnit->state() == QTextToSpeech::State::Ready && !bSpeechQueueing) {
         bSpeechQueueing = true;
+        // The engine says it is idle, so nothing is left of any utterance an
+        // earlier ttsSpeak() interrupted and this queued line is free to start.
+        speechInterrupting = false;
         TLuaInterpreter::ttsStateChanged(speechUnit->state());
     }
 
@@ -419,7 +464,21 @@ int TLuaInterpreter::ttsSpeak(lua_State* L)
     // recorded before say() because the engine can switch to Speaking inside
     // that call, and ttsStateChanged() reports speechCurrent with the event
     speechCurrent = textToSay;
+    speechStartAnnounced = false;
+    // Every engine stops what it is saying inside say() and reports Ready for
+    // it, some during the call and some shortly after. That Ready says the
+    // interrupted utterance ended, not that the engine has nothing to do, so
+    // ttsStateChanged() must not drain the queue over the top of this one.
+    speechInterrupting = (speechUnit->state() == QTextToSpeech::State::Speaking);
     speechUnit->say(textToSay);
+
+    // An engine that was already speaking stays in the Speaking state through
+    // all of that, and the events are raised off state edges - so without this
+    // nothing tells a script that what is being spoken has changed (#9659).
+    if (!speechStartAnnounced && speechUnit->state() == QTextToSpeech::State::Speaking) {
+        speechStartAnnounced = true;
+        raiseSpeechStartedEvent(textToSay);
+    }
     return 0;
 }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2947,10 +2947,19 @@ void TMap::clearTransferProgress()
 
 void TMap::requestMapOperationAbort()
 {
-    if (!mMapOperationDepth) {
+    if (!mMapOperationDepth || mMapOperationAbortRequested) {
         return;
     }
-    slot_mapProgressDialogCancelled();
+    mMapOperationAbortRequested = true;
+    // Deliberately not slot_mapProgressDialogCancelled(): that is the user
+    // pressing Abort and says so in the console, whereas this is the profile
+    // going away and has no console left to say it to. What it does share is
+    // the flag the JSON import and export poll at their next progress step, and
+    // dropping a download that would otherwise hold the close up on the network.
+    mMapProgressCancelRequested = true;
+    if (mMapProgressIsTransfer && mpNetworkReply) {
+        mpNetworkReply->abort();
+    }
 }
 
 void TMap::slot_mapProgressDialogCancelled()

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1596,6 +1596,7 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
 
 bool TMap::restore(QString location)
 {
+    const MapOperationScope operationScope(this);
     qDebug().noquote().nospace() << "TMap::restore(\"" << location << "\") INFO: restoring map of Profile: \"" << mProfileName << "\" URL: " << mpHost->getUrl();
 
     QElapsedTimer _time;
@@ -2498,6 +2499,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
 
 void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 {
+    const MapOperationScope operationScope(this);
     Host* pHost = mpHost;
     if (!pHost) {
         return;
@@ -2639,6 +2641,7 @@ bool TMap::importMap(QFile& file, QString* errMsg)
 
 bool TMap::readXmlMapFile(QFile& file, QString* errMsg)
 {
+    const MapOperationScope operationScope(this);
     Host* pHost = mpHost;
     bool isLocalImport = false;
     if (!pHost) {
@@ -2942,6 +2945,14 @@ void TMap::clearTransferProgress()
     }
 }
 
+void TMap::requestMapOperationAbort()
+{
+    if (!mMapOperationDepth) {
+        return;
+    }
+    slot_mapProgressDialogCancelled();
+}
+
 void TMap::slot_mapProgressDialogCancelled()
 {
     // The JSON path polls mMapProgressCancelRequested in its increment loop; the
@@ -3032,6 +3043,7 @@ void TMap::setRoomNamesShown(bool shown)
  */
 std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
 {
+    const MapOperationScope operationScope(this);
     QString destination{dest};
 
     if (destination.isEmpty()) {
@@ -3222,6 +3234,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
 // Lua sub-system and do need to report the file:
 std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool translatableTexts)
 {
+    const MapOperationScope operationScope(this);
     const QString oldDefaultAreaName{mDefaultAreaName};
     const QString oldUnnamedName{mUnnamedAreaName};
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -193,8 +193,10 @@ public:
     // Ask an operation that is in progress to stop at its next opportunity, so
     // that a caller waiting on the above does not wait for a whole map. Only the
     // JSON import and export poll this; an XML import or a download runs to its
-    // own end.
+    // own end. Asking twice does nothing, which mapOperationAbortRequested()
+    // also lets a caller polling in a loop see.
     void requestMapOperationAbort();
+    bool mapOperationAbortRequested() const { return mMapOperationAbortRequested; }
 
     // Show which rooms have which symbols:
     QHash<QString, QSet<int>> roomSymbolsHash();
@@ -403,6 +405,9 @@ private:
         explicit MapOperationScope(TMap* pMap)
         : mpMap(pMap)
         {
+            if (!mpMap->mMapOperationDepth) {
+                mpMap->mMapOperationAbortRequested = false;
+            }
             ++mpMap->mMapOperationDepth;
         }
         ~MapOperationScope() { --mpMap->mMapOperationDepth; }
@@ -414,6 +419,9 @@ private:
     };
 
     int mMapOperationDepth = 0;
+    // requestMapOperationAbort() is asked again on every retry of a deferred
+    // profile close, and asking twice would abort a network reply twice over.
+    bool mMapOperationAbortRequested = false;
 
     void addDirectionalRoute(QHash<unsigned int, route>& bestRoutes,
                              const QMap<QString, int>& exitWeights,

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -184,6 +184,18 @@ public:
     void disableTransferProgressCancel();
     void clearTransferProgress();
 
+    // True while a map import, export or download is on the stack. Those pump
+    // qApp->processEvents() to keep their progress display alive, so anything
+    // delivered from an event loop can find itself running nested inside one -
+    // and destroying this map's Host from there would free the operation's own
+    // "this" (#9520). Whoever would do that has to wait for this to go false.
+    bool mapOperationInProgress() const { return mMapOperationDepth > 0; }
+    // Ask an operation that is in progress to stop at its next opportunity, so
+    // that a caller waiting on the above does not wait for a whole map. Only the
+    // JSON import and export poll this; an XML import or a download runs to its
+    // own end.
+    void requestMapOperationAbort();
+
     // Show which rooms have which symbols:
     QHash<QString, QSet<int>> roomSymbolsHash();
 
@@ -381,6 +393,28 @@ public slots:
 
 
 private:
+    // Held for the whole of a map operation that pumps the event loop, so that
+    // mapOperationInProgress() can tell anything re-entered from that pump that
+    // this map is on the stack. Nested operations are counted, not flagged: an
+    // XML import can start from inside a download's pump.
+    class MapOperationScope
+    {
+    public:
+        explicit MapOperationScope(TMap* pMap)
+        : mpMap(pMap)
+        {
+            ++mpMap->mMapOperationDepth;
+        }
+        ~MapOperationScope() { --mpMap->mMapOperationDepth; }
+        MapOperationScope(const MapOperationScope&) = delete;
+        MapOperationScope& operator=(const MapOperationScope&) = delete;
+
+    private:
+        TMap* mpMap = nullptr;
+    };
+
+    int mMapOperationDepth = 0;
+
     void addDirectionalRoute(QHash<unsigned int, route>& bestRoutes,
                              const QMap<QString, int>& exitWeights,
                              unsigned int source,

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -688,55 +688,55 @@ DiscordRichPresence localDiscordPresence::convert() const
 void localDiscordPresence::setDetailText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mDetails, sizeof(mDetails), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mDetails, sizeof(mDetails), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setStateText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mState, sizeof(mState), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mState, sizeof(mState), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setLargeImageText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mLargeImageText, sizeof(mLargeImageText), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mLargeImageText, sizeof(mLargeImageText), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setLargeImageKey(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mLargeImageKey, sizeof(mLargeImageKey), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mLargeImageKey, sizeof(mLargeImageKey), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setSmallImageText(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mSmallImageText, sizeof(mSmallImageText), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mSmallImageText, sizeof(mSmallImageText), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setSmallImageKey(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mSmallImageKey, sizeof(mSmallImageKey), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mSmallImageKey, sizeof(mSmallImageKey), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setJoinSecret(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mJoinSecret, sizeof(mJoinSecret), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mJoinSecret, sizeof(mJoinSecret), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setMatchSecret(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mMatchSecret, sizeof(mMatchSecret), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mMatchSecret, sizeof(mMatchSecret), utf8Data.constData(), utf8Data.size());
 }
 
 void localDiscordPresence::setSpectateSecret(const QString& text)
 {
     const QByteArray utf8Data = text.toUtf8();
-    utils::copyString(mSpectateSecret, sizeof(mSpectateSecret), utf8Data.constData(), utf8Data.size());
+    utils::copyUtf8String(mSpectateSecret, sizeof(mSpectateSecret), utf8Data.constData(), utf8Data.size());
 }
 
 bool Discord::usingMudletsDiscordID(Host* pHost) const

--- a/src/discord.h
+++ b/src/discord.h
@@ -115,20 +115,28 @@ public:
     int8_t getInstance() const { return mInstance; }
 
 private:
-    char mState[128];
-    char mDetails[128];
+    // The limits Discord documents for each field, in bytes (see the struct
+    // comment above). The buffers are one byte larger than the limit they hold:
+    // sized at exactly the limit, the null terminator would take the last byte
+    // and a field of the full documented length would always lose its final
+    // character.
+    static constexpr size_t scmTextByteLimit = 128;
+    static constexpr size_t scmImageKeyByteLimit = 32;
+
+    char mState[scmTextByteLimit + 1];
+    char mDetails[scmTextByteLimit + 1];
     int64_t mStartTimestamp = 0;
     int64_t mEndTimestamp = 0;
-    char mLargeImageKey[32];
-    char mLargeImageText[128];
-    char mSmallImageKey[32];
-    char mSmallImageText[128];
-    char mPartyId[128];
+    char mLargeImageKey[scmImageKeyByteLimit + 1];
+    char mLargeImageText[scmTextByteLimit + 1];
+    char mSmallImageKey[scmImageKeyByteLimit + 1];
+    char mSmallImageText[scmTextByteLimit + 1];
+    char mPartyId[scmTextByteLimit + 1];
     int mPartySize = 0;
     int mPartyMax = 0;
-    char mMatchSecret[128];
-    char mJoinSecret[128];
-    char mSpectateSecret[128];
+    char mMatchSecret[scmTextByteLimit + 1];
+    char mJoinSecret[scmTextByteLimit + 1];
+    char mSpectateSecret[scmTextByteLimit + 1];
     int8_t mInstance = 1;
 };
 

--- a/src/discord.h
+++ b/src/discord.h
@@ -119,24 +119,26 @@ private:
     // comment above). The buffers are one byte larger than the limit they hold:
     // sized at exactly the limit, the null terminator would take the last byte
     // and a field of the full documented length would always lose its final
-    // character.
-    static constexpr size_t scmTextByteLimit = 128;
-    static constexpr size_t scmImageKeyByteLimit = 32;
+    // character. Named in the 'k' form the rest of the codebase gives an array
+    // size (TArea.cpp's kPixmapDataLineSize) rather than the 'scm' one it gives
+    // other static class members.
+    static constexpr size_t kTextByteLimit = 128;
+    static constexpr size_t kImageKeyByteLimit = 32;
 
-    char mState[scmTextByteLimit + 1];
-    char mDetails[scmTextByteLimit + 1];
+    char mState[kTextByteLimit + 1];
+    char mDetails[kTextByteLimit + 1];
     int64_t mStartTimestamp = 0;
     int64_t mEndTimestamp = 0;
-    char mLargeImageKey[scmImageKeyByteLimit + 1];
-    char mLargeImageText[scmTextByteLimit + 1];
-    char mSmallImageKey[scmImageKeyByteLimit + 1];
-    char mSmallImageText[scmTextByteLimit + 1];
-    char mPartyId[scmTextByteLimit + 1];
+    char mLargeImageKey[kImageKeyByteLimit + 1];
+    char mLargeImageText[kTextByteLimit + 1];
+    char mSmallImageKey[kImageKeyByteLimit + 1];
+    char mSmallImageText[kTextByteLimit + 1];
+    char mPartyId[kTextByteLimit + 1];
     int mPartySize = 0;
     int mPartyMax = 0;
-    char mMatchSecret[scmTextByteLimit + 1];
-    char mJoinSecret[scmTextByteLimit + 1];
-    char mSpectateSecret[scmTextByteLimit + 1];
+    char mMatchSecret[kTextByteLimit + 1];
+    char mJoinSecret[kTextByteLimit + 1];
+    char mSpectateSecret[kTextByteLimit + 1];
     int8_t mInstance = 1;
 };
 

--- a/src/mudlet-lua/tests/Discord_spec.lua
+++ b/src/mudlet-lua/tests/Discord_spec.lua
@@ -139,6 +139,21 @@ local function activityFrom(action, accept, timeoutMilliseconds)
   return activity
 end
 
+-- How many of the frames recorded after `mark` the fake Discord client could
+-- not decode. The fixture files a frame whose payload is not valid JSON (or not
+-- valid UTF-8, which JSON decoding of the payload requires) as {"raw": <text>}
+-- instead of the parsed object, so this counts exactly the presence updates a
+-- real Discord client would have had to throw away whole.
+local function undecodableFramesAfter(mark)
+  local count = 0
+  for _, frame in ipairs(framesAfter(mark)) do
+    if type(frame.payload) == "table" and frame.payload.raw ~= nil then
+      count = count + 1
+    end
+  end
+  return count
+end
+
 -- How many presence updates have reached the fake Discord client. Counting
 -- SET_ACTIVITY frames rather than all of them keeps an unrelated handshake or
 -- subscription from being mistaken for a presence update.
@@ -367,10 +382,32 @@ describe("setDiscordDetail", function()
     local overlong = string.rep("a", 200)
     local activity = activityFrom(function() setDiscordDetail(overlong) end,
                                   function(seen) return seen.details ~= nil end)
-    assert.equals(127, #activity.details)
-    assert.equals(string.rep("a", 127), activity.details)
+    -- The whole documented 128 bytes, not 127: the buffer holding this used to
+    -- be exactly 128 bytes and lost its last byte to the null terminator
+    -- (#9634).
+    assert.equals(128, #activity.details)
+    assert.equals(string.rep("a", 128), activity.details)
     -- Only what Discord is sent is truncated; Mudlet keeps the whole string.
     assert.equals(overlong, getDiscordDetail())
+  end)
+
+  it("cuts an overlong non-ASCII detail text between characters", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- #9634: the cut used to be made at the byte limit with no regard for
+    -- UTF-8, leaving the last character in the field as a lone lead byte. That
+    -- does not merely damage one field - the payload stops being decodable, so
+    -- the whole SET_ACTIVITY frame is discarded and every well-formed field in
+    -- it goes with it.
+    local mark = frameCount()
+    -- 65 two-byte characters, 130 bytes: two more than the field holds, so the
+    -- cut has to fall inside the 65th character.
+    local activity = activityFrom(function() setDiscordDetail(string.rep("ä", 65)) end,
+                                  function(seen) return seen.details ~= nil end)
+    assert.equals(string.rep("ä", 64), activity.details)
+    assert.equals(128, #activity.details)
+    assert.equals(0, undecodableFramesAfter(mark))
   end)
 end)
 
@@ -458,6 +495,20 @@ describe("setDiscordLargeIcon and setDiscordSmallIcon", function()
                                   function(seen) return seen.assets.small_image ~= nil end)
     assert.equals("shield", activity.assets.small_image)
     assert.equals("shield", getDiscordSmallIcon())
+  end)
+
+  it("sends a full length icon key without dropping its last character", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- #9634: a Discord asset key may be the full 32 bytes the API documents,
+    -- but the buffer was 32 bytes including the terminator, so the last
+    -- character was cut off and the icon never resolved.
+    local key = string.rep("a", 32)
+    local activity = activityFrom(function() setDiscordLargeIcon(key) end,
+                                  function(seen) return seen.assets.large_image ~= "mudlet" end)
+    assert.equals(32, #activity.assets.large_image)
+    assert.equals(key, activity.assets.large_image)
   end)
 
   it("sends the small icon's tooltip text", function()
@@ -811,10 +862,19 @@ describe("setDiscordApplicationID", function()
   end)
 end)
 
-describe("known Discord API defects", function()
-  it("truncates an overlong detail text on a character boundary", function()
-    pending("localDiscordPresence cuts the text at 127 bytes without regard for UTF-8, so 64 "
-            .. "two-byte characters reach Discord as 63 characters plus half of one - the frame is "
-            .. "no longer valid UTF-8. Fix the truncation in discord.cpp, then unpend this")
+describe("an icon key that has to be truncated", function()
+  it("cuts a non-ASCII key between characters and keeps the frame decodable", function()
+    if not readyForDiscord() then
+      return
+    end
+    -- The 32 byte fields cut in the same place as the 128 byte ones, so they
+    -- broke the frame in the same way (#9634). 16 two-byte characters are 32
+    -- bytes, which now fits exactly; a 17th has to go, whole.
+    local mark = frameCount()
+    local activity = activityFrom(function() setDiscordLargeIcon(string.rep("é", 17)) end,
+                                  function(seen) return seen.assets.large_image ~= "mudlet" end)
+    assert.equals(string.rep("é", 16), activity.assets.large_image)
+    assert.equals(32, #activity.assets.large_image)
+    assert.equals(0, undecodableFramesAfter(mark))
   end)
 end)

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -938,9 +938,6 @@ describe("Tests the text-to-speech Lua API", function()
         -- and the engine changes state inside say(), so the event carried the
         -- previous utterance. The handler has to be armed up front because the
         -- event is raised before ttsSpeak() returns.
-        -- The event only fires on a state transition, so the skip between the
-        -- two utterances is required: speaking over an utterance that is still
-        -- running raises no second event at all.
         local started = {}
         collect("ttsSpeechStarted", started)
 
@@ -951,6 +948,25 @@ describe("Tests the text-to-speech Lua API", function()
         ttsSkip()
         ttsSpeak("second spoken line")
         assert.same({"first spoken line", "second spoken line"}, started)
+      end)
+
+      it("announces an utterance spoken over one that is still running", function()
+        if noMockEngine() then
+          return
+        end
+        -- #9659: the events are raised off the engine's state edges, and an
+        -- engine that is already speaking has no edge to report when it is
+        -- handed something else - so a script tracking what is being spoken was
+        -- never told the text had changed, while ttsGetCurrentLine() moved on
+        -- underneath it. No ttsSkip() here: the interruption is the point.
+        local started = {}
+        collect("ttsSpeechStarted", started)
+
+        ttsClearQueue()
+        ttsSpeak("the utterance being spoken over")
+        ttsSpeak("the utterance spoken over it")
+        assert.same({"the utterance being spoken over", "the utterance spoken over it"}, started)
+        assert.equals("the utterance spoken over it", ttsGetCurrentLine())
       end)
 
       it("ttsSpeechStarted carries the queued line the drain started speaking", function()
@@ -976,17 +992,24 @@ describe("Tests the text-to-speech Lua API", function()
         if noMockEngine() then
           return
         end
-        -- Guards the ordering the two specs above rely on: ttsSpeak() records
-        -- the text before say(), so an engine that drained the queue from
-        -- inside say() would leave the queued line reported as the current one
-        -- instead of the utterance actually asked for. Speaking over a busy
-        -- engine does not pass through Ready, so no drain happens.
+        -- The utterance a script asks for outright has to survive the queue:
+        -- an engine reporting Ready for the utterance say() interrupted used to
+        -- be read as an idle engine, which drained the queued line straight
+        -- over the requested one (#9659). The mock engine reports no such Ready,
+        -- so what this spec can hold onto is the state ttsSpeak() leaves behind
+        -- - the guard itself is exercised by TtsInterruptingSpeakTest, which
+        -- delivers that Ready the way a real engine does.
+        local started = {}
+        collect("ttsSpeechStarted", started)
+
         ttsClearQueue()
         ttsSpeak("the busy utterance")
         ttsQueue("still queued")
         ttsSpeak("the direct utterance")
         assert.equals(1, #ttsGetQueue())
         assert.equals("the direct utterance", ttsGetCurrentLine())
+        -- ...and the queued line was not what got announced:
+        assert.same({"the busy utterance", "the direct utterance"}, started)
       end)
 
       it("ttsSetVoiceByName reports success for a voice it switched to", function()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2015,9 +2015,27 @@ void mudlet::closeHost(const QString& name)
         // again once the stack has unwound. Retried on a timer rather than
         // immediately: the retry would otherwise land back in the same pump,
         // spinning until the operation ends instead of letting it get there.
+        if (!pH->mpMap->mapOperationAbortRequested()) {
+            qDebug().nospace().noquote() << "mudlet::closeHost(\"" << name << "\") INFO - a map operation is still running, so the profile will be closed once it has stopped.";
+        }
         pH->mpMap->requestMapOperationAbort();
-        QTimer::singleShot(50ms, this, [this, name]() {
+        const QPointer<Host> pClosingHost(pH);
+        QTimer::singleShot(50ms, this, [this, name, pClosingHost]() {
+            if (mHostManager.getHost(name) != pClosingHost) {
+                // Somebody else closed it while we waited, and the name now
+                // belongs to a profile that was never asked to close.
+                return;
+            }
             closeHost(name);
+            // The callers that defer to us run their own follow-up before this
+            // retry comes round, when the profile is still open and it does
+            // nothing. Left out, closing the last profile mid-operation ends
+            // with no profile and no connection dialog either.
+            updateMainWindowToolbarState();
+            if (!mHostManager.getHostCount() && !mIsGoingDown) {
+                disableToolbarButtons();
+                slot_showConnectionDialog();
+            }
         });
         return;
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2007,6 +2007,21 @@ void mudlet::closeHost(const QString& name)
         return;
     }
 
+    if (pH->mpMap && pH->mpMap->mapOperationInProgress()) {
+        // A map import, export or download is on the stack, and it is that
+        // operation's own qApp->processEvents() that has delivered whatever
+        // asked for this close. Destroying the Host here would free the TMap
+        // under its running loop (#9520), so tell the operation to stop and try
+        // again once the stack has unwound. Retried on a timer rather than
+        // immediately: the retry would otherwise land back in the same pump,
+        // spinning until the operation ends instead of letting it get there.
+        pH->mpMap->requestMapOperationAbort();
+        QTimer::singleShot(50ms, this, [this, name]() {
+            closeHost(name);
+        });
+        return;
+    }
+
     migrateDebugConsole(pH);
 
     // Clean up any main window dock widgets for this profile

--- a/src/utils.h
+++ b/src/utils.h
@@ -74,6 +74,30 @@ public:
         return copyLen;
     }
 
+    // As copyString(), but for UTF-8 data that has to stay valid UTF-8: the copy
+    // stops at the last character that fits whole rather than at the last byte,
+    // so no trailing half-character is left behind. Use it wherever a truncated
+    // copy is handed on to something that decodes it - Discord discards an
+    // entire presence frame whose JSON payload carries an incomplete sequence.
+    // Returns the number of bytes copied (excluding the null terminator).
+    static size_t copyUtf8String(char* dest, size_t destSize, const char* src, size_t srcLen)
+    {
+        if (destSize == 0) {
+            return 0;
+        }
+        size_t copyLen = (srcLen < destSize) ? srcLen : destSize - 1;
+        // Every byte after the first of a multi-byte character has the form
+        // 10xxxxxx, so a cut in front of one is a cut inside a character: walk
+        // back to where that character starts. A cut that took everything (or
+        // that landed on a character start) needs no adjustment.
+        while (copyLen > 0 && copyLen < srcLen && (static_cast<unsigned char>(src[copyLen]) & 0xC0u) == 0x80u) {
+            --copyLen;
+        }
+        std::memcpy(dest, src, copyLen);
+        dest[copyLen] = '\0';
+        return copyLen;
+    }
+
     // This construct will be very useful for formatting tooltips and by
     // defining a static function/method here we can save using the same
     // qsl all over the place:

--- a/test/DiscordTest.cpp
+++ b/test/DiscordTest.cpp
@@ -155,14 +155,50 @@ private slots:
     void testStringTruncation()
     {
         localDiscordPresence presence;
-        // Details buffer is 128 bytes - test with a string longer than that
+        // Discord documents details as holding 128 bytes, so a longer string is
+        // cut down to exactly that - the buffer allows for its own terminator
+        // rather than spending one of those 128 bytes on it (#9634).
         QString longString(200, QChar('A'));
         presence.setDetailText(longString);
 
         DiscordRichPresence converted = presence.convert();
         QVERIFY(converted.details != nullptr);
-        // Should be truncated but not crash
-        QVERIFY(strlen(converted.details) < 128);
+        QCOMPARE(strlen(converted.details), size_t{128});
+    }
+
+    // A field of exactly the documented length has to arrive whole: an asset key
+    // that loses its last character resolves to no icon at all (#9634).
+    void testFullLengthFieldsSurviveWhole()
+    {
+        localDiscordPresence presence;
+        presence.setLargeImageKey(QString(32, QChar('a')));
+        presence.setStateText(QString(128, QChar('s')));
+
+        DiscordRichPresence converted = presence.convert();
+        QCOMPARE(strlen(converted.largeImageKey), size_t{32});
+        QCOMPARE(strlen(converted.state), size_t{128});
+    }
+
+    // Truncation has to fall between characters. A field cut through the middle
+    // of a multi-byte one is no longer valid UTF-8, and Discord discards the
+    // whole presence frame carrying it rather than just that field (#9634).
+    void testTruncationKeepsUtf8Intact()
+    {
+        localDiscordPresence presence;
+        // 65 two-byte characters: 130 bytes, so the cut has to fall inside the
+        // 65th and take all of it.
+        presence.setDetailText(QString(65, QChar(0x00E9)));
+        // 17 of the same in a 32 byte field, which holds 16 of them.
+        presence.setLargeImageKey(QString(17, QChar(0x00E9)));
+
+        DiscordRichPresence converted = presence.convert();
+        QCOMPARE(QByteArray(converted.details), QString(64, QChar(0x00E9)).toUtf8());
+        QCOMPARE(QByteArray(converted.largeImageKey), QString(16, QChar(0x00E9)).toUtf8());
+        // A three-byte character has two ways to be cut in half, so check the
+        // other one too: 43 of them are 129 bytes.
+        presence.setStateText(QString(43, QChar(0x4F60)));
+        converted = presence.convert();
+        QCOMPARE(QByteArray(converted.state), QString(42, QChar(0x4F60)).toUtf8());
     }
 
     // Test that Discord username comparison is case-insensitive.

--- a/test/DiscordTest.cpp
+++ b/test/DiscordTest.cpp
@@ -19,17 +19,17 @@
 
 #include <discord.h>
 #include <Host.h>
+#include <utils.h>
 #include <QFile>
 #include <QtTest/QtTest>
 
-class DiscordTest : public QObject {
+class DiscordTest : public QObject
+{
     Q_OBJECT
 
 private slots:
 
-    void initTestCase()
-    {
-    }
+    void initTestCase() {}
 
     // Test that convert() returns nullptr for empty string fields
     void testConvertNullIfEmpty()
@@ -199,6 +199,35 @@ private slots:
         presence.setStateText(QString(43, QChar(0x4F60)));
         converted = presence.convert();
         QCOMPARE(QByteArray(converted.state), QString(42, QChar(0x4F60)).toUtf8());
+
+        // And an emoji, the four-byte case, where the walk-back has to step
+        // over three continuation bytes: 33 of them are 132 bytes.
+        const char32_t grinningFace = 0x1F600;
+        const QString emoji = QString::fromUcs4(&grinningFace, 1);
+        presence.setDetailText(emoji.repeated(33));
+        converted = presence.convert();
+        QCOMPARE(QByteArray(converted.details), emoji.repeated(32).toUtf8());
+    }
+
+    // The truncation itself, at boundaries the fixed-size presence fields
+    // cannot reach.
+    void testCopyUtf8StringEdgeCases()
+    {
+        char buffer[8];
+        // Nothing to copy, and a destination too small even to terminate:
+        QCOMPARE(utils::copyUtf8String(buffer, sizeof(buffer), "", 0), size_t{0});
+        QCOMPARE(utils::copyUtf8String(buffer, 0, "abc", 3), size_t{0});
+        // Exactly filling the usable space is not a truncation, so there is
+        // nothing to walk back from:
+        QCOMPARE(utils::copyUtf8String(buffer, sizeof(buffer), "abcdefg", 7), size_t{7});
+        QCOMPARE(QByteArray(buffer), QByteArray("abcdefg"));
+        // One byte too many, cut between characters:
+        QCOMPARE(utils::copyUtf8String(buffer, sizeof(buffer), "abcdefgh", 8), size_t{7});
+        // Input that is nothing but continuation bytes cannot be cut anywhere
+        // valid, so an empty field is what comes out - never a broken sequence.
+        const char continuationBytes[] = "\x80\x80\x80\x80\x80\x80\x80\x80\x80";
+        QCOMPARE(utils::copyUtf8String(buffer, sizeof(buffer), continuationBytes, 9), size_t{0});
+        QCOMPARE(QByteArray(buffer), QByteArray());
     }
 
     // Test that Discord username comparison is case-insensitive.
@@ -269,9 +298,7 @@ private slots:
         QVERIFY2(checked >= 22, qPrintable(qsl("only categorised %1 Discord Lua functions - has the source moved?").arg(checked)));
     }
 
-    void cleanupTestCase()
-    {
-    }
+    void cleanupTestCase() {}
 };
 
 #include "DiscordTest.moc"

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -34,6 +34,8 @@ set(FUNCTIONAL_TEST_SOURCES
     PackageSelfUninstallTest.cpp
     MapRoundTripTest.cpp
     MapProgressDialogSeamTest.cpp
+    MapCloseDuringImportTest.cpp
+    TtsInterruptingSpeakTest.cpp
     UndoServerWrapTest.cpp
     NarrowWindowWrapTest.cpp
     HostWidgetDecouplingTest.cpp
@@ -132,7 +134,7 @@ endif()
 
 # The round-trip tests boot a full mudlet instance and save/reload profile and
 # map data, so they need a longer timeout
-set_tests_properties(ProfileRoundTripTest MapRoundTripTest MapProgressDialogSeamTest PROPERTIES TIMEOUT 300)
+set_tests_properties(ProfileRoundTripTest MapRoundTripTest MapProgressDialogSeamTest MapCloseDuringImportTest PROPERTIES TIMEOUT 300)
 
 # HostWidgetDecouplingTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(HostWidgetDecouplingTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/MapCloseDuringImportTest.cpp
+++ b/test/functional_tests/MapCloseDuringImportTest.cpp
@@ -72,7 +72,11 @@ class MapCloseDuringImportTest : public QObject
 
 private:
     const QString mSourceName = qsl("MapCloseDuringImportSource-Test");
-    const QString mTargetName = qsl("MapCloseDuringImportTarget-Test");
+    // A name of its own per test: a test that fails part way through can leave
+    // its deferred close pending on a timer, and a later test reusing the name
+    // would have that close land on its profile instead.
+    const QString mImportTargetName = qsl("MapCloseDuringImportTarget-Test");
+    const QString mExportTargetName = qsl("MapCloseDuringExportTarget-Test");
     QTemporaryDir mConfigDir;
     QTemporaryDir mSaveDir;
     QByteArray mSavedXdg;
@@ -161,7 +165,7 @@ private slots:
 
     void test_closingTheProfileDuringAJsonImportDoesNotFreeTheMap()
     {
-        Host* pTarget = addProfile(mTargetName);
+        Host* pTarget = addProfile(mImportTargetName);
         QVERIFY2(pTarget, "failed to create the target Host");
         TMap* pTargetMap = pTarget->mpMap.data();
         const QPointer<TMap> mapWatch(pTargetMap);
@@ -175,7 +179,7 @@ private slots:
             // The same slot the tab's close button and closeProfile() use: it
             // posts closeHost() as a zero-millisecond timer, which the import's
             // own processEvents() then delivers with the import on the stack.
-            mudlet::self()->slot_closeProfileByName(mTargetName);
+            mudlet::self()->slot_closeProfileByName(mImportTargetName);
         });
         const auto [read, readMessage] = pTargetMap->readJsonMapFile(mMapFile);
         disconnect(closeOnProgress);
@@ -187,14 +191,14 @@ private slots:
         QVERIFY2(!read, "the import was expected to stop once the close asked it to");
         QCOMPARE(readMessage, qsl("aborted by user"));
         // ...and deferring the close must not drop it:
-        QVERIFY2(waitForProfileToClose(mTargetName), "the deferred close never completed once the import had unwound");
+        QVERIFY2(waitForProfileToClose(mImportTargetName), "the deferred close never completed once the import had unwound");
         QVERIFY2(mapWatch.isNull(), "the TMap outlived the profile it belongs to");
     }
 
     // The export half of the same loop, which pumps the event loop the same way.
     void test_closingTheProfileDuringAJsonExportDoesNotFreeTheMap()
     {
-        Host* pTarget = addProfile(mTargetName);
+        Host* pTarget = addProfile(mExportTargetName);
         QVERIFY2(pTarget, "failed to create the target Host");
         TMap* pTargetMap = pTarget->mpMap.data();
         buildMap(pTarget);
@@ -209,16 +213,18 @@ private slots:
                 return;
             }
             closeRequested = true;
-            mudlet::self()->slot_closeProfileByName(mTargetName);
+            mudlet::self()->slot_closeProfileByName(mExportTargetName);
         });
         const auto [wrote, writeMessage] = pTargetMap->writeJsonMapFile(qsl("%1/close-during-export.json").arg(mSaveDir.path()));
         disconnect(closeOnProgress);
-        Q_UNUSED(wrote)
-        Q_UNUSED(writeMessage)
 
         QVERIFY2(closeRequested, "the export never announced any progress, so no close was delivered into its pump");
         QVERIFY2(!mapWatch.isNull(), "the TMap was destroyed while its own export loop was still on the stack");
-        QVERIFY2(waitForProfileToClose(mTargetName), "the deferred close never completed once the export had unwound");
+        // As with the import: the close stops the operation rather than writing
+        // a whole map out of a profile that is going away.
+        QVERIFY2(!wrote, "the export was expected to stop once the close asked it to");
+        QCOMPARE(writeMessage, qsl("aborted by user"));
+        QVERIFY2(waitForProfileToClose(mExportTargetName), "the deferred close never completed once the export had unwound");
         QVERIFY2(mapWatch.isNull(), "the TMap outlived the profile it belongs to");
     }
 };

--- a/test/functional_tests/MapCloseDuringImportTest.cpp
+++ b/test/functional_tests/MapCloseDuringImportTest.cpp
@@ -1,0 +1,242 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Regression guard for #9520: closing a profile while its map was being
+ * imported or exported used to free the TMap while its own loop was still
+ * running.
+ *
+ * Mudlet is single threaded, so nothing here is a race. The interleaving is
+ * re-entrancy: TMap::readJsonMapFile() and TMap::writeJsonMapFile() call
+ * qApp->processEvents() once per area to keep their progress display alive and
+ * its Abort button clickable, and that pump delivers whatever else the event
+ * loop is holding - including the zero-millisecond timer that
+ * mudlet::slot_closeProfileByName() posts to run mudlet::closeHost(). That call
+ * takes the profile's QSharedPointer<Host> out of the host pool, which destroys
+ * the Host and, with it, the TMap whose loop is still on the stack. Everything
+ * the reader touches after that is freed memory.
+ *
+ * These tests stage exactly that, through the same public slot the tab close
+ * and closeProfile() use, and let the operation's own pump deliver the timer. A
+ * QPointer to the map is how they tell: it goes null the moment the TMap is
+ * destroyed, so the failure is reported rather than left to whatever the freed
+ * memory happens to hold. Without the fix that assertion fails - and under ASan
+ * the run additionally reports the use-after-free that follows it.
+ *
+ * Run with: ctest -R MapCloseDuringImportTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QDeadlineTimer>
+#include <QPointer>
+#include <QTemporaryDir>
+
+#include <chrono>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForMapCloseDuringImportTest();
+
+class MapCloseDuringImportTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    const QString mSourceName = qsl("MapCloseDuringImportSource-Test");
+    const QString mTargetName = qsl("MapCloseDuringImportTarget-Test");
+    QTemporaryDir mConfigDir;
+    QTemporaryDir mSaveDir;
+    QByteArray mSavedXdg;
+    QString mMapFile;
+
+    // Enough areas that the operation pumps the event loop many times over: the
+    // progress increment that delivers the close is reached once per area.
+    static constexpr int areaCount = 40;
+
+    void buildMap(Host* pHost)
+    {
+        TMap* pMap = pHost->mpMap.data();
+        TRoomDB* pDB = pMap->mpRoomDB.get();
+        int roomId = 1;
+        for (int area = 0; area < areaCount; ++area) {
+            const int areaId = pDB->addArea(qsl("Area %1").arg(area));
+            QVERIFY(areaId > 0);
+            for (int room = 0; room < 5; ++room, ++roomId) {
+                QVERIFY(pMap->addRoom(roomId));
+                QVERIFY(pMap->setRoomArea(roomId, areaId, false));
+                QVERIFY(pMap->setRoomCoordinates(roomId, room, area, 0));
+            }
+        }
+    }
+
+    Host* addProfile(const QString& name)
+    {
+        auto& hostManager = mudlet::self()->getHostManager();
+        if (!hostManager.addHost(name, qsl("23"), QString(), QString())) {
+            return nullptr;
+        }
+        return hostManager.getHost(name);
+    }
+
+    // Runs the event loop until the profile is gone. The close is deferred
+    // until the map operation has unwound, so this is where it lands.
+    bool waitForProfileToClose(const QString& name)
+    {
+        QDeadlineTimer deadline(10s);
+        while (mudlet::self()->getHostManager().getHost(name)) {
+            if (deadline.hasExpired()) {
+                return false;
+            }
+            qApp->processEvents(QEventLoop::AllEvents, 20);
+        }
+        return true;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForMapCloseDuringImportTest();
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(mSaveDir.isValid());
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        // Kept for the whole run, so that closing the profile under test never
+        // leaves Mudlet with no profiles at all and popping its connection
+        // dialog at an offscreen test.
+        Host* pSource = addProfile(mSourceName);
+        QVERIFY2(pSource, "failed to create the source Host");
+        buildMap(pSource);
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+
+        mMapFile = qsl("%1/close-during-import.json").arg(mSaveDir.path());
+        const auto [wrote, writeMessage] = pSource->mpMap->writeJsonMapFile(mMapFile);
+        QVERIFY2(wrote, qPrintable(writeMessage));
+    }
+
+    void cleanupTestCase()
+    {
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_closingTheProfileDuringAJsonImportDoesNotFreeTheMap()
+    {
+        Host* pTarget = addProfile(mTargetName);
+        QVERIFY2(pTarget, "failed to create the target Host");
+        TMap* pTargetMap = pTarget->mpMap.data();
+        const QPointer<TMap> mapWatch(pTargetMap);
+
+        bool closeRequested = false;
+        const QMetaObject::Connection closeOnProgress = connect(pTargetMap, &TMap::signal_mapProgressSetValue, pTargetMap, [&]() {
+            if (closeRequested) {
+                return;
+            }
+            closeRequested = true;
+            // The same slot the tab's close button and closeProfile() use: it
+            // posts closeHost() as a zero-millisecond timer, which the import's
+            // own processEvents() then delivers with the import on the stack.
+            mudlet::self()->slot_closeProfileByName(mTargetName);
+        });
+        const auto [read, readMessage] = pTargetMap->readJsonMapFile(mMapFile);
+        disconnect(closeOnProgress);
+
+        QVERIFY2(closeRequested, "the import never announced any progress, so no close was delivered into its pump");
+        QVERIFY2(!mapWatch.isNull(), "the TMap was destroyed while its own import loop was still on the stack");
+        // A close asked for mid-import stops it rather than reading a whole map
+        // into a profile that is going away:
+        QVERIFY2(!read, "the import was expected to stop once the close asked it to");
+        QCOMPARE(readMessage, qsl("aborted by user"));
+        // ...and deferring the close must not drop it:
+        QVERIFY2(waitForProfileToClose(mTargetName), "the deferred close never completed once the import had unwound");
+        QVERIFY2(mapWatch.isNull(), "the TMap outlived the profile it belongs to");
+    }
+
+    // The export half of the same loop, which pumps the event loop the same way.
+    void test_closingTheProfileDuringAJsonExportDoesNotFreeTheMap()
+    {
+        Host* pTarget = addProfile(mTargetName);
+        QVERIFY2(pTarget, "failed to create the target Host");
+        TMap* pTargetMap = pTarget->mpMap.data();
+        buildMap(pTarget);
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+        const QPointer<TMap> mapWatch(pTargetMap);
+
+        bool closeRequested = false;
+        const QMetaObject::Connection closeOnProgress = connect(pTargetMap, &TMap::signal_mapProgressSetValue, pTargetMap, [&]() {
+            if (closeRequested) {
+                return;
+            }
+            closeRequested = true;
+            mudlet::self()->slot_closeProfileByName(mTargetName);
+        });
+        const auto [wrote, writeMessage] = pTargetMap->writeJsonMapFile(qsl("%1/close-during-export.json").arg(mSaveDir.path()));
+        disconnect(closeOnProgress);
+        Q_UNUSED(wrote)
+        Q_UNUSED(writeMessage)
+
+        QVERIFY2(closeRequested, "the export never announced any progress, so no close was delivered into its pump");
+        QVERIFY2(!mapWatch.isNull(), "the TMap was destroyed while its own export loop was still on the stack");
+        QVERIFY2(waitForProfileToClose(mTargetName), "the deferred close never completed once the export had unwound");
+        QVERIFY2(mapWatch.isNull(), "the TMap outlived the profile it belongs to");
+    }
+};
+
+void initializeQRCResourcesForMapCloseDuringImportTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "MapCloseDuringImportTest.moc"
+QTEST_MAIN(MapCloseDuringImportTest)

--- a/test/functional_tests/TtsInterruptingSpeakTest.cpp
+++ b/test/functional_tests/TtsInterruptingSpeakTest.cpp
@@ -1,0 +1,185 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Regression guard for #9659: an interrupting ttsSpeak() dropping the utterance
+ * it was asked to speak.
+ *
+ * Every speech engine Qt wraps stops the running utterance inside say() and
+ * reports Ready for it - speech-dispatcher, SAPI, WinRT and AVFoundation all
+ * do. Mudlet raises its TTS events off those state changes and drains
+ * ttsQueue() on any Ready, so that one was read as "the engine is idle": the
+ * queued line was spoken straight over the utterance the script had just asked
+ * for, and that utterance was never heard at all.
+ *
+ * Qt's mock engine, which the Lua specs in Media_spec.lua use, never reports
+ * that Ready - it stays in Speaking with no state change at all, which is the
+ * other half of the same issue and is covered there. So the guard itself needs
+ * that Ready delivered the way a real engine delivers it, which is what this
+ * test does: it drives the Lua API for everything else and hands
+ * TLuaInterpreter::ttsStateChanged() the state change the engine's
+ * QTextToSpeech::stateChanged signal would have carried.
+ *
+ * Run with: ctest -R TtsInterruptingSpeakTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QTemporaryDir>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "mudlet.h"
+
+#ifdef QT_TEXTTOSPEECH_LIB
+#include <QTextToSpeech>
+#endif
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForTtsInterruptingSpeakTest();
+
+class TtsInterruptingSpeakTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("TtsInterruptingSpeak-Test");
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+
+#ifdef QT_TEXTTOSPEECH_LIB
+    // Runs a snippet in the profile's Lua state, failing the test with the
+    // script's own error message when it does not run cleanly. Lua assert()s in
+    // the snippet are how the queue and the current line are read back.
+    bool runLua(const QString& script) { return mpHost->getLuaInterpreter()->compileAndExecuteScript(script); }
+#endif
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForTtsInterruptingSpeakTest();
+
+        QVERIFY(mConfigDir.isValid());
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+        // Picked up by TLuaInterpreter::ttsBuild(), which then asks for Qt's
+        // deterministic mock engine instead of whatever the host machine would
+        // otherwise speak out loud.
+        qputenv("MUDLET_TEST_MODE", "1");
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QVERIFY2(mudlet::self()->getHostManager().addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the Host");
+        mpHost = mudlet::self()->getHostManager().getHost(mProfileName);
+        QVERIFY(mpHost);
+        // A bare Host blocks script compilation until the full profile boot
+        // would clear this, and these tests need their snippets to compile:
+        mpHost->mBlockScriptCompile = false;
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mudlet::self();
+        qunsetenv("MUDLET_TEST_MODE");
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_theReadyFromAnInterruptedUtteranceDoesNotDrainTheQueue()
+    {
+#ifndef QT_TEXTTOSPEECH_LIB
+        QSKIP("Mudlet was built without text-to-speech support");
+#else
+        QVERIFY2(runLua(qsl("ttsClearQueue() ttsSkip()")), "could not reset the TTS state");
+        if (!runLua(qsl("assert(#ttsGetVoices() > 0)"))) {
+            QSKIP("Qt's mock speech engine is unavailable here, so nothing can be made to speak");
+        }
+
+        QVERIFY(runLua(qsl("ttsSpeak('the utterance already being spoken')")));
+        QVERIFY(runLua(qsl("ttsQueue('the queued line')")));
+        QVERIFY(runLua(qsl("ttsSpeak('the utterance the script asked for')")));
+
+        // What every real engine reports next: the utterance say() stopped has
+        // ended. It is not the engine falling idle, and the queue must survive
+        // it - the requested utterance is what should be being spoken.
+        TLuaInterpreter::ttsStateChanged(QTextToSpeech::State::Ready);
+
+        QVERIFY2(runLua(qsl("assert(#ttsGetQueue() == 1, 'the queued line was spoken over the utterance ttsSpeak() asked for, queue holds '..#ttsGetQueue())")),
+                 "the queue was drained by the Ready that reported the interrupted utterance ending");
+        QVERIFY2(runLua(qsl("assert(ttsGetCurrentLine() == 'the utterance the script asked for', 'the current line became: '..tostring(ttsGetCurrentLine()))")),
+                 "the drained line replaced the utterance the script asked for");
+
+        QVERIFY(runLua(qsl("ttsClearQueue() ttsSkip()")));
+#endif
+    }
+
+    // The other side of the same guard: an explicit stop really does leave the
+    // engine idle, so its Ready has to keep draining the queue as it always has.
+    void test_theReadyFromAnExplicitSkipStillDrainsTheQueue()
+    {
+#ifndef QT_TEXTTOSPEECH_LIB
+        QSKIP("Mudlet was built without text-to-speech support");
+#else
+        QVERIFY2(runLua(qsl("ttsClearQueue() ttsSkip()")), "could not reset the TTS state");
+        if (!runLua(qsl("assert(#ttsGetVoices() > 0)"))) {
+            QSKIP("Qt's mock speech engine is unavailable here, so nothing can be made to speak");
+        }
+
+        QVERIFY(runLua(qsl("ttsSpeak('the utterance being spoken over')")));
+        QVERIFY(runLua(qsl("ttsSpeak('the utterance the script asked for')")));
+        QVERIFY(runLua(qsl("ttsQueue('the queued line')")));
+        QVERIFY(runLua(qsl("ttsSkip()")));
+
+        QVERIFY2(runLua(qsl("assert(#ttsGetQueue() == 0, 'the queue still holds '..#ttsGetQueue())")), "an explicit skip left the queue undrained");
+        QVERIFY2(runLua(qsl("assert(ttsGetCurrentLine() == 'the queued line', 'the current line is: '..tostring(ttsGetCurrentLine()))")), "the skip did not start speaking the queued line");
+
+        QVERIFY(runLua(qsl("ttsClearQueue() ttsSkip()")));
+#endif
+    }
+};
+
+void initializeQRCResourcesForTtsInterruptingSpeakTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "TtsInterruptingSpeakTest.moc"
+QTEST_MAIN(TtsInterruptingSpeakTest)

--- a/test/functional_tests/TtsInterruptingSpeakTest.cpp
+++ b/test/functional_tests/TtsInterruptingSpeakTest.cpp
@@ -47,6 +47,8 @@
 #include "HostManager.h"
 #include "MudletInstanceCoordinator.h"
 #include "TLuaInterpreter.h"
+#include "TScript.h"
+#include "ScriptUnit.h"
 #include "mudlet.h"
 
 #ifdef QT_TEXTTOSPEECH_LIB
@@ -75,6 +77,22 @@ private:
     // script's own error message when it does not run cleanly. Lua assert()s in
     // the snippet are how the queue and the current line are read back.
     bool runLua(const QString& script) { return mpHost->getLuaInterpreter()->compileAndExecuteScript(script); }
+
+    // Counts ttsSpeechStarted from here on in the Lua global ttsStartedCount. A
+    // TScript rather than registerAnonymousEventHandler(): this console-less
+    // Host never loads LuaGlobals.lua, where that function is defined.
+    bool countStartedEvents()
+    {
+        auto pScript = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pScript);
+        pScript->setName(qsl("ttsStartedCounter"));
+        if (!pScript->setScript(qsl("ttsStartedCount = 0\nfunction ttsStartedCounter(event, text)\n  ttsStartedCount = ttsStartedCount + 1\nend\n"))) {
+            return false;
+        }
+        pScript->setEventHandlerList(QStringList{qsl("ttsSpeechStarted")});
+        pScript->setIsActive(true);
+        return true;
+    }
 #endif
 
 private slots:
@@ -113,6 +131,18 @@ private slots:
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
     }
 
+    // The TTS state - engine, queue, and the flags this fixes - is process
+    // global, so it is reset after every test method rather than at the end of
+    // each, where an assertion that fails would jump over it.
+    void cleanup()
+    {
+#ifdef QT_TEXTTOSPEECH_LIB
+        if (mpHost) {
+            runLua(qsl("ttsClearQueue() ttsSkip()"));
+        }
+#endif
+    }
+
     void test_theReadyFromAnInterruptedUtteranceDoesNotDrainTheQueue()
     {
 #ifndef QT_TEXTTOSPEECH_LIB
@@ -137,7 +167,37 @@ private slots:
         QVERIFY2(runLua(qsl("assert(ttsGetCurrentLine() == 'the utterance the script asked for', 'the current line became: '..tostring(ttsGetCurrentLine()))")),
                  "the drained line replaced the utterance the script asked for");
 
-        QVERIFY(runLua(qsl("ttsClearQueue() ttsSkip()")));
+        // The engine getting round to reporting that the requested utterance
+        // started must not announce it a second time: ttsSpeak() already did,
+        // there being no state edge at the time for it to have come from.
+        QVERIFY2(countStartedEvents(), "could not install the event handler that counts ttsSpeechStarted");
+        TLuaInterpreter::ttsStateChanged(QTextToSpeech::State::Speaking);
+        QVERIFY2(runLua(qsl("assert(ttsStartedCount == 0, 'the utterance was announced '..ttsStartedCount..' more time(s)')")),
+                 "the engine's late Speaking announced the same utterance a second time");
+#endif
+    }
+
+    // The control for the test above: with nothing interrupted, that same Ready
+    // is the engine going idle and has to drain the queue. Without this, a
+    // change that stopped ttsStateChanged() draining at all would leave the
+    // test above passing while the queue feature was dead.
+    void test_theReadyFromAnUninterruptedUtteranceStillDrainsTheQueue()
+    {
+#ifndef QT_TEXTTOSPEECH_LIB
+        QSKIP("Mudlet was built without text-to-speech support");
+#else
+        QVERIFY2(runLua(qsl("ttsClearQueue() ttsSkip()")), "could not reset the TTS state");
+        if (!runLua(qsl("assert(#ttsGetVoices() > 0)"))) {
+            QSKIP("Qt's mock speech engine is unavailable here, so nothing can be made to speak");
+        }
+
+        QVERIFY(runLua(qsl("ttsSpeak('the only utterance')")));
+        QVERIFY(runLua(qsl("ttsQueue('the queued line')")));
+
+        TLuaInterpreter::ttsStateChanged(QTextToSpeech::State::Ready);
+
+        QVERIFY2(runLua(qsl("assert(#ttsGetQueue() == 0, 'the queue was not drained, it holds '..#ttsGetQueue())")), "an idle engine left the queue undrained");
+        QVERIFY2(runLua(qsl("assert(ttsGetCurrentLine() == 'the queued line', 'the current line is: '..tostring(ttsGetCurrentLine()))")), "the drain did not start speaking the queued line");
 #endif
     }
 
@@ -160,8 +220,6 @@ private slots:
 
         QVERIFY2(runLua(qsl("assert(#ttsGetQueue() == 0, 'the queue still holds '..#ttsGetQueue())")), "an explicit skip left the queue undrained");
         QVERIFY2(runLua(qsl("assert(ttsGetCurrentLine() == 'the queued line', 'the current line is: '..tostring(ttsGetCurrentLine()))")), "the skip did not start speaking the queued line");
-
-        QVERIFY(runLua(qsl("ttsClearQueue() ttsSkip()")));
 #endif
     }
 };


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Closing a profile no longer frees the map out from under a running import, export or download. `TMap` counts the operations that pump `qApp->processEvents()`, and `mudlet::closeHost()` - which one of those pumps is what delivers it - stops the operation and destroys the `Host` once it has unwound, instead of half way through it.
- Discord presence fields keep their last character and are only ever cut between characters: each buffer is now the documented limit plus room for its terminator, and a new `utils::copyUtf8String()` walks the cut back to a character boundary.
- An interrupting `ttsSpeak()` announces the utterance it starts, and the `Ready` an engine reports for the utterance it cut off no longer drains `ttsQueue()` over the top of the one the script asked for.

#### Motivation for adding to Mudlet
Each is a filed defect, and each was reproduced before it was fixed. The map one is a use-after-free: ASan reports `heap-use-after-free` inside `TMap::readJsonMapFile()`, freed by `~TMap` <- `~Host` <- `HostManager::deleteHost` <- `mudlet::closeHost` delivered by the import's own `processEvents()`. The Discord one is worse than one field looking wrong: a single over-long non-ASCII field makes the whole `SET_ACTIVITY` payload undecodable, so the entire presence update is discarded - the fake Discord client recorded exactly that. The TTS one silently drops speech: `ttsQueue()` plus an interrupting `ttsSpeak()` speaks the queued line and never speaks the requested one.

#### Other info (issues closed, discussion etc)
Closes #9520, closes #9634, closes #9659.

`MapCloseDuringImportTest` stages the close through `mudlet::slot_closeProfileByName()` and lets the map operation's own pump deliver it; the functional tests build with ASan, so the pre-fix run is a sanitizer report rather than an inference. `TtsInterruptingSpeakTest` hands `ttsStateChanged()` the `Ready` a real engine sends, which Qt's mock engine never does - the mock-visible half is pinned in `Media_spec.lua`, where the two specs that recorded the old behaviour are updated. `Discord_spec.lua` gains four end-to-end specs against `CI/discord-ipc-fixture.py` asserting that the captured frame still decodes as JSON and that a field is cut on a character boundary, and `DiscordTest.cpp` covers the same at unit level. Every new or changed test was confirmed to fail without its fix.

Two things deliberately left alone, both older than this PR: `Host::requestClose()` still runs nested inside the map operation's pump (it saves the profile there), and an XML import or a map download has no cancel to poll, so a close waits for it rather than stopping it.

**Test case:** Export a large map with `exportJsonMap()` and close the profile's tab while it runs; then `setDiscordDetail(string.rep("ä", 65))` and confirm the presence still updates; then `ttsQueue("queued line") ttsSpeak("first")` followed immediately by `ttsSpeak("second")` and confirm "second" is what gets spoken.

Assisted-by: Claude:claude-opus-5
