### PR TITLE
fix: four security holes in the new browser sign-in

### DIFF
--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -70,6 +70,25 @@ GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
 : mpHost(pHost)
 {
     resetPerConnectionState();
+    // mTelnet is declared before this authenticator in Host, so it is already constructed here.
+    QObject::connect(&pHost->mTelnet, &cTelnet::signal_connected, pHost, [this]() {
+        resetForNewConnection();
+    });
+    QObject::connect(&pHost->mTelnet, &cTelnet::signal_disconnected, pHost, [this]() {
+        resetForNewConnection();
+    });
+}
+
+void GMCPAuthenticator::resetForNewConnection()
+{
+    // Anything still in flight belongs to the connection that started it: a deferred attempt would
+    // cancel the new connection's login timers and sign in with capabilities the new server never
+    // advertised, and a credential read landing there would replay a token nobody asked for.
+    ++mSignInScheduleGeneration;
+    ++mAuthAttemptGeneration;
+    mSignInAttemptPending = false;
+    mLastSignInAttempt.invalidate();
+    mUnpromptedBrowserOpenAvailable = true;
 }
 
 void GMCPAuthenticator::resetPerConnectionState()
@@ -224,8 +243,19 @@ void GMCPAuthenticator::sendCredentials(bool interactiveHandoff)
 #endif
 }
 
-void GMCPAuthenticator::sendReconnect(const QString& account, QString token)
+bool GMCPAuthenticator::sendReconnect(const QString& account, QString token)
 {
+    // The token signs in to the account without the player's password, and is replayed on whatever
+    // transport is live now rather than the one it was earned on: in the clear that hands the account
+    // to anyone on the path.
+    if (!mpHost->mTelnet.currentlySecure()) {
+        SecureStringUtils::secureStringClear(token);
+        qWarning().noquote() << "GMCP Char.Login.Reconnect - refusing to replay the saved sign-in token over an unencrypted connection.";
+        //: Shown when a saved password-less sign-in cannot be reused because this connection to the game is not encrypted.
+        mpHost->postMessage(tr("[ WARN ]  - Not using your saved sign-in because this connection is not encrypted; please sign in again."));
+        return false;
+    }
+
     QJsonObject payload;
     payload[qsl("account")] = account;
     payload[qsl("token")] = token;
@@ -263,6 +293,7 @@ void GMCPAuthenticator::sendReconnect(const QString& account, QString token)
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Sent GMCP reconnect for account:" << account;
 #endif
+    return true;
 }
 
 void GMCPAuthenticator::storeReconnectToken(const QString& account, QString token)
@@ -421,26 +452,34 @@ void GMCPAuthenticator::handleAuthUrl(const QString& packageMessage, const QStri
         return;
     }
 
-    // This message can arrive unsolicited, so only auto-open the browser when the player has sent input
-    // this connection (evidence they acted on the game's sign-in screen); otherwise offer the link to
-    // open deliberately, so a misbehaving server cannot pop a browser at an idle player.
-    if (mpHost->userSentInputThisConnection()) {
-        openSignInUrl(parsedUrl, provider);
+    // Char.Login.URL can arrive at any moment in a session, so it only auto-opens against user input.
+    offerOrOpenSignInUrl(parsedUrl, provider, false);
+}
+
+void GMCPAuthenticator::offerOrOpenSignInUrl(const QUrl& url, const QString& provider, bool answersTheGamesSignInOffer)
+{
+    const bool mayOpen = mpHost->userSentInputThisConnection() || (answersTheGamesSignInOffer && mUnpromptedBrowserOpenAvailable);
+    if (mayOpen) {
+        if (openSignInUrl(url, provider)) {
+            mUnpromptedBrowserOpenAvailable = false;
+            mpHost->setUserSentInputThisConnection(false);
+        }
         return;
     }
 
     //: %1 is the sign-in web address the user should open in their browser to sign in.
-    mpHost->postMessage(tr("[ INFO ]  - To sign in, open this link in your browser: %1").arg(url));
+    mpHost->postMessage(tr("[ INFO ]  - To sign in, open this link in your browser: %1").arg(url.toString()));
 }
 
-void GMCPAuthenticator::openSignInUrl(const QUrl& url, const QString& provider)
+bool GMCPAuthenticator::openSignInUrl(const QUrl& url, const QString& provider)
 {
     if (!QDesktopServices::openUrl(url)) {
         //: %1 is the sign-in web address the user should open manually in their browser.
         mpHost->postMessage(tr("[ WARN ]  - Could not open your browser. Open this link manually to sign in: %1").arg(url.toString()));
-        return;
+        return false;
     }
     announceBrowserHandoff(provider);
+    return true;
 }
 
 void GMCPAuthenticator::announceBrowserHandoff(const QString& provider)
@@ -465,15 +504,12 @@ void GMCPAuthenticator::startClientDrivenOAuth()
 
     // Parented to the Host so the flow (and its loopback listener) cannot outlive the profile.
     mpOAuthFlow = new OAuthClientFlow(mpHost);
-    QObject::connect(mpOAuthFlow, &OAuthClientFlow::authorizationCaptured, mpHost, [this](const QString& code, const QString& codeVerifier, const QString& redirectUri) {
-        sendAuthCode(code, codeVerifier, redirectUri);
+    QObject::connect(mpOAuthFlow, &OAuthClientFlow::authorizationCaptured, mpHost, [this](const QString& code, const QString& codeVerifier, const QString& redirectUri, const QString& nonce) {
+        sendAuthCode(code, codeVerifier, redirectUri, nonce);
     });
-    QObject::connect(mpOAuthFlow, &OAuthClientFlow::browserOpened, mpHost, [this]() {
-        announceBrowserHandoff(QString());
-    });
-    QObject::connect(mpOAuthFlow, &OAuthClientFlow::browserOpenFailed, mpHost, [this](const QString& url) {
-        //: %1 is the sign-in web address the user should open manually in their browser.
-        mpHost->postMessage(tr("[ WARN ]  - Could not open your browser. Open this link manually to sign in: %1").arg(url));
+    // This flow only starts from the game's own sign-in offer, so connecting is itself the request.
+    QObject::connect(mpOAuthFlow, &OAuthClientFlow::authorizationUrlReady, mpHost, [this](const QUrl& authorizationUrl) {
+        offerOrOpenSignInUrl(authorizationUrl, QString(), true);
     });
     QObject::connect(mpOAuthFlow, &OAuthClientFlow::flowFailed, mpHost, [this](const QString& logDetail) {
         qWarning().noquote() << "GMCP Char.Login client-driven OAuth failed:" << logDetail;
@@ -494,7 +530,7 @@ void GMCPAuthenticator::cancelClientDrivenOAuth()
     }
 }
 
-void GMCPAuthenticator::sendAuthCode(QString code, QString codeVerifier, const QString& redirectUri)
+void GMCPAuthenticator::sendAuthCode(QString code, QString codeVerifier, const QString& redirectUri, QString nonce)
 {
     // The spec forbids Char.Login.AuthCode on a cleartext connection: the authorization code and PKCE
     // verifier together would let an eavesdropper redeem the code at the provider. The flow only starts
@@ -502,6 +538,7 @@ void GMCPAuthenticator::sendAuthCode(QString code, QString codeVerifier, const Q
     if (!mpHost->mTelnet.currentlySecure()) {
         SecureStringUtils::secureStringClear(code);
         SecureStringUtils::secureStringClear(codeVerifier);
+        SecureStringUtils::secureStringClear(nonce);
         qWarning().noquote() << "GMCP Char.Login.AuthCode - refusing to send the authorization code over an unencrypted connection.";
         mpHost->mTelnet.setDontReconnect(true);
         // Tear down the in-flight flow and its loopback listener immediately: the sign-in is doomed, so
@@ -516,6 +553,13 @@ void GMCPAuthenticator::sendAuthCode(QString code, QString codeVerifier, const Q
     payload[qsl("code")] = code;
     payload[qsl("code_verifier")] = codeVerifier;
     payload[qsl("redirect_uri")] = redirectUri;
+    // The server, not this client, receives and validates the ID token, so it is the only party that
+    // can check the nonce claim - and only against the value chosen here.
+    if (!nonce.isEmpty()) {
+        payload[qsl("nonce")] = nonce;
+    } else if (mOAuthNonceRequired) {
+        qWarning().noquote() << "GMCP Char.Login.AuthCode - the server asked for a nonce but none was generated, so it cannot verify the ID token's nonce claim.";
+    }
     payload[qsl("version")] = mNegotiatedVersion;
     QByteArray json = QJsonDocument(payload).toJson(QJsonDocument::Compact);
     QString gmcpMessage = QString::fromUtf8(json);
@@ -543,6 +587,7 @@ void GMCPAuthenticator::sendAuthCode(QString code, QString codeVerifier, const Q
     // payloads, and the assembled telnet frame.
     SecureStringUtils::secureStringClear(code);
     SecureStringUtils::secureStringClear(codeVerifier);
+    SecureStringUtils::secureStringClear(nonce);
     SecureStringUtils::secureStringClear(gmcpMessage);
     SecureStringUtils::secureStdStringClear(plaintext);
     SecureStringUtils::secureStdStringClear(encoded);
@@ -687,16 +732,21 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
 #if defined(DEBUG_GMCP_AUTHENTICATION)
                                 qDebug() << "GMCP reconnect token was rotated by another instance; replaying the fresh token";
 #endif
-                                mConn.retriedRotatedToken = true;
-                                mConn.sentReconnectTokenHash = storedHash;
-                                mConn.reconnectingWithToken = true;
-                                mConn.awaitingReconnectResult = true;
-                                mConn.reconnectAccount = account;
-                                // This attempt is replaying a live token rather than recovering from a dead
-                                // one, so release the latch: the next Char.Login.Default is an ordinary
-                                // sign-in again and may use a stored token.
-                                mReconnectRejected = false;
-                                sendReconnect(account, std::move(token));
+                                if (sendReconnect(account, std::move(token))) {
+                                    mConn.retriedRotatedToken = true;
+                                    mConn.sentReconnectTokenHash = storedHash;
+                                    mConn.reconnectingWithToken = true;
+                                    mConn.awaitingReconnectResult = true;
+                                    mConn.reconnectAccount = account;
+                                    // This attempt is replaying a live token rather than recovering from a dead
+                                    // one, so release the latch: the next Char.Login.Default is an ordinary
+                                    // sign-in again and may use a stored token.
+                                    mReconnectRejected = false;
+                                    return;
+                                }
+                                // The other instance's token is live, so leave the stored entry alone. The
+                                // rejection latch stays armed: this connection cannot use a token at all.
+                                selectAuthMethod();
                                 return;
                             }
                             // Both branches above return, so reaching here means the stored token is not a
@@ -775,7 +825,7 @@ void GMCPAuthenticator::handleAuthGMCP(const QString& packageMessage, const QStr
         // deciding how to authenticate.
         resetPerConnectionState();
 
-        attemptReconnect();
+        scheduleSignInAttempt();
         return;
     }
 
@@ -847,6 +897,34 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Stored GMCP reconnect token for account:" << account;
 #endif
+}
+
+void GMCPAuthenticator::scheduleSignInAttempt()
+{
+    if (mSignInAttemptPending) {
+#if defined(DEBUG_GMCP_AUTHENTICATION)
+        qDebug() << "GMCP Char.Login.Default arrived while a sign-in attempt was already scheduled; folding it into that attempt";
+#endif
+        return;
+    }
+    if (!mLastSignInAttempt.isValid() || mLastSignInAttempt.durationElapsed() >= scmSignInAttemptInterval) {
+        mLastSignInAttempt.start();
+        attemptReconnect();
+        return;
+    }
+
+    // Inside the throttle window: serve the whole burst with one attempt when it closes, using the
+    // capabilities the last frame left behind, and drop it if that connection has gone by then.
+    mSignInAttemptPending = true;
+    const auto scheduleGeneration = mSignInScheduleGeneration;
+    QTimer::singleShot(scmSignInAttemptInterval - mLastSignInAttempt.durationElapsed(), mpHost, [this, scheduleGeneration]() {
+        if (scheduleGeneration != mSignInScheduleGeneration) {
+            return;
+        }
+        mSignInAttemptPending = false;
+        mLastSignInAttempt.start();
+        attemptReconnect();
+    });
 }
 
 void GMCPAuthenticator::attemptReconnect()
@@ -927,20 +1005,23 @@ void GMCPAuthenticator::readStoredSignIn(bool allowToken)
                             mConn.accountProvider = provider;
                         }
                         if (allowToken && !account.isEmpty() && !token.isEmpty()) {
-                            // This connection is logging in by replaying a saved token, so a Char.Login.Token
-                            // that comes back is a silent rotation rather than a first-time save to announce.
-                            mConn.reconnectingWithToken = true;
-                            mConn.awaitingReconnectResult = true;
-                            mConn.reconnectAccount = account;
                             // Remember only a hash of what we send: if the reconnect is rejected, comparing it
                             // against a fresh read tells a dead token apart from one another running instance
                             // (sharing this profile's keychain) rotated while ours was in flight.
                             QByteArray tokenBytes = token.toUtf8();
-                            mConn.sentReconnectTokenHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
+                            const QByteArray sentHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
                             SecureStringUtils::secureByteArrayClear(tokenBytes);
-                            // Move the token in so sendReconnect owns the sole copy and can scrub it after sending.
-                            sendReconnect(account, std::move(token));
-                            return;
+                            // Move the token in so sendReconnect owns the sole copy and can scrub it either way.
+                            if (sendReconnect(account, std::move(token))) {
+                                // This connection is logging in by replaying a saved token, so a Char.Login.Token
+                                // that comes back is a silent rotation rather than a first-time save to announce.
+                                mConn.reconnectingWithToken = true;
+                                mConn.awaitingReconnectResult = true;
+                                mConn.reconnectAccount = account;
+                                mConn.sentReconnectTokenHash = sentHash;
+                                return;
+                            }
+                            // Not sent, so nothing awaits a result on it; fall through to resume or hand-off.
                         }
                         if (!account.isEmpty() && !provider.isEmpty()) {
                             // No usable token, but we remember how this account signs in: ask the game to

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -23,6 +23,7 @@
 #include "Host.h"
 #include "utils.h"
 
+#include <QElapsedTimer>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -30,6 +31,7 @@
 #include <QString>
 #include <QVariantMap>
 
+#include <chrono>
 #include <functional>
 
 class OAuthClientFlow;
@@ -58,19 +60,28 @@ public:
 
 private:
     void handleAuthUrl(const QString& packageMessage, const QString& data);
-    void openSignInUrl(const QUrl& url, const QString& provider);
+    // The single place where a sign-in web address may reach the system browser, for both the
+    // server-driven (Char.Login.URL) and the client-driven flow. Auto-opens only against evidence that
+    // the player wants to sign in and consumes it, otherwise offers the address as a link.
+    // answersTheGamesSignInOffer marks an address reached from Char.Login.Default, where connecting is
+    // itself that evidence - once per connection.
+    void offerOrOpenSignInUrl(const QUrl& url, const QString& provider, bool answersTheGamesSignInOffer);
+    bool openSignInUrl(const QUrl& url, const QString& provider);
     void startClientDrivenOAuth();
     void cancelClientDrivenOAuth();
     void announceBrowserHandoff(const QString& provider);
-    void sendAuthCode(QString code, QString codeVerifier, const QString& redirectUri);
+    void sendAuthCode(QString code, QString codeVerifier, const QString& redirectUri, QString nonce);
     void selectAuthMethod();
+    void scheduleSignInAttempt();
     void attemptReconnect();
     // Reads the stored sign-in entry ({account, provider?, token?}) and acts on it: replay the token
     // (when allowToken), else send the resume form for a remembered provider, else fall through to
     // selectAuthMethod(). allowToken is false on the connection straight after a rejection, so a
     // not-yet-rewritten entry cannot loop us back into another rejected reconnect.
     void readStoredSignIn(bool allowToken);
-    void sendReconnect(const QString& account, QString token);
+    // Returns false when it refused to send: the token is a bearer secret and never goes out over a
+    // cleartext transport. It is scrubbed either way, and only a true return means a result is awaited.
+    bool sendReconnect(const QString& account, QString token);
     // Sends the resume form of Char.Login.Credentials: {account, provider, version}, no password -
     // asking the game to restart the browser sign-in for the provider remembered from an earlier
     // Char.Login.URL. The absence of a password (not the presence of provider) is what distinguishes it.
@@ -90,6 +101,8 @@ private:
     void storeResumeHint(const QString& account, const QString& provider);
     void discardReconnectToken(std::function<void(bool success)> callback = {});
     void resetPerConnectionState();
+    // Per socket connection, unlike resetPerConnectionState() which runs per Char.Login.Default.
+    void resetForNewConnection();
 
     bool clientDrivenOAuthAvailable() const;
 
@@ -165,6 +178,18 @@ private:
     // callback, so a result arriving after a newer connection began is discarded instead of driving a
     // sign-in on the wrong attempt. Not part of mConn: it must monotonically increase, never reset.
     unsigned int mAuthAttemptGeneration = 0;
+
+    // A server can pack thousands of Char.Login.Default frames into one packet and every sign-in
+    // attempt reads the credential store. Throttling bounds that cost by wall clock rather than by how
+    // much the server sent, and unlike a hard per-connection cap never refuses a legitimate re-offer.
+    inline static constexpr std::chrono::milliseconds scmSignInAttemptInterval = std::chrono::seconds(1);
+    QElapsedTimer mLastSignInAttempt;
+    bool mSignInAttemptPending = false;
+    // Bumped whenever a connection begins or ends, so a deferred attempt from a previous one is dropped.
+    unsigned int mSignInScheduleGeneration = 0;
+    // One automatic browser hand-off per connection for an address reached from the game's sign-in
+    // offer, so a server cannot turn a burst of frames into a burst of tabs.
+    bool mUnpromptedBrowserOpenAvailable = true;
 };
 
 #endif // MUDLET_AUTHENTICATOR_H

--- a/src/Host.h
+++ b/src/Host.h
@@ -197,9 +197,11 @@ public:
     void setPass(const QString& password) { mPass = password; }
     bool hasAutoLoginCredentials() const { return !mLogin.isEmpty() && !mPass.isEmpty(); }
     // True once the user has sent any command to the game on the current connection. It gates whether
-    // an unsolicited GMCP Char.Login.URL may auto-open the browser: a URL that arrives only after the
+    // an unsolicited GMCP sign-in address may auto-open the browser: one that arrives only after the
     // player acted (e.g. chose a provider on the game's own sign-in screen) is a consequence of their
     // input, whereas one at an untouched connection is not and must not silently launch a browser.
+    // GMCPAuthenticator clears it again when it auto-opens, so one player action can launch at most
+    // one browser hand-off however many sign-in addresses the game pushes.
     bool userSentInputThisConnection() const { return mUserSentInputThisConnection; }
     void setUserSentInputThisConnection(const bool b) { mUserSentInputThisConnection = b; }
     int getRetries() { return mRetries; }

--- a/src/OAuthClientFlow.cpp
+++ b/src/OAuthClientFlow.cpp
@@ -23,7 +23,6 @@
 #include "utils.h"
 
 #include <QCryptographicHash>
-#include <QDesktopServices>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkReply>
@@ -192,14 +191,7 @@ void OAuthClientFlow::handleDiscoveryReply(QNetworkReply* reply)
 
     mCodeVerifier = generateCodeVerifier();
     mState = randomUrlSafeToken(16);
-    const QUrl authorizationUrl = buildAuthorizationUrl(authorizationEndpoint, mClientId, mScopes, mRedirectUri, mState, codeChallengeS256(mCodeVerifier), mNonce);
-
-    if (QDesktopServices::openUrl(authorizationUrl)) {
-        emit browserOpened(authorizationUrl.toString());
-    } else {
-        // Keep the listener up: the user can still open the link by hand and complete the sign-in.
-        emit browserOpenFailed(authorizationUrl.toString());
-    }
+    emit authorizationUrlReady(buildAuthorizationUrl(authorizationEndpoint, mClientId, mScopes, mRedirectUri, mState, codeChallengeS256(mCodeVerifier), mNonce));
 }
 
 void OAuthClientFlow::handleRedirectConnection()
@@ -278,11 +270,15 @@ void OAuthClientFlow::readRedirectRequest(QTcpSocket* socket)
     respond(socket, "200 OK", tr("You are signed in. You can close this tab and return to Mudlet."));
 
     mCompleted = true;
+    // Move rather than copy: cleanup() scrubs mNonce next, and clearing a shared QString detaches,
+    // zeroing a fresh copy while the real value stays in the buffer this one still points at.
+    QString nonce = std::move(mNonce);
     cleanup();
-    emit authorizationCaptured(code, mCodeVerifier, mRedirectUri);
+    emit authorizationCaptured(code, mCodeVerifier, mRedirectUri, nonce);
     // The authorization code and verifier are single-use secrets; the receiver has taken its own copies
     // (and is responsible for scrubbing them), so drop ours now.
     SecureStringUtils::secureStringClear(code);
+    SecureStringUtils::secureStringClear(nonce);
     SecureStringUtils::secureStringClear(mCodeVerifier);
 }
 

--- a/src/OAuthClientFlow.h
+++ b/src/OAuthClientFlow.h
@@ -32,10 +32,12 @@ class QNetworkReply;
 class QTcpSocket;
 
 // Runs the client-driven GMCP Char.Login v2 OAuth flow: fetches the server's OpenID Connect
-// discovery document, opens the provider's authorization URL in the system browser with a PKCE
-// (S256) challenge, and captures the authorization code on a loopback (RFC 8252) redirect
-// listener. The token exchange itself stays on the game server - this class only produces the
-// {code, code_verifier, redirect_uri} triple that GMCPAuthenticator sends as Char.Login.AuthCode.
+// discovery document, builds the provider's authorization URL with a PKCE (S256) challenge, and
+// captures the authorization code on a loopback (RFC 8252) redirect listener. The token exchange
+// itself stays on the game server - this class only produces the {code, code_verifier,
+// redirect_uri, nonce} set that GMCPAuthenticator sends as Char.Login.AuthCode. Handing the
+// authorization URL to the system browser is the caller's job, so that the decision to launch a
+// browser at the player is made in one place for both this and the server-driven flow.
 class OAuthClientFlow : public QObject
 {
     Q_OBJECT
@@ -58,9 +60,8 @@ public:
                                       const QString& nonce);
 
 signals:
-    void authorizationCaptured(const QString& code, const QString& codeVerifier, const QString& redirectUri);
-    void browserOpened(const QString& url);
-    void browserOpenFailed(const QString& url);
+    void authorizationCaptured(const QString& code, const QString& codeVerifier, const QString& redirectUri, const QString& nonce);
+    void authorizationUrlReady(const QUrl& authorizationUrl);
     void flowFailed(const QString& logDetail);
 
 private:

--- a/test/OAuthClientFlowTest.cpp
+++ b/test/OAuthClientFlowTest.cpp
@@ -19,7 +19,6 @@
 
 #include <OAuthClientFlow.h>
 #include <QtTest/QtTest>
-#include <QDesktopServices>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRegularExpression>
@@ -96,11 +95,9 @@ class OAuthClientFlowTest : public QObject
     Q_OBJECT
 
 public slots:
-    void captureBrowserUrl(const QUrl& url) { mBrowserUrl = url; }
+    void captureAuthorizationUrl(const QUrl& url) { mAuthorizationUrl = url; }
 
 private slots:
-    void initTestCase();
-    void cleanupTestCase();
     void init();
     void testCodeVerifierFormat();
     void testCodeVerifierUnique();
@@ -116,22 +113,12 @@ private slots:
     void testEmptyCodeFailsFlow();
 
 private:
-    QUrl mBrowserUrl;
+    QUrl mAuthorizationUrl;
 };
-
-void OAuthClientFlowTest::initTestCase()
-{
-    QDesktopServices::setUrlHandler(QStringLiteral("http"), this, "captureBrowserUrl");
-}
-
-void OAuthClientFlowTest::cleanupTestCase()
-{
-    QDesktopServices::unsetUrlHandler(QStringLiteral("http"));
-}
 
 void OAuthClientFlowTest::init()
 {
-    mBrowserUrl.clear();
+    mAuthorizationUrl.clear();
 }
 
 
@@ -199,15 +186,16 @@ void OAuthClientFlowTest::testFullFlowCapturesAuthorizationCode()
 {
     MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
-    QSignalSpy openedSpy(&flow, &OAuthClientFlow::browserOpened);
+    QSignalSpy urlReadySpy(&flow, &OAuthClientFlow::authorizationUrlReady);
 
     flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, true);
-    QTRY_VERIFY(!mBrowserUrl.isEmpty());
-    QCOMPARE(openedSpy.count(), 1);
+    QTRY_VERIFY(!mAuthorizationUrl.isEmpty());
+    QCOMPARE(urlReadySpy.count(), 1);
 
-    const QUrlQuery query(mBrowserUrl);
+    const QUrlQuery query(mAuthorizationUrl);
     QCOMPARE(query.queryItemValue(QStringLiteral("response_type")), QStringLiteral("code"));
     QCOMPARE(query.queryItemValue(QStringLiteral("client_id")), QStringLiteral("test-client"));
     QCOMPARE(query.queryItemValue(QStringLiteral("scope"), QUrl::FullyDecoded), QStringLiteral("openid"));
@@ -231,6 +219,7 @@ void OAuthClientFlowTest::testFullFlowCapturesAuthorizationCode()
     QCOMPARE(args.at(0).toString(), QStringLiteral("test-auth-code"));
     QCOMPARE(OAuthClientFlow::codeChallengeS256(args.at(1).toString()), challenge);
     QCOMPARE(args.at(2).toString(), redirectUri.toString());
+    QCOMPARE(args.at(3).toString(), query.queryItemValue(QStringLiteral("nonce")));
     QCOMPARE(failedSpy.count(), 0);
 
     // Wait for the full status line (peek does not consume) so a split packet cannot yield a partial read.
@@ -241,12 +230,13 @@ void OAuthClientFlowTest::testStateMismatchFailsFlow()
 {
     MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
 
     flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
-    QTRY_VERIFY(!mBrowserUrl.isEmpty());
-    const QUrlQuery query(mBrowserUrl);
+    QTRY_VERIFY(!mAuthorizationUrl.isEmpty());
+    const QUrlQuery query(mAuthorizationUrl);
     const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
 
     QTcpSocket browser;
@@ -265,12 +255,13 @@ void OAuthClientFlowTest::testNonRedirectRequestIgnored()
 {
     MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
 
     flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
-    QTRY_VERIFY(!mBrowserUrl.isEmpty());
-    const QUrlQuery query(mBrowserUrl);
+    QTRY_VERIFY(!mAuthorizationUrl.isEmpty());
+    const QUrlQuery query(mAuthorizationUrl);
     const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
 
     // A browser side-request (no code/error) must be answered without ending the flow.
@@ -294,6 +285,7 @@ void OAuthClientFlowTest::testNonRedirectRequestIgnored()
 void OAuthClientFlowTest::testDiscoveryFetchFailureFailsFlow()
 {
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
     // A server that accepts the connection then closes it immediately guarantees the discovery
     // fetch fails deterministically, rather than relying on a host refusing a particular port.
@@ -305,6 +297,7 @@ void OAuthClientFlowTest::testDiscoveryFetchFailureFailsFlow()
 void OAuthClientFlowTest::testNonLoopbackHttpDiscoveryUrlRejected()
 {
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
     // Plain http is only acceptable for loopback hosts; anything else must be refused
     // before any network activity happens.
@@ -316,12 +309,13 @@ void OAuthClientFlowTest::testProviderErrorFailsFlow()
 {
     MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
 
     flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
-    QTRY_VERIFY(!mBrowserUrl.isEmpty());
-    const QUrlQuery query(mBrowserUrl);
+    QTRY_VERIFY(!mAuthorizationUrl.isEmpty());
+    const QUrlQuery query(mAuthorizationUrl);
     const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
 
     QTcpSocket browser;
@@ -337,12 +331,13 @@ void OAuthClientFlowTest::testEmptyCodeFailsFlow()
 {
     MiniDiscoveryServer discovery(QStringLiteral("http://127.0.0.1:1/authorize"));
     OAuthClientFlow flow;
+    connect(&flow, &OAuthClientFlow::authorizationUrlReady, this, &OAuthClientFlowTest::captureAuthorizationUrl);
     QSignalSpy capturedSpy(&flow, &OAuthClientFlow::authorizationCaptured);
     QSignalSpy failedSpy(&flow, &OAuthClientFlow::flowFailed);
 
     flow.start(discovery.discoveryUrl(), QStringLiteral("test-client"), {QStringLiteral("openid")}, false);
-    QTRY_VERIFY(!mBrowserUrl.isEmpty());
-    const QUrlQuery query(mBrowserUrl);
+    QTRY_VERIFY(!mAuthorizationUrl.isEmpty());
+    const QUrlQuery query(mAuthorizationUrl);
     const QUrl redirectUri(query.queryItemValue(QStringLiteral("redirect_uri"), QUrl::FullyDecoded));
 
     // A redirect with a matching state but an empty code (code= present but blank) must fail, not

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -123,7 +123,7 @@ set_tests_properties(TriggerSameLineMatchTest PROPERTIES
     TIMEOUT 300)
 
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
-set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 300)
+set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
 # InsertTextCapTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(InsertTextCapTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -25,11 +25,15 @@
 
 #include <QtTest/QtTest>
 #include <chrono>
+#include <QtNetwork/QSslCertificate>
+#include <QtNetwork/QSslKey>
+#include <QtNetwork/QSslSocket>
 #include <QtNetwork/QTcpServer>
 #include <QtNetwork/QTcpSocket>
 #include <QDesktopServices>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QUrlQuery>
 #include <functional>
 
 #include "CredentialManager.h"
@@ -41,12 +45,98 @@
 
 using namespace std::chrono_literals;
 
+// Self-signed loopback certificate, valid until 2126; the client accepts it via Host::mSslIgnoreAll.
+static const char* csmTestCertificatePem = R"PEM(-----BEGIN CERTIFICATE-----
+MIIDJzCCAg+gAwIBAgIULa4vwGAVOB+r6qtcLMPqwzBlEJgwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDgwNjE0MTM0OFoYDzIxMjYw
+NzEzMTQxMzQ4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDEg1HE09f69FW/OLD0jrWEQRbKkSkIkexLfV5OtzbI
+ZVDWcH3Y3NKrbZ60j8WEY8DqVzO2kMnOppc5LBEKGP1TTs6C9R+e5hlI6McoKown
+ha4aU9nqM7dsjY71xGZNN9DCVxhRpqadlZon7M4wzVvUO5VIRhFeA2AO6LRVQhyi
+9Whe/uJVlncb2tbiGgTavixWSQ5kH0ocE8Cp4SbuHuXPwgiZ9hYEIX2xAFSR48OB
+bjWgqVISptu/s+UkK2XckI42qdxqzwglLIIqjFYJ1HvGqhqV69DeqB0XNw6qp8W2
+qwTpv3gPGzI60vNL6aaHTivLxnsEClPbcrTfG1y8DnnLAgMBAAGjbzBtMB0GA1Ud
+DgQWBBSyDWWzo202vFbYncaD2crvY5V2pDAfBgNVHSMEGDAWgBSyDWWzo202vFbY
+ncaD2crvY5V2pDAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGCCWxvY2FsaG9z
+dIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAs5nw4GBPPHc9Nc08uLUYTDLkA2XM
+WPugjSO7OxUe8NptVh/v4GbeKzQ4FRIF6rca8De15+OOZgIDppRUoy+fd+ncoDan
+flw38rIj13XfV/3WF33Uag2xtZG0Hrpu4PFZQyIzr0MwGJJ/v2uRjMiV0CX+rc0L
+BJg2JS4oCbNdQpwH81qOktoH8aHirAyLjtm732GQgAGLe0fIBBsb4Dg2ZdvN+TF5
+xfKoFfri3H1rwju43zHXmUyCE/RPdIBR8flO6gzdgWAVY0jaixZi1fzQEQuReh2j
+d2iZYOFSrVDea41ltrUvRC6q6gxe/REVjj1nCSYU1x44J9DQ6n6ljvJCVw==
+-----END CERTIFICATE-----)PEM";
+
+static const char* csmTestPrivateKeyPem = R"PEM(-----BEGIN PRIVATE KEY-----
+MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDEg1HE09f69FW/
+OLD0jrWEQRbKkSkIkexLfV5OtzbIZVDWcH3Y3NKrbZ60j8WEY8DqVzO2kMnOppc5
+LBEKGP1TTs6C9R+e5hlI6McoKownha4aU9nqM7dsjY71xGZNN9DCVxhRpqadlZon
+7M4wzVvUO5VIRhFeA2AO6LRVQhyi9Whe/uJVlncb2tbiGgTavixWSQ5kH0ocE8Cp
+4SbuHuXPwgiZ9hYEIX2xAFSR48OBbjWgqVISptu/s+UkK2XckI42qdxqzwglLIIq
+jFYJ1HvGqhqV69DeqB0XNw6qp8W2qwTpv3gPGzI60vNL6aaHTivLxnsEClPbcrTf
+G1y8DnnLAgMBAAECggEBALRPHebwzfrI2CilttAeZXTdWDEzsifX5K17cd3eBBkp
+xVuNShuCupZq9bUNOhl4ghlDPALmpRTFDHp78YKHXWFkLN5CVeoxjL+2Po6fQ4w7
+/3zOtWNMYp/q32Kn+4ocjaLT0U+SDs0G6LR7dtGWjAyXQylWiTbu9+OWJ2kXSTlH
+QbdtamymoJrrjRTV1HUEq/a3qSHlqTA5/EKIcGeiETq2NR0fZ3NFbe+PLiOSpiNg
+uIiVEdsItuZTdINSEzOtMFvRd2od0ITDpMtLG404aGsI4Zisiuhr5naf4DWqK2aL
+n9Z/55LSuAdBqvrtJ9XVdtNsFdCRjbIj2R1qqDTFm/kCgYEA6W/+ufDXrhPi8XWS
+8+7tlOoUd0jYZL9N+N1hfho21SN3eH5TtNO0b/os/PN/M+5dKeWPtnyzwg49EksF
+Es9Z4+lLt/Z+71RDmYqSCwaLhXNKtUZluZmrGHcRogd4hJDYv9icgmpwMK5Hg634
+PYCgVYb9C1Wug/mZhgLg7Aw3hn8CgYEA14GxAPViaSszVNRps+a9WVEJklPbPR8U
+kAxWTP6n1SdT3Z9HRcHH9inIdTLyC/3ti4+4dc1pDkMrq+MUTjvF8BqN35uzJa7l
+6dnsXBmWvB1cIcwQb4SLnDb7jzmiK2uIjMrO54x3+atB83GdvESLOQ/9NAJL/+NX
+ILq5kAs2nrUCgYEAqq7/8pceLKNPybttMr0drEenpTx3NNsIORItydWDCD8BiPHd
+ZJdzFHk5Uc780EzWg97dQNJXYWmlz+1YjVNdZ57ahW1PjNDxCKBgfn1PoMkW9ArA
+MIAisSXGl9GcllmOkl/guB75Xy7fDXIz00xsb3zfIt2IV+k2Dt2l9hJMuyMCgYEA
+lv45ZHCJeSJZntANF41NkazjxfCXJaYHJD5goSWztfcOHbOhnlB9qA3yc5s0WA6c
+RzJ1jaRUPTf2+0HpUj8zGl2gldFjnb2DPWwA3S7YnAj+Knft9BSsNNGZQ+qfo0h+
+rhbTDQ0wanABj25FlEl6OornX29UjH9e5oGtziztIhkCgYEAppTHqOgLiKmeV15d
+i850uRyh7X6whywY8gm0VLO+xzCVsCR6CvgZY1MwwFuDwu2d/d5jdJXLpHueQwNU
+3HipTI77OuIRv4ykXwPOIemT9VmL/N21CgrckJGA6dYywTnc/JNpOKxdTM9srOyr
+Rcsgla9jttJevaHI71x2jLNBaKk=
+-----END PRIVATE KEY-----)PEM";
+
 extern void qInitResources_mudlet();
 extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
 static void initializeQRCResources();
+
+// Hands out QSslSocket connections when asked to, so the stub can offer an encrypted transport.
+class GmcpTcpServer : public QTcpServer
+{
+    Q_OBJECT
+
+public:
+    explicit GmcpTcpServer(QObject* parent = nullptr)
+    : QTcpServer(parent)
+    {
+    }
+
+    void setTls(bool tls) { mTls = tls; }
+
+protected:
+    void incomingConnection(qintptr socketDescriptor) override
+    {
+        if (!mTls) {
+            QTcpServer::incomingConnection(socketDescriptor);
+            return;
+        }
+        auto* socket = new QSslSocket(this);
+        if (!socket->setSocketDescriptor(socketDescriptor)) {
+            delete socket;
+            return;
+        }
+        socket->setLocalCertificate(QSslCertificate(QByteArray(csmTestCertificatePem)));
+        socket->setPrivateKey(QSslKey(QByteArray(csmTestPrivateKeyPem), QSsl::Rsa));
+        socket->startServerEncryption();
+        // QSslSocket buffers writes queued before the handshake, so this behaves like a plain socket.
+        addPendingConnection(socket);
+    }
+
+private:
+    bool mTls = false;
+};
 
 // A tiny GMCP-capable server: offers GMCP on connect, parses the telnet stream to
 // collect the client's GMCP messages, and can push Char.Login frames on demand.
@@ -65,8 +155,15 @@ public:
     // reads the actual port back via serverPort().
     bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
     quint16 serverPort() const { return mServer.serverPort(); }
+    void setTls(bool tls) { mServer.setTls(tls); }
 
     bool gmcpEnabled() const { return mGmcpEnabled; }
+    // So a test asserting on encrypted-transport behaviour cannot silently pass over a plain socket.
+    bool clientEncrypted() const
+    {
+        auto* sslClient = qobject_cast<QSslSocket*>(mClient.data());
+        return sslClient && sslClient->isEncrypted();
+    }
     QStringList receivedGmcp() const { return mReceivedGmcp; }
     void clearReceived() { mReceivedGmcp.clear(); }
 
@@ -200,7 +297,7 @@ private:
         mBuffer = mBuffer.mid(i);
     }
 
-    QTcpServer mServer;
+    GmcpTcpServer mServer;
     QPointer<QTcpSocket> mClient;
     QByteArray mBuffer;
     QStringList mReceivedGmcp;
@@ -208,20 +305,61 @@ private:
     int mConnectionCount = 0;
 };
 
+// Serves a static OpenID Connect discovery document over loopback http, which
+// OAuthClientFlow::acceptableEndpointUrl() permits, so no second certificate is needed.
+class DiscoveryServerStub : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit DiscoveryServerStub(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        connect(&mServer, &QTcpServer::newConnection, this, [this]() {
+            while (mServer.hasPendingConnections()) {
+                QTcpSocket* socket = mServer.nextPendingConnection();
+                connect(socket, &QTcpSocket::readyRead, socket, [this, socket]() {
+                    mRequests[socket] += socket->readAll();
+                    if (!mRequests.value(socket).contains("\r\n\r\n")) {
+                        return;
+                    }
+                    mRequests.remove(socket);
+                    const QByteArray body = QJsonDocument(QJsonObject{{qsl("authorization_endpoint"), authorizationEndpoint()}}).toJson(QJsonDocument::Compact);
+                    socket->write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " + QByteArray::number(body.size()) + "\r\nConnection: close\r\n\r\n" + body);
+                    socket->disconnectFromHost();
+                });
+                connect(socket, &QObject::destroyed, this, [this, socket]() {
+                    mRequests.remove(socket);
+                });
+                connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+            }
+        });
+    }
+
+    bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    QString discoveryUrl() const { return qsl("http://127.0.0.1:%1/.well-known/openid-configuration").arg(mServer.serverPort()); }
+    QString authorizationEndpoint() const { return qsl("http://127.0.0.1:%1/authorize").arg(mServer.serverPort()); }
+
+private:
+    QTcpServer mServer;
+    QHash<QTcpSocket*, QByteArray> mRequests;
+};
+
 class GMCPCharLoginTest : public QObject
 {
     Q_OBJECT
 
 public slots:
-    // Registered as the http/https URL handler so a Char.Login.URL the client auto-opens routes here
+    // Registered as the http/https URL handler so a sign-in address the client auto-opens routes here
     // instead of launching a real browser during the test.
-    void captureOpenedUrl(const QUrl& url) { mOpenedUrl = url; }
+    void captureOpenedUrl(const QUrl& url) { mOpenedUrls.append(url); }
 
 private:
     GmcpServerStub* mpServer = nullptr;
+    DiscoveryServerStub* mpDiscovery = nullptr;
     const QString mHostname = qsl("Test-CharLogin");
     quint16 mPort = 0; // assigned the stub's actual loopback port in init()
-    QUrl mOpenedUrl;
+    QList<QUrl> mOpenedUrls;
 
 private slots:
     void initTestCase()
@@ -245,7 +383,7 @@ private slots:
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
         mudlet::self()->init();
         mudlet::self()->setStorePasswordsSecurely(false);
-        mOpenedUrl.clear();
+        mOpenedUrls.clear();
         // Start each test from a clean credential state so a reconnect token saved by an earlier test
         // cannot leak into one that expects none (which would make the client replay it instead).
         CredentialManager::removeCredential(mHostname, qsl("reconnect"));
@@ -256,6 +394,8 @@ private slots:
     {
         delete mpServer;
         mpServer = nullptr;
+        delete mpDiscovery;
+        mpDiscovery = nullptr;
         deleteProfileDirectory(mHostname);
         delete mudlet::self();
     }
@@ -384,7 +524,7 @@ private slots:
 
     void testSavedTokenIsReplayedOnReconnect()
     {
-        Host* host = connectAndNegotiate();
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         host->setLogin(QString());
         host->setPass(QString());
@@ -402,9 +542,55 @@ private slots:
         QCOMPARE(sent.value(qsl("version")).toInt(), 2);
     }
 
-    void testRejectedReconnectTokenIsDiscarded()
+    void testSavedTokenIsNotReplayedOverCleartext()
     {
         Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        QVERIFY2(!host->mTelnet.currentlySecure(), "precondition: this connection is unencrypted");
+        host->setLogin(QString());
+        host->setPass(QString());
+        const QString tokenJson = qsl("{\"account\": \"acct:char\", \"token\": \"saved-token\"}");
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), tokenJson));
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "the sign-in should fall back to the interactive hand-off");
+        QVERIFY2(sent.isEmpty(), "the fall-back must be the empty {} hand-off");
+        QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
+        QVERIFY2(waitForConsoleContains(host, qsl("not encrypted")), "the user should be told why their saved sign-in was not used");
+        QVERIFY2(!CredentialManager::retrieveCredential(host->getName(), qsl("reconnect")).isEmpty(), "refusing to send the token must not destroy it");
+
+        // Nothing awaits a reconnect result, so an ordinary failed sign-in must not be mistaken for a
+        // rejected token - that would rewrite or delete the stored entry the player still needs.
+        mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Invalid credentials\"}"));
+        QVERIFY2(waitForConsoleContains(host, qsl("Could not log in to the game")), "a failed interactive sign-in should be reported as one");
+        QVERIFY2(!CredentialManager::retrieveCredential(host->getName(), qsl("reconnect")).isEmpty(), "the stored sign-in must survive an unrelated login failure");
+    }
+
+    void testCleartextTokenFallsBackToProviderResume()
+    {
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+        const QString tokenJson = qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"saved-token\"}");
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), tokenJson));
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not send the resume form");
+        QCOMPARE(sent.value(qsl("provider")).toString(), qsl("discord"));
+        QVERIFY2(!sent.contains(qsl("token")), "the resume form must not carry the token");
+        QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
+    }
+
+    void testRejectedReconnectTokenIsDiscarded()
+    {
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         host->setLogin(QString());
         host->setPass(QString());
@@ -426,7 +612,7 @@ private slots:
 
     void testRejectedReconnectKeepsResumeHint()
     {
-        Host* host = connectAndNegotiate();
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         host->setLogin(QString());
         host->setPass(QString());
@@ -491,7 +677,7 @@ private slots:
 
     void testRotatedTokenIsReplayedNotDiscarded()
     {
-        Host* host = connectAndNegotiate();
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         host->setLogin(QString());
         host->setPass(QString());
@@ -532,7 +718,7 @@ private slots:
 
     void testRotationReplayClearsTheRejectionLatch()
     {
-        Host* host = connectAndNegotiate();
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         host->setLogin(QString());
         host->setPass(QString());
@@ -622,7 +808,7 @@ private slots:
 
     void testStoredCredentialsOutrankSavedToken()
     {
-        Host* host = connectAndNegotiate();
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         // Both a saved reconnect token AND stored character name/password are present. The player's
         // typed credentials name the exact character, so they must win: the client sends
@@ -652,17 +838,40 @@ private slots:
         // Simulate the player having acted on the game's sign-in screen this connection; an unsolicited
         // Char.Login.URL is then a consequence of their input and must be auto-opened in the browser.
         host->setUserSentInputThisConnection(true);
-        mOpenedUrl.clear();
+        mOpenedUrls.clear();
         mpServer->sendGmcp(qsl("Char.Login.URL {\"url\": \"https://example.com/signin\", \"provider\": \"discord\"}"));
         QVERIFY2(waitForConsoleContains(host, qsl("Opening your browser to sign in with Discord")), "a prompted URL should be auto-opened with a provider-labelled handoff");
-        QCOMPARE(mOpenedUrl, QUrl(qsl("https://example.com/signin")));
+        QCOMPARE(mOpenedUrls, QList<QUrl>{QUrl(qsl("https://example.com/signin"))});
+    }
+
+    void testRepeatedAuthUrlsOpenOneBrowserPerUserAction()
+    {
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        host->setUserSentInputThisConnection(true);
+        mOpenedUrls.clear();
+
+        for (int i = 1; i <= 5; ++i) {
+            mpServer->sendGmcp(qsl("Char.Login.URL {\"url\": \"https://example.com/signin%1\"}").arg(i));
+        }
+        // GMCP frames are handled in order, so a reply to this one proves all five were processed.
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"password-credentials\"]}"));
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not work through the pushed sign-in addresses");
+        QCOMPARE(mOpenedUrls, QList<QUrl>{QUrl(qsl("https://example.com/signin1"))});
+
+        // A further player action re-arms it: a rate limit, not a one-per-connection cap.
+        host->setUserSentInputThisConnection(true);
+        mpServer->sendGmcp(qsl("Char.Login.URL {\"url\": \"https://example.com/signin6\"}"));
+        QTRY_COMPARE(mOpenedUrls.size(), 2);
+        QCOMPARE(mOpenedUrls.at(1), QUrl(qsl("https://example.com/signin6")));
     }
 
     // ---- Post-rejection loop guard (allowToken == false) -------------------
 
     void testReconnectAfterRejectionDoesNotReplayToken()
     {
-        Host* host = connectAndNegotiate();
+        Host* host = connectAndNegotiate(true);
         QVERIFY(host);
         host->setLogin(QString());
         host->setPass(QString());
@@ -708,6 +917,112 @@ private slots:
     // mReconnectRejected. Getting either wrong loses a player's freshly saved token or lets a rejected one
     // be replayed, and neither failure is reachable by hand.
 
+    // ---- Client-driven OAuth (Char.Login.AuthCode) -------------------------
+
+    void testClientDrivenOAuthOpensOneBrowserPerConnection()
+    {
+        Host* host = connectAndNegotiate(true);
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+        QVERIFY2(!host->userSentInputThisConnection(), "precondition: no user input yet");
+        startDiscoveryServer();
+        mOpenedUrls.clear();
+
+        // Connecting is itself the request, so the first offer opens the browser with nothing typed.
+        mpServer->sendGmcp(clientDrivenDefault());
+        QTRY_COMPARE(mOpenedUrls.size(), 1);
+
+        for (int i = 0; i < 4; ++i) {
+            mpServer->sendGmcp(clientDrivenDefault());
+        }
+        QVERIFY2(waitForConsoleContains(host, qsl("To sign in, open this link")), "a re-offered client-driven sign-in should be offered as a link");
+        QCOMPARE(mOpenedUrls.size(), 1);
+    }
+
+    void testAuthCodeCarriesTheNonceTheServerAskedFor()
+    {
+        Host* host = connectAndNegotiate(true);
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+        startDiscoveryServer();
+        mOpenedUrls.clear();
+        mpServer->clearReceived();
+
+        mpServer->sendGmcp(clientDrivenDefault());
+        QTRY_VERIFY(!mOpenedUrls.isEmpty());
+        const QUrlQuery authorizationQuery(mOpenedUrls.first());
+        const QString nonce = authorizationQuery.queryItemValue(qsl("nonce"));
+        QVERIFY2(!nonce.isEmpty(), "the authorization request should carry a nonce when the server asked for one");
+
+        // Play the identity provider: send the browser's redirect back to the loopback listener.
+        const QUrl redirectUri(authorizationQuery.queryItemValue(qsl("redirect_uri"), QUrl::FullyDecoded));
+        QTcpSocket browser;
+        browser.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+        QVERIFY(browser.waitForConnected(3000));
+        browser.write("GET /?code=test-auth-code&state=" + authorizationQuery.queryItemValue(qsl("state")).toLatin1() + " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.AuthCode"), sent), "client did not complete the client-driven sign-in");
+        QCOMPARE(sent.value(qsl("code")).toString(), qsl("test-auth-code"));
+        QVERIFY(!sent.value(qsl("code_verifier")).toString().isEmpty());
+        QCOMPARE(sent.value(qsl("redirect_uri")).toString(), redirectUri.toString());
+        QCOMPARE(sent.value(qsl("nonce")).toString(), nonce);
+    }
+
+    void testAuthCodeOmitsTheNonceWhenTheServerDidNotAskForIt()
+    {
+        Host* host = connectAndNegotiate(true);
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+        startDiscoveryServer();
+        mOpenedUrls.clear();
+        mpServer->clearReceived();
+
+        mpServer->sendGmcp(clientDrivenDefault(false));
+        QTRY_VERIFY(!mOpenedUrls.isEmpty());
+        const QUrlQuery authorizationQuery(mOpenedUrls.first());
+        QVERIFY2(!authorizationQuery.hasQueryItem(qsl("nonce")), "no nonce should be requested from the provider either");
+
+        const QUrl redirectUri(authorizationQuery.queryItemValue(qsl("redirect_uri"), QUrl::FullyDecoded));
+        QTcpSocket browser;
+        browser.connectToHost(redirectUri.host(), static_cast<quint16>(redirectUri.port()));
+        QVERIFY(browser.waitForConnected(3000));
+        browser.write("GET /?code=test-auth-code&state=" + authorizationQuery.queryItemValue(qsl("state")).toLatin1() + " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.AuthCode"), sent), "client did not complete the client-driven sign-in");
+        QVERIFY2(!sent.contains(qsl("nonce")), "an empty nonce must be left out rather than sent as an empty string");
+    }
+
+    // ---- Char.Login.Default flood ------------------------------------------
+
+    void testDefaultFloodIsThrottled()
+    {
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+
+        mpServer->clearReceived();
+        for (int i = 0; i < 200; ++i) {
+            mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+        }
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "the first frame should still be answered straight away");
+
+        // Cost is bounded by wall clock, not by how much the server sent: one immediate attempt plus
+        // one when the window closes, not 200. A range, so a loaded runner slipping into the next
+        // window does not flake, and a lower bound because a re-offer must still be answered.
+        QTest::qWait(2500ms);
+        const int attempts = mpServer->countReceived(qsl("Char.Login.Credentials"));
+        QVERIFY2(attempts >= 2, qPrintable(qsl("a throttled burst must still be answered, saw %1 attempts").arg(attempts)));
+        QVERIFY2(attempts <= 4, qPrintable(qsl("200 frames should not buy 200 sign-in attempts, saw %1").arg(attempts)));
+    }
+
     // ---- Char.Login.Result --------------------------------------------------
 
     void testFailedResultReportsError()
@@ -727,8 +1042,44 @@ private slots:
     }
 
 private:
-    // Drive the GUI to create/connect a profile, then wait for GMCP to negotiate.
-    Host* connectAndNegotiate()
+    void startDiscoveryServer()
+    {
+        mpDiscovery = new DiscoveryServerStub();
+        QVERIFY(mpDiscovery->start());
+    }
+
+    // Advertises the client-driven OAuth capability, which the client only honours over TLS.
+    QString clientDrivenDefault(bool requestNonce = true) const
+    {
+        return qsl(R"(Char.Login.Default {"version": 2, "type": ["oauth"], "location": "%1", "client_id": "test-client", "nonce": %2})")
+                .arg(mpDiscovery->discoveryUrl(), requestNonce ? qsl("true") : qsl("false"));
+    }
+
+    // Drive the GUI to create/connect a profile, then wait for GMCP to negotiate. Reaching TLS by
+    // reconnecting rather than creating the profile encrypted is what makes this deterministic:
+    // mSslTsl and mSslIgnoreAll are set on a live Host, before the attempt that reads them starts.
+    Host* connectAndNegotiate(bool secure = false)
+    {
+        Host* host = createProfileAndConnect();
+        if (!host || !secure) {
+            return host;
+        }
+        host->mSslTsl = true;
+        host->mSslIgnoreAll = true; // the stub's certificate is self-signed
+        mpServer->setTls(true);
+        const int plainConnection = mpServer->connectionCount();
+        host->mTelnet.reconnect();
+        if (!waitForNegotiatedConnection(plainConnection)) {
+            return nullptr;
+        }
+        if (!mpServer->clientEncrypted()) {
+            qWarning("The connection did not complete a TLS handshake");
+            return nullptr;
+        }
+        return host;
+    }
+
+    Host* createProfileAndConnect()
     {
         const QString port = QString::number(mPort);
         QTimer::singleShot(0ms, qApp, [this, port]() {
@@ -749,8 +1100,9 @@ private:
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 
+        // A fresh mudlet and profile per test on an instrumented, loaded runner is slow.
         QSignalSpy loaded(mudlet::self(), &mudlet::signal_profileLoaded);
-        if (!loaded.wait(5000)) {
+        if (!loaded.wait(20000)) {
             qWarning("Profile took too long to load");
             return nullptr;
         }
@@ -759,22 +1111,21 @@ private:
             qWarning("No active host");
             return nullptr;
         }
-        QSignalSpy connected(&(host->mTelnet), &cTelnet::signal_connected);
-        if (!connected.wait(3000)) {
-            qWarning("Could not connect to the stub");
-            return nullptr;
-        }
-        // Wait until the client has answered our GMCP offer (IAC DO GMCP) so that
-        // Char.Login frames we push afterwards are processed.
-        const bool negotiated = QTest::qWaitFor(
-                [this]() {
-                    return mpServer->gmcpEnabled();
+        return waitForNegotiatedConnection(0) ? host : nullptr;
+    }
+
+    // Also waits for the client to answer our GMCP offer, so frames pushed afterwards are processed.
+    bool waitForNegotiatedConnection(int afterConnectionCount)
+    {
+        const bool connected = QTest::qWaitFor(
+                [this, afterConnectionCount]() {
+                    return mpServer->connectionCount() > afterConnectionCount && mpServer->gmcpEnabled();
                 },
-                3000);
-        if (!negotiated) {
-            qWarning("GMCP was not negotiated");
+                15000);
+        if (!connected) {
+            qWarning("Could not connect to the stub, or GMCP was not negotiated");
         }
-        return host;
+        return connected;
     }
 
     // Wait until the client sends a GMCP message whose package matches, returning its JSON body.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Four security fixes to the GMCP `Char.Login` v2 browser sign-in added in #9378 *Add: sign in to supported games using your browser (e.g. Google, Discord, or the game's own account)*, found by the 5.0 QA sweep and reproduced on the wire. The game server is untrusted throughout: Mudlet connects to arbitrary user-specified MUDs.

- **A saved sign-in no longer goes out in the clear.** `Char.Login.Reconnect` carries a bearer token that signs into the player's account without their password, and Mudlet replayed it on whatever transport was live at the time - so a sign-in earned over TLS went out over plain telnet on the next connect. It is now refused on a cleartext transport, mirroring the `Char.Login.AuthCode` guard already in the same file; the player is told why and the sign-in falls back to the provider resume or the game's own sign-in screen.
- **A server can no longer open browser tabs at will.** The client-driven OAuth path reached `QDesktopServices::openUrl()` with a server-chosen address and no guard at all, once per frame the server sent (5 frames measured, 5 tabs). Both flows now go through one decision point with a budget of one automatic hand-off per connection, refilled whenever the player sends something to the game. The client-driven flow still opens the browser on connect - that is the sign-in the player came for - but a burst of frames buys one tab, not a tab each, and `Char.Login.URL`, which a server may push at any moment, still needs actual input first.
- **The OIDC nonce reaches the game, and a `Char.Login.Default` flood no longer buys credential-store churn.** With `"nonce": true` Mudlet generated a nonce and put it in the authorization URL but never sent it on, so the party that actually validates the ID token could not check its `nonce` claim; it now rides in `Char.Login.AuthCode`. Separately each `Char.Login.Default` frame started a fresh credential-store read (a 114 KB flood measured 4002 reads); sign-in attempts are now throttled to one per second, and dropped outright if the connection that scheduled them has gone.

#### Motivation for adding to Mudlet

All four are new in 5.0 and none was covered by a test, which is why they shipped. The token replay is the serious one: it hands a password-equivalent account credential to anyone on the path.

Two decisions worth a second opinion:

- The Char.Login 2 draft on Area 51 defines no `nonce` field in `Char.Login.AuthCode`, so this adds one. Without it `"nonce": true` cannot mean anything - nobody is in a position to verify the value. **The spec needs the field added to match.**
- The same draft explicitly permits sending the reconnect token over plain telnet ("a server may choose to issue and accept tokens only over `telnets://`"). It does not require a client to, so refusing is conformant, but it is deliberately stricter than the spec.

#### Other info (issues closed, discussion etc)



Test case: connect a profile with a saved sign-in to a game offering `Char.Login 2` over plain telnet - Mudlet says the connection is not encrypted and hands off to the game's own sign-in screen instead of replaying the token.

`GMCPCharLoginTest` gains a TLS-capable stub (embedded self-signed loopback certificate) and a loopback OpenID discovery stub, so the encrypted-transport and client-driven paths are exercised for real rather than assumed. The seven existing token tests move onto it, which is itself the proof that they were previously passing over cleartext. 80/80 `ctest` green.

Assisted-by: Claude:claude-opus-5
