### PR TITLE
fix: stop treating long-time Mudlet users as brand new players

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -176,7 +176,10 @@ mudlet::mudlet()
 void mudlet::init()
 {
     smFirstLaunch = !QFile::exists(mudlet::getMudletPath(enums::profilesPath));
-    // Has to happen here, before anything can create a profile - see rememberFirstLaunch()
+    // Has to happen after setupConfig() has created mpSettings and before
+    // anything can create a profile, which is only true here. Note this asks a
+    // slightly different question to smFirstLaunch above: an existing but empty
+    // profiles directory still counts as a first launch. See rememberFirstLaunch()
     rememberFirstLaunch(*mpSettings, mudlet::getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
 
     QFile gitShaFile(":/app-build.txt");
@@ -7554,25 +7557,57 @@ static constexpr int experiencedPlayerMonths = 6;
 
 static bool anyProfilesExist(const QString& profilesPath)
 {
-    return !QDir(profilesPath).entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty();
+    const QDir profiles(profilesPath);
+    if (!profiles.exists()) {
+        return false;
+    }
+    if (!QFileInfo(profilesPath).isReadable()) {
+        // An unlistable directory looks exactly like an empty one, and reading
+        // it as empty would stamp a long-time user with today's date as their
+        // first launch - permanently, since that is only ever written once.
+        qWarning() << "anyProfilesExist() WARNING - the profiles directory exists but cannot be read:" << profilesPath
+                   << "- assuming it holds profiles, so an existing user is not mistaken for a new one.";
+        return true;
+    }
+    return !profiles.entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty();
 }
 
-// Called once per run, before anything can create a profile, so "no profiles
-// yet" reliably means this is a brand new installation and today is the user's
-// day one. An installation that already has profiles was in use before this key
-// existed and its start date is simply not recoverable: profile directory and
-// file timestamps are rewritten by Mudlet's own saves, and a profile copied to a
-// new machine or restored from a backup looks new whichever timestamp is read.
-// Rather than record a guess, record nothing and let evaluateExperiencedPlayer()
-// fall back.
+// Evidence that Mudlet has run here before the first-launch key existed: a
+// profile, or any other setting already on file. Either rules out a first-ever
+// run, including for someone who kept their settings but not their profiles -
+// a restored backup, or a move to a new machine.
+static bool mudletUsedBefore(const QSettings& settings, const QString& profilesPath)
+{
+    return anyProfilesExist(profilesPath) || !settings.allKeys().isEmpty();
+}
+
+// Intended to be called exactly once, from init(), after setupConfig() has made
+// the settings available and before any profile or setting of this run can be
+// written - only then does "no trace of earlier use" really mean the user is
+// starting today.
+//
+// Where there is such a trace the start date is not recoverable, so nothing is
+// recorded and evaluateExperiencedPlayer() falls back instead. No timestamp can
+// stand in: Mudlet's own writes refresh them, and whether a copied or restored
+// profile keeps its modification times depends entirely on the tool used, while
+// its birth time is reset either way.
 /*static*/ void mudlet::rememberFirstLaunch(QSettings& settings, const QString& profilesPath, const QDateTime& now)
 {
-    if (settings.contains(settingsKeyFirstLaunch) || anyProfilesExist(profilesPath)) {
+    // The parse is deliberately not consulted: re-recording an unreadable value
+    // would restart the six month clock today, which is the harmful direction.
+    if (settings.contains(settingsKeyFirstLaunch) || mudletUsedBefore(settings, profilesPath)) {
         return;
     }
 
     settings.setValue(settingsKeyFirstLaunch, now.toUTC().toString(Qt::ISODate));
     settings.sync();
+    if (settings.status() != QSettings::NoError) {
+        // Worth saying out loud: the write is never retried, because by the next
+        // run the user has a profile and is indistinguishable from an upgrader.
+        // A newcomer who hits this loses their onboarding for good.
+        qWarning() << "mudlet::rememberFirstLaunch() WARNING - could not record the first launch date in" << settings.fileName() << "- QSettings status:" << settings.status()
+                   << "- this installation will later be taken for an experienced user's.";
+    }
 }
 
 // Returns true if the player has been using Mudlet long enough that first-time
@@ -7580,33 +7615,50 @@ static bool anyProfilesExist(const QString& profilesPath)
 // an interruption rather than a help.
 //
 // This used to be inferred from profile directory modification times, which
-// measured the opposite of what was wanted: a directory's mtime is bumped every
-// time a file inside it is created or renamed, which every QSaveFile profile
-// write does, so only a profile left untouched for six months looked old. An
-// active player of ten years' standing classified as brand new.
+// measured the opposite of what was wanted: the per-profile data writes (url,
+// port, password, profile.ini, command history) all land directly in the
+// profile directory and bump its mtime on every session, so only a profile left
+// untouched for the whole window ever looked old. An active player of ten
+// years' standing classified as brand new.
 /*static*/ bool mudlet::evaluateExperiencedPlayer(const QSettings& settings, const QString& profilesPath, const QDateTime& now)
 {
-    const QDateTime firstLaunch = QDateTime::fromString(settings.value(settingsKeyFirstLaunch).toString(), Qt::ISODate);
+    const QString recorded = settings.value(settingsKeyFirstLaunch).toString();
+    const QDateTime firstLaunch = QDateTime::fromString(recorded, Qt::ISODate);
     if (firstLaunch.isValid()) {
         return firstLaunch <= now.addMonths(-experiencedPlayerMonths);
     }
+    if (!recorded.isEmpty()) {
+        // The value is meant to be legible and hand-editable, so say when a
+        // hand-edit did not take rather than ignoring it in silence.
+        qWarning().nospace().noquote() << "evaluateExperiencedPlayer() WARNING - \"" << settingsKeyFirstLaunch << "\" holds \"" << recorded
+                                       << "\", which is not ISO 8601 - falling back to looking for signs of earlier use.";
+    }
 
-    // No record, so this installation predates the key - which is all we can
-    // tell, and owning a profile is the one thing that distinguishes it from a
-    // fresh install. Erring towards 'experienced' is deliberate: interrupting a
-    // veteran with a beginner tour is far worse than a newcomer missing one.
-    return anyProfilesExist(profilesPath);
+    // No usable record: an installation that predates the key, or one whose
+    // record was lost or corrupted. Either way the only signal left is whether
+    // Mudlet has been used here before. Erring towards 'experienced' is
+    // deliberate - interrupting a veteran with a beginner tour is far worse
+    // than a newcomer missing one.
+    return mudletUsedBefore(settings, profilesPath);
 }
 
 bool mudlet::experiencedMudletPlayer()
 {
     static std::optional<bool> cachedResult;
-    if (!cachedResult.has_value()) {
-        const auto* settings = getQSettings();
-        // Only reachable before setupConfig() has run, i.e. from tests: stay
-        // quiet rather than guess.
-        cachedResult = !settings || evaluateExperiencedPlayer(*settings, getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
+    if (cachedResult.has_value()) {
+        return cachedResult.value();
     }
+
+    const auto* settings = getQSettings();
+    if (!settings) {
+        // setupConfig() has not created them yet, so answer 'experienced',
+        // which shows nothing. Deliberately not cached: the answer is a guess,
+        // and caching it would pin every gate for the rest of the process.
+        qWarning() << "mudlet::experiencedMudletPlayer() WARNING - called before setupConfig(), so assuming an experienced player and showing no first-run guidance.";
+        return true;
+    }
+
+    cachedResult = evaluateExperiencedPlayer(*settings, getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
     return cachedResult.value();
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -176,6 +176,8 @@ mudlet::mudlet()
 void mudlet::init()
 {
     smFirstLaunch = !QFile::exists(mudlet::getMudletPath(enums::profilesPath));
+    // Has to happen here, before anything can create a profile - see rememberFirstLaunch()
+    rememberFirstLaunch(*mpSettings, mudlet::getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
 
     QFile gitShaFile(":/app-build.txt");
     if (!gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -7545,28 +7547,67 @@ void mudlet::showedCharacterModeWarning()
     mCharacterModeWarningsShown = std::min(mCharacterModeWarningsShown + 1, mCharacterModeWarningsMax);
 }
 
-// returns true if the Mudlet player is considered 'experienced' and doesn't need to be shown the basic
-// tutorial tips, such as splitscreen cancel shortcut
+// When Mudlet was first used on this installation, as UTC ISO-8601. Absent on
+// installations that predate the key - see rememberFirstLaunch().
+static const QLatin1String settingsKeyFirstLaunch("firstLaunchDate");
+static constexpr int experiencedPlayerMonths = 6;
+
+static bool anyProfilesExist(const QString& profilesPath)
+{
+    return !QDir(profilesPath).entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty();
+}
+
+// Called once per run, before anything can create a profile, so "no profiles
+// yet" reliably means this is a brand new installation and today is the user's
+// day one. An installation that already has profiles was in use before this key
+// existed and its start date is simply not recoverable: profile directory and
+// file timestamps are rewritten by Mudlet's own saves, and a profile copied to a
+// new machine or restored from a backup looks new whichever timestamp is read.
+// Rather than record a guess, record nothing and let evaluateExperiencedPlayer()
+// fall back.
+/*static*/ void mudlet::rememberFirstLaunch(QSettings& settings, const QString& profilesPath, const QDateTime& now)
+{
+    if (settings.contains(settingsKeyFirstLaunch) || anyProfilesExist(profilesPath)) {
+        return;
+    }
+
+    settings.setValue(settingsKeyFirstLaunch, now.toUTC().toString(Qt::ISODate));
+    settings.sync();
+}
+
+// Returns true if the player has been using Mudlet long enough that first-time
+// guidance - the interface tour, the starter UI, the one-line hints - would be
+// an interruption rather than a help.
+//
+// This used to be inferred from profile directory modification times, which
+// measured the opposite of what was wanted: a directory's mtime is bumped every
+// time a file inside it is created or renamed, which every QSaveFile profile
+// write does, so only a profile left untouched for six months looked old. An
+// active player of ten years' standing classified as brand new.
+/*static*/ bool mudlet::evaluateExperiencedPlayer(const QSettings& settings, const QString& profilesPath, const QDateTime& now)
+{
+    const QDateTime firstLaunch = QDateTime::fromString(settings.value(settingsKeyFirstLaunch).toString(), Qt::ISODate);
+    if (firstLaunch.isValid()) {
+        return firstLaunch <= now.addMonths(-experiencedPlayerMonths);
+    }
+
+    // No record, so this installation predates the key - which is all we can
+    // tell, and owning a profile is the one thing that distinguishes it from a
+    // fresh install. Erring towards 'experienced' is deliberate: interrupting a
+    // veteran with a beginner tour is far worse than a newcomer missing one.
+    return anyProfilesExist(profilesPath);
+}
+
 bool mudlet::experiencedMudletPlayer()
 {
     static std::optional<bool> cachedResult;
-    if (cachedResult.has_value()) {
-        return cachedResult.value();
+    if (!cachedResult.has_value()) {
+        const auto* settings = getQSettings();
+        // Only reachable before setupConfig() has run, i.e. from tests: stay
+        // quiet rather than guess.
+        cachedResult = !settings || evaluateExperiencedPlayer(*settings, getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
     }
-
-    // crude metric to check if the player is experienced in Mudlet: see if any of the profiles is more than 6mo old
-    QDir profilesDir(mudlet::getMudletPath(enums::profilesPath));
-    QFileInfoList entries = profilesDir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
-    QDateTime sixMonthsAgo = QDateTime::currentDateTime().addMonths(-6);
-
-    for (const QFileInfo& entry : std::as_const(entries)) {
-        if (entry.lastModified() < sixMonthsAgo) {
-            cachedResult = true;
-            return true;
-        }
-    }
-    cachedResult = false;
-    return false;
+    return cachedResult.value();
 }
 
 dlgTriggerEditor* mudlet::createMudletEditor()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -328,8 +328,13 @@ public:
     void showedMuteAllMediaTutorial();
     bool showCharacterModeWarning();
     void showedCharacterModeWarning();
+    // True if the player has used Mudlet long enough not to need the basic
+    // tutorial tips, the interface tour or the starter UI. Memoised.
     bool experiencedMudletPlayer();
+    // Records the first launch. Must be called exactly once, from init(),
+    // before any profile can exist - public only so it can be tested.
     static void rememberFirstLaunch(QSettings& settings, const QString& profilesPath, const QDateTime& now);
+    // The uncached body of experiencedMudletPlayer() - public only for testing.
     static bool evaluateExperiencedPlayer(const QSettings& settings, const QString& profilesPath, const QDateTime& now);
 
     // Telnet URI handling

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -60,6 +60,7 @@
 
 class QAction;
 class QCloseEvent;
+class QDateTime;
 class QDir;
 class QMediaDevices;
 class QMediaPlayer;
@@ -328,6 +329,8 @@ public:
     bool showCharacterModeWarning();
     void showedCharacterModeWarning();
     bool experiencedMudletPlayer();
+    static void rememberFirstLaunch(QSettings& settings, const QString& profilesPath, const QDateTime& now);
+    static bool evaluateExperiencedPlayer(const QSettings& settings, const QString& profilesPath, const QDateTime& now);
 
     // Telnet URI handling
     void handleTelnetUri(const QString& uri);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(FUNCTIONAL_TEST_SOURCES
     DialogTeardownTest.cpp
     TMediaLoopTest.cpp
     DefaultPackagesTest.cpp
+    ExperiencedPlayerGateTest.cpp
 )
 
 # The updater sources are only built with USE_UPDATER, and on macOS the

--- a/test/functional_tests/DefaultPackagesTest.cpp
+++ b/test/functional_tests/DefaultPackagesTest.cpp
@@ -135,8 +135,11 @@ private slots:
 
     // Games that install an interface of their own get a loader instead of the
     // starter UI, which would otherwise fight it for the same screen space.
+    // Every other game gets it, as long as the player is new to Mudlet - this
+    // config dir has no profiles and no recorded history, so they are.
     void test_gamesWithTheirOwnUiSkipTheStarterUi()
     {
+        QVERIFY(preinstallsFor(qsl("example.com")).contains(qsl(":/packages/mudlet-base-ui/mudlet-base-ui.mpackage")));
         QVERIFY(!preinstallsFor(qsl("mg.mud.de")).contains(qsl(":/packages/mudlet-base-ui/mudlet-base-ui.mpackage")));
         QVERIFY(preinstallsFor(qsl("mg.mud.de")).contains(qsl(":/packages/mg-loader/mg-loader.mpackage")));
     }

--- a/test/functional_tests/ExperiencedPlayerGateTest.cpp
+++ b/test/functional_tests/ExperiencedPlayerGateTest.cpp
@@ -1,0 +1,288 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Locks in who Mudlet considers an experienced player. That decision gates all
+ * of the first-time guidance - the interface tour, the starter UI package and
+ * the one-line hints - so getting it wrong either buries a newcomer's
+ * onboarding or drops a beginner tour on top of a ten-year veteran's session.
+ *
+ * The heuristic this replaced read profile *directory* mtimes, which record
+ * when a profile was last written, not how long it has existed: every
+ * QSaveFile profile write renames a temporary file into the directory and
+ * bumps its mtime, so only an abandoned profile ever looked old.
+ * test_upgraderWithFreshlyWrittenProfilesIsExperienced is that exact shape and
+ * is the regression this file exists for.
+ *
+ * mudlet::rememberFirstLaunch() and mudlet::evaluateExperiencedPlayer() take
+ * their settings, profiles path and "now" as arguments, so the table below runs
+ * without a mudlet instance. The last case drives the real setupConfig() to
+ * prove the recorded value and the reader agree on a live singleton.
+ *
+ * Run with: ctest -R ExperiencedPlayerGateTest -V
+ */
+
+#include <QtTest/QtTest>
+#include <QTimeZone>
+
+#include "mudlet.h"
+
+class ExperiencedPlayerGateTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QByteArray mSavedXdg;
+    // Fixed, so the six month arithmetic cannot straddle a real midnight
+    const QDateTime mNow = QDateTime(QDate(2026, 8, 5), QTime(12, 0), QTimeZone::UTC);
+    const QString mKey = qsl("firstLaunchDate");
+
+    QString profilesPathIn(const QString& configDir) const { return qsl("%1/profiles").arg(configDir); }
+
+    QString iniIn(const QString& configDir) const { return qsl("%1/Mudlet.ini").arg(configDir); }
+
+    // Returns the new profile directory, or an empty string if it could not be created
+    QString makeProfile(const QString& configDir, const QString& name) const
+    {
+        const QString path = qsl("%1/%2").arg(profilesPathIn(configDir), name);
+        return QDir().mkpath(path) ? path : QString();
+    }
+
+    void setFirstLaunch(QSettings& settings, const QDateTime& when) const { settings.setValue(mKey, when.toUTC().toString(Qt::ISODate)); }
+
+private slots:
+    void initTestCase() { mSavedXdg = qgetenv("XDG_CONFIG_HOME"); }
+
+    void cleanupTestCase()
+    {
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+        // The singleton the last case starts is intentionally not deleted: it
+        // was never init()'d, so its destructor would touch members only set up
+        // by init(), and the process exits right after anyway.
+    }
+
+    // --- a brand new installation --------------------------------------------
+
+    void test_freshInstallRecordsTodayAndIsNew()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        QVERIFY(!QDir(profilesPathIn(config.path())).exists());
+
+        mudlet::rememberFirstLaunch(settings, profilesPathIn(config.path()), mNow);
+
+        QCOMPARE(settings.value(mKey).toString(), mNow.toString(Qt::ISODate));
+        QVERIFY2(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow), "a first-ever launch must be treated as a new player");
+    }
+
+    // A profiles directory that exists but holds nothing is still a first run -
+    // an aborted earlier launch must not cost the user their onboarding.
+    void test_emptyProfilesDirectoryIsStillAFirstRun()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QVERIFY(QDir().mkpath(profilesPathIn(config.path())));
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+
+        mudlet::rememberFirstLaunch(settings, profilesPathIn(config.path()), mNow);
+
+        QVERIFY(settings.contains(mKey));
+        QVERIFY(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    // --- the recorded date, once there is one --------------------------------
+
+    void test_recentlyRecordedFirstLaunchIsNew()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        setFirstLaunch(settings, mNow.addMonths(-1));
+        QVERIFY(!makeProfile(config.path(), qsl("Achaea")).isEmpty());
+
+        QVERIFY2(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow), "a month of use is not enough to be experienced, even with a profile in hand");
+    }
+
+    void test_oldRecordedFirstLaunchIsExperienced()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        setFirstLaunch(settings, mNow.addYears(-3));
+
+        QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    void test_sixMonthBoundary()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        const QString profiles = profilesPathIn(config.path());
+
+        setFirstLaunch(settings, mNow.addMonths(-6).addDays(1));
+        QVERIFY2(!mudlet::evaluateExperiencedPlayer(settings, profiles, mNow), "one day short of six months is not yet experienced");
+
+        setFirstLaunch(settings, mNow.addMonths(-6));
+        QVERIFY2(mudlet::evaluateExperiencedPlayer(settings, profiles, mNow), "exactly six months of use is experienced");
+
+        setFirstLaunch(settings, mNow.addMonths(-6).addDays(-1));
+        QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profiles, mNow));
+    }
+
+    // A clock set forward and back, or settings carried between machines, can
+    // leave a first launch in the future. That is not tenure.
+    void test_futureDatedFirstLaunchIsNotExperienced()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        setFirstLaunch(settings, mNow.addYears(1));
+
+        QVERIFY(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    // --- upgrading users, who have no recorded first launch ------------------
+
+    // The regression: profiles written seconds ago by an installation that has
+    // been in use for years. The old directory-mtime heuristic called this a
+    // brand new player, which is how veterans ended up with the 5.0 tour.
+    void test_upgraderWithFreshlyWrittenProfilesIsExperienced()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        for (const auto& name : {qsl("Achaea"), qsl("StickMUD"), qsl("Legends of the Jedi")}) {
+            const QString profile = makeProfile(config.path(), name);
+            QVERIFY(!profile.isEmpty());
+            QFile url(qsl("%1/url").arg(profile));
+            QVERIFY(url.open(QIODevice::WriteOnly));
+            url.write("achaea.com");
+            url.close();
+            QVERIFY2(QFileInfo(profile).lastModified() > mNow.addMonths(-6), "the fixture is only meaningful while the profile directory looks brand new");
+        }
+
+        QVERIFY2(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow), "an installation with profiles but no recorded first launch predates the key, so it is experienced");
+    }
+
+    // Timestamps are not consulted at all, which is what makes a profile copied
+    // to a new machine or restored from a backup come out right - both reset
+    // every timestamp on it, including the birth time.
+    void test_restoredFromBackupIsExperienced()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        QVERIFY(!makeProfile(config.path(), qsl("Restored")).isEmpty());
+
+        QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    // Upgrading must not invent a first launch date - that would start the six
+    // month clock now and hand the veteran a tour six months from today.
+    void test_upgradeDoesNotRecordAFirstLaunch()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        QVERIFY(!makeProfile(config.path(), qsl("Achaea")).isEmpty());
+
+        mudlet::rememberFirstLaunch(settings, profilesPathIn(config.path()), mNow);
+
+        QVERIFY(!settings.contains(mKey));
+        QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow.addYears(1)));
+    }
+
+    void test_existingRecordIsNeverOverwritten()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        const QDateTime original = mNow.addMonths(-3);
+        setFirstLaunch(settings, original);
+
+        mudlet::rememberFirstLaunch(settings, profilesPathIn(config.path()), mNow);
+
+        QCOMPARE(settings.value(mKey).toString(), original.toString(Qt::ISODate));
+    }
+
+    // An unreadable or hand-edited value must not silently become "new player".
+    void test_unparseableRecordFallsBackToTheProfilesCheck()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        settings.setValue(mKey, qsl("not a date"));
+        QVERIFY(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+
+        QVERIFY(!makeProfile(config.path(), qsl("Achaea")).isEmpty());
+        QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    void test_recordedValueSurvivesAQSettingsRoundTrip()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        {
+            QSettings writer(iniIn(config.path()), QSettings::IniFormat);
+            mudlet::rememberFirstLaunch(writer, profilesPathIn(config.path()), mNow.addYears(-2));
+        }
+
+        QSettings reader(iniIn(config.path()), QSettings::IniFormat);
+        QVERIFY2(mudlet::evaluateExperiencedPlayer(reader, profilesPathIn(config.path()), mNow), "the recorded date must be readable back out of Mudlet.ini");
+
+        QFile ini(iniIn(config.path()));
+        QVERIFY(ini.open(QIODevice::ReadOnly | QIODevice::Text));
+        QVERIFY2(QString::fromUtf8(ini.readAll()).contains(qsl("firstLaunchDate=2024-08-05T12:00:00Z")), "the date is stored as plain ISO 8601, so it can be read and edited by hand");
+    }
+
+    // --- the live singleton --------------------------------------------------
+
+    // Proves the writer and the reader agree about which key and which profiles
+    // path they are using, through the real config resolution. Runs last
+    // because experiencedMudletPlayer() memoises for the life of the process.
+    void test_freshInstallIsNewThroughTheRealSettings()
+    {
+        if (QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()))) {
+            QSKIP("portable.txt present - setupConfig() takes the portable branch");
+        }
+        QTemporaryDir xdg;
+        QVERIFY(xdg.isValid());
+        // An empty $XDG_CONFIG_HOME/mudlet is the opt-in marker; without it
+        // setupConfig() would keep using the real ~/.config/mudlet
+        const QString configDir = qsl("%1/mudlet").arg(xdg.path());
+        QVERIFY(QDir().mkpath(configDir));
+        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), configDir);
+        const QString profiles = mudlet::getMudletPath(enums::profilesPath);
+        QVERIFY(!QDir(profiles).exists());
+
+        mudlet::rememberFirstLaunch(*mudlet::getQSettings(), profiles, QDateTime::currentDateTime());
+
+        QVERIFY(mudlet::getQSettings()->contains(mKey));
+        QVERIFY2(!mudlet::self()->experiencedMudletPlayer(), "a fresh install must classify as a new player through the real settings");
+    }
+};
+
+#include "ExperiencedPlayerGateTest.moc"
+QTEST_MAIN(ExperiencedPlayerGateTest)

--- a/test/functional_tests/ExperiencedPlayerGateTest.cpp
+++ b/test/functional_tests/ExperiencedPlayerGateTest.cpp
@@ -24,16 +24,16 @@
  * onboarding or drops a beginner tour on top of a ten-year veteran's session.
  *
  * The heuristic this replaced read profile *directory* mtimes, which record
- * when a profile was last written, not how long it has existed: every
- * QSaveFile profile write renames a temporary file into the directory and
- * bumps its mtime, so only an abandoned profile ever looked old.
+ * when a profile was last written rather than how long it has existed; see
+ * mudlet::evaluateExperiencedPlayer() for why that is backwards.
  * test_upgraderWithFreshlyWrittenProfilesIsExperienced is that exact shape and
  * is the regression this file exists for.
  *
  * mudlet::rememberFirstLaunch() and mudlet::evaluateExperiencedPlayer() take
- * their settings, profiles path and "now" as arguments, so the table below runs
- * without a mudlet instance. The last case drives the real setupConfig() to
- * prove the recorded value and the reader agree on a live singleton.
+ * their settings, profiles path and "now" as arguments, so the cases below run
+ * without a mudlet instance. The last two drive a real init() instead, to pin
+ * the production wiring: that init() records the date, and that the memoised
+ * experiencedMudletPlayer() reads back the same key from the same path.
  *
  * Run with: ctest -R ExperiencedPlayerGateTest -V
  */
@@ -41,7 +41,17 @@
 #include <QtTest/QtTest>
 #include <QTimeZone>
 
+#include "MudletInstanceCoordinator.h"
 #include "mudlet.h"
+
+// init() reads compiled-in resources, which are not registered automatically in
+// a test binary that links mudlet_core statically
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForExperiencedPlayerGateTest();
 
 class ExperiencedPlayerGateTest : public QObject
 {
@@ -49,7 +59,10 @@ class ExperiencedPlayerGateTest : public QObject
 
 private:
     QByteArray mSavedXdg;
-    // Fixed, so the six month arithmetic cannot straddle a real midnight
+    // Outlives the two live-singleton cases, which share one mudlet instance
+    QTemporaryDir mLiveConfig;
+    // Fixed, so the six month arithmetic is not at the mercy of the day the
+    // suite happens to run on
     const QDateTime mNow = QDateTime(QDate(2026, 8, 5), QTime(12, 0), QTimeZone::UTC);
     const QString mKey = qsl("firstLaunchDate");
 
@@ -57,7 +70,6 @@ private:
 
     QString iniIn(const QString& configDir) const { return qsl("%1/Mudlet.ini").arg(configDir); }
 
-    // Returns the new profile directory, or an empty string if it could not be created
     QString makeProfile(const QString& configDir, const QString& name) const
     {
         const QString path = qsl("%1/%2").arg(profilesPathIn(configDir), name);
@@ -66,15 +78,22 @@ private:
 
     void setFirstLaunch(QSettings& settings, const QDateTime& when) const { settings.setValue(mKey, when.toUTC().toString(Qt::ISODate)); }
 
+    // setupConfig() consults portable.txt before the XDG logic, so the
+    // live-singleton cases skip rather than report a baffling failure
+    bool portableMarkerPresent() const
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
 private slots:
     void initTestCase() { mSavedXdg = qgetenv("XDG_CONFIG_HOME"); }
 
     void cleanupTestCase()
     {
+        if (mudlet::self()) {
+            delete mudlet::self();
+        }
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
-        // The singleton the last case starts is intentionally not deleted: it
-        // was never init()'d, so its destructor would touch members only set up
-        // by init(), and the process exits right after anyway.
     }
 
     // --- a brand new installation --------------------------------------------
@@ -162,8 +181,8 @@ private slots:
     // --- upgrading users, who have no recorded first launch ------------------
 
     // The regression: profiles written seconds ago by an installation that has
-    // been in use for years. The old directory-mtime heuristic called this a
-    // brand new player, which is how veterans ended up with the 5.0 tour.
+    // been in use for years. The old directory-mtime heuristic classified this
+    // player as brand new, handing a veteran the beginner tour.
     void test_upgraderWithFreshlyWrittenProfilesIsExperienced()
     {
         QTemporaryDir config;
@@ -183,8 +202,9 @@ private slots:
     }
 
     // Timestamps are not consulted at all, which is what makes a profile copied
-    // to a new machine or restored from a backup come out right - both reset
-    // every timestamp on it, including the birth time.
+    // to a new machine or restored from a backup come out right: whether the
+    // modification times survive depends entirely on the tool used, and the
+    // birth time is reset either way.
     void test_restoredFromBackupIsExperienced()
     {
         QTemporaryDir config;
@@ -193,6 +213,47 @@ private slots:
         QVERIFY(!makeProfile(config.path(), qsl("Restored")).isEmpty());
 
         QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    // Settings restored without their profiles - a move to a new machine, or a
+    // user who deleted their last profile. Mudlet has clearly run here before,
+    // so they must not be stamped with today as their first launch.
+    void test_settingsWithoutProfilesStillCountAsEarlierUse()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        settings.setValue(qsl("pos"), QPoint(120, 80));
+        QVERIFY(!QDir(profilesPathIn(config.path())).exists());
+
+        mudlet::rememberFirstLaunch(settings, profilesPathIn(config.path()), mNow);
+
+        QVERIFY2(!settings.contains(mKey), "an installation with settings on file is not on its first run");
+        QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+    }
+
+    // A profiles directory that cannot be listed is indistinguishable from an
+    // empty one, so it must be read the safe way round - otherwise a home
+    // directory that mounted late would brand a veteran as a newcomer, for six
+    // months, with no way back.
+    void test_unreadableProfilesDirectoryIsTakenAsPopulated()
+    {
+        QTemporaryDir config;
+        QVERIFY(config.isValid());
+        QSettings settings(iniIn(config.path()), QSettings::IniFormat);
+        const QString profiles = profilesPathIn(config.path());
+        QVERIFY(!makeProfile(config.path(), qsl("Achaea")).isEmpty());
+        QVERIFY(QFile::setPermissions(profiles, QFileDevice::WriteOwner | QFileDevice::ExeOwner));
+        if (QFileInfo(profiles).isReadable()) {
+            QVERIFY(QFile::setPermissions(profiles, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner));
+            QSKIP("the profiles directory is readable despite the permissions - running as root?");
+        }
+
+        const bool experienced = mudlet::evaluateExperiencedPlayer(settings, profiles, mNow);
+        // Restore before asserting, so a failure does not leave QTemporaryDir
+        // unable to clean up after itself
+        QVERIFY(QFile::setPermissions(profiles, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner));
+        QVERIFY(experienced);
     }
 
     // Upgrading must not invent a first launch date - that would start the six
@@ -223,17 +284,21 @@ private slots:
         QCOMPARE(settings.value(mKey).toString(), original.toString(Qt::ISODate));
     }
 
-    // An unreadable or hand-edited value must not silently become "new player".
-    void test_unparseableRecordFallsBackToTheProfilesCheck()
+    // A corrupted or mistyped value must not be trusted as a date; it falls
+    // through to the earlier-use check, exactly like an upgrade does. It is also
+    // left alone rather than re-recorded, since re-recording would restart the
+    // six month clock today.
+    void test_unparseableRecordFallsBackToTheEarlierUseCheck()
     {
         QTemporaryDir config;
         QVERIFY(config.isValid());
         QSettings settings(iniIn(config.path()), QSettings::IniFormat);
         settings.setValue(mKey, qsl("not a date"));
-        QVERIFY(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
 
-        QVERIFY(!makeProfile(config.path(), qsl("Achaea")).isEmpty());
         QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
+
+        mudlet::rememberFirstLaunch(settings, profilesPathIn(config.path()), mNow);
+        QCOMPARE(settings.value(mKey).toString(), qsl("not a date"));
     }
 
     void test_recordedValueSurvivesAQSettingsRoundTrip()
@@ -255,34 +320,73 @@ private slots:
 
     // --- the live singleton --------------------------------------------------
 
-    // Proves the writer and the reader agree about which key and which profiles
-    // path they are using, through the real config resolution. Runs last
-    // because experiencedMudletPlayer() memoises for the life of the process.
-    void test_freshInstallIsNewThroughTheRealSettings()
+    // The whole fix rests on init() recording the date at a point where no
+    // profile can exist yet. Nothing else in the suite would notice that call
+    // being moved or dropped, and if it were, every fresh install would take
+    // the "used before" fallback and be classified experienced - silently
+    // killing the onboarding for exactly the people it is for.
+    void test_initRecordsTheFirstLaunchOnAFreshInstall()
     {
-        if (QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()))) {
+        if (portableMarkerPresent()) {
             QSKIP("portable.txt present - setupConfig() takes the portable branch");
         }
-        QTemporaryDir xdg;
-        QVERIFY(xdg.isValid());
-        // An empty $XDG_CONFIG_HOME/mudlet is the opt-in marker; without it
-        // setupConfig() would keep using the real ~/.config/mudlet
-        const QString configDir = qsl("%1/mudlet").arg(xdg.path());
+        QVERIFY(mLiveConfig.isValid());
+        // An empty $XDG_CONFIG_HOME/mudlet is the opt-in marker; on a machine
+        // with a legacy ~/.config/mudlet, setupConfig() would otherwise keep
+        // using that
+        const QString configDir = qsl("%1/mudlet").arg(mLiveConfig.path());
         QVERIFY(QDir().mkpath(configDir));
-        qputenv("XDG_CONFIG_HOME", xdg.path().toUtf8());
+        qputenv("XDG_CONFIG_HOME", mLiveConfig.path().toUtf8());
 
+        initializeQRCResourcesForExperiencedPlayerGateTest();
         mudlet::start();
         mudlet::self()->setupConfig();
         QCOMPARE(mudlet::getMudletPath(enums::mainPath), configDir);
-        const QString profiles = mudlet::getMudletPath(enums::profilesPath);
-        QVERIFY(!QDir(profiles).exists());
+        QVERIFY(!QDir(mudlet::getMudletPath(enums::profilesPath)).exists());
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
 
-        mudlet::rememberFirstLaunch(*mudlet::getQSettings(), profiles, QDateTime::currentDateTime());
+        mudlet::self()->init();
 
-        QVERIFY(mudlet::getQSettings()->contains(mKey));
-        QVERIFY2(!mudlet::self()->experiencedMudletPlayer(), "a fresh install must classify as a new player through the real settings");
+        QVERIFY2(mudlet::getQSettings()->contains(mKey), "init() must record the first launch date");
+        QCOMPARE(QDateTime::fromString(mudlet::getQSettings()->value(mKey).toString(), Qt::ISODate).isValid(), true);
+    }
+
+    // The direction that actually broke, through the memoised production path:
+    // an installation with a profile and no recorded date must come out
+    // experienced. Pins the key name and the profiles path that
+    // experiencedMudletPlayer() picks for itself, which the case above cannot -
+    // there, both branches would answer "new".
+    //
+    // Runs last: experiencedMudletPlayer() memoises for the life of the process.
+    void test_experiencedThroughTheRealSettings()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - setupConfig() takes the portable branch");
+        }
+        QVERIFY(mudlet::self());
+        auto* settings = mudlet::getQSettings();
+        QVERIFY(settings);
+        settings->remove(mKey);
+        QVERIFY(!makeProfile(mudlet::getMudletPath(enums::mainPath), qsl("Achaea")).isEmpty());
+
+        QVERIFY2(mudlet::self()->experiencedMudletPlayer(), "a profile with no recorded first launch must read as an experienced player");
     }
 };
+
+void initializeQRCResourcesForExperiencedPlayerGateTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
 
 #include "ExperiencedPlayerGateTest.moc"
 QTEST_MAIN(ExperiencedPlayerGateTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `experiencedMudletPlayer()` decided veteran status from profile **directory** mtimes. The per-profile data writes (url, port, password, `profile.ini`, command history) all land straight in that directory and bump its mtime every session, so only a profile *abandoned* for six months ever looked old - the more you use Mudlet, the more certainly it called you new. All 13 profiles on the maintainer's machine classified as "brand new player".
- Mudlet renewed those timestamps itself: the connection dialog rewrites `url`/`port`/`description` for the selected profile at startup, so merely launching Mudlet reset the value the gate read.
- Replaced with a `firstLaunchDate` key recorded in QSettings on a genuinely fresh install (written in `init()`, before anything can create a profile or save a setting). An installation with any trace of earlier use - a profile, or any other setting already on file - has no recoverable start date and is treated as experienced; timestamps cannot recover one, since a copied or restored profile keeps its modification times only if the tool used happened to preserve them, and loses its birth time regardless.

#### Motivation for adding to Mudlet
In 4.22.0 this gate only suppressed three one-line hints, but 5.0 hung the full-window "Welcome to Mudlet! New here?" tour (#9385, 69d7d4169 "Add: UI tour to complement the Mudlet tutorial") and the starter UI package (#9454, 69cd06b1c "add: starter interface with health bars, map and chat for new players") off it, so essentially every active 4.22.0 user upgrading to 5.0 would get a beginner tour dropped on top of their session.

#### Other info (issues closed, discussion etc)
The heuristic dates back to ae0564e6e "Improve: revise splitscreen tutorial (try 2)" (#7341); the two 5.0 consumers above are what turned it into a release blocker. New `ExperiencedPlayerGateTest` (18 cases) covers fresh install, upgrader with freshly-written profiles, settings restored without profiles, the six-month boundary, a profile restored from backup, future-dated, unparseable and unwritable records, and two live-singleton cases that pin the `init()` call site and the memoised read. Both directions were mutation-tested: dropping the `init()` call and restoring the old mtime heuristic each fail the suite. When in doubt the gate errs towards *experienced* - a veteran shown a new-user tour is a much worse outcome than a newcomer who misses it.

**Test case:** Seed a HOME that looks like an existing user (one profile, `Mudlet.ini` without `uiTourShown`), launch Mudlet and connect - before, the 6-step "Welcome to Mudlet!" tour appears; after, it does not. A HOME whose `Mudlet.ini` has a recent `firstLaunchDate` still gets the tour, and a genuinely empty HOME records one.

Assisted-by: Claude:claude-opus-5