### PR TITLE
infra: tidy up how CI installs Lua

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -92,48 +92,15 @@ jobs:
         cache: true
         modules: qt5compat qtmultimedia qtspeech
 
-    - name: Build Lua (lua.org with mirror fallback)
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: "ON"
-        # sha256 of lua-5.1.5.tar.gz - update when LUA_VERSION changes
-        LUA_SHA256: '2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333'
-      run: |
-        # Pre-build Lua into .lua/ so the gh-actions-lua steps below skip their
-        # own download - they only fetch from lua.org, which goes down at times
-        # and takes all of CI with it.
-        for url in \
-          "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz" \
-          "https://sources.buildroot.net/lua/lua-${LUA_VERSION}.tar.gz" \
-          "https://distfiles.macports.org/lua/lua-${LUA_VERSION}.tar.gz" \
-          "https://ftp.openbsd.org/pub/OpenBSD/distfiles/lua-${LUA_VERSION}.tar.gz"; do
-          echo "Downloading ${url}"
-          if curl -fsSL --connect-timeout 15 --max-time 120 -o lua.tar.gz "${url}" \
-             && echo "${LUA_SHA256}  lua.tar.gz" | shasum -a 256 -c -; then
-            break
-          fi
-          rm -f lua.tar.gz
-        done
-        if [ ! -f lua.tar.gz ]; then
-          echo "::error::could not download Lua ${LUA_VERSION} from any source"
-          exit 1
-        fi
-        tar xzf lua.tar.gz
-        if [ "${RUNNER_OS}" = "macOS" ]; then
-          brew install readline ncurses
-          make -C "lua-${LUA_VERSION}" -j macosx
-        else
-          sudo apt-get install -qy libreadline-dev libncurses-dev
-          make -C "lua-${LUA_VERSION}" -j linux
-        fi
-        make -C "lua-${LUA_VERSION}" INSTALL_TOP="${GITHUB_WORKSPACE}/.lua" install
-        rm -rf lua.tar.gz "lua-${LUA_VERSION}"
-
     - name: (macOS) Install Lua via GitHub Actions
       if: runner.os == 'macOS'
       uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: false
+        # The build cache both speeds runs up and keeps CI green through
+        # lua.org outages - the action downloads only from lua.org, so a cold
+        # cache during an outage is the one case that still needs it up
+        buildCache: true
 
     - name: (macOS) Install Luarocks via GitHub Actions
       if: runner.os == 'macOS'
@@ -207,7 +174,10 @@ jobs:
       if: runner.os == 'Linux'
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: false
+        # The build cache both speeds runs up and keeps CI green through
+        # lua.org outages - the action downloads only from lua.org, so a cold
+        # cache during an outage is the one case that still needs it up
+        buildCache: true
 
     - name: (Linux) Install Luarocks via GitHub Actions
       uses: leafo/gh-actions-luarocks@v6

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -92,12 +92,22 @@ jobs:
         cache: true
         modules: qt5compat qtmultimedia qtspeech
 
+    - name: Cache Lua build
+      uses: actions/cache@v6
+      with:
+        path: .lua
+        # Not gh-actions-lua's own buildCache: that shares one key across
+        # runner images, and a .lua built on ubuntu-latest cannot run on
+        # ubuntu-22.04 (newer glibc). The action skips its lua.org download
+        # whenever .lua already exists.
+        key: lua-${{ env.LUA_VERSION }}-${{ matrix.os }}-${{ runner.arch }}
+
     - name: (macOS) Install Lua via GitHub Actions
       if: runner.os == 'macOS'
       uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: true
+        buildCache: false
 
     - name: (macOS) Install Luarocks via GitHub Actions
       if: runner.os == 'macOS'
@@ -171,7 +181,7 @@ jobs:
       if: runner.os == 'Linux'
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: true
+        buildCache: false
 
     - name: (Linux) Install Luarocks via GitHub Actions
       uses: leafo/gh-actions-luarocks@v6

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -97,9 +97,6 @@ jobs:
       uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        # The build cache both speeds runs up and keeps CI green through
-        # lua.org outages - the action downloads only from lua.org, so a cold
-        # cache during an outage is the one case that still needs it up
         buildCache: true
 
     - name: (macOS) Install Luarocks via GitHub Actions
@@ -174,9 +171,6 @@ jobs:
       if: runner.os == 'Linux'
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        # The build cache both speeds runs up and keeps CI green through
-        # lua.org outages - the action downloads only from lua.org, so a cold
-        # cache during an outage is the one case that still needs it up
         buildCache: true
 
     - name: (Linux) Install Luarocks via GitHub Actions

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -83,9 +83,6 @@ jobs:
       uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        # The build cache both speeds runs up and keeps CI green through
-        # lua.org outages - the action downloads only from lua.org, so a cold
-        # cache during an outage is the one case that still needs it up
         buildCache: true
 
     - name: (macOS) Install Luarocks via GitHub Actions
@@ -160,9 +157,6 @@ jobs:
       if: runner.os == 'Linux'
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        # The build cache both speeds runs up and keeps CI green through
-        # lua.org outages - the action downloads only from lua.org, so a cold
-        # cache during an outage is the one case that still needs it up
         buildCache: true
 
     - name: (Linux) Install Luarocks via GitHub Actions

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -78,48 +78,15 @@ jobs:
         cache: true
         modules: qt5compat qtmultimedia qtspeech
 
-    - name: Build Lua (lua.org with mirror fallback)
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: "ON"
-        # sha256 of lua-5.1.5.tar.gz - update when LUA_VERSION changes
-        LUA_SHA256: '2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333'
-      run: |
-        # Pre-build Lua into .lua/ so the gh-actions-lua steps below skip their
-        # own download - they only fetch from lua.org, which goes down at times
-        # and takes all of CI with it.
-        for url in \
-          "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz" \
-          "https://sources.buildroot.net/lua/lua-${LUA_VERSION}.tar.gz" \
-          "https://distfiles.macports.org/lua/lua-${LUA_VERSION}.tar.gz" \
-          "https://ftp.openbsd.org/pub/OpenBSD/distfiles/lua-${LUA_VERSION}.tar.gz"; do
-          echo "Downloading ${url}"
-          if curl -fsSL --connect-timeout 15 --max-time 120 -o lua.tar.gz "${url}" \
-             && echo "${LUA_SHA256}  lua.tar.gz" | shasum -a 256 -c -; then
-            break
-          fi
-          rm -f lua.tar.gz
-        done
-        if [ ! -f lua.tar.gz ]; then
-          echo "::error::could not download Lua ${LUA_VERSION} from any source"
-          exit 1
-        fi
-        tar xzf lua.tar.gz
-        if [ "${RUNNER_OS}" = "macOS" ]; then
-          brew install readline ncurses
-          make -C "lua-${LUA_VERSION}" -j macosx
-        else
-          sudo apt-get install -qy libreadline-dev libncurses-dev
-          make -C "lua-${LUA_VERSION}" -j linux
-        fi
-        make -C "lua-${LUA_VERSION}" INSTALL_TOP="${GITHUB_WORKSPACE}/.lua" install
-        rm -rf lua.tar.gz "lua-${LUA_VERSION}"
-
     - name: (macOS) Install Lua via GitHub Actions
       if: runner.os == 'macOS'
       uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: false
+        # The build cache both speeds runs up and keeps CI green through
+        # lua.org outages - the action downloads only from lua.org, so a cold
+        # cache during an outage is the one case that still needs it up
+        buildCache: true
 
     - name: (macOS) Install Luarocks via GitHub Actions
       if: runner.os == 'macOS'
@@ -193,7 +160,10 @@ jobs:
       if: runner.os == 'Linux'
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: false
+        # The build cache both speeds runs up and keeps CI green through
+        # lua.org outages - the action downloads only from lua.org, so a cold
+        # cache during an outage is the one case that still needs it up
+        buildCache: true
 
     - name: (Linux) Install Luarocks via GitHub Actions
       uses: leafo/gh-actions-luarocks@v6

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -78,12 +78,22 @@ jobs:
         cache: true
         modules: qt5compat qtmultimedia qtspeech
 
+    - name: Cache Lua build
+      uses: actions/cache@v6
+      with:
+        path: .lua
+        # Not gh-actions-lua's own buildCache: that shares one key across
+        # runner images, and a .lua built on ubuntu-latest cannot run on
+        # ubuntu-22.04 (newer glibc). The action skips its lua.org download
+        # whenever .lua already exists.
+        key: lua-${{ env.LUA_VERSION }}-${{ matrix.os }}-${{ runner.arch }}
+
     - name: (macOS) Install Lua via GitHub Actions
       if: runner.os == 'macOS'
       uses: leafo/gh-actions-lua@v13
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: true
+        buildCache: false
 
     - name: (macOS) Install Luarocks via GitHub Actions
       if: runner.os == 'macOS'
@@ -157,7 +167,7 @@ jobs:
       if: runner.os == 'Linux'
       with:
         luaVersion: ${{ env.LUA_VERSION }}
-        buildCache: true
+        buildCache: false
 
     - name: (Linux) Install Luarocks via GitHub Actions
       uses: leafo/gh-actions-luarocks@v6


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- lua.org is reachable again, so the mirror-fallback pre-build step from #9732 is removed.
- `.lua/` is now cached with `actions/cache` under an image-qualified key (`lua-5.1.5-ubuntu-22.04-X64` etc.), so lua.org is only contacted when the cache is cold, and the nightly builds keep it warm.
- The action's own `buildCache` stays off: its key is shared across runner images (`lua:5.1.5:linux:x64`), and the entry other workflows built on ubuntu-latest needs a newer glibc than the ubuntu-22.04 build jobs have - enabling it failed CI on this very PR, which is presumably why it has been off since 2022.

#### Motivation for adding to Mudlet
The 35-line shell workaround duplicated the action's build logic in two files. The cache achieves nearly the same outage protection - the one remaining exposure is lua.org being down at the same time as a cache eviction (7 days unused).

#### Other info (issues closed, discussion etc)
Test case: this PR's own CI - each leg builds Lua once from lua.org on the cold key and saves it; the earlier commit that enabled the action's shared-key cache instead is what produced the `GLIBC_2.38' not found` failure.

Assisted-by: Claude:claude-fable-5