### PR TITLE
infrastructure: trim the comments around the experienced-player gate

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -176,10 +176,7 @@ mudlet::mudlet()
 void mudlet::init()
 {
     smFirstLaunch = !QFile::exists(mudlet::getMudletPath(enums::profilesPath));
-    // Has to happen after setupConfig() has created mpSettings and before
-    // anything can create a profile, which is only true here. Note this asks a
-    // slightly different question to smFirstLaunch above: an existing but empty
-    // profiles directory still counts as a first launch. See rememberFirstLaunch()
+    // Must be after setupConfig() created mpSettings and before anything of this run is written
     rememberFirstLaunch(*mpSettings, mudlet::getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
 
     QFile gitShaFile(":/app-build.txt");
@@ -7550,8 +7547,6 @@ void mudlet::showedCharacterModeWarning()
     mCharacterModeWarningsShown = std::min(mCharacterModeWarningsShown + 1, mCharacterModeWarningsMax);
 }
 
-// When Mudlet was first used on this installation, as UTC ISO-8601. Absent on
-// installations that predate the key - see rememberFirstLaunch().
 static const QLatin1String settingsKeyFirstLaunch("firstLaunchDate");
 static constexpr int experiencedPlayerMonths = 6;
 
@@ -7562,9 +7557,7 @@ static bool anyProfilesExist(const QString& profilesPath)
         return false;
     }
     if (!QFileInfo(profilesPath).isReadable()) {
-        // An unlistable directory looks exactly like an empty one, and reading
-        // it as empty would stamp a long-time user with today's date as their
-        // first launch - permanently, since that is only ever written once.
+        // Unlistable reads as empty, which would stamp an existing user with today as their first launch
         qWarning() << "anyProfilesExist() WARNING - the profiles directory exists but cannot be read:" << profilesPath
                    << "- assuming it holds profiles, so an existing user is not mistaken for a new one.";
         return true;
@@ -7572,29 +7565,20 @@ static bool anyProfilesExist(const QString& profilesPath)
     return !profiles.entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty();
 }
 
-// Evidence that Mudlet has run here before the first-launch key existed: a
-// profile, or any other setting already on file. Either rules out a first-ever
-// run, including for someone who kept their settings but not their profiles -
-// a restored backup, or a move to a new machine.
+// Settings count as well as profiles: someone who kept their Mudlet.ini but not
+// their profiles is still not on their first run.
 static bool mudletUsedBefore(const QSettings& settings, const QString& profilesPath)
 {
     return anyProfilesExist(profilesPath) || !settings.allKeys().isEmpty();
 }
 
-// Intended to be called exactly once, from init(), after setupConfig() has made
-// the settings available and before any profile or setting of this run can be
-// written - only then does "no trace of earlier use" really mean the user is
-// starting today.
-//
-// Where there is such a trace the start date is not recoverable, so nothing is
-// recorded and evaluateExperiencedPlayer() falls back instead. No timestamp can
-// stand in: Mudlet's own writes refresh them, and whether a copied or restored
-// profile keeps its modification times depends entirely on the tool used, while
-// its birth time is reset either way.
+// Called only from init(), before anything of this run has been written. Where
+// there is a trace of earlier use the start date is unrecoverable - no timestamp
+// survives Mudlet's own writes, nor a copy to another machine - so nothing is
+// recorded and evaluateExperiencedPlayer() falls back.
 /*static*/ void mudlet::rememberFirstLaunch(QSettings& settings, const QString& profilesPath, const QDateTime& now)
 {
-    // The parse is deliberately not consulted: re-recording an unreadable value
-    // would restart the six month clock today, which is the harmful direction.
+    // Not conditioned on the value parsing: re-recording would restart the clock today
     if (settings.contains(settingsKeyFirstLaunch) || mudletUsedBefore(settings, profilesPath)) {
         return;
     }
@@ -7602,24 +7586,11 @@ static bool mudletUsedBefore(const QSettings& settings, const QString& profilesP
     settings.setValue(settingsKeyFirstLaunch, now.toUTC().toString(Qt::ISODate));
     settings.sync();
     if (settings.status() != QSettings::NoError) {
-        // Worth saying out loud: the write is never retried, because by the next
-        // run the user has a profile and is indistinguishable from an upgrader.
-        // A newcomer who hits this loses their onboarding for good.
         qWarning() << "mudlet::rememberFirstLaunch() WARNING - could not record the first launch date in" << settings.fileName() << "- QSettings status:" << settings.status()
                    << "- this installation will later be taken for an experienced user's.";
     }
 }
 
-// Returns true if the player has been using Mudlet long enough that first-time
-// guidance - the interface tour, the starter UI, the one-line hints - would be
-// an interruption rather than a help.
-//
-// This used to be inferred from profile directory modification times, which
-// measured the opposite of what was wanted: the per-profile data writes (url,
-// port, password, profile.ini, command history) all land directly in the
-// profile directory and bump its mtime on every session, so only a profile left
-// untouched for the whole window ever looked old. An active player of ten
-// years' standing classified as brand new.
 /*static*/ bool mudlet::evaluateExperiencedPlayer(const QSettings& settings, const QString& profilesPath, const QDateTime& now)
 {
     const QString recorded = settings.value(settingsKeyFirstLaunch).toString();
@@ -7628,17 +7599,12 @@ static bool mudletUsedBefore(const QSettings& settings, const QString& profilesP
         return firstLaunch <= now.addMonths(-experiencedPlayerMonths);
     }
     if (!recorded.isEmpty()) {
-        // The value is meant to be legible and hand-editable, so say when a
-        // hand-edit did not take rather than ignoring it in silence.
         qWarning().nospace().noquote() << "evaluateExperiencedPlayer() WARNING - \"" << settingsKeyFirstLaunch << "\" holds \"" << recorded
                                        << "\", which is not ISO 8601 - falling back to looking for signs of earlier use.";
     }
 
-    // No usable record: an installation that predates the key, or one whose
-    // record was lost or corrupted. Either way the only signal left is whether
-    // Mudlet has been used here before. Erring towards 'experienced' is
-    // deliberate - interrupting a veteran with a beginner tour is far worse
-    // than a newcomer missing one.
+    // Erring towards 'experienced' is deliberate: interrupting a veteran with a
+    // beginner tour is worse than a newcomer missing one.
     return mudletUsedBefore(settings, profilesPath);
 }
 
@@ -7651,9 +7617,7 @@ bool mudlet::experiencedMudletPlayer()
 
     const auto* settings = getQSettings();
     if (!settings) {
-        // setupConfig() has not created them yet, so answer 'experienced',
-        // which shows nothing. Deliberately not cached: the answer is a guess,
-        // and caching it would pin every gate for the rest of the process.
+        // Not cached: a guess, and caching it would pin every gate for the process
         qWarning() << "mudlet::experiencedMudletPlayer() WARNING - called before setupConfig(), so assuming an experienced player and showing no first-run guidance.";
         return true;
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -328,13 +328,11 @@ public:
     void showedMuteAllMediaTutorial();
     bool showCharacterModeWarning();
     void showedCharacterModeWarning();
-    // True if the player has used Mudlet long enough not to need the basic
-    // tutorial tips, the interface tour or the starter UI. Memoised.
+    // True if the player has used Mudlet long enough not to need the tutorial
+    // tips, the interface tour or the starter UI. Memoised.
     bool experiencedMudletPlayer();
-    // Records the first launch. Must be called exactly once, from init(),
-    // before any profile can exist - public only so it can be tested.
+    // The two below are public only so they can be tested
     static void rememberFirstLaunch(QSettings& settings, const QString& profilesPath, const QDateTime& now);
-    // The uncached body of experiencedMudletPlayer() - public only for testing.
     static bool evaluateExperiencedPlayer(const QSettings& settings, const QString& profilesPath, const QDateTime& now);
 
     // Telnet URI handling

--- a/test/functional_tests/DefaultPackagesTest.cpp
+++ b/test/functional_tests/DefaultPackagesTest.cpp
@@ -135,8 +135,7 @@ private slots:
 
     // Games that install an interface of their own get a loader instead of the
     // starter UI, which would otherwise fight it for the same screen space.
-    // Every other game gets it, as long as the player is new to Mudlet - this
-    // config dir has no profiles and no recorded history, so they are.
+    // This config dir has no profiles, so the player counts as new to Mudlet.
     void test_gamesWithTheirOwnUiSkipTheStarterUi()
     {
         QVERIFY(preinstallsFor(qsl("example.com")).contains(qsl(":/packages/mudlet-base-ui/mudlet-base-ui.mpackage")));

--- a/test/functional_tests/ExperiencedPlayerGateTest.cpp
+++ b/test/functional_tests/ExperiencedPlayerGateTest.cpp
@@ -23,17 +23,10 @@
  * the one-line hints - so getting it wrong either buries a newcomer's
  * onboarding or drops a beginner tour on top of a ten-year veteran's session.
  *
- * The heuristic this replaced read profile *directory* mtimes, which record
- * when a profile was last written rather than how long it has existed; see
- * mudlet::evaluateExperiencedPlayer() for why that is backwards.
- * test_upgraderWithFreshlyWrittenProfilesIsExperienced is that exact shape and
- * is the regression this file exists for.
- *
  * mudlet::rememberFirstLaunch() and mudlet::evaluateExperiencedPlayer() take
- * their settings, profiles path and "now" as arguments, so the cases below run
+ * their settings, profiles path and "now" as arguments, so most cases run
  * without a mudlet instance. The last two drive a real init() instead, to pin
- * the production wiring: that init() records the date, and that the memoised
- * experiencedMudletPlayer() reads back the same key from the same path.
+ * the production wiring.
  *
  * Run with: ctest -R ExperiencedPlayerGateTest -V
  */
@@ -61,8 +54,7 @@ private:
     QByteArray mSavedXdg;
     // Outlives the two live-singleton cases, which share one mudlet instance
     QTemporaryDir mLiveConfig;
-    // Fixed, so the six month arithmetic is not at the mercy of the day the
-    // suite happens to run on
+    // Fixed, so the six month arithmetic does not depend on the day the suite runs
     const QDateTime mNow = QDateTime(QDate(2026, 8, 5), QTime(12, 0), QTimeZone::UTC);
     const QString mKey = qsl("firstLaunchDate");
 
@@ -78,8 +70,7 @@ private:
 
     void setFirstLaunch(QSettings& settings, const QDateTime& when) const { settings.setValue(mKey, when.toUTC().toString(Qt::ISODate)); }
 
-    // setupConfig() consults portable.txt before the XDG logic, so the
-    // live-singleton cases skip rather than report a baffling failure
+    // setupConfig() consults portable.txt before the XDG logic
     bool portableMarkerPresent() const
     {
         return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
@@ -96,7 +87,7 @@ private slots:
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
     }
 
-    // --- a brand new installation --------------------------------------------
+    // --- a brand new installation ---
 
     void test_freshInstallRecordsTodayAndIsNew()
     {
@@ -111,8 +102,6 @@ private slots:
         QVERIFY2(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow), "a first-ever launch must be treated as a new player");
     }
 
-    // A profiles directory that exists but holds nothing is still a first run -
-    // an aborted earlier launch must not cost the user their onboarding.
     void test_emptyProfilesDirectoryIsStillAFirstRun()
     {
         QTemporaryDir config;
@@ -126,7 +115,7 @@ private slots:
         QVERIFY(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
     }
 
-    // --- the recorded date, once there is one --------------------------------
+    // --- the recorded date, once there is one ---
 
     void test_recentlyRecordedFirstLaunchIsNew()
     {
@@ -166,8 +155,6 @@ private slots:
         QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profiles, mNow));
     }
 
-    // A clock set forward and back, or settings carried between machines, can
-    // leave a first launch in the future. That is not tenure.
     void test_futureDatedFirstLaunchIsNotExperienced()
     {
         QTemporaryDir config;
@@ -178,11 +165,8 @@ private slots:
         QVERIFY(!mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
     }
 
-    // --- upgrading users, who have no recorded first launch ------------------
+    // --- upgrading users, who have no recorded first launch ---
 
-    // The regression: profiles written seconds ago by an installation that has
-    // been in use for years. The old directory-mtime heuristic classified this
-    // player as brand new, handing a veteran the beginner tour.
     void test_upgraderWithFreshlyWrittenProfilesIsExperienced()
     {
         QTemporaryDir config;
@@ -201,10 +185,8 @@ private slots:
         QVERIFY2(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow), "an installation with profiles but no recorded first launch predates the key, so it is experienced");
     }
 
-    // Timestamps are not consulted at all, which is what makes a profile copied
-    // to a new machine or restored from a backup come out right: whether the
-    // modification times survive depends entirely on the tool used, and the
-    // birth time is reset either way.
+    // A restored profile may or may not keep its modification times, and never
+    // keeps its birth time, so no timestamp is consulted
     void test_restoredFromBackupIsExperienced()
     {
         QTemporaryDir config;
@@ -215,9 +197,6 @@ private slots:
         QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
     }
 
-    // Settings restored without their profiles - a move to a new machine, or a
-    // user who deleted their last profile. Mudlet has clearly run here before,
-    // so they must not be stamped with today as their first launch.
     void test_settingsWithoutProfilesStillCountAsEarlierUse()
     {
         QTemporaryDir config;
@@ -232,10 +211,6 @@ private slots:
         QVERIFY(mudlet::evaluateExperiencedPlayer(settings, profilesPathIn(config.path()), mNow));
     }
 
-    // A profiles directory that cannot be listed is indistinguishable from an
-    // empty one, so it must be read the safe way round - otherwise a home
-    // directory that mounted late would brand a veteran as a newcomer, for six
-    // months, with no way back.
     void test_unreadableProfilesDirectoryIsTakenAsPopulated()
     {
         QTemporaryDir config;
@@ -250,14 +225,11 @@ private slots:
         }
 
         const bool experienced = mudlet::evaluateExperiencedPlayer(settings, profiles, mNow);
-        // Restore before asserting, so a failure does not leave QTemporaryDir
-        // unable to clean up after itself
+        // Restore before asserting, or a failure leaves QTemporaryDir unable to clean up
         QVERIFY(QFile::setPermissions(profiles, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner));
         QVERIFY(experienced);
     }
 
-    // Upgrading must not invent a first launch date - that would start the six
-    // month clock now and hand the veteran a tour six months from today.
     void test_upgradeDoesNotRecordAFirstLaunch()
     {
         QTemporaryDir config;
@@ -284,10 +256,6 @@ private slots:
         QCOMPARE(settings.value(mKey).toString(), original.toString(Qt::ISODate));
     }
 
-    // A corrupted or mistyped value must not be trusted as a date; it falls
-    // through to the earlier-use check, exactly like an upgrade does. It is also
-    // left alone rather than re-recorded, since re-recording would restart the
-    // six month clock today.
     void test_unparseableRecordFallsBackToTheEarlierUseCheck()
     {
         QTemporaryDir config;
@@ -318,22 +286,18 @@ private slots:
         QVERIFY2(QString::fromUtf8(ini.readAll()).contains(qsl("firstLaunchDate=2024-08-05T12:00:00Z")), "the date is stored as plain ISO 8601, so it can be read and edited by hand");
     }
 
-    // --- the live singleton --------------------------------------------------
+    // --- the live singleton ---
 
-    // The whole fix rests on init() recording the date at a point where no
-    // profile can exist yet. Nothing else in the suite would notice that call
-    // being moved or dropped, and if it were, every fresh install would take
-    // the "used before" fallback and be classified experienced - silently
-    // killing the onboarding for exactly the people it is for.
+    // Nothing else in the suite notices the init() call being moved or dropped,
+    // which would make every fresh install take the "used before" fallback
     void test_initRecordsTheFirstLaunchOnAFreshInstall()
     {
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - setupConfig() takes the portable branch");
         }
         QVERIFY(mLiveConfig.isValid());
-        // An empty $XDG_CONFIG_HOME/mudlet is the opt-in marker; on a machine
-        // with a legacy ~/.config/mudlet, setupConfig() would otherwise keep
-        // using that
+        // An empty $XDG_CONFIG_HOME/mudlet is the opt-in marker, without which
+        // setupConfig() keeps using a legacy ~/.config/mudlet
         const QString configDir = qsl("%1/mudlet").arg(mLiveConfig.path());
         QVERIFY(QDir().mkpath(configDir));
         qputenv("XDG_CONFIG_HOME", mLiveConfig.path().toUtf8());
@@ -351,12 +315,8 @@ private slots:
         QCOMPARE(QDateTime::fromString(mudlet::getQSettings()->value(mKey).toString(), Qt::ISODate).isValid(), true);
     }
 
-    // The direction that actually broke, through the memoised production path:
-    // an installation with a profile and no recorded date must come out
-    // experienced. Pins the key name and the profiles path that
-    // experiencedMudletPlayer() picks for itself, which the case above cannot -
-    // there, both branches would answer "new".
-    //
+    // Pins the key and profiles path experiencedMudletPlayer() picks for itself,
+    // which the case above cannot - there both branches would answer "new".
     // Runs last: experiencedMudletPlayer() memoises for the life of the process.
     void test_experiencedThroughTheRealSettings()
     {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Comment-only follow-up to #9695 "fix: stop treating long-time Mudlet users as brand new players" - no code line changes at all.
- Removes every passage describing what the gate used to do; git history and the #9695 body carry that, and in source it goes stale the moment someone touches the line.
- Cuts what remains to the constraints a reader cannot derive from the code: the `init()` ordering requirement, why no filesystem timestamp can substitute for the recorded date, and why the fallback deliberately errs towards 'experienced'.

#### Motivation for adding to Mudlet
Applies the house comment standard to code that landed a few hours earlier: 112 comment lines out, 33 shorter ones in.

#### Other info (issues closed, discussion etc)
Test names carry the intent in `ExperiencedPlayerGateTest`, so per-assertion narration went; the `QVERIFY2` failure messages already say what each case is asserting. What was kept there: the permissions restore-before-assert ordering, the `$XDG_CONFIG_HOME/mudlet` opt-in marker, and the note that the live-singleton case must run last because `experiencedMudletPlayer()` memoises.

**Test case:** `ctest --output-on-failure` - 79/79, unchanged.

Assisted-by: Claude:claude-opus-5