### PR TITLE
fix: stop the test-only waitForEvent() wedging Mudlet on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,7 @@ set(mudlet_SRCS
     EditorMoveItemCommand.cpp
     EditorToggleActiveCommand.cpp
     EditorUndoStack.cpp
+    EventLoopPump.cpp
     exitstreewidget.cpp
     FileOpenHandler.cpp
     FontManager.cpp
@@ -315,6 +316,7 @@ set(mudlet_HDRS
     EditorToggleActiveCommand.h
     EditorUndoStack.h
     enums.h
+    EventLoopPump.h
     exitstreewidget.h
     FileOpenHandler.h
     FontManager.h

--- a/src/EventLoopPump.cpp
+++ b/src/EventLoopPump.cpp
@@ -21,6 +21,7 @@
 
 #include <QCoreApplication>
 #include <QDeadlineTimer>
+#include <QDebug>
 #include <QEventLoop>
 #include <QThread>
 
@@ -47,6 +48,14 @@
 // serviced whatever the platform run loop is or is not doing.
 bool EventLoopPump::pumpFor(const int timeoutMs, const std::function<bool()>& stopCondition)
 {
+    // Without a dispatcher QCoreApplication::processEvents() returns silently,
+    // which would turn this into a plain sleep that reports a timeout as though
+    // it had been waiting for something.
+    if (!QThread::currentThread()->eventDispatcher()) {
+        qWarning() << "EventLoopPump::pumpFor() called with no event dispatcher on this thread, no events can be delivered";
+        return false;
+    }
+
     QDeadlineTimer deadline(qMax(timeoutMs, 0));
     if (stopCondition && stopCondition()) {
         return true;

--- a/src/EventLoopPump.cpp
+++ b/src/EventLoopPump.cpp
@@ -25,32 +25,16 @@
 #include <QEventLoop>
 #include <QThread>
 
-// Why this pumps rather than running a nested QEventLoop::exec():
-//
-// On macOS a nested exec() entered from inside a Qt timer callback stops seeing
-// Qt timers, so a wait armed with a QTimer never ends. Stacks captured from a
-// wedged CI run (issue #9670) show the main thread in
-// QTimerInfoList::activateTimers() -> a Qt timer's slot -> a nested
-// QEventLoop::exec(), which QCocoaEventDispatcher services by re-entering
-// -[NSApplication run] from inside the run loop callout the outer loop is
-// already in. That nested [NSApp run] sat in
-// _BlockUntilNextEventMatchingListInModeWithFilter for every one of 3314
-// samples, using 0.02s of CPU in 86 seconds: no Qt timer fired again, including
-// the single-shot one whose timeout was the only way out.
-//
-// The difference is that QEventLoop::exec() asks the event dispatcher to
-// process events with QEventLoop::EventLoopExec set, and QCocoaEventDispatcher
-// answers that by handing control to AppKit and relying on the platform run
-// loop to wake it for the single CFRunLoopTimer that drives every Qt timer.
-// QCoreApplication::processEvents() runs the dispatcher without EventLoopExec,
-// and that branch calls the dispatcher's own processTimers() - i.e.
-// QTimerInfoList::activateTimers() - directly on each pass, so Qt timers are
-// serviced whatever the platform run loop is or is not doing.
+// A nested QEventLoop::exec() cannot be used here. exec() sets
+// QEventLoop::EventLoopExec, which QCocoaEventDispatcher answers by re-entering
+// -[NSApplication run] and leaving Qt's timers to the platform run loop; nested
+// inside a Qt timer callback that run loop never wakes it again, so not even
+// the wait's own timeout fires (issue #9670). processEvents() instead takes the
+// branch that drives the dispatcher's processTimers() on every pass.
 bool EventLoopPump::pumpFor(const int timeoutMs, const std::function<bool()>& stopCondition)
 {
-    // Without a dispatcher QCoreApplication::processEvents() returns silently,
-    // which would turn this into a plain sleep that reports a timeout as though
-    // it had been waiting for something.
+    // processEvents() returns silently without a dispatcher, which would make
+    // this a plain sleep that then reports a timeout as though it had waited.
     if (!QThread::currentThread()->eventDispatcher()) {
         qWarning() << "EventLoopPump::pumpFor() called with no event dispatcher on this thread, no events can be delivered";
         return false;
@@ -69,8 +53,8 @@ bool EventLoopPump::pumpFor(const int timeoutMs, const std::function<bool()>& st
         if (deadline.hasExpired()) {
             return false;
         }
-        // A pass returns as soon as nothing more is pending, so without a pause
-        // this would spin a core flat for the whole timeout.
+        // A pass returns as soon as nothing is pending, so without this the loop
+        // spins a core flat for the whole timeout.
         QThread::msleep(1);
     }
 }

--- a/src/EventLoopPump.cpp
+++ b/src/EventLoopPump.cpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "EventLoopPump.h"
+
+#include <QCoreApplication>
+#include <QDeadlineTimer>
+#include <QEventLoop>
+#include <QThread>
+
+// Why this pumps rather than running a nested QEventLoop::exec():
+//
+// On macOS a nested exec() entered from inside a Qt timer callback stops seeing
+// Qt timers, so a wait armed with a QTimer never ends. Stacks captured from a
+// wedged CI run (issue #9670) show the main thread in
+// QTimerInfoList::activateTimers() -> a Qt timer's slot -> a nested
+// QEventLoop::exec(), which QCocoaEventDispatcher services by re-entering
+// -[NSApplication run] from inside the run loop callout the outer loop is
+// already in. That nested [NSApp run] sat in
+// _BlockUntilNextEventMatchingListInModeWithFilter for every one of 3314
+// samples, using 0.02s of CPU in 86 seconds: no Qt timer fired again, including
+// the single-shot one whose timeout was the only way out.
+//
+// The difference is that QEventLoop::exec() asks the event dispatcher to
+// process events with QEventLoop::EventLoopExec set, and QCocoaEventDispatcher
+// answers that by handing control to AppKit and relying on the platform run
+// loop to wake it for the single CFRunLoopTimer that drives every Qt timer.
+// QCoreApplication::processEvents() runs the dispatcher without EventLoopExec,
+// and that branch calls the dispatcher's own processTimers() - i.e.
+// QTimerInfoList::activateTimers() - directly on each pass, so Qt timers are
+// serviced whatever the platform run loop is or is not doing.
+bool EventLoopPump::pumpFor(const int timeoutMs, const std::function<bool()>& stopCondition)
+{
+    QDeadlineTimer deadline(qMax(timeoutMs, 0));
+    if (stopCondition && stopCondition()) {
+        return true;
+    }
+
+    while (true) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+        if (stopCondition && stopCondition()) {
+            return true;
+        }
+        if (deadline.hasExpired()) {
+            return false;
+        }
+        // A pass returns as soon as nothing more is pending, so without a pause
+        // this would spin a core flat for the whole timeout.
+        QThread::msleep(1);
+    }
+}

--- a/src/EventLoopPump.h
+++ b/src/EventLoopPump.h
@@ -31,7 +31,7 @@ public:
     //
     // This is deliberately not a nested QEventLoop::exec(): see the comment in
     // EventLoopPump.cpp for why exec() cannot be used here.
-    static bool pumpFor(int timeoutMs, const std::function<bool()>& stopCondition = {});
+    [[nodiscard]] static bool pumpFor(int timeoutMs, const std::function<bool()>& stopCondition = {});
 };
 
 #endif // MUDLET_EVENTLOOPPUMP_H

--- a/src/EventLoopPump.h
+++ b/src/EventLoopPump.h
@@ -1,0 +1,37 @@
+#ifndef MUDLET_EVENTLOOPPUMP_H
+#define MUDLET_EVENTLOOPPUMP_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <functional>
+
+class EventLoopPump
+{
+public:
+    // Keeps delivering Qt events for up to timeoutMs milliseconds, returning
+    // early as soon as stopCondition (if given) returns true. Returns true if it
+    // stopped on the condition, false if it ran out of time.
+    //
+    // This is deliberately not a nested QEventLoop::exec(): see the comment in
+    // EventLoopPump.cpp for why exec() cannot be used here.
+    static bool pumpFor(int timeoutMs, const std::function<bool()>& stopCondition = {});
+};
+
+#endif // MUDLET_EVENTLOOPPUMP_H

--- a/src/EventLoopPump.h
+++ b/src/EventLoopPump.h
@@ -25,11 +25,8 @@
 class EventLoopPump
 {
 public:
-    // Keeps delivering Qt events for up to timeoutMs milliseconds, returning
-    // early as soon as stopCondition (if given) returns true. Returns true if it
-    // stopped on the condition, false if it ran out of time.
-    //
-    // This is deliberately not a nested QEventLoop::exec(): see the comment in
+    // Delivers Qt events for up to timeoutMs. True means stopCondition became
+    // true, false means the time ran out. Not a nested QEventLoop::exec(): see
     // EventLoopPump.cpp for why exec() cannot be used here.
     [[nodiscard]] static bool pumpFor(int timeoutMs, const std::function<bool()>& stopCondition = {});
 };

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -491,6 +491,16 @@ bool Host::requestClose()
         return true;
     }
 
+    // A test-mode waitForEvent() or pumpEvents() is pumping the event loop on
+    // this profile's lua_State, and closing takes the Host, its interpreter and
+    // that state with it while the pump is still holding all three. Refuse, the
+    // way resetProfile_phase1() does. Always false (so a no-op) outside
+    // MUDLET_TEST_MODE, where both helpers are inert.
+    if (mLuaInterpreter.pumpingEvents()) {
+        qWarning() << "Host::requestClose() called while the test-mode event pump is running, ignoring";
+        return false;
+    }
+
     // This call ends up at the (void) TMainConsole::closeEvent(...) and causes
     // the close() method called here to return a true if the event was
     // accepted:

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -900,10 +900,8 @@ bool Host::resetProfile_phase1()
         return false;
     }
 
-    // A test-mode waitForEvent() or pumpEvents() is pumping the event loop on
-    // this profile's lua_State; phase2 would lua_close() that state underneath
-    // it (a use-after-free). Refuse until the pump finishes. Always false (so a
-    // no-op) outside MUDLET_TEST_MODE, where both helpers are inert.
+    // Phase 2 lua_close()s the very state the pump is running Lua code on, so
+    // refuse rather than reset into a use-after-free.
     if (mLuaInterpreter.pumpingEvents()) {
         qWarning() << "Host::resetProfile_phase1() called while the test-mode event pump is running, ignoring";
         return false;

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -498,16 +498,6 @@ bool Host::requestClose()
         return true;
     }
 
-    // A test-mode waitForEvent() or pumpEvents() is pumping the event loop on
-    // this profile's lua_State, and closing takes the Host, its interpreter and
-    // that state with it while the pump is still holding all three. Refuse, the
-    // way resetProfile_phase1() does. Always false (so a no-op) outside
-    // MUDLET_TEST_MODE, where both helpers are inert.
-    if (mLuaInterpreter.pumpingEvents()) {
-        qWarning() << "Host::requestClose() called while the test-mode event pump is running, ignoring";
-        return false;
-    }
-
     // This call ends up at the (void) TMainConsole::closeEvent(...) and causes
     // the close() method called here to return a true if the event was
     // accepted:

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -873,8 +873,8 @@ bool Host::resetProfile_phase1()
         return false;
     }
 
-    // A test-mode waitForEvent() is blocked in a nested event loop on this
-    // profile's lua_State; phase2 would lua_close() that state underneath it (a
+    // A test-mode waitForEvent() is blocked pumping events on this profile's
+    // lua_State; phase2 would lua_close() that state underneath it (a
     // use-after-free). Refuse until the wait finishes. Always empty (so a no-op)
     // outside MUDLET_TEST_MODE, where waitForEvent() is inert.
     if (mLuaInterpreter.hasPendingEventWaits()) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -873,12 +873,12 @@ bool Host::resetProfile_phase1()
         return false;
     }
 
-    // A test-mode waitForEvent() is blocked pumping events on this profile's
-    // lua_State; phase2 would lua_close() that state underneath it (a
-    // use-after-free). Refuse until the wait finishes. Always empty (so a no-op)
-    // outside MUDLET_TEST_MODE, where waitForEvent() is inert.
-    if (mLuaInterpreter.hasPendingEventWaits()) {
-        qWarning() << "Host::resetProfile_phase1() called while a waitForEvent() is blocked, ignoring";
+    // A test-mode waitForEvent() or pumpEvents() is pumping the event loop on
+    // this profile's lua_State; phase2 would lua_close() that state underneath
+    // it (a use-after-free). Refuse until the pump finishes. Always false (so a
+    // no-op) outside MUDLET_TEST_MODE, where both helpers are inert.
+    if (mLuaInterpreter.pumpingEvents()) {
+        qWarning() << "Host::resetProfile_phase1() called while the test-mode event pump is running, ignoring";
         return false;
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4977,8 +4977,6 @@ int TLuaInterpreter::createEventArgsTableRef(const TEvent& pE)
 }
 
 // No documentation available in wiki - internal, test-only helper for waitForEvent()
-// If a waitForEvent() call is blocked waiting for this event, capture its
-// arguments so that call can stop waiting. Called from Host::raiseEvent().
 void TLuaInterpreter::captureEventForWaits(const TEvent& pE)
 {
     if (mPendingEventWaits.isEmpty() || pE.mArgumentList.isEmpty()) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4969,7 +4969,7 @@ int TLuaInterpreter::createEventArgsTableRef(const TEvent& pE)
 
 // No documentation available in wiki - internal, test-only helper for waitForEvent()
 // If a waitForEvent() call is blocked waiting for this event, capture its
-// arguments and quit that call's nested event loop. Called from Host::raiseEvent().
+// arguments so that call can stop waiting. Called from Host::raiseEvent().
 void TLuaInterpreter::captureEventForWaits(const TEvent& pE)
 {
     if (mPendingEventWaits.isEmpty() || pE.mArgumentList.isEmpty()) {
@@ -4982,9 +4982,6 @@ void TLuaInterpreter::captureEventForWaits(const TEvent& pE)
         }
         pWait->mArgsRef = createEventArgsTableRef(pE);
         pWait->mCaptured = true;
-        if (pWait->mpLoop) {
-            pWait->mpLoop->quit();
-        }
     }
 }
 
@@ -5400,6 +5397,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "tempLineTrigger", TLuaInterpreter::tempLineTrigger);
     lua_register(pGlobalLua, "raiseEvent", TLuaInterpreter::raiseEvent);
     lua_register(pGlobalLua, "waitForEvent", TLuaInterpreter::waitForEvent);
+    lua_register(pGlobalLua, "pumpEvents", TLuaInterpreter::pumpEvents);
     lua_register(pGlobalLua, "deleteLine", TLuaInterpreter::deleteLine);
     lua_register(pGlobalLua, "copy", TLuaInterpreter::copy);
     lua_register(pGlobalLua, "cut", TLuaInterpreter::cut);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -792,13 +792,10 @@ public:
     void freeLuaRegistryIndex(int index);
     void freeAllInLuaRegistry(TEvent);
 
-    // Test-only support for the waitForEvent() Lua helper (MUDLET_TEST_MODE):
-    // called from Host::raiseEvent() so an event that fires while a busted spec
-    // is blocked waiting for it can be captured and unblock it.
+    // Called from Host::raiseEvent(), to unblock a waitForEvent() on that event.
     void captureEventForWaits(const TEvent&);
-    // True while a waitForEvent() or pumpEvents() call is pumping the event
-    // loop. Lets Host refuse a profile reset that would lua_close() the state
-    // out from under it. Always false (a no-op) outside MUDLET_TEST_MODE.
+    // Lets callers refuse anything that would lua_close() the state the pump is
+    // running Lua on. Always false outside MUDLET_TEST_MODE.
     bool pumpingEvents() const { return !mPendingEventWaits.isEmpty() || mEventPumpDepth > 0; }
 
     inline static const QMap<Qt::MouseButton, QString> csmMouseButtons = {
@@ -925,8 +922,8 @@ private:
     QVector<QVector<QPair<QString, QString>>> mMultiCaptureNameGroups;
     QMap<QNetworkReply*, QString> downloadMap;
 
-    // A waitForEvent() call in progress: the event it is waiting for, and once
-    // that arrives a Lua registry reference to the captured arguments.
+    // A waitForEvent() call in progress. mArgsRef is a Lua registry reference,
+    // so it has to be unref'd once the waiter has read it.
     struct TEventWait
     {
         QString mName;
@@ -934,8 +931,8 @@ private:
         bool mCaptured = false;
     };
     QList<TEventWait*> mPendingEventWaits;
-    // Nesting depth of pumpEvents(), which has no TEventWait of its own to
-    // register but needs the same protection from a profile reset.
+    // pumpEvents() registers no TEventWait of its own, so it needs its own
+    // counter to be visible to pumpingEvents().
     int mEventPumpDepth = 0;
     int createEventArgsTableRef(const TEvent&);
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -62,7 +62,6 @@ extern "C" {
 #include <optional>
 
 class Host;
-class QEventLoop;
 class TAction;
 class TEvent;
 class TLuaThread;
@@ -797,10 +796,10 @@ public:
     // called from Host::raiseEvent() so an event that fires while a busted spec
     // is blocked waiting for it can be captured and unblock it.
     void captureEventForWaits(const TEvent&);
-    // True while a waitForEvent() call is blocked pumping events. Lets Host
-    // refuse a profile reset that would lua_close() the state out from under
-    // it. Always false (a no-op) outside MUDLET_TEST_MODE.
-    bool hasPendingEventWaits() const { return !mPendingEventWaits.isEmpty(); }
+    // True while a waitForEvent() or pumpEvents() call is pumping the event
+    // loop. Lets Host refuse a profile reset that would lua_close() the state
+    // out from under it. Always false (a no-op) outside MUDLET_TEST_MODE.
+    bool pumpingEvents() const { return !mPendingEventWaits.isEmpty() || mEventPumpDepth > 0; }
 
     inline static const QMap<Qt::MouseButton, QString> csmMouseButtons = {
             {Qt::NoButton, qsl("NoButton")},           {Qt::LeftButton, qsl("LeftButton")},       {Qt::RightButton, qsl("RightButton")},     {Qt::MiddleButton, qsl("MidButton")},
@@ -935,6 +934,9 @@ private:
         bool mCaptured = false;
     };
     QList<TEventWait*> mPendingEventWaits;
+    // Nesting depth of pumpEvents(), which has no TEventWait of its own to
+    // register but needs the same protection from a profile reset.
+    int mEventPumpDepth = 0;
     int createEventArgsTableRef(const TEvent&);
 
     lua_State* pGlobalLua = nullptr;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -398,6 +398,7 @@ public:
     static int tempLineTrigger(lua_State*);
     static int raiseEvent(lua_State*);
     static int waitForEvent(lua_State*);
+    static int pumpEvents(lua_State*);
     static int deleteLine(lua_State*);
     static int copy(lua_State*);
     static int cut(lua_State*);
@@ -794,11 +795,11 @@ public:
 
     // Test-only support for the waitForEvent() Lua helper (MUDLET_TEST_MODE):
     // called from Host::raiseEvent() so an event that fires while a busted spec
-    // is blocked inside a nested event loop can be captured and unblock it.
+    // is blocked waiting for it can be captured and unblock it.
     void captureEventForWaits(const TEvent&);
-    // True while a waitForEvent() call is blocked in its nested event loop. Lets
-    // Host refuse a profile reset that would lua_close() the state out from
-    // under it. Always false (a no-op) outside MUDLET_TEST_MODE.
+    // True while a waitForEvent() call is blocked pumping events. Lets Host
+    // refuse a profile reset that would lua_close() the state out from under
+    // it. Always false (a no-op) outside MUDLET_TEST_MODE.
     bool hasPendingEventWaits() const { return !mPendingEventWaits.isEmpty(); }
 
     inline static const QMap<Qt::MouseButton, QString> csmMouseButtons = {
@@ -925,12 +926,11 @@ private:
     QVector<QVector<QPair<QString, QString>>> mMultiCaptureNameGroups;
     QMap<QNetworkReply*, QString> downloadMap;
 
-    // A waitForEvent() call in progress: the nested event loop to quit when the
-    // named event arrives, plus a Lua registry reference to the captured args.
+    // A waitForEvent() call in progress: the event it is waiting for, and once
+    // that arrives a Lua registry reference to the captured arguments.
     struct TEventWait
     {
         QString mName;
-        QEventLoop* mpLoop = nullptr;
         int mArgsRef = LUA_NOREF;
         bool mCaptured = false;
     };

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -31,6 +31,7 @@
 #include "TLuaInterpreter.h"
 
 #include "EAction.h"
+#include "EventLoopPump.h"
 #include "Host.h"
 #include "TAlias.h"
 #include "TArea.h"
@@ -1549,14 +1550,21 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
     return 1;
 }
 
+// Nothing that spins the event loop should outlive the profile or the
+// application: pumping on past either would keep Lua running against objects
+// that are being torn down.
+static bool shuttingDown(const Host& host)
+{
+    return host.isClosingDown() || (mudlet::self() && mudlet::self()->isGoingDown());
+}
+
 // No documentation available in wiki - internal, test-only function
-// Blocks the calling Lua code inside a nested Qt event loop until the named
-// event is raised (returning the event name followed by its arguments, exactly
-// as an event handler would receive them) or the timeout elapses (returning
-// nil and an error message). Timers, networking and other events keep being
-// processed while blocked, which is what lets busted specs observe asynchronous
-// behaviour without sleeps. Gated behind MUDLET_TEST_MODE so it is inert for
-// normal users.
+// Blocks the calling Lua code until the named event is raised (returning the
+// event name followed by its arguments, exactly as an event handler would
+// receive them) or the timeout elapses (returning nil and an error message).
+// Timers, networking and other events keep being processed while blocked, which
+// is what lets busted specs observe asynchronous behaviour without sleeps.
+// Gated behind MUDLET_TEST_MODE so it is inert for normal users.
 int TLuaInterpreter::waitForEvent(lua_State* L)
 {
     if (!qEnvironmentVariableIsSet("MUDLET_TEST_MODE")) {
@@ -1598,20 +1606,14 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
         return 2;
     }
 
-    QEventLoop loop;
     TEventWait wait;
     wait.mName = eventName;
-    wait.mpLoop = &loop;
     pLuaInterpreter->mPendingEventWaits.append(&wait);
 
-    QTimer timeoutTimer;
-    timeoutTimer.setSingleShot(true);
-    QObject::connect(&timeoutTimer, &QTimer::timeout, &loop, &QEventLoop::quit);
-    timeoutTimer.start(timeoutMs);
+    EventLoopPump::pumpFor(timeoutMs, [&wait, &host]() {
+        return wait.mCaptured || shuttingDown(host);
+    });
 
-    loop.exec();
-
-    timeoutTimer.stop();
     pLuaInterpreter->mPendingEventWaits.removeAll(&wait);
 
     if (!wait.mCaptured) {
@@ -1642,6 +1644,42 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
     lua_remove(L, argsTableIndex);
     luaL_unref(L, LUA_REGISTRYINDEX, wait.mArgsRef);
     return argCount;
+}
+
+// No documentation available in wiki - internal, test-only function
+// Keeps Mudlet delivering events for the given number of milliseconds and then
+// returns true. This is the sleep a busted spec wants when it has to let queued
+// work - a zero-timer, a scheduled profile save, a network reply - actually
+// run, rather than waiting for a named event. Specs used to get this by calling
+// waitForEvent() with an event name nothing ever raises, which only ever
+// finished through the timeout path. Gated behind MUDLET_TEST_MODE so it is
+// inert for normal users.
+int TLuaInterpreter::pumpEvents(lua_State* L)
+{
+    if (!qEnvironmentVariableIsSet("MUDLET_TEST_MODE")) {
+        lua_pushnil(L);
+        lua_pushstring(L, "pumpEvents: only available in test mode (set the MUDLET_TEST_MODE environment variable)");
+        return 2;
+    }
+
+    // Matches waitForEvent()'s ceiling: long enough for the slowest thing a spec
+    // waits on, short enough that a runaway wait fails as a timeout rather than
+    // by having the whole suite killed.
+    constexpr int defaultTimeoutMs = 50;
+    constexpr int maximumTimeoutMs = 30000;
+    int timeoutMs = defaultTimeoutMs;
+    if (!lua_isnoneornil(L, 1)) {
+        timeoutMs = getVerifiedInt(L, __func__, 1, "duration in milliseconds", true);
+    }
+    timeoutMs = std::clamp(timeoutMs, 0, maximumTimeoutMs);
+
+    Host& host = getHostFromLua(L);
+    EventLoopPump::pumpFor(timeoutMs, [&host]() {
+        return shuttingDown(host);
+    });
+
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#raiseGlobalEvent

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -86,9 +86,7 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QEventLoop>
 #include <QFileDialog>
-#include <QTimer>
 #include <QFileInfo>
 #include <QMovie>
 #include <QVector>
@@ -1552,10 +1550,13 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
 
 // Nothing that spins the event loop should outlive the profile or the
 // application: pumping on past either would keep Lua running against objects
-// that are being torn down.
-static bool shuttingDown(const Host& host)
+// that are being torn down. A Host that has already gone, or a mudlet singleton
+// already past its destructor, counts as shutting down - those are further
+// along than the flags, not healthier.
+static bool shuttingDown(const QPointer<Host>& pHost)
 {
-    return host.isClosingDown() || (mudlet::self() && mudlet::self()->isGoingDown());
+    mudlet* pMudlet = mudlet::self();
+    return !pHost || pHost->isClosingDown() || !pMudlet || pMudlet->isGoingDown();
 }
 
 // No documentation available in wiki - internal, test-only function
@@ -1597,9 +1598,9 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
 
     // A profile reset recreates this profile's lua_State (initLuaGlobals() calls
     // lua_close()), and shutdown destroys the interpreter outright. Either would
-    // free the state L is executing on while we block, so refuse rather than risk
-    // a use-after-free when the nested loop unwinds. resetProfile_phase1() guards
-    // the mirror case where a reset is requested while we are already blocked.
+    // free the state L is executing on while we wait, so refuse rather than risk
+    // a use-after-free when the wait returns. resetProfile_phase1() guards the
+    // mirror case where a reset is requested while we are already blocked.
     if (host.profileResetInProgress() || host.isClosingDown()) {
         lua_pushnil(L);
         lua_pushstring(L, "waitForEvent: cannot wait while the profile is being reset or Mudlet is closing");
@@ -1610,15 +1611,23 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
     wait.mName = eventName;
     pLuaInterpreter->mPendingEventWaits.append(&wait);
 
-    EventLoopPump::pumpFor(timeoutMs, [&wait, &host]() {
-        return wait.mCaptured || shuttingDown(host);
+    const QPointer<Host> pHost(&host);
+    const bool stoppedEarly = EventLoopPump::pumpFor(timeoutMs, [&wait, &pHost]() {
+        return wait.mCaptured || shuttingDown(pHost);
     });
 
     pLuaInterpreter->mPendingEventWaits.removeAll(&wait);
 
     if (!wait.mCaptured) {
         lua_pushnil(L);
-        lua_pushstring(L, qsl("waitForEvent: timed out after %1ms waiting for event '%2'").arg(QString::number(timeoutMs), eventName).toUtf8().constData());
+        if (stoppedEarly) {
+            // The stop condition fired without capturing anything, so Mudlet is
+            // going away. Saying "timed out" here would send whoever reads the
+            // CI log hunting for a slow event that was never coming.
+            lua_pushstring(L, qsl("waitForEvent: gave up waiting for event '%1', Mudlet is shutting down").arg(eventName).toUtf8().constData());
+        } else {
+            lua_pushstring(L, qsl("waitForEvent: timed out after %1ms waiting for event '%2'").arg(QString::number(timeoutMs), eventName).toUtf8().constData());
+        }
         return 2;
     }
 
@@ -1662,9 +1671,10 @@ int TLuaInterpreter::pumpEvents(lua_State* L)
         return 2;
     }
 
-    // Matches waitForEvent()'s ceiling: long enough for the slowest thing a spec
-    // waits on, short enough that a runaway wait fails as a timeout rather than
-    // by having the whole suite killed.
+    // One step of a spec's own retry loop is the common case, so that is the
+    // default. The ceiling matches waitForEvent()'s: long enough for the slowest
+    // thing a spec waits on, short enough that a runaway pump shows up as its
+    // own failure rather than by having the whole suite killed.
     constexpr int defaultTimeoutMs = 50;
     constexpr int maximumTimeoutMs = 30000;
     int timeoutMs = defaultTimeoutMs;
@@ -1674,9 +1684,32 @@ int TLuaInterpreter::pumpEvents(lua_State* L)
     timeoutMs = std::clamp(timeoutMs, 0, maximumTimeoutMs);
 
     Host& host = getHostFromLua(L);
-    EventLoopPump::pumpFor(timeoutMs, [&host]() {
-        return shuttingDown(host);
+    TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+
+    // Same use-after-free hazard waitForEvent() guards: a profile reset closes
+    // the lua_State this is running on, and the pump is exactly what delivers
+    // the zero-timer that phase2 is armed on.
+    if (host.profileResetInProgress() || host.isClosingDown()) {
+        lua_pushnil(L);
+        lua_pushstring(L, "pumpEvents: cannot pump while the profile is being reset or Mudlet is closing");
+        return 2;
+    }
+
+    const QPointer<Host> pHost(&host);
+    ++pLuaInterpreter->mEventPumpDepth;
+    const bool stoppedEarly = EventLoopPump::pumpFor(timeoutMs, [&pHost]() {
+        return shuttingDown(pHost);
     });
+    --pLuaInterpreter->mEventPumpDepth;
+
+    if (stoppedEarly) {
+        // Ran for less than it was asked to, so whatever the caller queued may
+        // not have happened. Callers that only wanted a pause can ignore this;
+        // the ones flushing a queued profile save should not.
+        lua_pushnil(L);
+        lua_pushstring(L, "pumpEvents: stopped early, Mudlet is shutting down");
+        return 2;
+    }
 
     lua_pushboolean(L, true);
     return 1;

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -61,6 +61,8 @@
 #include "glwidget_integration.h"
 #endif
 
+#include <QScopeGuard>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -1707,10 +1709,12 @@ int TLuaInterpreter::pumpEvents(lua_State* L)
 
     const QPointer<Host> pHost(&host);
     ++pLuaInterpreter->mEventPumpDepth;
+    const auto pumpGuard = qScopeGuard([pLuaInterpreter]() {
+        --pLuaInterpreter->mEventPumpDepth;
+    });
     const bool stoppedEarly = EventLoopPump::pumpFor(timeoutMs, [&pHost]() {
         return shuttingDown(pHost);
     });
-    --pLuaInterpreter->mEventPumpDepth;
 
     if (stoppedEarly) {
         // Ran for less than it was asked to, so whatever the caller queued may

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -1560,11 +1560,9 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
     return 1;
 }
 
-// Nothing that spins the event loop should outlive the profile or the
-// application: pumping on past either would keep Lua running against objects
-// that are being torn down. A Host that has already gone, or a mudlet singleton
-// already past its destructor, counts as shutting down - those are further
-// along than the flags, not healthier.
+// A gone Host, or a mudlet singleton already past its destructor, is further
+// along than the flags rather than healthier, so the nulls count as shutting
+// down too.
 static bool shuttingDown(const QPointer<Host>& pHost)
 {
     mudlet* pMudlet = mudlet::self();
@@ -1572,12 +1570,9 @@ static bool shuttingDown(const QPointer<Host>& pHost)
 }
 
 // No documentation available in wiki - internal, test-only function
-// Blocks the calling Lua code until the named event is raised (returning the
-// event name followed by its arguments, exactly as an event handler would
-// receive them) or the timeout elapses (returning nil and an error message).
-// Timers, networking and other events keep being processed while blocked, which
-// is what lets busted specs observe asynchronous behaviour without sleeps.
-// Gated behind MUDLET_TEST_MODE so it is inert for normal users.
+// Blocks the calling Lua code until the named event is raised, returning the
+// event name and its arguments exactly as an event handler would receive them,
+// or nil and an error message. Timers and networking run on meanwhile.
 int TLuaInterpreter::waitForEvent(lua_State* L)
 {
     if (!qEnvironmentVariableIsSet("MUDLET_TEST_MODE")) {
@@ -1608,11 +1603,9 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
-    // A profile reset recreates this profile's lua_State (initLuaGlobals() calls
-    // lua_close()), and shutdown destroys the interpreter outright. Either would
-    // free the state L is executing on while we wait, so refuse rather than risk
-    // a use-after-free when the wait returns. resetProfile_phase1() guards the
-    // mirror case where a reset is requested while we are already blocked.
+    // A reset recreates this lua_State and a shutdown destroys the interpreter,
+    // either of which frees the state L runs on mid-wait. resetProfile_phase1()
+    // guards the mirror case, a reset asked for once we are already blocked.
     if (host.profileResetInProgress() || host.isClosingDown()) {
         lua_pushnil(L);
         lua_pushstring(L, "waitForEvent: cannot wait while the profile is being reset or Mudlet is closing");
@@ -1633,9 +1626,6 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
     if (!wait.mCaptured) {
         lua_pushnil(L);
         if (stoppedEarly) {
-            // The stop condition fired without capturing anything, so Mudlet is
-            // going away. Saying "timed out" here would send whoever reads the
-            // CI log hunting for a slow event that was never coming.
             lua_pushstring(L, qsl("waitForEvent: gave up waiting for event '%1', Mudlet is shutting down").arg(eventName).toUtf8().constData());
         } else {
             lua_pushstring(L, qsl("waitForEvent: timed out after %1ms waiting for event '%2'").arg(QString::number(timeoutMs), eventName).toUtf8().constData());
@@ -1668,13 +1658,9 @@ int TLuaInterpreter::waitForEvent(lua_State* L)
 }
 
 // No documentation available in wiki - internal, test-only function
-// Keeps Mudlet delivering events for the given number of milliseconds and then
-// returns true. This is the sleep a busted spec wants when it has to let queued
-// work - a zero-timer, a scheduled profile save, a network reply - actually
-// run, rather than waiting for a named event. Specs used to get this by calling
-// waitForEvent() with an event name nothing ever raises, which only ever
-// finished through the timeout path. Gated behind MUDLET_TEST_MODE so it is
-// inert for normal users.
+// Keeps Mudlet delivering events for the given number of milliseconds: the
+// sleep a spec wants to let queued work run when there is no named event to
+// wait for.
 int TLuaInterpreter::pumpEvents(lua_State* L)
 {
     if (!qEnvironmentVariableIsSet("MUDLET_TEST_MODE")) {
@@ -1683,10 +1669,8 @@ int TLuaInterpreter::pumpEvents(lua_State* L)
         return 2;
     }
 
-    // One step of a spec's own retry loop is the common case, so that is the
-    // default. The ceiling matches waitForEvent()'s: long enough for the slowest
-    // thing a spec waits on, short enough that a runaway pump shows up as its
-    // own failure rather than by having the whole suite killed.
+    // The ceiling matches waitForEvent()'s: below busted's per-spec CI timeout,
+    // so a runaway pump fails on its own rather than taking the suite with it.
     constexpr int defaultTimeoutMs = 50;
     constexpr int maximumTimeoutMs = 30000;
     int timeoutMs = defaultTimeoutMs;
@@ -1698,9 +1682,8 @@ int TLuaInterpreter::pumpEvents(lua_State* L)
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
-    // Same use-after-free hazard waitForEvent() guards: a profile reset closes
-    // the lua_State this is running on, and the pump is exactly what delivers
-    // the zero-timer that phase2 is armed on.
+    // Same use-after-free waitForEvent() guards, and worse here: the pump is
+    // itself what delivers the zero-timer phase2 is armed on.
     if (host.profileResetInProgress() || host.isClosingDown()) {
         lua_pushnil(L);
         lua_pushstring(L, "pumpEvents: cannot pump while the profile is being reset or Mudlet is closing");
@@ -1717,9 +1700,8 @@ int TLuaInterpreter::pumpEvents(lua_State* L)
     });
 
     if (stoppedEarly) {
-        // Ran for less than it was asked to, so whatever the caller queued may
-        // not have happened. Callers that only wanted a pause can ignore this;
-        // the ones flushing a queued profile save should not.
+        // Ran short, so whatever the caller queued may not have happened - a
+        // spec flushing a profile save needs to hear that, not just get true.
         lua_pushnil(L);
         lua_pushstring(L, "pumpEvents: stopped early, Mudlet is shutting down");
         return 2;

--- a/src/mudlet-lua/tests/MudletBusted_spec.lua
+++ b/src/mudlet-lua/tests/MudletBusted_spec.lua
@@ -101,8 +101,7 @@ describe("waitForEvent test helper", function()
       end)
 
     it("observes an event raised from inside another timer's callback", function()
-        -- The shape #9670 wedged on: a wait is armed from Lua that is itself
-        -- running inside a Qt timer callback.
+        -- The #9670 shape: the wait itself is armed from inside a timer callback.
         tempTimer(0, function()
             tempTimer(0.05, function() raiseEvent("mudletTestNestedTimer", "deep") end)
             _G.mudletTestNestedTimerResult = {waitForEvent("mudletTestNestedTimer", 2000)}
@@ -152,9 +151,8 @@ describe("pumpEvents test helper", function()
       end)
 
     it("keeps running timers when pumping from inside a timer's callback", function()
-        -- This is the #9670 shape: on macOS a nested QEventLoop::exec() entered
-        -- from a Qt timer callback stopped seeing Qt timers altogether, so
-        -- nothing - not even the wait's own timeout - could end it.
+        -- The #9670 shape: on macOS this position stops Qt timers entirely, so
+        -- a regression hangs the spec rather than failing it.
         local result = {}
         tempTimer(0, function()
             tempTimer(0.05, function() result.innerFired = true end)

--- a/src/mudlet-lua/tests/MudletBusted_spec.lua
+++ b/src/mudlet-lua/tests/MudletBusted_spec.lua
@@ -100,6 +100,25 @@ describe("waitForEvent test helper", function()
         assert.has_error(function() waitForEvent() end)
       end)
 
+    it("observes an event raised from inside another timer's callback", function()
+        -- The shape #9670 wedged on: a wait is armed from Lua that is itself
+        -- running inside a Qt timer callback.
+        tempTimer(0, function()
+            tempTimer(0.05, function() raiseEvent("mudletTestNestedTimer", "deep") end)
+            _G.mudletTestNestedTimerResult = {waitForEvent("mudletTestNestedTimer", 2000)}
+          end)
+        local waited = 0
+        while not _G.mudletTestNestedTimerResult and waited < 5000 do
+          pumpEvents(50)
+          waited = waited + 50
+        end
+        local result = _G.mudletTestNestedTimerResult
+        _G.mudletTestNestedTimerResult = nil
+        assert.is_table(result, "the wait inside the timer callback never returned")
+        assert.equals("mudletTestNestedTimer", result[1])
+        assert.equals("deep", result[2])
+      end)
+
     it("supports a nested waitForEvent while one is already blocked", function()
         local innerName
         tempTimer(0, function()
@@ -112,5 +131,43 @@ describe("waitForEvent test helper", function()
         assert.equals("mudletTestNested", outerName)
         assert.equals("payload", outerValue)
         assert.equals("mudletTestNested", innerName)
+      end)
+  end)
+
+describe("pumpEvents test helper", function()
+    it("returns true once the time is up", function()
+        assert.is_true(pumpEvents(20))
+      end)
+
+    it("accepts no argument and clamps a negative duration", function()
+        assert.is_true(pumpEvents())
+        assert.is_true(pumpEvents(-50))
+      end)
+
+    it("runs a timer that falls due while it is pumping", function()
+        local fired = false
+        tempTimer(0.05, function() fired = true end)
+        pumpEvents(300)
+        assert.is_true(fired, "a timer that came due during the pump did not fire")
+      end)
+
+    it("keeps running timers when pumping from inside a timer's callback", function()
+        -- This is the #9670 shape: on macOS a nested QEventLoop::exec() entered
+        -- from a Qt timer callback stopped seeing Qt timers altogether, so
+        -- nothing - not even the wait's own timeout - could end it.
+        local result = {}
+        tempTimer(0, function()
+            tempTimer(0.05, function() result.innerFired = true end)
+            pumpEvents(300)
+            result.firedDuringPump = result.innerFired == true
+            result.done = true
+          end)
+        local waited = 0
+        while not result.done and waited < 5000 do
+          pumpEvents(50)
+          waited = waited + 50
+        end
+        assert.is_true(result.done, "the pump inside the timer callback never returned")
+        assert.is_true(result.firedDuringPump, "a timer did not fire while pumping from inside a timer callback")
       end)
   end)

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -849,8 +849,6 @@ describe("MMCP effects against a scripted chat peer", function()
     return true
   end
 
-  -- Lets Mudlet's event loop run for ms without blocking it, so sockets and
-  -- timers get time to work.
   local function pump(ms)
     pumpEvents(ms)
   end

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -294,8 +294,8 @@ describe("Downloads and HTTP verbs against the local fixture server", function()
   -- checked too.
   --
   -- The requests are asynchronous: nothing is sent until the event loop runs,
-  -- which only happens inside waitForEvent(), so arming the wait after issuing
-  -- the request cannot miss the reply.
+  -- which only happens inside waitForEvent() and pumpEvents(), so arming the
+  -- wait after issuing the request cannot miss the reply.
   local httpPort = os.getenv("MUDLET_TEST_HTTP_PORT")
   -- the contents of CI/http-fixtures/fixture.txt
   local fixtureBody = "Mudlet self-test HTTP fixture.\n"

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -849,10 +849,10 @@ describe("MMCP effects against a scripted chat peer", function()
     return true
   end
 
-  -- Lets Mudlet's event loop run for ms without blocking it: waiting on an
-  -- event nothing raises is how a spec gives sockets and timers time to work.
+  -- Lets Mudlet's event loop run for ms without blocking it, so sockets and
+  -- timers get time to work.
   local function pump(ms)
-    waitForEvent("mmcpFixtureIdleEvent", ms)
+    pumpEvents(ms)
   end
 
   local function waitUntil(predicate, timeoutMs)

--- a/src/mudlet-lua/tests/Package_spec.lua
+++ b/src/mudlet-lua/tests/Package_spec.lua
@@ -17,9 +17,9 @@
 -- behind: the self-test profile is reused between runs, so a leak here would
 -- break the next run.
 
--- pumpEvents() is inert outside test mode, and without it these specs cannot
--- let the profile save finish - the uninstalls would fail and strand fixture
--- packages in the profile, so say so rather than make a mess of it.
+-- pumpEvents() is inert outside test mode, and without it the profile save
+-- never finishes: the uninstalls fail and strand fixture packages in the
+-- profile, so say so rather than make that mess.
 if not os.getenv("MUDLET_TEST_MODE") then
   describe("Tests the package and module lifecycle", function()
     it("needs test mode", function()
@@ -83,10 +83,8 @@ local function assertArgError(fn, needle)
   assert.is_true(contains(err, needle), tostring(err))
 end
 
--- pumpEvents() keeps Mudlet delivering events for the given time, which is how
--- a spec gives its queued work a chance to run: the install events are raised
--- from a zero-timer, and so is the profile save that uninstallPackage()
--- schedules.
+-- The install events, and the profile save uninstallPackage() schedules, are
+-- all raised from a zero-timer, so none of them happen unless a spec pumps.
 local function waitUntil(condition, timeoutMilliseconds)
   local waited = 0
   while waited < timeoutMilliseconds do

--- a/src/mudlet-lua/tests/Package_spec.lua
+++ b/src/mudlet-lua/tests/Package_spec.lua
@@ -753,7 +753,6 @@ describe("Tests the module accessors", function()
   -- unless a spec puts a synced module in the profile first.
   describe("Tests saving a profile that has a module to write", function()
     it("writes the synced module out again", function()
-      requireWorkingInstalls()
       -- rewriting this module's own .mpackage is only safe because
       -- installFixtureModule() installed a scratch copy, not the committed one
       defer(function() disableModuleSync(moduleName) end)

--- a/src/mudlet-lua/tests/Package_spec.lua
+++ b/src/mudlet-lua/tests/Package_spec.lua
@@ -17,13 +17,13 @@
 -- behind: the self-test profile is reused between runs, so a leak here would
 -- break the next run.
 
--- waitForEvent() is inert outside test mode, and without it these specs cannot
+-- pumpEvents() is inert outside test mode, and without it these specs cannot
 -- let the profile save finish - the uninstalls would fail and strand fixture
 -- packages in the profile, so say so rather than make a mess of it.
 if not os.getenv("MUDLET_TEST_MODE") then
   describe("Tests the package and module lifecycle", function()
     it("needs test mode", function()
-      pending("the package specs need MUDLET_TEST_MODE (waitForEvent() does nothing without it)")
+      pending("the package specs need MUDLET_TEST_MODE (pumpEvents() does nothing without it)")
     end)
   end)
   return
@@ -155,7 +155,7 @@ local function installUntilConfirmed(install, path, isInstalled, what)
     if isInstalled() then
       return
     end
-    waitForProfileSaveToPass()
+    assert.is_true(waitForProfileSaveToPass(), "a profile save was still running after 5s, so this install would be postponed")
     local ok, err = install(path)
     -- a postponed install can still be carried out while the pump below runs
     -- the event loop, so a repeat may legitimately come back "already installed"
@@ -176,7 +176,7 @@ end
 -- about the refusal waits for the save to pass and asks again.
 local function installUntilRefused(install, path)
   for attempt = 1, 3 do
-    waitForProfileSaveToPass()
+    assert.is_true(waitForProfileSaveToPass(), "a profile save was still running after 5s, so this install would be postponed")
     local ok, err = install(path)
     if ok == nil then
       return err
@@ -207,7 +207,7 @@ local function removeFixturePackage(name)
     if not packageInstalled(name) then
       return
     end
-    waitForProfileSaveToPass()
+    assert.is_true(waitForProfileSaveToPass(), "a profile save was still running after 5s, so this uninstall would be refused")
     -- uninstallPackage() refuses while a profile save is in progress, and the
     -- installs here start one, so keep asking until it takes
     assert.is_true(waitUntil(function() return uninstallPackage(name) == true end, 5000),
@@ -234,7 +234,7 @@ local function removeFixtureModule(name)
     if not moduleInstalled(name) then
       break
     end
-    waitForProfileSaveToPass()
+    assert.is_true(waitForProfileSaveToPass(), "a profile save was still running after 5s, so this uninstall would be refused")
     assert.is_true(waitUntil(function() return uninstallModule(name) == true end, 5000),
                    "could not uninstall the fixture module " .. name)
     pumpEvents(200)

--- a/src/mudlet-lua/tests/Package_spec.lua
+++ b/src/mudlet-lua/tests/Package_spec.lua
@@ -69,20 +69,6 @@ local function defer(cleanup)
   cleanups[#cleanups + 1] = cleanup
 end
 
--- Mudlet stops responding part way through this file on macOS: every install
--- and uninstall starts a profile save, and on that platform the run wedges
--- somewhere in the middle of them, so the one-minute CI step for the Lua tests
--- is killed. Linux (including the AddressSanitizer build) and Windows run the
--- whole file fine. Until the save is fixed the specs that install something are
--- pending on macOS; the contract specs still run there.
-local installsWedgeThisPlatform = getOS() == "mac"
-
-local function requireWorkingInstalls()
-  if installsWedgeThisPlatform then
-    pending("installing a package wedges Mudlet on macOS - see the PR that added this file")
-  end
-end
-
 local function contains(haystack, needle)
   return type(haystack) == "string" and haystack:find(needle, 1, true) ~= nil
 end
@@ -327,9 +313,6 @@ describe("Tests the functionality of installPackage", function()
     local runsBefore, installEvents, packageEvents, handlers
 
     setup(function()
-      if installsWedgeThisPlatform then
-        return
-      end
       runsBefore = mudletSpecMinimalRuns or 0
       local genericHandler, detailedHandler
       installEvents, genericHandler = collectEvents("sysInstall")
@@ -341,9 +324,6 @@ describe("Tests the functionality of installPackage", function()
     end)
 
     teardown(function()
-      if installsWedgeThisPlatform then
-        return
-      end
       for _, handler in ipairs(handlers) do
         killAnonymousEventHandler(handler)
       end
@@ -351,7 +331,6 @@ describe("Tests the functionality of installPackage", function()
     end)
 
     it("unpacks the package into the profile and runs its contents", function()
-      requireWorkingInstalls()
       local packageDirectory = getMudletHomeDir() .. "/" .. minimalPackage
       assert.is_true(fileExists(packageDirectory), "the package folder was not created")
       assert.is_true(fileExists(packageDirectory .. "/config.lua"))
@@ -362,7 +341,6 @@ describe("Tests the functionality of installPackage", function()
     end)
 
     it("raises sysInstall and sysInstallPackage once the install is complete", function()
-      requireWorkingInstalls()
       assert.equals(1, #installEvents)
       assert.equals(minimalPackage, installEvents[1][1])
       assert.equals(1, #packageEvents)
@@ -371,14 +349,12 @@ describe("Tests the functionality of installPackage", function()
     end)
 
     it("refuses to install a package that is already installed", function()
-      requireWorkingInstalls()
       local err = installUntilRefused(installPackage, fixtureDirectory .. "/" .. minimalPackage .. ".mpackage")
       assert.is_true(contains(err, "package " .. minimalPackage .. " is already installed"), tostring(err))
     end)
   end)
 
   it("unpacks a folder of resources that ships with a package", function()
-    requireWorkingInstalls()
     withFixturePackage(resourcesPackage)
 
     local packageDirectory = getMudletHomeDir() .. "/" .. resourcesPackage
@@ -394,7 +370,6 @@ describe("Tests the functionality of installPackage", function()
   end)
 
   it("names a package after its file when the archive has no config.lua", function()
-    requireWorkingInstalls()
     withFixturePackage("mudlet-spec-noconfig")
 
     assert.equals(1, exists("mudlet-spec-noconfig alias", "alias"))
@@ -402,7 +377,6 @@ describe("Tests the functionality of installPackage", function()
   end)
 
   it("installs a package from a plain XML file", function()
-    requireWorkingInstalls()
     local path = fixtureDirectory .. "/sources/mudlet-spec-xmlonly/mudlet-spec-xmlonly.xml"
     defer(function() removeFixturePackage("mudlet-spec-xmlonly") end)
     installUntilConfirmed(installPackage, path, function() return packageInstalled("mudlet-spec-xmlonly") end,
@@ -430,7 +404,6 @@ describe("Tests the functionality of uninstallPackage", function()
   end)
 
   it("removes the package, its items and its folder, and raises the uninstall events", function()
-    requireWorkingInstalls()
     withFixturePackage(minimalPackage)
     local packageDirectory = getMudletHomeDir() .. "/" .. minimalPackage
     assert.is_true(fileExists(packageDirectory))
@@ -464,14 +437,10 @@ end)
 
 describe("Tests the package info accessors", function()
   setup(function()
-    if not installsWedgeThisPlatform then
-      installFixturePackage(minimalPackage)
-    end
+    installFixturePackage(minimalPackage)
   end)
   teardown(function()
-    if not installsWedgeThisPlatform then
-      removeFixturePackage(minimalPackage)
-    end
+    removeFixturePackage(minimalPackage)
   end)
 
   describe("Tests the functionality of getPackageInfo", function()
@@ -480,12 +449,10 @@ describe("Tests the package info accessors", function()
     end)
 
     it("raises a Lua error when the requested field is not a string", function()
-      requireWorkingInstalls()
       assertArgError(function() getPackageInfo(minimalPackage, {}) end, "getPackageInfo: bad argument #2 type")
     end)
 
     it("returns everything the package's config.lua declared", function()
-      requireWorkingInstalls()
       assert.same({
         mpackage = minimalPackage,
         author = "Mudlet test suite",
@@ -496,13 +463,11 @@ describe("Tests the package info accessors", function()
     end)
 
     it("returns a single field when one is named", function()
-      requireWorkingInstalls()
       assert.equals("1.0", getPackageInfo(minimalPackage, "version"))
       assert.equals("Mudlet test suite", getPackageInfo(minimalPackage, "author"))
     end)
 
     it("returns an empty string for a field the package does not have", function()
-      requireWorkingInstalls()
       assert.equals("", getPackageInfo(minimalPackage, "no-such-field"))
     end)
 
@@ -517,12 +482,10 @@ describe("Tests the package info accessors", function()
     end)
 
     it("raises a Lua error when the value is missing", function()
-      requireWorkingInstalls()
       assertArgError(function() setPackageInfo(minimalPackage, "version") end, "setPackageInfo: bad argument #3 type")
     end)
 
     it("round-trips a value through getPackageInfo", function()
-      requireWorkingInstalls()
       defer(function() setPackageInfo(minimalPackage, "version", "1.0") end)
 
       assert.is_true(setPackageInfo(minimalPackage, "version", "9.9"))
@@ -531,7 +494,6 @@ describe("Tests the package info accessors", function()
     end)
 
     it("adds a field the package did not declare", function()
-      requireWorkingInstalls()
       assert.is_true(setPackageInfo(minimalPackage, "spec-added", "yes"))
       assert.equals("yes", getPackageInfo(minimalPackage, "spec-added"))
     end)
@@ -552,9 +514,6 @@ describe("Tests the functionality of installModule", function()
     local runsBefore, installEvents, moduleEvents, handlers, modulePath
 
     setup(function()
-      if installsWedgeThisPlatform then
-        return
-      end
       runsBefore = mudletSpecModuleRuns or 0
       local genericHandler, detailedHandler
       installEvents, genericHandler = collectEvents("sysInstall")
@@ -565,9 +524,6 @@ describe("Tests the functionality of installModule", function()
     end)
 
     teardown(function()
-      if installsWedgeThisPlatform then
-        return
-      end
       for _, handler in ipairs(handlers) do
         killAnonymousEventHandler(handler)
       end
@@ -575,7 +531,6 @@ describe("Tests the functionality of installModule", function()
     end)
 
     it("installs the module, unpacks it and runs its contents", function()
-      requireWorkingInstalls()
       assert.is_true(moduleInstalled(moduleName))
       -- a module is not a package: it must not turn up in getPackages()
       assert.is_false(packageInstalled(moduleName))
@@ -585,7 +540,6 @@ describe("Tests the functionality of installModule", function()
     end)
 
     it("raises sysInstall and sysLuaInstallModule", function()
-      requireWorkingInstalls()
       assert.equals(1, #installEvents)
       assert.equals(moduleName, installEvents[1][1])
       assert.equals(1, #moduleEvents)
@@ -594,7 +548,6 @@ describe("Tests the functionality of installModule", function()
     end)
 
     it("refuses to install a module that is already installed", function()
-      requireWorkingInstalls()
       local err = installUntilRefused(installModule, modulePath)
       assert.is_true(contains(err, "module " .. moduleName .. " is already installed"), tostring(err))
     end)
@@ -611,7 +564,6 @@ describe("Tests the functionality of uninstallModule", function()
   end)
 
   it("removes the module, its items and its folder, and raises the uninstall events", function()
-    requireWorkingInstalls()
     withFixtureModule(moduleName)
     local moduleDirectory = getMudletHomeDir() .. "/" .. moduleName
     assert.is_true(fileExists(moduleDirectory))
@@ -643,14 +595,10 @@ describe("Tests the module accessors", function()
   local modulePath
 
   setup(function()
-    if not installsWedgeThisPlatform then
-      modulePath = installFixtureModule(moduleName)
-    end
+    modulePath = installFixtureModule(moduleName)
   end)
   teardown(function()
-    if not installsWedgeThisPlatform then
-      removeFixtureModule(moduleName)
-    end
+    removeFixtureModule(moduleName)
   end)
 
   describe("Tests the functionality of getModuleInfo", function()
@@ -659,7 +607,6 @@ describe("Tests the module accessors", function()
     end)
 
     it("returns everything the module's config.lua declared", function()
-      requireWorkingInstalls()
       assert.same({
         mpackage = moduleName,
         author = "Mudlet test suite",
@@ -670,7 +617,6 @@ describe("Tests the module accessors", function()
     end)
 
     it("returns a single field when one is named", function()
-      requireWorkingInstalls()
       assert.equals("3.1", getModuleInfo(moduleName, "version"))
       assert.equals("", getModuleInfo(moduleName, "no-such-field"))
     end)
@@ -682,12 +628,10 @@ describe("Tests the module accessors", function()
 
   describe("Tests the functionality of setModuleInfo", function()
     it("raises a Lua error when the value is missing", function()
-      requireWorkingInstalls()
       assertArgError(function() setModuleInfo(moduleName, "version") end, "setModuleInfo: bad argument #3 type")
     end)
 
     it("round-trips a value through getModuleInfo", function()
-      requireWorkingInstalls()
       defer(function() setModuleInfo(moduleName, "version", "3.1") end)
 
       assert.is_true(setModuleInfo(moduleName, "version", "8.8"))
@@ -698,7 +642,6 @@ describe("Tests the module accessors", function()
 
   describe("Tests the functionality of getModulePath", function()
     it("returns the file the module was installed from", function()
-      requireWorkingInstalls()
       assert.equals(modulePath, getModulePath(moduleName))
     end)
   end)
@@ -722,7 +665,6 @@ describe("Tests the module accessors", function()
 
   describe("Tests the functionality of setModulePriority", function()
     it("raises a Lua error when the priority is missing", function()
-      requireWorkingInstalls()
       assertArgError(function() setModulePriority(moduleName) end, "setModulePriority: bad argument #2 type")
     end)
 
@@ -733,7 +675,6 @@ describe("Tests the module accessors", function()
     end)
 
     it("returns no values and is read back by getModulePriority", function()
-      requireWorkingInstalls()
       assert.equals(0, select('#', setModulePriority(moduleName, 7)))
       assert.equals(7, getModulePriority(moduleName))
       setModulePriority(moduleName, -2)
@@ -759,7 +700,6 @@ describe("Tests the module accessors", function()
     end)
 
     it("turns syncing on for an installed module", function()
-      requireWorkingInstalls()
       -- leave the module unsynced: a profile save rewrites a synced module's
       -- own .mpackage, and the fixture copy is thrown away when this block ends
       defer(function() disableModuleSync(moduleName) end)
@@ -778,7 +718,6 @@ describe("Tests the module accessors", function()
     end)
 
     it("turns syncing back off", function()
-      requireWorkingInstalls()
       defer(function() disableModuleSync(moduleName) end)
       assert.is_true(enableModuleSync(moduleName))
 
@@ -799,7 +738,6 @@ describe("Tests the module accessors", function()
     end)
 
     it("is false for a module that nobody has turned syncing on for", function()
-      requireWorkingInstalls()
       assert.is_false(getModuleSync(moduleName))
     end)
   end)
@@ -817,18 +755,13 @@ describe("Tests the functionality of reloadModule", function()
 
   describe("with the fixture module installed", function()
     setup(function()
-      if not installsWedgeThisPlatform then
-        installFixtureModule(moduleName)
-      end
+      installFixtureModule(moduleName)
     end)
     teardown(function()
-      if not installsWedgeThisPlatform then
-        removeFixtureModule(moduleName)
-      end
+      removeFixtureModule(moduleName)
     end)
 
     it("runs the module's scripts again", function()
-      requireWorkingInstalls()
       local runsBefore = mudletSpecModuleRuns
 
       reloadModuleUntil(moduleName, function() return mudletSpecModuleRuns > runsBefore end)
@@ -838,7 +771,6 @@ describe("Tests the functionality of reloadModule", function()
     end)
 
     it("re-reads the module's info from its config.lua", function()
-      requireWorkingInstalls()
       setModuleInfo(moduleName, "title", "changed by the spec")
       assert.equals("changed by the spec", getModuleInfo(moduleName, "title"))
 
@@ -848,7 +780,6 @@ describe("Tests the functionality of reloadModule", function()
     end)
 
     it("keeps the module's priority and sync setting", function()
-      requireWorkingInstalls()
       defer(function() disableModuleSync(moduleName) end)
       setModulePriority(moduleName, 4)
       assert.is_true(enableModuleSync(moduleName))
@@ -867,7 +798,6 @@ describe("Tests a package that uninstalls itself", function()
   -- used to free the TScript objects that Host::raiseEvent() was still
   -- iterating over. Package auto-updaters do exactly this.
   it("survives a package uninstalling itself from its own event handler", function()
-    requireWorkingInstalls()
     defer(function()
       removeFixturePackage("mudlet-spec-selfuninstall")
       mudletSpecSelfUninstallHandler = nil

--- a/src/mudlet-lua/tests/Package_spec.lua
+++ b/src/mudlet-lua/tests/Package_spec.lua
@@ -97,21 +97,17 @@ local function assertArgError(fn, needle)
   assert.is_true(contains(err, needle), tostring(err))
 end
 
--- waitForEvent() spins the Qt event loop, so waiting for an event nothing ever
--- raises is how a spec gives Mudlet's queued work a chance to run: the install
--- events are raised from a zero-timer, and so is the profile save that
--- uninstallPackage() schedules.
-local function pumpEventLoop(milliseconds)
-  waitForEvent("mudletPackageSpecIdleEvent", milliseconds)
-end
-
+-- pumpEvents() keeps Mudlet delivering events for the given time, which is how
+-- a spec gives its queued work a chance to run: the install events are raised
+-- from a zero-timer, and so is the profile save that uninstallPackage()
+-- schedules.
 local function waitUntil(condition, timeoutMilliseconds)
   local waited = 0
   while waited < timeoutMilliseconds do
     if condition() then
       return true
     end
-    pumpEventLoop(50)
+    pumpEvents(50)
     waited = waited + 50
   end
   return condition() and true or false
@@ -185,7 +181,7 @@ local function installUntilConfirmed(install, path, isInstalled, what)
     if isInstalled() then
       return
     end
-    pumpEventLoop(400 * attempt)
+    pumpEvents(400 * attempt)
   end
   assert.is_true(false, "could not install " .. what)
 end
@@ -199,7 +195,7 @@ local function installUntilRefused(install, path)
     if ok == nil then
       return err
     end
-    pumpEventLoop(400 * attempt)
+    pumpEvents(400 * attempt)
   end
   assert.is_true(false, "the install was postponed instead of being answered")
 end
@@ -212,7 +208,7 @@ local function reloadModuleUntil(name, reloaded)
     if waitUntil(reloaded, 300) then
       return
     end
-    pumpEventLoop(400 * attempt)
+    pumpEvents(400 * attempt)
   end
   assert.is_true(false, "the module was never reloaded")
 end
@@ -232,7 +228,7 @@ local function removeFixturePackage(name)
                    "could not uninstall the fixture package " .. name)
     -- let the profile save that uninstallPackage() queues run now, rather than
     -- during Mudlet's shutdown
-    pumpEventLoop(200)
+    pumpEvents(200)
   end
   assert.is_false(packageInstalled(name), "the fixture package " .. name .. " reinstalled itself")
 end
@@ -255,7 +251,7 @@ local function removeFixtureModule(name)
     waitForProfileSaveToPass()
     assert.is_true(waitUntil(function() return uninstallModule(name) == true end, 5000),
                    "could not uninstall the fixture module " .. name)
-    pumpEventLoop(200)
+    pumpEvents(200)
   end
   assert.is_false(moduleInstalled(name), "the fixture module " .. name .. " reinstalled itself")
   os.remove(scratchDirectory .. "/" .. name .. ".mpackage")
@@ -900,7 +896,7 @@ describe("Tests a package that uninstalls itself", function()
     assert.equals(0, exists("mudletSpecSelfUninstallSecondHandler", "script"))
     -- raising the event again must not reach the removed scripts
     raiseEvent("mudletSpecSelfUninstall")
-    pumpEventLoop(100)
+    pumpEvents(100)
     assert.is_false(packageInstalled("mudlet-spec-selfuninstall"))
   end)
 end)
@@ -979,6 +975,6 @@ describe("The package specs clean up after themselves", function()
     -- Let the profile save that the last uninstall queued run while the profile
     -- is still up: it dereferences the profile when it fires, and Mudlet may be
     -- shutting down by the time it would otherwise get its turn.
-    pumpEventLoop(1500)
+    pumpEvents(1500)
   end)
 end)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7535,6 +7535,21 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
 void mudlet::armForceClose()
 {
     QTimer::singleShot(0ms, this, [this]() {
+        // Deferring by one event loop iteration is meant to get out of Lua
+        // before closing, but a test-mode waitForEvent() or pumpEvents() runs
+        // the event loop from inside Lua, so this can land right back in it.
+        // Wait for the pump instead of closing on top of it - both are bounded
+        // at 30s. Always false (so a straight close) outside MUDLET_TEST_MODE,
+        // where both helpers are inert.
+        for (auto pHost : mHostManager) {
+            if (pHost->getLuaInterpreter()->pumpingEvents()) {
+                qWarning() << "mudlet::armForceClose() - the test-mode event pump is running, waiting for it to finish";
+                QTimer::singleShot(50ms, this, [this]() {
+                    armForceClose();
+                });
+                return;
+            }
+        }
         forceClose();
     });
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1711,13 +1711,9 @@ void mudlet::slot_closeProfileRequested(int tab)
     });
 }
 
-// Closing one profile takes its Host, its interpreter and its lua_State with it.
-// A test-mode waitForEvent() or pumpEvents() is holding all three while it runs,
-// and is exactly what delivers the queued call that got us here, so closing now
-// would pull them out from under Lua code that is still executing. The
+// Closing a profile destroys the lua_State the pump is still executing on. The
 // application-wide close paths are deliberately not guarded like this: refusing
-// there would cancel a shutdown nobody would retry. Always false (so a no-op)
-// outside MUDLET_TEST_MODE, where both helpers are inert.
+// there would cancel a shutdown nobody would retry.
 bool mudlet::closeHeldOffByEventPump(Host* pHost) const
 {
     if (!pHost->getLuaInterpreter()->pumpingEvents()) {
@@ -7535,12 +7531,9 @@ void mudlet::onlyShowProfiles(const QStringList& predefinedProfiles)
 void mudlet::armForceClose()
 {
     QTimer::singleShot(0ms, this, [this]() {
-        // Deferring by one event loop iteration is meant to get out of Lua
-        // before closing, but a test-mode waitForEvent() or pumpEvents() runs
-        // the event loop from inside Lua, so this can land right back in it.
-        // Wait for the pump instead of closing on top of it - both are bounded
-        // at 30s. Always false (so a straight close) outside MUDLET_TEST_MODE,
-        // where both helpers are inert.
+        // Deferring by one event loop iteration is meant to land outside Lua,
+        // but the pump runs the event loop from inside Lua, so it can land
+        // right back in it. Retrying terminates: the pump is capped at 30s.
         for (auto pHost : mHostManager) {
             if (pHost->getLuaInterpreter()->pumpingEvents()) {
                 qWarning() << "mudlet::armForceClose() - the test-mode event pump is running, waiting for it to finish";
@@ -7726,11 +7719,9 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
     }
 }
 
-// Unlike the tab-close slots, by the time we get here the window and its
-// bookkeeping are already gone, so simply dropping the close while a test-mode
-// event pump is running would leave the profile loaded with no way to reach it.
-// Wait the pump out instead, the way armForceClose() does. Outside
-// MUDLET_TEST_MODE there is never a pump, so this closes straight away.
+// Unlike the tab-close slots, the window and its bookkeeping are already gone by
+// the time we get here, so dropping the close while the pump runs would leave
+// the profile loaded with no way to reach it. Wait the pump out instead.
 void mudlet::closeHostOfClosedDetachedWindow(const QString& profileName)
 {
     Host* pHost = mHostManager.getHost(profileName);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7723,7 +7723,7 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
 
         // Properly close the host to avoid dangling connections
         Host* pHost = mHostManager.getHost(profileName);
-        if (pHost) {
+        if (pHost && !closeHeldOffByEventPump(pHost)) {
             if (pHost->requestClose()) {
                 QTimer::singleShot(0ms, this, [this, profileName] {
                     closeHost(profileName);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7722,20 +7722,39 @@ void mudlet::slot_detachedWindowClosed(const QString& profileName)
         updateMainWindowTitle();
 
         // Properly close the host to avoid dangling connections
-        Host* pHost = mHostManager.getHost(profileName);
-        if (pHost && !closeHeldOffByEventPump(pHost)) {
-            if (pHost->requestClose()) {
-                QTimer::singleShot(0ms, this, [this, profileName] {
-                    closeHost(profileName);
-                    // Check to see if there are any profiles left...
-                    if (!mHostManager.getHostCount() && !mIsGoingDown) {
-                        disableToolbarButtons();
-                        slot_showConnectionDialog();
-                        setWindowTitle(scmVersion);
-                    }
-                });
+        closeHostOfClosedDetachedWindow(profileName);
+    }
+}
+
+// Unlike the tab-close slots, by the time we get here the window and its
+// bookkeeping are already gone, so simply dropping the close while a test-mode
+// event pump is running would leave the profile loaded with no way to reach it.
+// Wait the pump out instead, the way armForceClose() does. Outside
+// MUDLET_TEST_MODE there is never a pump, so this closes straight away.
+void mudlet::closeHostOfClosedDetachedWindow(const QString& profileName)
+{
+    Host* pHost = mHostManager.getHost(profileName);
+    if (!pHost) {
+        return;
+    }
+
+    if (closeHeldOffByEventPump(pHost)) {
+        QTimer::singleShot(50ms, this, [this, profileName]() {
+            closeHostOfClosedDetachedWindow(profileName);
+        });
+        return;
+    }
+
+    if (pHost->requestClose()) {
+        QTimer::singleShot(0ms, this, [this, profileName] {
+            closeHost(profileName);
+            // Check to see if there are any profiles left...
+            if (!mHostManager.getHostCount() && !mIsGoingDown) {
+                disableToolbarButtons();
+                slot_showConnectionDialog();
+                setWindowTitle(scmVersion);
             }
-        }
+        });
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1691,6 +1691,10 @@ void mudlet::slot_closeProfileRequested(int tab)
         return;
     }
 
+    if (closeHeldOffByEventPump(pH)) {
+        return;
+    }
+
     if (!pH->requestClose()) {
         return;
     }
@@ -1707,10 +1711,30 @@ void mudlet::slot_closeProfileRequested(int tab)
     });
 }
 
+// Closing one profile takes its Host, its interpreter and its lua_State with it.
+// A test-mode waitForEvent() or pumpEvents() is holding all three while it runs,
+// and is exactly what delivers the queued call that got us here, so closing now
+// would pull them out from under Lua code that is still executing. The
+// application-wide close paths are deliberately not guarded like this: refusing
+// there would cancel a shutdown nobody would retry. Always false (so a no-op)
+// outside MUDLET_TEST_MODE, where both helpers are inert.
+bool mudlet::closeHeldOffByEventPump(Host* pHost) const
+{
+    if (!pHost->getLuaInterpreter()->pumpingEvents()) {
+        return false;
+    }
+    qWarning() << "mudlet: asked to close profile" << pHost->getName() << "while the test-mode event pump is running on it, ignoring";
+    return true;
+}
+
 void mudlet::slot_closeProfileByName(const QString& profileName)
 {
     Host* pH = mHostManager.getHost(profileName);
     if (!pH) {
+        return;
+    }
+
+    if (closeHeldOffByEventPump(pH)) {
         return;
     }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -780,6 +780,7 @@ private:
     QPointer<QDockWidget> mpCurrentMapDockWidget;
 
     // Helper methods for detached windows
+    void closeHostOfClosedDetachedWindow(const QString& profileName);
     void detachTab(int tabIndex, const QPoint& position);
     void reattachTab(const QString& profileName, int insertIndex = -1);
     TMainConsole* removeConsoleFromSplitter(const QString& profileName);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -238,6 +238,7 @@ public:
     // operating without either menubar or main toolbar showing.
     bool isControlsVisible() const;
     bool isGoingDown() { return mIsGoingDown; }
+    bool closeHeldOffByEventPump(Host*) const;
     Host* loadProfile(const QString&, const bool, const QString& saveFileName = QString());
     bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
     bool loadWindowLayout();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UNIT_TESTS
     TMxpEdgeCasesTest
     TMxpElementDefinitionHandlerTest
     TLuaInterfaceTest
+    EventLoopPumpTest
     TVariableEditorTest
     SecureStringUtilsTest
     CredentialManagerTest
@@ -49,6 +50,11 @@ foreach(test_name ${UNIT_TESTS})
         ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
     )
 endforeach()
+
+# EventLoopPumpTest is the regression test for #9670, where the thing it covers
+# hung rather than failed. A wedge here should end the job in a minute, not run
+# out ctest's default 25.
+set_tests_properties(EventLoopPumpTest PROPERTIES TIMEOUT 60)
 
 # DiscordTest checks the Lua API permission gating contract by scanning the source
 target_compile_definitions(DiscordTest PRIVATE MUDLET_SRC_DIR="${CMAKE_SOURCE_DIR}/src")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,9 +51,8 @@ foreach(test_name ${UNIT_TESTS})
     )
 endforeach()
 
-# EventLoopPumpTest is the regression test for #9670, where the thing it covers
-# hung rather than failed. A wedge here should end the job in a minute, not run
-# out ctest's default 25.
+# A regression in what EventLoopPumpTest covers hangs rather than fails, so cap
+# it well under ctest's default 25 minutes.
 set_tests_properties(EventLoopPumpTest PROPERTIES TIMEOUT 60)
 
 # TKeySequenceEditTest's focus traversal cases need an active window, which an X

--- a/test/EventLoopPumpTest.cpp
+++ b/test/EventLoopPumpTest.cpp
@@ -25,12 +25,9 @@
 #include "EventLoopPump.h"
 
 /*
- * EventLoopPump exists because a nested QEventLoop::exec() entered from inside a
- * Qt timer callback stops seeing Qt timers on macOS, so a wait armed with a
- * QTimer never ends (issue #9670). The case that matters most here is therefore
- * pumpingFromInsideATimerCallback(): on the platform the bug lives on, running a
- * nested exec() in that position is what wedges, and these run on the macOS CI
- * legs.
+ * The macOS CI legs are what make pumpingFromInsideATimerCallback() worth
+ * having: that is the position a nested QEventLoop::exec() stops seeing Qt
+ * timers in (issue #9670), and no other platform reproduces it.
  */
 class EventLoopPumpTest : public QObject
 {
@@ -100,8 +97,8 @@ void EventLoopPumpTest::stopsWithoutPumpingWhenTheConditionAlreadyHolds()
     }));
     QVERIFY2(!mDelivered, "a condition that already held should not have pumped anything");
 
-    // The event is still queued rather than lost, and draining it here keeps it
-    // from turning up in the middle of the next test.
+    // Drain the still-queued event so it cannot turn up mid-way through the
+    // next test.
     QVERIFY(!EventLoopPump::pumpFor(20));
     QVERIFY(mDelivered);
 }
@@ -119,9 +116,8 @@ void EventLoopPumpTest::deliversATimerThatComesDueWhilePumping()
 
 void EventLoopPumpTest::pumpingFromInsideATimerCallback()
 {
-    // The #9670 shape. If Qt timers stop being delivered once the pump is
-    // entered from a timer callback, the inner timer never fires and the outer
-    // callback never finishes.
+    // A regression here hangs rather than fails: nothing ever completes the
+    // outer callback.
     bool innerFired = false;
     bool firedDuringPump = false;
     bool outerDone = false;

--- a/test/EventLoopPumpTest.cpp
+++ b/test/EventLoopPumpTest.cpp
@@ -1,0 +1,145 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include <QElapsedTimer>
+#include <QTimer>
+
+#include "EventLoopPump.h"
+
+/*
+ * EventLoopPump exists because a nested QEventLoop::exec() entered from inside a
+ * Qt timer callback stops seeing Qt timers on macOS, so a wait armed with a
+ * QTimer never ends (issue #9670). The case that matters most here is therefore
+ * pumpingFromInsideATimerCallback(): on the platform the bug lives on, running a
+ * nested exec() in that position is what wedges, and these run on the macOS CI
+ * legs.
+ */
+class EventLoopPumpTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void runsOutTheClockWithNoCondition();
+    void makesOnePassForAZeroTimeout();
+    void stopsAsSoonAsTheConditionHolds();
+    void stopsWithoutPumpingWhenTheConditionAlreadyHolds();
+    void deliversATimerThatComesDueWhilePumping();
+    void pumpingFromInsideATimerCallback();
+
+private:
+    bool mDelivered = false;
+};
+
+void EventLoopPumpTest::runsOutTheClockWithNoCondition()
+{
+    QElapsedTimer elapsed;
+    elapsed.start();
+    QVERIFY(!EventLoopPump::pumpFor(120));
+    QVERIFY2(elapsed.elapsed() >= 110, qPrintable(QString::number(elapsed.elapsed())));
+}
+
+void EventLoopPumpTest::makesOnePassForAZeroTimeout()
+{
+    bool delivered = false;
+    QMetaObject::invokeMethod(
+            this,
+            [&delivered]() {
+                delivered = true;
+            },
+            Qt::QueuedConnection);
+
+    QVERIFY(!EventLoopPump::pumpFor(0));
+    QVERIFY2(delivered, "a zero timeout did not deliver the already-posted event");
+}
+
+void EventLoopPumpTest::stopsAsSoonAsTheConditionHolds()
+{
+    bool done = false;
+    QTimer::singleShot(50, this, [&done]() {
+        done = true;
+    });
+
+    QElapsedTimer elapsed;
+    elapsed.start();
+    QVERIFY(EventLoopPump::pumpFor(5000, [&done]() {
+        return done;
+    }));
+    QVERIFY2(elapsed.elapsed() < 2000, qPrintable(QString::number(elapsed.elapsed())));
+}
+
+void EventLoopPumpTest::stopsWithoutPumpingWhenTheConditionAlreadyHolds()
+{
+    mDelivered = false;
+    QMetaObject::invokeMethod(
+            this,
+            [this]() {
+                mDelivered = true;
+            },
+            Qt::QueuedConnection);
+
+    QVERIFY(EventLoopPump::pumpFor(1000, []() {
+        return true;
+    }));
+    QVERIFY2(!mDelivered, "a condition that already held should not have pumped anything");
+
+    // The event is still queued rather than lost, and draining it here keeps it
+    // from turning up in the middle of the next test.
+    QVERIFY(!EventLoopPump::pumpFor(20));
+    QVERIFY(mDelivered);
+}
+
+void EventLoopPumpTest::deliversATimerThatComesDueWhilePumping()
+{
+    bool fired = false;
+    QTimer::singleShot(40, this, [&fired]() {
+        fired = true;
+    });
+
+    QVERIFY(!EventLoopPump::pumpFor(300));
+    QVERIFY2(fired, "a timer that came due during the pump did not fire");
+}
+
+void EventLoopPumpTest::pumpingFromInsideATimerCallback()
+{
+    // The #9670 shape. If Qt timers stop being delivered once the pump is
+    // entered from a timer callback, the inner timer never fires and the outer
+    // callback never finishes.
+    bool innerFired = false;
+    bool firedDuringPump = false;
+    bool outerDone = false;
+
+    QTimer::singleShot(0, this, [&]() {
+        QTimer::singleShot(40, this, [&innerFired]() {
+            innerFired = true;
+        });
+        QVERIFY(!EventLoopPump::pumpFor(300));
+        firedDuringPump = innerFired;
+        outerDone = true;
+    });
+
+    QVERIFY(EventLoopPump::pumpFor(5000, [&outerDone]() {
+        return outerDone;
+    }));
+    QVERIFY2(firedDuringPump, "a timer did not fire while pumping from inside a timer callback");
+}
+
+QTEST_MAIN(EventLoopPumpTest)
+#include "EventLoopPumpTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Fixes #9670 "Mudlet stops responding on macOS part way through the package specs": the test-only `waitForEvent()` ran a nested `QEventLoop::exec()`, which the Cocoa dispatcher services by re-entering `-[NSApplication run]` from inside the timer callout it is already in - so no Qt timer, including the wait's own timeout, ever fires again. `EventLoopPump::pumpFor()` drives `processEvents()` against a deadline instead, which activates Qt's timers on every pass.
- Lifts the macOS pending gate the package specs have carried since they were written: ~40 specs now run on both macOS legs, green.
- Fixes four pre-existing crashes (each reproduced on `development` under ASan) when a profile or the application is closed from a handler delivered during a wait: profile closes are held off while a pump runs, application shutdowns postpone rather than cancel.

#### Motivation for adding to Mudlet

macOS was the only platform not running the package specs, and the hang wedged real CI runs.

#### Other info (issues closed, discussion etc)

Test case: #9689's harness with this fix runs the previously hanging suite to completion (2277/0) on both macOS runners; this PR's own legs: 2370/0 on both macOS arches, 2426/0 on Linux with ASan and leak checking.

Assisted-by: Claude:claude-opus-5