### PR TITLE
Fix: don't offer updates that don't yet have a sha256 sum

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -319,8 +319,16 @@ void Updater::setupPlatformUpdater()
     });
 
     connect(feed.get(), &dblsqd::Feed::downloadError, this, [this](const QString& error) {
+        // Only a check the user started reaches the console. An automatic one
+        // runs twice a day whether or not anybody is interested, so its failures
+        // would just repeat in red; once the update dialog is listening it
+        // reports them itself.
+        if (mManualCheckInProgress) {
+            qWarning() << "Manual update download failed:" << error;
+            emit signal_updateCheckFailed(error);
+            return;
+        }
         qWarning() << "Automatic update download failed:" << error;
-        emit signal_updateCheckFailed(error);
     });
 }
 #endif // !Q_OS_MACOS

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -265,7 +265,7 @@ bool Updater::downloadReleaseIfValid(const dblsqd::Release& release)
         }
         return false;
     }
-    feed->downloadRelease(release);
+    feed->downloadRelease(release, /*requireChecksums=*/true);
     return true;
 }
 

--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -91,8 +91,17 @@ QList<Release> Feed::getReleases() const
 
 QList<Release> Feed::getUpdates(const Release& currentRelease) const
 {
+    return selectUpdates(mReleases, currentRelease);
+}
+
+QList<Release> Feed::selectUpdates(const QList<Release>& releases, const Release& currentRelease)
+{
     QList<Release> updates;
-    for (const auto& release : mReleases) {
+    for (const auto& release : releases) {
+        const QUrl downloadUrl = release.getDownloadUrl();
+        if (!downloadUrl.isValid() || downloadUrl.isEmpty()) {
+            continue;
+        }
         if (currentRelease.getVersion().toLower() != release.getVersion().toLower() && currentRelease < release) {
             updates << release;
         }

--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -98,13 +98,22 @@ QList<Release> Feed::selectUpdates(const QList<Release>& releases, const Release
 {
     QList<Release> updates;
     for (const auto& release : releases) {
+        if (currentRelease.getVersion().toLower() == release.getVersion().toLower() || !(currentRelease < release)) {
+            continue;
+        }
         const QUrl downloadUrl = release.getDownloadUrl();
         if (!downloadUrl.isValid() || downloadUrl.isEmpty()) {
             continue;
         }
-        if (currentRelease.getVersion().toLower() != release.getVersion().toLower() && currentRelease < release) {
-            updates << release;
+        // Release warns about the missing binary itself; nothing else notices a
+        // release that has one but cannot be verified, and the user is only
+        // told they are up to date
+        const QUrl checksumsUrl = release.getChecksumsUrl();
+        if (!checksumsUrl.isValid() || checksumsUrl.isEmpty()) {
+            qWarning() << "Release" << release.getVersion() << "publishes no checksums to verify its download against - passing it over";
+            continue;
         }
+        updates << release;
     }
     return updates;
 }

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -55,7 +55,14 @@ public:
     // not a checksum file".
     static QString findChecksum(const QString& checksumData, const QString& downloadFilename, int* entriesParsed = nullptr);
 
+    // The releases newer than currentRelease that this platform can install. A
+    // release with no asset for this platform - a build job that failed, or
+    // assets that are still uploading - has nothing to fetch, so offering it
+    // only produces a download error the user can do nothing about. The
+    // changelog is built from getReleases() instead, and still covers them.
     QList<Release> getUpdates(const Release& currentRelease) const;
+    static QList<Release> selectUpdates(const QList<Release>& releases, const Release& currentRelease);
+
     QList<Release> getReleases() const;
     QString getDownloadFilePath() const;
     bool isReady() const;

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -57,9 +57,10 @@ public:
 
     // The releases newer than currentRelease that this platform can install. A
     // release with no asset for this platform - a build job that failed, or
-    // assets that are still uploading - has nothing to fetch, so offering it
-    // only produces a download error the user can do nothing about. The
-    // changelog is built from getReleases() instead, and still covers them.
+    // assets that are still uploading - or no SHA256SUMS.txt to verify the
+    // download against cannot be installed, so offering it only produces a
+    // download error the user can do nothing about. The changelog is built from
+    // getReleases() instead, and still covers them.
     QList<Release> getUpdates(const Release& currentRelease) const;
     static QList<Release> selectUpdates(const QList<Release>& releases, const Release& currentRelease);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,21 @@ set_tests_properties(UpdaterChecksumTest PROPERTIES
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
 )
 
+# Which releases the updater offers as an update. Built from the updater sources
+# rather than linked against the Mudlet library, because the library only
+# contains them when configured with USE_UPDATER.
+add_executable(UpdaterPlatformAssetTest
+    UpdaterPlatformAssetTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/Feed.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/Release.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/SemVer.cpp
+)
+target_link_libraries(UpdaterPlatformAssetTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
+add_test(NAME UpdaterPlatformAssetTest COMMAND $<TARGET_FILE:UpdaterPlatformAssetTest>)
+set_tests_properties(UpdaterPlatformAssetTest PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
+)
+
 # Checks the release-publishing scripts that keep SHA256SUMS.txt covering every
 # release binary - a binary without an entry is one the updater refuses to install
 if(NOT WIN32)

--- a/test/UpdaterPlatformAssetTest.cpp
+++ b/test/UpdaterPlatformAssetTest.cpp
@@ -33,13 +33,16 @@
  * users got a red "no download available for your platform" error on the
  * console on every check, because the release was offered as an update and the
  * download then had nothing to fetch. A partly published release is valid and
- * will happen again, so it has to be passed over instead.
+ * will happen again, so it has to be passed over instead - as does one that
+ * published a binary but no SHA256SUMS.txt, since the download refuses to
+ * install what it cannot verify.
  */
 
 namespace {
-// Only windowsOnlyTag is a real release; the newer complete one and the
-// installed one are constructed around it
+// Only windowsOnlyTag is a real release; the complete, unverifiable and
+// installed ones are constructed around it
 const auto windowsOnlyTag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-07-eaa991b9");
+const auto unverifiableTag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-07-5e4d3c2b");
 const auto completeTag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-06-1a2b3c4d");
 const auto windowsOnlyVersion = QStringLiteral("4.22.0-ptb-2026-08-07-eaa991b9");
 const auto completeVersion = QStringLiteral("4.22.0-ptb-2026-08-06-1a2b3c4d");
@@ -84,6 +87,12 @@ QJsonObject windowsOnlyRelease()
     return releaseJson(windowsOnlyTag, QStringLiteral("2026-08-07T02:14:11Z"), {windowsSuffix});
 }
 
+// Published its Linux binary, but not the checksums that binary is verified against
+QJsonObject unverifiableRelease()
+{
+    return releaseJson(unverifiableTag, QStringLiteral("2026-08-07T04:22:09Z"), {linuxSuffix}, /*withChecksums=*/false);
+}
+
 QJsonObject completeRelease()
 {
     return releaseJson(completeTag, QStringLiteral("2026-08-06T02:11:47Z"), {windowsSuffix, linuxSuffix, intelMacSuffix, appleSiliconSuffix});
@@ -111,7 +120,8 @@ private slots:
     void intelMacIsNotOfferedTheReleaseWithoutADmg();
     void appleSiliconIsNotOfferedTheReleaseWithoutADmg();
     void aReleaseWithOnlyItsChecksumsFileIsNotOffered();
-    void aReleaseWithoutChecksumsIsStillOffered();
+    void aReleaseWithoutChecksumsIsNotOffered();
+    void theVerifiableReleaseIsOfferedInsteadOfTheNewerUnverifiableOne();
     void aPlatformWithNoAssetsAtAllIsOfferedNothing();
     void nothingIsOfferedOnceTheOnlyNewerReleaseIsIncomplete();
     void thePassedOverReleaseStaysReadableForTheChangelog();
@@ -162,18 +172,24 @@ void UpdaterPlatformAssetTest::aReleaseWithOnlyItsChecksumsFileIsNotOffered()
     QVERIFY(dblsqd::Feed::selectUpdates(releases, installedRelease()).isEmpty());
 }
 
-// Whether the update can be verified is the download's business: it refuses to
-// install without checksums and says so, which is a different answer from
-// pretending there is nothing to update to
-void UpdaterPlatformAssetTest::aReleaseWithoutChecksumsIsStillOffered()
+// The download refuses to install what it cannot verify, so a release whose
+// SHA256SUMS.txt is missing is as uninstallable as one missing its binary
+void UpdaterPlatformAssetTest::aReleaseWithoutChecksumsIsNotOffered()
 {
-    const QList<dblsqd::Release> releases{
-            dblsqd::Release(releaseJson(completeTag, QStringLiteral("2026-08-06T02:11:47Z"), {linuxSuffix}, /*withChecksums=*/false), QStringLiteral("linux"), QStringLiteral("x86_64"))};
+    const QList<dblsqd::Release> releases{dblsqd::Release(unverifiableRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"))};
+
+    QVERIFY(dblsqd::Feed::selectUpdates(releases, installedRelease()).isEmpty());
+}
+
+void UpdaterPlatformAssetTest::theVerifiableReleaseIsOfferedInsteadOfTheNewerUnverifiableOne()
+{
+    const QList<dblsqd::Release> releases{dblsqd::Release(unverifiableRelease(), QStringLiteral("linux"), QStringLiteral("x86_64")),
+                                          dblsqd::Release(completeRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"))};
 
     const auto updates = dblsqd::Feed::selectUpdates(releases, installedRelease());
 
     QCOMPARE(updates.size(), 1);
-    QVERIFY(updates.first().getChecksumsUrl().isEmpty());
+    QCOMPARE(updates.first().getVersion(), completeVersion);
 }
 
 // Mudlet publishes no binaries for the platforms it is packaged for by others,

--- a/test/UpdaterPlatformAssetTest.cpp
+++ b/test/UpdaterPlatformAssetTest.cpp
@@ -1,0 +1,209 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "../src/updater/Feed.h"
+#include "../src/updater/Release.h"
+
+#include <QtTest/QtTest>
+
+#include <QJsonArray>
+#include <QJsonObject>
+
+/*
+ * Covers which releases the updater is willing to offer as an update.
+ *
+ * The 2026-08-07 PTB published a Windows installer and nothing else: the Linux
+ * and macOS build jobs failed, so their assets were never attached. Linux PTB
+ * users got a red "no download available for your platform" error on the
+ * console on every check, because the release was offered as an update and the
+ * download then had nothing to fetch. A partly published release is valid and
+ * will happen again, so it has to be passed over instead.
+ */
+
+namespace {
+// Only windowsOnlyTag is a real release; the newer complete one and the
+// installed one are constructed around it
+const auto windowsOnlyTag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-07-eaa991b9");
+const auto completeTag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-06-1a2b3c4d");
+const auto windowsOnlyVersion = QStringLiteral("4.22.0-ptb-2026-08-07-eaa991b9");
+const auto completeVersion = QStringLiteral("4.22.0-ptb-2026-08-06-1a2b3c4d");
+const auto installedVersion = QStringLiteral("4.22.0-ptb-2026-08-05-9f8e7d6c");
+
+const auto windowsSuffix = QStringLiteral("-windows-64.exe");
+const auto linuxSuffix = QStringLiteral("-linux-x64.AppImage.tar");
+const auto intelMacSuffix = QStringLiteral("-x86_64.dmg");
+const auto appleSiliconSuffix = QStringLiteral("-arm64.dmg");
+
+QJsonObject makeAsset(const QString& tag, const QString& name)
+{
+    QJsonObject asset;
+    asset.insert(QStringLiteral("name"), name);
+    asset.insert(QStringLiteral("browser_download_url"), QStringLiteral("https://github.com/Mudlet/Mudlet/releases/download/%1/%2").arg(tag, name));
+    asset.insert(QStringLiteral("size"), 137252032);
+    return asset;
+}
+
+QJsonObject releaseJson(const QString& tag, const QString& publishedAt, const QStringList& assetSuffixes, bool withChecksums = true)
+{
+    QJsonArray assets;
+    for (const auto& suffix : assetSuffixes) {
+        assets.append(makeAsset(tag, QStringLiteral("%1%2").arg(tag, suffix)));
+    }
+    if (withChecksums) {
+        assets.append(makeAsset(tag, QStringLiteral("SHA256SUMS.txt")));
+    }
+
+    QJsonObject release;
+    release.insert(QStringLiteral("tag_name"), tag);
+    release.insert(QStringLiteral("published_at"), publishedAt);
+    release.insert(QStringLiteral("prerelease"), true);
+    release.insert(QStringLiteral("draft"), false);
+    release.insert(QStringLiteral("body"), QStringLiteral("- fixed a thing\n"));
+    release.insert(QStringLiteral("assets"), assets);
+    return release;
+}
+
+QJsonObject windowsOnlyRelease()
+{
+    return releaseJson(windowsOnlyTag, QStringLiteral("2026-08-07T02:14:11Z"), {windowsSuffix});
+}
+
+QJsonObject completeRelease()
+{
+    return releaseJson(completeTag, QStringLiteral("2026-08-06T02:11:47Z"), {windowsSuffix, linuxSuffix, intelMacSuffix, appleSiliconSuffix});
+}
+
+// Newest first, the order Feed sorts its releases into
+QList<dblsqd::Release> feedReleases(const QString& os, const QString& arch)
+{
+    return {dblsqd::Release(windowsOnlyRelease(), os, arch), dblsqd::Release(completeRelease(), os, arch)};
+}
+
+dblsqd::Release installedRelease()
+{
+    return dblsqd::Release(installedVersion, QDateTime::fromString(QStringLiteral("2026-08-05T02:09:03Z"), Qt::ISODate));
+}
+} // namespace
+
+class UpdaterPlatformAssetTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void linuxIsNotOfferedTheReleaseWithoutALinuxAsset();
+    void windowsIsStillOfferedIt();
+    void intelMacIsNotOfferedTheReleaseWithoutADmg();
+    void appleSiliconIsNotOfferedTheReleaseWithoutADmg();
+    void aReleaseWithOnlyItsChecksumsFileIsNotOffered();
+    void aReleaseWithoutChecksumsIsStillOffered();
+    void aPlatformWithNoAssetsAtAllIsOfferedNothing();
+    void nothingIsOfferedOnceTheOnlyNewerReleaseIsIncomplete();
+    void thePassedOverReleaseStaysReadableForTheChangelog();
+};
+
+// The regression: this is the update that produced a red console error twice a day
+void UpdaterPlatformAssetTest::linuxIsNotOfferedTheReleaseWithoutALinuxAsset()
+{
+    const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("linux"), QStringLiteral("x86_64")), installedRelease());
+
+    QCOMPARE(updates.size(), 1);
+    QCOMPARE(updates.first().getVersion(), completeVersion);
+    QVERIFY(updates.first().getDownloadUrl().fileName().endsWith(linuxSuffix));
+}
+
+void UpdaterPlatformAssetTest::windowsIsStillOfferedIt()
+{
+    const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("win"), QStringLiteral("x86_64")), installedRelease());
+
+    QCOMPARE(updates.size(), 2);
+    QCOMPARE(updates.first().getVersion(), windowsOnlyVersion);
+    QCOMPARE(updates.last().getVersion(), completeVersion);
+}
+
+void UpdaterPlatformAssetTest::intelMacIsNotOfferedTheReleaseWithoutADmg()
+{
+    const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("mac"), QStringLiteral("x86_64")), installedRelease());
+
+    QCOMPARE(updates.size(), 1);
+    QCOMPARE(updates.first().getVersion(), completeVersion);
+    QVERIFY(updates.first().getDownloadUrl().fileName().endsWith(intelMacSuffix));
+}
+
+void UpdaterPlatformAssetTest::appleSiliconIsNotOfferedTheReleaseWithoutADmg()
+{
+    const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("mac"), QStringLiteral("arm64")), installedRelease());
+
+    QCOMPARE(updates.size(), 1);
+    QCOMPARE(updates.first().getVersion(), completeVersion);
+    QVERIFY(updates.first().getDownloadUrl().fileName().endsWith(appleSiliconSuffix));
+}
+
+// A release whose binaries are still uploading looks the same as one that lost a build job
+void UpdaterPlatformAssetTest::aReleaseWithOnlyItsChecksumsFileIsNotOffered()
+{
+    const QList<dblsqd::Release> releases{dblsqd::Release(releaseJson(windowsOnlyTag, QStringLiteral("2026-08-07T02:14:11Z"), {}), QStringLiteral("linux"), QStringLiteral("x86_64"))};
+
+    QVERIFY(dblsqd::Feed::selectUpdates(releases, installedRelease()).isEmpty());
+}
+
+// Whether the update can be verified is the download's business: it refuses to
+// install without checksums and says so, which is a different answer from
+// pretending there is nothing to update to
+void UpdaterPlatformAssetTest::aReleaseWithoutChecksumsIsStillOffered()
+{
+    const QList<dblsqd::Release> releases{
+            dblsqd::Release(releaseJson(completeTag, QStringLiteral("2026-08-06T02:11:47Z"), {linuxSuffix}, /*withChecksums=*/false), QStringLiteral("linux"), QStringLiteral("x86_64"))};
+
+    const auto updates = dblsqd::Feed::selectUpdates(releases, installedRelease());
+
+    QCOMPARE(updates.size(), 1);
+    QVERIFY(updates.first().getChecksumsUrl().isEmpty());
+}
+
+// Mudlet publishes no binaries for the platforms it is packaged for by others,
+// so those builds are told there is no update rather than shown a failure they
+// can do nothing about, twice a day, forever
+void UpdaterPlatformAssetTest::aPlatformWithNoAssetsAtAllIsOfferedNothing()
+{
+    QVERIFY(dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("freebsd"), QStringLiteral("x86_64")), installedRelease()).isEmpty());
+}
+
+// What a Linux user on the previous PTB sees: no update, rather than an error
+void UpdaterPlatformAssetTest::nothingIsOfferedOnceTheOnlyNewerReleaseIsIncomplete()
+{
+    const QList<dblsqd::Release> releases{dblsqd::Release(windowsOnlyRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"))};
+    const dblsqd::Release installed(completeVersion, QDateTime::fromString(QStringLiteral("2026-08-06T02:11:47Z"), Qt::ISODate));
+
+    QVERIFY(dblsqd::Feed::selectUpdates(releases, installed).isEmpty());
+}
+
+// A release passed over here still has to carry its version and notes: the
+// changelog dialogs render the unfiltered release list
+// (UpdateDialog::generateChangelogDocument)
+void UpdaterPlatformAssetTest::thePassedOverReleaseStaysReadableForTheChangelog()
+{
+    const dblsqd::Release release(windowsOnlyRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"));
+
+    QVERIFY(release.getDownloadUrl().isEmpty());
+    QCOMPARE(release.getVersion(), windowsOnlyVersion);
+    QCOMPARE(release.getChangelog(), QStringLiteral("- fixed a thing\n"));
+}
+
+#include "UpdaterPlatformAssetTest.moc"
+QTEST_MAIN(UpdaterPlatformAssetTest)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't offer updates that don't yet have a sha256 sum
#### Motivation for adding to Mudlet
They are incomplete anyhow.
#### Other info (issues closed, discussion etc)
