### PR TITLE
Fix user key bindings on Ctrl+1 to Ctrl+9 and Ctrl+Tab

### DIFF
--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -138,6 +138,21 @@ bool KeyUnit::processDataStream(const Qt::Key key, const Qt::KeyboardModifiers m
     return isMatchFound;
 }
 
+bool KeyUnit::wouldMatch(const Qt::Key key, const Qt::KeyboardModifiers modifiers) const
+{
+    for (auto keyObject : mKeyRootNodeList) {
+        if (!keyObject || !keyObject->isActive() || (keyObject->mpHost && keyObject->mpHost->isClosingDown())) {
+            continue;
+        }
+
+        if (keyObject->wouldMatch(key, modifiers)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void KeyUnit::compileAll()
 {
     for (auto key : mKeyRootNodeList) {

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -69,6 +69,9 @@ public:
     void uninstall(const QString&);
     void _uninstall(TKey* pChild, const QString& packageName);
     bool processDataStream(const Qt::Key, const Qt::KeyboardModifiers);
+    // Reports whether processDataStream() would find a binding for this key
+    // combination, without running any of them
+    bool wouldMatch(const Qt::Key, const Qt::KeyboardModifiers) const;
     void markCleanup(TKey* pT);
     void doCleanup();
     int processingDepth() const { return mProcessingDepth; }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -163,6 +163,20 @@ bool TCommandLine::keybindingMatched(QKeyEvent* keyEvent)
     return false;
 }
 
+bool TCommandLine::keybindingWouldMatchProfileSwitchShortcut(const QKeyEvent* keyEvent) const
+{
+    if (!mpKeyUnit || (mpHost && mpHost->isClosingDown())) {
+        return false;
+    }
+
+    auto* pMudlet = mudlet::self();
+    if (!pMudlet || !pMudlet->profileSwitchShortcutMatches(keyEvent)) {
+        return false;
+    }
+
+    return mpKeyUnit->wouldMatch(static_cast<Qt::Key>(keyEvent->key()), keyEvent->modifiers());
+}
+
 // This function overrides the QWidget::event() and should return true if the
 // event was recognized, otherwise it should return false. If the recognized
 // event was accepted (see QEvent::accepted), any further processing such as
@@ -183,6 +197,18 @@ bool TCommandLine::event(QEvent* event)
         // keys - so claim it here to make it arrive as a KeyPress for the
         // caret-toggling code below:
         if (mpHost->caretShortcutMatches(ke)) {
+            ke->accept();
+            return true;
+        }
+
+        // A user's own key binding beats the profile tab switching shortcuts,
+        // which is what handleCtrlTabChange() has always intended - but those
+        // are QShortcuts, and QShortcutMap consumes a matching key before the
+        // KeyPress is ever delivered here, so the binding has to be spotted
+        // now. Only asked about the keys those shortcuts occupy, and asked
+        // without running anything - the binding runs when the KeyPress that
+        // this claim lets through arrives:
+        if (keybindingWouldMatchProfileSwitchShortcut(ke)) {
             ke->accept();
             return true;
         }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -202,12 +202,12 @@ bool TCommandLine::event(QEvent* event)
         }
 
         // A user's own key binding beats the profile tab switching shortcuts,
-        // which is what handleCtrlTabChange() has always intended - but those
-        // are QShortcuts, and QShortcutMap consumes a matching key before the
-        // KeyPress is ever delivered here, so the binding has to be spotted
-        // now. Only asked about the keys those shortcuts occupy, and asked
-        // without running anything - the binding runs when the KeyPress that
-        // this claim lets through arrives:
+        // the precedence handleCtrlTabChange() below describes - but those are
+        // QShortcuts on the main window, and QShortcutMap consumes a matching
+        // key before the KeyPress is ever delivered here, so the binding has to
+        // be spotted now. Only the keys those shortcuts occupy are asked about,
+        // and asked without running anything - the binding runs when the
+        // KeyPress that this claim lets through arrives:
         if (keybindingWouldMatchProfileSwitchShortcut(ke)) {
             ke->accept();
             return true;
@@ -1357,6 +1357,14 @@ bool TCommandLine::handleCtrlTabChange(QKeyEvent* ke, int tabNumber)
         // hasn't created one then we fallback to tab switching - however
         // since some locales need the SHIFT modifier to enter numbers from the
         // top keyboard row (e.g. French AZERTY) we must ignore that one!
+        //
+        // Since the "Switch to profile N" QShortcuts were added this branch is
+        // no longer where that precedence is decided: whenever such a shortcut
+        // is set, the key only arrives here at all because event() claimed the
+        // ShortcutOverride for a matching binding, so the binding always wins
+        // and the tab switch below runs through the shortcut instead. The
+        // fallback still matters for Ctrl+0, which has no shortcut, and for
+        // shortcuts the user has cleared or remapped.
         if (keybindingMatched(ke)) {
             // Ah the user HAS created a matching binding:
             return true;

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -116,6 +116,7 @@ private:
     void enterCommand(QKeyEvent*);
     void processNormalKey(QEvent*);
     bool keybindingMatched(QKeyEvent*);
+    bool keybindingWouldMatchProfileSwitchShortcut(const QKeyEvent*) const;
     void spellCheckWord(QTextCursor& c);
     bool handleCtrlTabChange(QKeyEvent* key, int tabNumber);
     void restoreHistory();

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -105,9 +105,10 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
 
 bool TKey::wouldMatch(const Qt::Key key, const Qt::KeyboardModifiers modifier) const
 {
-    // Same re-entrancy guard as match(): cleanup may have deleted this key
-    // while the walk was still on the call stack
-    if (!mpMyChildrenList || !isActive()) {
+    // isActive() is also false for a half-destroyed key, so this covers the
+    // dereference below. Nothing runs during this walk, so unlike match() there
+    // is no re-entrancy to guard against:
+    if (!isActive()) {
         return false;
     }
 

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -103,6 +103,28 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
 }
 
 
+bool TKey::wouldMatch(const Qt::Key key, const Qt::KeyboardModifiers modifier) const
+{
+    // Same re-entrancy guard as match(): cleanup may have deleted this key
+    // while the walk was still on the call stack
+    if (!mpMyChildrenList || !isActive()) {
+        return false;
+    }
+
+    if (!isFolder() && (mKeyCode == key) && (mKeyModifier == modifier)) {
+        return true;
+    }
+
+    for (auto childKey : *mpMyChildrenList) {
+        if (childKey->wouldMatch(key, modifier)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
 bool TKey::registerKey()
 {
     if (!mpHost) {

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -64,6 +64,9 @@ public:
 
 
     bool match(const Qt::Key, const Qt::KeyboardModifiers, const bool);
+    // Same walk as match() but without running anything - for asking whether a
+    // key press is spoken for before deciding to let it through:
+    bool wouldMatch(const Qt::Key, const Qt::KeyboardModifiers) const;
     bool registerKey();
     void validateKeyBinding();
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2115,6 +2115,38 @@ void mudlet::switchToProfileTab(int index)
     }
 }
 
+// Whether this key press is one of the profile tab switching shortcuts, i.e.
+// one that a user's own key binding is allowed to take priority over:
+bool mudlet::profileSwitchShortcutMatches(const QKeyEvent* ke) const
+{
+    if (!ke) {
+        return false;
+    }
+
+    const QKeySequence pressed(ke->keyCombination());
+    // Shift+Tab arrives as Key_Backtab (with the Shift modifier retained) but
+    // the sequences are spelt with Key_Tab, so accept that spelling as well -
+    // the same asymmetry the sequence definitions above comment on. Stays
+    // empty, and so matches nothing, for every other key:
+    const QKeySequence backtabAlternative = (ke->key() == Qt::Key_Backtab) ? QKeySequence(QKeyCombination(ke->modifiers() | Qt::ShiftModifier, Qt::Key_Tab)) : QKeySequence();
+
+    auto matches = [&pressed, &backtabAlternative](const QKeySequence& sequence) {
+        return !sequence.isEmpty() && (sequence == pressed || sequence == backtabAlternative);
+    };
+
+    if (matches(mKeySequenceNextProfile) || matches(mKeySequencePreviousProfile)) {
+        return true;
+    }
+
+    for (const auto& sequence : mKeySequencesSwitchToProfile) {
+        if (matches(sequence)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Moved as much as possible to activateProfile()...
 void mudlet::slot_tabChanged(int tabID)
 {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -65,6 +65,7 @@
 #include <QFileDialog>
 #include <QJsonDocument>
 #include <QImage>
+#include <QKeyEvent>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QNetworkDiskCache>
@@ -2115,31 +2116,58 @@ void mudlet::switchToProfileTab(int index)
     }
 }
 
-// Whether this key press is one of the profile tab switching shortcuts, i.e.
-// one that a user's own key binding is allowed to take priority over:
+// Whether this key press would activate one of the profile tab switching
+// shortcuts. Has to reproduce QShortcutMap's matching rather than compare the
+// key press literally, because a shortcut can be spelt differently to the key
+// press that activates it:
 bool mudlet::profileSwitchShortcutMatches(const QKeyEvent* ke) const
 {
     if (!ke) {
         return false;
     }
 
-    const QKeySequence pressed(ke->keyCombination());
-    // Shift+Tab arrives as Key_Backtab (with the Shift modifier retained) but
-    // the sequences are spelt with Key_Tab, so accept that spelling as well -
-    // the same asymmetry the sequence definitions above comment on. Stays
-    // empty, and so matches nothing, for every other key:
-    const QKeySequence backtabAlternative = (ke->key() == Qt::Key_Backtab) ? QKeySequence(QKeyCombination(ke->modifiers() | Qt::ShiftModifier, Qt::Key_Tab)) : QKeySequence();
+    const auto key = static_cast<Qt::Key>(ke->key());
+    const Qt::KeyboardModifiers modifiers = ke->modifiers();
 
-    auto matches = [&pressed, &backtabAlternative](const QKeySequence& sequence) {
-        return !sequence.isEmpty() && (sequence == pressed || sequence == backtabAlternative);
+    // QShortcutMap retries the match with the modifiers the platform consumed
+    // producing the character stripped off, so a shortcut fires for presses
+    // spelt differently to itself. Both retries that reach these shortcuts land
+    // on the digits: Ctrl and a numpad digit activates Ctrl+1, and on layouts
+    // that need Shift for a top-row digit (French AZERTY) so does Ctrl+Shift+1 -
+    // which is the same reason handleCtrlTabChange() ignores Shift.
+    QList<QKeySequence> candidates;
+    const Qt::KeyboardModifiers strippable[] = {Qt::NoModifier, Qt::KeypadModifier, Qt::ShiftModifier, Qt::ShiftModifier | Qt::KeypadModifier};
+    for (const auto stripped : strippable) {
+        // Only single key combinations are ever produced here, so a shortcut
+        // remapped to a multi-step sequence would never be matched - none of
+        // the defaults are, and the shortcut editor cannot record one:
+        const QKeySequence candidate(QKeyCombination(modifiers & ~stripped, key));
+        if (!candidates.contains(candidate)) {
+            candidates.append(candidate);
+        }
+    }
+
+    if (key == Qt::Key_Backtab) {
+        // The other direction: Shift+Tab produces the Backtab keysym, while the
+        // sequences are spelt with Key_Tab (see mudlet::mudlet(), where they are
+        // defined). Shift is normally still set on such an event, but Qt's own
+        // Backtab handling does not rely on that, so put it back rather than
+        // assume it is there:
+        candidates.append(QKeySequence(QKeyCombination(modifiers | Qt::ShiftModifier, Qt::Key_Tab)));
+    }
+
+    auto shadows = [&candidates](const QKeySequence& sequence) {
+        // A shortcut the user cleared in the preferences is an empty sequence,
+        // and comparing it would match any candidate that was also empty:
+        return !sequence.isEmpty() && candidates.contains(sequence);
     };
 
-    if (matches(mKeySequenceNextProfile) || matches(mKeySequencePreviousProfile)) {
+    if (shadows(mKeySequenceNextProfile) || shadows(mKeySequencePreviousProfile)) {
         return true;
     }
 
     for (const auto& sequence : mKeySequencesSwitchToProfile) {
-        if (matches(sequence)) {
+        if (shadows(sequence)) {
             return true;
         }
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -61,6 +61,7 @@
 class QAction;
 class QCloseEvent;
 class QDir;
+class QKeyEvent;
 class QMediaDevices;
 class QMediaPlayer;
 class QMenu;
@@ -200,6 +201,7 @@ public:
     void setupConfig();
     void activateProfile(Host*);
     void switchToProfileTab(int index);
+    bool profileSwitchShortcutMatches(const QKeyEvent*) const;
     void takeOwnershipOfInstanceCoordinator(std::unique_ptr<MudletInstanceCoordinator>);
     MudletInstanceCoordinator* getInstanceCoordinator();
     void addConsoleForNewHost(Host*);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(FUNCTIONAL_TEST_SOURCES
     DialogTeardownTest.cpp
     TMediaLoopTest.cpp
     DefaultPackagesTest.cpp
+    ProfileSwitchShortcutTest.cpp
 )
 
 # The updater sources are only built with USE_UPDATER, and on macOS the

--- a/test/functional_tests/ProfileSwitchShortcutTest.cpp
+++ b/test/functional_tests/ProfileSwitchShortcutTest.cpp
@@ -1,0 +1,340 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The profile tab switching shortcuts (Ctrl+1 to Ctrl+9, Ctrl+Tab) are
+ * application-wide QShortcuts on the main window. Qt resolves a QShortcut by
+ * first sending a QEvent::ShortcutOverride to the focus widget and, unless that
+ * widget accepts it, running the shortcut and never delivering the KeyPress.
+ * A user's own key binding on one of those keys therefore only survives if the
+ * command line claims the override - which is what these tests check, along
+ * with the two ways it must NOT claim it: no binding, and a binding that is
+ * disabled (directly or through its group).
+ *
+ * Run with: ctest -R ProfileSwitchShortcutTest -V
+ */
+
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "Host.h"
+#include "KeyUnit.h"
+#include "MudletInstanceCoordinator.h"
+#include "TCommandLine.h"
+#include "TKey.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include <QShortcut>
+
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
+}
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForProfileSwitchShortcutTest();
+
+// Qt::CTRL is the Cmd key on macOS, where the "next profile" shortcut uses the
+// physical Control key (Qt::META) instead - mirrors mudlet::mudlet():
+#if defined(Q_OS_MACOS)
+static constexpr Qt::KeyboardModifier nextProfileModifier = Qt::MetaModifier;
+#else
+static constexpr Qt::KeyboardModifier nextProfileModifier = Qt::ControlModifier;
+#endif
+
+class ProfileSwitchShortcutTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "ProfileSwitchShortcut-Test";
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    const QString mLocalhost = "localhost";
+
+    TCommandLine* commandLine() const
+    {
+        if (!mpHost || !mpHost->mpConsole) {
+            return nullptr;
+        }
+        return mpHost->mpConsole->mpCommandLine;
+    }
+
+    // Replays what QShortcutMap does before it runs a shortcut: it offers the
+    // key to the focus widget as an ignored ShortcutOverride and only runs the
+    // shortcut if nobody accepted it.
+    bool overrideClaimed(int key, Qt::KeyboardModifiers modifiers) const
+    {
+        QKeyEvent event(QEvent::ShortcutOverride, key, modifiers);
+        event.ignore();
+        QApplication::sendEvent(commandLine(), &event);
+        return event.isAccepted();
+    }
+
+    void sendKeyPress(int key, Qt::KeyboardModifiers modifiers) const
+    {
+        QKeyEvent event(QEvent::KeyPress, key, modifiers);
+        QApplication::sendEvent(commandLine(), &event);
+    }
+
+    // The shortcuts are only worth overriding if they are actually installed,
+    // so every test that asserts a claim also proves the collision is real.
+    bool shortcutInstalledFor(const QKeySequence& sequence) const
+    {
+        const auto shortcuts = mudlet::self()->findChildren<QShortcut*>();
+        for (auto* shortcut : shortcuts) {
+            if (shortcut->key() == sequence && shortcut->isEnabled()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    int luaCounter(const QString& globalName) const
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, globalName.toUtf8().constData());
+        const int value = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        return value;
+    }
+
+    // Creates a permanent key binding whose script counts its own invocations
+    // into a Lua global, and returns its id.
+    int createCountingKey(const QString& name, int keycode, int modifier, const QString& counterName, const QString& parent = QString())
+    {
+        QString keyName = name;
+        QString parentName = parent;
+        QString script = qsl("%1 = (%1 or 0) + 1").arg(counterName);
+        auto [id, message] = mpHost->mLuaInterpreter.startPermKey(keyName, parentName, keycode, modifier, script);
+        if (id <= 0) {
+            qWarning() << "createCountingKey failed:" << message;
+        }
+        return id;
+    }
+
+    void removeAllKeys()
+    {
+        auto* keyUnit = mpHost->getKeyUnit();
+        const auto rootKeys = keyUnit->getKeyRootNodeList();
+        for (auto* key : rootKeys) {
+            delete key;
+        }
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForProfileSwitchShortcutTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+
+        startProfile(mHostname, mLocalhost, mPort);
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY2(mpHost, "No active host after profile creation");
+        QVERIFY2(commandLine(), "No command line available for the test");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    void cleanup() { removeAllKeys(); }
+
+    // The regression itself: a user binding on Ctrl+1 must beat "Switch to
+    // profile 1".
+    void test_userBindingOnCtrlNumberClaimsTheShortcut()
+    {
+        QVERIFY2(shortcutInstalledFor(QKeySequence(Qt::CTRL | Qt::Key_1)), "No profile switching shortcut is installed for Ctrl+1, so this test proves nothing");
+
+        QVERIFY(createCountingKey(qsl("Ctrl+1 binding"), Qt::Key_1, Qt::ControlModifier, qsl("_testCtrl1")) > 0);
+
+        QVERIFY2(overrideClaimed(Qt::Key_1, Qt::ControlModifier), "A user key binding on Ctrl+1 did not claim the key, so the profile switch shortcut swallows it");
+    }
+
+    // Without a binding the key has to be left alone so the tab switch happens.
+    void test_withoutUserBindingTheShortcutKeepsTheKey()
+    {
+        QVERIFY2(!overrideClaimed(Qt::Key_1, Qt::ControlModifier), "Ctrl+1 was claimed even though no user key binding matches it - profile switching would stop working");
+    }
+
+    // A binding on a key that no profile switching shortcut uses needs no
+    // claim - Ctrl+0 is the control case that always worked, because only nine
+    // shortcuts (Ctrl+1 to Ctrl+9) are installed.
+    void test_bindingOnAnUnshadowedKeyIsNotClaimed()
+    {
+        QVERIFY(createCountingKey(qsl("Ctrl+0 binding"), Qt::Key_0, Qt::ControlModifier, qsl("_testCtrl0")) > 0);
+
+        QVERIFY2(!overrideClaimed(Qt::Key_0, Qt::ControlModifier), "Ctrl+0 is not a profile switching shortcut, so the command line must not claim it");
+    }
+
+    // A disabled binding is not a binding, so it must not steal the key from
+    // the tab switch.
+    void test_disabledUserBindingDoesNotClaimTheShortcut()
+    {
+        const int id = createCountingKey(qsl("Disabled Ctrl+2 binding"), Qt::Key_2, Qt::ControlModifier, qsl("_testCtrl2"));
+        QVERIFY(id > 0);
+        QVERIFY(overrideClaimed(Qt::Key_2, Qt::ControlModifier));
+
+        auto* key = mpHost->getKeyUnit()->getKey(id);
+        QVERIFY(key);
+        key->setIsActive(false);
+
+        QVERIFY2(!overrideClaimed(Qt::Key_2, Qt::ControlModifier), "A disabled key binding still claimed Ctrl+2");
+    }
+
+    // Same for an active binding sitting inside a disabled group.
+    void test_userBindingInDisabledGroupDoesNotClaimTheShortcut()
+    {
+        const int groupId = createCountingKey(qsl("Key Group"), -1, 0, qsl("_testGroup"));
+        QVERIFY(groupId > 0);
+        auto* group = mpHost->getKeyUnit()->getKey(groupId);
+        QVERIFY(group);
+        group->setIsActive(true);
+
+        QVERIFY(createCountingKey(qsl("Grouped Ctrl+3 binding"), Qt::Key_3, Qt::ControlModifier, qsl("_testCtrl3"), qsl("Key Group")) > 0);
+        QVERIFY2(overrideClaimed(Qt::Key_3, Qt::ControlModifier), "A binding in an enabled group should claim Ctrl+3");
+
+        group->setIsActive(false);
+        QVERIFY2(!overrideClaimed(Qt::Key_3, Qt::ControlModifier), "A binding inside a disabled group still claimed Ctrl+3");
+    }
+
+    // Ctrl+Tab ("Next profile") is shadowed the same way and needs the same
+    // treatment, in both directions.
+    void test_userBindingOnCtrlTabClaimsTheShortcut()
+    {
+        QVERIFY2(!overrideClaimed(Qt::Key_Tab, nextProfileModifier), "Ctrl+Tab was claimed with no user key binding present");
+
+        QVERIFY(createCountingKey(qsl("Ctrl+Tab binding"), Qt::Key_Tab, nextProfileModifier, qsl("_testCtrlTab")) > 0);
+
+        QVERIFY2(overrideClaimed(Qt::Key_Tab, nextProfileModifier), "A user key binding on Ctrl+Tab did not claim the key");
+    }
+
+    // Claiming the override only defers the key - the binding must then run
+    // exactly once, off the KeyPress that the claim let through, and not a
+    // second time from the probe itself.
+    void test_claimedBindingRunsExactlyOnce()
+    {
+        QVERIFY(createCountingKey(qsl("Ctrl+4 binding"), Qt::Key_4, Qt::ControlModifier, qsl("_testCtrl4")) > 0);
+        QCOMPARE(luaCounter(qsl("_testCtrl4")), 0);
+
+        QVERIFY(overrideClaimed(Qt::Key_4, Qt::ControlModifier));
+        QCOMPARE(luaCounter(qsl("_testCtrl4")), 0); // the probe must not execute anything
+
+        sendKeyPress(Qt::Key_4, Qt::ControlModifier);
+        QCOMPARE(luaCounter(qsl("_testCtrl4")), 1);
+    }
+
+private:
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0ms, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy connectionSpy(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!connectionSpy.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForProfileSwitchShortcutTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "ProfileSwitchShortcutTest.moc"
+QTEST_MAIN(ProfileSwitchShortcutTest)

--- a/test/functional_tests/ProfileSwitchShortcutTest.cpp
+++ b/test/functional_tests/ProfileSwitchShortcutTest.cpp
@@ -19,13 +19,16 @@
 
 /*
  * The profile tab switching shortcuts (Ctrl+1 to Ctrl+9, Ctrl+Tab) are
- * application-wide QShortcuts on the main window. Qt resolves a QShortcut by
- * first sending a QEvent::ShortcutOverride to the focus widget and, unless that
- * widget accepts it, running the shortcut and never delivering the KeyPress.
- * A user's own key binding on one of those keys therefore only survives if the
- * command line claims the override - which is what these tests check, along
- * with the two ways it must NOT claim it: no binding, and a binding that is
- * disabled (directly or through its group).
+ * QShortcuts on the main window. Qt resolves a QShortcut by first sending a
+ * QEvent::ShortcutOverride to the focus widget and, unless that widget accepts
+ * it, running the shortcut and never delivering the KeyPress. A user's own key
+ * binding on one of those keys therefore only survives if the command line
+ * claims the override.
+ *
+ * The invariant under test: the command line claims the override exactly when
+ * a live user key binding matches a key press that would otherwise activate a
+ * profile switching shortcut - including the presses QShortcutMap matches to a
+ * differently spelt shortcut - and never otherwise.
  *
  * Run with: ctest -R ProfileSwitchShortcutTest -V
  */
@@ -39,6 +42,7 @@
 #include "TCommandLine.h"
 #include "TKey.h"
 #include "TLuaInterpreter.h"
+#include "ShortcutsManager.h"
 #include "TMainConsole.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
@@ -112,8 +116,9 @@ private:
         QApplication::sendEvent(commandLine(), &event);
     }
 
-    // The shortcuts are only worth overriding if they are actually installed,
-    // so every test that asserts a claim also proves the collision is real.
+    // A claim is only worth asserting if a shortcut is actually competing for
+    // the key, so every test that asserts one first proves the collision is
+    // real - otherwise a mis-mapped sequence would look like a code failure.
     bool shortcutInstalledFor(const QKeySequence& sequence) const
     {
         const auto shortcuts = mudlet::self()->findChildren<QShortcut*>();
@@ -123,6 +128,18 @@ private:
             }
         }
         return false;
+    }
+
+    // Read from the shortcuts manager rather than hard coded, since it is
+    // Alt+E on Linux and Windows but Ctrl+E on macOS.
+    std::pair<int, Qt::KeyboardModifiers> scriptEditorShortcut() const
+    {
+        auto* sequence = mudlet::self()->shortcutsManager()->getSequence(qsl("Script editor"));
+        if (!sequence || sequence->isEmpty()) {
+            return {Qt::Key_unknown, Qt::NoModifier};
+        }
+        const QKeyCombination combination = (*sequence)[0];
+        return {combination.key(), combination.keyboardModifiers()};
     }
 
     int luaCounter(const QString& globalName) const
@@ -148,10 +165,14 @@ private:
         return id;
     }
 
+    // Deleting the roots outright is only safe because every key here is
+    // permanent and none is killed or uninstalled, so KeyUnit's deferred-delete
+    // set is always empty. Add a temporary key or a killKey() call to this file
+    // and this has to go through markCleanup()/doCleanup() instead.
     void removeAllKeys()
     {
         auto* keyUnit = mpHost->getKeyUnit();
-        const auto rootKeys = keyUnit->getKeyRootNodeList();
+        const auto rootKeys = keyUnit->getKeyRootNodeList(); // by value: ~TKey mutates the real list
         for (auto* key : rootKeys) {
             delete key;
         }
@@ -176,6 +197,11 @@ private slots:
         mpHost = mudlet::self()->getActiveHost();
         QVERIFY2(mpHost, "No active host after profile creation");
         QVERIFY2(commandLine(), "No command line available for the test");
+
+        // The caret shortcut is checked before this code in TCommandLine::event()
+        // and CtrlTab would claim Ctrl+Tab itself, so pin it to the default
+        // rather than let an unrelated feature decide what these tests measure:
+        mpHost->mCaretShortcut = Host::CaretShortcut::None;
     }
 
     void cleanupTestCase()
@@ -217,18 +243,29 @@ private slots:
     }
 
     // A disabled binding is not a binding, so it must not steal the key from
-    // the tab switch.
+    // the tab switch. Disabled through KeyUnit::disableKey(), which is the path
+    // the editor and the Lua disableKey() take - it clears mActive, not the
+    // mUserActiveState that setIsActive() writes.
     void test_disabledUserBindingDoesNotClaimTheShortcut()
     {
-        const int id = createCountingKey(qsl("Disabled Ctrl+2 binding"), Qt::Key_2, Qt::ControlModifier, qsl("_testCtrl2"));
-        QVERIFY(id > 0);
+        const QString name = qsl("Disabled Ctrl+2 binding");
+        QVERIFY(createCountingKey(name, Qt::Key_2, Qt::ControlModifier, qsl("_testCtrl2")) > 0);
         QVERIFY(overrideClaimed(Qt::Key_2, Qt::ControlModifier));
 
-        auto* key = mpHost->getKeyUnit()->getKey(id);
-        QVERIFY(key);
-        key->setIsActive(false);
+        QVERIFY(mpHost->getKeyUnit()->disableKey(name));
 
         QVERIFY2(!overrideClaimed(Qt::Key_2, Qt::ControlModifier), "A disabled key binding still claimed Ctrl+2");
+    }
+
+    // The nine switch-to-profile shortcuts are generated in a loop, so check
+    // the far end of it too.
+    void test_userBindingOnCtrlNineClaimsTheShortcut()
+    {
+        QVERIFY2(shortcutInstalledFor(QKeySequence(Qt::CTRL | Qt::Key_9)), "No profile switching shortcut is installed for Ctrl+9, so this test proves nothing");
+
+        QVERIFY(createCountingKey(qsl("Ctrl+9 binding"), Qt::Key_9, Qt::ControlModifier, qsl("_testCtrl9")) > 0);
+
+        QVERIFY2(overrideClaimed(Qt::Key_9, Qt::ControlModifier), "A user key binding on Ctrl+9 did not claim the key");
     }
 
     // Same for an active binding sitting inside a disabled group.
@@ -251,11 +288,85 @@ private slots:
     // treatment, in both directions.
     void test_userBindingOnCtrlTabClaimsTheShortcut()
     {
+        QVERIFY2(shortcutInstalledFor(QKeySequence(nextProfileModifier | Qt::Key_Tab)), "No 'Next profile' shortcut is installed for Ctrl+Tab, so this test proves nothing");
         QVERIFY2(!overrideClaimed(Qt::Key_Tab, nextProfileModifier), "Ctrl+Tab was claimed with no user key binding present");
 
         QVERIFY(createCountingKey(qsl("Ctrl+Tab binding"), Qt::Key_Tab, nextProfileModifier, qsl("_testCtrlTab")) > 0);
 
         QVERIFY2(overrideClaimed(Qt::Key_Tab, nextProfileModifier), "A user key binding on Ctrl+Tab did not claim the key");
+    }
+
+    // "Previous profile" is Ctrl+Shift+Tab, but Shift+Tab reaches the widget as
+    // Key_Backtab with the Shift modifier kept, so the sequence (spelt with
+    // Key_Tab) and the key press disagree on the spelling and the match has to
+    // bridge that.
+    void test_userBindingOnCtrlShiftTabClaimsTheShortcut()
+    {
+        const auto modifiers = nextProfileModifier | Qt::ShiftModifier;
+        QVERIFY2(!overrideClaimed(Qt::Key_Backtab, modifiers), "Ctrl+Shift+Tab was claimed with no user key binding present");
+
+        QVERIFY(createCountingKey(qsl("Ctrl+Shift+Tab binding"), Qt::Key_Backtab, modifiers, qsl("_testCtrlShiftTab")) > 0);
+
+        QVERIFY2(overrideClaimed(Qt::Key_Backtab, modifiers), "A user key binding on Ctrl+Shift+Tab did not claim the key");
+    }
+
+    // Only the profile switching shortcuts are overridden. Every other
+    // application shortcut keeps its key, so a binding on the script editor
+    // shortcut must not be claimed.
+    void test_bindingOnAnotherApplicationShortcutIsNotClaimed()
+    {
+        auto [key, modifiers] = scriptEditorShortcut();
+        QVERIFY2(key != Qt::Key_unknown, "Could not read the script editor shortcut");
+
+        QVERIFY(createCountingKey(qsl("Script editor shortcut binding"), key, modifiers, qsl("_testEditor")) > 0);
+
+        QVERIFY2(!overrideClaimed(key, modifiers), "A key binding claimed the script editor shortcut, which is outside the profile switching set");
+    }
+
+    // Guards the "empty sequence matches everything" failure mode. A key press
+    // that is not Backtab has no alternative spelling to compare against, so
+    // without the isEmpty() guard a shortcut the user has cleared in
+    // Preferences would compare equal to every key and claim the lot.
+    void test_aClearedProfileShortcutDoesNotClaimEveryKey()
+    {
+        auto* sequence = mudlet::self()->shortcutsManager()->getSequence(qsl("Switch to profile 1"));
+        QVERIFY2(sequence, "'Switch to profile 1' is not registered with the shortcuts manager");
+        const QKeySequence saved = *sequence;
+        *sequence = QKeySequence();
+
+        auto [key, modifiers] = scriptEditorShortcut();
+        QVERIFY(createCountingKey(qsl("Script editor shortcut binding"), key, modifiers, qsl("_testEditorCleared")) > 0);
+        QVERIFY(createCountingKey(qsl("F5 binding"), Qt::Key_F5, Qt::NoModifier, qsl("_testF5")) > 0);
+
+        const bool editorClaimed = overrideClaimed(key, modifiers);
+        const bool f5Claimed = overrideClaimed(Qt::Key_F5, Qt::NoModifier);
+        *sequence = saved;
+
+        QVERIFY2(!editorClaimed, "A cleared profile switching shortcut made an unrelated bound key claim the override");
+        QVERIFY2(!f5Claimed, "A cleared profile switching shortcut made an unrelated bound key claim the override");
+    }
+
+    // QShortcutMap retries a match with the keypad modifier stripped, so Ctrl
+    // and a numpad digit activates the plain Ctrl+1 shortcut even though the
+    // two key combinations differ. Verified against the real thing: without the
+    // claim, Ctrl+numpad-2 switches profile and the binding never runs.
+    void test_userBindingOnAKeypadDigitClaimsTheShortcut()
+    {
+        const auto modifiers = Qt::ControlModifier | Qt::KeypadModifier;
+        QVERIFY(createCountingKey(qsl("Ctrl+keypad 1 binding"), Qt::Key_1, modifiers, qsl("_testKeypad1")) > 0);
+
+        QVERIFY2(overrideClaimed(Qt::Key_1, modifiers), "A user key binding on Ctrl and a keypad digit did not claim the key");
+    }
+
+    // Layouts that need Shift for a top-row digit (French AZERTY) record the
+    // binding with Shift and still activate the plain Ctrl+1 shortcut, because
+    // QShortcutMap drops the Shift that was consumed producing the digit.
+    void test_userBindingOnAShiftedDigitClaimsTheShortcut()
+    {
+        const auto modifiers = Qt::ControlModifier | Qt::ShiftModifier;
+        QVERIFY(createCountingKey(qsl("Ctrl+Shift+1 binding"), Qt::Key_1, modifiers, qsl("_testShift1")) > 0);
+
+        QVERIFY2(overrideClaimed(Qt::Key_1, modifiers), "A user key binding on Ctrl+Shift and a digit did not claim the key");
     }
 
     // Claiming the override only defers the key - the binding must then run


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The profile tab switching shortcuts added in #9460 "add: keyboard shortcuts to switch between game tabs" (`b649b60f0`) are `QShortcut`s on the main window, and Qt's `QShortcutMap` consumes a matching key inside `QApplication::notify` before the `KeyPress` ever reaches the command line. `TCommandLine::handleCtrlTabChange()`'s "let user-defined Ctrl+# keys match first" branch became unreachable, so user key bindings on Ctrl+1..Ctrl+9, Ctrl+Tab and Ctrl+Shift+Tab silently stopped working.
- `TCommandLine::event()` now claims `QEvent::ShortcutOverride` for exactly those key sequences when a user binding matches, which is the same escape hatch the accessibility caret shortcut already uses. Asking needs a non-executing query, hence `TKey`/`KeyUnit::wouldMatch()` - `keybindingMatched()` runs the binding and would fire it on every override probe. The match reproduces `QShortcutMap`'s own retries, so Ctrl and a numpad digit, and Ctrl+Shift and a digit on layouts that need Shift for the top row (French AZERTY), are covered too.
- Precedence, stated explicitly: a user binding wins over the built-in tab switch, which is what that comment always intended. A binding that is disabled, or sits in a disabled group, does not claim the key, and every other application shortcut is unaffected.

#### Motivation for adding to Mudlet

Ctrl+1 to Ctrl+9 is a common combat/target hotkey range and the one Mudlet's own key editor offers. Upgrading silently broke those bindings with no error and no warning, and the escape hatch (clearing the shortcut in Preferences) is undiscoverable.

#### Other info (issues closed, discussion etc)

Test case: `ctest -R ProfileSwitchShortcutTest` - 15 cases covering the claim, the no-claim controls, disabled bindings and groups, the keypad and shifted-digit spellings, Ctrl+Shift+Tab's `Key_Backtab` spelling, a cleared shortcut not claiming every key, and that a claimed binding runs exactly once. Verified to fail without the fix.

Not fixed here, reported instead: the caret-mode Ctrl+Tab toggle lives on `Host::mCaretShortcut` rather than `ShortcutsManager`, so #9449's shortcut clash warning still cannot see its collision with the "Next profile" default.

Assisted-by: Claude:claude-opus-5
