### PR TITLE
fix: a profile named "." or ".." deletes every profile when removed

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2187,8 +2187,12 @@ bool dlgConnectionProfiles::validateProfile()
         // whitespace too, as the entered name always arrives trimmed. Names
         // the rest of Mudlet cannot work with get no exemption: renaming them
         // is worse for the user than a profile whose password never saves.
+        // The exemption needs a folder that is genuinely the profile's own:
+        // "." and ".." also name something that exists, but not a profile.
         const QString selectedName = pItem->data(csmNameRole).toString();
-        const bool nameUnchangedAndOnDisk = (name == selectedName.trimmed()) && profileNameUsableAsIs(name) && QDir(mudlet::getMudletPath(enums::profileHomePath, selectedName)).exists();
+        const QString selectedFolder = profileFolderPath(mudlet::getMudletPath(enums::profilesPath), selectedName);
+        const bool nameIsFolderOnDisk = (name == selectedName.trimmed()) && !selectedFolder.isEmpty() && QDir(selectedFolder).exists();
+        const bool nameUnchangedAndOnDisk = nameIsFolderOnDisk && profileNameUsableAsIs(name);
         const QChar invalidChar = nameUnchangedAndOnDisk ? QChar() : firstInvalidProfileNameChar(name);
         if (!invalidChar.isNull()) {
             notificationAreaIconLabelWarning->show();
@@ -2198,10 +2202,12 @@ bool dlgConnectionProfiles::validateProfile()
             profile_name_entry->setText(name);
             validName = false;
             valid = false;
-        } else if (!nameUnchangedAndOnDisk && !name.isEmpty() && !profileNameUsableAsIs(name)) {
+        } else if (!nameIsFolderOnDisk && !name.isEmpty() && !profileNameUsableAsIs(name)) {
             // Every character is permitted on its own, but the name as a whole
             // still cannot be a folder of its own - there is nothing sensible
-            // to strip out of it, so leave it for the user to change:
+            // to strip out of it, so leave it for the user to change. A folder
+            // that really is on disk is exempt even from this: it loads today,
+            // and refusing it would stop the user reaching their own data.
             notificationAreaIconLabelWarning->show();
             notificationAreaMessageBox->setText(qsl("%1\n%2\n")
                                                         .arg(notificationAreaMessageBox->text(),

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -79,26 +79,21 @@ QChar dlgConnectionProfiles::firstInvalidProfileNameChar(const QString& name)
 // retrieve its password. Mirrors the pattern used there:
 const QRegularExpression dlgConnectionProfiles::scmUnusableProfileNameChars{qsl(R"REGEX(\.\.|[/\\<>:"|?*\x00-\x1f])REGEX")};
 
-// Whether an existing profile folder can be taken as-is instead of being put
-// through the stricter rules that apply to names typed into the dialog. A lone
-// "." is made entirely of permitted characters, yet every path built from it
-// addresses the profiles directory itself rather than a profile of its own -
+// A lone "." is made entirely of permitted characters, yet every path built
+// from it addresses the profiles directory rather than a profile of its own -
 // as does "..", which scmUnusableProfileNameChars already covers:
 bool dlgConnectionProfiles::profileNameUsableAsIs(const QString& name)
 {
     return !name.isEmpty() && name != qsl(".") && !name.contains(scmUnusableProfileNameChars);
 }
 
-// The folder holding a profile's data, or an empty string when the name does
-// not address a folder directly inside profilesPath. Resolved textually rather
-// than with QDir::canonicalPath() so that the answer does not depend on the
-// folder existing - the predefined games have no folder until they are saved -
-// and so that a profile folder which is a symbolic link keeps working.
+// Resolved textually rather than with QDir::canonicalPath() so that the answer
+// does not depend on the folder existing - a predefined game has none until it
+// is saved - and so that a symlinked profile folder still resolves.
 QString dlgConnectionProfiles::profileFolderPath(const QString& profilesPath, const QString& profile)
 {
-    // A name carrying a separator has to go before the parent check below, which
-    // QDir::cleanPath() would otherwise satisfy by collapsing "../profiles/Foo"
-    // straight back into the profiles directory:
+    // Must precede the parent check below, which QDir::cleanPath() would
+    // otherwise satisfy by collapsing "../profiles/Foo" straight back in:
     if (profile.isEmpty() || profile.contains(QLatin1Char('/')) || profile.contains(QLatin1Char('\\'))) {
         return {};
     }
@@ -1050,8 +1045,8 @@ void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
 
     QDir dir(profileFolder);
     if (!dir.removeRecursively()) {
-        // The profile is still on disk, so leave its stored password alone and
-        // leave it listed - removing either would strand the data that is left
+        // the profile is still on disk, so its password and its list entry stay:
+        // removing either would strand the data that is left
         qWarning().nospace() << "dlgConnectionProfiles::reallyDeleteProfile(\"" << profile << "\") ERROR - could not completely remove \"" << profileFolder << "\".";
         fillout_form();
         //: %1 is a profile name. Shown when some of the profile's files could not be deleted, e.g. because another program has them open
@@ -1123,14 +1118,10 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    // Everything a profile accumulates in use - saved games, maps, logs, media,
-    // packages - is a sub-directory, so a profile without one has never been
-    // played: that is how a predefined game looks until it is selected and has
-    // its connection details written out. Not all of a profile is directories
-    // though, so the loose files are matched against those details by name - a
-    // stored password or a personal dictionary sits among them and is the
-    // user's own. Listing what is expected, rather than what to watch out for,
-    // keeps an unrecognised file on the side of asking:
+    // A profile that has never been played holds nothing but the connection
+    // details written out when it was selected. Listing what is expected rather
+    // than what to watch out for keeps an unrecognised file - a stored password,
+    // a personal dictionary - on the side of asking:
     static const QStringList connectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
     const QDir profileDir(mudlet::getMudletPath(enums::profileHomePath, profile));
     bool nothingToLose = !profileDir.exists() || profileDir.entryList(QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot).isEmpty();
@@ -1176,9 +1167,8 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    // Each confirmation carries the profile it was raised for. It is not modal,
-    // so by the time it is answered the list selection may have moved on, and a
-    // second confirmation for a different profile may be open alongside it.
+    // The confirmation is not modal, so by the time it is answered the selection
+    // may have moved on, or a second confirmation may be open alongside it:
     connect(nameEntry, &QLineEdit::textChanged, delete_profile_dialog, [deleteButton, profile](const QString& text) {
         deleteButton->setEnabled(text == profile);
         if (deleteButton->isEnabled()) {
@@ -2226,8 +2216,8 @@ bool dlgConnectionProfiles::validateProfile()
         // whitespace too, as the entered name always arrives trimmed. Names
         // the rest of Mudlet cannot work with get no exemption: renaming them
         // is worse for the user than a profile whose password never saves.
-        // The exemption needs a folder that is genuinely the profile's own:
-        // "." and ".." also name something that exists, but not a profile.
+        // "." and ".." name something that exists without being a profile, so
+        // the exemption needs a folder that is genuinely the profile's own.
         const QString selectedName = pItem->data(csmNameRole).toString();
         const QString selectedFolder = profileFolderPath(mudlet::getMudletPath(enums::profilesPath), selectedName);
         const bool nameIsFolderOnDisk = (name == selectedName.trimmed()) && !selectedFolder.isEmpty() && QDir(selectedFolder).exists();
@@ -2242,11 +2232,8 @@ bool dlgConnectionProfiles::validateProfile()
             validName = false;
             valid = false;
         } else if (!nameIsFolderOnDisk && !name.isEmpty() && !profileNameUsableAsIs(name)) {
-            // Every character is permitted on its own, but the name as a whole
-            // still cannot be a folder of its own - there is nothing sensible
-            // to strip out of it, so leave it for the user to change. A folder
-            // that really is on disk is exempt even from this: it loads today,
-            // and refusing it would stop the user reaching their own data.
+            // Nothing to strip here, unlike the branch above: the characters
+            // are all permitted, it is the whole name that cannot be a folder
             notificationAreaIconLabelWarning->show();
             notificationAreaMessageBox->setText(
                     qsl("%1\n%2\n")

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -79,10 +79,11 @@ QChar dlgConnectionProfiles::firstInvalidProfileNameChar(const QString& name)
 // retrieve its password. Mirrors the pattern used there:
 const QRegularExpression dlgConnectionProfiles::scmUnusableProfileNameChars{qsl(R"REGEX(\.\.|[/\\<>:"|?*\x00-\x1f])REGEX")};
 
-// Whether a name can be used for a profile. A lone "." is made entirely of
-// permitted characters, yet every path built from it addresses the profiles
-// directory itself rather than a profile of its own - as does "..", which the
-// regex above already covers:
+// Whether an existing profile folder can be taken as-is instead of being put
+// through the stricter rules that apply to names typed into the dialog. A lone
+// "." is made entirely of permitted characters, yet every path built from it
+// addresses the profiles directory itself rather than a profile of its own -
+// as does "..", which scmUnusableProfileNameChars already covers:
 bool dlgConnectionProfiles::profileNameUsableAsIs(const QString& name)
 {
     return !name.isEmpty() && name != qsl(".") && !name.contains(scmUnusableProfileNameChars);
@@ -95,6 +96,9 @@ bool dlgConnectionProfiles::profileNameUsableAsIs(const QString& name)
 // and so that a profile folder which is a symbolic link keeps working.
 QString dlgConnectionProfiles::profileFolderPath(const QString& profilesPath, const QString& profile)
 {
+    // A name carrying a separator has to go before the parent check below, which
+    // QDir::cleanPath() would otherwise satisfy by collapsing "../profiles/Foo"
+    // straight back into the profiles directory:
     if (profile.isEmpty() || profile.contains(QLatin1Char('/')) || profile.contains(QLatin1Char('\\'))) {
         return {};
     }
@@ -1020,33 +1024,40 @@ void dlgConnectionProfiles::slot_addProfile()
     connect_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
 }
 
-// enables the deletion button once the correct text (profile name) is entered
-void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
+void dlgConnectionProfiles::showRemovalProblem(const QString& message)
 {
-    if (mProfileToDelete != text) {
-        delete_button->setEnabled(false);
-    } else {
-        delete_button->setEnabled(true);
-        delete_button->setFocus();
-    }
-}
-
-// actually performs the deletion once the correct text has been entered
-void dlgConnectionProfiles::slot_reallyDeleteProfile()
-{
-    reallyDeleteProfile(mProfileToDelete);
+    notificationArea->show();
+    notificationAreaIconLabelWarning->show();
+    notificationAreaIconLabelError->hide();
+    notificationAreaIconLabelInformation->hide();
+    notificationAreaMessageBox->show();
+    notificationAreaMessageBox->setText(message);
 }
 
 void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
 {
-    const QString profileFolder = profileFolderPath(mudlet::getMudletPath(enums::profilesPath), profile);
+    const QString profilesPath = mudlet::getMudletPath(enums::profilesPath);
+    const QString profileFolder = profileFolderPath(profilesPath, profile);
     if (profileFolder.isEmpty()) {
-        qWarning().nospace() << "dlgConnectionProfiles::reallyDeleteProfile(\"" << profile << "\") ERROR - refusing to delete: that name does not belong to a folder inside the profiles directory.";
+        qWarning().nospace() << "dlgConnectionProfiles::reallyDeleteProfile(\"" << profile << "\") ERROR - refusing to delete: that name does not address a folder inside \"" << profilesPath << "\".";
+        // rebuild the list first: it re-selects a profile, and that clears the
+        // notification area on its way through validateProfile()
+        fillout_form();
+        //: %1 is a profile name that does not name a folder of its own, so there is nothing that could be removed for it
+        showRemovalProblem(tr("'%1' has no profile folder of its own, so there is nothing to remove.").arg(profile));
         return;
     }
 
     QDir dir(profileFolder);
-    dir.removeRecursively();
+    if (!dir.removeRecursively()) {
+        // The profile is still on disk, so leave its stored password alone and
+        // leave it listed - removing either would strand the data that is left
+        qWarning().nospace() << "dlgConnectionProfiles::reallyDeleteProfile(\"" << profile << "\") ERROR - could not completely remove \"" << profileFolder << "\".";
+        fillout_form();
+        //: %1 is a profile name. Shown when some of the profile's files could not be deleted, e.g. because another program has them open
+        showRemovalProblem(tr("Could not remove everything belonging to '%1'. Close it if it is open elsewhere, check that you may write to its folder, and try again.").arg(profile));
+        return;
+    }
 
     // Clean up keychain entries for the deleted profile
     // Note: CredentialManager only supports one operation at a time, so we must
@@ -1112,13 +1123,26 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    // Skip the confirmation only when there is nothing in the profile folder
-    // the user could miss. Everything they would - saved games, maps, logs,
-    // media, packages, locally stored passwords - lives in a sub-directory,
-    // while the loose files at the top are the connection details this dialog
-    // writes there itself, which a predefined game gets just by being listed:
-    const QDir profileDirContents(mudlet::getMudletPath(enums::profileHomePath, profile));
-    if (!profileDirContents.exists() || profileDirContents.entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty()) {
+    // Everything a profile accumulates in use - saved games, maps, logs, media,
+    // packages - is a sub-directory, so a profile without one has never been
+    // played: that is how a predefined game looks until it is selected and has
+    // its connection details written out. Not all of a profile is directories
+    // though, so the loose files are matched against those details by name - a
+    // stored password or a personal dictionary sits among them and is the
+    // user's own. Listing what is expected, rather than what to watch out for,
+    // keeps an unrecognised file on the side of asking:
+    static const QStringList connectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
+    const QDir profileDir(mudlet::getMudletPath(enums::profileHomePath, profile));
+    bool nothingToLose = !profileDir.exists() || profileDir.entryList(QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot).isEmpty();
+    if (nothingToLose) {
+        for (const QString& fileName : profileDir.entryList(QDir::Files | QDir::Hidden)) {
+            if (!connectionDetailFiles.contains(fileName)) {
+                nothingToLose = false;
+                break;
+            }
+        }
+    }
+    if (nothingToLose) {
         reallyDeleteProfile(profile);
         return;
     }
@@ -1135,24 +1159,39 @@ void dlgConnectionProfiles::slot_deleteProfile()
     file.close();
 
     if (!delete_profile_dialog) {
+        qWarning() << "dlgConnectionProfiles::slot_deleteProfile() ERROR - the deletion confirmation did not load as a dialog.";
+        //: %1 is a profile name. Shown when the dialog asking the user to confirm a removal could not be built
+        showRemovalProblem(tr("Could not open the confirmation, so '%1' has not been removed.").arg(profile));
         return;
     }
 
-    delete_profile_lineedit = delete_profile_dialog->findChild<QLineEdit*>(qsl("delete_profile_lineedit"));
-    delete_button = delete_profile_dialog->findChild<QPushButton*>(qsl("delete_button"));
-    auto* cancel_button = delete_profile_dialog->findChild<QPushButton*>(qsl("cancel_button"));
+    auto* nameEntry = delete_profile_dialog->findChild<QLineEdit*>(qsl("delete_profile_lineedit"));
+    auto* deleteButton = delete_profile_dialog->findChild<QPushButton*>(qsl("delete_button"));
+    auto* cancelButton = delete_profile_dialog->findChild<QPushButton*>(qsl("cancel_button"));
 
-    if (!delete_profile_lineedit || !delete_button || !cancel_button) {
+    if (!nameEntry || !deleteButton || !cancelButton) {
+        qWarning() << "dlgConnectionProfiles::slot_deleteProfile() ERROR - the deletion confirmation is missing one of its widgets.";
+        showRemovalProblem(tr("Could not open the confirmation, so '%1' has not been removed.").arg(profile));
+        delete delete_profile_dialog;
         return;
     }
 
-    mProfileToDelete = profile;
-    connect(delete_profile_lineedit, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_deleteProfileCheck);
-    connect(delete_profile_dialog, &QDialog::accepted, this, &dlgConnectionProfiles::slot_reallyDeleteProfile);
+    // Each confirmation carries the profile it was raised for. It is not modal,
+    // so by the time it is answered the list selection may have moved on, and a
+    // second confirmation for a different profile may be open alongside it.
+    connect(nameEntry, &QLineEdit::textChanged, delete_profile_dialog, [deleteButton, profile](const QString& text) {
+        deleteButton->setEnabled(text == profile);
+        if (deleteButton->isEnabled()) {
+            deleteButton->setFocus();
+        }
+    });
+    connect(delete_profile_dialog, &QDialog::accepted, this, [this, profile]() {
+        reallyDeleteProfile(profile);
+    });
 
-    delete_profile_lineedit->setPlaceholderText(profile);
-    delete_profile_lineedit->setFocus();
-    delete_button->setEnabled(false);
+    nameEntry->setPlaceholderText(profile);
+    nameEntry->setFocus();
+    deleteButton->setEnabled(false);
     delete_profile_dialog->setWindowTitle(tr("Deleting '%1'").arg(profile));
     delete_profile_dialog->setAttribute(Qt::WA_DeleteOnClose);
 
@@ -2209,10 +2248,11 @@ bool dlgConnectionProfiles::validateProfile()
             // that really is on disk is exempt even from this: it loads today,
             // and refusing it would stop the user reaching their own data.
             notificationAreaIconLabelWarning->show();
-            notificationAreaMessageBox->setText(qsl("%1\n%2\n")
-                                                        .arg(notificationAreaMessageBox->text(),
-                                                             //: Shown when a profile name cannot be used for a folder of its own, e.g. "." or a name containing ".."
-                                                             tr("This name cannot be used for a profile. Please pick a different one.")));
+            notificationAreaMessageBox->setText(
+                    qsl("%1\n%2\n")
+                            .arg(notificationAreaMessageBox->text(),
+                                 //: Shown when a profile name would not name a folder of its own. Keep the quoted dots as they are, they are literal characters the user typed
+                                 tr("A profile name cannot be \".\" or contain \"..\", as those refer to other folders on your computer. Please pick a different name.")));
             validName = false;
             valid = false;
         }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -41,6 +41,7 @@
 #include <QApplication>
 #include <QColorDialog>
 #include <QDir>
+#include <QFileInfo>
 #include <QPointer>
 #include <QRandomGenerator>
 #include <QSettings>
@@ -78,11 +79,32 @@ QChar dlgConnectionProfiles::firstInvalidProfileNameChar(const QString& name)
 // retrieve its password. Mirrors the pattern used there:
 const QRegularExpression dlgConnectionProfiles::scmUnusableProfileNameChars{qsl(R"REGEX(\.\.|[/\\<>:"|?*\x00-\x1f])REGEX")};
 
-// Whether an existing profile folder can be taken as-is instead of being put
-// through the stricter rules that apply to names typed into the dialog:
+// Whether a name can be used for a profile. A lone "." is made entirely of
+// permitted characters, yet every path built from it addresses the profiles
+// directory itself rather than a profile of its own - as does "..", which the
+// regex above already covers:
 bool dlgConnectionProfiles::profileNameUsableAsIs(const QString& name)
 {
-    return !name.isEmpty() && !name.contains(scmUnusableProfileNameChars);
+    return !name.isEmpty() && name != qsl(".") && !name.contains(scmUnusableProfileNameChars);
+}
+
+// The folder holding a profile's data, or an empty string when the name does
+// not address a folder directly inside profilesPath. Resolved textually rather
+// than with QDir::canonicalPath() so that the answer does not depend on the
+// folder existing - the predefined games have no folder until they are saved -
+// and so that a profile folder which is a symbolic link keeps working.
+QString dlgConnectionProfiles::profileFolderPath(const QString& profilesPath, const QString& profile)
+{
+    if (profile.isEmpty() || profile.contains(QLatin1Char('/')) || profile.contains(QLatin1Char('\\'))) {
+        return {};
+    }
+
+    const QString profilesDir = QDir::cleanPath(profilesPath);
+    const QString candidate = QDir::cleanPath(qsl("%1/%2").arg(profilesDir, profile));
+    if (candidate == profilesDir || QFileInfo(candidate).path() != profilesDir) {
+        return {};
+    }
+    return candidate;
 }
 
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
@@ -1001,8 +1023,7 @@ void dlgConnectionProfiles::slot_addProfile()
 // enables the deletion button once the correct text (profile name) is entered
 void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
 {
-    const QString profile = listWidget_profiles->currentItem()->data(csmNameRole).toString();
-    if (profile != text) {
+    if (mProfileToDelete != text) {
         delete_button->setEnabled(false);
     } else {
         delete_button->setEnabled(true);
@@ -1013,13 +1034,18 @@ void dlgConnectionProfiles::slot_deleteProfileCheck(const QString& text)
 // actually performs the deletion once the correct text has been entered
 void dlgConnectionProfiles::slot_reallyDeleteProfile()
 {
-    const QString profile = listWidget_profiles->currentItem()->data(csmNameRole).toString();
-    reallyDeleteProfile(profile);
+    reallyDeleteProfile(mProfileToDelete);
 }
 
 void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
 {
-    QDir dir(mudlet::getMudletPath(enums::profileHomePath, profile));
+    const QString profileFolder = profileFolderPath(mudlet::getMudletPath(enums::profilesPath), profile);
+    if (profileFolder.isEmpty()) {
+        qWarning().nospace() << "dlgConnectionProfiles::reallyDeleteProfile(\"" << profile << "\") ERROR - refusing to delete: that name does not belong to a folder inside the profiles directory.";
+        return;
+    }
+
+    QDir dir(profileFolder);
     dir.removeRecursively();
 
     // Clean up keychain entries for the deleted profile
@@ -1086,9 +1112,13 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    const QDir profileDirContents(mudlet::getMudletPath(enums::profileXmlFilesPath, profile));
-    if (!profileDirContents.exists() || profileDirContents.isEmpty()) {
-        // shortcut - don't show profile deletion confirmation if there is no data to delete
+    // Skip the confirmation only when there is nothing in the profile folder
+    // the user could miss. Everything they would - saved games, maps, logs,
+    // media, packages, locally stored passwords - lives in a sub-directory,
+    // while the loose files at the top are the connection details this dialog
+    // writes there itself, which a predefined game gets just by being listed:
+    const QDir profileDirContents(mudlet::getMudletPath(enums::profileHomePath, profile));
+    if (!profileDirContents.exists() || profileDirContents.entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty()) {
         reallyDeleteProfile(profile);
         return;
     }
@@ -1116,6 +1146,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
+    mProfileToDelete = profile;
     connect(delete_profile_lineedit, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_deleteProfileCheck);
     connect(delete_profile_dialog, &QDialog::accepted, this, &dlgConnectionProfiles::slot_reallyDeleteProfile);
 
@@ -2165,6 +2196,17 @@ bool dlgConnectionProfiles::validateProfile()
                     qsl("%1\n%2\n%3\n").arg(notificationAreaMessageBox->text(), tr("The %1 character is not permitted. Use one of the following:").arg(invalidChar), scmAllowedProfileNameChars));
             name.remove(invalidChar);
             profile_name_entry->setText(name);
+            validName = false;
+            valid = false;
+        } else if (!nameUnchangedAndOnDisk && !name.isEmpty() && !profileNameUsableAsIs(name)) {
+            // Every character is permitted on its own, but the name as a whole
+            // still cannot be a folder of its own - there is nothing sensible
+            // to strip out of it, so leave it for the user to change:
+            notificationAreaIconLabelWarning->show();
+            notificationAreaMessageBox->setText(qsl("%1\n%2\n")
+                                                        .arg(notificationAreaMessageBox->text(),
+                                                             //: Shown when a profile name cannot be used for a folder of its own, e.g. "." or a name containing ".."
+                                                             tr("This name cannot be used for a profile. Please pick a different one.")));
             validName = false;
             valid = false;
         }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -54,6 +54,7 @@ public:
     static const int csmNameRole{Qt::UserRole};
     static QChar firstInvalidProfileNameChar(const QString& name);
     static bool profileNameUsableAsIs(const QString& name);
+    static QString profileFolderPath(const QString& profilesPath, const QString& profile);
     static const QString scmAllowedProfileNameChars;
     static const QRegularExpression scmUnusableProfileNameChars;
 
@@ -164,6 +165,10 @@ private:
     QPushButton* connect_button = nullptr;
     QLineEdit* delete_profile_lineedit = nullptr;
     QPushButton* delete_button = nullptr;
+    // The confirmation dialog is not modal, so the profile to delete is taken
+    // from here rather than from whatever happens to be selected by the time
+    // the user confirms:
+    QString mProfileToDelete;
     QString mDiscordApplicationId;
     QString mDiscordInviteURL;
     QAction* mpAction_revealPassword;

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -76,13 +76,11 @@ public slots:
     void slot_updateLogin(const QString&);
     void slot_updatePassword(const QString&);
     // Not used:    void slot_updateWebsite(const QString&);
-    void slot_deleteProfileCheck(const QString&);
     void slot_updateDescription();
 
     void slot_itemClicked(QListWidgetItem*);
     void slot_addProfile();
     void slot_deleteProfile();
-    void slot_reallyDeleteProfile();
 
     void slot_updateAutoConnect(int state);
     void slot_updateAutoReconnect(int state);
@@ -134,6 +132,7 @@ private:
     void deleteSecurePassword(const QString& profile);
     void setupMudProfile(QListWidgetItem*, const QString& mudServer, const QString& serverDescription, const QString& iconFileName);
     void reallyDeleteProfile(const QString& profile);
+    void showRemovalProblem(const QString& message);
     void continueProfileSave(QListWidgetItem* pItem, const QString& newProfileName, const QString& newProfileHost, const QString& newProfilePort, const int newProfileSslTsl);
     void setItemName(QListWidgetItem*, const QString&) const;
     QIcon customIcon(const QString&, const std::optional<QColor>&) const;
@@ -163,12 +162,6 @@ private:
     QTabBar* mpTabBar = nullptr;
     QPushButton* offline_button = nullptr;
     QPushButton* connect_button = nullptr;
-    QLineEdit* delete_profile_lineedit = nullptr;
-    QPushButton* delete_button = nullptr;
-    // The confirmation dialog is not modal, so the profile to delete is taken
-    // from here rather than from whatever happens to be selected by the time
-    // the user confirms:
-    QString mProfileToDelete;
     QString mDiscordApplicationId;
     QString mDiscordInviteURL;
     QAction* mpAction_revealPassword;

--- a/test/ProfileNameValidationTest.cpp
+++ b/test/ProfileNameValidationTest.cpp
@@ -20,18 +20,18 @@
 #include "dlgConnectionProfiles.h"
 #include "utils.h"
 
+#include <QDir>
 #include <QtTest/QtTest>
 
 /*
  * Tests for the profile name character validation used by the connection
  * dialog. Guards the character-set half of the fix for profile folders
  * duplicated outside of Mudlet (e.g. a file manager appending " (2)" to a
- * copied folder) which used to be rejected, greying out the Connect/Offline
- * buttons, and the rule that a name has to address a folder of its own - "."
- * and ".." name the profiles directory and Mudlet's configuration directory
- * instead. The on-disk exemption half is covered by
- * test/functional_tests/ProfileFolderNameTest.cpp, and the deletion path by
- * test/functional_tests/ProfileDeletionSafetyTest.cpp.
+ * copied folder), which Mudlet must not reject - doing so greys out the
+ * Connect/Offline buttons - and the rule that a name has to address a folder
+ * of its own, as "." and ".." name the profiles directory and Mudlet's
+ * configuration directory instead. The on-disk exemption half is covered by
+ * ProfileFolderNameTest, and the deletion path by ProfileDeletionSafetyTest.
  */
 class ProfileNameValidationTest : public QObject
 {
@@ -96,7 +96,6 @@ private slots:
         QTest::newRow("exclamation mark") << qsl("test!") << true;
         QTest::newRow("single dot") << qsl("my.profile") << true;
         QTest::newRow("version number") << qsl("Achaea 2.0") << true;
-        QTest::newRow("leading dot") << qsl(".hidden") << true;
 
         QTest::newRow("empty") << QString() << false;
         QTest::newRow("current directory") << qsl(".") << false;
@@ -157,7 +156,31 @@ private slots:
         QCOMPARE(dlgConnectionProfiles::profileFolderPath(qsl("/home/user/.config/mudlet/profiles"), name), expectedPath);
     }
 
-    // A trailing separator on the profiles directory must not change the answer
+    // The profiles directory is a native path, so the containment check has to
+    // hold for the roots the other platforms produce as well as a POSIX one
+    void folderPathHandlesNativeRoots_data()
+    {
+        QTest::addColumn<QString>("profilesPath");
+
+        QTest::newRow("posix") << qsl("/home/user/.config/mudlet/profiles");
+        QTest::newRow("windows drive") << qsl("C:/Users/user/.config/mudlet/profiles");
+        QTest::newRow("windows unc") << qsl("//server/share/mudlet/profiles");
+        QTest::newRow("macos") << qsl("/Users/user/Library/Application Support/mudlet/profiles");
+    }
+
+    void folderPathHandlesNativeRoots()
+    {
+        QFETCH(QString, profilesPath);
+
+        // a UNC root keeps its leading "//" on Windows and loses it elsewhere,
+        // so compare against the cleaned root rather than what was passed in
+        const QString root = QDir::cleanPath(profilesPath);
+        QCOMPARE(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("Achaea")), qsl("%1/Achaea").arg(root));
+        QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl(".")).isEmpty());
+        QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("..")).isEmpty());
+        QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("../..")).isEmpty());
+    }
+
     void folderPathIgnoresTrailingSeparator()
     {
         QCOMPARE(dlgConnectionProfiles::profileFolderPath(qsl("/home/user/.config/mudlet/profiles/"), qsl("Achaea")), qsl("/home/user/.config/mudlet/profiles/Achaea"));

--- a/test/ProfileNameValidationTest.cpp
+++ b/test/ProfileNameValidationTest.cpp
@@ -120,9 +120,7 @@ private slots:
         QCOMPARE(dlgConnectionProfiles::profileNameUsableAsIs(name), usable);
     }
 
-    // The guard deleting a profile relies on: a name that does not resolve to
-    // a folder directly inside the profiles directory gets no path at all, so
-    // nothing outside a single profile's own folder can be removed.
+    // No path at all means nothing for the deletion to act on
     void folderPath_data()
     {
         QTest::addColumn<QString>("name");
@@ -137,9 +135,7 @@ private slots:
         QTest::newRow("cyrillic") << qsl("Мудлет") << qsl("%1/Мудлет").arg(profilesPath);
         QTest::newRow("leading dot") << qsl(".hidden") << qsl("%1/.hidden").arg(profilesPath);
 
-        // the profiles directory itself
         QTest::newRow("current directory") << qsl(".") << QString();
-        // Mudlet's whole configuration directory
         QTest::newRow("parent directory") << qsl("..") << QString();
         QTest::newRow("grandparent directory") << qsl("../..") << QString();
         QTest::newRow("traversal back in") << qsl("../profiles/Achaea") << QString();
@@ -156,8 +152,7 @@ private slots:
         QCOMPARE(dlgConnectionProfiles::profileFolderPath(qsl("/home/user/.config/mudlet/profiles"), name), expectedPath);
     }
 
-    // The profiles directory is a native path, so the containment check has to
-    // hold for the roots the other platforms produce as well as a POSIX one
+    // The profiles directory is a native path, so every platform's root counts
     void folderPathHandlesNativeRoots_data()
     {
         QTest::addColumn<QString>("profilesPath");

--- a/test/ProfileNameValidationTest.cpp
+++ b/test/ProfileNameValidationTest.cpp
@@ -27,8 +27,11 @@
  * dialog. Guards the character-set half of the fix for profile folders
  * duplicated outside of Mudlet (e.g. a file manager appending " (2)" to a
  * copied folder) which used to be rejected, greying out the Connect/Offline
- * buttons. The on-disk exemption half is covered by
- * test/functional_tests/ProfileFolderNameTest.cpp.
+ * buttons, and the rule that a name has to address a folder of its own - "."
+ * and ".." name the profiles directory and Mudlet's configuration directory
+ * instead. The on-disk exemption half is covered by
+ * test/functional_tests/ProfileFolderNameTest.cpp, and the deletion path by
+ * test/functional_tests/ProfileDeletionSafetyTest.cpp.
  */
 class ProfileNameValidationTest : public QObject
 {
@@ -92,9 +95,14 @@ private slots:
         QTest::newRow("non-ascii") << qsl("café") << true;
         QTest::newRow("exclamation mark") << qsl("test!") << true;
         QTest::newRow("single dot") << qsl("my.profile") << true;
+        QTest::newRow("version number") << qsl("Achaea 2.0") << true;
+        QTest::newRow("leading dot") << qsl(".hidden") << true;
 
         QTest::newRow("empty") << QString() << false;
-        QTest::newRow("parent directory") << qsl("test..2") << false;
+        QTest::newRow("current directory") << qsl(".") << false;
+        QTest::newRow("parent directory") << qsl("..") << false;
+        QTest::newRow("parent directory in a path") << qsl("../..") << false;
+        QTest::newRow("embedded parent directory") << qsl("test..2") << false;
         QTest::newRow("path separator") << qsl("test/2") << false;
         QTest::newRow("windows path separator") << qsl("test\\2") << false;
         QTest::newRow("colon") << qsl("test:2") << false;
@@ -111,6 +119,49 @@ private slots:
         QFETCH(QString, name);
         QFETCH(bool, usable);
         QCOMPARE(dlgConnectionProfiles::profileNameUsableAsIs(name), usable);
+    }
+
+    // The guard deleting a profile relies on: a name that does not resolve to
+    // a folder directly inside the profiles directory gets no path at all, so
+    // nothing outside a single profile's own folder can be removed.
+    void folderPath_data()
+    {
+        QTest::addColumn<QString>("name");
+        QTest::addColumn<QString>("expectedPath");
+
+        const QString profilesPath = qsl("/home/user/.config/mudlet/profiles");
+
+        QTest::newRow("plain") << qsl("Achaea") << qsl("%1/Achaea").arg(profilesPath);
+        QTest::newRow("version number") << qsl("Achaea 2.0") << qsl("%1/Achaea 2.0").arg(profilesPath);
+        QTest::newRow("parentheses") << qsl("test (2)") << qsl("%1/test (2)").arg(profilesPath);
+        QTest::newRow("non-ascii") << qsl("café") << qsl("%1/café").arg(profilesPath);
+        QTest::newRow("cyrillic") << qsl("Мудлет") << qsl("%1/Мудлет").arg(profilesPath);
+        QTest::newRow("leading dot") << qsl(".hidden") << qsl("%1/.hidden").arg(profilesPath);
+
+        // the profiles directory itself
+        QTest::newRow("current directory") << qsl(".") << QString();
+        // Mudlet's whole configuration directory
+        QTest::newRow("parent directory") << qsl("..") << QString();
+        QTest::newRow("grandparent directory") << qsl("../..") << QString();
+        QTest::newRow("traversal back in") << qsl("../profiles/Achaea") << QString();
+        QTest::newRow("nested") << qsl("Achaea/current") << QString();
+        QTest::newRow("windows separator") << qsl("Achaea\\current") << QString();
+        QTest::newRow("absolute path") << qsl("/etc") << QString();
+        QTest::newRow("empty") << QString() << QString();
+    }
+
+    void folderPath()
+    {
+        QFETCH(QString, name);
+        QFETCH(QString, expectedPath);
+        QCOMPARE(dlgConnectionProfiles::profileFolderPath(qsl("/home/user/.config/mudlet/profiles"), name), expectedPath);
+    }
+
+    // A trailing separator on the profiles directory must not change the answer
+    void folderPathIgnoresTrailingSeparator()
+    {
+        QCOMPARE(dlgConnectionProfiles::profileFolderPath(qsl("/home/user/.config/mudlet/profiles/"), qsl("Achaea")), qsl("/home/user/.config/mudlet/profiles/Achaea"));
+        QCOMPARE(dlgConnectionProfiles::profileFolderPath(qsl("/home/user/.config/mudlet/profiles/"), qsl(".")), QString());
     }
 };
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(FUNCTIONAL_TEST_SOURCES
     HostWidgetDecouplingTest.cpp
     ActionSelfUninstallTest.cpp
     ProfileFolderNameTest.cpp
+    ProfileDeletionSafetyTest.cpp
     DialogTeardownTest.cpp
     TMediaLoopTest.cpp
     DefaultPackagesTest.cpp

--- a/test/functional_tests/DefaultGameDeleteTest.cpp
+++ b/test/functional_tests/DefaultGameDeleteTest.cpp
@@ -100,9 +100,9 @@ private slots:
 
     void test_deletedDefaultGameStaysInAllGames()
     {
-        // an on-disk profile dir makes the game appear under "My games"; no
-        // saved XMLs inside means slot_deleteProfile() deletes without raising
-        // the confirmation dialog
+        // an on-disk profile dir makes the game appear under "My games"; an
+        // empty one means slot_deleteProfile() deletes it without raising the
+        // confirmation dialog
         QVERIFY(QDir().mkpath(mudlet::getMudletPath(enums::profileHomePath, mGame)));
 
         auto* dlg = new dlgConnectionProfiles();
@@ -115,9 +115,10 @@ private slots:
         dlg->fillout_form();
         QVERIFY2(gameListed(dlg, mGame), "game with an on-disk profile should show under 'My games'");
 
-        // no saved XMLs is what makes slot_deleteProfile() skip the
-        // confirmation dialog; assert it so a change there fails loudly
-        QVERIFY(!QDir(mudlet::getMudletPath(enums::profileXmlFilesPath, mGame)).exists());
+        // having no sub-directory of its own - nothing but the connection
+        // details the dialog wrote there - is what makes slot_deleteProfile()
+        // skip the confirmation dialog; assert it so a change there fails loudly
+        QVERIFY(QDir(mudlet::getMudletPath(enums::profileHomePath, mGame)).entryList(QDir::Dirs | QDir::NoDotAndDotDot).isEmpty());
         const auto items = dlg->findData(*dlg->listWidget_profiles, mGame, dlgConnectionProfiles::csmNameRole);
         dlg->listWidget_profiles->setCurrentItem(items.first());
         dlg->slot_deleteProfile();

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -330,6 +330,26 @@ private slots:
         closeDialog(dlg);
     }
 
+    // A folder on disk is the user's data whatever it is called, so selecting
+    // one must never refuse it - not even a name that would be turned down if
+    // it were typed in fresh
+    void test_folderOnDiskWithATurnedDownNameIsStillUsable()
+    {
+        const QString awkward = qsl("QA..Dots");
+        QVERIFY(!dlgConnectionProfiles::profileNameUsableAsIs(awkward));
+        makeProfileWithSavedGame(awkward);
+        mudlet::self()->writeProfileData(awkward, qsl("url"), qsl("mudlet.org"));
+        mudlet::self()->writeProfileData(awkward, qsl("port"), qsl("23"));
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, awkward);
+
+        QCOMPARE(dlg->profile_name_entry->text(), awkward);
+        QVERIFY2(acceptButtonsEnabled(dlg), "a profile folder already on disk was refused");
+        QVERIFY2(QDir(profilePath(awkward)).exists(), "the folder was renamed behind the user's back");
+        closeDialog(dlg);
+    }
+
     void test_typedNamesThatAreProfilesAreAccepted_data()
     {
         QTest::addColumn<QString>("name");

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -19,10 +19,11 @@
 
 /*
  * Removing a profile from the connection dialog must never reach outside that
- * one profile's folder. A profile called "." named the profiles directory
- * itself and ".." named the whole Mudlet configuration directory, so removing
- * one wiped every profile the user had. Also covers the confirmation the user
- * gets before any of their data goes, and the names that must keep working.
+ * one profile's folder. A name like "." addresses the profiles directory
+ * itself and ".." the whole Mudlet configuration directory, so a name that is
+ * not a folder of its own must never reach removeRecursively(). Also covers
+ * the confirmation the user gets before any of their data goes, and the names
+ * that must keep working.
  *
  * Run with: ctest -R ProfileDeletionSafetyTest -V
  */
@@ -52,6 +53,13 @@ private:
 
     QString profilePath(const QString& profile) const { return mudlet::getMudletPath(enums::profileHomePath, profile); }
 
+    // setupConfig() consults portable.txt ahead of the XDG logic; skip rather
+    // than run against an unexpected config dir (see ConfigDirOverrideTest)
+    bool portableMarkerPresent() const
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
     void makeProfileWithSavedGame(const QString& profile) const
     {
         QVERIFY(QDir().mkpath(mudlet::getMudletPath(enums::profileXmlFilesPath, profile)));
@@ -62,15 +70,14 @@ private:
     }
 
     // Adds a list entry for a profile that has no folder of its own, the way
-    // the dialog does for a name being typed into it. This is the state the
-    // user was left in after naming a new profile "." or "..".
-    QListWidgetItem* addListEntry(dlgConnectionProfiles* dlg, const QString& profile) const
+    // the dialog does for a name being typed into it. The list takes ownership,
+    // and rebuilding it drops the entry again.
+    void addListEntry(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         auto* item = new QListWidgetItem();
         item->setData(dlgConnectionProfiles::csmNameRole, profile);
         dlg->listWidget_profiles->insertItem(0, item);
         dlg->listWidget_profiles->setCurrentItem(item);
-        return item;
     }
 
     // slot_itemClicked() ignores a repeat of the profile it was last given
@@ -88,7 +95,8 @@ private:
     QDialog* confirmation(dlgConnectionProfiles* dlg) const { return dlg->findChild<QDialog*>(qsl("delete_profile_confirmation")); }
 
     // Answers a raised confirmation the way an intent-on-deleting user would:
-    // by typing the profile name in, then pressing the delete button.
+    // by typing the profile name in and pressing the delete button, which the
+    // .ui wires to the dialog's accept()
     void confirmRemovalOf(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         auto* confirmationDialog = confirmation(dlg);
@@ -97,12 +105,15 @@ private:
         auto* deleteButton = confirmationDialog->findChild<QPushButton*>(qsl("delete_button"));
         QVERIFY(nameEntry && deleteButton);
 
+        nameEntry->setText(profile.left(profile.size() - 1));
+        QVERIFY2(!deleteButton->isEnabled(), "a partial profile name enabled the delete button");
+
         nameEntry->setText(profile);
-        QVERIFY(deleteButton->isEnabled());
-        confirmationDialog->accept();
+        QVERIFY2(deleteButton->isEnabled(), "typing the profile name did not enable this confirmation's delete button");
+        deleteButton->click();
     }
 
-    // Presses Remove and answers the confirmation, if one is raised at all
+    // Invokes the Remove handler and answers the confirmation, if one is raised
     void removeProfileAndConfirm(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         dlg->slot_deleteProfile();
@@ -139,6 +150,9 @@ private:
 private slots:
     void initTestCase()
     {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - cannot redirect the config dir for this test");
+        }
         initializeQRCResourcesForProfileDeletionSafetyTest();
 
         QVERIFY(mConfigDir.isValid());
@@ -169,35 +183,37 @@ private slots:
     void test_removingCurrentDirectoryProfileKeepsEveryProfile()
     {
         auto* dlg = openDialog();
-        auto* item = addListEntry(dlg, qsl("."));
+        addListEntry(dlg, qsl("."));
 
-        removeProfileAndConfirm(dlg, qsl("."));
+        dlg->slot_deleteProfile();
+        QVERIFY2(confirmation(dlg), "removal went ahead without asking");
+        confirmRemovalOf(dlg, qsl("."));
 
         QVERIFY2(QDir(mudlet::getMudletPath(enums::profilesPath)).exists(), "the profiles directory was deleted");
         QVERIFY2(QDir(profilePath(mKeeper)).exists(), "an unrelated profile was deleted");
         QVERIFY2(QFile::exists(qsl("%1/%2.xml").arg(mudlet::getMudletPath(enums::profileXmlFilesPath, mKeeper), mKeeper)), "an unrelated profile's saved game was deleted");
+        QVERIFY2(!dlg->notificationAreaMessageBox->text().isEmpty(), "the refusal was not reported to the user");
 
-        delete item;
         closeDialog(dlg);
     }
 
     void test_removingParentDirectoryProfileKeepsTheConfigurationDirectory()
     {
         auto* dlg = openDialog();
-        auto* item = addListEntry(dlg, qsl(".."));
+        addListEntry(dlg, qsl(".."));
 
-        removeProfileAndConfirm(dlg, qsl(".."));
+        dlg->slot_deleteProfile();
+        QVERIFY2(confirmation(dlg), "removal went ahead without asking");
+        confirmRemovalOf(dlg, qsl(".."));
 
         QVERIFY2(QDir(mudlet::getMudletPath(enums::mainPath)).exists(), "Mudlet's configuration directory was deleted");
         QVERIFY2(QDir(mudlet::getMudletPath(enums::profilesPath)).exists(), "the profiles directory was deleted");
         QVERIFY2(QDir(profilePath(mKeeper)).exists(), "an unrelated profile was deleted");
+        QVERIFY2(!dlg->notificationAreaMessageBox->text().isEmpty(), "the refusal was not reported to the user");
 
-        delete item;
         closeDialog(dlg);
     }
 
-    // Whatever a name resolves to, only a folder directly inside the profiles
-    // directory is ever a profile
     void test_onlyDirectChildrenOfTheProfilesDirectoryAreProfiles()
     {
         const QString profilesPath = mudlet::getMudletPath(enums::profilesPath);
@@ -206,6 +222,12 @@ private slots:
         QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl(".")).isEmpty());
         QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("..")).isEmpty());
         QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("%1/current").arg(mKeeper)).isEmpty());
+
+        // a predefined game has no folder until it is saved, and dismissing one
+        // still has to resolve to the folder it would have had
+        const QString neverPlayed = qsl("QA Never Played");
+        QVERIFY(!QDir(profilePath(neverPlayed)).exists());
+        QCOMPARE(dlgConnectionProfiles::profileFolderPath(profilesPath, neverPlayed), qsl("%1/%2").arg(profilesPath, neverPlayed));
     }
 
     // A profile whose folder holds no saved games but does hold something else
@@ -244,6 +266,62 @@ private slots:
         dlg->slot_deleteProfile();
         QVERIFY2(!confirmation(dlg), "a profile with nothing but connection details should not need confirming");
         QVERIFY2(!QDir(profilePath(unplayed)).exists(), "the profile was not removed");
+        closeDialog(dlg);
+    }
+
+    // A locally stored password sits loose in the profile folder rather than in
+    // a sub-directory, so the "nothing to lose" shortcut must not overlook it
+    void test_profileWithOnlyAStoredPasswordIsConfirmedBeforeRemoval()
+    {
+        const QString secretive = qsl("QA Secretive");
+        QVERIFY(QDir().mkpath(profilePath(secretive)));
+        mudlet::self()->writeProfileData(secretive, qsl("password"), qsl("hunter2"));
+        QVERIFY(QDir(profilePath(secretive)).entryList(QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot).isEmpty());
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, secretive);
+
+        dlg->slot_deleteProfile();
+        QVERIFY2(confirmation(dlg), "a profile holding a stored password was removed without asking");
+        QVERIFY2(QDir(profilePath(secretive)).exists(), "the profile was deleted before the user confirmed");
+
+        confirmation(dlg)->reject();
+        closeDialog(dlg);
+    }
+
+    // Two confirmations can be open together, so each must remove the profile
+    // it names rather than the one raised most recently
+    void test_eachConfirmationRemovesItsOwnProfile()
+    {
+        const QString first = qsl("QA First");
+        const QString second = qsl("QA Second");
+        makeProfileWithSavedGame(first);
+        makeProfileWithSavedGame(second);
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, first);
+        dlg->slot_deleteProfile();
+        auto* firstConfirmation = confirmation(dlg);
+        QVERIFY(firstConfirmation);
+
+        selectProfile(dlg, second);
+        dlg->slot_deleteProfile();
+        const auto confirmations = dlg->findChildren<QDialog*>(qsl("delete_profile_confirmation"));
+        QCOMPARE(confirmations.size(), 2);
+        auto* secondConfirmation = confirmations.first() == firstConfirmation ? confirmations.last() : confirmations.first();
+
+        // answer the first one, which names the first profile
+        auto* nameEntry = firstConfirmation->findChild<QLineEdit*>(qsl("delete_profile_lineedit"));
+        auto* deleteButton = firstConfirmation->findChild<QPushButton*>(qsl("delete_button"));
+        QVERIFY(nameEntry && deleteButton);
+        nameEntry->setText(first);
+        QVERIFY2(deleteButton->isEnabled(), "the first confirmation did not accept its own profile name");
+        deleteButton->click();
+
+        QVERIFY2(!QDir(profilePath(first)).exists(), "the first confirmation did not remove its own profile");
+        QVERIFY2(QDir(profilePath(second)).exists(), "the first confirmation removed the second profile instead");
+
+        secondConfirmation->reject();
         closeDialog(dlg);
     }
 
@@ -319,6 +397,9 @@ private slots:
 
         auto* dlg = openDialog();
         selectProfile(dlg, mKeeper);
+        // without this the assertion below also holds for an unrelated reason,
+        // e.g. an empty server address
+        QVERIFY2(acceptButtonsEnabled(dlg), "the profile was already unusable before the name was edited");
 
         // setText() drives the same textChanged path as typing does
         dlg->profile_name_entry->setText(name);
@@ -354,9 +435,8 @@ private slots:
     {
         QTest::addColumn<QString>("name");
 
-        QTest::newRow("version number") << qsl("Achaea 2.0");
+        QTest::newRow("version number") << qsl("QA Game 2.0");
         QTest::newRow("parentheses") << qsl("QA Keeper (2)");
-        QTest::newRow("leading dot") << qsl(".hidden");
     }
 
     void test_typedNamesThatAreProfilesAreAccepted()
@@ -370,7 +450,8 @@ private slots:
         QCOMPARE(dlg->profile_name_entry->text(), name);
         QVERIFY2(acceptButtonsEnabled(dlg), qPrintable(qsl("'%1' was refused as a profile name").arg(name)));
 
-        // put the on-disk name back so no rename can be left pending
+        // ~QDialog hiding the dialog fires editingFinished() into slot_saveName(),
+        // which renames the folder - so leave the on-disk name in the field
         dlg->profile_name_entry->setText(mKeeper);
         closeDialog(dlg);
     }

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -1,0 +1,375 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Removing a profile from the connection dialog must never reach outside that
+ * one profile's folder. A profile called "." named the profiles directory
+ * itself and ".." named the whole Mudlet configuration directory, so removing
+ * one wiped every profile the user had. Also covers the confirmation the user
+ * gets before any of their data goes, and the names that must keep working.
+ *
+ * Run with: ctest -R ProfileDeletionSafetyTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "MudletInstanceCoordinator.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForProfileDeletionSafetyTest();
+
+class ProfileDeletionSafetyTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    // the profile that must survive every attempt below
+    const QString mKeeper = qsl("QA Keeper");
+
+    QString profilePath(const QString& profile) const { return mudlet::getMudletPath(enums::profileHomePath, profile); }
+
+    void makeProfileWithSavedGame(const QString& profile) const
+    {
+        QVERIFY(QDir().mkpath(mudlet::getMudletPath(enums::profileXmlFilesPath, profile)));
+        QFile savedGame(qsl("%1/%2.xml").arg(mudlet::getMudletPath(enums::profileXmlFilesPath, profile), profile));
+        QVERIFY(savedGame.open(QIODevice::WriteOnly));
+        savedGame.write("<MudletPackage></MudletPackage>");
+        savedGame.close();
+    }
+
+    // Adds a list entry for a profile that has no folder of its own, the way
+    // the dialog does for a name being typed into it. This is the state the
+    // user was left in after naming a new profile "." or "..".
+    QListWidgetItem* addListEntry(dlgConnectionProfiles* dlg, const QString& profile) const
+    {
+        auto* item = new QListWidgetItem();
+        item->setData(dlgConnectionProfiles::csmNameRole, profile);
+        dlg->listWidget_profiles->insertItem(0, item);
+        dlg->listWidget_profiles->setCurrentItem(item);
+        return item;
+    }
+
+    // slot_itemClicked() ignores a repeat of the profile it was last given
+    // within 100ms, and that guard is static - it outlives the dialog, so
+    // consecutive tests picking the same profile have to wait it out
+    void selectProfile(dlgConnectionProfiles* dlg, const QString& profile) const
+    {
+        const auto items = dlg->findData(*dlg->listWidget_profiles, profile, dlgConnectionProfiles::csmNameRole);
+        QVERIFY2(!items.isEmpty(), qPrintable(qsl("profile '%1' was not listed").arg(profile)));
+        dlg->listWidget_profiles->setCurrentItem(items.first());
+        QTest::qWait(120);
+        dlg->slot_itemClicked(items.first());
+    }
+
+    QDialog* confirmation(dlgConnectionProfiles* dlg) const { return dlg->findChild<QDialog*>(qsl("delete_profile_confirmation")); }
+
+    // Answers a raised confirmation the way an intent-on-deleting user would:
+    // by typing the profile name in, then pressing the delete button.
+    void confirmRemovalOf(dlgConnectionProfiles* dlg, const QString& profile) const
+    {
+        auto* confirmationDialog = confirmation(dlg);
+        QVERIFY(confirmationDialog);
+        auto* nameEntry = confirmationDialog->findChild<QLineEdit*>(qsl("delete_profile_lineedit"));
+        auto* deleteButton = confirmationDialog->findChild<QPushButton*>(qsl("delete_button"));
+        QVERIFY(nameEntry && deleteButton);
+
+        nameEntry->setText(profile);
+        QVERIFY(deleteButton->isEnabled());
+        confirmationDialog->accept();
+    }
+
+    // Presses Remove and answers the confirmation, if one is raised at all
+    void removeProfileAndConfirm(dlgConnectionProfiles* dlg, const QString& profile) const
+    {
+        dlg->slot_deleteProfile();
+        if (confirmation(dlg)) {
+            confirmRemovalOf(dlg, profile);
+        }
+    }
+
+    dlgConnectionProfiles* openDialog() const
+    {
+        auto* dlg = new dlgConnectionProfiles();
+        dlg->show();
+        dlg->fillout_form();
+        return dlg;
+    }
+
+    void closeDialog(dlgConnectionProfiles* dlg) const
+    {
+        dlg->deleteLater();
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    }
+
+    // The Connect and Offline buttons are the dialog's only AcceptRole buttons
+    bool acceptButtonsEnabled(dlgConnectionProfiles* dlg) const
+    {
+        for (auto* button : dlg->dialog_buttonbox->buttons()) {
+            if (dlg->dialog_buttonbox->buttonRole(button) == QDialogButtonBox::AcceptRole && !button->isEnabled()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForProfileDeletionSafetyTest();
+
+        QVERIFY(mConfigDir.isValid());
+        // an existing $XDG_CONFIG_HOME/mudlet makes setupConfig() adopt it, so
+        // the test never goes near the user's own profiles
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        makeProfileWithSavedGame(mKeeper);
+        mudlet::self()->writeProfileData(mKeeper, qsl("url"), qsl("mudlet.org"));
+        mudlet::self()->writeProfileData(mKeeper, qsl("port"), qsl("23"));
+    }
+
+    void cleanupTestCase()
+    {
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_removingCurrentDirectoryProfileKeepsEveryProfile()
+    {
+        auto* dlg = openDialog();
+        auto* item = addListEntry(dlg, qsl("."));
+
+        removeProfileAndConfirm(dlg, qsl("."));
+
+        QVERIFY2(QDir(mudlet::getMudletPath(enums::profilesPath)).exists(), "the profiles directory was deleted");
+        QVERIFY2(QDir(profilePath(mKeeper)).exists(), "an unrelated profile was deleted");
+        QVERIFY2(QFile::exists(qsl("%1/%2.xml").arg(mudlet::getMudletPath(enums::profileXmlFilesPath, mKeeper), mKeeper)), "an unrelated profile's saved game was deleted");
+
+        delete item;
+        closeDialog(dlg);
+    }
+
+    void test_removingParentDirectoryProfileKeepsTheConfigurationDirectory()
+    {
+        auto* dlg = openDialog();
+        auto* item = addListEntry(dlg, qsl(".."));
+
+        removeProfileAndConfirm(dlg, qsl(".."));
+
+        QVERIFY2(QDir(mudlet::getMudletPath(enums::mainPath)).exists(), "Mudlet's configuration directory was deleted");
+        QVERIFY2(QDir(mudlet::getMudletPath(enums::profilesPath)).exists(), "the profiles directory was deleted");
+        QVERIFY2(QDir(profilePath(mKeeper)).exists(), "an unrelated profile was deleted");
+
+        delete item;
+        closeDialog(dlg);
+    }
+
+    // Whatever a name resolves to, only a folder directly inside the profiles
+    // directory is ever a profile
+    void test_onlyDirectChildrenOfTheProfilesDirectoryAreProfiles()
+    {
+        const QString profilesPath = mudlet::getMudletPath(enums::profilesPath);
+
+        QCOMPARE(dlgConnectionProfiles::profileFolderPath(profilesPath, mKeeper), qsl("%1/%2").arg(profilesPath, mKeeper));
+        QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl(".")).isEmpty());
+        QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("..")).isEmpty());
+        QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("%1/current").arg(mKeeper)).isEmpty());
+    }
+
+    // A profile whose folder holds no saved games but does hold something else
+    // still has data to lose, so it has to be confirmed
+    void test_profileWithOnlyAMapIsConfirmedBeforeRemoval()
+    {
+        const QString mapped = qsl("QA Mapped");
+        QVERIFY(QDir().mkpath(mudlet::getMudletPath(enums::profileMapsPath, mapped)));
+        QVERIFY(!QDir(mudlet::getMudletPath(enums::profileXmlFilesPath, mapped)).exists());
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, mapped);
+
+        dlg->slot_deleteProfile();
+        QVERIFY2(confirmation(dlg), "removal went ahead without asking");
+        QVERIFY2(QDir(profilePath(mapped)).exists(), "the profile was deleted before the user confirmed");
+
+        confirmation(dlg)->reject();
+        QVERIFY2(QDir(profilePath(mapped)).exists(), "the profile was deleted after the user cancelled");
+        closeDialog(dlg);
+    }
+
+    // A pre-installed game that was never played has nothing to lose - only
+    // the connection details this dialog wrote into its folder - so removing
+    // it goes ahead without a confirmation
+    void test_profileWithOnlyConnectionDetailsIsRemovedWithoutConfirmation()
+    {
+        const QString unplayed = qsl("QA Unplayed");
+        QVERIFY(QDir().mkpath(profilePath(unplayed)));
+        mudlet::self()->writeProfileData(unplayed, qsl("url"), qsl("mudlet.org"));
+        mudlet::self()->writeProfileData(unplayed, qsl("port"), qsl("23"));
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, unplayed);
+
+        dlg->slot_deleteProfile();
+        QVERIFY2(!confirmation(dlg), "a profile with nothing but connection details should not need confirming");
+        QVERIFY2(!QDir(profilePath(unplayed)).exists(), "the profile was not removed");
+        closeDialog(dlg);
+    }
+
+    void test_profileWithDataIsStillRemovable()
+    {
+        const QString doomed = qsl("QA Doomed");
+        makeProfileWithSavedGame(doomed);
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, doomed);
+
+        dlg->slot_deleteProfile();
+        QVERIFY2(confirmation(dlg), "removal of a profile with data went ahead without asking");
+        QVERIFY2(QDir(profilePath(doomed)).exists(), "the profile was deleted before the user confirmed");
+
+        confirmRemovalOf(dlg, doomed);
+
+        QVERIFY2(!QDir(profilePath(doomed)).exists(), "the confirmed profile was not removed");
+        QVERIFY2(QDir(profilePath(mKeeper)).exists(), "an unrelated profile was removed too");
+        closeDialog(dlg);
+    }
+
+    // A folder name Mudlet would not accept for a new profile is still a
+    // profile once it is on disk, and removing it must work
+    void test_nonAsciiProfileIsStillRemovable()
+    {
+        const QString doomed = qsl("Мудлет café");
+        makeProfileWithSavedGame(doomed);
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, doomed);
+
+        removeProfileAndConfirm(dlg, doomed);
+
+        QVERIFY2(!QDir(profilePath(doomed)).exists(), "the confirmed profile was not removed");
+        QVERIFY2(QDir(profilePath(mKeeper)).exists(), "an unrelated profile was removed too");
+        closeDialog(dlg);
+    }
+
+    // The confirmation dialog is not modal, so the profile it names is the one
+    // that gets removed even if the list selection moves on behind it
+    void test_confirmationRemovesTheProfileItNamed()
+    {
+        const QString doomed = qsl("QA Doomed Too");
+        makeProfileWithSavedGame(doomed);
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, doomed);
+        dlg->slot_deleteProfile();
+        QVERIFY(confirmation(dlg));
+
+        selectProfile(dlg, mKeeper);
+
+        confirmRemovalOf(dlg, doomed);
+
+        QVERIFY2(QDir(profilePath(mKeeper)).exists(), "the newly selected profile was removed instead");
+        QVERIFY2(!QDir(profilePath(doomed)).exists(), "the confirmed profile was not removed");
+        closeDialog(dlg);
+    }
+
+    void test_typedNamesThatAreNotProfilesAreRejected_data()
+    {
+        QTest::addColumn<QString>("name");
+
+        QTest::newRow("current directory") << qsl(".");
+        QTest::newRow("parent directory") << qsl("..");
+        QTest::newRow("embedded parent directory") << qsl("Achaea..Beta");
+    }
+
+    void test_typedNamesThatAreNotProfilesAreRejected()
+    {
+        QFETCH(QString, name);
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, mKeeper);
+
+        // setText() drives the same textChanged path as typing does
+        dlg->profile_name_entry->setText(name);
+        QVERIFY2(!acceptButtonsEnabled(dlg), qPrintable(qsl("'%1' was accepted as a profile name").arg(name)));
+        // the folder the profile came from must not have been renamed to it
+        QVERIFY(QDir(profilePath(mKeeper)).exists());
+
+        dlg->profile_name_entry->setText(mKeeper);
+        closeDialog(dlg);
+    }
+
+    void test_typedNamesThatAreProfilesAreAccepted_data()
+    {
+        QTest::addColumn<QString>("name");
+
+        QTest::newRow("version number") << qsl("Achaea 2.0");
+        QTest::newRow("parentheses") << qsl("QA Keeper (2)");
+        QTest::newRow("leading dot") << qsl(".hidden");
+    }
+
+    void test_typedNamesThatAreProfilesAreAccepted()
+    {
+        QFETCH(QString, name);
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, mKeeper);
+
+        dlg->profile_name_entry->setText(name);
+        QCOMPARE(dlg->profile_name_entry->text(), name);
+        QVERIFY2(acceptButtonsEnabled(dlg), qPrintable(qsl("'%1' was refused as a profile name").arg(name)));
+
+        // put the on-disk name back so no rename can be left pending
+        dlg->profile_name_entry->setText(mKeeper);
+        closeDialog(dlg);
+    }
+};
+
+void initializeQRCResourcesForProfileDeletionSafetyTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "ProfileDeletionSafetyTest.moc"
+QTEST_MAIN(ProfileDeletionSafetyTest)

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -48,7 +48,6 @@ class ProfileDeletionSafetyTest : public QObject
 private:
     QTemporaryDir mConfigDir;
     QByteArray mSavedXdg;
-    // the profile that must survive every attempt below
     const QString mKeeper = qsl("QA Keeper");
 
     QString profilePath(const QString& profile) const { return mudlet::getMudletPath(enums::profileHomePath, profile); }
@@ -69,9 +68,7 @@ private:
         savedGame.close();
     }
 
-    // Adds a list entry for a profile that has no folder of its own, the way
-    // the dialog does for a name being typed into it. The list takes ownership,
-    // and rebuilding it drops the entry again.
+    // The list takes ownership, and rebuilding it drops the entry again
     void addListEntry(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         auto* item = new QListWidgetItem();
@@ -81,8 +78,7 @@ private:
     }
 
     // slot_itemClicked() ignores a repeat of the profile it was last given
-    // within 100ms, and that guard is static - it outlives the dialog, so
-    // consecutive tests picking the same profile have to wait it out
+    // within 100ms, and that guard is static, so it outlives the dialog
     void selectProfile(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         const auto items = dlg->findData(*dlg->listWidget_profiles, profile, dlgConnectionProfiles::csmNameRole);
@@ -94,9 +90,7 @@ private:
 
     QDialog* confirmation(dlgConnectionProfiles* dlg) const { return dlg->findChild<QDialog*>(qsl("delete_profile_confirmation")); }
 
-    // Answers a raised confirmation the way an intent-on-deleting user would:
-    // by typing the profile name in and pressing the delete button, which the
-    // .ui wires to the dialog's accept()
+    // The .ui wires the delete button's clicked() to the dialog's accept()
     void confirmRemovalOf(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         auto* confirmationDialog = confirmation(dlg);
@@ -113,7 +107,6 @@ private:
         deleteButton->click();
     }
 
-    // Invokes the Remove handler and answers the confirmation, if one is raised
     void removeProfileAndConfirm(dlgConnectionProfiles* dlg, const QString& profile) const
     {
         dlg->slot_deleteProfile();
@@ -223,15 +216,12 @@ private slots:
         QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("..")).isEmpty());
         QVERIFY(dlgConnectionProfiles::profileFolderPath(profilesPath, qsl("%1/current").arg(mKeeper)).isEmpty());
 
-        // a predefined game has no folder until it is saved, and dismissing one
-        // still has to resolve to the folder it would have had
+        // a predefined game has no folder until it is saved
         const QString neverPlayed = qsl("QA Never Played");
         QVERIFY(!QDir(profilePath(neverPlayed)).exists());
         QCOMPARE(dlgConnectionProfiles::profileFolderPath(profilesPath, neverPlayed), qsl("%1/%2").arg(profilesPath, neverPlayed));
     }
 
-    // A profile whose folder holds no saved games but does hold something else
-    // still has data to lose, so it has to be confirmed
     void test_profileWithOnlyAMapIsConfirmedBeforeRemoval()
     {
         const QString mapped = qsl("QA Mapped");
@@ -250,9 +240,6 @@ private slots:
         closeDialog(dlg);
     }
 
-    // A pre-installed game that was never played has nothing to lose - only
-    // the connection details this dialog wrote into its folder - so removing
-    // it goes ahead without a confirmation
     void test_profileWithOnlyConnectionDetailsIsRemovedWithoutConfirmation()
     {
         const QString unplayed = qsl("QA Unplayed");
@@ -269,8 +256,7 @@ private slots:
         closeDialog(dlg);
     }
 
-    // A locally stored password sits loose in the profile folder rather than in
-    // a sub-directory, so the "nothing to lose" shortcut must not overlook it
+    // A stored password sits loose in the folder rather than in a sub-directory
     void test_profileWithOnlyAStoredPasswordIsConfirmedBeforeRemoval()
     {
         const QString secretive = qsl("QA Secretive");
@@ -289,8 +275,7 @@ private slots:
         closeDialog(dlg);
     }
 
-    // Two confirmations can be open together, so each must remove the profile
-    // it names rather than the one raised most recently
+    // Nothing stops a second confirmation being raised over the first
     void test_eachConfirmationRemovesItsOwnProfile()
     {
         const QString first = qsl("QA First");
@@ -310,7 +295,6 @@ private slots:
         QCOMPARE(confirmations.size(), 2);
         auto* secondConfirmation = confirmations.first() == firstConfirmation ? confirmations.last() : confirmations.first();
 
-        // answer the first one, which names the first profile
         auto* nameEntry = firstConfirmation->findChild<QLineEdit*>(qsl("delete_profile_lineedit"));
         auto* deleteButton = firstConfirmation->findChild<QPushButton*>(qsl("delete_button"));
         QVERIFY(nameEntry && deleteButton);
@@ -344,8 +328,7 @@ private slots:
         closeDialog(dlg);
     }
 
-    // A folder name Mudlet would not accept for a new profile is still a
-    // profile once it is on disk, and removing it must work
+    // A name Mudlet would turn down as a new profile is still a profile on disk
     void test_nonAsciiProfileIsStillRemovable()
     {
         const QString doomed = qsl("Мудлет café");
@@ -361,8 +344,7 @@ private slots:
         closeDialog(dlg);
     }
 
-    // The confirmation dialog is not modal, so the profile it names is the one
-    // that gets removed even if the list selection moves on behind it
+    // The confirmation is not modal, so the selection can move on behind it
     void test_confirmationRemovesTheProfileItNamed()
     {
         const QString doomed = qsl("QA Doomed Too");
@@ -397,23 +379,19 @@ private slots:
 
         auto* dlg = openDialog();
         selectProfile(dlg, mKeeper);
-        // without this the assertion below also holds for an unrelated reason,
-        // e.g. an empty server address
+        // else the assertion below also holds for an unrelated reason
         QVERIFY2(acceptButtonsEnabled(dlg), "the profile was already unusable before the name was edited");
 
         // setText() drives the same textChanged path as typing does
         dlg->profile_name_entry->setText(name);
         QVERIFY2(!acceptButtonsEnabled(dlg), qPrintable(qsl("'%1' was accepted as a profile name").arg(name)));
-        // the folder the profile came from must not have been renamed to it
         QVERIFY(QDir(profilePath(mKeeper)).exists());
 
         dlg->profile_name_entry->setText(mKeeper);
         closeDialog(dlg);
     }
 
-    // A folder on disk is the user's data whatever it is called, so selecting
-    // one must never refuse it - not even a name that would be turned down if
-    // it were typed in fresh
+    // A folder on disk is the user's data whatever it is called
     void test_folderOnDiskWithATurnedDownNameIsStillUsable()
     {
         const QString awkward = qsl("QA..Dots");
@@ -450,8 +428,7 @@ private slots:
         QCOMPARE(dlg->profile_name_entry->text(), name);
         QVERIFY2(acceptButtonsEnabled(dlg), qPrintable(qsl("'%1' was refused as a profile name").arg(name)));
 
-        // ~QDialog hiding the dialog fires editingFinished() into slot_saveName(),
-        // which renames the folder - so leave the on-disk name in the field
+        // ~QDialog fires editingFinished() into slot_saveName(), which renames
         dlg->profile_name_entry->setText(mKeeper);
         closeDialog(dlg);
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Validation: a typed profile name must be a folder of its own - rejects a lone `.` and anything containing `..`. Folders already on disk stay exempt
- Containment: `reallyDeleteProfile()` refuses any path that is not a direct child of `profiles/`, and now checks `removeRecursively()` instead of failing mute
- Confirmation: the "nothing to delete" shortcut no longer fires when a map, stored password or dictionary is present

#### Motivation for adding to Mudlet
A profile named `.` or `..` turned **Remove** into a wipe: `.` resolves to `profiles/`, `..` to the whole `~/.config/mudlet`. The name was accepted with no error, and the confirmation was skipped because a fresh profile looks empty - two clicks deep on the first screen every user sees.

#### Other info (issues closed, discussion etc)
Pre-existing, not a 5.0 regression - shipped 4.22.0 behaves identically. Dots have been allowed deliberately since 2011 (`ee1fd051c`), and `Achaea 2.0` keeps working.

**Test case:** name a new profile `.` and press Remove - previously every profile was deleted with no prompt, now the name is refused.

New `ProfileDeletionSafetyTest` drives the real dialog against a temporary config dir, plus `profileFolderPath`/`profileNameUsableAsIs` rows in `ProfileNameValidationTest`. 81/81 ctest pass.

Assisted-by: Claude:claude-opus-5
