### PR TITLE
Fix macOS builds sometimes failing their tests for no reason

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -615,8 +615,8 @@ jobs:
 
     - name: (Linux) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'Linux'
-      # Longer than the other platforms': this leg also drives the real
-      # discord-rpc library, whose reconnects happen in wall-clock time.
+      # This leg drives the real discord-rpc library, whose reconnects
+      # happen in wall-clock time.
       timeout-minutes: 3
       run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror
       env:
@@ -650,7 +650,8 @@ jobs:
 
     - name: (macOS) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
-      timeout-minutes: 1
+      # The suite alone can run past a minute on the slower Intel runners
+      timeout-minutes: 3
       run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror
       env:
         AUTORUN_BUSTED_TESTS: 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -626,8 +626,8 @@ jobs:
 
     - name: (Linux) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'Linux'
-      # Longer than the other platforms': this leg also drives the real
-      # discord-rpc library, whose reconnects happen in wall-clock time.
+      # This leg drives the real discord-rpc library, whose reconnects
+      # happen in wall-clock time.
       timeout-minutes: 3
       run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror
       env:
@@ -661,7 +661,8 @@ jobs:
 
     - name: (macOS) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
-      timeout-minutes: 1
+      # The suite alone can run past a minute on the slower Intel runners
+      timeout-minutes: 3
       run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror
       env:
         AUTORUN_BUSTED_TESTS: 'true'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The macOS Lua test step's 1-minute timeout now fires mid-suite on a slow Intel runner: the suite takes 43-60s there (31s on arm64), so a slow run gets killed while tests are still finishing and the job reads as a failure.
- The timed-out runs were not hung: in the 2026-08-07 failure, `mudlet::closeEvent` arrived 0.6 seconds before the 60-second cutoff, with every spec already passed.
- Raise the step timeout to 3 minutes, matching the Linux leg, in both paired build workflows.

#### Motivation for adding to Mudlet
Three required-check failures on 2026-08-07 (two on development pushes, one on a PR) were this timeout, not real breakage. All previous "macOS timed out" theories pointed at a shutdown hang; the step logs' timestamps show there is none.

#### Other info (issues closed, discussion etc)
Test case: timestamp analysis of passing vs timed-out runs of `(macOS) Run Lua tests` (jobs 93008145745 and 92999008773) - the failed run's shutdown began 59.6s into a 60s budget. No timeout existed before 2026-08-07 because the suite only recently grew past a minute on the slower runners.

Assisted-by: Claude:claude-fable-5