### PR TITLE
infrastructure: assign milestones with the built-in token, not a PAT

### DIFF
--- a/.github/workflows/tag-pull-requests.yml
+++ b/.github/workflows/tag-pull-requests.yml
@@ -3,9 +3,13 @@ name: Pull request
 on:
   pull_request_target:
 
+# issues covers reading the milestone list and setting the milestone on the
+# pull request, which the REST API treats as an issue; pull-requests is granted
+# as well because GitHub gates issue endpoints on it when the target is a PR
 permissions:
   contents: read
-  issues: read
+  issues: write
+  pull-requests: write
 
 jobs:
   add-milestone:
@@ -46,16 +50,14 @@ jobs:
 
     - name: Assign PR to milestone
       env:
-        GH_TOKEN: ${{ secrets.GH_PAT_UPDATE_PULL_REQUESTS }}
+        # The built-in token has write access here because pull_request_target
+        # runs in the base repository; the fine-grained PAT this replaces was
+        # blocked by the organisation's 366-day token lifetime policy
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         set -euo pipefail
-
-        if [ -z "${GH_TOKEN:-}" ]; then
-          echo "::error::GH_PAT_UPDATE_PULL_REQUESTS is not available, so the milestone cannot be set"
-          exit 1
-        fi
 
         if [ -z "${MILESTONE_NUMBER:-}" ]; then
           echo "::error::No milestone number was resolved by the previous step"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The add-milestone check now fails on every PR: the Mudlet org forbids fine-grained PATs with a lifetime over 366 days, so every API call made with `GH_PAT_UPDATE_PULL_REQUESTS` returns HTTP 403. The old workflow swallowed this with unchecked `curl -s`; the strict error handling from #9679 (infrastructure: fix milestone assignment, unbreak the key sequence tests) surfaced it - first failure 25 minutes after that merge.
- Switches the "Assign PR to milestone" step to the built-in `GITHUB_TOKEN`, which already works in this workflow (the milestone-resolving step uses it and succeeded in the failing runs). `pull_request_target` runs in the base repository, so it has write access with `issues: write` / `pull-requests: write` granted.
- Removes the dependency on the `GH_PAT_UPDATE_PULL_REQUESTS` secret entirely, so no PAT needs re-minting and no future expiry can break this again.

Note: because this runs on `pull_request_target`, the default-branch copy of the workflow executes - the fix only takes effect after merge, so the add-milestone check on this PR itself will still fail.

#### Test case

The failing run's own log shows `GITHUB_TOKEN` succeeding at the milestone-read step while the PAT step 403s, confirming the built-in token works where the PAT does not.

Assisted-by: Claude:claude-fable-5