### PR TITLE
infrastructure: keep the profile-removal file list from going stale

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1105,6 +1105,15 @@ void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
     listWidget_profiles->setFocus();
 }
 
+// A profile that has never been played holds nothing but the connection details
+// written out while it was being set up. Listing what is expected rather than
+// what to watch out for keeps an unrecognised file - a stored password, a
+// personal dictionary - on the side of asking. Anything else that comes to be
+// written before a profile is first played belongs here too, otherwise its
+// removal asks needlessly; ProfileDeletionSafetyTest pins this list to what the
+// dialog actually writes:
+const QStringList dlgConnectionProfiles::scmConnectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
+
 // called when the 'delete' button is pressed, raises a dialog to confirm deletion
 // if this profile has been used
 void dlgConnectionProfiles::slot_deleteProfile()
@@ -1120,16 +1129,11 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    // A profile that has never been played holds nothing but the connection
-    // details written out when it was selected. Listing what is expected rather
-    // than what to watch out for keeps an unrecognised file - a stored password,
-    // a personal dictionary - on the side of asking:
-    static const QStringList connectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
     const QDir profileDir(mudlet::getMudletPath(enums::profileHomePath, profile));
     bool nothingToLose = !profileDir.exists() || profileDir.entryList(QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot).isEmpty();
     if (nothingToLose) {
         for (const QString& fileName : profileDir.entryList(QDir::Files | QDir::Hidden)) {
-            if (!connectionDetailFiles.contains(fileName)) {
+            if (!scmConnectionDetailFiles.contains(fileName)) {
                 nothingToLose = false;
                 break;
             }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -79,6 +79,16 @@ QChar dlgConnectionProfiles::firstInvalidProfileNameChar(const QString& name)
 // retrieve its password. Mirrors the pattern used there:
 const QRegularExpression dlgConnectionProfiles::scmUnusableProfileNameChars{qsl(R"REGEX(\.\.|[/\\<>:"|?*\x00-\x1f])REGEX")};
 
+// What the connection form writes out, and so all that a profile which has
+// never been played holds. slot_deleteProfile() removes such a profile without
+// asking, so listing what is expected rather than what to watch out for keeps
+// an unrecognised file - a stored password, a personal dictionary - on the side
+// of asking; text the user typed in themselves, such as a character name, is
+// their own and is deliberately absent for the same reason.
+// ProfileDeletionSafetyTest fails if the form comes to write anything this list
+// does not name:
+const QStringList dlgConnectionProfiles::scmConnectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
+
 // A lone "." is made entirely of permitted characters, yet every path built
 // from it addresses the profiles directory rather than a profile of its own -
 // as does "..", which scmUnusableProfileNameChars already covers:
@@ -1105,15 +1115,6 @@ void dlgConnectionProfiles::reallyDeleteProfile(const QString& profile)
     listWidget_profiles->setFocus();
 }
 
-// A profile that has never been played holds nothing but the connection details
-// written out while it was being set up. Listing what is expected rather than
-// what to watch out for keeps an unrecognised file - a stored password, a
-// personal dictionary - on the side of asking. Anything else that comes to be
-// written before a profile is first played belongs here too, otherwise its
-// removal asks needlessly; ProfileDeletionSafetyTest pins this list to what the
-// dialog actually writes:
-const QStringList dlgConnectionProfiles::scmConnectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
-
 // called when the 'delete' button is pressed, raises a dialog to confirm deletion
 // if this profile has been used
 void dlgConnectionProfiles::slot_deleteProfile()
@@ -1212,6 +1213,10 @@ QString dlgConnectionProfiles::readProfileData(const QString& profile, const QSt
     return ret;
 }
 
+// Whether an item written here for a profile that has never been played lets
+// its removal skip the confirmation depends on scmConnectionDetailFiles above.
+// Unlike mudlet::writeProfileData() this does not create the profile's folder,
+// so a write before there is one is quietly dropped.
 QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& profile, const QString& item, const QString& what)
 {
     QSaveFile file(mudlet::getMudletPath(enums::profileDataItemPath, profile, item));

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -79,14 +79,10 @@ QChar dlgConnectionProfiles::firstInvalidProfileNameChar(const QString& name)
 // retrieve its password. Mirrors the pattern used there:
 const QRegularExpression dlgConnectionProfiles::scmUnusableProfileNameChars{qsl(R"REGEX(\.\.|[/\\<>:"|?*\x00-\x1f])REGEX")};
 
-// What the connection form writes out, and so all that a profile which has
-// never been played holds. slot_deleteProfile() removes such a profile without
-// asking, so listing what is expected rather than what to watch out for keeps
-// an unrecognised file - a stored password, a personal dictionary - on the side
-// of asking; text the user typed in themselves, such as a character name, is
-// their own and is deliberately absent for the same reason.
-// ProfileDeletionSafetyTest fails if the form comes to write anything this list
-// does not name:
+// Listing what is expected rather than what to watch out for keeps an
+// unrecognised file - a stored password, a character name the user typed - on
+// the side of asking. ProfileDeletionSafetyTest fails if the connection form
+// comes to write anything this does not name:
 const QStringList dlgConnectionProfiles::scmConnectionDetailFiles{qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("description"), qsl("website"), qsl("autologin"), qsl("autoreconnect")};
 
 // A lone "." is made entirely of permitted characters, yet every path built
@@ -1213,10 +1209,9 @@ QString dlgConnectionProfiles::readProfileData(const QString& profile, const QSt
     return ret;
 }
 
-// Whether an item written here for a profile that has never been played lets
-// its removal skip the confirmation depends on scmConnectionDetailFiles above.
-// Unlike mudlet::writeProfileData() this does not create the profile's folder,
-// so a write before there is one is quietly dropped.
+// A new item here may need adding to scmConnectionDetailFiles above. Unlike
+// mudlet::writeProfileData() this does not create the profile's folder, so a
+// write before there is one is quietly dropped.
 QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& profile, const QString& item, const QString& what)
 {
     QSaveFile file(mudlet::getMudletPath(enums::profileDataItemPath, profile, item));

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -57,8 +57,7 @@ public:
     static QString profileFolderPath(const QString& profilesPath, const QString& profile);
     static const QString scmAllowedProfileNameChars;
     static const QRegularExpression scmUnusableProfileNameChars;
-    // everything a profile that has never been played may hold; see the
-    // definition in dlgConnectionProfiles.cpp
+    // files whose presence alone does not warrant confirming a profile's removal
     static const QStringList scmConnectionDetailFiles;
 
     QString btn_connect_enabled_accessDesc;

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -57,6 +57,9 @@ public:
     static QString profileFolderPath(const QString& profilesPath, const QString& profile);
     static const QString scmAllowedProfileNameChars;
     static const QRegularExpression scmUnusableProfileNameChars;
+    // everything a profile that has never been played may hold; see the
+    // definition in dlgConnectionProfiles.cpp
+    static const QStringList scmConnectionDetailFiles;
 
     QString btn_connect_enabled_accessDesc;
     QString btn_load_enabled_accessDesc;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4702,9 +4702,6 @@ QString mudlet::readProfileData(const QString& profile, const QString& item)
     return ret;
 }
 
-// Whether an item written for a profile that has never been played lets its
-// removal skip the confirmation depends on the list at the top of
-// dlgConnectionProfiles.cpp (scmConnectionDetailFiles).
 QPair<bool, QString> mudlet::writeProfileData(const QString& profile, const QString& item, const QString& what)
 {
     // Ensure the profile directory exists before attempting to write profile data

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4702,6 +4702,9 @@ QString mudlet::readProfileData(const QString& profile, const QString& item)
     return ret;
 }
 
+// An item written before a profile has ever been played must also be listed in
+// dlgConnectionProfiles::scmConnectionDetailFiles, which is what lets removing
+// such a profile skip the confirmation.
 QPair<bool, QString> mudlet::writeProfileData(const QString& profile, const QString& item, const QString& what)
 {
     // Ensure the profile directory exists before attempting to write profile data

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4702,9 +4702,9 @@ QString mudlet::readProfileData(const QString& profile, const QString& item)
     return ret;
 }
 
-// An item written before a profile has ever been played must also be listed in
-// dlgConnectionProfiles::scmConnectionDetailFiles, which is what lets removing
-// such a profile skip the confirmation.
+// Whether an item written for a profile that has never been played lets its
+// removal skip the confirmation depends on the list at the top of
+// dlgConnectionProfiles.cpp (scmConnectionDetailFiles).
 QPair<bool, QString> mudlet::writeProfileData(const QString& profile, const QString& item, const QString& what)
 {
     // Ensure the profile directory exists before attempting to write profile data

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -256,9 +256,10 @@ private slots:
         closeDialog(dlg);
     }
 
-    // The shortcut above only holds while dlgConnectionProfiles::scmConnectionDetailFiles
-    // still covers everything the dialog writes for a new profile, so set one up
-    // the way the user does and hold what lands on disk against that list
+    // test_profileWithOnlyConnectionDetailsIsRemovedWithoutConfirmation only
+    // holds while dlgConnectionProfiles::scmConnectionDetailFiles still covers
+    // what the connection form writes, so fill one in the way a user does and
+    // hold what lands on disk against that list
     void test_newProfileOnlyWritesListedConnectionDetails()
     {
         const QString unplayed = qsl("QA Just Set Up");
@@ -267,12 +268,15 @@ private slots:
         auto* dlg = openDialog();
         dlg->slot_addProfile();
         dlg->profile_name_entry->setText(unplayed);
-        // what the name field emits once the user moves on to the next one;
-        // this is also what creates the profile's folder
+        // what leaving the name field does, and what creates the profile's
+        // folder - it only gets that far synchronously because initTestCase()
+        // turned secure password storage off, else it waits on the keychain
         dlg->slot_saveName();
         QVERIFY2(QDir(profilePath(unplayed)).exists(), "naming a new profile did not create its folder");
 
-        // the rest of what a user fills in before ever playing
+        // the rest of the connection form. The character name and the password
+        // are left out on purpose: they are the user's own, so a profile
+        // holding either is still confirmed - see the two cases below
         dlg->host_name_entry->setText(qsl("mudlet.org"));
         dlg->port_entry->setText(qsl("23"));
         dlg->port_ssl_tsl->setChecked(true);
@@ -280,12 +284,16 @@ private slots:
         dlg->auto_reconnect->setChecked(true);
         dlg->mud_description_textedit->setPlainText(qsl("a game to try later"));
 
-        // picking the profile out of the list writes as well, but only once
-        // there is a folder to write into, so it goes after the naming above
+        // refilling the form by selecting the profile writes through the same
+        // field signals, so the selection path is covered as well
         selectProfile(dlg, unplayed);
 
         const QStringList written = QDir(profilePath(unplayed)).entryList(QDir::Files | QDir::Hidden);
-        QVERIFY2(!written.isEmpty(), "setting a profile up wrote nothing at all, so this test proves nothing");
+        // a field that stops saving would otherwise quietly shrink what the
+        // check below covers, while still passing it
+        for (const QString& expected : {qsl("url"), qsl("port"), qsl("ssl_tsl"), qsl("autologin"), qsl("autoreconnect"), qsl("description")}) {
+            QVERIFY2(written.contains(expected), qPrintable(qsl("filling the form in no longer writes '%1', so this case has stopped covering it").arg(expected)));
+        }
         for (const QString& fileName : written) {
             QVERIFY2(dlgConnectionProfiles::scmConnectionDetailFiles.contains(fileName),
                      qPrintable(qsl("setting a profile up wrote '%1', which dlgConnectionProfiles::scmConnectionDetailFiles does not list - add it there, or "
@@ -313,6 +321,26 @@ private slots:
         dlg->slot_deleteProfile();
         QVERIFY2(confirmation(dlg), "a profile holding a stored password was removed without asking");
         QVERIFY2(QDir(profilePath(secretive)).exists(), "the profile was deleted before the user confirmed");
+
+        confirmation(dlg)->reject();
+        closeDialog(dlg);
+    }
+
+    // The character name typed into the login field is the user's own text
+    // rather than one of the connection details the shortcut waves through
+    void test_profileWithACharacterNameIsConfirmedBeforeRemoval()
+    {
+        const QString named = qsl("QA Named");
+        QVERIFY(QDir().mkpath(profilePath(named)));
+        mudlet::self()->writeProfileData(named, qsl("url"), qsl("mudlet.org"));
+        mudlet::self()->writeProfileData(named, qsl("login"), qsl("Aurelius"));
+
+        auto* dlg = openDialog();
+        selectProfile(dlg, named);
+
+        dlg->slot_deleteProfile();
+        QVERIFY2(confirmation(dlg), "a profile holding a character name was removed without asking");
+        QVERIFY2(QDir(profilePath(named)).exists(), "the profile was deleted before the user confirmed");
 
         confirmation(dlg)->reject();
         closeDialog(dlg);

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -256,6 +256,49 @@ private slots:
         closeDialog(dlg);
     }
 
+    // The shortcut above only holds while dlgConnectionProfiles::scmConnectionDetailFiles
+    // still covers everything the dialog writes for a new profile, so set one up
+    // the way the user does and hold what lands on disk against that list
+    void test_newProfileOnlyWritesListedConnectionDetails()
+    {
+        const QString unplayed = qsl("QA Just Set Up");
+        QVERIFY(!QDir(profilePath(unplayed)).exists());
+
+        auto* dlg = openDialog();
+        dlg->slot_addProfile();
+        dlg->profile_name_entry->setText(unplayed);
+        // what the name field emits once the user moves on to the next one;
+        // this is also what creates the profile's folder
+        dlg->slot_saveName();
+        QVERIFY2(QDir(profilePath(unplayed)).exists(), "naming a new profile did not create its folder");
+
+        // the rest of what a user fills in before ever playing
+        dlg->host_name_entry->setText(qsl("mudlet.org"));
+        dlg->port_entry->setText(qsl("23"));
+        dlg->port_ssl_tsl->setChecked(true);
+        dlg->autologin_checkBox->setChecked(true);
+        dlg->auto_reconnect->setChecked(true);
+        dlg->mud_description_textedit->setPlainText(qsl("a game to try later"));
+
+        // picking the profile out of the list writes as well, but only once
+        // there is a folder to write into, so it goes after the naming above
+        selectProfile(dlg, unplayed);
+
+        const QStringList written = QDir(profilePath(unplayed)).entryList(QDir::Files | QDir::Hidden);
+        QVERIFY2(!written.isEmpty(), "setting a profile up wrote nothing at all, so this test proves nothing");
+        for (const QString& fileName : written) {
+            QVERIFY2(dlgConnectionProfiles::scmConnectionDetailFiles.contains(fileName),
+                     qPrintable(qsl("setting a profile up wrote '%1', which dlgConnectionProfiles::scmConnectionDetailFiles does not list - add it there, or "
+                                    "reconsider removing such a profile without confirmation")
+                                        .arg(fileName)));
+        }
+
+        dlg->slot_deleteProfile();
+        QVERIFY2(!confirmation(dlg), "a profile that was only ever set up should not need confirming");
+        QVERIFY2(!QDir(profilePath(unplayed)).exists(), "the profile was not removed");
+        closeDialog(dlg);
+    }
+
     // A stored password sits loose in the folder rather than in a sub-directory
     void test_profileWithOnlyAStoredPasswordIsConfirmedBeforeRemoval()
     {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Hoists the list `slot_deleteProfile()` checks a never-played profile against out of the function to `dlgConnectionProfiles::scmConnectionDetailFiles`, beside the file's other `scm*` constants, and points at it from both `writeProfileData()` implementations.
- Adds a `ProfileDeletionSafetyTest` case that sets a profile up through the real dialog (New profile, name it, fill the connection form in, re-select it) and fails if anything it wrote is missing from the list.
- Pins the deliberate exclusions too: a profile holding a stored password or a typed-in character name still asks before removal.

#### Motivation for adding to Mudlet
Nothing linked that list to the ~15 places profile data gets written, so it could silently go stale; because it is an allowlist a stale entry only ever costs an extra confirmation prompt, but the maintenance trap was worth closing.

#### Other info (issues closed, discussion etc)
Follows up https://github.com/Mudlet/Mudlet/pull/9722#discussion_r3740581754 on #9722 (fix: a profile named "." or ".." deletes every profile when removed). No behaviour change.

**Test case:** `ctest -R ProfileDeletionSafetyTest` (20 cases). Removing an entry from the constant makes it fail naming the file; adding `login` makes the character-name case fail.

Assisted-by: Claude:claude-opus-5