### PR TITLE
infrastructure: reject a release tag that does not match APP_VERSION

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -161,9 +161,9 @@ jobs:
 
           if [[ "$REF" == refs/tags/Mudlet-* ]]; then
             # Last gate before anything is published. The build-time copy of this
-            # check runs from the tagged commit, so it is missing when an older
-            # commit is tagged; this workflow always runs from the default branch
-            bash release-scripts/CI/check-release-tag.sh "${REF#refs/tags/}" "${VERSION}"
+            # check runs from the tagged commit, so it is missing whenever an older
+            # commit is tagged
+            bash release-scripts/CI/check-release-tag.sh "${VERSION}" "${REF#refs/tags/}"
 
             echo "type=release" >> "$GITHUB_OUTPUT"
             echo "tag=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
@@ -174,6 +174,12 @@ jobs:
               echo "::error::COMMIT field is empty or missing in release metadata for PTB"
               exit 1
             fi
+            # A PTB's tag is generated rather than pushed, so it cannot disagree
+            # with APP_VERSION - but a two-component APP_VERSION makes the version
+            # it carries unofferable in exactly the same way, and no build-time
+            # check runs on the development branch to catch that
+            bash release-scripts/CI/check-release-tag.sh "${VERSION}"
+
             PTB_TAG="Mudlet-${VERSION}${BUILD_SUFFIX}-${COMMIT}"
             echo "type=ptb" >> "$GITHUB_OUTPUT"
             echo "tag=${PTB_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -160,9 +160,8 @@ jobs:
           COMMIT=$(echo "$META" | jq -r '.commit')
 
           if [[ "$REF" == refs/tags/Mudlet-* ]]; then
-            # Last gate before anything is published. The build-time copy of this
-            # check runs from the tagged commit, so it is missing whenever an older
-            # commit is tagged
+            # release-scripts/ is this workflow's own ref, so the guard is present
+            # even when the tagged commit predates it
             bash release-scripts/CI/check-release-tag.sh "${VERSION}" "${REF#refs/tags/}"
 
             echo "type=release" >> "$GITHUB_OUTPUT"
@@ -174,10 +173,8 @@ jobs:
               echo "::error::COMMIT field is empty or missing in release metadata for PTB"
               exit 1
             fi
-            # A PTB's tag is generated rather than pushed, so it cannot disagree
-            # with APP_VERSION - but a two-component APP_VERSION makes the version
-            # it carries unofferable in exactly the same way, and no build-time
-            # check runs on the development branch to catch that
+            # Nothing validates APP_VERSION on development, and a two-component one
+            # makes a PTB unofferable the same way
             bash release-scripts/CI/check-release-tag.sh "${VERSION}"
 
             PTB_TAG="Mudlet-${VERSION}${BUILD_SUFFIX}-${COMMIT}"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -160,6 +160,11 @@ jobs:
           COMMIT=$(echo "$META" | jq -r '.commit')
 
           if [[ "$REF" == refs/tags/Mudlet-* ]]; then
+            # Last gate before anything is published. The build-time copy of this
+            # check runs from the tagged commit, so it is missing when an older
+            # commit is tagged; this workflow always runs from the default branch
+            bash release-scripts/CI/check-release-tag.sh "${REF#refs/tags/}" "${VERSION}"
+
             echo "type=release" >> "$GITHUB_OUTPUT"
             echo "tag=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
             echo "title=Mudlet ${VERSION}" >> "$GITHUB_OUTPUT"

--- a/CI/check-release-tag.sh
+++ b/CI/check-release-tag.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Asserts that a release tag is spelled exactly "Mudlet-<APP_VERSION>", with a
+# three-component APP_VERSION.
+#
+# This exists because getting the tag wrong fails silently. The updater takes the
+# version it offers from the release tag, not from APP_VERSION
+# (Release::Release() in src/updater/Release.cpp strips the "Mudlet-" prefix), and
+# SemVer::getRegExp() in src/updater/SemVer.cpp only accepts three components. Tag
+# "Mudlet-5.0" and every installed copy of Mudlet decides the release is not newer
+# than what it already has, so nobody is ever offered the update - with no error,
+# no warning and no log line anywhere.
+#
+# CI/prepare-release-assets.sh cannot catch this: its check is a tag *prefix* match
+# against the asset names, and "Mudlet-5.0.0-linux-x64.AppImage.tar" does start with
+# "Mudlet-5.0". The opposite mistake - a stale APP_VERSION with a correct tag - is
+# caught there, which is exactly why this one is worth a check of its own.
+#
+# Usage: check-release-tag.sh <tag> <version>
+
+set -uo pipefail
+
+TAG="${1:-}"
+VERSION="${2:-}"
+
+if [ -z "${TAG}" ] || [ -z "${VERSION}" ]; then
+  echo "usage: $(basename "$0") <tag> <version>" >&2
+  exit 2
+fi
+
+# The explanation below is worth reading in full, but it will not be turned into a
+# GitHub annotation, so leave a one-line summary where a red X is looked for first
+annotate() {
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::error::$1"
+  fi
+}
+
+# A two-component APP_VERSION is just as fatal, and it would sail past the equality
+# check below because the tag built from it would match
+if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  annotate "APP_VERSION '${VERSION}' is not a three-component version - a release built from it would never be offered to anyone who already has Mudlet installed"
+  cat >&2 <<EOF
+error: APP_VERSION '${VERSION}' is not a three-component version like 5.0.0.
+
+Mudlet's updater only recognises three-component semantic versions, so a release
+built from this version is never offered to anyone who already has Mudlet
+installed. Set a three-component version in set(APP_VERSION ...) in CMakeLists.txt.
+EOF
+  exit 1
+fi
+
+if [ "${TAG}" != "Mudlet-${VERSION}" ]; then
+  annotate "Release tag '${TAG}' does not match APP_VERSION '${VERSION}' - it has to be exactly 'Mudlet-${VERSION}', or auto-update silently stops working for every existing user"
+  cat >&2 <<EOF
+error: release tag '${TAG}' does not match APP_VERSION '${VERSION}'.
+The tag has to be exactly 'Mudlet-${VERSION}'.
+
+Publishing under a mismatched tag breaks auto-update for everyone, silently. The
+updater reads the version it offers from the tag rather than from the binary, so a
+tag like 'Mudlet-5.0' offers version '5.0' - which is not a three-component
+semantic version, is therefore never treated as newer than the installed 4.22.0,
+and is never offered. No error is shown and nothing is logged: every existing user
+simply stops receiving updates, on every platform. macOS breaks the same way by a
+different route, because create-github-release.yml puts the tag's version into
+<sparkle:version> while the app itself reports APP_VERSION as its CFBundleVersion.
+
+Delete the tag and push it again as 'Mudlet-${VERSION}'. If '${VERSION}' is not the
+version you meant to release, change set(APP_VERSION ...) in CMakeLists.txt first.
+EOF
+  exit 1
+fi
+
+echo "Release tag '${TAG}' matches APP_VERSION '${VERSION}'."

--- a/CI/check-release-tag.sh
+++ b/CI/check-release-tag.sh
@@ -1,68 +1,84 @@
 #!/bin/bash
-# Asserts that a release tag is spelled exactly "Mudlet-<APP_VERSION>", with a
-# three-component APP_VERSION.
+# Asserts that the version a release will be published under can actually be
+# offered as an update: APP_VERSION has to be a three-component semantic version,
+# and the release tag - when there is one - has to be exactly "Mudlet-<APP_VERSION>".
 #
-# This exists because getting the tag wrong fails silently. The updater takes the
-# version it offers from the release tag, not from APP_VERSION
-# (Release::Release() in src/updater/Release.cpp strips the "Mudlet-" prefix), and
-# SemVer::getRegExp() in src/updater/SemVer.cpp only accepts three components. Tag
-# "Mudlet-5.0" and every installed copy of Mudlet decides the release is not newer
-# than what it already has, so nobody is ever offered the update - with no error,
-# no warning and no log line anywhere.
+# This exists because getting it wrong fails silently. The updater takes the version
+# it offers from the release tag, not from APP_VERSION (Release::Release() in
+# src/updater/Release.cpp strips the "Mudlet-" prefix), and SemVer::getRegExp() in
+# src/updater/SemVer.cpp needs three components. Tag "Mudlet-5.0" and every
+# installed copy of Mudlet decides the release is not newer than what it already
+# has. Nothing is raised and the update check logs "0 update(s) available", which is
+# exactly what it logs in a week when there genuinely is no release - so there is no
+# signal to notice.
 #
 # CI/prepare-release-assets.sh cannot catch this: its check is a tag *prefix* match
 # against the asset names, and "Mudlet-5.0.0-linux-x64.AppImage.tar" does start with
 # "Mudlet-5.0". The opposite mistake - a stale APP_VERSION with a correct tag - is
 # caught there, which is exactly why this one is worth a check of its own.
 #
-# Usage: check-release-tag.sh <tag> <version>
+# Suffixed release tags such as "Mudlet-5.0.0-rc1" are rejected too. Not because the
+# updater could not parse them - SemVer does accept a prerelease component - but
+# because APP_VERSION cannot carry the suffix (CI/validate_deployment.sh requires
+# three plain components), so tag and binary would disagree and the assets, which
+# are named after APP_VERSION, would all fail the prefix match above. Supporting a
+# release candidate means teaching APP_VERSION and this guard about it together.
+#
+# Usage: check-release-tag.sh <version> [tag]
+#   With no tag - a PTB, whose tag is generated rather than pushed - only the shape
+#   of the version is checked, which is the half that breaks a PTB the same way.
 
-set -uo pipefail
+set -euo pipefail
 
-TAG="${1:-}"
-VERSION="${2:-}"
+VERSION="${1:-}"
+TAG="${2:-}"
 
-if [ -z "${TAG}" ] || [ -z "${VERSION}" ]; then
-  echo "usage: $(basename "$0") <tag> <version>" >&2
+if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "${VERSION}" ]; then
+  echo "usage: $(basename "$0") <version> [tag]" >&2
   exit 2
 fi
 
-# The explanation below is worth reading in full, but it will not be turned into a
-# GitHub annotation, so leave a one-line summary where a red X is looked for first
+# The explanations below are worth reading in full, but a multi-line message cannot
+# become a GitHub annotation, so leave a one-line summary where a red X is looked
+# for first
 annotate() {
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
     echo "::error::$1"
   fi
 }
 
-# A two-component APP_VERSION is just as fatal, and it would sail past the equality
-# check below because the tag built from it would match
-if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  annotate "APP_VERSION '${VERSION}' is not a three-component version - a release built from it would never be offered to anyone who already has Mudlet installed"
+# Same shape SemVer::getRegExp() accepts, leading zeros and all
+if ! [[ "${VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  annotate "APP_VERSION '${VERSION}' is not a three-component version - nothing built from it would ever be offered as an update to anyone who already has Mudlet installed"
   cat >&2 <<EOF
 error: APP_VERSION '${VERSION}' is not a three-component version like 5.0.0.
 
-Mudlet's updater only recognises three-component semantic versions, so a release
-built from this version is never offered to anyone who already has Mudlet
-installed. Set a three-component version in set(APP_VERSION ...) in CMakeLists.txt.
+Mudlet's updater only recognises three-component semantic versions, so a build
+carrying this version is never offered to anyone who already has Mudlet installed -
+including public test builds. Set a three-component version in
+set(APP_VERSION ...) in CMakeLists.txt.
 EOF
   exit 1
 fi
 
-if [ "${TAG}" != "Mudlet-${VERSION}" ]; then
-  annotate "Release tag '${TAG}' does not match APP_VERSION '${VERSION}' - it has to be exactly 'Mudlet-${VERSION}', or auto-update silently stops working for every existing user"
+if [ -n "${TAG}" ] && [ "${TAG}" != "Mudlet-${VERSION}" ]; then
+  annotate "Release tag '${TAG}' does not match APP_VERSION '${VERSION}' - it has to be exactly 'Mudlet-${VERSION}', or auto-update stops working for every existing user without saying so"
   cat >&2 <<EOF
 error: release tag '${TAG}' does not match APP_VERSION '${VERSION}'.
 The tag has to be exactly 'Mudlet-${VERSION}'.
 
-Publishing under a mismatched tag breaks auto-update for everyone, silently. The
+Publishing under a mismatched tag breaks auto-update, without saying so. The
 updater reads the version it offers from the tag rather than from the binary, so a
-tag like 'Mudlet-5.0' offers version '5.0' - which is not a three-component
-semantic version, is therefore never treated as newer than the installed 4.22.0,
-and is never offered. No error is shown and nothing is logged: every existing user
-simply stops receiving updates, on every platform. macOS breaks the same way by a
-different route, because create-github-release.yml puts the tag's version into
-<sparkle:version> while the app itself reports APP_VERSION as its CFBundleVersion.
+tag like 'Mudlet-5.0' offers version '5.0' - not a three-component semantic
+version, therefore never newer than the installed 4.22.0, therefore never offered.
+No error is shown and the update check logs "0 update(s) available", the same line
+it logs when there is genuinely nothing new, so nobody notices until the download
+numbers do not move.
+
+It also desynchronises macOS: create-github-release.yml puts the tag's version into
+<sparkle:version> while the app reports APP_VERSION as its CFBundleVersion, so a
+tag ahead of APP_VERSION leaves Sparkle re-offering an update the installed app can
+never satisfy.
 
 Delete the tag and push it again as 'Mudlet-${VERSION}'. If '${VERSION}' is not the
 version you meant to release, change set(APP_VERSION ...) in CMakeLists.txt first.
@@ -70,4 +86,8 @@ EOF
   exit 1
 fi
 
-echo "Release tag '${TAG}' matches APP_VERSION '${VERSION}'."
+if [ -n "${TAG}" ]; then
+  echo "Release tag '${TAG}' matches APP_VERSION '${VERSION}'."
+else
+  echo "APP_VERSION '${VERSION}' can be offered as an update."
+fi

--- a/CI/check-release-tag.sh
+++ b/CI/check-release-tag.sh
@@ -86,8 +86,9 @@ EOF
   exit 1
 fi
 
+# Silence would be ambiguous on the one path where it matters: a release log with no
+# line here looks the same whether the tag was checked or the guard was never
+# reached. A PTB says nothing, since it runs nightly and has no tag to report
 if [ -n "${TAG}" ]; then
   echo "Release tag '${TAG}' matches APP_VERSION '${VERSION}'."
-else
-  echo "APP_VERSION '${VERSION}' can be offered as an update."
 fi

--- a/CI/check-release-tag.sh
+++ b/CI/check-release-tag.sh
@@ -1,32 +1,16 @@
 #!/bin/bash
-# Asserts that the version a release will be published under can actually be
-# offered as an update: APP_VERSION has to be a three-component semantic version,
-# and the release tag - when there is one - has to be exactly "Mudlet-<APP_VERSION>".
-#
-# This exists because getting it wrong fails silently. The updater takes the version
-# it offers from the release tag, not from APP_VERSION (Release::Release() in
-# src/updater/Release.cpp strips the "Mudlet-" prefix), and SemVer::getRegExp() in
-# src/updater/SemVer.cpp needs three components. Tag "Mudlet-5.0" and every
-# installed copy of Mudlet decides the release is not newer than what it already
-# has. Nothing is raised and the update check logs "0 update(s) available", which is
-# exactly what it logs in a week when there genuinely is no release - so there is no
-# signal to notice.
-#
-# CI/prepare-release-assets.sh cannot catch this: its check is a tag *prefix* match
-# against the asset names, and "Mudlet-5.0.0-linux-x64.AppImage.tar" does start with
-# "Mudlet-5.0". The opposite mistake - a stale APP_VERSION with a correct tag - is
-# caught there, which is exactly why this one is worth a check of its own.
-#
-# Suffixed release tags such as "Mudlet-5.0.0-rc1" are rejected too. Not because the
-# updater could not parse them - SemVer does accept a prerelease component - but
-# because APP_VERSION cannot carry the suffix (CI/validate_deployment.sh requires
-# three plain components), so tag and binary would disagree and the assets, which
-# are named after APP_VERSION, would all fail the prefix match above. Supporting a
-# release candidate means teaching APP_VERSION and this guard about it together.
-#
 # Usage: check-release-tag.sh <version> [tag]
-#   With no tag - a PTB, whose tag is generated rather than pushed - only the shape
-#   of the version is checked, which is the half that breaks a PTB the same way.
+#
+# The updater offers the version from the release tag, not from APP_VERSION
+# (src/updater/Release.cpp), and SemVer needs three components - so "Mudlet-5.0" is
+# never offered to anyone, silently. CI/prepare-release-assets.sh cannot see it: that
+# check matches the tag as a prefix of the asset names, and "Mudlet-5.0.0-linux-x64"
+# does start with "Mudlet-5.0". Only the opposite mistake fails there.
+#
+# "Mudlet-5.0.0-rc1" is rejected as well - SemVer would accept it, but APP_VERSION
+# cannot carry a suffix, so the assets named after it would not match the tag.
+#
+# A PTB passes no tag, its tag being generated rather than pushed.
 
 set -euo pipefail
 
@@ -38,9 +22,7 @@ if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "${VERSION}" ]; then
   exit 2
 fi
 
-# The explanations below are worth reading in full, but a multi-line message cannot
-# become a GitHub annotation, so leave a one-line summary where a red X is looked
-# for first
+# A multi-line message cannot become a GitHub annotation, so summarise in one line
 annotate() {
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
     echo "::error::$1"
@@ -72,8 +54,7 @@ updater reads the version it offers from the tag rather than from the binary, so
 tag like 'Mudlet-5.0' offers version '5.0' - not a three-component semantic
 version, therefore never newer than the installed 4.22.0, therefore never offered.
 No error is shown and the update check logs "0 update(s) available", the same line
-it logs when there is genuinely nothing new, so nobody notices until the download
-numbers do not move.
+it logs when there is genuinely nothing new.
 
 It also desynchronises macOS: create-github-release.yml puts the tag's version into
 <sparkle:version> while the app reports APP_VERSION as its CFBundleVersion, so a
@@ -86,9 +67,8 @@ EOF
   exit 1
 fi
 
-# Silence would be ambiguous on the one path where it matters: a release log with no
-# line here looks the same whether the tag was checked or the guard was never
-# reached. A PTB says nothing, since it runs nightly and has no tag to report
+# A release log with no line here reads the same whether the tag was compared or the
+# guard was never reached
 if [ -n "${TAG}" ]; then
   echo "Release tag '${TAG}' matches APP_VERSION '${VERSION}'."
 fi

--- a/CI/validate-deployment-for-windows.sh
+++ b/CI/validate-deployment-for-windows.sh
@@ -25,19 +25,24 @@ function validate_cmake() {
   # there is no static "APP_BUILD" line left to validate here.
 }
 
-# A tag that does not spell out the same version as APP_VERSION disables
-# auto-update for every existing user without a word of complaint anywhere - see
-# CI/check-release-tag.sh
+# Release tags have to spell out APP_VERSION - CI/check-release-tag.sh explains
+# what goes wrong when they do not
 function validate_release_tag() {
   local TAG_NAME=""
   if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
     TAG_NAME="${GITHUB_REF#refs/tags/}"
   fi
+  if [ -z "${TAG_NAME}" ]; then
+    error "This is a release build, but the tag being built could not be determined from GITHUB_REF."
+  fi
 
   local APP_VERSION
   APP_VERSION=$(pcre2grep --only-matching=1 "set\(APP_VERSION (.+)\)$" < CMakeLists.txt)
+  if [ -z "${APP_VERSION}" ]; then
+    error "No set(APP_VERSION ...) line could be read out of CMakeLists.txt."
+  fi
 
-  bash "$(dirname "${BASH_SOURCE[0]}")/check-release-tag.sh" "${TAG_NAME}" "${APP_VERSION}" || exit $?
+  bash "$(dirname "${BASH_SOURCE[0]}")/check-release-tag.sh" "${APP_VERSION}" "${TAG_NAME}" || exit $?
 }
 
 function validate_updater_environment_variable() {
@@ -46,7 +51,7 @@ function validate_updater_environment_variable() {
   fi
 }
 
-validate_cmake
 validate_release_tag
+validate_cmake
 validate_updater_environment_variable
 

--- a/CI/validate-deployment-for-windows.sh
+++ b/CI/validate-deployment-for-windows.sh
@@ -25,6 +25,21 @@ function validate_cmake() {
   # there is no static "APP_BUILD" line left to validate here.
 }
 
+# A tag that does not spell out the same version as APP_VERSION disables
+# auto-update for every existing user without a word of complaint anywhere - see
+# CI/check-release-tag.sh
+function validate_release_tag() {
+  local TAG_NAME=""
+  if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
+    TAG_NAME="${GITHUB_REF#refs/tags/}"
+  fi
+
+  local APP_VERSION
+  APP_VERSION=$(pcre2grep --only-matching=1 "set\(APP_VERSION (.+)\)$" < CMakeLists.txt)
+
+  bash "$(dirname "${BASH_SOURCE[0]}")/check-release-tag.sh" "${TAG_NAME}" "${APP_VERSION}" || exit $?
+}
+
 function validate_updater_environment_variable() {
   if [ "$WITH_UPDATER" == "NO" ]; then
     error "Updater is disabled in a release build."
@@ -32,5 +47,6 @@ function validate_updater_environment_variable() {
 }
 
 validate_cmake
+validate_release_tag
 validate_updater_environment_variable
 

--- a/CI/validate-deployment-for-windows.sh
+++ b/CI/validate-deployment-for-windows.sh
@@ -25,8 +25,6 @@ function validate_cmake() {
   # there is no static "APP_BUILD" line left to validate here.
 }
 
-# Release tags have to spell out APP_VERSION - CI/check-release-tag.sh explains
-# what goes wrong when they do not
 function validate_release_tag() {
   local TAG_NAME=""
   if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then

--- a/CI/validate_deployment.sh
+++ b/CI/validate_deployment.sh
@@ -26,6 +26,21 @@ else
     # there is no static "APP_BUILD" line left to validate here.
   }
 
+  # A tag that does not spell out the same version as APP_VERSION disables
+  # auto-update for every existing user without a word of complaint anywhere - see
+  # CI/check-release-tag.sh
+  function validate_release_tag() {
+    local TAG_NAME="${TRAVIS_TAG:-}"
+    if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
+      TAG_NAME="${GITHUB_REF#refs/tags/}"
+    fi
+
+    local APP_VERSION
+    APP_VERSION=$(pcre2grep --only-matching=1 "set\(APP_VERSION (.+)\)$" < CMakeLists.txt)
+
+    bash "$(dirname "${BASH_SOURCE[0]}")/check-release-tag.sh" "${TAG_NAME}" "${APP_VERSION}" || exit $?
+  }
+
   function validate_updater_environment_variable() {
     if [ "$WITH_UPDATER" == "NO" ]; then
        error "Updater is disabled in a release build."
@@ -33,5 +48,6 @@ else
   }
 
   validate_cmake
+  validate_release_tag
   validate_updater_environment_variable
 fi

--- a/CI/validate_deployment.sh
+++ b/CI/validate_deployment.sh
@@ -26,8 +26,6 @@ else
     # there is no static "APP_BUILD" line left to validate here.
   }
 
-  # Release tags have to spell out APP_VERSION - CI/check-release-tag.sh explains
-  # what goes wrong when they do not
   function validate_release_tag() {
     local TAG_NAME="${TRAVIS_TAG:-}"
     if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then

--- a/CI/validate_deployment.sh
+++ b/CI/validate_deployment.sh
@@ -26,19 +26,24 @@ else
     # there is no static "APP_BUILD" line left to validate here.
   }
 
-  # A tag that does not spell out the same version as APP_VERSION disables
-  # auto-update for every existing user without a word of complaint anywhere - see
-  # CI/check-release-tag.sh
+  # Release tags have to spell out APP_VERSION - CI/check-release-tag.sh explains
+  # what goes wrong when they do not
   function validate_release_tag() {
     local TAG_NAME="${TRAVIS_TAG:-}"
     if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
       TAG_NAME="${GITHUB_REF#refs/tags/}"
     fi
+    if [ -z "${TAG_NAME}" ]; then
+      error "This is a release build, but the tag being built could not be determined from GITHUB_REF or TRAVIS_TAG."
+    fi
 
     local APP_VERSION
     APP_VERSION=$(pcre2grep --only-matching=1 "set\(APP_VERSION (.+)\)$" < CMakeLists.txt)
+    if [ -z "${APP_VERSION}" ]; then
+      error "No set(APP_VERSION ...) line could be read out of CMakeLists.txt."
+    fi
 
-    bash "$(dirname "${BASH_SOURCE[0]}")/check-release-tag.sh" "${TAG_NAME}" "${APP_VERSION}" || exit $?
+    bash "$(dirname "${BASH_SOURCE[0]}")/check-release-tag.sh" "${APP_VERSION}" "${TAG_NAME}" || exit $?
   }
 
   function validate_updater_environment_variable() {
@@ -47,7 +52,7 @@ else
     fi
   }
 
-  validate_cmake
   validate_release_tag
+  validate_cmake
   validate_updater_environment_variable
 fi

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,15 @@ if(NOT WIN32)
     )
 endif()
 
+# Checks the guard that keeps a release from being published under a tag that does
+# not spell out APP_VERSION - the updater reads its version from the tag, so a tag
+# like "Mudlet-5.0" stops every existing user being offered the release, silently
+if(NOT WIN32)
+    add_test(NAME ReleaseTagVersionTest
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/ci/release-tag-version-test.sh
+    )
+endif()
+
 # Checks the milestone lookup that add-milestone runs - the one that matched a
 # title that no longer existed and assigned nothing for months, without ever
 # failing. gh is stubbed, so there is no network and no token

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,9 +102,8 @@ if(NOT WIN32)
     )
 endif()
 
-# Checks the guard that keeps a release from being published under a tag that does
-# not spell out APP_VERSION - the updater reads its version from the tag, so a tag
-# like "Mudlet-5.0" stops every existing user being offered the release, silently
+# The updater reads its version from the release tag, so a tag like "Mudlet-5.0"
+# stops every existing user being offered the release, silently
 if(NOT WIN32)
     add_test(NAME ReleaseTagVersionTest
         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/ci/release-tag-version-test.sh

--- a/test/ci/release-tag-version-test.sh
+++ b/test/ci/release-tag-version-test.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
 # Tests CI/check-release-tag.sh, the guard that keeps a release from being
-# published under a tag that does not spell out APP_VERSION.
+# published under a version nobody can be offered.
 #
-# The mistake it catches is invisible without it. Tagging "Mudlet-5.0" while
-# APP_VERSION is 5.0.0 passes every existing check - CI/prepare-release-assets.sh
-# only matches the tag as a prefix of the asset names, and
-# "Mudlet-5.0.0-linux-x64.AppImage.tar" does start with "Mudlet-5.0" - yet the
-# updater offers version "5.0", which is not a three-component semantic version and
-# is therefore never treated as newer than an installed 4.22.0. Every existing user
-# stops being offered updates and nothing anywhere says so.
+# The mistake it catches leaves no trace. Tagging "Mudlet-5.0" while APP_VERSION is
+# 5.0.0 passes every existing check - CI/prepare-release-assets.sh only matches the
+# tag as a prefix of the asset names, and "Mudlet-5.0.0-linux-x64.AppImage.tar" does
+# start with "Mudlet-5.0" - yet the updater then offers version "5.0", which is not
+# a three-component semantic version and is therefore never treated as newer than an
+# installed 4.22.0. Every existing user stops being offered updates and the update
+# check goes on logging "0 update(s) available".
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 CHECK="${REPO_DIR}/CI/check-release-tag.sh"
+RELEASE_WORKFLOW="${REPO_DIR}/.github/workflows/create-github-release.yml"
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
+OUT="${WORK_DIR}/out"
 FAILURES=0
 
 start_test() {
@@ -30,95 +32,159 @@ fail() {
   FAILURES=$((FAILURES + 1))
 }
 
-# Runs the guard and leaves its combined output in ${WORK_DIR}/out
+# Runs the guard, leaving its combined output in ${OUT} and echoing its status
 run_check() {
-  bash "${CHECK}" "$1" "$2" > "${WORK_DIR}/out" 2>&1
+  bash "${CHECK}" "$@" > "${OUT}" 2>&1
   echo $?
 }
 
 assert_status() {
   local expected="$1" actual="$2"
+  # An empty or non-numeric status would make the comparison below error out and
+  # take the false branch, quietly turning every assertion into a pass
+  case "${actual}" in
+    ''|*[!0-9]*)
+      fail "expected exit ${expected}, got a non-numeric status '${actual}'"
+      return
+      ;;
+  esac
   if [ "${actual}" -ne "${expected}" ]; then
     fail "expected exit ${expected}, got ${actual}, output:"
-    sed 's/^/        /' "${WORK_DIR}/out" >&2
+    sed 's/^/        /' "${OUT}" >&2
   fi
 }
 
 assert_contains() {
-  local needle="$1"
-  if ! grep -qF -- "${needle}" "${WORK_DIR}/out"; then
-    fail "expected '${needle}' in the output:"
-    sed 's/^/        /' "${WORK_DIR}/out" >&2
+  local file="$1" needle="$2"
+  if ! grep -qF -- "${needle}" "${file}"; then
+    fail "expected '${needle}' in ${file}:"
+    sed 's/^/        /' "${file}" >&2
   fi
 }
 
 start_test "the tag a 5.0 release has to carry is accepted"
-assert_status 0 "$(run_check "Mudlet-5.0.0" "5.0.0")"
+assert_status 0 "$(run_check "5.0.0" "Mudlet-5.0.0")"
 
-start_test "every tag Mudlet has released under so far is accepted"
+start_test "the tags of every release since 4.19 are accepted, and plausible future ones"
 for version in 4.19.0 4.20.1 4.21.0 4.22.0 5.0.0 10.11.12; do
-  assert_status 0 "$(run_check "Mudlet-${version}" "${version}")"
+  assert_status 0 "$(run_check "${version}" "Mudlet-${version}")"
 done
 
 start_test "the two-component tag that silently disables auto-update is rejected"
-assert_status 1 "$(run_check "Mudlet-5.0" "5.0.0")"
-assert_contains "Mudlet-5.0.0"
-assert_contains "auto-update"
+assert_status 1 "$(run_check "5.0.0" "Mudlet-5.0")"
+assert_contains "${OUT}" "Mudlet-5.0.0"
+assert_contains "${OUT}" "auto-update"
 
 start_test "a stale tag against a bumped APP_VERSION is rejected"
-assert_status 1 "$(run_check "Mudlet-4.22.0" "5.0.0")"
+assert_status 1 "$(run_check "5.0.0" "Mudlet-4.22.0")"
 
 start_test "a stale APP_VERSION against a bumped tag is rejected"
-assert_status 1 "$(run_check "Mudlet-5.0.0" "4.22.0")"
+assert_status 1 "$(run_check "4.22.0" "Mudlet-5.0.0")"
 
 start_test "a two-component APP_VERSION is rejected even though its tag matches"
-assert_status 1 "$(run_check "Mudlet-5.0" "5.0")"
-assert_contains "three-component"
+assert_status 1 "$(run_check "5.0" "Mudlet-5.0")"
+assert_contains "${OUT}" "three-component"
+
+start_test "a version SemVer would reject for its leading zeros is rejected"
+assert_status 1 "$(run_check "5.01.0" "Mudlet-5.01.0")"
+
+# Release.cpp only strips a capitalised "Mudlet-", while the asset check matches
+# case-insensitively and set-build-info.sh lowercases the version - so a lowercase
+# tag is a mistake the surrounding tooling invites, and it fails the same silent way
+start_test "a lowercase tag is rejected"
+assert_status 1 "$(run_check "4.22.0" "mudlet-4.22.0")"
 
 start_test "a tag missing the Mudlet- prefix is rejected"
 assert_status 1 "$(run_check "5.0.0" "5.0.0")"
 
-start_test "a suffixed tag is rejected - releases are tagged clean"
-assert_status 1 "$(run_check "Mudlet-5.0.0-rc1" "5.0.0")"
+# Not because the updater could not parse "5.0.0-rc1", but because APP_VERSION
+# cannot carry the suffix, so the tag and the assets named after APP_VERSION would
+# disagree. Supporting release candidates means changing both together
+start_test "a suffixed tag is rejected while APP_VERSION cannot carry a suffix"
+assert_status 1 "$(run_check "5.0.0" "Mudlet-5.0.0-rc1")"
 
-start_test "a missing argument is a usage error, not a silent pass"
-assert_status 2 "$(run_check "Mudlet-5.0.0" "")"
-assert_status 2 "$(run_check "" "5.0.0")"
+start_test "a PTB checks its version without a tag to compare against"
+assert_status 0 "$(run_check "5.0.0")"
+assert_status 1 "$(run_check "5.0")"
+assert_contains "${OUT}" "three-component"
+
+start_test "a missing or surplus argument is a usage error, not a silent pass"
+assert_status 2 "$(run_check "")"
+assert_status 2 "$(run_check)"
+assert_status 2 "$(run_check "5.0.0" "Mudlet-5.0.0" "extra")"
 
 start_test "the failure is annotated for GitHub Actions, not only printed"
-GITHUB_ACTIONS=true bash "${CHECK}" "Mudlet-5.0" "5.0.0" > "${WORK_DIR}/out" 2>&1
-assert_contains "::error::"
+GITHUB_ACTIONS=true bash "${CHECK}" "5.0.0" "Mudlet-5.0" > "${OUT}" 2>&1
+assert_contains "${OUT}" "::error::"
 
-# The guard is only useful if the release scripts actually reach it
+# The guard is only worth anything if the release scripts actually reach it
 start_test "the tag-push build validation calls the guard"
-if command -v pcre2grep > /dev/null; then
+if ! command -v pcre2grep > /dev/null; then
+  # Silence here would hide the only assertions that prove the wiring, and CI has
+  # pcre2grep, so a missing one there is a broken runner rather than a local quirk
+  if [ -n "${CI:-}${GITHUB_ACTIONS:-}" ]; then
+    fail "pcre2grep is missing, so the build validation scripts cannot be exercised"
+  else
+    echo "    skipped: pcre2grep is not installed"
+  fi
+else
   mkdir -p "${WORK_DIR}/repo"
   printf 'set(APP_VERSION 5.0.0)\n' > "${WORK_DIR}/repo/CMakeLists.txt"
 
   for script in validate_deployment.sh validate-deployment-for-windows.sh; do
     (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/tags/Mudlet-5.0.0" GITHUB_REPO_TAG=true WITH_UPDATER=YES \
-      bash "${REPO_DIR}/CI/${script}") > "${WORK_DIR}/out" 2>&1
+      bash "${REPO_DIR}/CI/${script}") > "${OUT}" 2>&1
     assert_status 0 "$?"
 
     (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/tags/Mudlet-5.0" GITHUB_REPO_TAG=true WITH_UPDATER=YES \
-      bash "${REPO_DIR}/CI/${script}") > "${WORK_DIR}/out" 2>&1
+      bash "${REPO_DIR}/CI/${script}") > "${OUT}" 2>&1
     assert_status 1 "$?"
-    assert_contains "does not match APP_VERSION"
+    assert_contains "${OUT}" "does not match APP_VERSION"
   done
 
-  # A development build has no tag to check and must not be blocked by one
-  (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" GITHUB_REPO_TAG=false WITH_UPDATER=YES \
-    bash "${REPO_DIR}/CI/validate_deployment.sh") > "${WORK_DIR}/out" 2>&1
+  # The Windows script decides it is a release build from GITHUB_REPO_TAG but takes
+  # the tag from GITHUB_REF, so the two can disagree. That is still a hard failure,
+  # but it has to say what could not be determined rather than print a usage line
+  (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" GITHUB_REPO_TAG=true WITH_UPDATER=YES \
+    bash "${REPO_DIR}/CI/validate-deployment-for-windows.sh") > "${OUT}" 2>&1
+  assert_status 1 "$?"
+  assert_contains "${OUT}" "could not be determined"
+
+  # A development build has no tag to check and must not be blocked by one. The two
+  # scripts decide that from different variables, so both are exercised
+  (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" WITH_UPDATER=YES \
+    bash "${REPO_DIR}/CI/validate_deployment.sh") > "${OUT}" 2>&1
   assert_status 0 "$?"
-  assert_contains "skipping release validation"
-else
-  echo "    skipped: pcre2grep is not installed"
+  assert_contains "${OUT}" "skipping release validation"
+
+  (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" GITHUB_REPO_TAG=false WITH_UPDATER=YES \
+    bash "${REPO_DIR}/CI/validate-deployment-for-windows.sh") > "${OUT}" 2>&1
+  assert_status 0 "$?"
+  assert_contains "${OUT}" "skipping release validation"
 fi
 
 start_test "the release workflow calls the guard before it publishes anything"
-if ! grep -qF 'CI/check-release-tag.sh' "${REPO_DIR}/.github/workflows/create-github-release.yml"; then
-  fail "create-github-release.yml no longer calls CI/check-release-tag.sh"
-fi
+# Blank out comments while keeping the line numbering, so a call that has merely
+# been commented out cannot satisfy any of this
+UNCOMMENTED="${WORK_DIR}/workflow-without-comments"
+sed 's/^[[:space:]]*#.*$//' "${RELEASE_WORKFLOW}" > "${UNCOMMENTED}"
+
+# The release-scripts/ prefix matters: the checkout of the tagged commit may predate
+# the guard, so the copy taken from this workflow's own ref is the one to run
+release_call='^[[:space:]]*bash release-scripts/CI/check-release-tag\.sh "\$\{VERSION\}" "\$\{REF#refs/tags/\}"[[:space:]]*$'
+ptb_call='^[[:space:]]*bash release-scripts/CI/check-release-tag\.sh "\$\{VERSION\}"[[:space:]]*$'
+publish_line=$(grep -n 'gh release create' "${UNCOMMENTED}" | head -1 | cut -d: -f1)
+
+for description in "release:${release_call}" "PTB:${ptb_call}"; do
+  guard_line=$(grep -nE "${description#*:}" "${UNCOMMENTED}" | head -1 | cut -d: -f1)
+  if [ -z "${guard_line}" ]; then
+    fail "create-github-release.yml no longer runs the guard on the ${description%%:*} path"
+  elif [ -z "${publish_line}" ]; then
+    fail "could not find the publishing step in create-github-release.yml"
+  elif [ "${guard_line}" -ge "${publish_line}" ]; then
+    fail "the ${description%%:*} guard at line ${guard_line} runs after the release is published at line ${publish_line}"
+  fi
+done
 
 if [ "${FAILURES}" -gt 0 ]; then
   echo "${FAILURES} check(s) failed"

--- a/test/ci/release-tag-version-test.sh
+++ b/test/ci/release-tag-version-test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Tests CI/check-release-tag.sh, the guard that keeps a release from being
+# published under a tag that does not spell out APP_VERSION.
+#
+# The mistake it catches is invisible without it. Tagging "Mudlet-5.0" while
+# APP_VERSION is 5.0.0 passes every existing check - CI/prepare-release-assets.sh
+# only matches the tag as a prefix of the asset names, and
+# "Mudlet-5.0.0-linux-x64.AppImage.tar" does start with "Mudlet-5.0" - yet the
+# updater offers version "5.0", which is not a three-component semantic version and
+# is therefore never treated as newer than an installed 4.22.0. Every existing user
+# stops being offered updates and nothing anywhere says so.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CHECK="${REPO_DIR}/CI/check-release-tag.sh"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+FAILURES=0
+
+start_test() {
+  echo "=== $1"
+}
+
+fail() {
+  echo "    FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# Runs the guard and leaves its combined output in ${WORK_DIR}/out
+run_check() {
+  bash "${CHECK}" "$1" "$2" > "${WORK_DIR}/out" 2>&1
+  echo $?
+}
+
+assert_status() {
+  local expected="$1" actual="$2"
+  if [ "${actual}" -ne "${expected}" ]; then
+    fail "expected exit ${expected}, got ${actual}, output:"
+    sed 's/^/        /' "${WORK_DIR}/out" >&2
+  fi
+}
+
+assert_contains() {
+  local needle="$1"
+  if ! grep -qF -- "${needle}" "${WORK_DIR}/out"; then
+    fail "expected '${needle}' in the output:"
+    sed 's/^/        /' "${WORK_DIR}/out" >&2
+  fi
+}
+
+start_test "the tag a 5.0 release has to carry is accepted"
+assert_status 0 "$(run_check "Mudlet-5.0.0" "5.0.0")"
+
+start_test "every tag Mudlet has released under so far is accepted"
+for version in 4.19.0 4.20.1 4.21.0 4.22.0 5.0.0 10.11.12; do
+  assert_status 0 "$(run_check "Mudlet-${version}" "${version}")"
+done
+
+start_test "the two-component tag that silently disables auto-update is rejected"
+assert_status 1 "$(run_check "Mudlet-5.0" "5.0.0")"
+assert_contains "Mudlet-5.0.0"
+assert_contains "auto-update"
+
+start_test "a stale tag against a bumped APP_VERSION is rejected"
+assert_status 1 "$(run_check "Mudlet-4.22.0" "5.0.0")"
+
+start_test "a stale APP_VERSION against a bumped tag is rejected"
+assert_status 1 "$(run_check "Mudlet-5.0.0" "4.22.0")"
+
+start_test "a two-component APP_VERSION is rejected even though its tag matches"
+assert_status 1 "$(run_check "Mudlet-5.0" "5.0")"
+assert_contains "three-component"
+
+start_test "a tag missing the Mudlet- prefix is rejected"
+assert_status 1 "$(run_check "5.0.0" "5.0.0")"
+
+start_test "a suffixed tag is rejected - releases are tagged clean"
+assert_status 1 "$(run_check "Mudlet-5.0.0-rc1" "5.0.0")"
+
+start_test "a missing argument is a usage error, not a silent pass"
+assert_status 2 "$(run_check "Mudlet-5.0.0" "")"
+assert_status 2 "$(run_check "" "5.0.0")"
+
+start_test "the failure is annotated for GitHub Actions, not only printed"
+GITHUB_ACTIONS=true bash "${CHECK}" "Mudlet-5.0" "5.0.0" > "${WORK_DIR}/out" 2>&1
+assert_contains "::error::"
+
+# The guard is only useful if the release scripts actually reach it
+start_test "the tag-push build validation calls the guard"
+if command -v pcre2grep > /dev/null; then
+  mkdir -p "${WORK_DIR}/repo"
+  printf 'set(APP_VERSION 5.0.0)\n' > "${WORK_DIR}/repo/CMakeLists.txt"
+
+  for script in validate_deployment.sh validate-deployment-for-windows.sh; do
+    (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/tags/Mudlet-5.0.0" GITHUB_REPO_TAG=true WITH_UPDATER=YES \
+      bash "${REPO_DIR}/CI/${script}") > "${WORK_DIR}/out" 2>&1
+    assert_status 0 "$?"
+
+    (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/tags/Mudlet-5.0" GITHUB_REPO_TAG=true WITH_UPDATER=YES \
+      bash "${REPO_DIR}/CI/${script}") > "${WORK_DIR}/out" 2>&1
+    assert_status 1 "$?"
+    assert_contains "does not match APP_VERSION"
+  done
+
+  # A development build has no tag to check and must not be blocked by one
+  (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" GITHUB_REPO_TAG=false WITH_UPDATER=YES \
+    bash "${REPO_DIR}/CI/validate_deployment.sh") > "${WORK_DIR}/out" 2>&1
+  assert_status 0 "$?"
+  assert_contains "skipping release validation"
+else
+  echo "    skipped: pcre2grep is not installed"
+fi
+
+start_test "the release workflow calls the guard before it publishes anything"
+if ! grep -qF 'CI/check-release-tag.sh' "${REPO_DIR}/.github/workflows/create-github-release.yml"; then
+  fail "create-github-release.yml no longer calls CI/check-release-tag.sh"
+fi
+
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "${FAILURES} check(s) failed"
+  exit 1
+fi
+
+echo "All checks passed"

--- a/test/ci/release-tag-version-test.sh
+++ b/test/ci/release-tag-version-test.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
-# Tests CI/check-release-tag.sh, the guard that keeps a release from being
-# published under a version nobody can be offered.
-#
-# The mistake it catches leaves no trace. Tagging "Mudlet-5.0" while APP_VERSION is
-# 5.0.0 passes every existing check - CI/prepare-release-assets.sh only matches the
-# tag as a prefix of the asset names, and "Mudlet-5.0.0-linux-x64.AppImage.tar" does
-# start with "Mudlet-5.0" - yet the updater then offers version "5.0", which is not
-# a three-component semantic version and is therefore never treated as newer than an
-# installed 4.22.0. Every existing user stops being offered updates and the update
-# check goes on logging "0 update(s) available".
+# Tests CI/check-release-tag.sh, which catches a mistake that otherwise leaves no
+# trace: "Mudlet-5.0" passes every existing check and is then never offered to a
+# single existing user. See that script for why.
 
 set -uo pipefail
 
@@ -32,7 +25,6 @@ fail() {
   FAILURES=$((FAILURES + 1))
 }
 
-# Runs the guard, leaving its combined output in ${OUT} and echoing its status
 run_check() {
   bash "${CHECK}" "$@" > "${OUT}" 2>&1
   echo $?
@@ -40,8 +32,8 @@ run_check() {
 
 assert_status() {
   local expected="$1" actual="$2"
-  # An empty or non-numeric status would make the comparison below error out and
-  # take the false branch, quietly turning every assertion into a pass
+  # -ne on an empty status errors out and takes the false branch, turning every
+  # assertion into a pass
   case "${actual}" in
     ''|*[!0-9]*)
       fail "expected exit ${expected}, got a non-numeric status '${actual}'"
@@ -88,18 +80,14 @@ assert_contains "${OUT}" "three-component"
 start_test "a version SemVer would reject for its leading zeros is rejected"
 assert_status 1 "$(run_check "5.01.0" "Mudlet-5.01.0")"
 
-# Release.cpp only strips a capitalised "Mudlet-", while the asset check matches
-# case-insensitively and set-build-info.sh lowercases the version - so a lowercase
-# tag is a mistake the surrounding tooling invites, and it fails the same silent way
+# Release.cpp strips only a capitalised "Mudlet-", while the asset check is
+# case-insensitive and set-build-info.sh lowercases the version
 start_test "a lowercase tag is rejected"
 assert_status 1 "$(run_check "4.22.0" "mudlet-4.22.0")"
 
 start_test "a tag missing the Mudlet- prefix is rejected"
 assert_status 1 "$(run_check "5.0.0" "5.0.0")"
 
-# Not because the updater could not parse "5.0.0-rc1", but because APP_VERSION
-# cannot carry the suffix, so the tag and the assets named after APP_VERSION would
-# disagree. Supporting release candidates means changing both together
 start_test "a suffixed tag is rejected while APP_VERSION cannot carry a suffix"
 assert_status 1 "$(run_check "5.0.0" "Mudlet-5.0.0-rc1")"
 
@@ -117,11 +105,9 @@ start_test "the failure is annotated for GitHub Actions, not only printed"
 GITHUB_ACTIONS=true bash "${CHECK}" "5.0.0" "Mudlet-5.0" > "${OUT}" 2>&1
 assert_contains "${OUT}" "::error::"
 
-# The guard is only worth anything if the release scripts actually reach it
 start_test "the tag-push build validation calls the guard"
 if ! command -v pcre2grep > /dev/null; then
-  # Silence here would hide the only assertions that prove the wiring, and CI has
-  # pcre2grep, so a missing one there is a broken runner rather than a local quirk
+  # Skipping is a local convenience; on CI a missing pcre2grep is a broken runner
   if [ -n "${CI:-}${GITHUB_ACTIONS:-}" ]; then
     fail "pcre2grep is missing, so the build validation scripts cannot be exercised"
   else
@@ -143,15 +129,13 @@ else
   done
 
   # The Windows script decides it is a release build from GITHUB_REPO_TAG but takes
-  # the tag from GITHUB_REF, so the two can disagree. That is still a hard failure,
-  # but it has to say what could not be determined rather than print a usage line
+  # the tag from GITHUB_REF, so the two can disagree
   (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" GITHUB_REPO_TAG=true WITH_UPDATER=YES \
     bash "${REPO_DIR}/CI/validate-deployment-for-windows.sh") > "${OUT}" 2>&1
   assert_status 1 "$?"
   assert_contains "${OUT}" "could not be determined"
 
-  # A development build has no tag to check and must not be blocked by one. The two
-  # scripts decide that from different variables, so both are exercised
+  # The two scripts decide "not a release build" from different variables
   (cd "${WORK_DIR}/repo" && GITHUB_REF="refs/heads/development" WITH_UPDATER=YES \
     bash "${REPO_DIR}/CI/validate_deployment.sh") > "${OUT}" 2>&1
   assert_status 0 "$?"
@@ -164,13 +148,10 @@ else
 fi
 
 start_test "the release workflow calls the guard before it publishes anything"
-# Blank out comments while keeping the line numbering, so a call that has merely
-# been commented out cannot satisfy any of this
+# Keeps the line numbering, so a commented-out call cannot satisfy any of this
 UNCOMMENTED="${WORK_DIR}/workflow-without-comments"
 sed 's/^[[:space:]]*#.*$//' "${RELEASE_WORKFLOW}" > "${UNCOMMENTED}"
 
-# The release-scripts/ prefix matters: the checkout of the tagged commit may predate
-# the guard, so the copy taken from this workflow's own ref is the one to run
 release_call='^[[:space:]]*bash release-scripts/CI/check-release-tag\.sh "\$\{VERSION\}" "\$\{REF#refs/tags/\}"[[:space:]]*$'
 ptb_call='^[[:space:]]*bash release-scripts/CI/check-release-tag\.sh "\$\{VERSION\}"[[:space:]]*$'
 publish_line=$(grep -n 'gh release create' "${UNCOMMENTED}" | head -1 | cut -d: -f1)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Adds `CI/check-release-tag.sh`: APP_VERSION must be three-component, and a release tag must be exactly `Mudlet-<APP_VERSION>`.
- Wires it into the tag-build validation (`CI/validate_deployment.sh`, `CI/validate-deployment-for-windows.sh`) so a bad tag fails minutes after the push, before an asset exists, and into `create-github-release.yml` as the last gate before anything is published. The PTB path gets the version-shape half, which nothing checks on `development` today.
- Covers it with `test/ci/release-tag-version-test.sh`, registered as `ReleaseTagVersionTest`.

#### Motivation for adding to Mudlet
Tagging `Mudlet-5.0` instead of `Mudlet-5.0.0` would strand the entire 4.22.0 user base with no error anywhere, and it is the one version mistake CI does not currently catch.

The updater takes the version it offers from the tag, not the binary: `Release::Release()` strips the `Mudlet-` prefix (`src/updater/Release.cpp:49`) and `SemVer::getRegExp()` needs three components (`src/updater/SemVer.cpp:111`), so `"5.0"` is invalid, `Release::operator<` (`src/updater/Release.cpp:96`) reports the release as not newer, and `Feed::getUpdates()` returns nothing. The update check goes on logging `0 update(s) available` - the same line as a week with no release.

The asymmetry is what makes it dangerous. A stale APP_VERSION with a correct tag fails loudly, because `CI/prepare-release-assets.sh:62` rejects assets by tag prefix. A short tag with a correct APP_VERSION passes everything, because `Mudlet-5.0.0-linux-x64.AppImage.tar` genuinely does start with `Mudlet-5.0`.

**Why the build scripts and not only the workflow:** `create-github-release.yml` is `workflow_run`-triggered, so it cannot fail before the assets are built - by the time it runs, the full matrix has already finished. The validate scripts run at the start of every tag build on all three platforms and already parse APP_VERSION, so that is where the fast failure belongs. The workflow keeps a copy because it always runs from the default branch, so it still guards a tag placed on a commit that predates this change.

APP_VERSION is deliberately left at 4.22.0 - bumping it is a release decision, not a QA fix. This guard is what catches a mismatch when the bump happens.

#### Other info (issues closed, discussion etc)
From the 5.0 release QA sweep, finding C1, "A two-component release tag silently disables auto-update for every existing user". Pre-existing mechanism, no single commit introduced it.

Three claims from an earlier draft did not survive checking and were corrected: `src/sparkleupdater.mm` installs no `versionComparatorForUpdater:`, so Sparkle's default component-wise comparator would still offer `5.0` over `4.22.0` (macOS breaks on the opposite mismatch instead); the update check does log, it is just indistinguishable from having nothing to offer; and SemVer does accept a prerelease component, so rejecting `Mudlet-5.0.0-rc1` follows from APP_VERSION being unable to carry a suffix, not from the updater.

No video - a CI guard is not visually observable. The shell output below is the evidence instead.

**Test case:** `ctest -R ReleaseTagVersionTest`, and the guard run directly:

```
$ CI/check-release-tag.sh 5.0.0 Mudlet-5.0.0
Release tag 'Mudlet-5.0.0' matches APP_VERSION '5.0.0'.
exit=0

$ CI/check-release-tag.sh 5.0.0 Mudlet-5.0
error: release tag 'Mudlet-5.0' does not match APP_VERSION '5.0.0'.
The tag has to be exactly 'Mudlet-5.0.0'.

Publishing under a mismatched tag breaks auto-update, without saying so. [...]
exit=1
```

Replayed over every release tag since 4.18.5, each against the APP_VERSION at that tag - all accepted, so the guard blocks nothing Mudlet has actually shipped. Executing the real `Determine release type` step under GitHub's shell flags fails on `Mudlet-5.0` + `5.0.0` and on a PTB with APP_VERSION `5.0`, and passes on `Mudlet-5.0.0` + `5.0.0` and on a normal PTB. The updater trace was confirmed by compiling `Release.cpp` + `SemVer.cpp` and comparing: tag `Mudlet-5.0.0` gives `(4.22.0 < release) = true`, tag `Mudlet-5.0` gives `false`.

Assisted-by: Claude:claude-opus-5