### PR TITLE
infrastructure: leak checking now gates the functional tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -766,7 +766,7 @@ endif(USE_UPDATER)
 # Embed the LeakSanitizer suppression list into the binary so that
 # sanitizer-enabled builds (PTBs, testing AppImages) filter third-party noise
 # out of leak reports without needing LSAN_OPTIONS set at runtime; picked up
-# by __lsan_default_suppressions() in main.cpp
+# by __lsan_default_suppressions() in LsanHooks.cpp
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${mudlet_SOURCE_DIR}/asan-suppressions.txt")
 file(READ "${mudlet_SOURCE_DIR}/asan-suppressions.txt" MUDLET_LSAN_SUPPRESSIONS_CONTENT)
 string(REPLACE "\\" "\\\\" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPRESSIONS_CONTENT}")
@@ -774,6 +774,17 @@ string(REPLACE "\"" "\\\"" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPR
 string(REPLACE "\n" "\\n" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPRESSIONS_CONTENT}")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/LsanSuppressions.h.in" "${CMAKE_CURRENT_BINARY_DIR}/LsanSuppressions.h" @ONLY)
 target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+# LeakSanitizer resolves __lsan_default_suppressions/__lsan_default_options as
+# weak symbols, and a weak reference never pulls a member out of a static
+# archive. Keeping them inside ${LIB_MUDLET_TARGET} therefore only worked for
+# the mudlet executable, which drags the same object in for main(); the Qt Test
+# binaries supply their own main() via QTEST_MAIN and so linked no suppressions
+# at all. An OBJECT library gets its objects put on the link line directly, so
+# every target that links it definitely has the hooks.
+add_library(mudlet_lsan_hooks OBJECT LsanHooks.cpp)
+target_include_directories(mudlet_lsan_hooks PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+set_target_properties(mudlet_lsan_hooks PROPERTIES AUTOMOC OFF POSITION_INDEPENDENT_CODE ON)
 
 if(USE_3DMAPPER)
   target_link_libraries(${LIB_MUDLET_TARGET} OpenGL::GLU)
@@ -790,7 +801,7 @@ target_compile_options(${LIB_MUDLET_TARGET} PUBLIC -Wno-deprecated)
 
 add_executable(${EXE_MUDLET_TARGET} emptyFile.cpp)
 set_target_properties(${EXE_MUDLET_TARGET} PROPERTIES OUTPUT_NAME ${EXE_MUDLET_NAME})
-target_link_libraries(${EXE_MUDLET_TARGET} ${LIB_MUDLET_TARGET})
+target_link_libraries(${EXE_MUDLET_TARGET} ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
 
 # Enable symbol exports from the main executable so that dynamically loaded Lua modules
 # can find and use Lua API symbols (like lua_gettop) at runtime. Without this, modules

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -775,13 +775,11 @@ string(REPLACE "\n" "\\n" MUDLET_LSAN_SUPPRESSIONS_CONTENT "${MUDLET_LSAN_SUPPRE
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/LsanSuppressions.h.in" "${CMAKE_CURRENT_BINARY_DIR}/LsanSuppressions.h" @ONLY)
 target_include_directories(${LIB_MUDLET_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-# LeakSanitizer resolves __lsan_default_suppressions/__lsan_default_options as
-# weak symbols, and a weak reference never pulls a member out of a static
-# archive. Keeping them inside ${LIB_MUDLET_TARGET} therefore only worked for
-# the mudlet executable, which drags the same object in for main(); the Qt Test
-# binaries supply their own main() via QTEST_MAIN and so linked no suppressions
-# at all. An OBJECT library gets its objects put on the link line directly, so
-# every target that links it definitely has the hooks.
+# LeakSanitizer resolves its hooks as weak symbols and a weak reference never
+# pulls a member out of a static archive, so they cannot live in
+# ${LIB_MUDLET_TARGET}: binaries that bring their own main() (the Qt Test ones,
+# via QTEST_MAIN) would link no suppressions at all. An OBJECT library puts the
+# definitions on the link line of every target that links it.
 add_library(mudlet_lsan_hooks OBJECT LsanHooks.cpp)
 target_include_directories(mudlet_lsan_hooks PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(mudlet_lsan_hooks PROPERTIES AUTOMOC OFF POSITION_INDEPENDENT_CODE ON)

--- a/src/LsanHooks.cpp
+++ b/src/LsanHooks.cpp
@@ -19,23 +19,14 @@
 
 #include "LsanSuppressions.h"
 
-// These hooks are only consulted when the LeakSanitizer runtime is linked in
-// (USE_SANITIZER builds, i.e. PTBs and testing builds); elsewhere they are two
-// inert functions. They cannot be guarded with an "is ASAN on" macro check:
-// Mudlet only applies -fsanitize=address at link time, so no compiler macro is
-// set, and Qt's qcompilerdetection.h shims __has_feature to 0 on GCC anyway.
+// Inert unless the LeakSanitizer runtime is linked in. They cannot be guarded
+// with an "is ASAN on" macro check: Mudlet only applies -fsanitize=address at
+// link time, so no compiler macro is set, and Qt's qcompilerdetection.h shims
+// __has_feature to 0 on GCC anyway. Built as their own OBJECT library, see
+// src/CMakeLists.txt.
 
-// They live in their own translation unit, built as the mudlet_lsan_hooks
-// OBJECT library, because LeakSanitizer looks them up as weak symbols. A weak
-// reference does not pull a member out of a static archive, so keeping them in
-// mudlet_core would leave every binary that brings its own main() - the Qt Test
-// executables, which get theirs from QTEST_MAIN - without any suppressions at
-// all. Linking the OBJECT library directly puts the definitions on the link
-// line unconditionally, where the weak reference can bind to them.
-
-// Embeds the suppression list into the binary so leak reports shown to users
-// by testing/PTB builds exclude third-party noise (GPU drivers, font stack)
-// with no LSAN_OPTIONS needed at runtime:
+// Keeps third-party noise (GPU drivers, font stack) out of the leak reports
+// that testing/PTB builds show users, with no LSAN_OPTIONS set at runtime
 extern "C" const char* __lsan_default_suppressions()
 {
     return mudletLsanSuppressions;

--- a/src/LsanHooks.cpp
+++ b/src/LsanHooks.cpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "LsanSuppressions.h"
+
+// These hooks are only consulted when the LeakSanitizer runtime is linked in
+// (USE_SANITIZER builds, i.e. PTBs and testing builds); elsewhere they are two
+// inert functions. They cannot be guarded with an "is ASAN on" macro check:
+// Mudlet only applies -fsanitize=address at link time, so no compiler macro is
+// set, and Qt's qcompilerdetection.h shims __has_feature to 0 on GCC anyway.
+
+// They live in their own translation unit, built as the mudlet_lsan_hooks
+// OBJECT library, because LeakSanitizer looks them up as weak symbols. A weak
+// reference does not pull a member out of a static archive, so keeping them in
+// mudlet_core would leave every binary that brings its own main() - the Qt Test
+// executables, which get theirs from QTEST_MAIN - without any suppressions at
+// all. Linking the OBJECT library directly puts the definitions on the link
+// line unconditionally, where the weak reference can bind to them.
+
+// Embeds the suppression list into the binary so leak reports shown to users
+// by testing/PTB builds exclude third-party noise (GPU drivers, font stack)
+// with no LSAN_OPTIONS needed at runtime:
+extern "C" const char* __lsan_default_suppressions()
+{
+    return mudletLsanSuppressions;
+}
+
+// Without this, LeakSanitizer appends a "Suppressions used" summary to every
+// clean exit, which reads like an error to users:
+extern "C" const char* __lsan_default_options()
+{
+    return "print_suppressions=0";
+}

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1002,17 +1002,17 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     }
     protocolMenu->clear();
 
-    mEnableCHARSET = new QAction(tr("CHARSET: Character Encoding Standard"), nullptr);
+    mEnableCHARSET = new QAction(tr("CHARSET: Character Encoding Standard"), protocolMenu);
     mEnableCHARSET->setCheckable(true);
     mEnableCHARSET->setChecked(pHost->mEnableCHARSET);
     protocolMenu->addAction(mEnableCHARSET);
 
-    mEnableGMCP = new QAction(tr("GMCP: Generic Mud Communication Protocol"), nullptr);
+    mEnableGMCP = new QAction(tr("GMCP: Generic Mud Communication Protocol"), protocolMenu);
     mEnableGMCP->setCheckable(true);
     mEnableGMCP->setChecked(pHost->mEnableGMCP);
     protocolMenu->addAction(mEnableGMCP);
 
-    mEnableMNES = new QAction(tr("MNES: Mud New-Environ Standard"), nullptr);
+    mEnableMNES = new QAction(tr("MNES: Mud New-Environ Standard"), protocolMenu);
     mEnableMNES->setCheckable(true);
     mEnableMNES->setChecked(pHost->mEnableMNES);
     //: Tooltip for MNES protocol option explaining mutual exclusivity with NEW-ENVIRON
@@ -1020,37 +1020,37 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                                "including OSC link support."));
     protocolMenu->addAction(mEnableMNES);
 
-    mEnableMSDP = new QAction(tr("MSDP: Mud Server Data Protocol"), nullptr);
+    mEnableMSDP = new QAction(tr("MSDP: Mud Server Data Protocol"), protocolMenu);
     mEnableMSDP->setCheckable(true);
     mEnableMSDP->setChecked(pHost->mEnableMSDP);
     protocolMenu->addAction(mEnableMSDP);
 
-    mEnableMSP = new QAction(tr("MSP: Mud Sound Protocol"), nullptr);
+    mEnableMSP = new QAction(tr("MSP: Mud Sound Protocol"), protocolMenu);
     mEnableMSP->setCheckable(true);
     mEnableMSP->setChecked(pHost->mEnableMSP);
     protocolMenu->addAction(mEnableMSP);
 
-    mEnableMSSP = new QAction(tr("MSSP: Mud Server Status Protocol"), nullptr);
+    mEnableMSSP = new QAction(tr("MSSP: Mud Server Status Protocol"), protocolMenu);
     mEnableMSSP->setCheckable(true);
     mEnableMSSP->setChecked(pHost->mEnableMSSP);
     protocolMenu->addAction(mEnableMSSP);
 
-    mEnableMTTS = new QAction(tr("MTTS: Mud Terminal Type Standard"), nullptr);
+    mEnableMTTS = new QAction(tr("MTTS: Mud Terminal Type Standard"), protocolMenu);
     mEnableMTTS->setCheckable(true);
     mEnableMTTS->setChecked(pHost->mEnableMTTS);
     protocolMenu->addAction(mEnableMTTS);
 
-    mEnableMXP = new QAction(tr("MXP: Mud eXtension Protocol"), nullptr);
+    mEnableMXP = new QAction(tr("MXP: Mud eXtension Protocol"), protocolMenu);
     mEnableMXP->setCheckable(true);
     mEnableMXP->setChecked(pHost->mEnableMXP);
     protocolMenu->addAction(mEnableMXP);
 
-    mEnableNAWS = new QAction(tr("NAWS: Negotiate About Window Size"), nullptr);
+    mEnableNAWS = new QAction(tr("NAWS: Negotiate About Window Size"), protocolMenu);
     mEnableNAWS->setCheckable(true);
     mEnableNAWS->setChecked(pHost->mEnableNAWS);
     protocolMenu->addAction(mEnableNAWS);
 
-    mEnableNEWENVIRON = new QAction(tr("NEW-ENVIRON: Client Variables Standard"), nullptr);
+    mEnableNEWENVIRON = new QAction(tr("NEW-ENVIRON: Client Variables Standard"), protocolMenu);
     mEnableNEWENVIRON->setCheckable(true);
     mEnableNEWENVIRON->setChecked(pHost->mEnableNEWENVIRON);
     //: Tooltip for NEW-ENVIRON protocol option explaining mutual exclusivity with MNES
@@ -1069,7 +1069,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     pushButton_chooseProfiles->setEnabled(false);
     pushButton_copyMap->setEnabled(false);
     if (!mpMenu) {
-        mpMenu = new QMenu(tr("Other profiles to Map to:"));
+        mpMenu = new QMenu(tr("Other profiles to Map to:"), this);
     }
 
     mpMenu->clear();
@@ -1082,7 +1082,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             continue;
         }
 
-        auto pItem = new QAction(s, nullptr);
+        auto pItem = new QAction(s, mpMenu);
         pItem->setCheckable(true);
         pItem->setChecked(false);
         mpMenu->addAction(pItem);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,6 @@
 #include "TAccessibleConsole.h"
 #include "TAccessibleTextEdit.h"
 #include "FileOpenHandler.h"
-#include "LsanSuppressions.h"
 #include "SentryWrapper.h"
 #include "utils.h"
 #include <QFileInfo>
@@ -77,27 +76,6 @@
 #endif
 
 using namespace std::chrono_literals;
-
-// These hooks are only consulted when the LeakSanitizer runtime is linked in
-// (USE_SANITIZER builds, i.e. PTBs and testing builds); elsewhere they are two
-// inert functions. They cannot be guarded with an "is ASAN on" macro check:
-// Mudlet only applies -fsanitize=address at link time, so no compiler macro is
-// set, and Qt's qcompilerdetection.h shims __has_feature to 0 on GCC anyway.
-
-// Embeds the suppression list into the binary so leak reports shown to users
-// by testing/PTB builds exclude third-party noise (GPU drivers, font stack)
-// with no LSAN_OPTIONS needed at runtime:
-extern "C" const char* __lsan_default_suppressions()
-{
-    return mudletLsanSuppressions;
-}
-
-// Without this, LeakSanitizer appends a "Suppressions used" summary to every
-// clean exit, which reads like an error to users:
-extern "C" const char* __lsan_default_options()
-{
-    return "print_suppressions=0";
-}
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -951,7 +951,15 @@ void mudlet::setupConfig()
     }
     qDebug() << "mudlet::setupConfig() INFO:" << "using config dir:" << confPath;
 
-    mpSettings = new QSettings(qsl("%1/Mudlet.ini").arg(confPath), QSettings::IniFormat);
+    // delete any previous instance (tests call setupConfig() repeatedly) and
+    // parent the new one to the application, not this window: the window
+    // deletes itself on close (WA_DeleteOnClose) and the Updater - which
+    // holds this QSettings - must outlive it to offer an update after the
+    // last window closes (#9388). For the same reason setupConfig() must not
+    // be re-run once init() has created the Updater, as the delete would
+    // dangle the pointer the Updater holds.
+    delete mpSettings;
+    mpSettings = new QSettings(qsl("%1/Mudlet.ini").arg(confPath), QSettings::IniFormat, qApp);
     migrateConfig(*mpSettings);
 }
 
@@ -964,6 +972,18 @@ void mudlet::setupConfig()
 
 void mudlet::initEdbee()
 {
+    // edbee's init() has no re-entry guard - a second call reassigns all of
+    // its manager members and orphans the previous graph. Everything set up
+    // here is process-global (the edbee singleton, the Lua function list, Qt
+    // metatype registration), so one pass suffices even when tests construct
+    // several mudlet instances in one process (QTest's per-method init()
+    // re-runs mudlet::start() + mudlet::init() in many functional tests).
+    static bool initialised = false;
+    if (initialised) {
+        return;
+    }
+    initialised = true;
+
     auto edbee = edbee::Edbee::instance();
     edbee->init();
     edbee->autoShutDownOnAppExit();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -954,13 +954,10 @@ void mudlet::setupConfig()
     }
     qDebug() << "mudlet::setupConfig() INFO:" << "using config dir:" << confPath;
 
-    // delete any previous instance (tests call setupConfig() repeatedly) and
-    // parent the new one to the application, not this window: the window
-    // deletes itself on close (WA_DeleteOnClose) and the Updater - which
-    // holds this QSettings - must outlive it to offer an update after the
-    // last window closes (#9388). For the same reason setupConfig() must not
-    // be re-run once init() has created the Updater, as the delete would
-    // dangle the pointer the Updater holds.
+    // parented to the application, not this window: the window deletes itself
+    // on close and the Updater keeps using this QSettings past that point.
+    // Which is also why setupConfig() must not run again once init() has
+    // created the Updater - the delete below would dangle its pointer.
     delete mpSettings;
     mpSettings = new QSettings(qsl("%1/Mudlet.ini").arg(confPath), QSettings::IniFormat, qApp);
     migrateConfig(*mpSettings);
@@ -975,12 +972,10 @@ void mudlet::setupConfig()
 
 void mudlet::initEdbee()
 {
-    // edbee's init() has no re-entry guard - a second call reassigns all of
-    // its manager members and orphans the previous graph. Everything set up
-    // here is process-global (the edbee singleton, the Lua function list, Qt
-    // metatype registration), so one pass suffices even when tests construct
-    // several mudlet instances in one process (QTest's per-method init()
-    // re-runs mudlet::start() + mudlet::init() in many functional tests).
+    // edbee's init() has no re-entry guard - a second call reassigns all of its
+    // manager members and orphans the previous graph. Everything set up here is
+    // process-global, so one pass is enough however many mudlet instances a
+    // test constructs.
     static bool initialised = false;
     if (initialised) {
         return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,8 @@ set(UNIT_TESTS
 foreach(test_name ${UNIT_TESTS})
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} ${LIB_MUDLET_TARGET})
-    target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
+    # mudlet_lsan_hooks carries __lsan_default_suppressions; see src/CMakeLists.txt
+    target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
     set_tests_properties(${test_name} PROPERTIES
         ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,7 @@ set(UNIT_TESTS
 foreach(test_name ${UNIT_TESTS})
     add_executable(${test_name} ${test_name}.cpp)
     add_dependencies(${test_name} ${LIB_MUDLET_TARGET})
-    # mudlet_lsan_hooks carries __lsan_default_suppressions; see src/CMakeLists.txt
+    # mudlet_lsan_hooks has to be linked explicitly, see src/CMakeLists.txt
     target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
     set_tests_properties(${test_name} PROPERTIES

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -44,6 +44,7 @@ set(FUNCTIONAL_TEST_SOURCES
     ActionSelfUninstallTest.cpp
     ProfileFolderNameTest.cpp
     DialogTeardownTest.cpp
+    EdbeeReinitTest.cpp
     TMediaLoopTest.cpp
     DefaultPackagesTest.cpp
 )

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -91,11 +91,9 @@ if(REGISTER_PERF_BENCHMARK)
         TIMEOUT 600)
 endif()
 
-# Leak checking is on by default: LeakSanitizer's non-zero exit code makes a
-# leaking test fail ctest on sanitizer builds. Tests listed here still leak
-# and stay unchecked until their defects are fixed:
-# - dlgTriggerEditorUndoRedoTest: ~3.4MB editor tree-item QIcon/QPixmap graph,
-#   the dlgTriggerEditor instance is never destroyed by the test
+# These still leak and stay unchecked until their defects are fixed:
+# - dlgTriggerEditorUndoRedoTest: never destroys its dlgTriggerEditor, leaving
+#   ~3.4MB of tree-item QIcon/QPixmap behind
 # - UpdaterTeardownTest: Qt's one-time system CA-certificate store load on
 #   first TLS use, cached for the process lifetime
 set(leakCheckExcludedTests
@@ -103,9 +101,7 @@ set(leakCheckExcludedTests
     UpdaterTeardownTest
 )
 
-# mudlet_lsan_hooks below carries __lsan_default_suppressions; it has to be
-# linked explicitly because these binaries get their main() from QTEST_MAIN and
-# so never pull main.o (and with it the hooks) out of the mudlet_core archive.
+# mudlet_lsan_hooks has to be linked explicitly, see src/CMakeLists.txt
 foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     get_filename_component(test_name ${test_file} NAME_WE)
     add_executable(${test_name} ${test_file} ${FUNCTIONAL_TEST_UTILS})
@@ -113,9 +109,8 @@ foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
     set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+    # Apple's ASan runtime has no LeakSanitizer
     if(APPLE OR test_name IN_LIST leakCheckExcludedTests)
-        # Apple's ASan runtime does not support LeakSanitizer; the listed
-        # tests still leak (see leakCheckExcludedTests above)
         set(leakCheck "detect_leaks=0")
     else()
         set(leakCheck "detect_leaks=1")

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -63,7 +63,7 @@ set(FUNCTIONAL_TEST_UTILS
 # output - built but deliberately not registered with ctest:
 add_executable(UndoServerWrapReplay UndoServerWrapReplay.cpp ${FUNCTIONAL_TEST_UTILS})
 add_dependencies(UndoServerWrapReplay ${LIB_MUDLET_TARGET})
-target_link_libraries(UndoServerWrapReplay PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
+target_link_libraries(UndoServerWrapReplay PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
 set_target_properties(UndoServerWrapReplay PROPERTIES ENABLE_EXPORTS ON)
 
 # Report-only perf harness for manual before/after comparisons
@@ -75,7 +75,7 @@ set_target_properties(UndoServerWrapReplay PROPERTIES ENABLE_EXPORTS ON)
 option(REGISTER_PERF_BENCHMARK "Register the report-only PipelineBenchmark with ctest (it is built either way)" OFF)
 add_executable(PipelineBenchmark PipelineBenchmark.cpp ${FUNCTIONAL_TEST_UTILS})
 add_dependencies(PipelineBenchmark ${LIB_MUDLET_TARGET})
-target_link_libraries(PipelineBenchmark PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
+target_link_libraries(PipelineBenchmark PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
 set_target_properties(PipelineBenchmark PROPERTIES ENABLE_EXPORTS ON)
 if(REGISTER_PERF_BENCHMARK)
     add_test(NAME PipelineBenchmark COMMAND $<TARGET_FILE:PipelineBenchmark>)
@@ -86,11 +86,14 @@ if(REGISTER_PERF_BENCHMARK)
         TIMEOUT 600)
 endif()
 
+# mudlet_lsan_hooks below carries __lsan_default_suppressions; it has to be
+# linked explicitly because these binaries get their main() from QTEST_MAIN and
+# so never pull main.o (and with it the hooks) out of the mudlet_core archive.
 foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     get_filename_component(test_name ${test_file} NAME_WE)
     add_executable(${test_name} ${test_file} ${FUNCTIONAL_TEST_UTILS})
     add_dependencies(${test_name} ${LIB_MUDLET_TARGET})
-    target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET})
+    target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
     set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
     set_tests_properties(${test_name} PROPERTIES

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -86,6 +86,18 @@ if(REGISTER_PERF_BENCHMARK)
         TIMEOUT 600)
 endif()
 
+# Leak checking is on by default: LeakSanitizer's non-zero exit code makes a
+# leaking test fail ctest on sanitizer builds. Tests listed here still leak
+# and stay unchecked until their defects are fixed:
+# - dlgTriggerEditorUndoRedoTest: ~3.4MB editor tree-item QIcon/QPixmap graph,
+#   the dlgTriggerEditor instance is never destroyed by the test
+# - UpdaterTeardownTest: Qt's one-time system CA-certificate store load on
+#   first TLS use, cached for the process lifetime
+set(leakCheckExcludedTests
+    dlgTriggerEditorUndoRedoTest
+    UpdaterTeardownTest
+)
+
 # mudlet_lsan_hooks below carries __lsan_default_suppressions; it has to be
 # linked explicitly because these binaries get their main() from QTEST_MAIN and
 # so never pull main.o (and with it the hooks) out of the mudlet_core archive.
@@ -96,8 +108,15 @@ foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
     set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
     add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+    if(APPLE OR test_name IN_LIST leakCheckExcludedTests)
+        # Apple's ASan runtime does not support LeakSanitizer; the listed
+        # tests still leak (see leakCheckExcludedTests above)
+        set(leakCheck "detect_leaks=0")
+    else()
+        set(leakCheck "detect_leaks=1")
+    endif()
     set_tests_properties(${test_name} PROPERTIES
-        ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=detect_leaks=0"
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=${leakCheck}"
         LABELS "functional"
         TIMEOUT 60  # seconds
     )

--- a/test/functional_tests/DialogTeardownTest.cpp
+++ b/test/functional_tests/DialogTeardownTest.cpp
@@ -324,10 +324,6 @@ private slots:
         QVERIFY2(mpHost->getTriggerUnit()->findTrigger(nameBefore), "The trigger lost its name while the editor was destroyed");
     }
 
-    // The protocol actions are parented to their menu so QMenu::clear() in
-    // initWithHost() can delete them (they used to leak on every preferences
-    // open). Prove a reopened dialog repopulates the menu with live actions
-    // whose connections still fire
     void test_protocolActionsFireAfterPreferencesReopen()
     {
         mudlet::self()->showOptionsDialog(qsl("tab_general"), mpHost);
@@ -351,8 +347,8 @@ private slots:
         }
         QVERIFY2(gmcpAction, "GMCP protocol action not found under the reopened dialog - parenting to the menu broke discovery or population");
 
-        // initWithHost() connects the action's toggled() to this button's
-        // setEnabled(), so the button flipping proves the fresh action is wired
+        // initWithHost() wires GMCP's toggled() to this button's setEnabled(),
+        // so the button flipping proves the fresh action is connected
         const bool enabledBefore = preferences->pushButton_forgetSavedSignIn->isEnabled();
         QCOMPARE(enabledBefore, gmcpAction->isChecked());
         gmcpAction->toggle();

--- a/test/functional_tests/DialogTeardownTest.cpp
+++ b/test/functional_tests/DialogTeardownTest.cpp
@@ -40,6 +40,7 @@
 #include <QtTest/QtTest>
 #include <chrono>
 
+#include <QAction>
 #include <QKeySequenceEdit>
 #include <QLineEdit>
 #include <QScopeGuard>
@@ -321,6 +322,45 @@ private slots:
         // shows whether it ran while the editor was being destroyed
         QVERIFY2(!mpHost->getTriggerUnit()->findTrigger(typedName), "Being destroyed made the editor rename the trigger");
         QVERIFY2(mpHost->getTriggerUnit()->findTrigger(nameBefore), "The trigger lost its name while the editor was destroyed");
+    }
+
+    // The protocol actions are parented to their menu so QMenu::clear() in
+    // initWithHost() can delete them (they used to leak on every preferences
+    // open). Prove a reopened dialog repopulates the menu with live actions
+    // whose connections still fire
+    void test_protocolActionsFireAfterPreferencesReopen()
+    {
+        mudlet::self()->showOptionsDialog(qsl("tab_general"), mpHost);
+        QTest::qWait(100ms);
+        auto* first = mpHost->mpDlgProfilePreferences.data();
+        QVERIFY2(first, "Preferences dialog was not created");
+        delete first;
+        QVERIFY2(mpHost->mpDlgProfilePreferences.isNull(), "Preferences dialog should have been destroyed");
+
+        mudlet::self()->showOptionsDialog(qsl("tab_general"), mpHost);
+        QTest::qWait(100ms);
+        auto* preferences = mpHost->mpDlgProfilePreferences.data();
+        QVERIFY2(preferences, "Preferences dialog was not recreated");
+
+        QAction* gmcpAction = nullptr;
+        for (auto* action : preferences->findChildren<QAction*>()) {
+            if (action->text().startsWith(qsl("GMCP"))) {
+                gmcpAction = action;
+                break;
+            }
+        }
+        QVERIFY2(gmcpAction, "GMCP protocol action not found under the reopened dialog - parenting to the menu broke discovery or population");
+
+        // initWithHost() connects the action's toggled() to this button's
+        // setEnabled(), so the button flipping proves the fresh action is wired
+        const bool enabledBefore = preferences->pushButton_forgetSavedSignIn->isEnabled();
+        QCOMPARE(enabledBefore, gmcpAction->isChecked());
+        gmcpAction->toggle();
+        QCOMPARE(preferences->pushButton_forgetSavedSignIn->isEnabled(), !enabledBefore);
+        gmcpAction->toggle();
+        QCOMPARE(preferences->pushButton_forgetSavedSignIn->isEnabled(), enabledBefore);
+
+        delete preferences;
     }
 };
 

--- a/test/functional_tests/EdbeeReinitTest.cpp
+++ b/test/functional_tests/EdbeeReinitTest.cpp
@@ -18,13 +18,10 @@
  ***************************************************************************/
 
 /*
- * mudlet::initEdbee() runs only once per process: edbee's own init() has no
- * re-entry guard and a second call orphans the whole manager graph (~75KB a
- * time). This test pins the other half of that bargain - after a mudlet
- * instance is destroyed and a new one constructed (as every functional test
- * with a per-method init() does), the edbee singleton must still be fully
- * alive: Lua grammar present, Mudlet theme present, and the script editor
- * must open against them.
+ * mudlet::initEdbee() only runs once per process, so destroying a mudlet
+ * instance and constructing another - what every functional test with a
+ * per-method init() does - must leave the edbee singleton fully usable: Lua
+ * grammar, Mudlet theme, and a script editor that opens against them.
  *
  * Run with: ctest -R EdbeeReinitTest -V
  */
@@ -182,12 +179,9 @@ private slots:
 
     void test_editorAliveAfterMudletReconstruction()
     {
-        // first mudlet instance primes edbee, then goes away - the pattern of
-        // every functional test whose per-method init() re-boots mudlet
         bootMudlet();
         delete mudlet::self();
 
-        // second instance: initEdbee() takes its early return here
         bootMudlet();
         deleteProfileDirectory(mProfileName);
 

--- a/test/functional_tests/EdbeeReinitTest.cpp
+++ b/test/functional_tests/EdbeeReinitTest.cpp
@@ -1,0 +1,213 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * mudlet::initEdbee() runs only once per process: edbee's own init() has no
+ * re-entry guard and a second call orphans the whole manager graph (~75KB a
+ * time). This test pins the other half of that bargain - after a mudlet
+ * instance is destroyed and a new one constructed (as every functional test
+ * with a per-method init() does), the edbee singleton must still be fully
+ * alive: Lua grammar present, Mudlet theme present, and the script editor
+ * must open against them.
+ *
+ * Run with: ctest -R EdbeeReinitTest -V
+ */
+
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "dlgTriggerEditor.h"
+#include "mudlet.h"
+
+#include "edbee/edbee.h"
+#include "edbee/models/textgrammar.h"
+#include "edbee/views/texttheme.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+
+static void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+class EdbeeReinitTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("EdbeeReinit-Test-Profile");
+    QString mPort;
+    const QString mLocalhost = qsl("localhost");
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+        if (dir.exists() && !dir.removeRecursively()) {
+            qWarning() << "deleteProfileDirectory: could not remove" << path << "- later failures may stem from this stale state";
+        }
+    }
+
+    static void bootMudlet()
+    {
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+    }
+
+    void startProfile(const QString& profileName, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0ms, qApp, [profileName, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+
+            dlgConnectionProfiles* connectionDialog = mudlet::self()->mpConnectionDialog;
+            if (!connectionDialog || !connectionDialog->new_profile_button) {
+                qWarning() << "startProfile: connection dialog did not appear";
+                return;
+            }
+            QTest::mouseClick(connectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+
+            const auto focusedWidget = [](const char* step) -> QWidget* {
+                QWidget* widget = QApplication::focusWidget();
+                if (!widget) {
+                    qWarning() << "startProfile: no focused widget at step" << step;
+                }
+                return widget;
+            };
+
+            QWidget* nameField = focusedWidget("profile name");
+            if (!nameField) {
+                return;
+            }
+            QTest::keyClicks(nameField, profileName);
+            QTest::qWait(100ms);
+            QTest::keyClick(nameField, Qt::Key_Tab);
+            QTest::qWait(100ms);
+
+            QWidget* addressField = focusedWidget("address");
+            if (!addressField) {
+                return;
+            }
+            QTest::keyClicks(addressField, address);
+            QTest::qWait(100ms);
+            QTest::keyClick(addressField, Qt::Key_Tab);
+            QTest::qWait(100ms);
+
+            QWidget* portField = focusedWidget("port");
+            if (!portField) {
+                return;
+            }
+            QTest::keyClicks(portField, port);
+            QTest::qWait(100ms);
+            QTest::keyClick(portField, Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(2000)) {
+            QFAIL("Profile took too long to load.");
+        }
+
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResources();
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), qPrintable(qsl("TelnetServerStub failed to start: %1").arg(mpServer->errorString())));
+        mPort = QString::number(mpServer->serverPort());
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mProfileName);
+        delete mudlet::self();
+    }
+
+    void test_editorAliveAfterMudletReconstruction()
+    {
+        // first mudlet instance primes edbee, then goes away - the pattern of
+        // every functional test whose per-method init() re-boots mudlet
+        bootMudlet();
+        delete mudlet::self();
+
+        // second instance: initEdbee() takes its early return here
+        bootMudlet();
+        deleteProfileDirectory(mProfileName);
+
+        auto* edbee = edbee::Edbee::instance();
+        auto* luaGrammar = edbee->grammarManager()->get(qsl("source.lua"));
+        QVERIFY2(luaGrammar, "Lua grammar gone after mudlet reconstruction - initEdbee()'s once-guard left edbee unprimed");
+        // the editor picks its grammar by filename, so that path must agree
+        QCOMPARE(edbee->grammarManager()->detectGrammarWithFilename(qsl("Buck.lua")), luaGrammar);
+        QVERIFY2(edbee->themeManager()->theme(qsl("Mudlet")), "Mudlet editor theme gone after mudlet reconstruction");
+
+        startProfile(mProfileName, mLocalhost, mPort);
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+
+        mudlet::self()->slot_showScriptDialog();
+        QTest::qWait(100ms);
+        QVERIFY2(mpHost->mpEditorDialog, "Script editor did not open on the reconstructed mudlet instance");
+    }
+};
+
+#include "EdbeeReinitTest.moc"
+QTEST_MAIN(EdbeeReinitTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- 43 of 45 functional tests now run with `detect_leaks=1` and fail CI if they leak (the suite leaked 11.83MB before this PR). The LSan suppression hooks move into an OBJECT library so they actually bind into the test binaries.
- Fixes the three production leaks behind nearly all of it: the unparented `QSettings` (now application-parented, since the Updater holds the pointer past window close), edbee re-initialisation orphaning its managers on every repeat `mudlet::init()`, and the preferences dialog's menu `QAction`s (`QMenu::addAction()` does not take ownership).
- New `EdbeeReinitTest` and a preferences-reopen test lock the fixes in. Still excluded: `dlgTriggerEditorUndoRedoTest` (fixed in #9700) and `UpdaterTeardownTest` (Qt's one-time CA-store load).

#### Motivation for adding to Mudlet

Leaks in code covered by the functional suite now fail the build instead of accumulating silently, and two of the three fixes stop real leaks in production.

#### Other info (issues closed, discussion etc)

Test case: full serial suite passes twice, 45/45; settings persistence verified end-to-end under Xvfb. Startup unchanged (median 213ms vs 214ms); the suite's +62s is LSan's at-exit scan, no individual test regressed.

Assisted-by: Claude:claude-fable-5