### PR TITLE
fix: a trigger that re-creates itself freezes Mudlet

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1103,9 +1103,12 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                 // again from any pass that re-enters in the meantime (a later
                 // trigger's script calling feedTriggers(), most commonly).
                 // setIsActive(false) rather than deactivate(), matching
-                // TriggerUnit::killTrigger(): it also clears the user-active state,
-                // so an enableTrigger() before the deferred free cannot resurrect a
-                // trigger that has already spent its last fire.
+                // TriggerUnit::killTrigger(): it also clears the user-active state.
+                // What stops an enableTrigger() before the deferred free from
+                // resurrecting a trigger that has spent its last fire is the
+                // markCleanup() below: TriggerUnit::enableTrigger() skips anything
+                // in mCleanupSet, as clearing the user-active state alone would
+                // not - enableTrigger() sets it straight back.
                 setIsActive(false);
                 mpHost->getTriggerUnit()->markCleanup(this);
 

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -307,68 +307,80 @@ int TriggerUnit::getNewID()
     return ++mMaxID;
 }
 
-// Ends a same-line creation loop that has used up the generation budget, and
-// tells the user which trigger to go and fix.
+// Ends a run of same-line trigger creation that has spent its budget, and tells
+// the user which trigger to go and fix.
 //
-// Abandoning the remaining generations is not enough on its own: everything the
-// loop created this pass is a live root trigger matching the same pattern, so
-// the next line would start with a budget's worth of them and each would spawn a
-// budget's worth again. Measured at 50 fires on the first such line and 2600 on
-// the second - the freeze would only be postponed by a few lines. The pass
-// therefore disowns what it created: temporary triggers go the way
-// killTrigger() sends them (deactivated now, freed once no script is on the
-// stack), permanent ones are only deactivated - deleting something the user can
-// see in the editor is not this function's call to make. A pass that is 50
-// generations deep is a runaway by construction, so nothing a working script
-// created can be caught by this.
+// Stopping the pass is not enough on its own: everything the loop created is a
+// live root trigger matching the same pattern, so the next line would start with
+// a budget's worth of them and each would spawn a budget's worth again. Measured
+// on the previous line: 50 fires on the first such line, 2600 on the second, so
+// the freeze would only be postponed. The pass therefore disowns what it
+// created, from firstNodeAddedThisPass to the end of the list.
 //
-// pendingIndex is where the generation that could not be run starts; the first
-// trigger still there names the script doing the re-creating, which in every
-// looping shape is the same script as its creator's.
-void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass, const qsizetype pendingIndex)
+// That range is every root trigger registered while this pass ran, not only the
+// loop's own offspring - the list records no lineage, so a capture trigger armed
+// by an unrelated script earlier on the same line is caught too. It is a
+// deliberate trade: on a line that has hit this budget the profile is producing
+// triggers faster than it can process them, and one missed capture beats a
+// frozen client. Temporary triggers go the way killTrigger() sends them
+// (deactivated now, freed once no script is on the stack); permanent ones are
+// only deactivated, and with deactivate() rather than setIsActive(false),
+// because the latter clears the user-active state that XMLexport writes to the
+// profile - the user would find them switched off after a restart.
+void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass)
 {
     QString triggerName;
-    for (qsizetype i = pendingIndex; i < mRootNodesAddedWhileProcessing.size(); ++i) {
-        if (auto trigger = mRootNodesAddedWhileProcessing.at(i); trigger) {
-            triggerName = trigger->getName();
-            break;
-        }
-    }
-
-    int disabledCount = 0;
+    int killedCount = 0;
+    int deactivatedCount = 0;
     for (qsizetype i = firstNodeAddedThisPass; i < mRootNodesAddedWhileProcessing.size(); ++i) {
         auto trigger = mRootNodesAddedWhileProcessing.at(i);
         if (!trigger) {
             continue;
         }
-        trigger->setIsActive(false);
+        // The last trigger created is the newest link in the chain, and its
+        // creator runs the same script in every looping shape seen so far
+        triggerName = trigger->getName();
         if (trigger->isTemporary()) {
+            trigger->setIsActive(false);
             markCleanup(trigger);
+            ++killedCount;
+        } else {
+            trigger->deactivate();
+            ++deactivatedCount;
         }
-        ++disabledCount;
     }
 
-    qWarning().nospace() << "TriggerUnit::processDataStream(...) aborting: triggers created while processing a line reached the limit of " << scmMaxProcessingDepth
-                         << " - probably a trigger that re-creates itself. " << disabledCount << " trigger(s) created during the line have been disabled.";
+    qWarning().nospace() << "TriggerUnit::processDataStream(...) aborting: triggers created while processing one line reached the limit of " << scmMaxSameLineCreations
+                         << " - probably a trigger that re-creates itself. Profile: " << (mpHost ? mpHost->getName() : QString()) << ", triggers removed: " << killedCount
+                         << ", deactivated: " << deactivatedCount << ", last one created: " << triggerName;
     if (!mpHost) {
         return;
     }
-    if (triggerName.isEmpty()) {
-        //: %n is a count of triggers. Shown in the game window when a trigger keeps creating new triggers that match the same line, which would otherwise never end
-        mpHost->postMessage(tr("[ ERROR ] - Trigger processing stopped to prevent a freeze: a trigger (or another trigger it creates) keeps creating new triggers that match the line being "
-                               "processed, so that line never finishes. The %n trigger(s) created while processing this line have been disabled. Create the trigger once, outside its own "
-                               "script, or give it a pattern that does not match the line it is created on.",
-                               nullptr,
-                               disabledCount));
+    // A runaway whose creator outlives the line trips again on every matching
+    // line, and this message is long enough to bury the game text if it is
+    // repeated. Say it, then hold off; the qWarning() above is not throttled, so
+    // a log or a crash report still has every occurrence.
+    constexpr qint64 reportIntervalMs = 10000;
+    if (mSameLineLoopReportTimer.isValid() && mSameLineLoopReportTimer.elapsed() < reportIntervalMs) {
         return;
     }
-    //: %1 is the name of a trigger - the name of a trigger made by tempTrigger() and friends is its id number - and %n is a count of triggers
+    mSameLineLoopReportTimer.start();
+
+    //: %n is a count of triggers. Shown in the game window when a trigger keeps creating new triggers that match the same line, which would otherwise never end
+    const QString created = tr("%n trigger(s) created while processing this line have been stopped: temporary ones removed, permanent ones switched off until the profile is reloaded.",
+                               nullptr,
+                               killedCount + deactivatedCount);
+    if (triggerName.isEmpty()) {
+        //: %1 is the sentence above, about the triggers that were stopped
+        mpHost->postMessage(tr("[ ERROR ] - Trigger processing stopped to prevent a freeze: a trigger (or another trigger it creates) keeps creating new triggers that match the line being "
+                               "processed, so that line never finishes. %1 Create the trigger once, outside its own script, or give it a pattern that does not match the line it is created on.")
+                                    .arg(created));
+        return;
+    }
+    //: %1 is the name of a trigger - the name of a trigger made by tempTrigger() and friends is its id number - and %2 is the sentence above, about the triggers that were stopped
     mpHost->postMessage(tr("[ ERROR ] - Trigger processing stopped to prevent a freeze: trigger '%1' (or another trigger it creates) keeps creating new triggers that match the line being "
-                           "processed, so that line never finishes. The %n trigger(s) created while processing this line have been disabled. Create the trigger once, outside its own "
-                           "script, or give it a pattern that does not match the line it is created on.",
-                           nullptr,
-                           disabledCount)
-                                .arg(triggerName));
+                           "processed, so that line never finishes. %2 Create the trigger once, outside its own script, or give it a pattern that does not match the line it is created on.")
+                                .arg(triggerName, created));
 }
 
 void TriggerUnit::processDataStream(const QString& data, int line)
@@ -388,13 +400,9 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     memcpy(subject, utf8Ptr, utf8Length);
     subject[utf8Length] = '\0';
 
-    const int entryProcessingDepth = mProcessingDepth;
     mProcessingDepth++;
-    // Restores rather than decrements: the same-line drain below spends a level
-    // of depth per generation of triggers it processes, and any of them can leave
-    // through this guard.
-    const auto processingGuard = qScopeGuard([this, entryProcessingDepth] {
-        mProcessingDepth = entryProcessingDepth;
+    const auto processingGuard = qScopeGuard([this] {
+        mProcessingDepth--;
         Q_ASSERT(mProcessingDepth >= 0);
         if (mProcessingDepth == 0) {
             // Deletion is deferred while any pass runs, so these pointers stayed
@@ -426,28 +434,23 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     }
     // Index-based loop: a match here can register yet more triggers, growing
     // the list; they too get a shot at the current line, just as with the
-    // live-list iteration. Taken one generation at a time - the triggers added
-    // while the previous generation ran - so that each round of same-line
-    // re-processing costs a level of the shared processing-depth budget. A
-    // trigger that re-creates itself otherwise extends the list in front of the
-    // loop for ever and the line never finishes: the depth stays at 1, so
-    // neither the feedTriggers() guard nor anything else notices (#9458 restored
-    // the same-line match without bounding it).
-    for (qsizetype generationStart = firstNodeAddedThisPass; generationStart < mRootNodesAddedWhileProcessing.size();) {
-        if (mProcessingDepth >= scmMaxProcessingDepth) {
-            stopSameLineCreationLoop(firstNodeAddedThisPass, generationStart);
+    // live-list iteration. That growth needs a ceiling, or a trigger that
+    // re-creates itself extends the list in front of the loop for ever and the
+    // line never finishes - 100% CPU and unbounded memory from one line of game
+    // text (#9458 restored the same-line match without bounding it). Nothing
+    // else catches it: no C++ frame recurses, so mProcessingDepth stays put and
+    // the feedTriggers() depth guard never sees it.
+    const qsizetype sameLineCreationBudget = firstNodeAddedThisPass + scmMaxSameLineCreations;
+    for (qsizetype i = firstNodeAddedThisPass; i < mRootNodesAddedWhileProcessing.size(); ++i) {
+        if (i >= sameLineCreationBudget) {
+            stopSameLineCreationLoop(firstNodeAddedThisPass);
             break;
         }
-        mProcessingDepth++;
-        const qsizetype generationEnd = mRootNodesAddedWhileProcessing.size();
-        for (qsizetype i = generationStart; i < generationEnd; ++i) {
-            auto trigger = mRootNodesAddedWhileProcessing.at(i);
-            if (!trigger || !trigger->isActive()) {
-                continue;
-            }
-            trigger->match(subject, data, line);
+        auto trigger = mRootNodesAddedWhileProcessing.at(i);
+        if (!trigger || !trigger->isActive()) {
+            continue;
         }
-        generationStart = generationEnd;
+        trigger->match(subject, data, line);
     }
     free(subject);
 }
@@ -513,13 +516,12 @@ bool TriggerUnit::enableTrigger(const QString& name)
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
         // A killed or expired temporary trigger is only unlinked from the lookup
-        // table once doCleanup() frees it, which is deferred while a trigger
-        // script is on the call stack - so it is still findable by name for the
-        // rest of the line. Re-activating that corpse resurrects it: a one-shot
-        // trigger fires a second time, and killTrigger() is undone from another
-        // script - see the guarantee TTrigger::match() relies on when it expires
-        // a trigger, and killTrigger() below, which skips corpses for the same
-        // reason.
+        // table once doCleanup() frees it, which does not happen while a pass is
+        // running - so it is still findable by name for the rest of the line.
+        // Re-activating that corpse resurrects it: a one-shot trigger fires a
+        // second time, and killTrigger() is undone from another script. This skip
+        // is what makes the guarantee TTrigger::match() states where it expires a
+        // trigger true; killTrigger() below skips corpses too, for its own reason.
         if (mCleanupSet.contains(it.value())) {
             continue;
         }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -313,9 +313,9 @@ int TriggerUnit::getNewID()
 // Stopping the pass is not enough on its own: everything the loop created is a
 // live root trigger matching the same pattern, so the next line would start with
 // a budget's worth of them and each would spawn a budget's worth again. Measured
-// on the previous line: 50 fires on the first such line, 2600 on the second, so
-// the freeze would only be postponed. The pass therefore disowns what it
-// created, from firstNodeAddedThisPass to the end of the list.
+// while trying that (with a smaller budget): 50 fires on the first such line,
+// 2600 on the second, so the freeze would only be postponed. The pass therefore
+// disowns what it created, from firstNodeAddedThisPass to the end of the list.
 //
 // That range is every root trigger registered while this pass ran, not only the
 // loop's own offspring - the list records no lineage, so a capture trigger armed

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -515,14 +515,16 @@ bool TriggerUnit::enableTrigger(const QString& name)
     // start mid-run and skip duplicates on some QMultiMap implementations
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
-        // A killed or expired temporary trigger is only unlinked from the lookup
-        // table once doCleanup() frees it, which does not happen while a pass is
+        // A trigger waiting to be freed is only unlinked from the lookup table
+        // once doCleanup() gets to it, which does not happen while a pass is
         // running - so it is still findable by name for the rest of the line.
         // Re-activating that corpse resurrects it: a one-shot trigger fires a
-        // second time, and killTrigger() is undone from another script. This skip
-        // is what makes the guarantee TTrigger::match() states where it expires a
-        // trigger true; killTrigger() below skips corpses too, for its own reason.
-        if (mCleanupSet.contains(it.value())) {
+        // second time, killTrigger() is undone from another script, and a trigger
+        // whose package a script uninstalled mid-pass (uninstallList, filled by
+        // uninstall() at a non-zero depth) starts firing again. This skip is what
+        // makes the guarantee TTrigger::match() states where it expires a trigger
+        // true; killTrigger() below skips mCleanupSet too, for its own reason.
+        if (mCleanupSet.contains(it.value()) || uninstallList.contains(it.value())) {
             continue;
         }
         it.value()->setIsActive(true);

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -307,6 +307,70 @@ int TriggerUnit::getNewID()
     return ++mMaxID;
 }
 
+// Ends a same-line creation loop that has used up the generation budget, and
+// tells the user which trigger to go and fix.
+//
+// Abandoning the remaining generations is not enough on its own: everything the
+// loop created this pass is a live root trigger matching the same pattern, so
+// the next line would start with a budget's worth of them and each would spawn a
+// budget's worth again. Measured at 50 fires on the first such line and 2600 on
+// the second - the freeze would only be postponed by a few lines. The pass
+// therefore disowns what it created: temporary triggers go the way
+// killTrigger() sends them (deactivated now, freed once no script is on the
+// stack), permanent ones are only deactivated - deleting something the user can
+// see in the editor is not this function's call to make. A pass that is 50
+// generations deep is a runaway by construction, so nothing a working script
+// created can be caught by this.
+//
+// pendingIndex is where the generation that could not be run starts; the first
+// trigger still there names the script doing the re-creating, which in every
+// looping shape is the same script as its creator's.
+void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass, const qsizetype pendingIndex)
+{
+    QString triggerName;
+    for (qsizetype i = pendingIndex; i < mRootNodesAddedWhileProcessing.size(); ++i) {
+        if (auto trigger = mRootNodesAddedWhileProcessing.at(i); trigger) {
+            triggerName = trigger->getName();
+            break;
+        }
+    }
+
+    int disabledCount = 0;
+    for (qsizetype i = firstNodeAddedThisPass; i < mRootNodesAddedWhileProcessing.size(); ++i) {
+        auto trigger = mRootNodesAddedWhileProcessing.at(i);
+        if (!trigger) {
+            continue;
+        }
+        trigger->setIsActive(false);
+        if (trigger->isTemporary()) {
+            markCleanup(trigger);
+        }
+        ++disabledCount;
+    }
+
+    qWarning().nospace() << "TriggerUnit::processDataStream(...) aborting: triggers created while processing a line reached the limit of " << scmMaxProcessingDepth
+                         << " - probably a trigger that re-creates itself. " << disabledCount << " trigger(s) created during the line have been disabled.";
+    if (!mpHost) {
+        return;
+    }
+    if (triggerName.isEmpty()) {
+        //: %n is a count of triggers. Shown in the game window when a trigger keeps creating new triggers that match the same line, which would otherwise never end
+        mpHost->postMessage(tr("[ ERROR ] - Trigger processing stopped to prevent a freeze: a trigger (or another trigger it creates) keeps creating new triggers that match the line being "
+                               "processed, so that line never finishes. The %n trigger(s) created while processing this line have been disabled. Create the trigger once, outside its own "
+                               "script, or give it a pattern that does not match the line it is created on.",
+                               nullptr,
+                               disabledCount));
+        return;
+    }
+    //: %1 is the name of a trigger - the name of a trigger made by tempTrigger() and friends is its id number - and %n is a count of triggers
+    mpHost->postMessage(tr("[ ERROR ] - Trigger processing stopped to prevent a freeze: trigger '%1' (or another trigger it creates) keeps creating new triggers that match the line being "
+                           "processed, so that line never finishes. The %n trigger(s) created while processing this line have been disabled. Create the trigger once, outside its own "
+                           "script, or give it a pattern that does not match the line it is created on.",
+                           nullptr,
+                           disabledCount)
+                                .arg(triggerName));
+}
+
 void TriggerUnit::processDataStream(const QString& data, int line)
 {
     if (data.isEmpty()) {
@@ -324,9 +388,13 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     memcpy(subject, utf8Ptr, utf8Length);
     subject[utf8Length] = '\0';
 
+    const int entryProcessingDepth = mProcessingDepth;
     mProcessingDepth++;
-    const auto processingGuard = qScopeGuard([this] {
-        mProcessingDepth--;
+    // Restores rather than decrements: the same-line drain below spends a level
+    // of depth per generation of triggers it processes, and any of them can leave
+    // through this guard.
+    const auto processingGuard = qScopeGuard([this, entryProcessingDepth] {
+        mProcessingDepth = entryProcessingDepth;
         Q_ASSERT(mProcessingDepth >= 0);
         if (mProcessingDepth == 0) {
             // Deletion is deferred while any pass runs, so these pointers stayed
@@ -358,13 +426,28 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     }
     // Index-based loop: a match here can register yet more triggers, growing
     // the list; they too get a shot at the current line, just as with the
-    // live-list iteration.
-    for (qsizetype i = firstNodeAddedThisPass; i < mRootNodesAddedWhileProcessing.size(); ++i) {
-        auto trigger = mRootNodesAddedWhileProcessing.at(i);
-        if (!trigger || !trigger->isActive()) {
-            continue;
+    // live-list iteration. Taken one generation at a time - the triggers added
+    // while the previous generation ran - so that each round of same-line
+    // re-processing costs a level of the shared processing-depth budget. A
+    // trigger that re-creates itself otherwise extends the list in front of the
+    // loop for ever and the line never finishes: the depth stays at 1, so
+    // neither the feedTriggers() guard nor anything else notices (#9458 restored
+    // the same-line match without bounding it).
+    for (qsizetype generationStart = firstNodeAddedThisPass; generationStart < mRootNodesAddedWhileProcessing.size();) {
+        if (mProcessingDepth >= scmMaxProcessingDepth) {
+            stopSameLineCreationLoop(firstNodeAddedThisPass, generationStart);
+            break;
         }
-        trigger->match(subject, data, line);
+        mProcessingDepth++;
+        const qsizetype generationEnd = mRootNodesAddedWhileProcessing.size();
+        for (qsizetype i = generationStart; i < generationEnd; ++i) {
+            auto trigger = mRootNodesAddedWhileProcessing.at(i);
+            if (!trigger || !trigger->isActive()) {
+                continue;
+            }
+            trigger->match(subject, data, line);
+        }
+        generationStart = generationEnd;
     }
     free(subject);
 }
@@ -429,6 +512,17 @@ bool TriggerUnit::enableTrigger(const QString& name)
     // start mid-run and skip duplicates on some QMultiMap implementations
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
+        // A killed or expired temporary trigger is only unlinked from the lookup
+        // table once doCleanup() frees it, which is deferred while a trigger
+        // script is on the call stack - so it is still findable by name for the
+        // rest of the line. Re-activating that corpse resurrects it: a one-shot
+        // trigger fires a second time, and killTrigger() is undone from another
+        // script - see the guarantee TTrigger::match() relies on when it expires
+        // a trigger, and killTrigger() below, which skips corpses for the same
+        // reason.
+        if (mCleanupSet.contains(it.value())) {
+            continue;
+        }
         it.value()->setIsActive(true);
         found = true;
     }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -26,6 +26,7 @@
 
 #include "utils.h"
 
+#include <QCoreApplication>
 #include <QMultiMap>
 #include <QPointer>
 #include <QSet>
@@ -38,6 +39,7 @@ class TTrigger;
 
 class TriggerUnit
 {
+    Q_DECLARE_TR_FUNCTIONS(TriggerUnit) // Needed so we can use tr() even though TriggerUnit is NOT derived from QObject
     friend class XMLexport;
     friend class XMLimport;
 
@@ -85,6 +87,8 @@ public:
     // it overflows the stack. Sized for the smallest platform stack (~1MB on
     // Windows, where the original crash hit before Lua's own 200-C-call guard):
     // a few times any legitimate nesting, comfortably below the native limit.
+    // The same budget bounds the generations of triggers that can be created
+    // while one line is being processed - see processDataStream().
     inline static const int scmMaxProcessingDepth = 50;
 
     QList<TTrigger*> uninstallList;
@@ -97,6 +101,7 @@ private:
     void addTrigger(TTrigger* pT);
     void removeTriggerRootNode(TTrigger* pT);
     void removeTrigger(TTrigger*);
+    void stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass, const qsizetype pendingIndex);
 
     QPointer<Host> mpHost;
     QMap<int, TTrigger*> mTriggerMap;

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -27,6 +27,7 @@
 #include "utils.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QMultiMap>
 #include <QPointer>
 #include <QSet>
@@ -87,9 +88,15 @@ public:
     // it overflows the stack. Sized for the smallest platform stack (~1MB on
     // Windows, where the original crash hit before Lua's own 200-C-call guard):
     // a few times any legitimate nesting, comfortably below the native limit.
-    // The same budget bounds the generations of triggers that can be created
-    // while one line is being processed - see processDataStream().
     inline static const int scmMaxProcessingDepth = 50;
+    // How many triggers created while one line is being processed may match that
+    // same line - see processDataStream(). A separate budget from the recursion
+    // depth above, which measures the C stack: this one measures how far a script
+    // can grow the list the pass is walking, and nothing recurses while it does.
+    // The behaviour it bounds (a room-capture script arming a catch-all trigger
+    // from the room title line) needs a handful; 100 leaves two orders of
+    // magnitude of headroom while keeping a runaway to a few milliseconds.
+    inline static const qsizetype scmMaxSameLineCreations = 100;
 
     QList<TTrigger*> uninstallList;
 
@@ -101,7 +108,7 @@ private:
     void addTrigger(TTrigger* pT);
     void removeTriggerRootNode(TTrigger* pT);
     void removeTrigger(TTrigger*);
-    void stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass, const qsizetype pendingIndex);
+    void stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass);
 
     QPointer<Host> mpHost;
     QMap<int, TTrigger*> mTriggerMap;
@@ -120,6 +127,9 @@ private:
     // pass can match the ones created during it against the line being
     // processed - see processDataStream(). Cleared once the outermost pass ends.
     QList<TTrigger*> mRootNodesAddedWhileProcessing;
+    // Throttles the same-line creation loop report: a runaway whose creator
+    // survives the line trips again on every matching line thereafter.
+    QElapsedTimer mSameLineLoopReportTimer;
 };
 
 #endif // MUDLET_TRIGGERUNIT_H

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -988,6 +988,25 @@ describe("Trigger processing", function()
             assert.are.equal(1, fires, "a trigger with expireAfter = 1 must not fire a second time")
         end)
 
+        it("does not let enableTrigger revive a trigger that is waiting to be freed", function()
+            -- a killed temporary trigger stays in the by-name lookup table until
+            -- the deferred delete runs, so it is still findable by name - but
+            -- enabling it again would resurrect a trigger already killed, and the
+            -- same window reopens a one-shot trigger that has spent its last fire
+            local name = "Spec Enable Resurrection"
+            _G.EnableResurrectionSpec = 0
+            finally(function() _G.EnableResurrectionSpec = nil end)
+
+            tempComplexRegexTrigger(name, "^enable_resurrection$",
+                [[_G.EnableResurrectionSpec = _G.EnableResurrectionSpec + 1]], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            assert.is_true(killTrigger(name))
+            assert.is_false(enableTrigger(name), "a killed trigger must not be re-enabled before it is freed")
+
+            feedTriggers("\nenable_resurrection\n")
+
+            assert.are.equal(0, _G.EnableResurrectionSpec, "a killed trigger must not fire, whatever enableTrigger was told")
+        end)
+
         it("keeps a same-named permanent trigger in the lookup table", function()
             local name = "Spec Name Eviction"
             _G.NameEvictionSpec = 0

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -110,11 +110,15 @@ set_tests_properties(ResetProfileTest PROPERTIES TIMEOUT 300)
 set_tests_properties(dlgTriggerEditorUndoRedoTest PROPERTIES TIMEOUT 300)
 
 # TriggerSameLineMatchTest creates a fresh profile per test method, so it needs a
-# longer timeout. Its self-re-creating-trigger cases are also the only thing
-# standing between a regression there and a test run that never ends - without
-# the generation budget in TriggerUnit::processDataStream() they do not fail,
-# they hang - so this timeout is what turns that into a reported failure.
-set_tests_properties(TriggerSameLineMatchTest PROPERTIES TIMEOUT 300)
+# longer timeout. Its self-re-creating-trigger cases do not fail on a regression,
+# they hang and grow the heap by ~110MB/s, so the two backstops below are what
+# turn that into a reported failure: an RSS ceiling that aborts in seconds rather
+# than letting a runner's OOM killer pick a victim, and the timeout behind it.
+# The ENVIRONMENT here replaces the one the loop above sets, so it repeats
+# QT_QPA_PLATFORM.
+set_tests_properties(TriggerSameLineMatchTest PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=detect_leaks=0:hard_rss_limit_mb=3000"
+    TIMEOUT 300)
 
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -109,6 +109,13 @@ set_tests_properties(ResetProfileTest PROPERTIES TIMEOUT 300)
 # Undo/redo tests need a longer timeout due to large batch operations
 set_tests_properties(dlgTriggerEditorUndoRedoTest PROPERTIES TIMEOUT 300)
 
+# TriggerSameLineMatchTest creates a fresh profile per test method, so it needs a
+# longer timeout. Its self-re-creating-trigger cases are also the only thing
+# standing between a regression there and a test run that never ends - without
+# the generation budget in TriggerUnit::processDataStream() they do not fail,
+# they hang - so this timeout is what turns that into a reported failure.
+set_tests_properties(TriggerSameLineMatchTest PROPERTIES TIMEOUT 300)
+
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 300)
 

--- a/test/functional_tests/TriggerSameLineMatchTest.cpp
+++ b/test/functional_tests/TriggerSameLineMatchTest.cpp
@@ -230,9 +230,11 @@ private slots:
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
         QVERIFY2(bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "Expected the same-line re-creation abort error in the console buffer");
         // One fire from the trigger that was already there when the line arrived,
-        // then one per generation the budget allows.
-        QVERIFY2(bufferContains(qsl("LOOPFIRES=%1").arg(TriggerUnit::scmMaxProcessingDepth)),
-                 qPrintable(qsl("Expected the re-arming trigger to fire exactly %1 times").arg(TriggerUnit::scmMaxProcessingDepth)));
+        // then one per trigger the budget lets the re-arming chain add to it. The
+        // trailing # anchors the count: without it the check also passes on ten
+        // times the number.
+        const int expectedFires = 1 + static_cast<int>(TriggerUnit::scmMaxSameLineCreations);
+        QVERIFY2(bufferContains(qsl("LOOPFIRES=%1#").arg(expectedFires)), qPrintable(qsl("Expected the re-arming trigger to fire exactly %1 times").arg(expectedFires)));
     }
 
     // The abort has to name the trigger to be actionable - the user has to know
@@ -275,16 +277,17 @@ private slots:
                                                                "echo('CHAINFIRES=' .. chainFires .. '#\\n')\n"));
 
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
-        QVERIFY2(bufferContains(qsl("CHAINFIRES=10")), "Expected all ten generations of the finite chain to match the current line");
+        QVERIFY2(bufferContains(qsl("CHAINFIRES=10#")), "Expected all ten generations of the finite chain to match the current line");
         QVERIFY2(!bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "A chain that ends on its own must not trip the same-line generation budget");
     }
 
     // Stopping the line is only half of it. A re-arming trigger with no expiry
     // leaves everything it created still active, so the next line would start
     // with a budget's worth of them and each would spawn a budget's worth again:
-    // measured at 50 fires on the first line and 2600 on the second, i.e. the
-    // freeze merely postponed. The abort therefore disables what the loop created
-    // during the line, which holds it at the same cost per line for ever.
+    // measured at 50 fires on the first line and 2600 on the second (with an
+    // earlier, smaller budget), i.e. the freeze merely postponed. The abort
+    // therefore stops what was created during the line, which holds the cost at
+    // one budget per line for ever.
     void test_selfRecreatingTriggerDoesNotAccumulateAcrossLines()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -302,8 +305,68 @@ private slots:
                                                                "echo('KEPTFIRES=' .. keptFires .. '#\\n')\n"));
 
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
-        QVERIFY2(bufferContains(qsl("KEPTFIRES=%1").arg(2 * TriggerUnit::scmMaxProcessingDepth)),
-                 qPrintable(qsl("Expected the second line to cost the same %1 fires as the first, not a multiple of them").arg(TriggerUnit::scmMaxProcessingDepth)));
+        const int firesPerLine = 1 + static_cast<int>(TriggerUnit::scmMaxSameLineCreations);
+        QVERIFY2(bufferContains(qsl("KEPTFIRES=%1#").arg(2 * firesPerLine)),
+                 qPrintable(qsl("Expected the second line to cost the same %1 fires as the first, not a multiple of them").arg(firesPerLine)));
+    }
+
+    // permRegexTrigger() from a trigger's script loops the same way, and those
+    // objects are saved with the profile. They must be stopped like the temporary
+    // ones, but not deleted (the user owns them, and they are visible in the
+    // editor) and not switched off in a way that survives a save: deactivate()
+    // leaves the user-active state XMLexport writes alone, so a restart brings
+    // them back rather than confronting the user with a tree of unticked
+    // triggers they never touched.
+    void test_selfRecreatingPermanentTriggerIsStoppedButNotDeleted()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("permFires = 0\n"
+                                                               "function armPerm()\n"
+                                                               "  permRegexTrigger('Perm Loop', '', {'^permloop$'}, [[permFires = permFires + 1; armPerm()]])\n"
+                                                               "end\n"
+                                                               "armPerm()\n"
+                                                               "feedTriggers('permloop\\n')\n"
+                                                               "echo('PERMFIRES=' .. permFires .. '#\\n')\n"
+                                                               "echo('PERMACTIVE=' .. isActive('Perm Loop', 'trigger') .. '#\\n')\n"
+                                                               "echo('PERMEXISTS=' .. exists('Perm Loop', 'trigger') .. '#\\n')\n"));
+
+        const int expectedFires = 1 + static_cast<int>(TriggerUnit::scmMaxSameLineCreations);
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "Expected a permanent trigger re-creating itself to be stopped too");
+        QVERIFY2(bufferContains(qsl("PERMFIRES=%1#").arg(expectedFires)), qPrintable(qsl("Expected the re-arming permanent trigger to fire exactly %1 times").arg(expectedFires)));
+        QVERIFY2(bufferContains(qsl("PERMACTIVE=1#")), "Expected only the trigger that predates the line to still be active");
+        QVERIFY2(bufferContains(qsl("PERMEXISTS=%1#").arg(expectedFires + 1)), "Expected the stopped permanent triggers to still exist - stopping them is not deleting them");
+    }
+
+    // A runaway inside a nested feedTriggers() pass must stop that pass only: the
+    // outer line's own mid-pass triggers were registered before the nested pass
+    // began, so they stay live and still match the outer line afterwards.
+    void test_nestedPassAbortLeavesTheOuterLineAlone()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("seen = {}\n"
+                                                               "function armInner()\n"
+                                                               "  tempRegexTrigger('^inner$', [[armInner()]], 1)\n"
+                                                               "end\n"
+                                                               "armInner()\n"
+                                                               "tempRegexTrigger('^outer$', [=[\n"
+                                                               "  tempRegexTrigger('^(.*)$', [[table.insert(seen, matches[2])]], 10)\n"
+                                                               "  feedTriggers('inner\\n')\n"
+                                                               "]=], 1)\n"
+                                                               "feedTriggers('outer\\n')\n"
+                                                               "echo('SEEN=' .. table.concat(seen, ',') .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "Expected the runaway in the nested pass to be stopped");
+        QVERIFY2(bufferContains(qsl("SEEN=inner,outer#")), "Expected the capture trigger created by the outer line to survive the nested pass's abort and still match the outer line");
     }
 
     // The loop is not a feedTriggers() curiosity: an ordinary line arriving from

--- a/test/functional_tests/TriggerSameLineMatchTest.cpp
+++ b/test/functional_tests/TriggerSameLineMatchTest.cpp
@@ -204,6 +204,129 @@ private slots:
         QVERIFY2(bufferContains(qsl("NESTED=inner,outer#")), "Expected the mid-pass trigger to match the nested line first, then the outer line it was created on");
     }
 
+    // The counterweight to all of the above: giving mid-pass triggers the current
+    // line means a trigger that re-creates itself keeps extending the list the
+    // pass is walking, so the line never finishes - 100% CPU and unbounded memory
+    // on the first matching line, from ordinary game text. The naive "one-shot
+    // that re-arms itself at the end of its own handler" shape is the one users
+    // write, so it is the one pinned here. Without the generation budget in
+    // TriggerUnit::processDataStream() this test does not fail, it hangs, and only
+    // the ctest TIMEOUT ends it.
+    void test_selfRecreatingTriggerIsStopped()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("loopFires = 0\n"
+                                                               "function arm()\n"
+                                                               "  tempRegexTrigger('^hploop$', [[loopFires = loopFires + 1; arm()]], 1)\n"
+                                                               "end\n"
+                                                               "arm()\n"
+                                                               "feedTriggers('hploop\\n')\n"
+                                                               "echo('LOOPFIRES=' .. loopFires .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "Expected the same-line re-creation abort error in the console buffer");
+        // One fire from the trigger that was already there when the line arrived,
+        // then one per generation the budget allows.
+        QVERIFY2(bufferContains(qsl("LOOPFIRES=%1").arg(TriggerUnit::scmMaxProcessingDepth)),
+                 qPrintable(qsl("Expected the re-arming trigger to fire exactly %1 times").arg(TriggerUnit::scmMaxProcessingDepth)));
+    }
+
+    // The abort has to name the trigger to be actionable - the user has to know
+    // which of their scripts to change.
+    void test_selfRecreatingTriggerAbortNamesTheTrigger()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("function armNamed()\n"
+                                                               "  tempComplexRegexTrigger('hpWatcher', '^hpnamed$', [[armNamed()]], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)\n"
+                                                               "end\n"
+                                                               "armNamed()\n"
+                                                               "feedTriggers('hpnamed\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("trigger 'hpWatcher'")), "Expected the abort message to name the trigger that keeps re-creating itself");
+    }
+
+    // A chain that ends on its own must not be cut short: only the runaway case
+    // may hit the budget, and legitimate chains are a handful of generations deep.
+    void test_finiteCreationChainIsUnaffected()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("chainFires = 0\n"
+                                                               "function chainStep()\n"
+                                                               "  chainFires = chainFires + 1\n"
+                                                               "  if chainFires < 10 then\n"
+                                                               "    tempRegexTrigger('^chain$', [[chainStep()]], 1)\n"
+                                                               "  end\n"
+                                                               "end\n"
+                                                               "tempRegexTrigger('^chain$', [[chainStep()]], 1)\n"
+                                                               "feedTriggers('chain\\n')\n"
+                                                               "echo('CHAINFIRES=' .. chainFires .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("CHAINFIRES=10")), "Expected all ten generations of the finite chain to match the current line");
+        QVERIFY2(!bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "A chain that ends on its own must not trip the same-line generation budget");
+    }
+
+    // Stopping the line is only half of it. A re-arming trigger with no expiry
+    // leaves everything it created still active, so the next line would start
+    // with a budget's worth of them and each would spawn a budget's worth again:
+    // measured at 50 fires on the first line and 2600 on the second, i.e. the
+    // freeze merely postponed. The abort therefore disables what the loop created
+    // during the line, which holds it at the same cost per line for ever.
+    void test_selfRecreatingTriggerDoesNotAccumulateAcrossLines()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("keptFires = 0\n"
+                                                               "function armKept()\n"
+                                                               "  tempRegexTrigger('^kept$', [[keptFires = keptFires + 1; armKept()]])\n"
+                                                               "end\n"
+                                                               "armKept()\n"
+                                                               "feedTriggers('kept\\n')\n"
+                                                               "feedTriggers('kept\\n')\n"
+                                                               "echo('KEPTFIRES=' .. keptFires .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("KEPTFIRES=%1").arg(2 * TriggerUnit::scmMaxProcessingDepth)),
+                 qPrintable(qsl("Expected the second line to cost the same %1 fires as the first, not a multiple of them").arg(TriggerUnit::scmMaxProcessingDepth)));
+    }
+
+    // The loop is not a feedTriggers() curiosity: an ordinary line arriving from
+    // the game reaches processDataStream() the same way, and froze Mudlet on the
+    // login banner. Driving it from the socket also proves the abort leaves the
+    // event loop running rather than wedging the connection.
+    void test_selfRecreatingTriggerFromServerTextIsStopped()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("function armFromServer()\n"
+                                                               "  tempRegexTrigger('^HP: 100/100$', [[armFromServer()]], 1)\n"
+                                                               "end\n"
+                                                               "armFromServer()\n"));
+
+        mpServer->sendRaw(QByteArray("HP: 100/100\r\n"));
+        QTRY_VERIFY2_WITH_TIMEOUT(bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "Expected server text to reach the same-line generation budget and be stopped", 10000);
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+    }
+
     void cleanup()
     {
         delete mpServer;

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -534,6 +534,34 @@ private slots:
         QCOMPARE(readGlobalInt(qsl("oneShotFires")), 1);
     }
 
+    // The skip must not stop the walk: a corpse and a live trigger can share a
+    // name (tempComplexRegexTrigger() takes a user-supplied one), and #9366's
+    // guarantee that enable-by-name reaches every same-named trigger still holds
+    // for the ones that are actually alive.
+    void test_triggerEnableByNameStillReachesALiveSameNamedTrigger()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const QStringList permPatterns{qsl("mixed_corpse_perm")};
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermSubstringTrigger(qsl("mixed corpse placeholder"), QString(), permPatterns, QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        const QString sharedName = QString::number(permId + 1);
+        unit->getTrigger(permId)->setName(sharedName);
+
+        const int tempId = mpHost->mLuaInterpreter.startTempTrigger(qsl("mixed_corpse_temp"), QString());
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTrigger(sharedName), "the temporary trigger should be the one killed");
+        unit->getTrigger(permId)->setIsActive(false);
+
+        QVERIFY2(unit->enableTrigger(sharedName), "enableTrigger must walk past the corpse to the live trigger filed under the same name");
+        QVERIFY2(unit->getTrigger(permId)->isActive(), "the live same-named trigger should have been enabled");
+        QVERIFY2(!unit->getTrigger(tempId)->isActive(), "the killed trigger must stay dead");
+
+        unit->doCleanup();
+        QVERIFY(!unit->getTrigger(tempId));
+    }
+
     // Helpers (reused from the ResetProfileTest pattern)
 
     int readGlobalInt(const QString& name)

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -485,7 +485,74 @@ private slots:
         QVERIFY2(!unit->getKey(id), "the key should have been freed exactly once");
     }
 
+    // The other half of the corpse-is-still-findable-by-name premise: killTrigger()
+    // skips an item that is only waiting to be freed, but enableTrigger() used to
+    // re-activate every same-named entry unconditionally. That resurrects the
+    // corpse, contradicting the guarantee TTrigger::match() states where it expires
+    // a trigger ("an enableTrigger() before the deferred free cannot resurrect a
+    // trigger that has already spent its last fire").
+    void test_triggerEnableByNameCannotReviveKilled()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const int id = mpHost->mLuaInterpreter.startTempTrigger(qsl("resurrect_trigger"), QString(), -1);
+        QVERIFY(id > 0);
+        auto* pTrigger = unit->getTrigger(id);
+        QVERIFY(pTrigger);
+        const QString name = QString::number(id);
+        QVERIFY(pTrigger->isActive());
+
+        QVERIFY2(unit->killTrigger(name), "the temporary trigger should be killable by name");
+        QVERIFY2(!pTrigger->isActive(), "killTrigger() must deactivate as well as queue the delete");
+        QVERIFY2(unit->mCleanupSet.contains(pTrigger), "the killed trigger should be waiting to be freed");
+
+        QVERIFY2(!unit->enableTrigger(name), "enableTrigger() must not report success for a trigger that is only waiting to be freed");
+        QVERIFY2(!pTrigger->isActive(), "a killed trigger must stay dead until it is freed");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getTrigger(id), "the killed trigger should still have been freed");
+    }
+
+    // The same thing as a user meets it: a one-shot trigger has spent its single
+    // fire on this line, and a script running later on the same line enables it by
+    // name. It must not fire a second time when the line is fed again.
+    void test_triggerEnableByNameCannotReviveExpiredOneShot()
+    {
+        mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("oneShotFires = 0\n"
+                                                            "reviverRan = false\n"
+                                                            "tempComplexRegexTrigger('watchOnce', '^ONESHOT$', [[oneShotFires = oneShotFires + 1]], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)\n"
+                                                            "tempRegexTrigger('^ONESHOT$', [[\n"
+                                                            "  if not reviverRan then\n"
+                                                            "    reviverRan = true\n"
+                                                            "    enableTrigger('watchOnce')\n"
+                                                            "    feedTriggers('ONESHOT\\n')\n"
+                                                            "  end\n"
+                                                            "]], 1)\n"
+                                                            "feedTriggers('ONESHOT\\n')\n"));
+
+        QCOMPARE(mpHost->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(readGlobalBool(qsl("reviverRan")), "the script that calls enableTrigger() has to have run for this to test anything");
+        QCOMPARE(readGlobalInt(qsl("oneShotFires")), 1);
+    }
+
     // Helpers (reused from the ResetProfileTest pattern)
+
+    int readGlobalInt(const QString& name)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, name.toUtf8().constData());
+        const int value = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        return value;
+    }
+
+    bool readGlobalBool(const QString& name)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, name.toUtf8().constData());
+        const bool value = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        return value;
+    }
 
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -534,6 +534,34 @@ private slots:
         QCOMPARE(readGlobalInt(qsl("oneShotFires")), 1);
     }
 
+    // The other deferred-delete container needs the same treatment: uninstall()
+    // at a non-zero processing depth deactivates its package's triggers, drops
+    // them from mCleanupSet to keep the two paths disjoint, and leaves them in
+    // uninstallList to be freed at depth 0. They stay in the lookup table for
+    // that window, so enableTrigger() would otherwise bring a trigger belonging
+    // to an already-uninstalled package back to life. The container is populated
+    // directly, as the cases below do: reaching this state from Lua needs a
+    // package-owned temporary item, which no current import path produces.
+    void test_triggerEnableByNameCannotReviveAnUninstalledTrigger()
+    {
+        auto* unit = mpHost->getTriggerUnit();
+        const int id = mpHost->mLuaInterpreter.startTempTrigger(qsl("uninstall_revive_trigger"), QString(), -1);
+        QVERIFY(id > 0);
+        auto* pTrigger = unit->getTrigger(id);
+        QVERIFY(pTrigger);
+        const QString name = QString::number(id);
+
+        pTrigger->setIsActive(false);
+        unit->uninstallList.append(pTrigger);
+        QVERIFY2(!unit->mCleanupSet.contains(pTrigger), "uninstall() keeps the two deferred-delete containers disjoint");
+
+        QVERIFY2(!unit->enableTrigger(name), "enableTrigger() must not report success for a trigger an uninstall is waiting to free");
+        QVERIFY2(!pTrigger->isActive(), "a trigger whose package has been uninstalled must stay inactive");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getTrigger(id), "the uninstalled trigger should still have been freed");
+    }
+
     // The skip must not stop the walk: a corpse and a live trigger can share a
     // name (tempComplexRegexTrigger() takes a user-supplied one), and #9366's
     // guarantee that enable-by-name reaches every same-named trigger still holds


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A trigger whose script creates another trigger matching the same line kept extending the list `TriggerUnit::processDataStream()` walks, so the line never finished: 100% CPU and RSS climbing 1.7 GB to 5.9 GB in 44 seconds, from one ordinary line of game text. Same-line matching for triggers created mid-pass now has a budget (100 per line); when it runs out the offending trigger is named in an error and what the loop created during that line is stopped - temporary ones removed, permanent ones switched off for the session only, so nothing is saved to the profile.
- `enableTrigger()` could resurrect a killed or expired temporary trigger during the window before its deferred delete runs, so a one-shot fired twice and a `killTrigger()`ed trigger fired 49 more times. It now skips anything queued for cleanup, which is what makes the guarantee `TTrigger::match()` states actually true.
- The behaviour restored by #9458 ("fix: triggers created by other triggers react to the current line again") is kept: triggers created while a line is being processed still match that line, chained creation included. 10 new tests, and the 6 that pin that behaviour still pass.

#### Motivation for adding to Mudlet

Release blocker for 5.0 - the freeze is reachable from ordinary server text with the standard "one-shot trigger that re-arms itself" idiom, and 4.22.0 was not affected.

#### Other info (issues closed, discussion etc)

5.0 QA findings C11 (hang) and C12. C11 was introduced by eb2627383 (#9458), which deliberately restored pre-#9267 same-line semantics without bounding them; #9368's depth guard cannot see it, because nothing recurses. The budget is deliberately its own constant rather than the `feedTriggers()` recursion depth: the two measure different resources, and sharing one made a pass entered deep in nested `feedTriggers()` abort before running anything.

**Test case:** run `function arm() tempRegexTrigger("^HP: 100/100$", [[arm()]], 1) end arm()` then `feedTriggers("HP: 100/100\n")` - on development Mudlet freezes for good; here it reports the trigger and carries on.

Assisted-by: Claude:claude-opus-5