### PR TITLE
fix: MXP frames overlapping UI packages that reserve screen space

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -747,6 +747,12 @@ void TConsole::resizeEvent(QResizeEvent* event)
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());
     }
 
+    // MXP frames are positioned by hand against the space the borders leave, so
+    // they have to be moved whenever the window or those borders change
+    if ((mType & MainConsole) && !mpHost.isNull()) {
+        mpHost->mMxpFrameManager.scheduleRelayout();
+    }
+
     // Sync Host dimensions on resize so wraps and NAWS reflect the current pane width.
     if ((mType & MainConsole) && !mpHost.isNull() && mUpperPane && !mUpperPane->visibleRegion().isEmpty()) {
         const int paneWidthPx = mUpperPane->visibleRegion().boundingRect().width();

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -124,6 +124,11 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
     qDebug() << "TMxpFrameManager::createFrame:" << name << "TITLE attr:" << attributes.value(qsl("TITLE")) << "title:" << frame->title << "floating:" << frame->floating;
 #endif
 
+    // Store the frame before laying it out: laying out pushes new borders, which
+    // resizes the console, which asks for a relayout of every known frame
+    mFrames[name] = frame;
+    mFrameOrder.append(frame);
+
     // Create the appropriate UI layout
     if (frame->isInternal) {
         if (!frame->dockFrame.isEmpty() && frame->align == qsl("client")) {
@@ -134,9 +139,6 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
     } else {
         layoutExternalFrame(frame);
     }
-
-    // Store the frame
-    mFrames[name] = frame;
 
     return true;
 }
@@ -176,6 +178,7 @@ bool TMxpFrameManager::closeFrame(const QString& name)
 
             // Remove from frames map and delete
             mFrames.remove(name);
+            mFrameOrder.removeOne(frame);
             delete frame;
 
             // No need to recalculate borders for tab frames since they don't affect main window borders
@@ -200,10 +203,11 @@ bool TMxpFrameManager::closeFrame(const QString& name)
     removeFrameFromHierarchy(frame);
 
     mFrames.remove(name);
+    mFrameOrder.removeOne(frame);
     delete frame;
 
-    // Recalculate borders after frame removal to reclaim space
-    recalculateBorders();
+    // Reposition what is left so it reclaims the space the frame gave up
+    relayoutFrames();
 
     return true;
 }
@@ -257,6 +261,7 @@ void TMxpFrameManager::resetAllFrames()
         closeFrame(name);
     }
 
+    mFrameOrder.clear();
     mMxpBorders = QMargins();
 
     if (mpHost) {
@@ -350,29 +355,37 @@ QStringList TMxpFrameManager::getFrameNames() const
     return mFrames.keys();
 }
 
-void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
+QRect TMxpFrameManager::availableFrameArea() const
 {
-    if (!mpHost || !mpHost->mpConsole) {
-        qWarning() << "TMxpFrameManager::layoutInternalFrame: No console available";
-        return;
+    if (!mpHost || mpHost->mpConsole.isNull()) {
+        return {};
     }
 
-    TMainConsole* mainConsole = mpHost->mpConsole.data();
-
-    // Note: DOCK tabbing is handled in createFrame() when ALIGN=CLIENT is set.
-    // Per CMUD, ALIGN=CLIENT + DOCK creates tabbed frames.
-    // This is a CMUD extension, not part of the official MXP 1.0 specification.
-
-    // Check if we're inside a DEST - if so, nest this frame inside the destination
-    TMxpFrame* parentFrame = nullptr;
-    if (!mCurrentDestination.isEmpty()) {
-        parentFrame = getFrame(mCurrentDestination);
+    // getMainWindowSize() is the space frames are placed in: mpMainFrame's own
+    // geometry is briefly wrong during a resize, and this is also the size Lua
+    // scripts lay themselves out against. Taking the user borders off it keeps
+    // frames out of the space a package such as the base UI has reserved for
+    // itself with setBorderRight() and friends.
+    QRect area = QRect(QPoint(0, 0), mpHost->mpConsole->getMainWindowSize()).marginsRemoved(mpHost->userBorders());
+    if (area.width() < 0) {
+        area.setWidth(0);
     }
+    if (area.height() < 0) {
+        area.setHeight(0);
+    }
+    return area;
+}
 
+// Works out where a frame goes, consuming the space it takes from mMxpBorders
+// when it is a top level frame. Callers are responsible for pushing the updated
+// borders to the Host.
+QRect TMxpFrameManager::calculateFrameGeometry(TMxpFrame* frame, TMxpFrame* parentFrame)
+{
     // Determine the container for this frame
     QSize containerSize;
     int containerX = 0;
     int containerY = 0;
+    QRect area;
 
     if (parentFrame && parentFrame->widget) {
         // Nested frame - position relative to parent
@@ -384,12 +397,14 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         containerY += parentFrame->usedHeight;
         containerSize.setHeight(containerSize.height() - parentFrame->usedHeight);
     } else {
+        // A parent with no widget of its own gives nothing to place against, so
+        // such a frame is treated as a top level one throughout
+        parentFrame = nullptr;
         // Top-level frame - use MXP-specific borders (not Host borders which are for Lua)
-        containerSize = mainConsole->size();
-        containerX = mMxpBorders.left();
-        containerY = mMxpBorders.top();
-        containerSize.setWidth(containerSize.width() - mMxpBorders.left() - mMxpBorders.right());
-        containerSize.setHeight(containerSize.height() - mMxpBorders.top() - mMxpBorders.bottom());
+        area = availableFrameArea();
+        containerX = area.x() + mMxpBorders.left();
+        containerY = area.y() + mMxpBorders.top();
+        containerSize = QSize(area.width() - mMxpBorders.left() - mMxpBorders.right(), area.height() - mMxpBorders.top() - mMxpBorders.bottom());
     }
 
     // Calculate frame dimensions relative to container
@@ -404,13 +419,14 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
     }
 
     // Ensure minimum size for visibility
-    if (frameWidth < 50)
+    if (frameWidth < 50) {
         frameWidth = 100;
+    }
 
     // For character-based height specs, handle minimum size more carefully
-    bool isCharacterHeight = frame->height.trimmed().endsWith('c', Qt::CaseInsensitive);
-    bool isCharacterWidth = frame->width.trimmed().endsWith('c', Qt::CaseInsensitive);
-    bool willHaveTitle = !frame->floating && frame->hasExplicitTitle;
+    const bool isCharacterHeight = frame->height.trimmed().endsWith('c', Qt::CaseInsensitive);
+    const bool isCharacterWidth = frame->width.trimmed().endsWith('c', Qt::CaseInsensitive);
+    const bool willHaveTitle = !frame->floating && frame->hasExplicitTitle;
 
     // Apply minimum size for visibility to non-character-based frames
     if (frameHeight < 20 && !isCharacterHeight) {
@@ -455,7 +471,7 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
     // Calculate position based on alignment
     int x = containerX;
     int y = containerY;
-    QString align = frame->align.toLower();
+    const QString align = frame->align.toLower();
 
     if (parentFrame) {
         // Nested frame - position within parent's bounds using VBox/HBox logic
@@ -473,61 +489,90 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
             y = containerY + containerSize.height() - frameHeight;
             frameWidth = containerSize.width();
         }
-    } else {
-        // Top-level frame - position at window edges and update MXP borders
-        QSize windowSize = mainConsole->size();
 
-        // Check for LEFT/TOP absolute positioning first - these take precedence over alignment
-        bool hasAbsolutePosition = !frame->left.isEmpty() || !frame->top.isEmpty();
-
-        if (hasAbsolutePosition) {
-            // Absolute positioning via LEFT/TOP attributes
-            if (!frame->left.isEmpty()) {
-                QSize leftSize = calculateFrameSize(frame->left, windowSize, false);
-                if (leftSize.width() > 0) {
-                    x = leftSize.width();
-                }
-            }
-            if (!frame->top.isEmpty()) {
-                QSize topSize = calculateFrameSize(frame->top, windowSize, true);
-                if (topSize.height() > 0) {
-                    y = topSize.height();
-                }
-            }
-            // Absolute positioned frames don't modify MXP borders
-        } else if (align == qsl("left")) {
-            // Left-aligned: position at actual left edge (after existing left MXP frames)
-            x = mMxpBorders.left();
-            y = 0;
-            frameHeight = windowSize.height();
-            // Update MXP left border
-            mMxpBorders.setLeft(mMxpBorders.left() + frameWidth);
-        } else if (align == qsl("right")) {
-            // Right-aligned: position at right edge
-            x = windowSize.width() - mMxpBorders.right() - frameWidth;
-            y = 0;
-            frameHeight = windowSize.height();
-            mMxpBorders.setRight(mMxpBorders.right() + frameWidth);
-        } else if (align == qsl("top")) {
-            // Top-aligned: position at top edge
-            x = mMxpBorders.left();
-            y = mMxpBorders.top();
-            frameWidth = windowSize.width() - mMxpBorders.left() - mMxpBorders.right();
-            mMxpBorders.setTop(mMxpBorders.top() + frameHeight);
-        } else if (align == qsl("bottom")) {
-            // Bottom-aligned: position at bottom edge
-            x = mMxpBorders.left();
-            y = windowSize.height() - mMxpBorders.bottom() - frameHeight;
-            frameWidth = windowSize.width() - mMxpBorders.left() - mMxpBorders.right();
-            mMxpBorders.setBottom(mMxpBorders.bottom() + frameHeight);
-        } else {
-            // No alignment and no absolute positioning - use container defaults
-            x = containerX;
-            y = containerY;
-        }
-
-        mpHost->setMxpBorders(mMxpBorders);
+        return {x, y, frameWidth, frameHeight};
     }
+
+    // Top-level frame - position at the edges of the available area and update MXP borders
+
+    // Check for LEFT/TOP absolute positioning first - these take precedence over alignment
+    const bool hasAbsolutePosition = !frame->left.isEmpty() || !frame->top.isEmpty();
+
+    if (hasAbsolutePosition) {
+        // Absolute positioning via LEFT/TOP attributes
+        if (!frame->left.isEmpty()) {
+            QSize leftSize = calculateFrameSize(frame->left, area.size(), false);
+            if (leftSize.width() > 0) {
+                x = area.x() + leftSize.width();
+            }
+        }
+        if (!frame->top.isEmpty()) {
+            QSize topSize = calculateFrameSize(frame->top, area.size(), true);
+            if (topSize.height() > 0) {
+                y = area.y() + topSize.height();
+            }
+        }
+        // Absolute positioned frames don't modify MXP borders
+    } else if (align == qsl("left")) {
+        // Left-aligned: position at actual left edge (after existing left MXP frames)
+        x = area.x() + mMxpBorders.left();
+        y = area.y();
+        frameHeight = area.height();
+        // Update MXP left border
+        mMxpBorders.setLeft(mMxpBorders.left() + frameWidth);
+    } else if (align == qsl("right")) {
+        // Right-aligned: position at right edge
+        x = area.x() + area.width() - mMxpBorders.right() - frameWidth;
+        y = area.y();
+        frameHeight = area.height();
+        mMxpBorders.setRight(mMxpBorders.right() + frameWidth);
+    } else if (align == qsl("top")) {
+        // Top-aligned: position at top edge
+        x = area.x() + mMxpBorders.left();
+        y = area.y() + mMxpBorders.top();
+        frameWidth = area.width() - mMxpBorders.left() - mMxpBorders.right();
+        mMxpBorders.setTop(mMxpBorders.top() + frameHeight);
+    } else if (align == qsl("bottom")) {
+        // Bottom-aligned: position at bottom edge
+        x = area.x() + mMxpBorders.left();
+        y = area.y() + area.height() - mMxpBorders.bottom() - frameHeight;
+        frameWidth = area.width() - mMxpBorders.left() - mMxpBorders.right();
+        mMxpBorders.setBottom(mMxpBorders.bottom() + frameHeight);
+    }
+
+    return {x, y, frameWidth, frameHeight};
+}
+
+void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
+{
+    if (!mpHost || !mpHost->mpConsole) {
+        qWarning() << "TMxpFrameManager::layoutInternalFrame: No console available";
+        return;
+    }
+
+    TMainConsole* mainConsole = mpHost->mpConsole.data();
+
+    // Note: DOCK tabbing is handled in createFrame() when ALIGN=CLIENT is set.
+    // Per CMUD, ALIGN=CLIENT + DOCK creates tabbed frames.
+    // This is a CMUD extension, not part of the official MXP 1.0 specification.
+
+    // Check if we're inside a DEST - if so, nest this frame inside the destination
+    TMxpFrame* parentFrame = nullptr;
+    if (!mCurrentDestination.isEmpty()) {
+        parentFrame = getFrame(mCurrentDestination);
+    }
+
+    const QRect geometry = calculateFrameGeometry(frame, parentFrame);
+    const int x = geometry.x();
+    const int y = geometry.y();
+    const int frameWidth = geometry.width();
+    const int frameHeight = geometry.height();
+
+    // A no-op for a nested frame, which leaves the borders alone
+    mpHost->setMxpBorders(mMxpBorders);
+
+    const bool isCharacterHeight = frame->height.trimmed().endsWith('c', Qt::CaseInsensitive);
+    const bool willHaveTitle = !frame->floating && frame->hasExplicitTitle;
 
     // FLOATING attribute, no explicit title, or very small height = borderless frame without header
     // Exception: character-based frames with explicit titles always show headers
@@ -1002,51 +1047,52 @@ void TMxpFrameManager::layoutTabIntoExistingFrame(TMxpFrame* frame, TMxpFrame* t
     console->show();
 }
 
-void TMxpFrameManager::recalculateBorders()
+void TMxpFrameManager::scheduleRelayout()
+{
+    if (mRelayoutPending || mFrames.isEmpty()) {
+        return;
+    }
+
+    // Deferred so that the layout of the widgets frames are placed against has
+    // settled, and so that pushing new borders from here cannot re-enter the
+    // resize handling that asked for the relayout
+    mRelayoutPending = true;
+    QTimer::singleShot(0, mpHost, [this]() {
+        mRelayoutPending = false;
+        relayoutFrames();
+    });
+}
+
+void TMxpFrameManager::relayoutFrames()
 {
     if (!mpHost) {
         return;
     }
 
-    // Reset borders and recalculate based on remaining frames
+    // Recalculating from scratch keeps the borders in step with where the
+    // frames actually ended up, whatever the available area has become
     mMxpBorders = QMargins();
 
-    if (!mpHost->mpConsole) {
+    if (mpHost->mpConsole.isNull() || !mpHost->mpConsole->mpMainFrame) {
         mpHost->setMxpBorders(mMxpBorders);
         return;
     }
 
-    QSize windowSize = mpHost->mpConsole->size();
+    const QWidget* mainFrame = mpHost->mpConsole->mpMainFrame;
 
-    // Recalculate borders by examining all remaining top-level frames
-    // (frames without parents that affect the main window borders)
-    for (auto* frame : mFrames.values()) {
-        if (!frame || frame->parentFrame) {
-            continue; // Skip child frames, only process top-level frames
-        }
+    for (auto* frame : std::as_const(mFrameOrder)) {
+        frame->usedHeight = 0;
+    }
 
-        // Only frames that were positioned using alignment (not absolute positioning)
-        // contribute to MXP borders
-        bool hasAbsolutePosition = !frame->left.isEmpty() || !frame->top.isEmpty();
-        if (hasAbsolutePosition) {
+    for (auto* frame : std::as_const(mFrameOrder)) {
+        // Frames docked as a tab, and external ones in their own window, are
+        // placed by a layout or the window manager rather than by us
+        if (!frame->widget || frame->widget->parentWidget() != mainFrame) {
             continue;
         }
 
-        QString align = frame->align.toLower();
-        QSize widthSize = calculateFrameSize(frame->width, windowSize, false);
-        QSize heightSize = calculateFrameSize(frame->height, windowSize, true);
-
-        if (align == qsl("left")) {
-            mMxpBorders.setLeft(mMxpBorders.left() + widthSize.width());
-        } else if (align == qsl("right")) {
-            mMxpBorders.setRight(mMxpBorders.right() + widthSize.width());
-        } else if (align == qsl("top")) {
-            mMxpBorders.setTop(mMxpBorders.top() + heightSize.height());
-        } else if (align == qsl("bottom")) {
-            mMxpBorders.setBottom(mMxpBorders.bottom() + heightSize.height());
-        }
+        frame->widget->setGeometry(calculateFrameGeometry(frame, frame->parentFrame));
     }
 
-    // Apply the recalculated borders
     mpHost->setMxpBorders(mMxpBorders);
 }

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -124,8 +124,8 @@ bool TMxpFrameManager::createFrame(const QString& name, const QMap<QString, QStr
     qDebug() << "TMxpFrameManager::createFrame:" << name << "TITLE attr:" << attributes.value(qsl("TITLE")) << "title:" << frame->title << "floating:" << frame->floating;
 #endif
 
-    // Store the frame before laying it out: laying out pushes new borders, which
-    // resizes the console, which asks for a relayout of every known frame
+    // relayoutFrames() works off mFrameOrder, so nothing may lay a frame out
+    // before it is in there
     mFrames[name] = frame;
     mFrameOrder.append(frame);
 
@@ -361,11 +361,11 @@ QRect TMxpFrameManager::availableFrameArea() const
         return {};
     }
 
-    // getMainWindowSize() is the space frames are placed in: mpMainFrame's own
-    // geometry is briefly wrong during a resize, and this is also the size Lua
-    // scripts lay themselves out against. Taking the user borders off it keeps
-    // frames out of the space a package such as the base UI has reserved for
-    // itself with setBorderRight() and friends.
+    // getMainWindowSize() rather than mpMainFrame's own geometry, which
+    // TConsole::resizeEvent() sets to the full console size until the layout
+    // corrects it. It is also the size Lua scripts lay themselves out against,
+    // so taking the user borders off it keeps frames out of the space a package
+    // such as the base UI has reserved with setBorderRight() and friends.
     QRect area = QRect(QPoint(0, 0), mpHost->mpConsole->getMainWindowSize()).marginsRemoved(mpHost->userBorders());
     if (area.width() < 0) {
         area.setWidth(0);
@@ -376,9 +376,10 @@ QRect TMxpFrameManager::availableFrameArea() const
     return area;
 }
 
-// Works out where a frame goes, consuming the space it takes from mMxpBorders
-// when it is a top level frame. Callers are responsible for pushing the updated
-// borders to the Host.
+// Works out where a frame goes. An edge aligned top level frame consumes the
+// space it takes from mMxpBorders and a nested one advances its parent's
+// usedHeight; an absolutely positioned frame consumes neither. Callers are
+// responsible for pushing the updated borders to the Host.
 QRect TMxpFrameManager::calculateFrameGeometry(TMxpFrame* frame, TMxpFrame* parentFrame)
 {
     // Determine the container for this frame
@@ -398,9 +399,12 @@ QRect TMxpFrameManager::calculateFrameGeometry(TMxpFrame* frame, TMxpFrame* pare
         containerSize.setHeight(containerSize.height() - parentFrame->usedHeight);
     } else {
         // A parent with no widget of its own gives nothing to place against, so
-        // such a frame is treated as a top level one throughout
+        // such a frame is placed as a top level one for the rest of this
+        // calculation - frame->parentFrame still records the hierarchy
         parentFrame = nullptr;
-        // Top-level frame - use MXP-specific borders (not Host borders which are for Lua)
+        // MXP borders stack inwards from the area the user borders leave.
+        // userBorders() and not borders(), which already carries the MXP borders
+        // this function is in the middle of recomputing.
         area = availableFrameArea();
         containerX = area.x() + mMxpBorders.left();
         containerY = area.y() + mMxpBorders.top();
@@ -568,7 +572,8 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
     const int frameWidth = geometry.width();
     const int frameHeight = geometry.height();
 
-    // A no-op for a nested frame, which leaves the borders alone
+    // A nested frame never touches mMxpBorders, so this hands Host the margins
+    // it already has and setBorders() drops it
     mpHost->setMxpBorders(mMxpBorders);
 
     const bool isCharacterHeight = frame->height.trimmed().endsWith('c', Qt::CaseInsensitive);
@@ -1055,7 +1060,9 @@ void TMxpFrameManager::scheduleRelayout()
 
     // Deferred so that the layout of the widgets frames are placed against has
     // settled, and so that pushing new borders from here cannot re-enter the
-    // resize handling that asked for the relayout
+    // resize handling that asked for the relayout. The push at the end of a
+    // relayout does schedule one more pass, which then finds the same borders
+    // and stops there because Host::setBorders() ignores an unchanged value.
     mRelayoutPending = true;
     QTimer::singleShot(0, mpHost, [this]() {
         mRelayoutPending = false;
@@ -1069,8 +1076,8 @@ void TMxpFrameManager::relayoutFrames()
         return;
     }
 
-    // Recalculating from scratch keeps the borders in step with where the
-    // frames actually ended up, whatever the available area has become
+    // calculateFrameGeometry() accumulates into these, so they have to start
+    // empty or every pass would count the same frames again
     mMxpBorders = QMargins();
 
     if (mpHost->mpConsole.isNull() || !mpHost->mpConsole->mpMainFrame) {
@@ -1080,14 +1087,18 @@ void TMxpFrameManager::relayoutFrames()
 
     const QWidget* mainFrame = mpHost->mpConsole->mpMainFrame;
 
+    // calculateFrameGeometry() also accumulates into a parent's usedHeight, so
+    // without this nested frames would march further down on every pass
     for (auto* frame : std::as_const(mFrameOrder)) {
         frame->usedHeight = 0;
     }
 
     for (auto* frame : std::as_const(mFrameOrder)) {
-        // Frames docked as a tab, and external ones in their own window, are
-        // placed by a layout or the window manager rather than by us
-        if (!frame->widget || frame->widget->parentWidget() != mainFrame) {
+        // Skip a frame whose layout never produced a widget, one docked as a tab
+        // (the QTabWidget places it), and one in a window of its own. An external
+        // frame keeps mpMainFrame as its parent even after Qt::Window is set on
+        // it, so isWindow() rather than the parent is what tells them apart.
+        if (!frame->widget || frame->widget->isWindow() || frame->widget->parentWidget() != mainFrame) {
             continue;
         }
 

--- a/src/TMxpFrameManager.h
+++ b/src/TMxpFrameManager.h
@@ -27,6 +27,7 @@
 #include <QMap>
 #include <QMargins>
 #include <QPointer>
+#include <QRect>
 #include <QSize>
 #include <QString>
 #include <QStringList>
@@ -111,31 +112,40 @@ public:
     QStringList getFrameNames() const;
     bool frameExists(const QString& name) const { return mFrames.contains(name); }
     int frameCount() const { return mFrames.size(); }
-    
+
+    // Reposition every frame once the space they are laid out in has changed
+    void scheduleRelayout();
+
     // Configuration
     static constexpr int MAX_FRAMES = 20;
     
 private:
     Host* mpHost;
     QMap<QString, TMxpFrame*> mFrames;
+    // Frames in creation order: borders accumulate inwards, so the order frames
+    // were opened in decides where each one sits
+    QList<TMxpFrame*> mFrameOrder;
     QString mCurrentDestination;  // Current output target (empty = main console)
     QMargins mMxpBorders;         // MXP-specific borders, separate from Host::mBorders
-    
+    bool mRelayoutPending = false;
+
     // Layout and sizing helpers
     void layoutInternalFrame(TMxpFrame* frame);
     void layoutExternalFrame(TMxpFrame* frame);
     void layoutTabFrame(TMxpFrame* frame);
     void layoutTabIntoExistingFrame(TMxpFrame* frame, TMxpFrame* targetFrame);
+    QRect availableFrameArea() const;
+    QRect calculateFrameGeometry(TMxpFrame* frame, TMxpFrame* parentFrame);
     QSize calculateFrameSize(const QString& spec, const QSize& containerSize, bool isHeight);
+    void relayoutFrames();
     Qt::DockWidgetArea alignmentToDockArea(const QString& align);
-    
+
     // Validation
     bool validateFrameName(const QString& name) const;
     bool canCreateFrame() const;
-    
+
     // Cleanup
     void removeFrameFromHierarchy(TMxpFrame* frame);
-    void recalculateBorders();
 };
 
 #endif // MUDLET_TMXPFRAMEMANAGER_H

--- a/src/TMxpFrameManager.h
+++ b/src/TMxpFrameManager.h
@@ -113,7 +113,8 @@ public:
     bool frameExists(const QString& name) const { return mFrames.contains(name); }
     int frameCount() const { return mFrames.size(); }
 
-    // Reposition every frame once the space they are laid out in has changed
+    // Reposition every frame on the next event loop turn, once the space they
+    // are laid out in has changed. Does nothing while no frames are open.
     void scheduleRelayout();
 
     // Configuration

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(FUNCTIONAL_TEST_SOURCES
     MainConsoleSelectionTest.cpp
     EnableDisableByNameTest.cpp
     UnitDeferredDeleteTest.cpp
+    MxpFramePlacementTest.cpp
     ColorTriggerFilterChildTest.cpp
     GMCPCharLoginTest.cpp
     InsertTextCapTest.cpp

--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -1,0 +1,304 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QSignalSpy>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForMxpFramePlacementTest();
+
+// Covers issue #9698: a package that reserves space with setBorderRight() and
+// friends - the base UI does exactly that - used to have MXP frames placed on
+// top of the space it had claimed.
+class MxpFramePlacementTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "MxpFramePlacement-Test-Host";
+    QString mPort;
+    const QString mLocalhost = "localhost";
+
+    void runLua(const QString& script) { QVERIFY2(mpHost->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(script)); }
+
+    // the space frames may be placed in: the main window, less whatever a
+    // package has reserved for itself
+    QRect area() const { return QRect(QPoint(0, 0), mpHost->mpConsole->getMainWindowSize()).marginsRemoved(mpHost->userBorders()); }
+
+    QRect frameGeometry(const QString& name) const
+    {
+        const TMxpFrame* frame = mpHost->mMxpFrameManager.getFrame(name);
+        if (!frame || !frame->widget) {
+            return {};
+        }
+        return frame->widget->geometry();
+    }
+
+    bool createFrame(const QString& name, const QString& align, const QString& width, const QString& height)
+    {
+        QMap<QString, QString> attributes;
+        attributes.insert(qsl("NAME"), name);
+        attributes.insert(qsl("ALIGN"), align);
+        attributes.insert(qsl("WIDTH"), width);
+        attributes.insert(qsl("HEIGHT"), height);
+        const bool created = mpHost->mMxpFrameManager.createFrame(name, attributes);
+        settle();
+        return created;
+    }
+
+    // border changes and window resizes reposition frames from a zero timer
+    void settle() { QTest::qWait(50ms); }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForMxpFramePlacementTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        delete mudlet::self();
+        QDir(path).removeRecursively();
+    }
+
+    void init()
+    {
+        QVERIFY(mpHost);
+        QVERIFY(mpHost->mpConsole);
+        mpHost->mMxpProcessor.enable();
+        mudlet::self()->resize(1200, 800);
+        settle();
+    }
+
+    // runs even when a QVERIFY aborts a test body, so nothing leaks into the next one
+    void cleanup()
+    {
+        mpHost->mMxpFrameManager.resetAllFrames();
+        runLua(qsl("setBorderSizes(0)"));
+        settle();
+    }
+
+    void test_rightFrameKeepsClearOfAReservedRightBorder()
+    {
+        runLua(qsl("setBorderRight(300)"));
+        settle();
+        const QRect reservedArea = area();
+
+        QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+
+        const QRect frame = frameGeometry(qsl("status"));
+        QCOMPARE(frame.width(), 200);
+        QCOMPARE(frame.x(), reservedArea.right() + 1 - 200);
+        QVERIFY2(frame.right() < mpHost->mpConsole->mpMainFrame->width() - 300, "the frame was placed inside the space the package reserved");
+    }
+
+    // the console has to give up room for the frame on top of what the package took
+    void test_frameBorderStacksOnTopOfTheUserBorder()
+    {
+        runLua(qsl("setBorderRight(300)"));
+        settle();
+
+        QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+
+        QCOMPARE(mpHost->userBorders().right(), 300);
+        QCOMPARE(mpHost->borders().right(), 500);
+        QVERIFY2(mpHost->mpConsole->mpMainDisplay->geometry().right() < frameGeometry(qsl("status")).left(), "the main display overlaps the frame");
+    }
+
+    // with nothing reserved a right frame still goes right up to the edge
+    void test_rightFrameHugsTheEdgeWithoutAUserBorder()
+    {
+        QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+
+        QCOMPARE(frameGeometry(qsl("status")).right() + 1, mpHost->mpConsole->mpMainFrame->width());
+    }
+
+    void test_frameFollowsABorderThatChangesAfterwards()
+    {
+        runLua(qsl("setBorderRight(300)"));
+        settle();
+
+        QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+
+        runLua(qsl("setBorderRight(100)"));
+        settle();
+
+        QCOMPARE(frameGeometry(qsl("status")).x(), area().right() + 1 - 200);
+        QCOMPARE(mpHost->borders().right(), 300);
+    }
+
+    void test_frameFollowsAWindowResize()
+    {
+        runLua(qsl("setBorderRight(300)"));
+        settle();
+
+        QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+        const int widthBefore = mpHost->mpConsole->mpMainFrame->width();
+
+        mudlet::self()->resize(1000, 700);
+        settle();
+
+        QVERIFY2(mpHost->mpConsole->mpMainFrame->width() != widthBefore, "the window did not actually resize");
+        QCOMPARE(frameGeometry(qsl("status")).x(), area().right() + 1 - 200);
+    }
+
+    void test_leftFrameStartsAfterAReservedLeftBorder()
+    {
+        runLua(qsl("setBorderLeft(150)"));
+        settle();
+
+        QVERIFY(createFrame(qsl("nav"), qsl("left"), qsl("120px"), qsl("100%")));
+
+        QCOMPARE(frameGeometry(qsl("nav")).x(), 150);
+        QCOMPARE(mpHost->borders().left(), 270);
+    }
+
+    void test_bottomFrameKeepsClearOfAReservedBottomBorder()
+    {
+        runLua(qsl("setBorderBottom(120)"));
+        settle();
+        const QRect reservedArea = area();
+
+        QVERIFY(createFrame(qsl("chat"), qsl("bottom"), qsl("100%"), qsl("80px")));
+
+        const QRect frame = frameGeometry(qsl("chat"));
+        QCOMPARE(frame.height(), 80);
+        QCOMPARE(frame.y(), reservedArea.bottom() + 1 - 80);
+        QCOMPARE(mpHost->borders().bottom(), 200);
+    }
+
+    // frames stack inwards, so the second one has to clear both the reserved
+    // border and its neighbour
+    void test_twoRightFramesStackInwardsFromTheReservedBorder()
+    {
+        runLua(qsl("setBorderRight(200)"));
+        settle();
+        const QRect reservedArea = area();
+
+        QVERIFY(createFrame(qsl("outer"), qsl("right"), qsl("150px"), qsl("100%")));
+        QVERIFY(createFrame(qsl("inner"), qsl("right"), qsl("100px"), qsl("100%")));
+
+        QCOMPARE(frameGeometry(qsl("outer")).x(), reservedArea.right() + 1 - 150);
+        QCOMPARE(frameGeometry(qsl("inner")).x(), reservedArea.right() + 1 - 150 - 100);
+        QCOMPARE(mpHost->borders().right(), 450);
+    }
+
+    // closing the outer frame has to pull the inner one back out to the edge
+    void test_closingAFrameRepositionsTheRest()
+    {
+        runLua(qsl("setBorderRight(200)"));
+        settle();
+        const QRect reservedArea = area();
+
+        QVERIFY(createFrame(qsl("outer"), qsl("right"), qsl("150px"), qsl("100%")));
+        QVERIFY(createFrame(qsl("inner"), qsl("right"), qsl("100px"), qsl("100%")));
+
+        QVERIFY(mpHost->mMxpFrameManager.closeFrame(qsl("outer")));
+        settle();
+
+        QCOMPARE(frameGeometry(qsl("inner")).x(), reservedArea.right() + 1 - 100);
+        QCOMPARE(mpHost->borders().right(), 300);
+    }
+};
+
+void initializeQRCResourcesForMxpFramePlacementTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "MxpFramePlacementTest.moc"
+QTEST_MAIN(MxpFramePlacementTest)

--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -40,8 +40,8 @@ extern void qInitResources_mudlet_fonts_posix();
 void initializeQRCResourcesForMxpFramePlacementTest();
 
 // Covers issue #9698: a package that reserves space with setBorderRight() and
-// friends - the base UI does exactly that - used to have MXP frames placed on
-// top of the space it had claimed.
+// friends - the base UI does exactly that - must not have MXP frames placed on
+// top of the space it claimed.
 class MxpFramePlacementTest : public QObject
 {
     Q_OBJECT
@@ -55,8 +55,10 @@ private:
 
     void runLua(const QString& script) { QVERIFY2(mpHost->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(script)); }
 
-    // the space frames may be placed in: the main window, less whatever a
-    // package has reserved for itself
+    // The space frames may be placed in: the main window, less whatever a
+    // package has reserved for itself. This repeats TMxpFrameManager's own
+    // formula, so tests that need an anchor independent of it assert against a
+    // literal or against another widget's geometry instead.
     QRect area() const { return QRect(QPoint(0, 0), mpHost->mpConsole->getMainWindowSize()).marginsRemoved(mpHost->userBorders()); }
 
     QRect frameGeometry(const QString& name) const
@@ -68,13 +70,17 @@ private:
         return frame->widget->geometry();
     }
 
-    bool createFrame(const QString& name, const QString& align, const QString& width, const QString& height)
+    bool createFrame(const QString& name, const QString& align, const QString& width, const QString& height, const QMap<QString, QString>& extraAttributes = {})
     {
-        QMap<QString, QString> attributes;
+        QMap<QString, QString> attributes = extraAttributes;
         attributes.insert(qsl("NAME"), name);
         attributes.insert(qsl("ALIGN"), align);
-        attributes.insert(qsl("WIDTH"), width);
-        attributes.insert(qsl("HEIGHT"), height);
+        if (!width.isEmpty()) {
+            attributes.insert(qsl("WIDTH"), width);
+        }
+        if (!height.isEmpty()) {
+            attributes.insert(qsl("HEIGHT"), height);
+        }
         const bool created = mpHost->mMxpFrameManager.createFrame(name, attributes);
         settle();
         return created;
@@ -154,11 +160,14 @@ private slots:
         settle();
     }
 
-    // runs even when a QVERIFY aborts a test body, so nothing leaks into the next one
+    // runs even when a QVERIFY aborts a test body, so no state carries into the
+    // next test - or, through the window geometry Mudlet saves on exit, into the
+    // next run of this binary
     void cleanup()
     {
         mpHost->mMxpFrameManager.resetAllFrames();
         runLua(qsl("setBorderSizes(0)"));
+        mudlet::self()->resize(1200, 800);
         settle();
     }
 
@@ -173,7 +182,8 @@ private slots:
         const QRect frame = frameGeometry(qsl("status"));
         QCOMPARE(frame.width(), 200);
         QCOMPARE(frame.x(), reservedArea.right() + 1 - 200);
-        QVERIFY2(frame.right() < mpHost->mpConsole->mpMainFrame->width() - 300, "the frame was placed inside the space the package reserved");
+        // the console and the frame have to tile the unreserved space between them
+        QCOMPARE(mpHost->mpConsole->mpMainDisplay->geometry().right() + 1, frame.x());
     }
 
     // the console has to give up room for the frame on top of what the package took
@@ -194,7 +204,8 @@ private slots:
     {
         QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
 
-        QCOMPARE(frameGeometry(qsl("status")).right() + 1, mpHost->mpConsole->mpMainFrame->width());
+        QCOMPARE(frameGeometry(qsl("status")).right() + 1, area().width());
+        QCOMPARE(mpHost->mpConsole->mpMainDisplay->geometry().right() + 1, frameGeometry(qsl("status")).x());
     }
 
     void test_frameFollowsABorderThatChangesAfterwards()
@@ -209,6 +220,14 @@ private slots:
 
         QCOMPARE(frameGeometry(qsl("status")).x(), area().right() + 1 - 200);
         QCOMPARE(mpHost->borders().right(), 300);
+
+        // growing the reservation is the direction that would leave the frame
+        // sitting inside it
+        runLua(qsl("setBorderRight(400)"));
+        settle();
+
+        QCOMPARE(frameGeometry(qsl("status")).x(), area().right() + 1 - 200);
+        QCOMPARE(mpHost->borders().right(), 600);
     }
 
     void test_frameFollowsAWindowResize()
@@ -237,6 +256,19 @@ private slots:
         QCOMPARE(mpHost->borders().left(), 270);
     }
 
+    void test_topFrameStartsAfterAReservedTopBorder()
+    {
+        runLua(qsl("setBorderTop(150)"));
+        settle();
+
+        QVERIFY(createFrame(qsl("banner"), qsl("top"), qsl("100%"), qsl("60px")));
+
+        const QRect frame = frameGeometry(qsl("banner"));
+        QCOMPARE(frame.y(), 150);
+        QCOMPARE(frame.height(), 60);
+        QCOMPARE(mpHost->borders().top(), 210);
+    }
+
     void test_bottomFrameKeepsClearOfAReservedBottomBorder()
     {
         runLua(qsl("setBorderBottom(120)"));
@@ -249,6 +281,48 @@ private slots:
         QCOMPARE(frame.height(), 80);
         QCOMPARE(frame.y(), reservedArea.bottom() + 1 - 80);
         QCOMPARE(mpHost->borders().bottom(), 200);
+        // an anchor that does not go through the same formula: the frame has to
+        // clear the command line as well as the reserved strip
+        QCOMPARE(frame.bottom() + 1, mpHost->mpConsole->height() - mpHost->mpConsole->mpCommandLine->height() - 120);
+    }
+
+    // WIDTH defaults to a percentage, which now resolves against the space the
+    // package left rather than the whole window
+    void test_percentageWidthResolvesAgainstTheUnreservedSpace()
+    {
+        runLua(qsl("setBorderRight(400)"));
+        settle();
+        const QRect reservedArea = area();
+
+        QVERIFY(createFrame(qsl("status"), qsl("right"), QString(), qsl("100%")));
+
+        QCOMPARE(frameGeometry(qsl("status")).width(), reservedArea.width() / 4);
+    }
+
+    // a frame opened while a DEST is active nests inside it and takes no space
+    // from the main console
+    void test_nestedFrameLeavesTheBordersAlone()
+    {
+        QVERIFY(createFrame(qsl("outer"), qsl("right"), qsl("300px"), qsl("100%")));
+        const QMargins bordersWithOuter = mpHost->borders();
+
+        mpHost->mMxpFrameManager.setDestination(qsl("outer"), false, false);
+        QVERIFY(createFrame(qsl("nested"), qsl("top"), qsl("100%"), qsl("40px")));
+        mpHost->mMxpFrameManager.clearDestination();
+
+        QCOMPARE(mpHost->borders(), bordersWithOuter);
+        QVERIFY2(frameGeometry(qsl("outer")).contains(frameGeometry(qsl("nested"))), "the nested frame is not inside its parent");
+
+        // Relayouts have to be idempotent: a top-aligned nested frame sits at its
+        // parent's top edge, and usedHeight accumulates, so without a reset each
+        // pass would march it further down.
+        for (int i = 0; i < 3; ++i) {
+            runLua(qsl("setBorderLeft(%1)").arg(i * 10));
+            settle();
+            QCOMPARE(frameGeometry(qsl("nested")).y(), frameGeometry(qsl("outer")).y());
+        }
+
+        QCOMPARE(mpHost->borders().right(), bordersWithOuter.right());
     }
 
     // frames stack inwards, so the second one has to clear both the reserved
@@ -265,6 +339,24 @@ private slots:
         QCOMPARE(frameGeometry(qsl("outer")).x(), reservedArea.right() + 1 - 150);
         QCOMPARE(frameGeometry(qsl("inner")).x(), reservedArea.right() + 1 - 150 - 100);
         QCOMPARE(mpHost->borders().right(), 450);
+    }
+
+    // an EXTERNAL frame lives in its own window: it neither takes space from the
+    // main console nor may be dragged into main window coordinates by a relayout
+    void test_externalFrameIsLeftAloneByARelayout()
+    {
+        QVERIFY(createFrame(qsl("popup"), qsl("left"), qsl("200px"), qsl("150px"), {{qsl("EXTERNAL"), qsl("true")}}));
+        const TMxpFrame* frame = mpHost->mMxpFrameManager.getFrame(qsl("popup"));
+        QVERIFY(frame);
+        QVERIFY2(frame->widget && frame->widget->isWindow(), "the external frame is not a window of its own");
+        const QRect geometryBefore = frame->widget->geometry();
+        QCOMPARE(mpHost->borders(), QMargins());
+
+        mudlet::self()->resize(1000, 700);
+        settle();
+
+        QCOMPARE(mpHost->borders(), QMargins());
+        QCOMPARE(frame->widget->geometry(), geometryBefore);
     }
 
     // closing the outer frame has to pull the inner one back out to the edge
@@ -286,18 +378,22 @@ private slots:
 
     // How the base UI reserves its space, so this is #9698 as reported. Declared
     // last on purpose: an adjustable container leaves deferred timers of its own
-    // behind that resize the main window out from under whatever runs next.
+    // behind that resize the main window out from under whatever runs next, so
+    // add new tests above this one rather than below it. For the same reason the
+    // expectation is evaluated at assert time rather than captured up front.
     void test_rightFrameKeepsClearOfAnAttachedAdjustableContainer()
     {
         runLua(qsl("panel = Adjustable.Container:new({name = 'mxpTestPanel', x = '-25%', y = 0, width = '25%', height = '100%', autoSave = false, autoLoad = false})\n"
                    "panel:attachToBorder('right')"));
         settle();
-        QVERIFY2(mpHost->userBorders().right() > 0, "the adjustable container did not reserve a border");
-        const QRect reservedArea = area();
+        const int reservedRight = mpHost->userBorders().right();
+        QVERIFY2(reservedRight > 0, "the adjustable container did not reserve a border");
 
         QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+        settle();
 
-        QCOMPARE(frameGeometry(qsl("status")).x(), reservedArea.right() + 1 - 200);
+        QCOMPARE(frameGeometry(qsl("status")).x(), area().right() + 1 - 200);
+        QCOMPARE(mpHost->borders().right(), reservedRight + 200);
 
         runLua(qsl("panel:detach() panel:hide()"));
         settle();

--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -243,6 +243,11 @@ private slots:
 
         QVERIFY2(mpHost->mpConsole->mpMainFrame->width() != widthBefore, "the window did not actually resize");
         QCOMPARE(frameGeometry(qsl("status")).x(), area().right() + 1 - 200);
+        // a container that moves without its text area following it would look
+        // to the player like the frame did not move at all
+        const TMxpFrame* frame = mpHost->mMxpFrameManager.getFrame(qsl("status"));
+        QVERIFY(frame && frame->console);
+        QCOMPARE(frame->console->size(), frame->widget->size());
     }
 
     void test_leftFrameStartsAfterAReservedLeftBorder()

--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -283,6 +283,25 @@ private slots:
         QCOMPARE(frameGeometry(qsl("inner")).x(), reservedArea.right() + 1 - 100);
         QCOMPARE(mpHost->borders().right(), 300);
     }
+
+    // How the base UI reserves its space, so this is #9698 as reported. Declared
+    // last on purpose: an adjustable container leaves deferred timers of its own
+    // behind that resize the main window out from under whatever runs next.
+    void test_rightFrameKeepsClearOfAnAttachedAdjustableContainer()
+    {
+        runLua(qsl("panel = Adjustable.Container:new({name = 'mxpTestPanel', x = '-25%', y = 0, width = '25%', height = '100%', autoSave = false, autoLoad = false})\n"
+                   "panel:attachToBorder('right')"));
+        settle();
+        QVERIFY2(mpHost->userBorders().right() > 0, "the adjustable container did not reserve a border");
+        const QRect reservedArea = area();
+
+        QVERIFY(createFrame(qsl("status"), qsl("right"), qsl("200px"), qsl("100%")));
+
+        QCOMPARE(frameGeometry(qsl("status")).x(), reservedArea.right() + 1 - 200);
+
+        runLua(qsl("panel:detach() panel:hide()"));
+        settle();
+    }
 };
 
 void initializeQRCResourcesForMxpFramePlacementTest()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- MXP `<FRAME>` windows were positioned against the whole main window, so an edge-aligned frame landed on top of space a package had reserved with `setBorderRight()` and friends. They now lay out inside the area the user borders leave.
- Frames are repositioned when those borders or the window size change, instead of staying where they were first put.
- Frames in a window of their own (`EXTERNAL`) are left alone by that repositioning.

#### Motivation for adding to Mudlet
With the base UI installed, a game using MXP frames drew its frames on top of the UI panel instead of beside it.

#### Other info (issues closed, discussion etc)
Fixes #9698

New functional test `MxpFramePlacementTest` (16 cases) covers each edge, border changes, window resizes, nested frames, external frames, and a Geyser `Adjustable.Container` attached to the right border, which is how the base UI reserves its space. 8 of the cases fail on `development`.

**Test case:** With the base UI installed, connect to `eden-test.rpgframework.de 4000` - the MXP frames sit beside the UI panel rather than under it.

Assisted-by: Claude:claude-opus-5