### PR TITLE
fix: two ways a profile save could lose or resurrect your data

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -68,6 +68,25 @@ VarUnit* LuaInterface::getVarUnit()
     return varUnit.data();
 }
 
+lua_State* LuaInterface::getState()
+{
+    return mL;
+}
+
+// Hands back the Lua registry references taken for reference-keyed variables
+// (a table or a function used as a key has no printable name, so it is named by
+// its registry reference instead). getVars() calls this for the tree it is
+// about to replace; anything that builds a tree it then throws away has to call
+// it itself, as the destructor cannot - a profile reset closes the lua_State
+// before the Host's LuaInterface is replaced.
+void LuaInterface::releaseVariableReferences()
+{
+    for (const int ref : std::as_const(lrefs)) {
+        luaL_unref(mL, LUA_REGISTRYINDEX, ref);
+    }
+    lrefs.clear();
+}
+
 QStringList LuaInterface::varName(TVar* var)
 {
     QStringList names;
@@ -830,12 +849,7 @@ void LuaInterface::getVars(bool hide)
     auto global = new TVar();
     global->setName("_G", LUA_TSTRING);
     global->setValue("{}", LUA_TTABLE);
-    QListIterator<int> it(lrefs);
-    while (it.hasNext()) {
-        const int ref = it.next();
-        luaL_unref(mL, LUA_REGISTRYINDEX, ref);
-    }
-    lrefs.clear();
+    releaseVariableReferences();
     varUnit->clear();
     varUnit->setBase(global);
     varUnit->addVariable(global);

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -49,11 +49,8 @@ LuaInterface::LuaInterface(lua_State* L)
     lua_atpanic(L, &onPanic);
 }
 
-// Deliberately does not hand back the Lua registry references in lrefs: a
-// profile reset closes the lua_State before this object is replaced
-// (Host::resetProfile_phase2()), so unref'ing here would write into a freed
-// state. Anything that builds a variable tree it then throws away calls
-// releaseVariableReferences() itself instead.
+// Does not release lrefs: a profile reset closes the lua_State before this
+// object is replaced, so unref'ing here would write into a freed state.
 LuaInterface::~LuaInterface() = default;
 
 int LuaInterface::onPanic(lua_State* L)
@@ -78,10 +75,6 @@ lua_State* LuaInterface::getState() const
     return mL;
 }
 
-// Hands back the Lua registry references taken for reference-keyed variables
-// (a table or a function used as a key has no printable name, so it is named by
-// its registry reference instead). getVars() calls this for the tree it is
-// about to replace.
 void LuaInterface::releaseVariableReferences()
 {
     for (const int ref : std::as_const(lrefs)) {
@@ -847,12 +840,9 @@ void LuaInterface::getVars(bool hide)
     //returns the base item
     // QElapsedTimer t;
     // t.start();
-    // Guarded like every other Lua-touching method here: onPanic() longjmp()s
-    // to the shared buf, and without a setjmp of our own that jump lands in
-    // whichever frame set it last - usually one that has already returned.
-    // Returning instead leaves a partial tree, but lets the caller's scope run,
-    // which is what frees a tree built for a profile save and hands its registry
-    // references back.
+    // onPanic() longjmp()s to the shared buf, so without a setjmp of our own
+    // that jump lands in whichever frame set it last - usually one that has
+    // already returned, taking the caller's scope down with it.
     if (setjmp(buf) != 0) {
         qWarning() << "LuaInterface::getVars() WARNING - Lua panicked while reading the variables in; the variable tree is incomplete.";
         return;

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -49,6 +49,11 @@ LuaInterface::LuaInterface(lua_State* L)
     lua_atpanic(L, &onPanic);
 }
 
+// Deliberately does not hand back the Lua registry references in lrefs: a
+// profile reset closes the lua_State before this object is replaced
+// (Host::resetProfile_phase2()), so unref'ing here would write into a freed
+// state. Anything that builds a variable tree it then throws away calls
+// releaseVariableReferences() itself instead.
 LuaInterface::~LuaInterface() = default;
 
 int LuaInterface::onPanic(lua_State* L)
@@ -68,7 +73,7 @@ VarUnit* LuaInterface::getVarUnit()
     return varUnit.data();
 }
 
-lua_State* LuaInterface::getState()
+lua_State* LuaInterface::getState() const
 {
     return mL;
 }
@@ -76,9 +81,7 @@ lua_State* LuaInterface::getState()
 // Hands back the Lua registry references taken for reference-keyed variables
 // (a table or a function used as a key has no printable name, so it is named by
 // its registry reference instead). getVars() calls this for the tree it is
-// about to replace; anything that builds a tree it then throws away has to call
-// it itself, as the destructor cannot - a profile reset closes the lua_State
-// before the Host's LuaInterface is replaced.
+// about to replace.
 void LuaInterface::releaseVariableReferences()
 {
     for (const int ref : std::as_const(lrefs)) {
@@ -844,6 +847,16 @@ void LuaInterface::getVars(bool hide)
     //returns the base item
     // QElapsedTimer t;
     // t.start();
+    // Guarded like every other Lua-touching method here: onPanic() longjmp()s
+    // to the shared buf, and without a setjmp of our own that jump lands in
+    // whichever frame set it last - usually one that has already returned.
+    // Returning instead leaves a partial tree, but lets the caller's scope run,
+    // which is what frees a tree built for a profile save and hands its registry
+    // references back.
+    if (setjmp(buf) != 0) {
+        qWarning() << "LuaInterface::getVars() WARNING - Lua panicked while reading the variables in; the variable tree is incomplete.";
+        return;
+    }
     lua_pushnil(mL);
     depth = 0;
     auto global = new TVar();

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -65,13 +65,16 @@ public:
     void renameVar(TVar*);
     void createVar(TVar*);
     VarUnit* getVarUnit();
+    // Hands the Lua registry references this interface took for reference-keyed
+    // variables back to the state. Anything that builds a variable tree and then
+    // throws it away owes this call; the destructor cannot make it - see there.
     void releaseVariableReferences();
     bool loadVar(TVar* var);
     bool reparentCVariable(TVar* from, TVar* to, TVar* curVar);
     bool reparentVariable(QTreeWidgetItem*, QTreeWidgetItem*, QTreeWidgetItem*);
     std::pair<bool, QString> validMove(QTreeWidgetItem*);
     void getAllChildren(TVar* var, QList<TVar*>* list);
-    lua_State* getState();
+    lua_State* getState() const;
     static int onPanic(lua_State*);
 
 private:

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -65,6 +65,7 @@ public:
     void renameVar(TVar*);
     void createVar(TVar*);
     VarUnit* getVarUnit();
+    void releaseVariableReferences();
     bool loadVar(TVar* var);
     bool reparentCVariable(TVar* from, TVar* to, TVar* curVar);
     bool reparentVariable(QTreeWidgetItem*, QTreeWidgetItem*, QTreeWidgetItem*);

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -65,9 +65,8 @@ public:
     void renameVar(TVar*);
     void createVar(TVar*);
     VarUnit* getVarUnit();
-    // Hands the Lua registry references this interface took for reference-keyed
-    // variables back to the state. Anything that builds a variable tree and then
-    // throws it away owes this call; the destructor cannot make it - see there.
+    // Anything that builds a variable tree and throws it away owes this call:
+    // ~LuaInterface cannot make it, see there.
     void releaseVariableReferences();
     bool loadVar(TVar* var);
     bool reparentCVariable(TVar* from, TVar* to, TVar* curVar);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -95,7 +95,6 @@ void XMLexport::writeModuleXML(const QString& moduleName)
     auto triggerPackage = mudletPackage.append_child("TriggerPackage");
     //we go a level down for all these functions so as to not infinitely nest the module
     for (auto& it : pHost->mTriggerUnit.mTriggerRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mTriggerUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
@@ -106,7 +105,6 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto timerPackage = mudletPackage.append_child("TimerPackage");
     for (auto& it : pHost->mTimerUnit.mTimerRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mTimerUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
@@ -117,7 +115,6 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto aliasPackage = mudletPackage.append_child("AliasPackage");
     for (auto& it : pHost->mAliasUnit.mAliasRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mAliasUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
@@ -128,7 +125,6 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto actionPackage = mudletPackage.append_child("ActionPackage");
     for (auto& it : pHost->mActionUnit.mActionRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mActionUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
@@ -139,7 +135,6 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto scriptPackage = mudletPackage.append_child("ScriptPackage");
     for (auto& it : pHost->mScriptUnit.mScriptRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mScriptUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
@@ -150,7 +145,6 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto keyPackage = mudletPackage.append_child("KeyPackage");
     for (auto& it : pHost->mKeyUnit.mKeyRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mKeyUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
@@ -789,21 +783,14 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
         }
     }
 
-    // The variables have to be read out of Lua afresh here or a variable (or a
-    // saved table's member) that a script created since the tree was last built
-    // is silently dropped from the save - the tree is otherwise only rebuilt at
-    // profile load and reset, and whenever the Variables editor populates or
-    // searches it (#9492, #9517). That reading goes into a throwaway tree of
-    // its own: the live one is what the Variables editor's QTreeWidgetItems
-    // point into, and rebuilding it from here would strand every one of them -
-    // killing the editor's variable search results, and losing whatever the
-    // user is doing on the Variables view if it happens to be open.
+    // Into a throwaway tree rather than the live one: the Variables editor's
+    // QTreeWidgetItems point into the live tree, so rebuilding it here would
+    // strand every one of them. Reusing it as it stands is no good either - only
+    // the editor rebuilds it, so anything a script did since is missing from it.
     LuaInterface saveTimeInterface(lI->getState());
     VarUnit* saveTimeUnit = saveTimeInterface.getVarUnit();
-    // A tree built from scratch carries no per-variable saved/hidden flags, so
-    // isSaved() and isHidden() have to answer from these name-keyed sets
-    // instead (shouldSave() reads the TVar itself and needs nothing carried
-    // over):
+    // A fresh tree carries no per-variable saved/hidden flags, so isSaved() and
+    // isHidden() have to answer from these name-keyed sets.
     saveTimeUnit->savedVars = vu->savedVars;
     saveTimeUnit->hidden = vu->hidden;
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
@@ -815,21 +802,13 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
             writeVariable(itVariable.next(), &saveTimeInterface, saveTimeUnit, variablePackage);
         }
     }
-    // ~LuaInterface deliberately does not do this - a profile reset closes the
-    // lua_State before the Host's own LuaInterface is replaced - so the
-    // registry references this pass took have to be handed back by hand:
     saveTimeInterface.releaseVariableReferences();
 }
 
-// A unit's uninstallList holds items whose package has been uninstalled but
-// whose delete the unit had to defer because it was busy executing one of them
-// (#9337/#9383). They are gone as far as the profile is concerned, so a save
-// taken before the unit's doCleanup() flushes them must not write them back in
-// - doing so resurrects them on the next load as items of a package that is no
-// longer installed, which the Package Manager then cannot remove. The list is
-// empty at every other moment, so the check costs nothing the rest of the time.
-// Every writer that walks a root node list, writeModuleXML() included, filters
-// on it for this reason.
+// A unit busy executing an item of a package being uninstalled can only
+// deactivate it; it stays registered in uninstallList until doCleanup() flushes
+// it. Such an item is gone as far as the profile is concerned, so no writer that
+// walks a root node list may serialize it. The list is empty at any other time.
 void XMLexport::writeKeyPackage(const Host* pHost, pugi::xml_node& mudletPackage, bool skipModuleMembers)
 {
     auto keyPackage = mudletPackage.append_child("KeyPackage");
@@ -845,7 +824,6 @@ void XMLexport::writeScriptPackage(const Host* pHost, pugi::xml_node& mudletPack
 {
     auto scriptPackage = mudletPackage.append_child("ScriptPackage");
     for (auto it : pHost->mScriptUnit.mScriptRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mScriptUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -857,7 +835,6 @@ void XMLexport::writeActionPackage(const Host* pHost, pugi::xml_node& mudletPack
 {
     auto actionPackage = mudletPackage.append_child("ActionPackage");
     for (auto it : pHost->mActionUnit.mActionRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mActionUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -869,7 +846,6 @@ void XMLexport::writeAliasPackage(const Host* pHost, pugi::xml_node& mudletPacka
 {
     auto aliasPackage = mudletPackage.append_child("AliasPackage");
     for (auto it : pHost->mAliasUnit.mAliasRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mAliasUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -883,7 +859,6 @@ void XMLexport::writeTimerPackage(const Host* pHost, pugi::xml_node& mudletPacka
 {
     auto timerPackage = mudletPackage.append_child("TimerPackage");
     for (auto it : pHost->mTimerUnit.mTimerRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mTimerUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -897,7 +872,6 @@ void XMLexport::writeTriggerPackage(const Host* pHost, pugi::xml_node& mudletPac
 {
     auto triggerPackage = mudletPackage.append_child("TriggerPackage");
     for (auto it : pHost->mTriggerUnit.mTriggerRootNodeList) {
-        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mTriggerUnit.uninstallList.contains(it) || (ignoreModuleMembers && it->mModuleMember)) {
             continue;
         }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -95,7 +95,8 @@ void XMLexport::writeModuleXML(const QString& moduleName)
     auto triggerPackage = mudletPackage.append_child("TriggerPackage");
     //we go a level down for all these functions so as to not infinitely nest the module
     for (auto& it : pHost->mTriggerUnit.mTriggerRootNodeList) {
-        if (!it || it->mPackageName != moduleName) {
+        // deferred-delete filter, see writeKeyPackage()
+        if (!it || pHost->mTriggerUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
         if (!it->isTemporary() && it->mModuleMember) {
@@ -105,7 +106,8 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto timerPackage = mudletPackage.append_child("TimerPackage");
     for (auto& it : pHost->mTimerUnit.mTimerRootNodeList) {
-        if (!it || it->mPackageName != moduleName) {
+        // deferred-delete filter, see writeKeyPackage()
+        if (!it || pHost->mTimerUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
         if (!it->isTemporary() && it->mModuleMember) {
@@ -115,7 +117,8 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto aliasPackage = mudletPackage.append_child("AliasPackage");
     for (auto& it : pHost->mAliasUnit.mAliasRootNodeList) {
-        if (!it || it->mPackageName != moduleName) {
+        // deferred-delete filter, see writeKeyPackage()
+        if (!it || pHost->mAliasUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
         if (!it->isTemporary() && it->mModuleMember) {
@@ -125,7 +128,8 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto actionPackage = mudletPackage.append_child("ActionPackage");
     for (auto& it : pHost->mActionUnit.mActionRootNodeList) {
-        if (!it || it->mPackageName != moduleName) {
+        // deferred-delete filter, see writeKeyPackage()
+        if (!it || pHost->mActionUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
         if (it->mModuleMember) {
@@ -135,7 +139,8 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto scriptPackage = mudletPackage.append_child("ScriptPackage");
     for (auto& it : pHost->mScriptUnit.mScriptRootNodeList) {
-        if (!it || it->mPackageName != moduleName) {
+        // deferred-delete filter, see writeKeyPackage()
+        if (!it || pHost->mScriptUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
         if (it->mModuleMember) {
@@ -145,7 +150,8 @@ void XMLexport::writeModuleXML(const QString& moduleName)
 
     auto keyPackage = mudletPackage.append_child("KeyPackage");
     for (auto& it : pHost->mKeyUnit.mKeyRootNodeList) {
-        if (!it || it->mPackageName != moduleName) {
+        // deferred-delete filter, see writeKeyPackage()
+        if (!it || pHost->mKeyUnit.uninstallList.contains(it) || it->mPackageName != moduleName) {
             continue;
         }
         if (!it->isTemporary() && it->mModuleMember) {
@@ -786,16 +792,18 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     // The variables have to be read out of Lua afresh here or a variable (or a
     // saved table's member) that a script created since the tree was last built
     // is silently dropped from the save - the tree is otherwise only rebuilt at
-    // profile load and when the Variables editor populates it (#9492, #9517).
-    // That reading goes into a throwaway tree of its own: the live one is what
-    // the Variables editor's QTreeWidgetItems point into, and rebuilding it
-    // from here would strand every one of them - killing the editor's variable
-    // search results, and losing whatever the user is doing on the Variables
-    // view if it happens to be open.
+    // profile load and reset, and whenever the Variables editor populates or
+    // searches it (#9492, #9517). That reading goes into a throwaway tree of
+    // its own: the live one is what the Variables editor's QTreeWidgetItems
+    // point into, and rebuilding it from here would strand every one of them -
+    // killing the editor's variable search results, and losing whatever the
+    // user is doing on the Variables view if it happens to be open.
     LuaInterface saveTimeInterface(lI->getState());
     VarUnit* saveTimeUnit = saveTimeInterface.getVarUnit();
     // A tree built from scratch carries no per-variable saved/hidden flags, so
-    // isSaved(), isHidden() and shouldSave() answer from these name-keyed sets:
+    // isSaved() and isHidden() have to answer from these name-keyed sets
+    // instead (shouldSave() reads the TVar itself and needs nothing carried
+    // over):
     saveTimeUnit->savedVars = vu->savedVars;
     saveTimeUnit->hidden = vu->hidden;
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
@@ -813,18 +821,19 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     saveTimeInterface.releaseVariableReferences();
 }
 
+// A unit's uninstallList holds items whose package has been uninstalled but
+// whose delete the unit had to defer because it was busy executing one of them
+// (#9337/#9383). They are gone as far as the profile is concerned, so a save
+// taken before the unit's doCleanup() flushes them must not write them back in
+// - doing so resurrects them on the next load as items of a package that is no
+// longer installed, which the Package Manager then cannot remove. The list is
+// empty at every other moment, so the check costs nothing the rest of the time.
+// Every writer that walks a root node list, writeModuleXML() included, filters
+// on it for this reason.
 void XMLexport::writeKeyPackage(const Host* pHost, pugi::xml_node& mudletPackage, bool skipModuleMembers)
 {
     auto keyPackage = mudletPackage.append_child("KeyPackage");
     for (auto it : pHost->mKeyUnit.mKeyRootNodeList) {
-        // uninstallList holds items whose package has been uninstalled but
-        // whose delete the unit had to defer because it was busy executing one
-        // of them (#9337/#9383). They are gone as far as the profile is
-        // concerned, so a save taken before the unit's processing depth returns
-        // to zero must not write them back in - doing so resurrects them on the
-        // next load as items of a package that is no longer installed, which
-        // the Package Manager then cannot remove. Every unit below is filtered
-        // for the same reason.
         if (!it || pHost->mKeyUnit.uninstallList.contains(it) || it->isTemporary() || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -836,6 +845,7 @@ void XMLexport::writeScriptPackage(const Host* pHost, pugi::xml_node& mudletPack
 {
     auto scriptPackage = mudletPackage.append_child("ScriptPackage");
     for (auto it : pHost->mScriptUnit.mScriptRootNodeList) {
+        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mScriptUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -847,6 +857,7 @@ void XMLexport::writeActionPackage(const Host* pHost, pugi::xml_node& mudletPack
 {
     auto actionPackage = mudletPackage.append_child("ActionPackage");
     for (auto it : pHost->mActionUnit.mActionRootNodeList) {
+        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mActionUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -858,6 +869,7 @@ void XMLexport::writeAliasPackage(const Host* pHost, pugi::xml_node& mudletPacka
 {
     auto aliasPackage = mudletPackage.append_child("AliasPackage");
     for (auto it : pHost->mAliasUnit.mAliasRootNodeList) {
+        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mAliasUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -871,6 +883,7 @@ void XMLexport::writeTimerPackage(const Host* pHost, pugi::xml_node& mudletPacka
 {
     auto timerPackage = mudletPackage.append_child("TimerPackage");
     for (auto it : pHost->mTimerUnit.mTimerRootNodeList) {
+        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mTimerUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
@@ -884,6 +897,7 @@ void XMLexport::writeTriggerPackage(const Host* pHost, pugi::xml_node& mudletPac
 {
     auto triggerPackage = mudletPackage.append_child("TriggerPackage");
     for (auto it : pHost->mTriggerUnit.mTriggerRootNodeList) {
+        // deferred-delete filter, see writeKeyPackage()
         if (!it || pHost->mTriggerUnit.uninstallList.contains(it) || (ignoreModuleMembers && it->mModuleMember)) {
             continue;
         }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -783,33 +783,49 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
         }
     }
 
-    // Refresh the variable tree so it reflects the current Lua state. The tree
-    // is otherwise only rebuilt at profile load and when the Variables editor
-    // populates it, so a variable (or saved table member) a script created
-    // afterwards would be missing here and silently dropped from the saved
-    // profile. Skip the refresh only while that editor view is on screen: it
-    // owns the tree and rebuilding it here would invalidate the widget the user
-    // is interacting with (its variables would stop responding until refreshed).
-    const bool variablesEditorOnScreen = pHost->mpEditorDialog && pHost->mpEditorDialog->variablesViewActive();
-    TVar* base = vu->getBase();
-    if (!variablesEditorOnScreen || !base) {
-        lI->getVars(false);
-        base = vu->getBase();
-    }
+    // The variables have to be read out of Lua afresh here or a variable (or a
+    // saved table's member) that a script created since the tree was last built
+    // is silently dropped from the save - the tree is otherwise only rebuilt at
+    // profile load and when the Variables editor populates it (#9492, #9517).
+    // That reading goes into a throwaway tree of its own: the live one is what
+    // the Variables editor's QTreeWidgetItems point into, and rebuilding it
+    // from here would strand every one of them - killing the editor's variable
+    // search results, and losing whatever the user is doing on the Variables
+    // view if it happens to be open.
+    LuaInterface saveTimeInterface(lI->getState());
+    VarUnit* saveTimeUnit = saveTimeInterface.getVarUnit();
+    // A tree built from scratch carries no per-variable saved/hidden flags, so
+    // isSaved(), isHidden() and shouldSave() answer from these name-keyed sets:
+    saveTimeUnit->savedVars = vu->savedVars;
+    saveTimeUnit->hidden = vu->hidden;
+    saveTimeUnit->hiddenByUser = vu->hiddenByUser;
+    saveTimeInterface.getVars(false);
 
-    if (base) {
+    if (TVar* base = saveTimeUnit->getBase()) {
         QListIterator<TVar*> itVariable(base->getChildren(false));
         while (itVariable.hasNext()) {
-            writeVariable(itVariable.next(), lI, vu, variablePackage);
+            writeVariable(itVariable.next(), &saveTimeInterface, saveTimeUnit, variablePackage);
         }
     }
+    // ~LuaInterface deliberately does not do this - a profile reset closes the
+    // lua_State before the Host's own LuaInterface is replaced - so the
+    // registry references this pass took have to be handed back by hand:
+    saveTimeInterface.releaseVariableReferences();
 }
 
 void XMLexport::writeKeyPackage(const Host* pHost, pugi::xml_node& mudletPackage, bool skipModuleMembers)
 {
     auto keyPackage = mudletPackage.append_child("KeyPackage");
     for (auto it : pHost->mKeyUnit.mKeyRootNodeList) {
-        if (!it || it->isTemporary() || (skipModuleMembers && it->mModuleMember)) {
+        // uninstallList holds items whose package has been uninstalled but
+        // whose delete the unit had to defer because it was busy executing one
+        // of them (#9337/#9383). They are gone as far as the profile is
+        // concerned, so a save taken before the unit's processing depth returns
+        // to zero must not write them back in - doing so resurrects them on the
+        // next load as items of a package that is no longer installed, which
+        // the Package Manager then cannot remove. Every unit below is filtered
+        // for the same reason.
+        if (!it || pHost->mKeyUnit.uninstallList.contains(it) || it->isTemporary() || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
         writeKey(it, keyPackage);
@@ -820,7 +836,7 @@ void XMLexport::writeScriptPackage(const Host* pHost, pugi::xml_node& mudletPack
 {
     auto scriptPackage = mudletPackage.append_child("ScriptPackage");
     for (auto it : pHost->mScriptUnit.mScriptRootNodeList) {
-        if (!it || (skipModuleMembers && it->mModuleMember)) {
+        if (!it || pHost->mScriptUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
         writeScript(it, scriptPackage);
@@ -831,7 +847,7 @@ void XMLexport::writeActionPackage(const Host* pHost, pugi::xml_node& mudletPack
 {
     auto actionPackage = mudletPackage.append_child("ActionPackage");
     for (auto it : pHost->mActionUnit.mActionRootNodeList) {
-        if (!it || (skipModuleMembers && it->mModuleMember)) {
+        if (!it || pHost->mActionUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
         writeAction(it, actionPackage);
@@ -842,7 +858,7 @@ void XMLexport::writeAliasPackage(const Host* pHost, pugi::xml_node& mudletPacka
 {
     auto aliasPackage = mudletPackage.append_child("AliasPackage");
     for (auto it : pHost->mAliasUnit.mAliasRootNodeList) {
-        if (!it || (skipModuleMembers && it->mModuleMember)) {
+        if (!it || pHost->mAliasUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
         if (!it->isTemporary()) {
@@ -855,7 +871,7 @@ void XMLexport::writeTimerPackage(const Host* pHost, pugi::xml_node& mudletPacka
 {
     auto timerPackage = mudletPackage.append_child("TimerPackage");
     for (auto it : pHost->mTimerUnit.mTimerRootNodeList) {
-        if (!it || (skipModuleMembers && it->mModuleMember)) {
+        if (!it || pHost->mTimerUnit.uninstallList.contains(it) || (skipModuleMembers && it->mModuleMember)) {
             continue;
         }
         if (!it->isTemporary()) {
@@ -868,7 +884,7 @@ void XMLexport::writeTriggerPackage(const Host* pHost, pugi::xml_node& mudletPac
 {
     auto triggerPackage = mudletPackage.append_child("TriggerPackage");
     for (auto it : pHost->mTriggerUnit.mTriggerRootNodeList) {
-        if (!it || (ignoreModuleMembers && it->mModuleMember)) {
+        if (!it || pHost->mTriggerUnit.uninstallList.contains(it) || (ignoreModuleMembers && it->mModuleMember)) {
             continue;
         }
         if (!it->isTemporary()) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -9637,11 +9637,6 @@ EditorViewType dlgTriggerEditor::determineViewFromVisibleTree()
     return EditorViewType::cmUnknownView;
 }
 
-bool dlgTriggerEditor::variablesViewActive() const
-{
-    return isVisible() && mCurrentView == EditorViewType::cmVarsView;
-}
-
 EditorViewType dlgTriggerEditor::resolveCurrentView()
 {
     if (mCurrentView != EditorViewType::cmUnknownView) {

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -204,9 +204,6 @@ public:
     int canRecast(QTreeWidgetItem*, int newNameType, int newValueType);
     void saveVar();
     void repopulateVars();
-    // true while the Variables view is the one shown on screen, so a profile
-    // save can avoid rebuilding the tree out from under the live widget
-    bool variablesViewActive() const;
     void changeView(EditorViewType);
     void recurseVariablesUp(QTreeWidgetItem* const, QList<QTreeWidgetItem*>&);
     void recurseVariablesDown(QTreeWidgetItem* const, QList<QTreeWidgetItem*>&);

--- a/test/functional_tests/PackageSelfUninstallTest.cpp
+++ b/test/functional_tests/PackageSelfUninstallTest.cpp
@@ -32,17 +32,15 @@
  * compileScript() was in the middle of compiling - heap corruption every way.
  * TriggerUnit/AliasUnit/KeyUnit gained a processing-depth deferral in #9383;
  * this covers TimerUnit and ScriptUnit (both the event-dispatch and the
- * compile-time body paths). The resurrection half below covers the trigger,
- * alias, timer, button and event-dispatch routes.
+ * compile-time body paths).
  *
  * Under AddressSanitizer the pre-fix code aborts with heap-use-after-free
  * inside TTimer::execute() / Host::raiseEvent() / TScript::compileScript(); with
  * the deferral in place all scenarios complete cleanly.
  *
- * The second half of the file covers the other side of that deferral: an item
- * whose delete is outstanding is still registered, and a profile save taken
- * before the unit goes idle again used to write it back out - resurrecting the
- * uninstalled package's items as orphans the Package Manager cannot remove.
+ * The second half covers the other side of that deferral: an item whose delete
+ * is outstanding is still registered, and must not be written back into the
+ * profile by a save taken before the unit goes idle.
  *
  * Run with: ctest -R PackageSelfUninstallTest -V
  */
@@ -89,12 +87,9 @@ extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResourcesForPackageSelfUninstallTest();
 
-// TriggerUnit raises its processing depth inside processDataStream() and hands
-// it back before returning, so the only way to take a save at depth from a
-// trigger is from a trigger's own script - which is exactly the reported case
-// (a script-driven uninstall followed by a save). This stands in for the Lua
-// saveProfile() such a script would call; a bare test Host has no console for
-// the real one to serialize.
+// TriggerUnit only holds its depth inside processDataStream(), so a save at
+// depth has to come from a trigger's own script. Stands in for the Lua
+// saveProfile() one would call - a bare test Host has no console for that.
 static Host* gpMidPassExportHost = nullptr;
 static QString gMidPassExportPath;
 static QString gMidPassExportedXml;
@@ -107,9 +102,8 @@ static int exportProfileMidPass(lua_State* L)
         return 0;
     }
     auto writer = std::make_shared<XMLexport>(gpMidPassExportHost);
-    // variables included: this is the only export in the file that builds the
-    // variable tree, and doing it from here means doing it with a Lua call
-    // frame live, which is how a script-driven save reaches it
+    // variables included: the only export here that builds the variable tree,
+    // and it does so with a Lua call frame live
     if (!writer->exportPackage(gMidPassExportPath, true, false)) {
         qWarning() << "exportProfileMidPass() - the export itself failed";
         return 0;
@@ -322,21 +316,10 @@ private slots:
         QVERIFY2(!mpHost->getTimerUnit()->findFirstTimer(qsl("selfUninstallTimer")), "uninstalled package timer is still registered");
     }
 
-    // The deferral above keeps the uninstalled items registered until the unit
-    // is idle again, and the XML writers used to serialize whatever was
-    // registered. A save taken in that window - which is what the mpkg /
-    // auto-updater shape does, uninstalling from a script and saving straight
-    // after - therefore wrote the just-uninstalled package's items back into
-    // the profile. They return on the next load as items of a package that is
-    // no longer installed, so the Package Manager does not list them and
-    // uninstallPackage() will not remove them: the only way out is deleting
-    // them by hand in the editor.
-    //
-    // This is the trigger route, driven the whole way: the package's own
-    // trigger fires, uninstalls its package and saves, all inside the pass.
-    // It also carries the cross-check between this file's two halves - its
-    // export is the only one here that includes the variables, so the variable
-    // tree gets built from inside a live Lua call frame.
+    // The trigger route, driven the whole way: the package's own trigger fires,
+    // uninstalls its package and saves, all inside the pass. Its export is the
+    // only one here that includes the variables, so it doubles as the check that
+    // the variable tree can be built from inside a live Lua call frame.
     void test_saveFromTriggerScriptDoesNotResurrectItsPackage()
     {
         const QString packageName = qsl("resurrect-trigger");
@@ -363,8 +346,8 @@ private slots:
         pKicker->setName(qsl("resurrectTriggerKicker"));
         pKicker->setIsActive(true);
 
-        // a sibling that never runs, to show the whole group goes, not just the
-        // one trigger that happened to be executing
+        // a sibling that never runs: the whole group must go, not just the one
+        // that fired
         auto pBystander = new TTrigger(pGroup, mpHost);
         pBystander->setRegexCodeList({qsl("^never matched$")}, {REGEX_PERL});
         pBystander->registerTrigger();
@@ -384,16 +367,13 @@ private slots:
         QVERIFY2(keeperError.isEmpty(), qPrintable(keeperError));
         QVERIFY2(gMidPassExportedXml.contains(qsl("saved from inside the pass")), "the variables were not read out of Lua by a save taken from inside a script");
 
-        // the pass ended, so the deferred deletes must have been flushed
         QVERIFY2(mpHost->getTriggerUnit()->findItems(qsl("resurrectTriggerKicker")).empty(), "uninstalled trigger is still registered");
 
         mpHost->getLuaInterface()->getVarUnit()->savedVars.remove(qsl("midPassSavedVar"));
         gpMidPassExportHost = nullptr;
     }
 
-    // The alias route, driven the same way. This is the likeliest real-world
-    // shape of the bug: a package ships a "<name> uninstall" alias that removes
-    // its own package and saves.
+    // The alias route: a package shipping its own "uninstall" alias.
     void test_saveFromAliasScriptDoesNotResurrectItsPackage()
     {
         const QString packageName = qsl("resurrect-alias");
@@ -424,13 +404,8 @@ private slots:
         gpMidPassExportHost = nullptr;
     }
 
-    // The timer route matters because TimerUnit's depth covers the whole of
-    // TTimer::execute(), so anything the callback reaches that saves the profile
-    // synchronously - a Lua saveProfile(), an installPackage() - saves at depth,
-    // and a callback that spins the event loop itself lets even the save
-    // uninstallPackage() queues run there. When that is the session's last save
-    // there is nothing left to undo it. beginProcessing()/endProcessing() below
-    // are the very calls TTimer::execute() wraps its callback in.
+    // The timer route. beginProcessing()/endProcessing() below are the calls
+    // TTimer::execute() wraps its whole callback in.
     void test_saveDuringTimerCallbackDoesNotResurrectItsPackage()
     {
         const QString packageName = qsl("resurrect-timer");
@@ -446,7 +421,7 @@ private slots:
         QString xml;
         {
             mpHost->getTimerUnit()->beginProcessing();
-            // a failed QVERIFY returns from the slot, and a level left on would
+            // a failed QVERIFY returns from the slot; a level left on would
             // wedge every later test's doCleanup()
             const auto depthGuard = qScopeGuard([this]() {
                 mpHost->getTimerUnit()->endProcessing();
@@ -494,8 +469,7 @@ private slots:
         QVERIFY2(!mpHost->getActionUnit()->findAction(qsl("resurrectAction")), "uninstalled button is still registered");
     }
 
-    // The event-handler route: Host::raiseEvent() holds ScriptUnit's depth for
-    // the whole dispatch.
+    // The event-handler route: Host::raiseEvent() holds ScriptUnit's depth.
     void test_saveDuringEventDispatchDoesNotResurrectItsPackage()
     {
         const QString packageName = qsl("resurrect-script");
@@ -527,11 +501,9 @@ private slots:
         QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("resurrectScript")).empty(), "uninstalled script is still registered");
     }
 
-    // The module writer has the same hazard with an extra twist: reloading a
-    // module (Host::reloadModule(), reachable from Lua) uninstalls and
-    // reinstalls it back to back, so from inside a script the old items are
-    // still registered when the new ones arrive and the module's own file gets
-    // written with both copies - which then both come back on the next load.
+    // Host::reloadModule() - reachable from Lua - uninstalls and reinstalls a
+    // module back to back, so from a script the old items are still registered
+    // when the new ones arrive.
     void test_moduleSaveDuringReloadDoesNotDuplicateItsItems()
     {
         const QString moduleName = qsl("resurrect-module");
@@ -547,8 +519,7 @@ private slots:
                 mpHost->getTimerUnit()->endProcessing();
                 mpHost->getTimerUnit()->doCleanup();
             });
-            // the uninstall half of a reload: at depth the old timer is only
-            // deactivated, and stays registered
+            // the uninstall half: at depth the old timer only gets deactivated
             QVERIFY(mpHost->uninstallPackage(moduleName, enums::PackageModuleType::ModuleSync));
             // ... and the reinstall half brings the module back with fresh items
             registerModuleAs(moduleName);
@@ -563,11 +534,9 @@ private slots:
     }
 
 private:
-    // One item per unit belonging to a package that is never uninstalled. Every
-    // assertion about the deferred-delete filter is an absence, so without these
-    // an over-broad filter - or a writer that gave up on the whole unit while a
-    // delete was outstanding - would pass every test in this file while emptying
-    // the user's profile.
+    // Items of a package that is never uninstalled. Every other assertion here
+    // is an absence, so without these an over-broad filter passes the whole file
+    // while emptying the user's profile.
     void createKeeperItems()
     {
         const QString keeperPackage = qsl("keeper-package");
@@ -615,14 +584,10 @@ private:
     }
 
     // The module-member flag is private to XMLimport, so a genuine module item
-    // can only be made by importing one. Importing under a package name with the
-    // module flag set gives each unit the module's master folder, which is what
-    // writeModuleXML() writes; renaming the timer's one afterwards is what makes
-    // the copy from before a reload tellable from the copy after it.
+    // can only be made by importing one: that creates the module's master folder
+    // per unit, and renaming the timer's tells the two copies apart.
     bool importModuleTimerNamed(const QString& moduleName, const QString& itemName)
     {
-        // the file to import is written by Mudlet's own timer exporter, so its
-        // shape cannot drift away from what the importer expects
         const QString path = qsl("%1/%2-import.xml").arg(mConfigDir.path(), itemName);
         auto* pSeed = new TTimer(itemName, QTime(0, 0, 30), mpHost);
         mpHost->getTimerUnit()->registerTimer(pSeed);
@@ -653,8 +618,7 @@ private:
         return true;
     }
 
-    // The module half of the same thing: builds the document writeModuleXML()
-    // produces for a profile save and reads it back.
+    // Builds the document writeModuleXML() produces for a save and reads it back.
     QString exportedModuleXml(const QString& moduleName)
     {
         const QString path = qsl("%1/module-export.xml").arg(mConfigDir.path());
@@ -666,8 +630,8 @@ private:
         return readBack(path);
     }
 
-    // Writes the profile's items out through the same writers a profile save
-    // uses, without needing the console a full Host::saveProfile() would.
+    // The writers a profile save uses, without the console Host::saveProfile()
+    // would need.
     QString exportedProfileXml()
     {
         const QString path = qsl("%1/profile-export.xml").arg(mConfigDir.path());

--- a/test/functional_tests/PackageSelfUninstallTest.cpp
+++ b/test/functional_tests/PackageSelfUninstallTest.cpp
@@ -99,8 +99,9 @@ static Host* gpMidPassExportHost = nullptr;
 static QString gMidPassExportPath;
 static QString gMidPassExportedXml;
 
-static int exportProfileMidPass(lua_State*)
+static int exportProfileMidPass(lua_State* L)
 {
+    Q_UNUSED(L)
     gMidPassExportedXml.clear();
     if (!gpMidPassExportHost) {
         return 0;

--- a/test/functional_tests/PackageSelfUninstallTest.cpp
+++ b/test/functional_tests/PackageSelfUninstallTest.cpp
@@ -38,6 +38,11 @@
  * inside TTimer::execute() / Host::raiseEvent() / TScript::compileScript(); with
  * the deferral in place all scenarios complete cleanly.
  *
+ * The second half of the file covers the other side of that deferral: an item
+ * whose delete is outstanding is still registered, and a profile save taken
+ * before the unit goes idle again used to write it back out - resurrecting the
+ * uninstalled package's items as orphans the Package Manager cannot remove.
+ *
  * Run with: ctest -R PackageSelfUninstallTest -V
  */
 
@@ -45,15 +50,28 @@
 
 #include <QTemporaryDir>
 
+#include "ActionUnit.h"
 #include "Host.h"
 #include "HostManager.h"
 #include "MudletInstanceCoordinator.h"
 #include "ScriptUnit.h"
+#include "TAction.h"
 #include "TEvent.h"
 #include "TScript.h"
 #include "TTimer.h"
+#include "TTrigger.h"
 #include "TimerUnit.h"
+#include "TriggerUnit.h"
+#include "XMLexport.h"
 #include "mudlet.h"
+
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lua.h>
+#else
+#include <lua.h>
+#endif
+}
 
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
@@ -61,6 +79,33 @@ extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResourcesForPackageSelfUninstallTest();
+
+// TriggerUnit raises its processing depth inside processDataStream() and hands
+// it back before returning, so the only way to take a save at depth from a
+// trigger is from a trigger's own script - which is exactly the reported case
+// (a script-driven uninstall followed by a save). This stands in for the Lua
+// saveProfile() such a script would call; a bare test Host has no console for
+// the real one to serialize.
+static Host* gpMidPassExportHost = nullptr;
+static QString gMidPassExportPath;
+static QString gMidPassExportedXml;
+
+static int exportProfileMidPass(lua_State*)
+{
+    gMidPassExportedXml.clear();
+    if (!gpMidPassExportHost) {
+        return 0;
+    }
+    auto writer = std::make_shared<XMLexport>(gpMidPassExportHost);
+    if (!writer->exportPackage(gMidPassExportPath, true, true)) {
+        return 0;
+    }
+    QFile file(gMidPassExportPath);
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        gMidPassExportedXml = QString::fromUtf8(file.readAll());
+    }
+    return 0;
+}
 
 class PackageSelfUninstallTest : public QObject
 {
@@ -256,6 +301,161 @@ private slots:
         // be properly gone - not lingering deactivated where the next profile
         // save would serialize it back in:
         QVERIFY2(!mpHost->getTimerUnit()->findFirstTimer(qsl("selfUninstallTimer")), "uninstalled package timer is still registered");
+    }
+
+    // The deferral above keeps the uninstalled items registered until the unit
+    // is idle again, and the XML writers used to serialize whatever was
+    // registered. A save taken in that window - which is what the mpkg /
+    // auto-updater shape does, uninstalling from a script and saving straight
+    // after - therefore wrote the just-uninstalled package's items back into
+    // the profile. They return on the next load as items of a package that is
+    // no longer installed, so the Package Manager does not list them and
+    // uninstallPackage() will not remove them: the only way out is deleting
+    // them by hand in the editor.
+    //
+    // This is the trigger route, driven the whole way: the package's own
+    // trigger fires, uninstalls its package and saves, all inside the pass.
+    void test_saveFromTriggerScriptDoesNotResurrectItsPackage()
+    {
+        const QString packageName = qsl("resurrect-trigger");
+        mpHost->mInstalledPackages << packageName;
+
+        gpMidPassExportHost = mpHost;
+        gMidPassExportPath = qsl("%1/mid-pass-export.xml").arg(mConfigDir.path());
+        lua_register(mpHost->mLuaInterpreter.getLuaGlobalState(), "qaExportProfileMidPass", exportProfileMidPass);
+
+        auto pGroup = new TTrigger(nullptr, mpHost);
+        pGroup->setIsFolder(true);
+        pGroup->registerTrigger();
+        pGroup->setName(qsl("resurrectTriggerGroup"));
+        pGroup->mPackageName = packageName;
+        pGroup->setIsActive(true);
+
+        auto pKicker = new TTrigger(pGroup, mpHost);
+        pKicker->setRegexCodeList({qsl("^resurrect me$")}, {REGEX_PERL});
+        pKicker->registerTrigger();
+        QVERIFY2(pKicker->setScript(qsl("uninstallPackage(\"%1\")\nqaExportProfileMidPass()").arg(packageName)), "trigger script failed to compile");
+        pKicker->setName(qsl("resurrectTriggerKicker"));
+        pKicker->setIsActive(true);
+
+        // a sibling that never runs, to show the whole group goes, not just the
+        // one trigger that happened to be executing
+        auto pBystander = new TTrigger(pGroup, mpHost);
+        pBystander->setRegexCodeList({qsl("^never matched$")}, {REGEX_PERL});
+        pBystander->registerTrigger();
+        pBystander->setName(qsl("resurrectTriggerBystander"));
+        pBystander->setIsActive(true);
+
+        mpHost->getTriggerUnit()->processDataStream(qsl("resurrect me"), -1);
+
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "package was not uninstalled");
+        QVERIFY2(!gMidPassExportedXml.isEmpty(), "the mid-pass export produced nothing to check");
+        QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectTriggerGroup")), "a save taken mid-pass wrote the uninstalled package's trigger group back into the profile");
+        QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectTriggerKicker")), "a save taken mid-pass wrote the uninstalled package's trigger back into the profile");
+        QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectTriggerBystander")), "a save taken mid-pass wrote the uninstalled package's trigger back into the profile");
+
+        // the pass ended, so the deferred deletes must have been flushed
+        QVERIFY2(mpHost->getTriggerUnit()->findItems(qsl("resurrectTriggerKicker")).empty(), "uninstalled trigger is still registered");
+        gpMidPassExportHost = nullptr;
+    }
+
+    // The timer route is the one that makes the corruption permanent: TTimer's
+    // processing depth is held for the whole of execute(), so even the save
+    // uninstallPackage() defers to the next event loop pass runs inside it, and
+    // when that is the last save of the session there is nothing left to undo
+    // it. beginProcessing()/endProcessing() here are the very calls
+    // TTimer::execute() wraps its callback in.
+    void test_saveDuringTimerCallbackDoesNotResurrectItsPackage()
+    {
+        const QString packageName = qsl("resurrect-timer");
+        mpHost->mInstalledPackages << packageName;
+
+        auto pTimer = new TTimer(qsl("resurrectTimer"), QTime(0, 0, 30), mpHost);
+        mpHost->getTimerUnit()->registerTimer(pTimer);
+        pTimer->mPackageName = packageName;
+        QVERIFY2(pTimer->setScript(qsl("local noop = true\n")), "timer script failed to compile");
+
+        QVERIFY2(exportedProfileXml().contains(qsl("resurrectTimer")), "the timer should be in the profile before its package is uninstalled");
+
+        mpHost->getTimerUnit()->beginProcessing();
+        QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
+        const QString xml = exportedProfileXml();
+        mpHost->getTimerUnit()->endProcessing();
+        mpHost->getTimerUnit()->doCleanup();
+
+        QVERIFY2(!xml.isEmpty(), "the export produced nothing to check");
+        QVERIFY2(!xml.contains(qsl("resurrectTimer")), "a save taken during a timer callback wrote the uninstalled package's timer back into the profile");
+        QVERIFY2(!mpHost->getTimerUnit()->findFirstTimer(qsl("resurrectTimer")), "uninstalled timer is still registered");
+    }
+
+    // The button route: TAction::execute() holds ActionUnit's depth the same way.
+    void test_saveDuringButtonScriptDoesNotResurrectItsPackage()
+    {
+        const QString packageName = qsl("resurrect-action");
+        mpHost->mInstalledPackages << packageName;
+
+        auto pAction = new TAction(qsl("resurrectAction"), mpHost);
+        mpHost->getActionUnit()->registerAction(pAction);
+        pAction->mPackageName = packageName;
+        QVERIFY2(pAction->setScript(qsl("local noop = true\n")), "button script failed to compile");
+
+        QVERIFY2(exportedProfileXml().contains(qsl("resurrectAction")), "the button should be in the profile before its package is uninstalled");
+
+        mpHost->getActionUnit()->beginProcessing();
+        QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
+        const QString xml = exportedProfileXml();
+        mpHost->getActionUnit()->endProcessing();
+        mpHost->getActionUnit()->doCleanup();
+
+        QVERIFY2(!xml.isEmpty(), "the export produced nothing to check");
+        QVERIFY2(!xml.contains(qsl("resurrectAction")), "a save taken during a button script wrote the uninstalled package's button back into the profile");
+        QVERIFY2(!mpHost->getActionUnit()->findAction(qsl("resurrectAction")), "uninstalled button is still registered");
+    }
+
+    // The event-handler route: Host::raiseEvent() holds ScriptUnit's depth for
+    // the whole dispatch.
+    void test_saveDuringEventDispatchDoesNotResurrectItsPackage()
+    {
+        const QString packageName = qsl("resurrect-script");
+        mpHost->mInstalledPackages << packageName;
+
+        auto pScript = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pScript);
+        pScript->mPackageName = packageName;
+        pScript->setName(qsl("resurrectScript"));
+        QVERIFY2(pScript->setScript(qsl("local noop = true\n")), "script failed to compile");
+
+        QVERIFY2(exportedProfileXml().contains(qsl("resurrectScript")), "the script should be in the profile before its package is uninstalled");
+
+        mpHost->getScriptUnit()->beginProcessing();
+        QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
+        const QString xml = exportedProfileXml();
+        mpHost->getScriptUnit()->endProcessing();
+        mpHost->getScriptUnit()->doCleanup();
+
+        QVERIFY2(!xml.isEmpty(), "the export produced nothing to check");
+        QVERIFY2(!xml.contains(qsl("resurrectScript")), "a save taken during an event dispatch wrote the uninstalled package's script back into the profile");
+        QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("resurrectScript")).empty(), "uninstalled script is still registered");
+    }
+
+private:
+    // Writes the profile's items out through the same writers a profile save
+    // uses, without needing the console a full Host::saveProfile() would.
+    QString exportedProfileXml()
+    {
+        const QString path = qsl("%1/profile-export.xml").arg(mConfigDir.path());
+        auto writer = std::make_shared<XMLexport>(mpHost);
+        if (!writer->exportPackage(path, true, true)) {
+            return {};
+        }
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return {};
+        }
+        const QString xml = QString::fromUtf8(file.readAll());
+        file.close();
+        QFile::remove(path);
+        return xml;
     }
 };
 

--- a/test/functional_tests/PackageSelfUninstallTest.cpp
+++ b/test/functional_tests/PackageSelfUninstallTest.cpp
@@ -32,7 +32,8 @@
  * compileScript() was in the middle of compiling - heap corruption every way.
  * TriggerUnit/AliasUnit/KeyUnit gained a processing-depth deferral in #9383;
  * this covers TimerUnit and ScriptUnit (both the event-dispatch and the
- * compile-time body paths).
+ * compile-time body paths). The resurrection half below covers the trigger,
+ * alias, timer, button and event-dispatch routes.
  *
  * Under AddressSanitizer the pre-fix code aborts with heap-use-after-free
  * inside TTimer::execute() / Host::raiseEvent() / TScript::compileScript(); with
@@ -48,27 +49,35 @@
 
 #include <QtTest/QtTest>
 
+#include <QScopeGuard>
 #include <QTemporaryDir>
 
 #include "ActionUnit.h"
+#include "AliasUnit.h"
 #include "Host.h"
 #include "HostManager.h"
+#include "LuaInterface.h"
 #include "MudletInstanceCoordinator.h"
 #include "ScriptUnit.h"
 #include "TAction.h"
+#include "TAlias.h"
 #include "TEvent.h"
 #include "TScript.h"
 #include "TTimer.h"
 #include "TTrigger.h"
 #include "TimerUnit.h"
 #include "TriggerUnit.h"
+#include "VarUnit.h"
 #include "XMLexport.h"
+#include "XMLimport.h"
 #include "mudlet.h"
 
 extern "C" {
 #if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
 #include <lua5.1/lua.h>
 #else
+#include <lauxlib.h>
 #include <lua.h>
 #endif
 }
@@ -97,13 +106,21 @@ static int exportProfileMidPass(lua_State*)
         return 0;
     }
     auto writer = std::make_shared<XMLexport>(gpMidPassExportHost);
-    if (!writer->exportPackage(gMidPassExportPath, true, true)) {
+    // variables included: this is the only export in the file that builds the
+    // variable tree, and doing it from here means doing it with a Lua call
+    // frame live, which is how a script-driven save reaches it
+    if (!writer->exportPackage(gMidPassExportPath, true, false)) {
+        qWarning() << "exportProfileMidPass() - the export itself failed";
         return 0;
     }
     QFile file(gMidPassExportPath);
-    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        gMidPassExportedXml = QString::fromUtf8(file.readAll());
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning() << "exportProfileMidPass() - could not read back" << gMidPassExportPath;
+        return 0;
     }
+    gMidPassExportedXml = QString::fromUtf8(file.readAll());
+    file.close();
+    QFile::remove(gMidPassExportPath);
     return 0;
 }
 
@@ -144,6 +161,7 @@ private slots:
         // NB: mLoadedOk is left false on purpose - the deferred saveProfile()
         // that uninstallPackage() schedules then declines to run, which this
         // console-less test Host could not service anyway.
+        createKeeperItems();
     }
 
     void cleanupTestCase()
@@ -315,6 +333,9 @@ private slots:
     //
     // This is the trigger route, driven the whole way: the package's own
     // trigger fires, uninstalls its package and saves, all inside the pass.
+    // It also carries the cross-check between this file's two halves - its
+    // export is the only one here that includes the variables, so the variable
+    // tree gets built from inside a live Lua call frame.
     void test_saveFromTriggerScriptDoesNotResurrectItsPackage()
     {
         const QString packageName = qsl("resurrect-trigger");
@@ -322,7 +343,10 @@ private slots:
 
         gpMidPassExportHost = mpHost;
         gMidPassExportPath = qsl("%1/mid-pass-export.xml").arg(mConfigDir.path());
-        lua_register(mpHost->mLuaInterpreter.getLuaGlobalState(), "qaExportProfileMidPass", exportProfileMidPass);
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_register(L, "qaExportProfileMidPass", exportProfileMidPass);
+        QCOMPARE(luaL_dostring(L, "midPassSavedVar = 'saved from inside the pass'"), 0);
+        mpHost->getLuaInterface()->getVarUnit()->savedVars.insert(qsl("midPassSavedVar"));
 
         auto pGroup = new TTrigger(nullptr, mpHost);
         pGroup->setIsFolder(true);
@@ -346,6 +370,8 @@ private slots:
         pBystander->setName(qsl("resurrectTriggerBystander"));
         pBystander->setIsActive(true);
 
+        QVERIFY2(exportedProfileXml().contains(qsl("resurrectTriggerGroup")), "the trigger group should be in the profile before its package is uninstalled");
+
         mpHost->getTriggerUnit()->processDataStream(qsl("resurrect me"), -1);
 
         QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "package was not uninstalled");
@@ -353,18 +379,57 @@ private slots:
         QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectTriggerGroup")), "a save taken mid-pass wrote the uninstalled package's trigger group back into the profile");
         QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectTriggerKicker")), "a save taken mid-pass wrote the uninstalled package's trigger back into the profile");
         QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectTriggerBystander")), "a save taken mid-pass wrote the uninstalled package's trigger back into the profile");
+        const QString keeperError = keepersMissingFrom(gMidPassExportedXml);
+        QVERIFY2(keeperError.isEmpty(), qPrintable(keeperError));
+        QVERIFY2(gMidPassExportedXml.contains(qsl("saved from inside the pass")), "the variables were not read out of Lua by a save taken from inside a script");
 
         // the pass ended, so the deferred deletes must have been flushed
         QVERIFY2(mpHost->getTriggerUnit()->findItems(qsl("resurrectTriggerKicker")).empty(), "uninstalled trigger is still registered");
+
+        mpHost->getLuaInterface()->getVarUnit()->savedVars.remove(qsl("midPassSavedVar"));
         gpMidPassExportHost = nullptr;
     }
 
-    // The timer route is the one that makes the corruption permanent: TTimer's
-    // processing depth is held for the whole of execute(), so even the save
-    // uninstallPackage() defers to the next event loop pass runs inside it, and
-    // when that is the last save of the session there is nothing left to undo
-    // it. beginProcessing()/endProcessing() here are the very calls
-    // TTimer::execute() wraps its callback in.
+    // The alias route, driven the same way. This is the likeliest real-world
+    // shape of the bug: a package ships a "<name> uninstall" alias that removes
+    // its own package and saves.
+    void test_saveFromAliasScriptDoesNotResurrectItsPackage()
+    {
+        const QString packageName = qsl("resurrect-alias");
+        mpHost->mInstalledPackages << packageName;
+
+        gpMidPassExportHost = mpHost;
+        gMidPassExportPath = qsl("%1/mid-pass-alias-export.xml").arg(mConfigDir.path());
+        lua_register(mpHost->mLuaInterpreter.getLuaGlobalState(), "qaExportProfileMidPass", exportProfileMidPass);
+
+        auto pAlias = new TAlias(qsl("resurrectAlias"), mpHost);
+        pAlias->setRegexCode(qsl("^resurrect me$"));
+        mpHost->getAliasUnit()->registerAlias(pAlias);
+        pAlias->mPackageName = packageName;
+        QVERIFY2(pAlias->setScript(qsl("uninstallPackage(\"%1\")\nqaExportProfileMidPass()").arg(packageName)), "alias script failed to compile");
+        pAlias->setIsActive(true);
+
+        QVERIFY2(exportedProfileXml().contains(qsl("resurrectAlias")), "the alias should be in the profile before its package is uninstalled");
+
+        mpHost->getAliasUnit()->processDataStream(qsl("resurrect me"));
+
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "package was not uninstalled");
+        QVERIFY2(!gMidPassExportedXml.isEmpty(), "the mid-pass export produced nothing to check");
+        QVERIFY2(!gMidPassExportedXml.contains(qsl("resurrectAlias")), "a save taken mid-pass wrote the uninstalled package's alias back into the profile");
+        const QString keeperError = keepersMissingFrom(gMidPassExportedXml);
+        QVERIFY2(keeperError.isEmpty(), qPrintable(keeperError));
+
+        QVERIFY2(!mpHost->getAliasUnit()->findFirstAlias(qsl("resurrectAlias")), "uninstalled alias is still registered");
+        gpMidPassExportHost = nullptr;
+    }
+
+    // The timer route matters because TimerUnit's depth covers the whole of
+    // TTimer::execute(), so anything the callback reaches that saves the profile
+    // synchronously - a Lua saveProfile(), an installPackage() - saves at depth,
+    // and a callback that spins the event loop itself lets even the save
+    // uninstallPackage() queues run there. When that is the session's last save
+    // there is nothing left to undo it. beginProcessing()/endProcessing() below
+    // are the very calls TTimer::execute() wraps its callback in.
     void test_saveDuringTimerCallbackDoesNotResurrectItsPackage()
     {
         const QString packageName = qsl("resurrect-timer");
@@ -377,14 +442,23 @@ private slots:
 
         QVERIFY2(exportedProfileXml().contains(qsl("resurrectTimer")), "the timer should be in the profile before its package is uninstalled");
 
-        mpHost->getTimerUnit()->beginProcessing();
-        QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
-        const QString xml = exportedProfileXml();
-        mpHost->getTimerUnit()->endProcessing();
-        mpHost->getTimerUnit()->doCleanup();
+        QString xml;
+        {
+            mpHost->getTimerUnit()->beginProcessing();
+            // a failed QVERIFY returns from the slot, and a level left on would
+            // wedge every later test's doCleanup()
+            const auto depthGuard = qScopeGuard([this]() {
+                mpHost->getTimerUnit()->endProcessing();
+                mpHost->getTimerUnit()->doCleanup();
+            });
+            QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
+            xml = exportedProfileXml();
+        }
 
         QVERIFY2(!xml.isEmpty(), "the export produced nothing to check");
         QVERIFY2(!xml.contains(qsl("resurrectTimer")), "a save taken during a timer callback wrote the uninstalled package's timer back into the profile");
+        const QString keeperError = keepersMissingFrom(xml);
+        QVERIFY2(keeperError.isEmpty(), qPrintable(keeperError));
         QVERIFY2(!mpHost->getTimerUnit()->findFirstTimer(qsl("resurrectTimer")), "uninstalled timer is still registered");
     }
 
@@ -401,14 +475,21 @@ private slots:
 
         QVERIFY2(exportedProfileXml().contains(qsl("resurrectAction")), "the button should be in the profile before its package is uninstalled");
 
-        mpHost->getActionUnit()->beginProcessing();
-        QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
-        const QString xml = exportedProfileXml();
-        mpHost->getActionUnit()->endProcessing();
-        mpHost->getActionUnit()->doCleanup();
+        QString xml;
+        {
+            mpHost->getActionUnit()->beginProcessing();
+            const auto depthGuard = qScopeGuard([this]() {
+                mpHost->getActionUnit()->endProcessing();
+                mpHost->getActionUnit()->doCleanup();
+            });
+            QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
+            xml = exportedProfileXml();
+        }
 
         QVERIFY2(!xml.isEmpty(), "the export produced nothing to check");
         QVERIFY2(!xml.contains(qsl("resurrectAction")), "a save taken during a button script wrote the uninstalled package's button back into the profile");
+        const QString keeperError = keepersMissingFrom(xml);
+        QVERIFY2(keeperError.isEmpty(), qPrintable(keeperError));
         QVERIFY2(!mpHost->getActionUnit()->findAction(qsl("resurrectAction")), "uninstalled button is still registered");
     }
 
@@ -427,18 +508,163 @@ private slots:
 
         QVERIFY2(exportedProfileXml().contains(qsl("resurrectScript")), "the script should be in the profile before its package is uninstalled");
 
-        mpHost->getScriptUnit()->beginProcessing();
-        QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
-        const QString xml = exportedProfileXml();
-        mpHost->getScriptUnit()->endProcessing();
-        mpHost->getScriptUnit()->doCleanup();
+        QString xml;
+        {
+            mpHost->getScriptUnit()->beginProcessing();
+            const auto depthGuard = qScopeGuard([this]() {
+                mpHost->getScriptUnit()->endProcessing();
+                mpHost->getScriptUnit()->doCleanup();
+            });
+            QVERIFY(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package));
+            xml = exportedProfileXml();
+        }
 
         QVERIFY2(!xml.isEmpty(), "the export produced nothing to check");
         QVERIFY2(!xml.contains(qsl("resurrectScript")), "a save taken during an event dispatch wrote the uninstalled package's script back into the profile");
+        const QString keeperError = keepersMissingFrom(xml);
+        QVERIFY2(keeperError.isEmpty(), qPrintable(keeperError));
         QVERIFY2(mpHost->getScriptUnit()->findItems(qsl("resurrectScript")).empty(), "uninstalled script is still registered");
     }
 
+    // The module writer has the same hazard with an extra twist: reloading a
+    // module (Host::reloadModule(), reachable from Lua) uninstalls and
+    // reinstalls it back to back, so from inside a script the old items are
+    // still registered when the new ones arrive and the module's own file gets
+    // written with both copies - which then both come back on the next load.
+    void test_moduleSaveDuringReloadDoesNotDuplicateItsItems()
+    {
+        const QString moduleName = qsl("resurrect-module");
+        registerModuleAs(moduleName);
+        QVERIFY2(importModuleTimerNamed(moduleName, qsl("moduleTimerBeforeReload")), "could not import the module's timer");
+
+        QVERIFY2(exportedModuleXml(moduleName).contains(qsl("moduleTimerBeforeReload")), "the module's timer should be in its file before the reload");
+
+        QString xml;
+        {
+            mpHost->getTimerUnit()->beginProcessing();
+            const auto depthGuard = qScopeGuard([this]() {
+                mpHost->getTimerUnit()->endProcessing();
+                mpHost->getTimerUnit()->doCleanup();
+            });
+            // the uninstall half of a reload: at depth the old timer is only
+            // deactivated, and stays registered
+            QVERIFY(mpHost->uninstallPackage(moduleName, enums::PackageModuleType::ModuleSync));
+            // ... and the reinstall half brings the module back with fresh items
+            registerModuleAs(moduleName);
+            QVERIFY2(importModuleTimerNamed(moduleName, qsl("moduleTimerAfterReload")), "could not re-import the module's timer");
+
+            xml = exportedModuleXml(moduleName);
+        }
+
+        QVERIFY2(!xml.isEmpty(), "the module export produced nothing to check");
+        QVERIFY2(xml.contains(qsl("moduleTimerAfterReload")), "the reloaded module's timer must be written to its file");
+        QVERIFY2(!xml.contains(qsl("moduleTimerBeforeReload")), "a module save taken mid-reload wrote the pre-reload copy of the timer back into the module file");
+    }
+
 private:
+    // One item per unit belonging to a package that is never uninstalled. Every
+    // assertion about the deferred-delete filter is an absence, so without these
+    // an over-broad filter - or a writer that gave up on the whole unit while a
+    // delete was outstanding - would pass every test in this file while emptying
+    // the user's profile.
+    void createKeeperItems()
+    {
+        const QString keeperPackage = qsl("keeper-package");
+        mpHost->mInstalledPackages << keeperPackage;
+
+        auto pTrigger = new TTrigger(nullptr, mpHost);
+        pTrigger->setRegexCodeList({qsl("^never matched$")}, {REGEX_PERL});
+        pTrigger->registerTrigger();
+        pTrigger->setName(qsl("keeperTrigger"));
+        pTrigger->mPackageName = keeperPackage;
+
+        auto pAlias = new TAlias(qsl("keeperAlias"), mpHost);
+        pAlias->setRegexCode(qsl("^never matched$"));
+        mpHost->getAliasUnit()->registerAlias(pAlias);
+        pAlias->mPackageName = keeperPackage;
+
+        auto pTimer = new TTimer(qsl("keeperTimer"), QTime(0, 0, 30), mpHost);
+        mpHost->getTimerUnit()->registerTimer(pTimer);
+        pTimer->mPackageName = keeperPackage;
+
+        auto pAction = new TAction(qsl("keeperAction"), mpHost);
+        mpHost->getActionUnit()->registerAction(pAction);
+        pAction->mPackageName = keeperPackage;
+
+        auto pScript = new TScript(nullptr, mpHost);
+        mpHost->getScriptUnit()->registerScript(pScript);
+        pScript->setName(qsl("keeperScript"));
+        pScript->mPackageName = keeperPackage;
+    }
+
+    QString keepersMissingFrom(const QString& xml) const
+    {
+        for (const auto& name : {qsl("keeperTrigger"), qsl("keeperAlias"), qsl("keeperTimer"), qsl("keeperAction"), qsl("keeperScript")}) {
+            if (!xml.contains(name)) {
+                return qsl("a save taken while a delete was outstanding dropped \"%1\", which belongs to a package that is still installed").arg(name);
+            }
+        }
+        return {};
+    }
+
+    void registerModuleAs(const QString& moduleName)
+    {
+        mpHost->mInstalledModules[moduleName] = QStringList{qsl("%1/%2.xml").arg(mConfigDir.path(), moduleName), qsl("0")};
+        mpHost->mModulesLoadedOk << moduleName;
+    }
+
+    // The module-member flag is private to XMLimport, so a genuine module item
+    // can only be made by importing one. Importing under a package name with the
+    // module flag set gives each unit the module's master folder, which is what
+    // writeModuleXML() writes; renaming the timer's one afterwards is what makes
+    // the copy from before a reload tellable from the copy after it.
+    bool importModuleTimerNamed(const QString& moduleName, const QString& itemName)
+    {
+        // the file to import is written by Mudlet's own timer exporter, so its
+        // shape cannot drift away from what the importer expects
+        const QString path = qsl("%1/%2-import.xml").arg(mConfigDir.path(), itemName);
+        auto* pSeed = new TTimer(itemName, QTime(0, 0, 30), mpHost);
+        mpHost->getTimerUnit()->registerTimer(pSeed);
+        pSeed->setScript(qsl("local noop = true\n"));
+        const bool exported = XMLexport(pSeed).exportTimer(path);
+        mpHost->getTimerUnit()->unregisterTimer(pSeed);
+        delete pSeed;
+        if (!exported) {
+            return false;
+        }
+
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return false;
+        }
+        XMLimport importer(mpHost);
+        const bool imported = importer.importPackage(&file, moduleName, 1).first;
+        file.close();
+        QFile::remove(path);
+        if (!imported) {
+            return false;
+        }
+        TTimer* pTimer = mpHost->getTimerUnit()->findFirstTimer(moduleName);
+        if (!pTimer) {
+            return false;
+        }
+        pTimer->setName(itemName);
+        return true;
+    }
+
+    // The module half of the same thing: builds the document writeModuleXML()
+    // produces for a profile save and reads it back.
+    QString exportedModuleXml(const QString& moduleName)
+    {
+        const QString path = qsl("%1/module-export.xml").arg(mConfigDir.path());
+        XMLexport writer(mpHost);
+        writer.writeModuleXML(moduleName);
+        if (!XMLexport::saveXmlDocToFile(path, *writer.cloneExportDocument())) {
+            return {};
+        }
+        return readBack(path);
+    }
+
     // Writes the profile's items out through the same writers a profile save
     // uses, without needing the console a full Host::saveProfile() would.
     QString exportedProfileXml()
@@ -448,6 +674,11 @@ private:
         if (!writer->exportPackage(path, true, true)) {
             return {};
         }
+        return readBack(path);
+    }
+
+    static QString readBack(const QString& path)
+    {
         QFile file(path);
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
             return {};

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -112,11 +112,9 @@ private slots:
     // must still be written out - the save path has to refresh the tree.
     void test_lateCreatedSavedVariableIsExported()
     {
-        // the slots up to test_exportDoesNotLeakLuaRegistryReferences() stand
-        // for a profile whose Variables view was never opened, and QTest runs
-        // them in declaration order - so none of the slots that do open it may
-        // be declared before them. (Profile load builds the editor dialog
-        // itself, so the thing to check is that no test has shown it yet.)
+        // QTest runs slots in declaration order and these stand for a profile
+        // whose Variables view was never opened. Profile load builds the editor
+        // dialog itself, so what matters is that no slot has shown it yet.
         QVERIFY2(!mpEditor, "a Variables-view test was declared before the ones that must run without it");
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
@@ -398,11 +396,9 @@ private slots:
         vu->removeHidden(qsl("userHiddenPrefVar"));
     }
 
-    // VarUnit keeps two hidden-variable sets: hiddenByUser, which the tests
-    // above cover, and hidden, which Host::hideMudletsVariables() fills with the
-    // whole of Mudlet's own Lua API at profile load. Both have to reach the tree
-    // the export builds, or a saved table's members would drag Mudlet's
-    // internals into the profile XML.
+    // VarUnit has two hidden sets: hiddenByUser, and hidden, which
+    // Host::hideMudletsVariables() fills with Mudlet's own Lua API. Both have to
+    // reach the export's tree or a saved table drags the internals into the XML.
     void test_internallyHiddenMemberOfSavedTableIsNotExported()
     {
         LuaInterface* lI = mpHost->getLuaInterface();
@@ -423,23 +419,18 @@ private slots:
         QCOMPARE(luaL_dostring(L, "internalHiddenTable = nil"), 0);
     }
 
-    // Reference-keyed variables are named by a Lua registry reference, so
-    // building a variable tree takes one per such key. The tree the export
-    // builds is thrown away, and if its references went with it the registry
-    // would grow by that many slots on every save - every two minutes with the
-    // editor focused, and on every package install or uninstall.
+    // A variable tree takes a Lua registry reference per reference-keyed entry.
+    // The export throws its tree away, so if the references went with it the
+    // registry would grow by that many slots on every save.
     void test_exportDoesNotLeakLuaRegistryReferences()
     {
         lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
         // several reference-keyed members, so a leak grows the registry visibly
         QCOMPARE(luaL_dostring(L, "refKeyLeakTable = {} for i = 1, 20 do refKeyLeakTable[{}] = i end"), 0);
 
-        // luaL_unref returns slots to the registry's free list and luaL_ref
-        // hands them straight back out, so the number a fresh reference gets
-        // stops climbing once the registry is big enough for one pass's worth.
-        // Measuring after one export rather than before it takes that one-off
-        // growth out of the comparison; what is left is per-export growth,
-        // which only happens if a pass keeps its references.
+        // freed slots go on a free list and come straight back out, so the
+        // number stops climbing once the registry fits one pass's worth.
+        // Measuring after the first export leaves that one-off growth out.
         QVERIFY(!exportProfileXml().isEmpty());
         lua_pushboolean(L, 1);
         const int refAfterOne = luaL_ref(L, LUA_REGISTRYINDEX);
@@ -460,13 +451,9 @@ private slots:
         QCOMPARE(luaL_dostring(L, "refKeyLeakTable = nil"), 0);
     }
 
-    // The everyday shape of the loss: the script editor is parked on the
-    // Variables view (the last save of a session is taken with whatever view
-    // was left on screen, so quitting from there is enough), a script adds to a
-    // saved table, and the save has to carry that addition. The export used to
-    // skip its refresh whenever that view was on screen, on the grounds that
-    // the editor keeps the tree current - but the editor only rebuilds it on
-    // entering the view, so everything a script did afterwards was lost.
+    // A script adds to a saved table while the editor sits on the Variables
+    // view. A session's last save is taken with whatever view was left on
+    // screen, so quitting from there is enough to reach this.
     void test_savedTableMemberIsExportedWithVariablesViewOpen()
     {
         QVERIFY2(showEditorOnVariablesView(), "the script editor could not be opened on the Variables view");
@@ -477,22 +464,19 @@ private slots:
         QCOMPARE(luaL_dostring(L, "varsViewTable = {seedMember = 'seed member value'}"), 0);
         vu->savedVars.insert(qsl("varsViewTable"));
         vu->savedVars.insert(qsl("varsViewTable.seedMember"));
-        // populating the view is what builds the tree the export used to reuse
         mpEditor->repopulateVars();
 
-        // ... and this is a script running afterwards, with the view still up
+        // a script running afterwards, with the view still up
         QCOMPARE(luaL_dostring(L, "varsViewTable.lateMember = 'late member value'"), 0);
         QCOMPARE(luaL_dostring(L, "varsViewTable.seedMember = nil"), 0);
 
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
         QVERIFY2(xml.contains(qsl("late member value")), "a member added while the Variables view was open must still be saved");
-        // belt and braces rather than the regression guard: writeVariable()
-        // re-reads the value out of Lua, so a stale tree writes this one out
-        // empty rather than with its old value
+        // secondary: writeVariable() re-reads values from Lua, so a stale tree
+        // writes this one out empty rather than with its old value
         QVERIFY2(!xml.contains(qsl("seed member value")), "a member a script removed while the Variables view was open must not be saved back");
 
-        // and the view must survive the save it was open for
         auto* pVariablesTree = mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_variables"));
         QVERIFY2(pVariablesTree, "the editor has no variables tree widget");
         QTreeWidgetItem* pBaseItem = pVariablesTree->topLevelItem(0);
@@ -525,11 +509,9 @@ private slots:
         QCOMPARE(luaL_dostring(L, "varsViewLateVar = nil"), 0);
     }
 
-    // The other side of the same interaction: a save must not pull the variable
-    // tree out from under the editor. Its variables tree widget and its search
-    // results resolve their items through VarUnit's item -> TVar map, and an
-    // export that rebuilt the shared tree emptied that map, leaving every
-    // variable search result silently dead until the search was re-run.
+    // The other side: a save must not pull the tree out from under the editor.
+    // Its tree widget and search results resolve items through VarUnit's
+    // item -> TVar map, which rebuilding the shared tree empties.
     void test_variablesEditorItemMappingSurvivesExport()
     {
         QVERIFY2(showEditorOnVariablesView(), "the script editor could not be opened on the Variables view");
@@ -544,9 +526,7 @@ private slots:
         TVar* pMappedBefore = vu->getWVar(pVariableItem);
         QVERIFY2(pMappedBefore, "the Variables view's items should resolve to a variable");
 
-        // a save from a view other than Variables is the reported case - the
-        // editor's own Save Profile button, its autosave, or any package
-        // install or uninstall
+        // any save does it: the Save Profile button, the autosave, a package change
         mpEditor->slot_showTriggers();
         QVERIFY(!exportProfileXml().isEmpty());
 
@@ -554,10 +534,8 @@ private slots:
     }
 
 private:
-    // The editor is created lazily so that the tests above run in the state a
-    // profile that never opened it is in. Returns false rather than asserting:
-    // a QVERIFY here would only return from this helper, leaving its caller to
-    // dereference a null editor.
+    // Returns false rather than asserting: a QVERIFY here would only return from
+    // this helper, leaving the caller to dereference a null editor.
     bool showEditorOnVariablesView()
     {
         if (!mpEditor) {

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -112,6 +112,12 @@ private slots:
     // must still be written out - the save path has to refresh the tree.
     void test_lateCreatedSavedVariableIsExported()
     {
+        // the slots up to test_exportDoesNotLeakLuaRegistryReferences() stand
+        // for a profile whose Variables view was never opened, and QTest runs
+        // them in declaration order - so none of the slots that do open it may
+        // be declared before them. (Profile load builds the editor dialog
+        // itself, so the thing to check is that no test has shown it yet.)
+        QVERIFY2(!mpEditor, "a Variables-view test was declared before the ones that must run without it");
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
         // build the tree directly, standing in for the initial build that
@@ -392,6 +398,68 @@ private slots:
         vu->removeHidden(qsl("userHiddenPrefVar"));
     }
 
+    // VarUnit keeps two hidden-variable sets: hiddenByUser, which the tests
+    // above cover, and hidden, which Host::hideMudletsVariables() fills with the
+    // whole of Mudlet's own Lua API at profile load. Both have to reach the tree
+    // the export builds, or a saved table's members would drag Mudlet's
+    // internals into the profile XML.
+    void test_internallyHiddenMemberOfSavedTableIsNotExported()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "internalHiddenTable = {plainMember = 'plain member value', internalMember = 'internal member value'}"), 0);
+        vu->savedVars.insert(qsl("internalHiddenTable"));
+        // what addHidden(TVar*, 0) records - the non-user half of the pair
+        vu->hidden.insert(qsl("internalHiddenTable.internalMember"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("plain member value")), "a plain member of a saved table must be exported");
+        QVERIFY2(!xml.contains(qsl("internal member value")), "a member hidden by Mudlet itself must not ride along with its saved table");
+
+        vu->savedVars.remove(qsl("internalHiddenTable"));
+        vu->hidden.remove(qsl("internalHiddenTable.internalMember"));
+        QCOMPARE(luaL_dostring(L, "internalHiddenTable = nil"), 0);
+    }
+
+    // Reference-keyed variables are named by a Lua registry reference, so
+    // building a variable tree takes one per such key. The tree the export
+    // builds is thrown away, and if its references went with it the registry
+    // would grow by that many slots on every save - every two minutes with the
+    // editor focused, and on every package install or uninstall.
+    void test_exportDoesNotLeakLuaRegistryReferences()
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        // several reference-keyed members, so a leak grows the registry visibly
+        QCOMPARE(luaL_dostring(L, "refKeyLeakTable = {} for i = 1, 20 do refKeyLeakTable[{}] = i end"), 0);
+
+        // luaL_unref returns slots to the registry's free list and luaL_ref
+        // hands them straight back out, so the number a fresh reference gets
+        // stops climbing once the registry is big enough for one pass's worth.
+        // Measuring after one export rather than before it takes that one-off
+        // growth out of the comparison; what is left is per-export growth,
+        // which only happens if a pass keeps its references.
+        QVERIFY(!exportProfileXml().isEmpty());
+        lua_pushboolean(L, 1);
+        const int refAfterOne = luaL_ref(L, LUA_REGISTRYINDEX);
+        luaL_unref(L, LUA_REGISTRYINDEX, refAfterOne);
+
+        for (int i = 0; i < 5; ++i) {
+            QVERIFY(!exportProfileXml().isEmpty());
+        }
+
+        lua_pushboolean(L, 1);
+        const int refAfterSix = luaL_ref(L, LUA_REGISTRYINDEX);
+        luaL_unref(L, LUA_REGISTRYINDEX, refAfterSix);
+
+        // five more exports keeping 20 references each would put this 100 higher
+        QVERIFY2(refAfterSix < refAfterOne + 20,
+                 qPrintable(qsl("the exports pinned Lua registry slots: a reference taken after one export was %1, one taken after six was %2").arg(refAfterOne).arg(refAfterSix)));
+
+        QCOMPARE(luaL_dostring(L, "refKeyLeakTable = nil"), 0);
+    }
+
     // The everyday shape of the loss: the script editor is parked on the
     // Variables view (the last save of a session is taken with whatever view
     // was left on screen, so quitting from there is enough), a script adds to a
@@ -401,7 +469,7 @@ private slots:
     // entering the view, so everything a script did afterwards was lost.
     void test_savedTableMemberIsExportedWithVariablesViewOpen()
     {
-        showEditorOnVariablesView();
+        QVERIFY2(showEditorOnVariablesView(), "the script editor could not be opened on the Variables view");
 
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
@@ -419,7 +487,17 @@ private slots:
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
         QVERIFY2(xml.contains(qsl("late member value")), "a member added while the Variables view was open must still be saved");
+        // belt and braces rather than the regression guard: writeVariable()
+        // re-reads the value out of Lua, so a stale tree writes this one out
+        // empty rather than with its old value
         QVERIFY2(!xml.contains(qsl("seed member value")), "a member a script removed while the Variables view was open must not be saved back");
+
+        // and the view must survive the save it was open for
+        auto* pVariablesTree = mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_variables"));
+        QVERIFY2(pVariablesTree, "the editor has no variables tree widget");
+        QTreeWidgetItem* pBaseItem = pVariablesTree->topLevelItem(0);
+        QVERIFY2(pBaseItem && pBaseItem->childCount() > 0, "the Variables view did not populate");
+        QVERIFY2(vu->getWVar(pBaseItem->child(0)), "a save taken with the Variables view on screen must leave its items resolving to their variables");
 
         vu->savedVars.remove(qsl("varsViewTable"));
         vu->savedVars.remove(qsl("varsViewTable.seedMember"));
@@ -429,7 +507,7 @@ private slots:
     // ... and the same for a whole variable rather than a table member.
     void test_lateSavedVariableIsExportedWithVariablesViewOpen()
     {
-        showEditorOnVariablesView();
+        QVERIFY2(showEditorOnVariablesView(), "the script editor could not be opened on the Variables view");
 
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
@@ -454,7 +532,7 @@ private slots:
     // variable search result silently dead until the search was re-run.
     void test_variablesEditorItemMappingSurvivesExport()
     {
-        showEditorOnVariablesView();
+        QVERIFY2(showEditorOnVariablesView(), "the script editor could not be opened on the Variables view");
         mpEditor->repopulateVars();
 
         VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
@@ -467,8 +545,8 @@ private slots:
         QVERIFY2(pMappedBefore, "the Variables view's items should resolve to a variable");
 
         // a save from a view other than Variables is the reported case - the
-        // editor's own Save Profile button, the two-minute autosave, or any
-        // package install or uninstall
+        // editor's own Save Profile button, its autosave, or any package
+        // install or uninstall
         mpEditor->slot_showTriggers();
         QVERIFY(!exportProfileXml().isEmpty());
 
@@ -477,17 +555,22 @@ private slots:
 
 private:
     // The editor is created lazily so that the tests above run in the state a
-    // profile that never opened it is in.
-    void showEditorOnVariablesView()
+    // profile that never opened it is in. Returns false rather than asserting:
+    // a QVERIFY here would only return from this helper, leaving its caller to
+    // dereference a null editor.
+    bool showEditorOnVariablesView()
     {
         if (!mpEditor) {
             mudlet::self()->slot_showScriptDialog();
             QTest::qWait(100);
             mpEditor = mpHost->mpEditorDialog;
-            QVERIFY2(mpEditor, "the script editor was not created");
+            if (!mpEditor) {
+                return false;
+            }
         }
         mpEditor->slot_showVariables();
         QTest::qWait(50);
+        return true;
     }
 
     QString exportProfileXml()

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -40,7 +40,10 @@
 #include "XMLexport.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
+#include "dlgTriggerEditor.h"
 #include "mudlet.h"
+
+#include <QTreeWidget>
 
 extern "C" {
 #if defined(INCLUDE_VERSIONED_LUA_HEADERS)
@@ -68,6 +71,7 @@ class XMLexportVariablesTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
+    dlgTriggerEditor* mpEditor = nullptr;
     const QString mHostname = "XMLexportVars-Test";
     const QString mLocalhost = "localhost";
 
@@ -95,6 +99,7 @@ private slots:
 
     void cleanupTestCase()
     {
+        mpEditor = nullptr;
         mpHost = nullptr;
         delete mpServer;
         mpServer = nullptr;
@@ -387,7 +392,104 @@ private slots:
         vu->removeHidden(qsl("userHiddenPrefVar"));
     }
 
+    // The everyday shape of the loss: the script editor is parked on the
+    // Variables view (the last save of a session is taken with whatever view
+    // was left on screen, so quitting from there is enough), a script adds to a
+    // saved table, and the save has to carry that addition. The export used to
+    // skip its refresh whenever that view was on screen, on the grounds that
+    // the editor keeps the tree current - but the editor only rebuilds it on
+    // entering the view, so everything a script did afterwards was lost.
+    void test_savedTableMemberIsExportedWithVariablesViewOpen()
+    {
+        showEditorOnVariablesView();
+
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "varsViewTable = {seedMember = 'seed member value'}"), 0);
+        vu->savedVars.insert(qsl("varsViewTable"));
+        vu->savedVars.insert(qsl("varsViewTable.seedMember"));
+        // populating the view is what builds the tree the export used to reuse
+        mpEditor->repopulateVars();
+
+        // ... and this is a script running afterwards, with the view still up
+        QCOMPARE(luaL_dostring(L, "varsViewTable.lateMember = 'late member value'"), 0);
+        QCOMPARE(luaL_dostring(L, "varsViewTable.seedMember = nil"), 0);
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("late member value")), "a member added while the Variables view was open must still be saved");
+        QVERIFY2(!xml.contains(qsl("seed member value")), "a member a script removed while the Variables view was open must not be saved back");
+
+        vu->savedVars.remove(qsl("varsViewTable"));
+        vu->savedVars.remove(qsl("varsViewTable.seedMember"));
+        QCOMPARE(luaL_dostring(L, "varsViewTable = nil"), 0);
+    }
+
+    // ... and the same for a whole variable rather than a table member.
+    void test_lateSavedVariableIsExportedWithVariablesViewOpen()
+    {
+        showEditorOnVariablesView();
+
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        mpEditor->repopulateVars();
+
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "varsViewLateVar = 'late variable value'"), 0);
+        vu->savedVars.insert(qsl("varsViewLateVar"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("late variable value")), "a saved variable created while the Variables view was open must still be saved");
+
+        vu->savedVars.remove(qsl("varsViewLateVar"));
+        QCOMPARE(luaL_dostring(L, "varsViewLateVar = nil"), 0);
+    }
+
+    // The other side of the same interaction: a save must not pull the variable
+    // tree out from under the editor. Its variables tree widget and its search
+    // results resolve their items through VarUnit's item -> TVar map, and an
+    // export that rebuilt the shared tree emptied that map, leaving every
+    // variable search result silently dead until the search was re-run.
+    void test_variablesEditorItemMappingSurvivesExport()
+    {
+        showEditorOnVariablesView();
+        mpEditor->repopulateVars();
+
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        auto* pVariablesTree = mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_variables"));
+        QVERIFY2(pVariablesTree, "the editor has no variables tree widget");
+        QTreeWidgetItem* pBaseItem = pVariablesTree->topLevelItem(0);
+        QVERIFY2(pBaseItem && pBaseItem->childCount() > 0, "the Variables view did not populate");
+        QTreeWidgetItem* pVariableItem = pBaseItem->child(0);
+        TVar* pMappedBefore = vu->getWVar(pVariableItem);
+        QVERIFY2(pMappedBefore, "the Variables view's items should resolve to a variable");
+
+        // a save from a view other than Variables is the reported case - the
+        // editor's own Save Profile button, the two-minute autosave, or any
+        // package install or uninstall
+        mpEditor->slot_showTriggers();
+        QVERIFY(!exportProfileXml().isEmpty());
+
+        QVERIFY2(vu->getWVar(pVariableItem) == pMappedBefore, "a profile save must leave the Variables editor's items resolving to their variables");
+    }
+
 private:
+    // The editor is created lazily so that the tests above run in the state a
+    // profile that never opened it is in.
+    void showEditorOnVariablesView()
+    {
+        if (!mpEditor) {
+            mudlet::self()->slot_showScriptDialog();
+            QTest::qWait(100);
+            mpEditor = mpHost->mpEditorDialog;
+            QVERIFY2(mpEditor, "the script editor was not created");
+        }
+        mpEditor->slot_showVariables();
+        QTest::qWait(50);
+    }
+
     QString exportProfileXml()
     {
         const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/xmlexport-test.xml");


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Variables: the export skipped its refresh whenever the editor's Variables view was on screen, so anything a script wrote into a saved variable while it sat open was dropped from the save - including the session's last save, which is taken with whatever view the editor was left on. The variables are now read into a throwaway tree, which also stops a save stranding the editor's variable search results.
- Packages: a save taken while a unit was still executing an item of a package that had just been uninstalled wrote that package's items back into the profile, where they returned as orphans the Package Manager could not remove. The XML writers now skip what the units have queued for a deferred delete, the module writer included - reloading a module from a script used to write both the pre- and post-reload copies of its items into the module file.
- `LuaInterface::getVars()` is now `setjmp`-guarded like every other Lua-touching method there, so a panic cannot jump past the export's scope with its variable tree and registry references still held.

#### Motivation for adding to Mudlet
Both are silent data loss in everyday use: quitting with the editor on the Variables tab, and the `mpkg`/auto-updater shape of uninstalling a package from a script.

#### Other info (issues closed, discussion etc)
From the 5.0 QA sweep, findings C13 and C14. The variables half re-opens the loss that `20009c5ec` "fix: variables added while playing are no longer lost when saving (#9492)" fixed, via the guard it added; the packages half is the missing counterpart to the self-uninstall deferral in `276e8bbfd` (#9383) and its follow-ups. #9492's own cases still pass unchanged.

**Test case:** create a table from the command line, tick it to be saved in the editor's Variables view, leave the editor there, run `lua myTable.later = "x"`, quit and reopen - `later` is still there. `ctest -R 'XMLexportVariablesTest|PackageSelfUninstallTest'` covers both halves; all 12 new cases were verified to fail against the unfixed source.

Assisted-by: Claude:claude-opus-5