### PR TITLE
infrastructure: trim the comments left behind by two merged QA fixes

### DIFF
--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -69,8 +69,7 @@ public:
     void uninstall(const QString&);
     void _uninstall(TKey* pChild, const QString& packageName);
     bool processDataStream(const Qt::Key, const Qt::KeyboardModifiers);
-    // Reports whether processDataStream() would find a binding for this key
-    // combination, without running any of them
+    // Query-only counterpart to processDataStream(), which executes what it matches
     bool wouldMatch(const Qt::Key, const Qt::KeyboardModifiers) const;
     void markCleanup(TKey* pT);
     void doCleanup();

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -201,13 +201,10 @@ bool TCommandLine::event(QEvent* event)
             return true;
         }
 
-        // A user's own key binding beats the profile tab switching shortcuts,
-        // the precedence handleCtrlTabChange() below describes - but those are
-        // QShortcuts on the main window, and QShortcutMap consumes a matching
-        // key before the KeyPress is ever delivered here, so the binding has to
-        // be spotted now. Only the keys those shortcuts occupy are asked about,
-        // and asked without running anything - the binding runs when the
-        // KeyPress that this claim lets through arrives:
+        // QShortcutMap consumes a key matching one of the profile switching
+        // shortcuts before the KeyPress ever reaches here, so a user binding on
+        // one has to be spotted now - and only spotted, since the binding runs
+        // off the KeyPress this claim lets through:
         if (keybindingWouldMatchProfileSwitchShortcut(ke)) {
             ke->accept();
             return true;
@@ -1357,14 +1354,6 @@ bool TCommandLine::handleCtrlTabChange(QKeyEvent* ke, int tabNumber)
         // hasn't created one then we fallback to tab switching - however
         // since some locales need the SHIFT modifier to enter numbers from the
         // top keyboard row (e.g. French AZERTY) we must ignore that one!
-        //
-        // Since the "Switch to profile N" QShortcuts were added this branch is
-        // no longer where that precedence is decided: whenever such a shortcut
-        // is set, the key only arrives here at all because event() claimed the
-        // ShortcutOverride for a matching binding, so the binding always wins
-        // and the tab switch below runs through the shortcut instead. The
-        // fallback still matters for Ctrl+0, which has no shortcut, and for
-        // shortcuts the user has cleared or remapped.
         if (keybindingMatched(ke)) {
             // Ah the user HAS created a matching binding:
             return true;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -105,9 +105,7 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
 
 bool TKey::wouldMatch(const Qt::Key key, const Qt::KeyboardModifiers modifier) const
 {
-    // isActive() is also false for a half-destroyed key, so this covers the
-    // dereference below. Nothing runs during this walk, so unlike match() there
-    // is no re-entrancy to guard against:
+    // Also covers the dereference below - isActive() is false once mpMyChildrenList is gone
     if (!isActive()) {
         return false;
     }

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -64,8 +64,7 @@ public:
 
 
     bool match(const Qt::Key, const Qt::KeyboardModifiers, const bool);
-    // Same walk as match() but without running anything - for asking whether a
-    // key press is spoken for before deciding to let it through:
+    // Query-only counterpart to match(), which executes what it matches
     bool wouldMatch(const Qt::Key, const Qt::KeyboardModifiers) const;
     bool registerKey();
     void validateKeyBinding();

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1098,17 +1098,11 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
             mExpiryCount--;
 
             if (mExpiryCount == 0) {
-                // The delete is deferred until the outermost processDataStream()
-                // pass ends, so an expired trigger that is still active would fire
-                // again from any pass that re-enters in the meantime (a later
-                // trigger's script calling feedTriggers(), most commonly).
-                // setIsActive(false) rather than deactivate(), matching
-                // TriggerUnit::killTrigger(): it also clears the user-active state.
-                // What stops an enableTrigger() before the deferred free from
-                // resurrecting a trigger that has spent its last fire is the
-                // markCleanup() below: TriggerUnit::enableTrigger() skips anything
-                // in mCleanupSet, as clearing the user-active state alone would
-                // not - enableTrigger() sets it straight back.
+                // The delete is deferred to the end of the outermost pass, so an
+                // expired trigger left active would fire again from any pass that
+                // re-enters meanwhile. What stops enableTrigger() resurrecting it
+                // in that window is the markCleanup() below, not the deactivation:
+                // enableTrigger() skips anything in mCleanupSet.
                 setIsActive(false);
                 mpHost->getTriggerUnit()->markCleanup(this);
 

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -308,11 +308,11 @@ int TriggerUnit::getNewID()
 }
 
 // Stopping the pass is not enough: what the loop created is still live and still
-// matching, so the next line starts with a budget's worth of them and each spawns
-// a budget's worth again - measured at 50 fires on the first such line and 2600
-// on the second. Everything registered during the pass is disowned, not just the
-// loop's offspring: the list records no lineage, so an unrelated capture trigger
-// armed on the same line is caught too. Permanent triggers get deactivate() and
+// matching, so the next line would start with a budget's worth of them and each
+// would spawn a budget's worth again, costing a multiple of the line before it.
+// Everything registered during the pass is disowned, not just the loop's
+// offspring: the list records no lineage, so an unrelated capture trigger armed
+// on the same line is caught too. Permanent triggers get deactivate() and
 // not setIsActive(false), which would clear the user-active state XMLexport saves
 // and leave them switched off after a restart.
 void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass)

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -307,26 +307,14 @@ int TriggerUnit::getNewID()
     return ++mMaxID;
 }
 
-// Ends a run of same-line trigger creation that has spent its budget, and tells
-// the user which trigger to go and fix.
-//
-// Stopping the pass is not enough on its own: everything the loop created is a
-// live root trigger matching the same pattern, so the next line would start with
-// a budget's worth of them and each would spawn a budget's worth again. Measured
-// while trying that (with a smaller budget): 50 fires on the first such line,
-// 2600 on the second, so the freeze would only be postponed. The pass therefore
-// disowns what it created, from firstNodeAddedThisPass to the end of the list.
-//
-// That range is every root trigger registered while this pass ran, not only the
-// loop's own offspring - the list records no lineage, so a capture trigger armed
-// by an unrelated script earlier on the same line is caught too. It is a
-// deliberate trade: on a line that has hit this budget the profile is producing
-// triggers faster than it can process them, and one missed capture beats a
-// frozen client. Temporary triggers go the way killTrigger() sends them
-// (deactivated now, freed once no script is on the stack); permanent ones are
-// only deactivated, and with deactivate() rather than setIsActive(false),
-// because the latter clears the user-active state that XMLexport writes to the
-// profile - the user would find them switched off after a restart.
+// Stopping the pass is not enough: what the loop created is still live and still
+// matching, so the next line starts with a budget's worth of them and each spawns
+// a budget's worth again - measured at 50 fires on the first such line and 2600
+// on the second. Everything registered during the pass is disowned, not just the
+// loop's offspring: the list records no lineage, so an unrelated capture trigger
+// armed on the same line is caught too. Permanent triggers get deactivate() and
+// not setIsActive(false), which would clear the user-active state XMLexport saves
+// and leave them switched off after a restart.
 void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPass)
 {
     QString triggerName;
@@ -337,8 +325,7 @@ void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPas
         if (!trigger) {
             continue;
         }
-        // The last trigger created is the newest link in the chain, and its
-        // creator runs the same script in every looping shape seen so far
+        // keeps the last: the newest link in the chain names the culprit
         triggerName = trigger->getName();
         if (trigger->isTemporary()) {
             trigger->setIsActive(false);
@@ -356,10 +343,8 @@ void TriggerUnit::stopSameLineCreationLoop(const qsizetype firstNodeAddedThisPas
     if (!mpHost) {
         return;
     }
-    // A runaway whose creator outlives the line trips again on every matching
-    // line, and this message is long enough to bury the game text if it is
-    // repeated. Say it, then hold off; the qWarning() above is not throttled, so
-    // a log or a crash report still has every occurrence.
+    // A runaway whose creator outlives the line trips on every matching line and
+    // would bury the game text; the qWarning() above is not throttled.
     constexpr qint64 reportIntervalMs = 10000;
     if (mSameLineLoopReportTimer.isValid() && mSameLineLoopReportTimer.elapsed() < reportIntervalMs) {
         return;
@@ -432,14 +417,11 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         }
         trigger->match(subject, data, line);
     }
-    // Index-based loop: a match here can register yet more triggers, growing
-    // the list; they too get a shot at the current line, just as with the
-    // live-list iteration. That growth needs a ceiling, or a trigger that
-    // re-creates itself extends the list in front of the loop for ever and the
-    // line never finishes - 100% CPU and unbounded memory from one line of game
-    // text (#9458 restored the same-line match without bounding it). Nothing
-    // else catches it: no C++ frame recurses, so mProcessingDepth stays put and
-    // the feedTriggers() depth guard never sees it.
+    // A match here can register more triggers, which also get a shot at the
+    // current line - so the list grows in front of the loop, and a trigger that
+    // re-creates itself never lets the line finish. Nothing else catches that: no
+    // C++ frame recurses, so mProcessingDepth stays put and the feedTriggers()
+    // depth guard never sees it.
     const qsizetype sameLineCreationBudget = firstNodeAddedThisPass + scmMaxSameLineCreations;
     for (qsizetype i = firstNodeAddedThisPass; i < mRootNodesAddedWhileProcessing.size(); ++i) {
         if (i >= sameLineCreationBudget) {
@@ -515,15 +497,10 @@ bool TriggerUnit::enableTrigger(const QString& name)
     // start mid-run and skip duplicates on some QMultiMap implementations
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
-        // A trigger waiting to be freed is only unlinked from the lookup table
-        // once doCleanup() gets to it, which does not happen while a pass is
-        // running - so it is still findable by name for the rest of the line.
-        // Re-activating that corpse resurrects it: a one-shot trigger fires a
-        // second time, killTrigger() is undone from another script, and a trigger
-        // whose package a script uninstalled mid-pass (uninstallList, filled by
-        // uninstall() at a non-zero depth) starts firing again. This skip is what
-        // makes the guarantee TTrigger::match() states where it expires a trigger
-        // true; killTrigger() below skips mCleanupSet too, for its own reason.
+        // A trigger queued for deletion stays in the lookup table until
+        // doCleanup() frees it, which cannot run mid-pass - re-activating one
+        // resurrects a spent one-shot, a killTrigger()ed trigger, or a trigger
+        // whose package was uninstalled mid-pass.
         if (mCleanupSet.contains(it.value()) || uninstallList.contains(it.value())) {
             continue;
         }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -89,13 +89,10 @@ public:
     // Windows, where the original crash hit before Lua's own 200-C-call guard):
     // a few times any legitimate nesting, comfortably below the native limit.
     inline static const int scmMaxProcessingDepth = 50;
-    // How many triggers created while one line is being processed may match that
-    // same line - see processDataStream(). A separate budget from the recursion
-    // depth above, which measures the C stack: this one measures how far a script
-    // can grow the list the pass is walking, and nothing recurses while it does.
-    // The behaviour it bounds (a room-capture script arming a catch-all trigger
-    // from the room title line) needs a handful; 100 leaves two orders of
-    // magnitude of headroom while keeping a runaway to a few milliseconds.
+    // How many triggers created while one line is processed may match that same
+    // line. Separate from the depth above, which measures the C stack: nothing
+    // recurses here, it is the list processDataStream() walks that grows. A
+    // room-capture script needs a handful, so 100 is ample.
     inline static const qsizetype scmMaxSameLineCreations = 100;
 
     QList<TTrigger*> uninstallList;
@@ -127,8 +124,6 @@ private:
     // pass can match the ones created during it against the line being
     // processed - see processDataStream(). Cleared once the outermost pass ends.
     QList<TTrigger*> mRootNodesAddedWhileProcessing;
-    // Throttles the same-line creation loop report: a runaway whose creator
-    // survives the line trips again on every matching line thereafter.
     QElapsedTimer mSameLineLoopReportTimer;
 };
 

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -989,10 +989,8 @@ describe("Trigger processing", function()
         end)
 
         it("does not let enableTrigger revive a trigger that is waiting to be freed", function()
-            -- a killed temporary trigger stays in the by-name lookup table until
-            -- the deferred delete runs, so it is still findable by name - but
-            -- enabling it again would resurrect a trigger already killed, and the
-            -- same window reopens a one-shot trigger that has spent its last fire
+            -- a killed trigger stays findable by name until the deferred delete
+            -- runs, so enabling it again would resurrect it
             local name = "Spec Enable Resurrection"
             _G.EnableResurrectionSpec = 0
             finally(function() _G.EnableResurrectionSpec = nil end)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2119,9 +2119,8 @@ void mudlet::switchToProfileTab(int index)
 }
 
 // Whether this key press would activate one of the profile tab switching
-// shortcuts. Has to reproduce QShortcutMap's matching rather than compare the
-// key press literally, because a shortcut can be spelt differently to the key
-// press that activates it:
+// shortcuts. Comparing it to them literally is not enough - a shortcut can be
+// spelt differently to the press that activates it:
 bool mudlet::profileSwitchShortcutMatches(const QKeyEvent* ke) const
 {
     if (!ke) {
@@ -2131,18 +2130,13 @@ bool mudlet::profileSwitchShortcutMatches(const QKeyEvent* ke) const
     const auto key = static_cast<Qt::Key>(ke->key());
     const Qt::KeyboardModifiers modifiers = ke->modifiers();
 
-    // QShortcutMap retries the match with the modifiers the platform consumed
-    // producing the character stripped off, so a shortcut fires for presses
-    // spelt differently to itself. Both retries that reach these shortcuts land
-    // on the digits: Ctrl and a numpad digit activates Ctrl+1, and on layouts
-    // that need Shift for a top-row digit (French AZERTY) so does Ctrl+Shift+1 -
-    // which is the same reason handleCtrlTabChange() ignores Shift.
+    // QShortcutMap retries with the modifiers the platform consumed producing
+    // the character stripped off, so Ctrl and a numpad digit activates Ctrl+1,
+    // and so does Ctrl+Shift+1 on layouts needing Shift for a top-row digit
+    // (French AZERTY) - the same reason handleCtrlTabChange() ignores Shift.
     QList<QKeySequence> candidates;
     const Qt::KeyboardModifiers strippable[] = {Qt::NoModifier, Qt::KeypadModifier, Qt::ShiftModifier, Qt::ShiftModifier | Qt::KeypadModifier};
     for (const auto stripped : strippable) {
-        // Only single key combinations are ever produced here, so a shortcut
-        // remapped to a multi-step sequence would never be matched - none of
-        // the defaults are, and the shortcut editor cannot record one:
         const QKeySequence candidate(QKeyCombination(modifiers & ~stripped, key));
         if (!candidates.contains(candidate)) {
             candidates.append(candidate);
@@ -2150,17 +2144,14 @@ bool mudlet::profileSwitchShortcutMatches(const QKeyEvent* ke) const
     }
 
     if (key == Qt::Key_Backtab) {
-        // The other direction: Shift+Tab produces the Backtab keysym, while the
-        // sequences are spelt with Key_Tab (see mudlet::mudlet(), where they are
-        // defined). Shift is normally still set on such an event, but Qt's own
-        // Backtab handling does not rely on that, so put it back rather than
-        // assume it is there:
+        // Shift+Tab produces the Backtab keysym while the sequences are spelt
+        // with Key_Tab. Shift is normally still set here, but Qt's own Backtab
+        // handling does not rely on that, so put it back rather than assume:
         candidates.append(QKeySequence(QKeyCombination(modifiers | Qt::ShiftModifier, Qt::Key_Tab)));
     }
 
     auto shadows = [&candidates](const QKeySequence& sequence) {
-        // A shortcut the user cleared in the preferences is an empty sequence,
-        // and comparing it would match any candidate that was also empty:
+        // A shortcut cleared in the preferences is empty, and would match any candidate that was too
         return !sequence.isEmpty() && candidates.contains(sequence);
     };
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -111,13 +111,10 @@ set_tests_properties(ResetProfileTest PROPERTIES TIMEOUT 300)
 # Undo/redo tests need a longer timeout due to large batch operations
 set_tests_properties(dlgTriggerEditorUndoRedoTest PROPERTIES TIMEOUT 300)
 
-# TriggerSameLineMatchTest creates a fresh profile per test method, so it needs a
-# longer timeout. Its self-re-creating-trigger cases do not fail on a regression,
-# they hang and grow the heap by ~110MB/s, so the two backstops below are what
-# turn that into a reported failure: an RSS ceiling that aborts in seconds rather
-# than letting a runner's OOM killer pick a victim, and the timeout behind it.
-# The ENVIRONMENT here replaces the one the loop above sets, so it repeats
-# QT_QPA_PLATFORM.
+# A regression in the self-re-creating-trigger cases does not fail, it hangs and
+# grows the heap by ~110MB/s: the RSS ceiling and the timeout are what turn that
+# into a reported failure. ENVIRONMENT replaces the loop's, hence QT_QPA_PLATFORM
+# again.
 set_tests_properties(TriggerSameLineMatchTest PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=detect_leaks=0:hard_rss_limit_mb=3000"
     TIMEOUT 300)

--- a/test/functional_tests/ProfileSwitchShortcutTest.cpp
+++ b/test/functional_tests/ProfileSwitchShortcutTest.cpp
@@ -109,7 +109,7 @@ private:
         QApplication::sendEvent(commandLine(), &event);
     }
 
-    // Asserted before each expected claim, so a mis-mapped sequence cannot
+    // Asserted where a claim is expected, so a mis-mapped sequence cannot
     // masquerade as a code failure
     bool shortcutInstalledFor(const QKeySequence& sequence) const
     {
@@ -224,8 +224,6 @@ private slots:
         QVERIFY2(!overrideClaimed(Qt::Key_0, Qt::ControlModifier), "Ctrl+0 is not a profile switching shortcut, so the command line must not claim it");
     }
 
-    // Through KeyUnit::disableKey(), the path the editor and Lua take: it
-    // clears mActive, not the mUserActiveState setIsActive() writes
     void test_disabledUserBindingDoesNotClaimTheShortcut()
     {
         const QString name = qsl("Disabled Ctrl+2 binding");
@@ -293,8 +291,6 @@ private slots:
         QVERIFY2(!overrideClaimed(key, modifiers), "A key binding claimed the script editor shortcut, which is outside the profile switching set");
     }
 
-    // Without the isEmpty() guard a shortcut cleared in Preferences compares
-    // equal to every key press and claims the lot
     void test_aClearedProfileShortcutDoesNotClaimEveryKey()
     {
         auto* sequence = mudlet::self()->shortcutsManager()->getSequence(qsl("Switch to profile 1"));

--- a/test/functional_tests/ProfileSwitchShortcutTest.cpp
+++ b/test/functional_tests/ProfileSwitchShortcutTest.cpp
@@ -18,17 +18,12 @@
  ***************************************************************************/
 
 /*
- * The profile tab switching shortcuts (Ctrl+1 to Ctrl+9, Ctrl+Tab) are
- * QShortcuts on the main window. Qt resolves a QShortcut by first sending a
- * QEvent::ShortcutOverride to the focus widget and, unless that widget accepts
- * it, running the shortcut and never delivering the KeyPress. A user's own key
- * binding on one of those keys therefore only survives if the command line
- * claims the override.
- *
- * The invariant under test: the command line claims the override exactly when
- * a live user key binding matches a key press that would otherwise activate a
- * profile switching shortcut - including the presses QShortcutMap matches to a
- * differently spelt shortcut - and never otherwise.
+ * The command line must claim the ShortcutOverride exactly when a live user key
+ * binding matches a press that would otherwise activate a profile switching
+ * shortcut (Ctrl+1 to Ctrl+9, Ctrl+Tab) - including presses QShortcutMap
+ * matches to a differently spelt shortcut - and never otherwise. Claiming it is
+ * the only way the binding survives, since QShortcutMap otherwise runs the
+ * shortcut and never delivers the KeyPress.
  *
  * Run with: ctest -R ProfileSwitchShortcutTest -V
  */
@@ -72,8 +67,7 @@ extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResourcesForProfileSwitchShortcutTest();
 
-// Qt::CTRL is the Cmd key on macOS, where the "next profile" shortcut uses the
-// physical Control key (Qt::META) instead - mirrors mudlet::mudlet():
+// Qt::CTRL is Cmd on macOS, where "next profile" uses Qt::META - see mudlet::mudlet()
 #if defined(Q_OS_MACOS)
 static constexpr Qt::KeyboardModifier nextProfileModifier = Qt::MetaModifier;
 #else
@@ -99,9 +93,8 @@ private:
         return mpHost->mpConsole->mpCommandLine;
     }
 
-    // Replays what QShortcutMap does before it runs a shortcut: it offers the
-    // key to the focus widget as an ignored ShortcutOverride and only runs the
-    // shortcut if nobody accepted it.
+    // QShortcutMap offers the key as an ignored ShortcutOverride and only runs
+    // the shortcut if nobody accepted it
     bool overrideClaimed(int key, Qt::KeyboardModifiers modifiers) const
     {
         QKeyEvent event(QEvent::ShortcutOverride, key, modifiers);
@@ -116,9 +109,8 @@ private:
         QApplication::sendEvent(commandLine(), &event);
     }
 
-    // A claim is only worth asserting if a shortcut is actually competing for
-    // the key, so every test that asserts one first proves the collision is
-    // real - otherwise a mis-mapped sequence would look like a code failure.
+    // Asserted before each expected claim, so a mis-mapped sequence cannot
+    // masquerade as a code failure
     bool shortcutInstalledFor(const QKeySequence& sequence) const
     {
         const auto shortcuts = mudlet::self()->findChildren<QShortcut*>();
@@ -130,8 +122,7 @@ private:
         return false;
     }
 
-    // Read from the shortcuts manager rather than hard coded, since it is
-    // Alt+E on Linux and Windows but Ctrl+E on macOS.
+    // Alt+E on Linux and Windows, Ctrl+E on macOS
     std::pair<int, Qt::KeyboardModifiers> scriptEditorShortcut() const
     {
         auto* sequence = mudlet::self()->shortcutsManager()->getSequence(qsl("Script editor"));
@@ -151,8 +142,6 @@ private:
         return value;
     }
 
-    // Creates a permanent key binding whose script counts its own invocations
-    // into a Lua global, and returns its id.
     int createCountingKey(const QString& name, int keycode, int modifier, const QString& counterName, const QString& parent = QString())
     {
         QString keyName = name;
@@ -165,10 +154,9 @@ private:
         return id;
     }
 
-    // Deleting the roots outright is only safe because every key here is
-    // permanent and none is killed or uninstalled, so KeyUnit's deferred-delete
-    // set is always empty. Add a temporary key or a killKey() call to this file
-    // and this has to go through markCleanup()/doCleanup() instead.
+    // Safe only while every key here is permanent and none is killed or
+    // uninstalled, leaving KeyUnit's deferred-delete set empty; otherwise this
+    // has to go through markCleanup()/doCleanup()
     void removeAllKeys()
     {
         auto* keyUnit = mpHost->getKeyUnit();
@@ -198,9 +186,8 @@ private slots:
         QVERIFY2(mpHost, "No active host after profile creation");
         QVERIFY2(commandLine(), "No command line available for the test");
 
-        // The caret shortcut is checked before this code in TCommandLine::event()
-        // and CtrlTab would claim Ctrl+Tab itself, so pin it to the default
-        // rather than let an unrelated feature decide what these tests measure:
+        // Checked ahead of the claim in TCommandLine::event(), so CtrlTab here
+        // would take Ctrl+Tab out of these tests' hands
         mpHost->mCaretShortcut = Host::CaretShortcut::None;
     }
 
@@ -215,8 +202,6 @@ private slots:
 
     void cleanup() { removeAllKeys(); }
 
-    // The regression itself: a user binding on Ctrl+1 must beat "Switch to
-    // profile 1".
     void test_userBindingOnCtrlNumberClaimsTheShortcut()
     {
         QVERIFY2(shortcutInstalledFor(QKeySequence(Qt::CTRL | Qt::Key_1)), "No profile switching shortcut is installed for Ctrl+1, so this test proves nothing");
@@ -226,15 +211,12 @@ private slots:
         QVERIFY2(overrideClaimed(Qt::Key_1, Qt::ControlModifier), "A user key binding on Ctrl+1 did not claim the key, so the profile switch shortcut swallows it");
     }
 
-    // Without a binding the key has to be left alone so the tab switch happens.
     void test_withoutUserBindingTheShortcutKeepsTheKey()
     {
         QVERIFY2(!overrideClaimed(Qt::Key_1, Qt::ControlModifier), "Ctrl+1 was claimed even though no user key binding matches it - profile switching would stop working");
     }
 
-    // A binding on a key that no profile switching shortcut uses needs no
-    // claim - Ctrl+0 is the control case that always worked, because only nine
-    // shortcuts (Ctrl+1 to Ctrl+9) are installed.
+    // Only nine shortcuts are installed, so Ctrl+0 has nothing to beat
     void test_bindingOnAnUnshadowedKeyIsNotClaimed()
     {
         QVERIFY(createCountingKey(qsl("Ctrl+0 binding"), Qt::Key_0, Qt::ControlModifier, qsl("_testCtrl0")) > 0);
@@ -242,10 +224,8 @@ private slots:
         QVERIFY2(!overrideClaimed(Qt::Key_0, Qt::ControlModifier), "Ctrl+0 is not a profile switching shortcut, so the command line must not claim it");
     }
 
-    // A disabled binding is not a binding, so it must not steal the key from
-    // the tab switch. Disabled through KeyUnit::disableKey(), which is the path
-    // the editor and the Lua disableKey() take - it clears mActive, not the
-    // mUserActiveState that setIsActive() writes.
+    // Through KeyUnit::disableKey(), the path the editor and Lua take: it
+    // clears mActive, not the mUserActiveState setIsActive() writes
     void test_disabledUserBindingDoesNotClaimTheShortcut()
     {
         const QString name = qsl("Disabled Ctrl+2 binding");
@@ -257,8 +237,6 @@ private slots:
         QVERIFY2(!overrideClaimed(Qt::Key_2, Qt::ControlModifier), "A disabled key binding still claimed Ctrl+2");
     }
 
-    // The nine switch-to-profile shortcuts are generated in a loop, so check
-    // the far end of it too.
     void test_userBindingOnCtrlNineClaimsTheShortcut()
     {
         QVERIFY2(shortcutInstalledFor(QKeySequence(Qt::CTRL | Qt::Key_9)), "No profile switching shortcut is installed for Ctrl+9, so this test proves nothing");
@@ -268,7 +246,6 @@ private slots:
         QVERIFY2(overrideClaimed(Qt::Key_9, Qt::ControlModifier), "A user key binding on Ctrl+9 did not claim the key");
     }
 
-    // Same for an active binding sitting inside a disabled group.
     void test_userBindingInDisabledGroupDoesNotClaimTheShortcut()
     {
         const int groupId = createCountingKey(qsl("Key Group"), -1, 0, qsl("_testGroup"));
@@ -284,8 +261,6 @@ private slots:
         QVERIFY2(!overrideClaimed(Qt::Key_3, Qt::ControlModifier), "A binding inside a disabled group still claimed Ctrl+3");
     }
 
-    // Ctrl+Tab ("Next profile") is shadowed the same way and needs the same
-    // treatment, in both directions.
     void test_userBindingOnCtrlTabClaimsTheShortcut()
     {
         QVERIFY2(shortcutInstalledFor(QKeySequence(nextProfileModifier | Qt::Key_Tab)), "No 'Next profile' shortcut is installed for Ctrl+Tab, so this test proves nothing");
@@ -296,10 +271,8 @@ private slots:
         QVERIFY2(overrideClaimed(Qt::Key_Tab, nextProfileModifier), "A user key binding on Ctrl+Tab did not claim the key");
     }
 
-    // "Previous profile" is Ctrl+Shift+Tab, but Shift+Tab reaches the widget as
-    // Key_Backtab with the Shift modifier kept, so the sequence (spelt with
-    // Key_Tab) and the key press disagree on the spelling and the match has to
-    // bridge that.
+    // Shift+Tab reaches the widget as Key_Backtab while the sequence is spelt
+    // with Key_Tab, so the match has to bridge the two spellings
     void test_userBindingOnCtrlShiftTabClaimsTheShortcut()
     {
         const auto modifiers = nextProfileModifier | Qt::ShiftModifier;
@@ -310,9 +283,6 @@ private slots:
         QVERIFY2(overrideClaimed(Qt::Key_Backtab, modifiers), "A user key binding on Ctrl+Shift+Tab did not claim the key");
     }
 
-    // Only the profile switching shortcuts are overridden. Every other
-    // application shortcut keeps its key, so a binding on the script editor
-    // shortcut must not be claimed.
     void test_bindingOnAnotherApplicationShortcutIsNotClaimed()
     {
         auto [key, modifiers] = scriptEditorShortcut();
@@ -323,10 +293,8 @@ private slots:
         QVERIFY2(!overrideClaimed(key, modifiers), "A key binding claimed the script editor shortcut, which is outside the profile switching set");
     }
 
-    // Guards the "empty sequence matches everything" failure mode. A key press
-    // that is not Backtab has no alternative spelling to compare against, so
-    // without the isEmpty() guard a shortcut the user has cleared in
-    // Preferences would compare equal to every key and claim the lot.
+    // Without the isEmpty() guard a shortcut cleared in Preferences compares
+    // equal to every key press and claims the lot
     void test_aClearedProfileShortcutDoesNotClaimEveryKey()
     {
         auto* sequence = mudlet::self()->shortcutsManager()->getSequence(qsl("Switch to profile 1"));
@@ -346,10 +314,8 @@ private slots:
         QVERIFY2(!f5Claimed, "A cleared profile switching shortcut made an unrelated bound key claim the override");
     }
 
-    // QShortcutMap retries a match with the keypad modifier stripped, so Ctrl
-    // and a numpad digit activates the plain Ctrl+1 shortcut even though the
-    // two key combinations differ. Verified against the real thing: without the
-    // claim, Ctrl+numpad-2 switches profile and the binding never runs.
+    // QShortcutMap retries with the keypad modifier stripped, so Ctrl and a
+    // numpad digit activates the plain Ctrl+1 shortcut
     void test_userBindingOnAKeypadDigitClaimsTheShortcut()
     {
         const auto modifiers = Qt::ControlModifier | Qt::KeypadModifier;
@@ -358,9 +324,8 @@ private slots:
         QVERIFY2(overrideClaimed(Qt::Key_1, modifiers), "A user key binding on Ctrl and a keypad digit did not claim the key");
     }
 
-    // Layouts that need Shift for a top-row digit (French AZERTY) record the
-    // binding with Shift and still activate the plain Ctrl+1 shortcut, because
-    // QShortcutMap drops the Shift that was consumed producing the digit.
+    // Layouts needing Shift for a top-row digit (French AZERTY) record the
+    // binding with Shift, and QShortcutMap drops the Shift it consumed
     void test_userBindingOnAShiftedDigitClaimsTheShortcut()
     {
         const auto modifiers = Qt::ControlModifier | Qt::ShiftModifier;
@@ -369,9 +334,6 @@ private slots:
         QVERIFY2(overrideClaimed(Qt::Key_1, modifiers), "A user key binding on Ctrl+Shift and a digit did not claim the key");
     }
 
-    // Claiming the override only defers the key - the binding must then run
-    // exactly once, off the KeyPress that the claim let through, and not a
-    // second time from the probe itself.
     void test_claimedBindingRunsExactlyOnce()
     {
         QVERIFY(createCountingKey(qsl("Ctrl+4 binding"), Qt::Key_4, Qt::ControlModifier, qsl("_testCtrl4")) > 0);

--- a/test/functional_tests/TriggerSameLineMatchTest.cpp
+++ b/test/functional_tests/TriggerSameLineMatchTest.cpp
@@ -269,8 +269,8 @@ private slots:
         QVERIFY2(!bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "A chain that ends on its own must not trip the same-line generation budget");
     }
 
-    // Without disowning what the loop created, the second line costs a multiple
-    // of the first: measured at 50 fires, then 2600.
+    // Without disowning what the loop created, each line costs a multiple of the
+    // one before it, so the freeze is postponed rather than prevented.
     void test_selfRecreatingTriggerDoesNotAccumulateAcrossLines()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);

--- a/test/functional_tests/TriggerSameLineMatchTest.cpp
+++ b/test/functional_tests/TriggerSameLineMatchTest.cpp
@@ -204,14 +204,8 @@ private slots:
         QVERIFY2(bufferContains(qsl("NESTED=inner,outer#")), "Expected the mid-pass trigger to match the nested line first, then the outer line it was created on");
     }
 
-    // The counterweight to all of the above: giving mid-pass triggers the current
-    // line means a trigger that re-creates itself keeps extending the list the
-    // pass is walking, so the line never finishes - 100% CPU and unbounded memory
-    // on the first matching line, from ordinary game text. The naive "one-shot
-    // that re-arms itself at the end of its own handler" shape is the one users
-    // write, so it is the one pinned here. Without the generation budget in
-    // TriggerUnit::processDataStream() this test does not fail, it hangs, and only
-    // the ctest TIMEOUT ends it.
+    // The naive "one-shot that re-arms itself at the end of its own handler" is
+    // the shape users write. Without the budget this does not fail, it hangs.
     void test_selfRecreatingTriggerIsStopped()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -229,16 +223,12 @@ private slots:
 
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
         QVERIFY2(bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "Expected the same-line re-creation abort error in the console buffer");
-        // One fire from the trigger that was already there when the line arrived,
-        // then one per trigger the budget lets the re-arming chain add to it. The
-        // trailing # anchors the count: without it the check also passes on ten
-        // times the number.
+        // one fire from the trigger already there, then one per budgeted creation;
+        // the trailing # keeps the check from also passing on ten times the number
         const int expectedFires = 1 + static_cast<int>(TriggerUnit::scmMaxSameLineCreations);
         QVERIFY2(bufferContains(qsl("LOOPFIRES=%1#").arg(expectedFires)), qPrintable(qsl("Expected the re-arming trigger to fire exactly %1 times").arg(expectedFires)));
     }
 
-    // The abort has to name the trigger to be actionable - the user has to know
-    // which of their scripts to change.
     void test_selfRecreatingTriggerAbortNamesTheTrigger()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -256,8 +246,6 @@ private slots:
         QVERIFY2(bufferContains(qsl("trigger 'hpWatcher'")), "Expected the abort message to name the trigger that keeps re-creating itself");
     }
 
-    // A chain that ends on its own must not be cut short: only the runaway case
-    // may hit the budget, and legitimate chains are a handful of generations deep.
     void test_finiteCreationChainIsUnaffected()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -281,13 +269,8 @@ private slots:
         QVERIFY2(!bufferContains(qsl("Trigger processing stopped to prevent a freeze")), "A chain that ends on its own must not trip the same-line generation budget");
     }
 
-    // Stopping the line is only half of it. A re-arming trigger with no expiry
-    // leaves everything it created still active, so the next line would start
-    // with a budget's worth of them and each would spawn a budget's worth again:
-    // measured at 50 fires on the first line and 2600 on the second (with an
-    // earlier, smaller budget), i.e. the freeze merely postponed. The abort
-    // therefore stops what was created during the line, which holds the cost at
-    // one budget per line for ever.
+    // Without disowning what the loop created, the second line costs a multiple
+    // of the first: measured at 50 fires, then 2600.
     void test_selfRecreatingTriggerDoesNotAccumulateAcrossLines()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -310,13 +293,9 @@ private slots:
                  qPrintable(qsl("Expected the second line to cost the same %1 fires as the first, not a multiple of them").arg(firesPerLine)));
     }
 
-    // permRegexTrigger() from a trigger's script loops the same way, and those
-    // objects are saved with the profile. They must be stopped like the temporary
-    // ones, but not deleted (the user owns them, and they are visible in the
-    // editor) and not switched off in a way that survives a save: deactivate()
-    // leaves the user-active state XMLexport writes alone, so a restart brings
-    // them back rather than confronting the user with a tree of unticked
-    // triggers they never touched.
+    // Permanent triggers are saved with the profile, so they are stopped without
+    // being deleted and with deactivate(), which leaves the user-active state
+    // XMLexport writes alone.
     void test_selfRecreatingPermanentTriggerIsStoppedButNotDeleted()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -342,9 +321,8 @@ private slots:
         QVERIFY2(bufferContains(qsl("PERMEXISTS=%1#").arg(expectedFires + 1)), "Expected the stopped permanent triggers to still exist - stopping them is not deleting them");
     }
 
-    // A runaway inside a nested feedTriggers() pass must stop that pass only: the
-    // outer line's own mid-pass triggers were registered before the nested pass
-    // began, so they stay live and still match the outer line afterwards.
+    // The outer line's own mid-pass triggers were registered before the nested
+    // pass began, so its abort must not take them.
     void test_nestedPassAbortLeavesTheOuterLineAlone()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -369,10 +347,8 @@ private slots:
         QVERIFY2(bufferContains(qsl("SEEN=inner,outer#")), "Expected the capture trigger created by the outer line to survive the nested pass's abort and still match the outer line");
     }
 
-    // The loop is not a feedTriggers() curiosity: an ordinary line arriving from
-    // the game reaches processDataStream() the same way, and froze Mudlet on the
-    // login banner. Driving it from the socket also proves the abort leaves the
-    // event loop running rather than wedging the connection.
+    // Not a feedTriggers() curiosity - real socket text takes the same path - and
+    // driving it from the socket also proves the abort leaves the event loop running.
     void test_selfRecreatingTriggerFromServerTextIsStopped()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -485,12 +485,8 @@ private slots:
         QVERIFY2(!unit->getKey(id), "the key should have been freed exactly once");
     }
 
-    // The other half of the corpse-is-still-findable-by-name premise: killTrigger()
-    // skips an item that is only waiting to be freed, but enableTrigger() used to
-    // re-activate every same-named entry unconditionally. That resurrects the
-    // corpse, contradicting the guarantee TTrigger::match() states where it expires
-    // a trigger ("an enableTrigger() before the deferred free cannot resurrect a
-    // trigger that has already spent its last fire").
+    // killTrigger() skips an item that is only waiting to be freed; enableTrigger()
+    // has to as well, or it resurrects the corpse.
     void test_triggerEnableByNameCannotReviveKilled()
     {
         auto* unit = mpHost->getTriggerUnit();
@@ -512,9 +508,8 @@ private slots:
         QVERIFY2(!unit->getTrigger(id), "the killed trigger should still have been freed");
     }
 
-    // The same thing as a user meets it: a one-shot trigger has spent its single
-    // fire on this line, and a script running later on the same line enables it by
-    // name. It must not fire a second time when the line is fed again.
+    // As a user meets it: a one-shot has spent its fire and a script later on the
+    // same line enables it by name.
     void test_triggerEnableByNameCannotReviveExpiredOneShot()
     {
         mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("oneShotFires = 0\n"
@@ -534,14 +529,10 @@ private slots:
         QCOMPARE(readGlobalInt(qsl("oneShotFires")), 1);
     }
 
-    // The other deferred-delete container needs the same treatment: uninstall()
-    // at a non-zero processing depth deactivates its package's triggers, drops
-    // them from mCleanupSet to keep the two paths disjoint, and leaves them in
-    // uninstallList to be freed at depth 0. They stay in the lookup table for
-    // that window, so enableTrigger() would otherwise bring a trigger belonging
-    // to an already-uninstalled package back to life. The container is populated
-    // directly, as the cases below do: reaching this state from Lua needs a
-    // package-owned temporary item, which no current import path produces.
+    // uninstall() at a non-zero processing depth leaves its package's triggers in
+    // uninstallList rather than mCleanupSet, still in the lookup table. Populated
+    // directly: reaching that state from Lua needs a package-owned temporary item,
+    // which no current import path produces.
     void test_triggerEnableByNameCannotReviveAnUninstalledTrigger()
     {
         auto* unit = mpHost->getTriggerUnit();
@@ -563,9 +554,7 @@ private slots:
     }
 
     // The skip must not stop the walk: a corpse and a live trigger can share a
-    // name (tempComplexRegexTrigger() takes a user-supplied one), and #9366's
-    // guarantee that enable-by-name reaches every same-named trigger still holds
-    // for the ones that are actually alive.
+    // name, and enable-by-name still has to reach every live one.
     void test_triggerEnableByNameStillReachesALiveSameNamedTrigger()
     {
         auto* unit = mpHost->getTriggerUnit();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Comment-only. `git diff origin/development...HEAD` changes no statement, expression or declaration - every added and removed line is a comment. 238 comment lines become 98.
- Applies the house standard to the comments added by "fix: a trigger that re-creates itself freezes Mudlet" (#9697) and "Fix user key bindings on Ctrl+1 to Ctrl+9 and Ctrl+Tab" (#9703): no historical passages, and the rest cut to what a reader cannot derive from the code.
- Corrects four claims that were wrong, two of them inherited from those PRs: a fires-per-line measurement taken with a smaller budget than the one that shipped, an over-general note on `shortcutInstalledFor()`, a `KeyUnit::disableKey()` note that had the mechanism backwards, and a test comment crediting the `isEmpty()` guard for a result it does not produce.

#### Motivation for adding to Mudlet
Both PRs merged while their comment-reduction pass was still in flight, so the trim never landed with them.

#### Other info (issues closed, discussion etc)
The gotchas worth keeping survive in shorter form: why the same-line creation budget is counted per pass rather than sharing the `feedTriggers()` depth counter, why permanent triggers get `deactivate()` and not `setIsActive(false)`, why `mCleanupSet` rather than the deactivation is what stops `enableTrigger()` resurrecting a spent trigger, that `QShortcutMap` retries with consumed modifiers stripped, and the `Key_Backtab` versus `Shift+Tab` spelling.

The matching trim for "fix: stop treating long-time Mudlet users as brand new players" (#9695) already landed separately as #9707, so it is not repeated here.

No demo video: a comment-only change is not observable on screen.

**Test case:** `ctest` in the build directory - 79/80, with `TelnetBenchmark` timing out only under parallel load (31s standalone against a 60s limit) on a path this PR does not touch. `TriggerSameLineMatchTest`, `UnitDeferredDeleteTest`, `ProfileSwitchShortcutTest` and `ExperiencedPlayerGateTest` all pass.

Assisted-by: Claude:claude-opus-5