### PR TITLE
fix: pausing a track and then playing a different one left you with silence

### DIFF
--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -2706,6 +2706,12 @@ int TLuaInterpreter::pauseVideos(lua_State* L)
 int TLuaInterpreter::purgeMediaCache(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushboolean(L, host.mTelnet.purgeMediaCache());
+    const auto [purged, message] = host.mTelnet.purgeMediaCache();
+
+    if (!purged) {
+        return warnArgumentValue(L, __func__, message);
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -37,8 +37,8 @@
 #include <QTimer>
 
 namespace {
-// Marks a player as belonging to the play() call that is setting it up, and gives it back
-// however that call returns. See TMediaPlayer::reservedForPlay().
+// Holds TMediaPlayer::reservedForPlay() for as long as a play() call is setting that player up,
+// however that call returns.
 class MediaPlayerReservation
 {
 public:
@@ -53,8 +53,13 @@ public:
 
     void reserve(const std::shared_ptr<TMediaPlayer>& player)
     {
+        if (mPlayer) {
+            mPlayer->setReservedForPlay(false);
+        }
         mPlayer = player;
-        mPlayer->setReservedForPlay(true);
+        if (mPlayer) {
+            mPlayer->setReservedForPlay(true);
+        }
     }
 
 private:
@@ -456,7 +461,6 @@ std::pair<bool, QString> TMedia::purgeMediaCache()
 
     if (!mediaDir.removeRecursively()) {
         qWarning() << qsl("TMedia::purgeMediaCache() WARNING - not able to remove all of directory: %1").arg(mediaPath);
-        // Whatever could be removed has been, so the caller is told which of the two it got.
         return {false, qsl("removed what could be removed, but not all of the media directory \"%1\" - some files may be in use or write protected").arg(mediaPath)};
     }
 
@@ -1158,16 +1162,14 @@ void TMedia::downloadFile(TMediaData& mediaData)
     if (scheme != qsl("http") && scheme != qsl("https")) {
         qWarning() << qsl("TMedia::downloadFile() WARNING - refused to download media from a non-HTTP(S) URL: %1").arg(fileUrl.toString());
 
-        // Reported the same way a download that fails is, so a script waiting on the media it
-        // asked for is told the request is over rather than left waiting on it.
+        // Told the same way a download that fails is, so a script waiting on this media learns
+        // the request is over rather than waiting on it forever.
         TEvent event{};
         event.mArgumentList << qsl("sysDownloadError");
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        event.mArgumentList << qsl("Media can only be downloaded from an http:// or https:// URL");
+        event.mArgumentList << qsl("Media can only be downloaded from an http:// or https:// URL, not \"%1\"").arg(fileUrl.toString());
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << mediaData.mediaAbsolutePathFileName();
-        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        event.mArgumentList << fileUrl.toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         mpHost->raiseEvent(event);
         return;
@@ -1687,11 +1689,23 @@ void TMedia::releaseMediaSourceAfterEvents(const std::shared_ptr<TMediaPlayer>& 
     });
 }
 
-// Ends the playback a player picked up between tracks is still holding, so the track taking it
-// over starts from a player that has nothing loaded. A paused one is what makes this necessary:
-// it keeps its source, and handing setSource() a player that is not stopped stops it, which
-// would otherwise be reported as the *new* track ending - the media data has moved on by then -
-// and could clear the new source a turn later.
+// Hands a player over to a track that is about to start on it. Call only once the request is
+// certain to go ahead - a request that is then refused must not have ended anything.
+void TMedia::claimPlayerFor(const std::shared_ptr<TMediaPlayer>& player, TMediaData& mediaData, const QUrl& mediaSource)
+{
+    // In this order: the ending is reported under the key and tag the player still carries for
+    // the track that ended, and its source is released before claimSource() bumps the generation
+    // that any release still pending on this player is judged against.
+    endDisplacedPlayback(player);
+    player->setMediaData(mediaData);
+    player->claimSource(mediaSource);
+}
+
+// Ends whatever playback the player is still holding, so the track taking it over starts from a
+// player with nothing loaded. A paused one is what makes this necessary: it keeps its source, and
+// handing setSource() a player that is not stopped stops it - which would otherwise be reported
+// as the new track ending, under the new track's key and tag, and could clear its source a turn
+// later.
 void TMedia::endDisplacedPlayback(const std::shared_ptr<TMediaPlayer>& player)
 {
     if (!player || !player->mediaPlayer() || player->mediaPlayer()->source().isEmpty()) {
@@ -1701,12 +1715,6 @@ void TMedia::endDisplacedPlayback(const std::shared_ptr<TMediaPlayer>& player)
     // Read before the source goes, because releasing is what makes it unreadable.
     const TMediaData endedData = player->mediaData();
     const QUrl endedUrl = player->mediaPlayer()->source();
-
-    // The playlist is the new track's to fill; anything left in it would restart the displaced
-    // one from the EndOfMedia handler.
-    if (player->playlist()) {
-        player->playlist()->clear();
-    }
 
     player->mediaPlayer()->stop();
     player->releaseSource();
@@ -1723,7 +1731,7 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
 
     if (playbackState == QMediaPlayer::StoppedState) {
         if (player->claimingSource()) {
-            // The previous track being displaced, not this one ending - see claimingSource().
+            qDebug() << "TMedia::handlePlayerPlaybackStateChanged() - stopped a player that is being handed a new source; the playback it stopped was ended by whoever handed it over.";
             return;
         }
 
@@ -1928,18 +1936,16 @@ void TMedia::play(TMediaData& mediaData)
             qWarning() << "TMedia::play() - Failed to create a new TMediaPlayer.";
             return;
         }
-
-        reservation.reserve(pPlayer);
-        endDisplacedPlayback(pPlayer);
-        // After the displaced track has been reported, since that report names the track that
-        // ended by the key and tag the player is still carrying for it.
-        pPlayer->setMediaData(mediaData);
     }
 
     if (!pPlayer->mediaPlayer()) {
         qWarning() << "TMedia::play() - mediaPlayer() is null!";
         return;
     }
+
+    // The stops below raise sysMediaFinished into script handlers synchronously - see
+    // TMediaPlayer::reservedForPlay().
+    reservation.reserve(pPlayer);
 
     // Ensure the player has a valid playlist
     TMediaPlaylist* playlist = pPlayer->playlist();
@@ -1983,7 +1989,7 @@ void TMedia::play(TMediaData& mediaData)
         }
 
         const QUrl mediaSource = mediaData.mediaInput() == TMediaData::MediaInputFile ? QUrl::fromLocalFile(absolutePathFileName) : QUrl(absolutePathFileName);
-        pPlayer->claimSource(mediaSource);
+        claimPlayerFor(pPlayer, mediaData, mediaSource);
     } else {
         if (mediaData.mediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
             playlist->setPlaybackMode(TMediaPlaylist::Loop);
@@ -2049,7 +2055,7 @@ void TMedia::play(TMediaData& mediaData)
 
         playlist->setCurrentIndex(0);
         pPlayer->setPlaylist(playlist);
-        pPlayer->claimSource(playlist->currentMedia());
+        claimPlayerFor(pPlayer, mediaData, playlist->currentMedia());
     }
 
     // Set volume and start position

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -36,6 +36,32 @@
 #include <QStandardPaths>
 #include <QTimer>
 
+namespace {
+// Marks a player as belonging to the play() call that is setting it up, and gives it back
+// however that call returns. See TMediaPlayer::reservedForPlay().
+class MediaPlayerReservation
+{
+public:
+    MediaPlayerReservation() = default;
+    ~MediaPlayerReservation()
+    {
+        if (mPlayer) {
+            mPlayer->setReservedForPlay(false);
+        }
+    }
+    Q_DISABLE_COPY(MediaPlayerReservation)
+
+    void reserve(const std::shared_ptr<TMediaPlayer>& player)
+    {
+        mPlayer = player;
+        mPlayer->setReservedForPlay(true);
+    }
+
+private:
+    std::shared_ptr<TMediaPlayer> mPlayer;
+};
+} // namespace
+
 // Public
 TMedia::TMedia(Host* pHost, const QString& profileName)
 {
@@ -416,24 +442,25 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#purgeMediaCache
-bool TMedia::purgeMediaCache()
+std::pair<bool, QString> TMedia::purgeMediaCache()
 {
     const QString mediaPath = mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName());
     QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
-        qWarning() << qsl("TMedia::purgeMediaCache() WARNING - not able to reference directory: %1").arg(mudlet::getMudletPath(enums::profileMediaPath, mpHost->getName()));
-        return false;
+        qWarning() << qsl("TMedia::purgeMediaCache() WARNING - not able to reference directory: %1").arg(mediaPath);
+        return {false, qsl("could not access the media directory \"%1\"").arg(mediaPath)};
     }
 
     stopAllMediaPlayers();
 
     if (!mediaDir.removeRecursively()) {
         qWarning() << qsl("TMedia::purgeMediaCache() WARNING - not able to remove all of directory: %1").arg(mediaPath);
-        return false;
+        // Whatever could be removed has been, so the caller is told which of the two it got.
+        return {false, qsl("removed what could be removed, but not all of the media directory \"%1\" - some files may be in use or write protected").arg(mediaPath)};
     }
 
-    return true;
+    return {true, QString()};
 }
 
 void TMedia::refreshAudioDevices()
@@ -1130,6 +1157,19 @@ void TMedia::downloadFile(TMediaData& mediaData)
     const QString scheme = fileUrl.scheme();
     if (scheme != qsl("http") && scheme != qsl("https")) {
         qWarning() << qsl("TMedia::downloadFile() WARNING - refused to download media from a non-HTTP(S) URL: %1").arg(fileUrl.toString());
+
+        // Reported the same way a download that fails is, so a script waiting on the media it
+        // asked for is told the request is over rather than left waiting on it.
+        TEvent event{};
+        event.mArgumentList << qsl("sysDownloadError");
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        event.mArgumentList << qsl("Media can only be downloaded from an http:// or https:// URL");
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        event.mArgumentList << mediaData.mediaAbsolutePathFileName();
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        event.mArgumentList << fileUrl.toString();
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        mpHost->raiseEvent(event);
         return;
     }
 
@@ -1430,8 +1470,11 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
             continue;
         }
 
+        if (existingPlayer->reservedForPlay()) {
+            continue; // Another play() call is setting this one up
+        }
+
         if (existingPlayer->getPlaybackState() != QMediaPlayer::PlayingState && existingPlayer->mediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-            existingPlayer->setMediaData(mediaData);
             return existingPlayer; // Reuse existing player
         }
     }
@@ -1470,7 +1513,6 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
         return nullptr;
     }
 
-    newPlayer->setMediaData(mediaData);
     connectMediaPlayer(newPlayer);
     mediaPlayerList.append(newPlayer);
 
@@ -1645,6 +1687,34 @@ void TMedia::releaseMediaSourceAfterEvents(const std::shared_ptr<TMediaPlayer>& 
     });
 }
 
+// Ends the playback a player picked up between tracks is still holding, so the track taking it
+// over starts from a player that has nothing loaded. A paused one is what makes this necessary:
+// it keeps its source, and handing setSource() a player that is not stopped stops it, which
+// would otherwise be reported as the *new* track ending - the media data has moved on by then -
+// and could clear the new source a turn later.
+void TMedia::endDisplacedPlayback(const std::shared_ptr<TMediaPlayer>& player)
+{
+    if (!player || !player->mediaPlayer() || player->mediaPlayer()->source().isEmpty()) {
+        return;
+    }
+
+    // Read before the source goes, because releasing is what makes it unreadable.
+    const TMediaData endedData = player->mediaData();
+    const QUrl endedUrl = player->mediaPlayer()->source();
+
+    // The playlist is the new track's to fill; anything left in it would restart the displaced
+    // one from the EndOfMedia handler.
+    if (player->playlist()) {
+        player->playlist()->clear();
+    }
+
+    player->mediaPlayer()->stop();
+    player->releaseSource();
+
+    // Skipped when the stop above already announced it - see endAnnounced().
+    raiseMediaFinishedEvent(player, endedUrl, endedData);
+}
+
 void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playbackState, const std::shared_ptr<TMediaPlayer>& player)
 {
     if (!player) {
@@ -1652,6 +1722,11 @@ void TMedia::handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playback
     }
 
     if (playbackState == QMediaPlayer::StoppedState) {
+        if (player->claimingSource()) {
+            // The previous track being displaced, not this one ending - see claimingSource().
+            return;
+        }
+
         if (!player->mediaPlayer() || player->mediaPlayer()->source().isEmpty()) {
             // Whoever released the source already ended this playback and raised its event. A
             // second one from here would carry an empty file name and path, because the URL
@@ -1836,6 +1911,7 @@ void TMedia::play(TMediaData& mediaData)
     }
 
     std::shared_ptr<TMediaPlayer> pPlayer;
+    MediaPlayerReservation reservation;
 
     // Only match an existing media player for music and video
     if (mediaData.mediaType() == TMediaData::MediaTypeMusic || mediaData.mediaType() == TMediaData::MediaTypeVideo) {
@@ -1852,6 +1928,12 @@ void TMedia::play(TMediaData& mediaData)
             qWarning() << "TMedia::play() - Failed to create a new TMediaPlayer.";
             return;
         }
+
+        reservation.reserve(pPlayer);
+        endDisplacedPlayback(pPlayer);
+        // After the displaced track has been reported, since that report names the track that
+        // ended by the key and tag the player is still carrying for it.
+        pPlayer->setMediaData(mediaData);
     }
 
     if (!pPlayer->mediaPlayer()) {

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -32,6 +32,7 @@
 #include "TMediaPlaylist.h"
 
 #include <memory>
+#include <utility>
 #include <QAudioOutput>
 #include <QMediaPlayer>
 #include <QUrl>
@@ -86,15 +87,23 @@ public:
             if (mMediaPlayer->playbackState() == QMediaPlayer::StoppedState && !mMediaPlayer->source().isEmpty()) {
                 releaseSource();
             }
+            mClaimingSource = true;
             mMediaPlayer->setSource(media);
+            mClaimingSource = false;
         }
     }
     void continuePlaying(const QUrl& media)
     {
         ++mContinuationGeneration;
-        mEndAnnounced = false;
         if (mMediaPlayer) {
             mMediaPlayer->setSource(media);
+            // Cleared after the source is installed, not before: a backend that delivers
+            // EndOfMedia while the player is still playing makes this setSource() a real
+            // playing-to-stopped transition, whose handler announces the pass that just ended.
+            // Clearing first would let that announcement latch the flag for the pass about to
+            // start, and the last pass of a finite track has no continuation left to clear it
+            // again - so its genuine ending would never be announced (#9569, macOS).
+            mEndAnnounced = false;
             mMediaPlayer->play();
         }
     }
@@ -118,6 +127,19 @@ public:
     // Cleared by the two ways this player is given something new to play, above.
     bool endAnnounced() const { return mEndAnnounced; }
     void noteEndAnnounced() { mEndAnnounced = true; }
+
+    // True only while claimSource() is installing a new source. Handing a source to a player
+    // that is not already stopped stops it, and that stop is the previous track being displaced
+    // rather than this one ending - whoever displaced it has already said so, with the metadata
+    // the player no longer holds.
+    bool claimingSource() const { return mClaimingSource; }
+
+    // A play() call owns the player it is setting up until it returns. Announcing the displaced
+    // track runs script handlers synchronously, and one that starts media of its own must be
+    // given a different player: two play() calls sharing one overwrite each other's playlist
+    // and media data, and the outer request is the one that loses.
+    bool reservedForPlay() const { return mReservedForPlay; }
+    void setReservedForPlay(const bool reserved) { mReservedForPlay = reserved; }
 
     // Read-only uses and playback control are fine; do not setSource() on it, for the reason
     // given above claimSource().
@@ -179,6 +201,8 @@ private:
     quint64 mClaimGeneration = 0;
     quint64 mContinuationGeneration = 0;
     bool mEndAnnounced = false;
+    bool mClaimingSource = false;
+    bool mReservedForPlay = false;
 };
 
 class TMedia : public QObject
@@ -204,7 +228,8 @@ public:
     void pauseMedia(TMediaData& mediaData);
     void stopMedia(TMediaData& mediaData);
     void parseGMCP(QString& packageMessage, QString& gmcp);
-    bool purgeMediaCache();
+    // On failure the message says what could not be removed, for the script that asked.
+    std::pair<bool, QString> purgeMediaCache();
     void refreshAudioDevices();
     void muteMedia(const TMediaData::MediaProtocol mediaProtocol);
     void unmuteMedia(const TMediaData::MediaProtocol mediaProtocol);
@@ -268,6 +293,7 @@ private:
     // endedUrl and endedData are passed in rather than read off the player, so a caller that has
     // already released the source can still say what it was that ended.
     void raiseMediaFinishedEvent(const std::shared_ptr<TMediaPlayer>& player, const QUrl& endedUrl, const TMediaData& endedData);
+    void endDisplacedPlayback(const std::shared_ptr<TMediaPlayer>& player);
     void releaseMediaSourceAfterEvents(const std::shared_ptr<TMediaPlayer>& player, const TMediaData& endedData, const PlaybackEnd endedBy);
     void handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playbackState, const std::shared_ptr<TMediaPlayer>& player);
     bool setupVideo(const std::shared_ptr<TMediaPlayer>& player);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -97,12 +97,11 @@ public:
         ++mContinuationGeneration;
         if (mMediaPlayer) {
             mMediaPlayer->setSource(media);
-            // Cleared after the source is installed, not before: a backend that delivers
-            // EndOfMedia while the player is still playing makes this setSource() a real
-            // playing-to-stopped transition, whose handler announces the pass that just ended.
-            // Clearing first would let that announcement latch the flag for the pass about to
-            // start, and the last pass of a finite track has no continuation left to clear it
-            // again - so its genuine ending would never be announced (#9569, macOS).
+            // Cleared after the source is installed, not before. On a backend that delivers
+            // EndOfMedia while the player is still playing this setSource() is a real
+            // playing-to-stopped transition, and its handler announces the pass that just ended.
+            // Clearing first leaves that announcement standing for the pass about to start, and
+            // the last pass has no continuation left to clear it again.
             mEndAnnounced = false;
             mMediaPlayer->play();
         }
@@ -128,16 +127,15 @@ public:
     bool endAnnounced() const { return mEndAnnounced; }
     void noteEndAnnounced() { mEndAnnounced = true; }
 
-    // True only while claimSource() is installing a new source. Handing a source to a player
-    // that is not already stopped stops it, and that stop is the previous track being displaced
-    // rather than this one ending - whoever displaced it has already said so, with the metadata
-    // the player no longer holds.
+    // True only while claimSource() is installing a new source. A stop delivered during that is
+    // the previous track being displaced rather than this one ending, and whoever displaced it
+    // has already said so - with the metadata the player no longer holds.
     bool claimingSource() const { return mClaimingSource; }
 
-    // A play() call owns the player it is setting up until it returns. Announcing the displaced
-    // track runs script handlers synchronously, and one that starts media of its own must be
-    // given a different player: two play() calls sharing one overwrite each other's playlist
-    // and media data, and the outer request is the one that loses.
+    // A play() call owns the player it is setting up until it returns, because the events it
+    // raises run script handlers synchronously. A handler that starts media of its own must be
+    // given a different player: two play() calls sharing one overwrite each other's playlist and
+    // media data.
     bool reservedForPlay() const { return mReservedForPlay; }
     void setReservedForPlay(const bool reserved) { mReservedForPlay = reserved; }
 
@@ -228,7 +226,6 @@ public:
     void pauseMedia(TMediaData& mediaData);
     void stopMedia(TMediaData& mediaData);
     void parseGMCP(QString& packageMessage, QString& gmcp);
-    // On failure the message says what could not be removed, for the script that asked.
     std::pair<bool, QString> purgeMediaCache();
     void refreshAudioDevices();
     void muteMedia(const TMediaData::MediaProtocol mediaProtocol);
@@ -293,6 +290,7 @@ private:
     // endedUrl and endedData are passed in rather than read off the player, so a caller that has
     // already released the source can still say what it was that ended.
     void raiseMediaFinishedEvent(const std::shared_ptr<TMediaPlayer>& player, const QUrl& endedUrl, const TMediaData& endedData);
+    void claimPlayerFor(const std::shared_ptr<TMediaPlayer>& player, TMediaData& mediaData, const QUrl& mediaSource);
     void endDisplacedPlayback(const std::shared_ptr<TMediaPlayer>& player);
     void releaseMediaSourceAfterEvents(const std::shared_ptr<TMediaPlayer>& player, const TMediaData& endedData, const PlaybackEnd endedBy);
     void handlePlayerPlaybackStateChanged(QMediaPlayerPlaybackState playbackState, const std::shared_ptr<TMediaPlayer>& player);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4337,7 +4337,7 @@ void cTelnet::slot_tlsUpgradeResponse(const bool accepted)
 }
 #endif
 
-bool cTelnet::purgeMediaCache()
+std::pair<bool, QString> cTelnet::purgeMediaCache()
 {
     return mpHost->mpMedia->purgeMediaCache();
 }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -52,6 +52,7 @@
 #include <iostream>
 #include <queue>
 #include <string>
+#include <utility>
 
 #if defined(Q_OS_WINDOWS)
 #include <ws2tcpip.h>
@@ -192,7 +193,7 @@ public:
     void setMSSPVariables(const QByteArray&);
     void setMSPVariables(const QByteArray&);
     bool isIPAddress(const QString&);
-    bool purgeMediaCache();
+    std::pair<bool, QString> purgeMediaCache();
     void atcpComposerCancel();
     void atcpComposerSave(QString);
     void checkNAWS();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1346,7 +1346,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                        // that are not handled here!
+                    // that are not handled here!
                     }
                 }
             }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2100,9 +2100,11 @@ void dlgProfilePreferences::slot_purgeMediaCache()
         return;
     }
 
-    if (!pHost->mpMedia->purgeMediaCache()) {
-        //: Shown after the "Clear stored media" button in preferences fails to empty the profile's media directory.
-        pHost->postMessage(tr("[ WARN ]  - Could not clear all of the stored media; some files may still be in use."));
+    const auto [purged, message] = pHost->mpMedia->purgeMediaCache();
+
+    if (!purged) {
+        //: Shown after the "Clear stored media" button in preferences fails to empty the profile's media directory. %1 is the reason, which is not translated.
+        pHost->postMessage(tr("[ WARN ]  - Could not clear the stored media: %1.").arg(message));
         return;
     }
 

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -269,14 +269,13 @@ describe("Media playback effects with a generated sound file", function()
   end
 
   -- Waits until collected holds count entries. A media event can be raised
-  -- inside the call that caused it, so a spec cannot arm waitForEvent() first
-  -- and has to be able to find the event already collected.
+  -- inside the call that caused it, so waiting has to start with a look.
   local function waitForCount(eventName, collected, count)
-    for _ = 1, 10 do
+    for _ = 1, 5 do
       if #collected >= count then
         return
       end
-      waitForEvent(eventName, 2000)
+      waitForEvent(eventName, 1000)
     end
   end
 
@@ -305,6 +304,7 @@ describe("Media playback effects with a generated sound file", function()
       if not playbackObserved then
         os.remove(mediaDirectory .. "/" .. soundFile)
         os.remove(mediaDirectory .. "/" .. longSoundFile)
+        os.remove(mediaDirectory .. "/" .. otherLongSoundFile)
       end
     end
     if playbackObserved then
@@ -447,8 +447,6 @@ describe("Media playback effects with a generated sound file", function()
 
     assert.is_true(playSoundFile({name = otherLongSoundFile, key = "busted-replacement"}))
 
-    -- the paused track is the one that ended, and it is reported under its own
-    -- key and tag rather than the replacement's
     assert.equals(1, #finished)
     assert.equals(longSoundFile, finished[1].file)
     assert.equals("busted-parked", finished[1].key)
@@ -461,6 +459,64 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(1, #playing)
     assert.equals(otherLongSoundFile, playing[1].name)
     assert.equals(0, #getPausedSounds())
+  end)
+
+  it("playing different music while some is paused ends the paused track", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished, started = {}, {}
+    collect("sysMediaFinished", finished)
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playMusicFile({name = longSoundFile, key = "busted-music-parked", tag = "busted-music-parked-tag"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(pauseMusic())
+    assert.equals(1, #getPausedMusic())
+
+    assert.is_true(playMusicFile({name = otherLongSoundFile, key = "busted-music-new"}))
+
+    assert.equals(1, #finished)
+    assert.equals(longSoundFile, finished[1].file)
+    assert.equals("busted-music-parked", finished[1].key)
+    assert.equals("busted-music-parked-tag", finished[1].tag)
+
+    waitForCount("sysMediaStarted", started, 2)
+    local music = getPlayingMusic()
+    assert.equals(1, #music)
+    assert.equals(otherLongSoundFile, music[1].name)
+    assert.equals(0, #getPausedMusic())
+  end)
+
+  it("a request refused on priority leaves the paused sound it would have taken over", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished, started = {}, {}
+    collect("sysMediaFinished", finished)
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    -- first, because a priority of its own would stop every sound that has none
+    assert.is_true(playSoundFile({name = otherLongSoundFile, key = "busted-priority-loud", priority = 90}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-priority-parked"}))
+    waitForCount("sysMediaStarted", started, 2)
+    assert.is_true(pauseSounds({key = "busted-priority-parked"}))
+    assert.equals(1, #getPausedSounds())
+    assert.equals(1, #getPlayingSounds())
+
+    -- refused, since the sound already playing is louder - and a paused player
+    -- is what a request is handed before anything else in the pool
+    assert.is_true(playSoundFile({name = soundFile, key = "busted-priority-refused", priority = 10}))
+
+    assert.equals(0, #getPlayingSounds({key = "busted-priority-refused"}))
+    assert.equals(0, #finished)
+    local paused = getPausedSounds()
+    assert.equals(1, #paused)
+    assert.equals(longSoundFile, paused[1].name)
+    assert.equals("busted-priority-parked", paused[1].key)
   end)
 
   it("a finite loop count plays every pass and reports each one", function()
@@ -477,9 +533,11 @@ describe("Media playback effects with a generated sound file", function()
 
     assert.equals(2, #started)
     assert.equals(2, #finished)
-    assert.equals(soundFile, finished[2].file)
-    assert.equals("busted-looped", finished[2].key)
-    assert.equals("busted-looped-tag", finished[2].tag)
+    for _, pass in ipairs(finished) do
+      assert.equals(soundFile, pass.file)
+      assert.equals("busted-looped", pass.key)
+      assert.equals("busted-looped-tag", pass.tag)
+    end
     assert.equals(0, #getPlayingSounds())
   end)
 
@@ -489,10 +547,9 @@ describe("Media playback effects with a generated sound file", function()
     end
     writeSoundFiles()
 
-    -- The re-entrant call can only reach the player this call is setting up if
-    -- that player is already in the pool, and a player joins the pool only once
-    -- the play() that made it has returned. So warm several up, each started
-    -- while the one before it is playing.
+    -- A player joins the pool only once the play() that made it has returned,
+    -- so warming several up - each started while the one before it is playing -
+    -- is what puts the re-entrant call in reach of the one being set up below.
     local warmed = {}
     collect("sysMediaStarted", warmed)
     for index, key in ipairs({"busted-warm-one", "busted-warm-two", "busted-warm-three"}) do
@@ -518,6 +575,7 @@ describe("Media playback effects with a generated sound file", function()
     local loud = getPlayingSounds({key = "busted-loud"})
     assert.equals(1, #loud)
     assert.equals(longSoundFile, loud[1].name)
+    assert.is_true(#getPlayingSounds({key = "busted-handler-sound"}) > 0)
   end)
 
   it("the key filter picks out which sound is listed and stopped", function()
@@ -609,9 +667,6 @@ describe("Media playback effects with a generated sound file", function()
   end)
 
   it("purgeMediaCache returns nil and a message when it cannot empty the directory", function()
-    if mediaPlaybackUnavailable() then
-      return
-    end
     if getOS() == "windows" then
       pending("staging an undeletable file needs chmod")
       return
@@ -641,8 +696,7 @@ describe("Media playback effects with a generated sound file", function()
     local ok, err = purgeMediaCache()
     assert.is_nil(ok)
     assert.is_true(contains(err, mediaDirectory), tostring(err))
-    -- everything it could remove is gone, so the caller is told about a purge
-    -- that half happened rather than one that did not happen
+    -- a purge that half happened, not one that did not happen
     assert.is_nil(lfs.attributes(mediaDirectory .. "/" .. soundFile, "mode"))
   end)
 
@@ -653,8 +707,7 @@ describe("Media playback effects with a generated sound file", function()
     end)
     finally(function() killAnonymousEventHandler(handler) end)
 
-    -- a file the media directory does not have, so the url is the only way to
-    -- get it and refusing to fetch it ends the request
+    -- a file the media directory does not have, so the url is the only way to get it
     assert.is_true(playSoundFile({name = "busted-media-absent-scheme.wav", url = "ftp://example.invalid/sounds"}))
     waitForCount("sysDownloadError", errors, 1)
     assert.equals(1, #errors)

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -188,8 +188,10 @@ describe("Media playback effects with a generated sound file", function()
   -- own, and a long one for the specs that have to still be playing when they
   -- stop or pause it, so a slow runner cannot turn a natural finish into a
   -- spurious failure.
+  -- A second long file so a spec can tell one playback from another by name.
   local soundFile = "busted-media-tone.wav"
   local longSoundFile = "busted-media-hold.wav"
+  local otherLongSoundFile = "busted-media-hold-other.wav"
   local mediaDirectory = getMudletHomeDir() .. "/media"
   local playbackObserved
 
@@ -224,6 +226,7 @@ describe("Media playback effects with a generated sound file", function()
   local function writeSoundFiles()
     writeMediaFile(soundFile, 150)
     writeMediaFile(longSoundFile, 10000)
+    writeMediaFile(otherLongSoundFile, 10000)
   end
 
   -- purgeMediaCache() empties the whole media directory, not just the fixtures
@@ -234,7 +237,7 @@ describe("Media playback effects with a generated sound file", function()
     local stash = getMudletHomeDir() .. "/busted-media-stash"
     local preserved = {}
     for entry in lfs.dir(mediaDirectory) do
-      if entry ~= "." and entry ~= ".." and entry ~= soundFile and entry ~= longSoundFile then
+      if entry ~= "." and entry ~= ".." and entry ~= soundFile and entry ~= longSoundFile and entry ~= otherLongSoundFile then
         preserved[#preserved + 1] = entry
       end
     end
@@ -263,6 +266,18 @@ describe("Media playback effects with a generated sound file", function()
       into[#into + 1] = {file = file, path = path, mediaType = mediaType, key = key, tag = tag}
     end)
     finally(function() killAnonymousEventHandler(handler) end)
+  end
+
+  -- Waits until collected holds count entries. A media event can be raised
+  -- inside the call that caused it, so a spec cannot arm waitForEvent() first
+  -- and has to be able to find the event already collected.
+  local function waitForCount(eventName, collected, count)
+    for _ = 1, 10 do
+      if #collected >= count then
+        return
+      end
+      waitForEvent(eventName, 2000)
+    end
   end
 
   -- The media events carry QUrl::path(), which puts a slash in front of a
@@ -416,6 +431,95 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(0, #getPausedSounds())
   end)
 
+  it("playing a different sound while one is paused ends the paused one and starts the new one", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished, started = {}, {}
+    collect("sysMediaFinished", finished)
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-parked", tag = "busted-parked-tag"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(pauseSounds())
+    assert.equals(1, #getPausedSounds())
+
+    assert.is_true(playSoundFile({name = otherLongSoundFile, key = "busted-replacement"}))
+
+    -- the paused track is the one that ended, and it is reported under its own
+    -- key and tag rather than the replacement's
+    assert.equals(1, #finished)
+    assert.equals(longSoundFile, finished[1].file)
+    assert.equals("busted-parked", finished[1].key)
+    assert.equals("busted-parked-tag", finished[1].tag)
+
+    waitForCount("sysMediaStarted", started, 2)
+    assert.equals(2, #started)
+    assert.equals(otherLongSoundFile, started[2].file)
+    local playing = getPlayingSounds()
+    assert.equals(1, #playing)
+    assert.equals(otherLongSoundFile, playing[1].name)
+    assert.equals(0, #getPausedSounds())
+  end)
+
+  it("a finite loop count plays every pass and reports each one", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished, started = {}, {}
+    collect("sysMediaFinished", finished)
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = soundFile, key = "busted-looped", tag = "busted-looped-tag", loops = 2}))
+    waitForCount("sysMediaFinished", finished, 2)
+
+    assert.equals(2, #started)
+    assert.equals(2, #finished)
+    assert.equals(soundFile, finished[2].file)
+    assert.equals("busted-looped", finished[2].key)
+    assert.equals("busted-looped-tag", finished[2].tag)
+    assert.equals(0, #getPlayingSounds())
+  end)
+
+  it("a sysMediaFinished handler that starts a sound leaves the caller's own request playing", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+
+    -- The re-entrant call can only reach the player this call is setting up if
+    -- that player is already in the pool, and a player joins the pool only once
+    -- the play() that made it has returned. So warm several up, each started
+    -- while the one before it is playing.
+    local warmed = {}
+    collect("sysMediaStarted", warmed)
+    for index, key in ipairs({"busted-warm-one", "busted-warm-two", "busted-warm-three"}) do
+      assert.is_true(playSoundFile({name = longSoundFile, key = key}))
+      waitForCount("sysMediaStarted", warmed, index)
+    end
+    assert.equals(3, #getPlayingSounds())
+    assert.is_true(stopSounds())
+
+    local reentered = 0
+    local handler = registerAnonymousEventHandler("sysMediaFinished", function()
+      reentered = reentered + 1
+      playSoundFile({name = otherLongSoundFile, key = "busted-handler-sound"})
+    end)
+    finally(function() killAnonymousEventHandler(handler) end)
+
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-quiet", priority = 10}))
+    -- stops the sound above while it is still loading, which raises
+    -- sysMediaFinished into the handler from inside this very call
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-loud", priority = 90, loops = 3}))
+
+    assert.is_true(reentered > 0, "the priority stop raised no sysMediaFinished, so nothing re-entered")
+    local loud = getPlayingSounds({key = "busted-loud"})
+    assert.equals(1, #loud)
+    assert.equals(longSoundFile, loud[1].name)
+  end)
+
   it("the key filter picks out which sound is listed and stopped", function()
     if mediaPlaybackUnavailable() then
       return
@@ -502,6 +606,60 @@ describe("Media playback effects with a generated sound file", function()
     -- it stops every player before removing the directory
     assert.equals(0, #getPlayingSounds())
     assert.is_nil(lfs.attributes(soundPath, "mode"))
+  end)
+
+  it("purgeMediaCache returns nil and a message when it cannot empty the directory", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    if getOS() == "windows" then
+      pending("staging an undeletable file needs chmod")
+      return
+    end
+    writeSoundFiles()
+    preserveMediaDirectory()
+
+    local lockedDirectory = mediaDirectory .. "/busted-media-locked"
+    lfs.mkdir(lockedDirectory)
+    local pinnedFile = lockedDirectory .. "/busted-media-pinned.wav"
+    local handle = io.open(pinnedFile, "wb")
+    assert.is_not_nil(handle, "could not write the pinned media fixture")
+    handle:write("pinned")
+    handle:close()
+    os.execute("chmod 500 '" .. lockedDirectory .. "'")
+    finally(function()
+      os.execute("chmod 700 '" .. lockedDirectory .. "'")
+      os.remove(pinnedFile)
+      lfs.rmdir(lockedDirectory)
+    end)
+
+    if os.remove(pinnedFile) then
+      pending("this user can delete files out of a directory it cannot write")
+      return
+    end
+
+    local ok, err = purgeMediaCache()
+    assert.is_nil(ok)
+    assert.is_true(contains(err, mediaDirectory), tostring(err))
+    -- everything it could remove is gone, so the caller is told about a purge
+    -- that half happened rather than one that did not happen
+    assert.is_nil(lfs.attributes(mediaDirectory .. "/" .. soundFile, "mode"))
+  end)
+
+  it("a media url that is not http(s) reports a download error", function()
+    local errors = {}
+    local handler = registerAnonymousEventHandler("sysDownloadError", function(_, message, path)
+      errors[#errors + 1] = {message = message, path = path}
+    end)
+    finally(function() killAnonymousEventHandler(handler) end)
+
+    -- a file the media directory does not have, so the url is the only way to
+    -- get it and refusing to fetch it ends the request
+    assert.is_true(playSoundFile({name = "busted-media-absent-scheme.wav", url = "ftp://example.invalid/sounds"}))
+    waitForCount("sysDownloadError", errors, 1)
+    assert.equals(1, #errors)
+    assert.is_true(contains(errors[1].message, "http"), tostring(errors[1].message))
+    assert.is_true(contains(errors[1].path, "busted-media-absent-scheme.wav"), tostring(errors[1].path))
   end)
 end)
 

--- a/test/functional_tests/TMediaLoopTest.cpp
+++ b/test/functional_tests/TMediaLoopTest.cpp
@@ -196,6 +196,35 @@ private slots:
         QVERIFY2(cleanedUp, "A loops=3 track never finished and released its source - the deferred cleanup did not take over from the last pass.");
     }
 
+    // Staged rather than played: only a backend that delivers EndOfMedia before StoppedState
+    // announces a pass from inside continuePlaying()'s setSource(), and no runner this suite has
+    // does. sourceChanged stands in for that announcement, being emitted from inside the same
+    // setSource() call.
+    void test_continuingToTheNextPassClearsTheEarlierAnnouncement()
+    {
+        const QString path = qsl("%1/pass.wav").arg(mProbeDir.path());
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write(wavBytes());
+        file.close();
+
+        TMediaData data{};
+        TMediaPlayer player(nullptr, data);
+        QVERIFY(player.isInitialized());
+
+        bool announcedFromInsideSetSource = false;
+        connect(player.mediaPlayer(), &QMediaPlayer::sourceChanged, player.mediaPlayer(), [&](const QUrl&) {
+            player.noteEndAnnounced();
+            announcedFromInsideSetSource = true;
+        });
+
+        player.continuePlaying(QUrl::fromLocalFile(path));
+        player.mediaPlayer()->stop();
+
+        QVERIFY2(announcedFromInsideSetSource, "setSource() emitted nothing synchronously, so the ordering this test is about was never staged.");
+        QVERIFY2(!player.endAnnounced(), "The new pass started already counted as announced, so its own ending would be swallowed as a duplicate.");
+    }
+
     // The deferred cleanup must still fire for a genuinely finished track, otherwise the
     // media source release added by #9237 is lost. Releasing the source is what this asserts
     // on because playingMedia() has already dropped the player by the time the cleanup runs.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Ending a track is now done before its player is handed to the next one, so pausing a sound (or music) and playing a *different* file plays it, and reports the paused track's own ending rather than a spurious `sysMediaFinished` carrying the new request's key and tag.
- A `play()` call now owns the player it is setting up, so a `sysMediaFinished` handler that starts media of its own can no longer take that player over and make the caller's higher-priority request disappear.
- `purgeMediaCache()` returns `nil, message` instead of a bare `false`, a media URL whose scheme is not http(s) now raises `sysDownloadError` instead of being refused silently, and the last pass of a `loops = N` track can no longer have its ending swallowed.

#### Motivation for adding to Mudlet

"Pause the ambience, start the combat theme" is an ordinary GMCP/script sequence and in 5.0 it produced silence plus a misleading event.

#### Other info (issues closed, discussion etc)

Found by the 5.0 QA sweep (finding C16). The three commits behind it were each reviewed alone and share one state machine: `92f01b850` "fix: Client.Media loops=-1 plays once (#9569)", `3474cb58d` "fix: playing a sound again right after stopping it (#9611)" and `8dd99e4db` "fix: media that fails to load never reports it (#9612)".

Pause `a.wav`, then play `b.wav`, on `origin/development` and on this branch:

```
before   sysMediaFinished  file=a.wav key=k2 tag=t2   <- old file, new request's key
         (nothing playing, the paused track is gone too)
after    sysMediaFinished  file=a.wav key=k1 tag=t1
         sysMediaStarted   file=b.wav key=k2 tag=t2   <- b.wav plays
```

Contract change worth a changelog line: `purgeMediaCache()` returned `false` on failure and now returns `nil` plus a message. `if not purgeMediaCache()` still behaves the same; `== false` no longer matches.

Adjacent and deliberately left alone: `stopSounds{fadeaway = true}` issued while a track is still loading is lost, and the track then plays forever. That is byte-identical in 4.22.0, so it is not a 5.0 regression. `downloadFile()`'s five other refusals (path traversal, three directory-creation failures, an invalid URL) are still silent, also pre-existing.

**Test case:** `playSoundFile{name = "a.wav", key = "k1"}`, `pauseSounds()`, then `playSoundFile{name = "b.wav", key = "k2"}` - b.wav plays and exactly one `sysMediaFinished` arrives, naming a.wav and k1. Seven new specs in `Media_spec.lua` (six of them fail against `origin/development`) and one new case in `TMediaLoopTest` cover this, pause-then-play for music, a refused-on-priority request, re-entrant `play()`, `loops = 2`, and both failure contracts.

Assisted-by: Claude:claude-opus-5