### PR TITLE
Fix: underscores and descenders no longer clipped at certain font sizes

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5845,7 +5845,7 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     // we will NOT need a closing "</span>"
     if (showTimeStamp && !timeBuffer.at(row).isEmpty()) {
         // Use the console's background so the timestamp blends in with the
-        // rest of the text, as done in TTextEdit::drawLine(...).
+        // rest of the text, as done in TTextEdit::layoutLine(...).
         const QColor timeStampBgColor{mpConsole ? mpConsole->getConsoleBgColor() : QColor(Qt::black)};
         s.append(qsl("<span style=\"color: rgb(200,150,0); background: %1; \">%2").arg(timeStampBgColor.name(), timeBuffer.at(row).left(mudlet::smTimeStampFormat.length())));
         // Set the current idea of what the formatting is so we can spot if it

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2251,7 +2251,9 @@ void TTextEdit::slot_copySelectionToClipboardImage()
 
     auto widthpx = std::min(65500, largestLine);
     auto rect = QRect(mPA.x(), mPA.y(), widthpx, heightpx);
-    auto pixmap = QPixmap(widthpx, heightpx);
+    // The bottom line's ink can reach past its cell, so paint into a spare row
+    // and keep only as much of it as the glyphs actually used.
+    auto pixmap = QPixmap(widthpx, std::min(65500, heightpx + mFontHeight));
     auto solidColor = QColor(mBgColor);
     solidColor.setAlpha(255);
     pixmap.fill(solidColor);
@@ -2266,17 +2268,33 @@ void TTextEdit::slot_copySelectionToClipboardImage()
     mSelectedRegion = QRegion(0, 0, 0, 0);
 
     auto result = drawTextForClipboard(painter, rect, lineOffset);
+    painter.end();
 
     highlightSelection();
 
-    // if we cut didn't finish painting the complete picture, trim the bottom of the image
+    const QImage image = pixmap.toImage();
+    int keepHeight = heightpx + overflowRowsUsed(image, heightpx, solidColor);
     if (!result.first) {
-        const auto& smallerPixmap = pixmap.scaled(QSize(widthpx, result.second * mFontHeight), Qt::KeepAspectRatio);
-        QApplication::clipboard()->setImage(smallerPixmap.toImage());
-        return;
+        // ran out of time, so cut back to the lines that did get painted
+        keepHeight = std::max(1, result.second * mFontHeight);
     }
+    QApplication::clipboard()->setImage(image.copy(0, 0, widthpx, std::min(image.height(), keepHeight)));
+}
 
-    QApplication::clipboard()->setImage(pixmap.toImage());
+// How many rows below fromRow the glyph ink actually reached into.
+int TTextEdit::overflowRowsUsed(const QImage& image, const int fromRow, const QColor& background)
+{
+    const QRgb backgroundPixel = background.rgb();
+    int used = 0;
+    for (int y = std::max(0, fromRow); y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            if ((image.pixel(x, y) | 0xff000000) != backgroundPixel) {
+                used = y - fromRow + 1;
+                break;
+            }
+        }
+    }
+    return used;
 }
 
 // a stateless version of drawForeground that doesn't do any caching
@@ -2292,7 +2310,7 @@ std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect re
     const TChar timeStampStyle = timeStampCharStyle();
     LineLayout previousLine;
     LineLayout currentLine;
-    for (int i = 0; i <= lineCount; i++, linesDrawn++) {
+    for (int i = 0; i < lineCount; i++, linesDrawn++) {
         if (!hasBufferLine(i + lineOffset)) {
             break;
         }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -452,29 +452,20 @@ void TTextEdit::scrollDown(int lines)
     }
 }
 
-void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, int* offset) const
+void TTextEdit::layoutLine(int lineNumber, int lineOfScreen, const TChar& timeStampStyle, LineLayout& layout, int* offset) const
 {
+    layout.clear();
     QPoint cursor(-mCursorX, lineOfScreen);
-    QString lineText = mpBuffer->lineBuffer.at(lineNumber);
+    const QString& lineText = mpBuffer->lineBuffer.at(lineNumber);
     QTextBoundaryFinder boundaryFinder(QTextBoundaryFinder::Grapheme, lineText);
     int currentSize = lineText.size();
     if (mpConsole->showTimeStamps()) {
-        TChar timeStampStyle(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
-        QString timestamp(mpBuffer->timeBuffer.at(lineNumber));
-        QVector<QColor> fgColors;
-        QVector<QRect> textRects;
-        QVector<int> charWidths;
-        QVector<QString> graphemes;
+        const QString timestamp(mpBuffer->timeBuffer.at(lineNumber));
         for (const QChar c : timestamp) {
             // The column argument is not incremented here (is fixed at 0) so
             // the timestamp does not take up any places when it is clicked on
             // by the mouse...
-            cursor.setX(cursor.x() + drawGraphemeBackground(painter, fgColors, textRects, graphemes, charWidths, cursor, c, 0, lineNumber, timeStampStyle));
-        }
-        int index = -1;
-        for (const QChar c : timestamp) {
-            ++index;
-            drawGraphemeForeground(painter, fgColors.at(index), textRects.at(index), c, timeStampStyle);
+            cursor.setX(cursor.x() + layoutGrapheme(layout, cursor, c, 0, lineNumber, timeStampStyle));
         }
         currentSize += mudlet::smTimeStampFormat.size();
     }
@@ -485,372 +476,367 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
     }
 
     int columnWithOutTimestamp = 0;
-    QVector<QColor> fgColors;
-    QVector<QRect> textRects;
-    QVector<int> charWidths;
-    QVector<QString> graphemes;
     for (int indexOfChar = 0, total = lineText.size(); indexOfChar < total;) {
-        int nextBoundary = boundaryFinder.toNextBoundary();
+        const int nextBoundary = boundaryFinder.toNextBoundary();
 
-        TChar& charStyle = mpBuffer->buffer.at(lineNumber).at(indexOfChar);
-        int graphemeWidth = drawGraphemeBackground(
-                painter, fgColors, textRects, graphemes, charWidths, cursor, lineText.mid(indexOfChar, nextBoundary - indexOfChar), columnWithOutTimestamp, lineNumber, charStyle);
+        const TChar& charStyle = mpBuffer->buffer.at(lineNumber).at(indexOfChar);
+        const int graphemeWidth = layoutGrapheme(layout, cursor, lineText.mid(indexOfChar, nextBoundary - indexOfChar), columnWithOutTimestamp, lineNumber, charStyle);
         cursor.setX(cursor.x() + graphemeWidth);
         indexOfChar = nextBoundary;
         columnWithOutTimestamp += graphemeWidth;
     }
-    boundaryFinder.toStart();
-    int index = -1;
-    for (int indexOfChar = 0, total = lineText.size(); indexOfChar < total;) {
-        int nextBoundary = boundaryFinder.toNextBoundary();
-
-        TChar& charStyle = mpBuffer->buffer.at(lineNumber).at(indexOfChar);
-        ++index;
-        drawGraphemeForeground(painter, fgColors.at(index), textRects.at(index), graphemes.at(index), charStyle);
-        indexOfChar = nextBoundary;
-    }
 
     // If caret mode is enabled and the line is empty, still draw the caret.
     if (mpHost && mpHost->caretEnabled() && mCaretLine == lineNumber && lineText.isEmpty()) {
-        auto textRect = QRect(0, mFontHeight * lineOfScreen, mFontWidth, mFontHeight);
-        painter.fillRect(textRect, mCaretColor);
+        GraphemeRun caretRun;
+        caretRun.textRect = QRect(0, mFontHeight * lineOfScreen, mFontWidth, mFontHeight);
+        caretRun.bgColor = mCaretColor;
+        caretRun.paintBackground = true;
+        layout.push_back(std::move(caretRun));
     }
 }
 
-void TTextEdit::replaceControlCharacterWith_Picture(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
+void TTextEdit::paintBackgrounds(QPainter& painter, const LineLayout& layout) const
+{
+    for (const GraphemeRun& run : layout) {
+        if (run.paintBackground) {
+            painter.fillRect(run.textRect, run.bgColor);
+        }
+    }
+}
+
+void TTextEdit::paintForegrounds(QPainter& painter, const LineLayout& layout) const
+{
+    for (const GraphemeRun& run : layout) {
+        if (run.style) {
+            paintGraphemeForeground(painter, run);
+        }
+    }
+}
+
+void TTextEdit::replaceControlCharacterWith_Picture(const uint unicode, const QString& grapheme, const int column, QString& outGrapheme, int& charWidth) const
 {
     switch (unicode) {
     case 0:
-        graphemes.append(QChar(0x2400));
+        outGrapheme = QChar(0x2400);
         charWidth = 1;
         break; // NUL - not sure that this can appear
     case 1:
-        graphemes.append(QChar(0x2401));
+        outGrapheme = QChar(0x2401);
         charWidth = 1;
         break; // SOH
     case 2:
-        graphemes.append(QChar(0x2402));
+        outGrapheme = QChar(0x2402);
         charWidth = 1;
         break; // STX
     case 3:
-        graphemes.append(QChar(0x2403));
+        outGrapheme = QChar(0x2403);
         charWidth = 1;
         break; // ETX
     case 4:
-        graphemes.append(QChar(0x2404));
+        outGrapheme = QChar(0x2404);
         charWidth = 1;
         break; // EOT
     case 5:
-        graphemes.append(QChar(0x2405));
+        outGrapheme = QChar(0x2405);
         charWidth = 1;
         break; // ENQ
     case 6:
-        graphemes.append(QChar(0x2406));
+        outGrapheme = QChar(0x2406);
         charWidth = 1;
         break; // ACK
     case 7:
-        graphemes.append(QChar(0x2407));
+        outGrapheme = QChar(0x2407);
         charWidth = 1;
         break; // BEL - the (audio) handling of this gets done when it is received, not when it is displayed here:
     case 8:
-        graphemes.append(QChar(0x2408));
+        outGrapheme = QChar(0x2408);
         charWidth = 1;
         break; // BS
     case 9:    // HT
         // Makes the spacing behave like a tab
         charWidth = mTabStopwidth - (column % mTabStopwidth);
         // But print the "control picture" on top
-        graphemes.append(QChar(0x2409));
+        outGrapheme = QChar(0x2409);
         break;
     case 10:
-        graphemes.append(QChar(0x240A));
+        outGrapheme = QChar(0x240A);
         charWidth = 1;
         break; // LF - may not ever appear!
     case 11:
-        graphemes.append(QChar(0x240B));
+        outGrapheme = QChar(0x240B);
         charWidth = 1;
         break; // VT
     case 12:
-        graphemes.append(QChar(0x240C));
+        outGrapheme = QChar(0x240C);
         charWidth = 1;
         break; // FF
     case 13:
-        graphemes.append(QChar(0x240D));
+        outGrapheme = QChar(0x240D);
         charWidth = 1;
         break; // CR - shouldn't appear but does seem to crop up somehow!
     case 14:
-        graphemes.append(QChar(0x240E));
+        outGrapheme = QChar(0x240E);
         charWidth = 1;
         break; // SO
     case 15:
-        graphemes.append(QChar(0x240F));
+        outGrapheme = QChar(0x240F);
         charWidth = 1;
         break; // SI
     case 16:
-        graphemes.append(QChar(0x2410));
+        outGrapheme = QChar(0x2410);
         charWidth = 1;
         break; // DLE
     case 17:
-        graphemes.append(QChar(0x2411));
+        outGrapheme = QChar(0x2411);
         charWidth = 1;
         break; // DC1
     case 18:
-        graphemes.append(QChar(0x2412));
+        outGrapheme = QChar(0x2412);
         charWidth = 1;
         break; // DC2
     case 19:
-        graphemes.append(QChar(0x2413));
+        outGrapheme = QChar(0x2413);
         charWidth = 1;
         break; // DC3
     case 20:
-        graphemes.append(QChar(0x2414));
+        outGrapheme = QChar(0x2414);
         charWidth = 1;
         break; // DC4
     case 21:
-        graphemes.append(QChar(0x2415));
+        outGrapheme = QChar(0x2415);
         charWidth = 1;
         break; // NAK
     case 22:
-        graphemes.append(QChar(0x2416));
+        outGrapheme = QChar(0x2416);
         charWidth = 1;
         break; // SYN
     case 23:
-        graphemes.append(QChar(0x2417));
+        outGrapheme = QChar(0x2417);
         charWidth = 1;
         break; // ETB
     case 24:
-        graphemes.append(QChar(0x2418));
+        outGrapheme = QChar(0x2418);
         charWidth = 1;
         break; // CAN
     case 25:
-        graphemes.append(QChar(0x2419));
+        outGrapheme = QChar(0x2419);
         charWidth = 1;
         break; // EM
     case 26:
-        graphemes.append(QChar(0x241A));
+        outGrapheme = QChar(0x241A);
         charWidth = 1;
         break; // SUB
     case 27:
-        graphemes.append(QChar(0x241B));
+        outGrapheme = QChar(0x241B);
         charWidth = 1;
         break; // ESC - shouldn't appear as will have been intercepted previously
     case 28:
-        graphemes.append(QChar(0x241C));
+        outGrapheme = QChar(0x241C);
         charWidth = 1;
         break; // FS
     case 29:
-        graphemes.append(QChar(0x241D));
+        outGrapheme = QChar(0x241D);
         charWidth = 1;
         break; // GS
     case 30:
-        graphemes.append(QChar(0x241E));
+        outGrapheme = QChar(0x241E);
         charWidth = 1;
         break; // RS
     case 31:
-        graphemes.append(QChar(0x241F));
+        outGrapheme = QChar(0x241F);
         charWidth = 1;
         break; // US
     case 127:
-        graphemes.append(QChar(0x2421));
+        outGrapheme = QChar(0x2421);
         charWidth = 1;
         break; // DEL
     default:
         charWidth = getGraphemeWidth(unicode);
-        graphemes.append((charWidth < 1) ? QChar() : grapheme);
+        outGrapheme = (charWidth < 1) ? QChar() : grapheme;
     }
 }
 
-void TTextEdit::replaceControlCharacterWith_OEMFont(const uint unicode, const QString& grapheme, const int column, QVector<QString>& graphemes, int& charWidth) const
+void TTextEdit::replaceControlCharacterWith_OEMFont(const uint unicode, const QString& grapheme, const int column, QString& outGrapheme, int& charWidth) const
 {
     Q_UNUSED(column)
     switch (unicode) {
     case 0:
-        graphemes.append(QString(QChar::Space));
+        outGrapheme = QString(QChar::Space);
         charWidth = 1;
         break; // NUL - not sure that this can appear and the OEM font treats it as a space
     case 1:
-        graphemes.append(QChar(0x263A));
+        outGrapheme = QChar(0x263A);
         charWidth = 1;
         break; // SOH - White Smiling Face
     case 2:
-        graphemes.append(QChar(0x263B));
+        outGrapheme = QChar(0x263B);
         charWidth = 1;
         break; // STX - Black Smiling Face
     case 3:
-        graphemes.append(QChar(0x2665));
+        outGrapheme = QChar(0x2665);
         charWidth = 1;
         break; // ETX - Black Heart Suite
     case 4:
-        graphemes.append(QChar(0x2666));
+        outGrapheme = QChar(0x2666);
         charWidth = 1;
         break; // EOT - Black Diamond Suite
     case 5:
-        graphemes.append(QChar(0x2663));
+        outGrapheme = QChar(0x2663);
         charWidth = 1;
         break; // ENQ - Black ClubsSuite
     case 6:
-        graphemes.append(QChar(0x2660));
+        outGrapheme = QChar(0x2660);
         charWidth = 1;
         break; // ACK - Black Spade Suite
     case 7:
-        graphemes.append(QChar(0x2022));
+        outGrapheme = QChar(0x2022);
         charWidth = 1;
         break; // BEL - Bullet - the handling of this gets done when it is received, not when it is displayed here:
     case 8:
-        graphemes.append(QChar(0x25D8));
+        outGrapheme = QChar(0x25D8);
         charWidth = 1;
         break; // BS  - Inverse Bullet
     case 9:
         // NOTE THAT WE DO NOT USE TAB SPACING FOR THIS MODE:
-        graphemes.append(QChar(0x25CB));
+        outGrapheme = QChar(0x25CB);
         charWidth = 1;
         break; // HT  - Circle
     case 10:
-        graphemes.append(QChar(0x25D9));
+        outGrapheme = QChar(0x25D9);
         charWidth = 1;
         break; // LF  - Inverse Circle
     case 11:
-        graphemes.append(QChar(0x2642));
+        outGrapheme = QChar(0x2642);
         charWidth = 1;
         break; // VT  - Male Sign
     case 12:
-        graphemes.append(QChar(0x2640));
+        outGrapheme = QChar(0x2640);
         charWidth = 1;
         break; // FF  - Female Sign
     case 13:
-        graphemes.append(QChar(0x266A));
+        outGrapheme = QChar(0x266A);
         charWidth = 1;
         break; // CR  - Single Quaver - shouldn't appear but does seem to crop up somehow!
     case 14:
-        graphemes.append(QChar(0x266B));
+        outGrapheme = QChar(0x266B);
         charWidth = 1;
         break; // SO  - Double Quaver
     case 15:
-        graphemes.append(QChar(0x263C));
+        outGrapheme = QChar(0x263C);
         charWidth = 1;
         break; // SI  - White Sun with Rays
     case 16:
-        graphemes.append(QChar(0x25BA));
+        outGrapheme = QChar(0x25BA);
         charWidth = 1;
         break; // DLE - Black Right-Pointing Pointer
     case 17:
-        graphemes.append(QChar(0x25C4));
+        outGrapheme = QChar(0x25C4);
         charWidth = 1;
         break; // DC1 - Black Left-Pointing Pointer
     case 18:
-        graphemes.append(QChar(0x2195));
+        outGrapheme = QChar(0x2195);
         charWidth = 1;
         break; // DC2 - Up Down ArroW
     case 19:
-        graphemes.append(QChar(0x203C));
+        outGrapheme = QChar(0x203C);
         charWidth = 1;
         break; // DC3 - Double Exclaimation Mark
     case 20:
-        graphemes.append(QChar(0x00B6));
+        outGrapheme = QChar(0x00B6);
         charWidth = 1;
         break; // DC4 - Pilcrow
     case 21:
-        graphemes.append(QChar(0x00A7));
+        outGrapheme = QChar(0x00A7);
         charWidth = 1;
         break; // NAK - Section Sign
     case 22:
-        graphemes.append(QChar(0x25AC));
+        outGrapheme = QChar(0x25AC);
         charWidth = 1;
         break; // SYN - Black Rectangle
     case 23:
-        graphemes.append(QChar(0x21A8));
+        outGrapheme = QChar(0x21A8);
         charWidth = 1;
         break; // ETB - Up Down Arrow With Base
     case 24:
-        graphemes.append(QChar(0x2191));
+        outGrapheme = QChar(0x2191);
         charWidth = 1;
         break; // CAN - Up Arrow
     case 25:
-        graphemes.append(QChar(0x2193));
+        outGrapheme = QChar(0x2193);
         charWidth = 1;
         break; // EM  - Down Arrow
     case 26:
-        graphemes.append(QChar(0x2192));
+        outGrapheme = QChar(0x2192);
         charWidth = 1;
         break; // SUB - Right Arrow
     case 27:
-        graphemes.append(QChar(0x2190));
+        outGrapheme = QChar(0x2190);
         charWidth = 1;
         break; // ESC - Left Arrow - shouldn't appear as will have been intercepted previously
     case 28:
-        graphemes.append(QChar(0x221F));
+        outGrapheme = QChar(0x221F);
         charWidth = 1;
         break; // FS  - Right Angle
     case 29:
-        graphemes.append(QChar(0x2194));
+        outGrapheme = QChar(0x2194);
         charWidth = 1;
         break; // GS  - Left Right Arrow
     case 30:
-        graphemes.append(QChar(0x25B2));
+        outGrapheme = QChar(0x25B2);
         charWidth = 1;
         break; // RS  - Black Up-Pointing Pointer
     case 31:
-        graphemes.append(QChar(0x25BC));
+        outGrapheme = QChar(0x25BC);
         charWidth = 1;
         break; // US  - Black Down-Pointing Pointer
     case 127:
-        graphemes.append(QChar(0x2302));
+        outGrapheme = QChar(0x2302);
         charWidth = 1;
         break; // DEL - House
     default:
         charWidth = getGraphemeWidth(unicode);
-        graphemes.append((charWidth < 1) ? QChar() : grapheme);
+        outGrapheme = (charWidth < 1) ? QChar() : grapheme;
     }
 }
 
-int TTextEdit::drawGraphemeBackground(QPainter& painter,
-                                      QVector<QColor>& fgColors,
-                                      QVector<QRect>& textRects,
-                                      QVector<QString>& graphemes,
-                                      QVector<int>& charWidths,
-                                      QPoint& cursor,
-                                      const QString& grapheme,
-                                      const int column,
-                                      const int line,
-                                      TChar& charStyle) const
+int TTextEdit::layoutGrapheme(LineLayout& layout, const QPoint& cursor, const QString& grapheme, const int column, const int line, const TChar& charStyle) const
 {
-    uint unicode = graphemeInfo::getBaseCharacter(grapheme);
+    const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
     int charWidth = 0;
+    GraphemeRun run;
+    run.style = &charStyle;
 
     switch (mpConsole->mControlCharacter) {
     default:
         // No special handling, except for these:
         if (Q_UNLIKELY(unicode == '\t')) {
             charWidth = mTabStopwidth - (column % mTabStopwidth);
-            graphemes.append(QString(QChar::Tabulation));
+            run.grapheme = QString(QChar::Tabulation);
         } else {
             charWidth = graphemeInfo::getWidth(unicode, mWideAmbigousWidthGlyphs);
-            graphemes.append((charWidth < 1) ? QChar() : grapheme);
+            run.grapheme = (charWidth < 1) ? QString() : grapheme;
         }
         break;
     case ControlCharacterMode::Picture:
-        replaceControlCharacterWith_Picture(unicode, grapheme, column, graphemes, charWidth);
+        replaceControlCharacterWith_Picture(unicode, grapheme, column, run.grapheme, charWidth);
         break;
     case ControlCharacterMode::OEM:
-        replaceControlCharacterWith_OEMFont(unicode, grapheme, column, graphemes, charWidth);
+        replaceControlCharacterWith_OEMFont(unicode, grapheme, column, run.grapheme, charWidth);
         break;
     } // End of switch
-    charWidths.append(charWidth);
 
-    QRect textRect;
     if (charWidth > 0) {
-        textRect = QRect(mFontWidth * cursor.x(), mFontHeight * cursor.y(), mFontWidth * charWidth, mFontHeight);
+        run.textRect = QRect(mFontWidth * cursor.x(), mFontHeight * cursor.y(), mFontWidth * charWidth, mFontHeight);
     }
-    textRects.append(textRect);
-    QColor bgColor;
-    bool caretIsHere = mpHost && mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
+    const bool caretIsHere = mpHost && mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
     if (Q_UNLIKELY(charStyle.isFound())) {
         if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
-            fgColors.append(mSearchHighlightBgColor);
-            bgColor = mSearchHighlightFgColor;
+            run.fgColor = mSearchHighlightBgColor;
+            run.bgColor = mSearchHighlightFgColor;
         } else {
-            fgColors.append(mSearchHighlightFgColor);
-            bgColor = mSearchHighlightBgColor;
+            run.fgColor = mSearchHighlightFgColor;
+            run.bgColor = mSearchHighlightBgColor;
         }
     } else {
         if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
@@ -858,41 +844,37 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter,
             // and foreground equals background (hidden text),
             // only reverse one color to make the text readable
             if (charStyle.foreground() == charStyle.background()) {
-                fgColors.append(charStyle.foreground());
+                run.fgColor = charStyle.foreground();
                 // Invert background: use white for dark colors, black for light colors
-                bgColor = (charStyle.background().lightness() < 128) ? Qt::white : Qt::black;
+                run.bgColor = (charStyle.background().lightness() < 128) ? Qt::white : Qt::black;
             } else {
-                fgColors.append(charStyle.background());
-                bgColor = charStyle.foreground();
+                run.fgColor = charStyle.background();
+                run.bgColor = charStyle.foreground();
             }
         } else {
-            fgColors.append(charStyle.foreground());
-            bgColor = charStyle.background();
+            run.fgColor = charStyle.foreground();
+            run.bgColor = charStyle.background();
         }
     }
     if (caretIsHere) {
-        bgColor = mCaretColor;
+        run.bgColor = mCaretColor;
     }
-    // Fill the cell background when:
-    //  - the text bg differs from the console bg (e.g. coloured text), or
-    //  - the main console has a background image to paint the text bg over (#8885), or
-    //  - the main console bg is partially transparent and would otherwise let
-    //    the underlying surface bleed through.
-    // Skipping the fill when the bg matches an opaque console bg lets glyph
-    // descenders that extend slightly past mFontHeight (e.g. underscores at
-    // certain font sizes) survive the next line's drawing (#9070).
-    const bool fillNeeded = bgColor != mpConsole->getConsoleBgColor()
-                            || (mpConsole->getType() == TConsole::MainConsole
-                                && (mpConsole->mBgImageMode > 0 || bgColor.alpha() < 255));
-    if (!textRect.isNull() && fillNeeded) {
-        painter.fillRect(textRect, bgColor);
-    }
+    // The main console always paints its cells so that a background image or a
+    // partially transparent console background does not bleed through the text
+    // (#8885). Other console types leave cells that match the console
+    // background untouched, letting the widget underneath show through.
+    run.paintBackground = !run.textRect.isNull() && (mpConsole->getType() == TConsole::MainConsole || run.bgColor != mpConsole->getConsoleBgColor());
+    layout.push_back(std::move(run));
     return charWidth;
 }
 
-void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor, const QRect& textRect, const QString& grapheme, TChar& charStyle) const
+void TTextEdit::paintGraphemeForeground(QPainter& painter, const GraphemeRun& run) const
 {
-    TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
+    const QColor& fgColor = run.fgColor;
+    const QRect& textRect = run.textRect;
+    const QString& grapheme = run.grapheme;
+    const TChar& charStyle = *run.style;
+    const TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
     const bool isBold = attributes & TChar::Bold;
     const bool isBlinking = attributes & (TChar::Blink | TChar::FastBlink);
 
@@ -953,9 +935,9 @@ void TTextEdit::drawGraphemeForeground(QPainter& painter, const QColor& fgColor,
     drawCustomDecorations(painter, effectiveFgColor, textRect, charStyle);
 }
 
-void TTextEdit::drawCustomDecorations(QPainter& painter, const QColor& defaultColor, const QRect& textRect, TChar& charStyle) const
+void TTextEdit::drawCustomDecorations(QPainter& painter, const QColor& defaultColor, const QRect& textRect, const TChar& charStyle) const
 {
-    TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
+    const TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();
     QFontMetrics fm(painter.font());
 
     // Calculate decoration positions
@@ -1163,8 +1145,11 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     bool reusedCachedScreenContent = false;
 
     qreal dpr = devicePixelRatioF();
-    QPixmap screenPixmap;
-    QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * dpr, mScreenHeight * mFontHeight * dpr);
+    // One spare row below the last character cell, so that ink which overflows
+    // the bottom cell - descenders and underscores do at many font sizes - has
+    // somewhere to go instead of being cut off by the edge of the pixmap.
+    const int pixmapHeight = (mScreenHeight + 1) * mFontHeight;
+    QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * dpr, pixmapHeight * dpr);
     pixmap.setDevicePixelRatio(dpr);
     pixmap.fill(Qt::transparent);
 
@@ -1196,7 +1181,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
         mScrollVector = 0;
         noScroll = true;
     }
-    if ((r.height() < rect().height()) && (lineOffset > 0) && (mScreenWidth * mFontWidth * dpr <= mScreenMap.width()) && (mScreenHeight * mFontHeight * dpr <= mScreenMap.height())) {
+    if ((r.height() < rect().height()) && (lineOffset > 0) && (mScreenWidth * mFontWidth * dpr <= mScreenMap.width()) && (pixmapHeight * dpr <= mScreenMap.height())) {
         p.drawPixmap(0, 0, mScreenMap);
         reusedCachedScreenContent = true;
         from = y_top;
@@ -1208,38 +1193,75 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
             mScrollVector = 0;
         }
     }
-    if ((!noScroll) && (mScrollVector >= 0) && (mScrollVector <= mScreenHeight) && (!mForceUpdate)) {
-        if (mScrollVector * mFontHeight < mScreenMap.height() && mScreenWidth * mFontWidth <= mScreenMap.width() && (mScreenHeight - mScrollVector) * mFontHeight > 0
-            && (mScreenHeight - mScrollVector) * mFontHeight <= mScreenMap.height()) {
-            screenPixmap = mScreenMap.copy(0, mScrollVector * mFontHeight * dpr, mScreenWidth * mFontWidth * dpr, (mScreenHeight - mScrollVector) * mFontHeight * dpr);
-            p.drawPixmap(0, 0, screenPixmap);
+    if (!noScroll && !mForceUpdate && abs(mScrollVector) <= mScreenHeight) {
+        const int scrolledRows = abs(mScrollVector);
+        if (scrolledRows * mFontHeight < mScreenMap.height() && mScreenWidth * mFontWidth <= mScreenMap.width() && (mScreenHeight - scrolledRows) * mFontHeight > 0
+            && (mScreenHeight - scrolledRows) * mFontHeight <= mScreenMap.height()) {
+            p.drawPixmap(0, -mScrollVector * mFontHeight, mScreenMap);
             reusedCachedScreenContent = true;
-            from = mScreenHeight - mScrollVector - 1;
-        }
-    } else if ((!noScroll) && (mScrollVector < 0 && mScrollVector >= ((-1) * mScreenHeight)) && (!mForceUpdate)) {
-        if (abs(mScrollVector) * mFontHeight < mScreenMap.height() && mScreenWidth * mFontWidth <= mScreenMap.width() && (mScreenHeight - abs(mScrollVector)) * mFontHeight > 0
-            && (mScreenHeight - abs(mScrollVector)) * mFontHeight <= mScreenMap.height()) {
-            screenPixmap = mScreenMap.copy(0, 0, mScreenWidth * mFontWidth * dpr, (mScreenHeight - abs(mScrollVector)) * mFontHeight * dpr);
-            p.drawPixmap(0, abs(mScrollVector) * mFontHeight, screenPixmap);
-            reusedCachedScreenContent = true;
-            from = 0;
-            y_bottom = abs(mScrollVector);
+            if (mScrollVector >= 0) {
+                from = mScreenHeight - mScrollVector - 1;
+            } else {
+                from = 0;
+                y_bottom = scrolledRows;
+            }
         }
     }
 
+    const int drawFrom = qMax(0, from);
+    // One row past the dirty region: the last dirty row's ink can spill into the
+    // row below, which would otherwise be left showing the ink of whatever used
+    // to be on that last row.
+    const int drawTo = qMin(y_bottom + 1, mScreenHeight - 1);
+
     //delete non used characters.
     //needed for horizontal scrolling because there sometimes characters didn't get cleared
-    QRect deleteRect = QRect(0, from * mFontHeight, x_right * mFontWidth, (y_bottom + 1) * mFontHeight);
+    int clearHeight = (drawTo + 1 - drawFrom) * mFontHeight;
+    if (drawTo == mScreenHeight - 1) {
+        // the bottom row is being repainted, so its spare row goes too
+        clearHeight += mFontHeight;
+    }
+    const QRect deleteRect(0, drawFrom * mFontHeight, x_right * mFontWidth, clearHeight);
     p.setCompositionMode(QPainter::CompositionMode_Source);
     p.fillRect(deleteRect, Qt::transparent);
 
     p.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    for (int i = from; i <= y_bottom; ++i) {
+    const TChar timeStampStyle(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
+
+    // The line above the cleared band keeps its cell but loses whatever it had
+    // spilled into the band, so put its glyphs back clipped to the band. Drawing
+    // the whole line again would paint it on top of itself and thicken its
+    // antialiasing.
+    mOverflowLineLayout.clear();
+    if (drawFrom > 0 && drawTo >= drawFrom && static_cast<int>(mpBuffer->buffer.size()) > drawFrom - 1 + lineOffset) {
+        layoutLine(drawFrom - 1 + lineOffset, drawFrom - 1, timeStampStyle, mOverflowLineLayout);
+    }
+
+    // Each line's backgrounds go down before the previous line's glyphs, so that
+    // no background fill can wipe out ink which overflowed out of its cell.
+    mPreviousLineLayout.clear();
+    for (int i = drawFrom; i <= drawTo; ++i) {
         if (static_cast<int>(mpBuffer->buffer.size()) <= i + lineOffset) {
             break;
         }
-        drawLine(p, i + lineOffset, i, &mScreenOffset);
+        layoutLine(i + lineOffset, i, timeStampStyle, mCurrentLineLayout, &mScreenOffset);
+        paintBackgrounds(p, mCurrentLineLayout);
+        if (i == drawFrom && !mOverflowLineLayout.empty()) {
+            p.save();
+            p.setClipRect(deleteRect);
+            paintForegrounds(p, mOverflowLineLayout);
+            p.restore();
+        }
+        paintForegrounds(p, mPreviousLineLayout);
+        mPreviousLineLayout.swap(mCurrentLineLayout);
     }
+    paintForegrounds(p, mPreviousLineLayout);
+    // The layouts borrow TChar pointers from the buffer, so do not keep them
+    // past the paint they were built for.
+    mPreviousLineLayout.clear();
+    mCurrentLineLayout.clear();
+    mOverflowLineLayout.clear();
+
     calculateHMaxRange();
     if (Q_UNLIKELY(mpConsole->mHScrollBarEnabled && mpConsole->mpHScrollBar)) {
         updateHorizontalScrollBar();
@@ -2222,17 +2244,26 @@ std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect re
     int lineCount = rectangle.height() / mFontHeight;
     int linesDrawn = 0;
     auto timeout = mudlet::self()->mCopyAsImageTimeout;
+    const TChar timeStampStyle(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
+    LineLayout previousLine;
+    LineLayout currentLine;
     for (int i = 0; i <= lineCount; i++, linesDrawn++) {
         if (static_cast<int>(mpBuffer->buffer.size()) <= i + lineOffset) {
             break;
         }
-        drawLine(painter, i + lineOffset, i);
+        // Same background-before-previous-foreground ordering as drawForeground()
+        layoutLine(i + lineOffset, i, timeStampStyle, currentLine);
+        paintBackgrounds(painter, currentLine);
+        paintForegrounds(painter, previousLine);
+        previousLine.swap(currentLine);
 
         if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - mCopyImageStartTime).count() >= timeout) {
             qDebug().nospace() << "timeout for image copy (" << timeout << "s) reached, managed to draw " << i << " lines";
+            paintForegrounds(painter, previousLine);
             return {false, linesDrawn};
         }
     }
+    paintForegrounds(painter, previousLine);
     return {true, linesDrawn};
 }
 
@@ -3025,10 +3056,7 @@ void TTextEdit::slot_analyseSelection()
             quint8 columnsToUse = qMax(size_t{2}, utf8Width);
 
             if (includeThisCodePoint) {
-                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>")
-                                            .arg(QString::number(columnsToUse),
-                                                 QString::number(index + 1),
-                                                 QString::number(index + 2)));
+                utf16indexes.append(qsl("<th colspan=\"%1\"><center>%2 & %3</center></th>").arg(QString::number(columnsToUse), QString::number(index + 1), QString::number(index + 2)));
 
                 // The use of one qsl inside another is because it is
                 // impossible to force an upper-case alphabet to Hex digits otherwise
@@ -3036,19 +3064,18 @@ void TTextEdit::slot_analyseSelection()
                 // &#8232; is the Unicode Line Separator.
                 // The static casts are only needed since Qt 6.9.0 but they
                 // shouldn't do any harm prior to that:
-                utf16Vals.append(qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
-                                         .arg(QString::number(columnsToUse),
-                                              qsl("%1").arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index),
-                                                                                                         mpBuffer->lineBuffer.at(line).at(index + 1))),
-                                                            4, 16, zero).toUpper())
-                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
-                                         .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
+                utf16Vals.append(
+                        qsl("<td colspan=\"%1\" style=\"white-space:no-wrap vertical-align:top\"><center>%2</center>&#8232;<center>(0x%3:0x%4)</center></td>")
+                                .arg(QString::number(columnsToUse),
+                                     qsl("%1")
+                                             .arg(static_cast<uint32_t>(QChar::surrogateToUcs4(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))), 4, 16, zero)
+                                             .toUpper())
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index).unicode()), 4, 16, zero)
+                                .arg(static_cast<uint16_t>(mpBuffer->lineBuffer.at(line).at(index + 1).unicode()), 4, 16, zero));
 
                 // Note the addition to the index here to jump over the low-surrogate:
                 graphemes.append(qsl("<td colspan=\"%1\">%2</td>")
-                                         .arg(QString::number(columnsToUse),
-                                              convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index),
-                                                                        mpBuffer->lineBuffer.at(line).at(index + 1))));
+                                         .arg(QString::number(columnsToUse), convertWhitespaceToVisual(mpBuffer->lineBuffer.at(line).at(index), mpBuffer->lineBuffer.at(line).at(index + 1))));
             }
 
             switch (utf8Width) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -452,11 +452,21 @@ void TTextEdit::scrollDown(int lines)
     }
 }
 
+bool TTextEdit::hasBufferLine(int lineNumber) const
+{
+    return lineNumber >= 0 && lineNumber < static_cast<int>(mpBuffer->buffer.size());
+}
+
+TChar TTextEdit::timeStampCharStyle() const
+{
+    return TChar(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
+}
+
 void TTextEdit::layoutLine(int lineNumber, int lineOfScreen, const TChar& timeStampStyle, LineLayout& layout, int* offset) const
 {
     layout.clear();
     QPoint cursor(-mCursorX, lineOfScreen);
-    const QString& lineText = mpBuffer->lineBuffer.at(lineNumber);
+    const QString lineText = mpBuffer->lineBuffer.at(lineNumber);
     QTextBoundaryFinder boundaryFinder(QTextBoundaryFinder::Grapheme, lineText);
     int currentSize = lineText.size();
     if (mpConsole->showTimeStamps()) {
@@ -478,6 +488,11 @@ void TTextEdit::layoutLine(int lineNumber, int lineOfScreen, const TChar& timeSt
     int columnWithOutTimestamp = 0;
     for (int indexOfChar = 0, total = lineText.size(); indexOfChar < total;) {
         const int nextBoundary = boundaryFinder.toNextBoundary();
+        if (Q_UNLIKELY(nextBoundary <= indexOfChar)) {
+            // toNextBoundary() reports -1 once it can no longer advance, which
+            // would send indexOfChar backwards and index the line out of bounds
+            break;
+        }
 
         const TChar& charStyle = mpBuffer->buffer.at(lineNumber).at(indexOfChar);
         const int graphemeWidth = layoutGrapheme(layout, cursor, lineText.mid(indexOfChar, nextBoundary - indexOfChar), columnWithOutTimestamp, lineNumber, charStyle);
@@ -491,7 +506,7 @@ void TTextEdit::layoutLine(int lineNumber, int lineOfScreen, const TChar& timeSt
         GraphemeRun caretRun;
         caretRun.textRect = QRect(0, mFontHeight * lineOfScreen, mFontWidth, mFontHeight);
         caretRun.bgColor = mCaretColor;
-        caretRun.paintBackground = true;
+        caretRun.fillsBackground = true;
         layout.push_back(std::move(caretRun));
     }
 }
@@ -499,18 +514,28 @@ void TTextEdit::layoutLine(int lineNumber, int lineOfScreen, const TChar& timeSt
 void TTextEdit::paintBackgrounds(QPainter& painter, const LineLayout& layout) const
 {
     for (const GraphemeRun& run : layout) {
-        if (run.paintBackground) {
+        if (run.fillsBackground) {
             painter.fillRect(run.textRect, run.bgColor);
         }
     }
 }
 
-void TTextEdit::paintForegrounds(QPainter& painter, const LineLayout& layout) const
+void TTextEdit::paintForegrounds(QPainter& painter, const LineLayout& layout, const QRect& clip) const
 {
+    if (layout.empty()) {
+        return;
+    }
+    if (!clip.isNull()) {
+        painter.save();
+        painter.setClipRect(clip);
+    }
     for (const GraphemeRun& run : layout) {
         if (run.style) {
             paintGraphemeForeground(painter, run);
         }
+    }
+    if (!clip.isNull()) {
+        painter.restore();
     }
 }
 
@@ -653,7 +678,7 @@ void TTextEdit::replaceControlCharacterWith_Picture(const uint unicode, const QS
         break; // DEL
     default:
         charWidth = getGraphemeWidth(unicode);
-        outGrapheme = (charWidth < 1) ? QChar() : grapheme;
+        outGrapheme = (charWidth < 1) ? QString() : grapheme;
     }
 }
 
@@ -796,7 +821,7 @@ void TTextEdit::replaceControlCharacterWith_OEMFont(const uint unicode, const QS
         break; // DEL - House
     default:
         charWidth = getGraphemeWidth(unicode);
-        outGrapheme = (charWidth < 1) ? QChar() : grapheme;
+        outGrapheme = (charWidth < 1) ? QString() : grapheme;
     }
 }
 
@@ -830,40 +855,41 @@ int TTextEdit::layoutGrapheme(LineLayout& layout, const QPoint& cursor, const QS
         run.textRect = QRect(mFontWidth * cursor.x(), mFontHeight * cursor.y(), mFontWidth * charWidth, mFontHeight);
     }
     const bool caretIsHere = mpHost && mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
+    const bool swapColors = charStyle.isReversed() != (charStyle.isSelected() != caretIsHere);
     if (Q_UNLIKELY(charStyle.isFound())) {
-        if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
+        if (Q_UNLIKELY(swapColors)) {
             run.fgColor = mSearchHighlightBgColor;
             run.bgColor = mSearchHighlightFgColor;
         } else {
             run.fgColor = mSearchHighlightFgColor;
             run.bgColor = mSearchHighlightBgColor;
         }
-    } else {
-        if (Q_UNLIKELY(charStyle.isReversed() != (charStyle.isSelected() != caretIsHere))) {
-            // When colors would be swapped (e.g., during selection)
-            // and foreground equals background (hidden text),
-            // only reverse one color to make the text readable
-            if (charStyle.foreground() == charStyle.background()) {
-                run.fgColor = charStyle.foreground();
-                // Invert background: use white for dark colors, black for light colors
-                run.bgColor = (charStyle.background().lightness() < 128) ? Qt::white : Qt::black;
-            } else {
-                run.fgColor = charStyle.background();
-                run.bgColor = charStyle.foreground();
-            }
-        } else {
+    } else if (Q_UNLIKELY(swapColors)) {
+        // When colors would be swapped (e.g., during selection)
+        // and foreground equals background (hidden text),
+        // only reverse one color to make the text readable
+        if (charStyle.foreground() == charStyle.background()) {
             run.fgColor = charStyle.foreground();
-            run.bgColor = charStyle.background();
+            // Invert background: use white for dark colors, black for light colors
+            run.bgColor = (charStyle.background().lightness() < 128) ? Qt::white : Qt::black;
+        } else {
+            run.fgColor = charStyle.background();
+            run.bgColor = charStyle.foreground();
         }
+    } else {
+        run.fgColor = charStyle.foreground();
+        run.bgColor = charStyle.background();
     }
     if (caretIsHere) {
         run.bgColor = mCaretColor;
     }
-    // The main console always paints its cells so that a background image or a
-    // partially transparent console background does not bleed through the text
-    // (#8885). Other console types leave cells that match the console
-    // background untouched, letting the widget underneath show through.
-    run.paintBackground = !run.textRect.isNull() && (mpConsole->getType() == TConsole::MainConsole || run.bgColor != mpConsole->getConsoleBgColor());
+    // Main console cells are always filled: over a background image or a
+    // translucent console background the cell has to be opaque (#8885), and
+    // keeping it unconditional leaves the paint order in drawForeground() as the
+    // only thing protecting ink that overflows its cell (#9070, #9719). Other
+    // console types skip cells matching the console background so that the
+    // widget underneath shows through.
+    run.fillsBackground = !run.textRect.isNull() && (mpConsole->getType() == TConsole::MainConsole || run.bgColor != mpConsole->getConsoleBgColor());
     layout.push_back(std::move(run));
     return charWidth;
 }
@@ -1160,7 +1186,6 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
 
     int y_top = r.top() / mFontHeight;
     int y_bottom = r.bottom() / mFontHeight;
-    int x_right = std::min(r.right(), (mScreenWidth * mFontWidth)) / mFontWidth;
 
     int lineOffset = imageTopLine();
     int from = 0;
@@ -1193,8 +1218,8 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
             mScrollVector = 0;
         }
     }
-    if (!noScroll && !mForceUpdate && abs(mScrollVector) <= mScreenHeight) {
-        const int scrolledRows = abs(mScrollVector);
+    const int scrolledRows = qAbs(mScrollVector);
+    if (!noScroll && !mForceUpdate && scrolledRows <= mScreenHeight) {
         if (scrolledRows * mFontHeight < mScreenMap.height() && mScreenWidth * mFontWidth <= mScreenMap.width() && (mScreenHeight - scrolledRows) * mFontHeight > 0
             && (mScreenHeight - scrolledRows) * mFontHeight <= mScreenMap.height()) {
             p.drawPixmap(0, -mScrollVector * mFontHeight, mScreenMap);
@@ -1208,54 +1233,74 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
         }
     }
 
+    const int lastRow = mScreenHeight - 1;
     const int drawFrom = qMax(0, from);
     // One row past the dirty region: the last dirty row's ink can spill into the
     // row below, which would otherwise be left showing the ink of whatever used
     // to be on that last row.
-    const int drawTo = qMin(y_bottom + 1, mScreenHeight - 1);
+    const int drawTo = qMin(y_bottom + 1, lastRow);
+    const bool bottomRowIsRepainted = drawTo == lastRow;
 
     //delete non used characters.
     //needed for horizontal scrolling because there sometimes characters didn't get cleared
     int clearHeight = (drawTo + 1 - drawFrom) * mFontHeight;
-    if (drawTo == mScreenHeight - 1) {
-        // the bottom row is being repainted, so its spare row goes too
+    if (bottomRowIsRepainted) {
         clearHeight += mFontHeight;
     }
-    const QRect deleteRect(0, drawFrom * mFontHeight, x_right * mFontWidth, clearHeight);
+    const QRect deleteRect(0, drawFrom * mFontHeight, mScreenWidth * mFontWidth, clearHeight);
     p.setCompositionMode(QPainter::CompositionMode_Source);
     p.fillRect(deleteRect, Qt::transparent);
+    // Scrolling shifts the cached screen by whole cells, which drops a complete
+    // line of text into the spare row. Nothing but the bottom line's overflow
+    // belongs there, so rebuild it from scratch whenever it is not already part
+    // of the band above.
+    QRect spareRowRect;
+    if (!bottomRowIsRepainted) {
+        spareRowRect = QRect(0, mScreenHeight * mFontHeight, mScreenWidth * mFontWidth, mFontHeight);
+        p.fillRect(spareRowRect, Qt::transparent);
+    }
 
     p.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    const TChar timeStampStyle(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
+    const TChar timeStampStyle = timeStampCharStyle();
 
     // The line above the cleared band keeps its cell but loses whatever it had
     // spilled into the band, so put its glyphs back clipped to the band. Drawing
     // the whole line again would paint it on top of itself and thicken its
     // antialiasing.
     mOverflowLineLayout.clear();
-    if (drawFrom > 0 && drawTo >= drawFrom && static_cast<int>(mpBuffer->buffer.size()) > drawFrom - 1 + lineOffset) {
+    if (drawFrom > 0 && hasBufferLine(drawFrom - 1 + lineOffset)) {
         layoutLine(drawFrom - 1 + lineOffset, drawFrom - 1, timeStampStyle, mOverflowLineLayout);
     }
 
     // Each line's backgrounds go down before the previous line's glyphs, so that
     // no background fill can wipe out ink which overflowed out of its cell.
     mPreviousLineLayout.clear();
+    bool lineAboveRestored = false;
     for (int i = drawFrom; i <= drawTo; ++i) {
-        if (static_cast<int>(mpBuffer->buffer.size()) <= i + lineOffset) {
+        if (!hasBufferLine(i + lineOffset)) {
             break;
         }
         layoutLine(i + lineOffset, i, timeStampStyle, mCurrentLineLayout, &mScreenOffset);
         paintBackgrounds(p, mCurrentLineLayout);
-        if (i == drawFrom && !mOverflowLineLayout.empty()) {
-            p.save();
-            p.setClipRect(deleteRect);
-            paintForegrounds(p, mOverflowLineLayout);
-            p.restore();
+        if (!lineAboveRestored) {
+            paintForegrounds(p, mOverflowLineLayout, deleteRect);
+            lineAboveRestored = true;
         }
         paintForegrounds(p, mPreviousLineLayout);
         mPreviousLineLayout.swap(mCurrentLineLayout);
     }
-    paintForegrounds(p, mPreviousLineLayout);
+    if (!lineAboveRestored) {
+        paintForegrounds(p, mOverflowLineLayout, deleteRect);
+    }
+    // Anything below the band is cached content that already holds this line's
+    // overflow, so clip it away rather than compositing the same ink twice.
+    const QRect bandRect(0, drawFrom * mFontHeight, mScreenWidth * mFontWidth, (drawTo + 1 - drawFrom) * mFontHeight);
+    paintForegrounds(p, mPreviousLineLayout, bottomRowIsRepainted ? QRect() : bandRect);
+
+    if (!spareRowRect.isNull() && hasBufferLine(lastRow + lineOffset)) {
+        layoutLine(lastRow + lineOffset, lastRow, timeStampStyle, mOverflowLineLayout);
+        paintForegrounds(p, mOverflowLineLayout, spareRowRect);
+    }
     // The layouts borrow TChar pointers from the buffer, so do not keep them
     // past the paint they were built for.
     mPreviousLineLayout.clear();
@@ -2244,14 +2289,14 @@ std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect re
     int lineCount = rectangle.height() / mFontHeight;
     int linesDrawn = 0;
     auto timeout = mudlet::self()->mCopyAsImageTimeout;
-    const TChar timeStampStyle(QColor(200, 150, 0), mpConsole->getConsoleBgColor());
+    const TChar timeStampStyle = timeStampCharStyle();
     LineLayout previousLine;
     LineLayout currentLine;
     for (int i = 0; i <= lineCount; i++, linesDrawn++) {
-        if (static_cast<int>(mpBuffer->buffer.size()) <= i + lineOffset) {
+        if (!hasBufferLine(i + lineOffset)) {
             break;
         }
-        // Same background-before-previous-foreground ordering as drawForeground()
+        // A line's backgrounds have to go down before the previous line's glyphs
         layoutLine(i + lineOffset, i, timeStampStyle, currentLine);
         paintBackgrounds(painter, currentLine);
         paintForegrounds(painter, previousLine);

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -59,35 +59,12 @@ class TTextEdit : public QWidget
     friend class TAccessibleTextEdit;
 
 public:
-    // The cell, or cells for a wide glyph, that one grapheme occupies.
-    struct GraphemeRun
-    {
-        QRect textRect;
-        QColor fgColor;
-        QColor bgColor;
-        QString grapheme;
-        // Borrowed from TBuffer::buffer (or from the caller's timestamp style).
-        // Only valid while the line is being painted, during which the buffer
-        // must not be modified. A null pointer marks a background-only run,
-        // such as the caret block on an empty line.
-        const TChar* style = nullptr;
-        bool paintBackground = false;
-    };
-    using LineLayout = std::vector<GraphemeRun>;
-
     Q_DISABLE_COPY(TTextEdit)
     TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isLowerPane);
     ~TTextEdit();
     void paintEvent(QPaintEvent*) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void drawForeground(QPainter&, const QRect&);
-    // Laying a line out without painting it lets a caller put every line's
-    // backgrounds down before any glyphs, so that ink which overflows its cell
-    // cannot be erased by the background fill of the line below.
-    void layoutLine(int lineNumber, int rowOfScreen, const TChar& timeStampStyle, LineLayout& layout, int* offset = nullptr) const;
-    void paintBackgrounds(QPainter&, const LineLayout&) const;
-    void paintForegrounds(QPainter&, const LineLayout&) const;
-    void drawCustomDecorations(QPainter&, const QColor&, const QRect&, const TChar&) const;
     void showNewLines();
     void forceUpdate();
     void needUpdate(int, int);
@@ -216,14 +193,42 @@ private:
     inline void replaceControlCharacterWith_Picture(const uint, const QString&, const int, QString&, int&) const;
     inline void replaceControlCharacterWith_OEMFont(const uint, const QString&, const int, QString&, int&) const;
     int offsetForPosition(int line, int column) const;
+    bool hasBufferLine(int lineNumber) const;
+    TChar timeStampCharStyle() const;
+
+    // One grapheme's painted cell (or cells, for a wide glyph): where it goes,
+    // the colours resolved for it, and the style they were resolved from.
+    struct GraphemeRun
+    {
+        QRect textRect;
+        QColor fgColor;
+        QColor bgColor;
+        QString grapheme;
+        // Borrowed from TBuffer::buffer, or from the caller's timestamp style.
+        // Only valid for the duration of one paint, during which the buffer must
+        // not be modified. A null pointer marks a background-only run, such as
+        // the caret block on an empty line.
+        const TChar* style = nullptr;
+        bool fillsBackground = false;
+    };
+    using LineLayout = std::vector<GraphemeRun>;
+
+    // Laying a line out without painting it lets the callers put line N's
+    // backgrounds down before line N-1's glyphs, so that ink overflowing out of
+    // the bottom of a cell cannot be erased by the line below it. Both callers
+    // depend on that order, which is why none of this is reachable from outside.
+    void layoutLine(int lineNumber, int lineOfScreen, const TChar& timeStampStyle, LineLayout& layout, int* offset = nullptr) const;
+    void paintBackgrounds(QPainter&, const LineLayout&) const;
+    void paintForegrounds(QPainter&, const LineLayout&, const QRect& clip = QRect()) const;
+    void drawCustomDecorations(QPainter&, const QColor&, const QRect&, const TChar&) const;
     int layoutGrapheme(LineLayout& layout, const QPoint& cursor, const QString& grapheme, const int column, const int line, const TChar& charStyle) const;
     void paintGraphemeForeground(QPainter&, const GraphemeRun&) const;
+
     // Reused between paints to keep their capacity rather than reallocating a
     // line's worth of graphemes on every repaint.
     mutable LineLayout mPreviousLineLayout;
     mutable LineLayout mCurrentLineLayout;
     mutable LineLayout mOverflowLineLayout;
-
     int mFontHeight;
     int mFontWidth;
     bool mForceUpdate = false;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -32,6 +32,7 @@
 #include <QElapsedTimer>
 #include <QMap>
 #include <QPointer>
+#include <QImage>
 #include <QRect>
 #include <QTimer>
 #include <QWidget>
@@ -194,6 +195,7 @@ private:
     inline void replaceControlCharacterWith_OEMFont(const uint, const QString&, const int, QString&, int&) const;
     int offsetForPosition(int line, int column) const;
     bool hasBufferLine(int lineNumber) const;
+    static int overflowRowsUsed(const QImage& image, const int fromRow, const QColor& background);
     TChar timeStampCharStyle() const;
 
     // One grapheme's painted cell (or cells, for a wide glyph): where it goes,

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -28,14 +28,17 @@
  ***************************************************************************/
 
 
+#include <QColor>
 #include <QElapsedTimer>
 #include <QMap>
 #include <QPointer>
+#include <QRect>
 #include <QTimer>
 #include <QWidget>
 
 #include <chrono>
 #include <string>
+#include <vector>
 
 #include "THyperlinkStyling.h"
 
@@ -56,16 +59,35 @@ class TTextEdit : public QWidget
     friend class TAccessibleTextEdit;
 
 public:
+    // The cell, or cells for a wide glyph, that one grapheme occupies.
+    struct GraphemeRun
+    {
+        QRect textRect;
+        QColor fgColor;
+        QColor bgColor;
+        QString grapheme;
+        // Borrowed from TBuffer::buffer (or from the caller's timestamp style).
+        // Only valid while the line is being painted, during which the buffer
+        // must not be modified. A null pointer marks a background-only run,
+        // such as the caret block on an empty line.
+        const TChar* style = nullptr;
+        bool paintBackground = false;
+    };
+    using LineLayout = std::vector<GraphemeRun>;
+
     Q_DISABLE_COPY(TTextEdit)
     TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isLowerPane);
     ~TTextEdit();
     void paintEvent(QPaintEvent*) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void drawForeground(QPainter&, const QRect&);
-    void drawLine(QPainter& painter, int lineNumber, int rowOfScreen, int* offset = nullptr) const;
-    int drawGraphemeBackground(QPainter&, QVector<QColor>&, QVector<QRect>&, QVector<QString>&, QVector<int>&, QPoint&, const QString&, const int, const int, TChar&) const;
-    void drawGraphemeForeground(QPainter&, const QColor&, const QRect&, const QString&, TChar&) const;
-    void drawCustomDecorations(QPainter&, const QColor&, const QRect&, TChar&) const;
+    // Laying a line out without painting it lets a caller put every line's
+    // backgrounds down before any glyphs, so that ink which overflows its cell
+    // cannot be erased by the background fill of the line below.
+    void layoutLine(int lineNumber, int rowOfScreen, const TChar& timeStampStyle, LineLayout& layout, int* offset = nullptr) const;
+    void paintBackgrounds(QPainter&, const LineLayout&) const;
+    void paintForegrounds(QPainter&, const LineLayout&) const;
+    void drawCustomDecorations(QPainter&, const QColor&, const QRect&, const TChar&) const;
     void showNewLines();
     void forceUpdate();
     void needUpdate(int, int);
@@ -191,9 +213,16 @@ private:
     bool establishSelectedText();
     void expandSelectionToWords();
     void expandSelectionToLine(int);
-    inline void replaceControlCharacterWith_Picture(const uint, const QString&, const int, QVector<QString>&, int&) const;
-    inline void replaceControlCharacterWith_OEMFont(const uint, const QString&, const int, QVector<QString>&, int&) const;
+    inline void replaceControlCharacterWith_Picture(const uint, const QString&, const int, QString&, int&) const;
+    inline void replaceControlCharacterWith_OEMFont(const uint, const QString&, const int, QString&, int&) const;
     int offsetForPosition(int line, int column) const;
+    int layoutGrapheme(LineLayout& layout, const QPoint& cursor, const QString& grapheme, const int column, const int line, const TChar& charStyle) const;
+    void paintGraphemeForeground(QPainter&, const GraphemeRun&) const;
+    // Reused between paints to keep their capacity rather than reallocating a
+    // line's worth of graphemes on every repaint.
+    mutable LineLayout mPreviousLineLayout;
+    mutable LineLayout mCurrentLineLayout;
+    mutable LineLayout mOverflowLineLayout;
 
     int mFontHeight;
     int mFontWidth;

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -149,6 +149,10 @@ set_tests_properties(TriggerSameLineMatchTest PROPERTIES
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
+# GlyphOverflowTest creates a fresh profile per test method and sweeps two font
+# families across 22 sizes, so it needs a longer timeout
+set_tests_properties(GlyphOverflowTest PROPERTIES TIMEOUT 600)
+
 # InsertTextCapTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(InsertTextCapTest PROPERTIES TIMEOUT 300)
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(FUNCTIONAL_TEST_SOURCES
     EnableDisableByNameTest.cpp
     UnitDeferredDeleteTest.cpp
     ColorTriggerFilterChildTest.cpp
+    GlyphOverflowTest.cpp
     GMCPCharLoginTest.cpp
     InsertTextCapTest.cpp
     SetScriptCallbackTest.cpp

--- a/test/functional_tests/GlyphOverflowTest.cpp
+++ b/test/functional_tests/GlyphOverflowTest.cpp
@@ -1,0 +1,452 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QPainter>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TTextEdit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResources();
+
+// TTextEdit lays text out in cells of QFontMetrics::height(), which is a
+// typographic measure rather than the glyph ink box. At a good number of font
+// sizes the ink of "_gjpqy$@()" reaches a pixel past the bottom of its cell, so
+// those glyphs only render completely if nothing paints over that pixel
+// afterwards. #9070 and #9719 are both reports of underscores vanishing because
+// something did.
+class GlyphOverflowTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = "Test-GlyphOverflow";
+    QString mPort; // assigned the stub's actual loopback port in init()
+    const QString mLocalhost = "localhost";
+
+    // What the line below the underscores looks like. Each of these used to
+    // paint over the overflow pixel of the line above it.
+    struct Underlay
+    {
+        QString name;
+        QString colourTag;
+        bool selected = false;
+    };
+
+    static QVector<Underlay> underlays()
+    {
+        return {
+                {qsl("the console background"), qsl("<white>")},
+                {qsl("an explicit background colour"), qsl("<white:blue>")},
+                {qsl("a bright background colour"), qsl("<black:yellow>")},
+                {qsl("a selection"), qsl("<blue>"), true},
+        };
+    }
+
+    static constexpr int kUnderscoreCount = 40;
+    static constexpr int kFillerCount = 60;
+    // Column used to sample what a pixel row looks like where no glyph was
+    // drawn: past the underscores, still inside the filler line.
+    static constexpr int kBackgroundSampleColumn = 50;
+    // How far a channel has to move from its row's background before the pixel
+    // counts as glyph ink rather than antialiasing noise.
+    static constexpr int kInkThreshold = 24;
+    // How far past the bottom of a cell to look for ink that overflowed out of it
+    static constexpr int kOverflowScanRows = 4;
+    static constexpr int kFirstSize = 9;
+    static constexpr int kLastSize = 30;
+
+    static bool pixelIsInk(QRgb pixel, QRgb background)
+    {
+        return qAbs(qRed(pixel) - qRed(background)) > kInkThreshold || qAbs(qGreen(pixel) - qGreen(background)) > kInkThreshold || qAbs(qBlue(pixel) - qBlue(background)) > kInkThreshold;
+    }
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        // Port 0 asks the OS for an ephemeral port so parallel test runs do not
+        // collide on a hardcoded one
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), "TelnetServerStub failed to bind a loopback port");
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+    }
+
+    // A line has to render all of its ink whatever the line below it looks like,
+    // and that ink has to match the glyph drawn on its own with the same font,
+    // cell geometry and painter flags.
+    void test_lineBelowDoesNotEraseOverflowingInk()
+    {
+        Host* host = startOfflineProfile();
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY2(pane, "No upper pane available");
+
+        int sizesWithOverflow = 0;
+        for (const QString& family : {qsl("Bitstream Vera Sans Mono"), qsl("Ubuntu Mono")}) {
+            for (int size = kFirstSize; size <= kLastSize; ++size) {
+                applyFont(host, family, size);
+                const int cellHeight = cellHeightOf(pane);
+                const int expectedBottom = referenceInkBottom(pane->font(), qsl("_"), cellWidthOf(pane), cellHeight);
+                if (expectedBottom >= cellHeight) {
+                    ++sizesWithOverflow;
+                }
+
+                for (const Underlay& underlay : underlays()) {
+                    const QVector<QPoint> ink = renderAndCollectInk(host, underlay);
+                    const QString where = qsl("%1 %2pt below %3").arg(family).arg(size).arg(underlay.name);
+                    QVERIFY2(!ink.isEmpty(), qPrintable(qsl("%1: no underscore ink rendered at all").arg(where)));
+
+                    int actualBottom = ink.first().y();
+                    for (const QPoint& point : ink) {
+                        actualBottom = qMax(actualBottom, point.y());
+                    }
+                    QVERIFY2(actualBottom == expectedBottom,
+                             qPrintable(qsl("%1: underscore ink ends %2 rows below the cell top, expected %3 (cell is %4 tall)").arg(where).arg(actualBottom).arg(expectedBottom).arg(cellHeight)));
+                }
+            }
+        }
+
+        QVERIFY2(sizesWithOverflow > 0, "None of the tested font sizes overflow their cell, so this test proves nothing - pick different sizes");
+    }
+
+    // The screen is rendered into a pixmap sized from the number of whole
+    // character cells that fit, so the bottom line's overflow used to be cut off
+    // by the edge of that pixmap regardless of what was painted afterwards.
+    void test_bottomLineOverflowSurvivesThePixmapEdge()
+    {
+        Host* host = startOfflineProfile();
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY2(pane, "No upper pane available");
+
+        int checkedSizes = 0;
+        for (int size = kFirstSize; size <= kLastSize; ++size) {
+            applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
+            const int cellHeight = cellHeightOf(pane);
+            const int cellWidth = cellWidthOf(pane);
+            const int expectedBottom = referenceInkBottom(pane->font(), qsl("_"), cellWidth, cellHeight);
+            if (expectedBottom < cellHeight) {
+                continue; // this size keeps its ink inside the cell, nothing to check
+            }
+            // A pane whose height is an exact multiple of the cell height has no
+            // pixel left over for the bottom line's overflow to appear in.
+            if (pane->height() % cellHeight == 0) {
+                continue;
+            }
+            ++checkedSizes;
+
+            const int screenHeight = pane->getScreenHeight();
+            runLua(host, qsl("clearWindow()"));
+            runLua(host, qsl("cecho('<white>' .. string.rep('filler\\n', %1) .. '%2\\n')").arg(screenHeight - 1).arg(QString(kUnderscoreCount, QLatin1Char('_'))));
+            pane->forceUpdate();
+            QApplication::processEvents();
+
+            const QImage rendered = renderPane(host);
+            const int cellTop = (screenHeight - 1) * cellHeight;
+            const int actualBottom = inkBottom(collectInk(rendered, cellTop, cellHeight, cellWidth));
+            QVERIFY2(actualBottom == expectedBottom,
+                     qPrintable(qsl("%1pt: the bottom line's underscore ink ends %2 rows below the cell top, expected %3").arg(size).arg(actualBottom).arg(expectedBottom)));
+        }
+
+        QVERIFY2(checkedSizes > 0, "No font size produced an overflowing bottom line, so this test proves nothing");
+    }
+
+    // Repainting part of the pane clears whole character cells, which takes the
+    // previous line's overflow pixel with it. That line sits outside the dirty
+    // region and is not redrawn, so the pixel has to be put back explicitly.
+    void test_partialRepaintKeepsTheLineAboveIntact()
+    {
+        Host* host = startOfflineProfile();
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY2(pane, "No upper pane available");
+
+        int checkedSizes = 0;
+        for (int size = kFirstSize; size <= kLastSize; ++size) {
+            applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
+            const int cellHeight = cellHeightOf(pane);
+            const int cellWidth = cellWidthOf(pane);
+            const int expectedBottom = referenceInkBottom(pane->font(), qsl("_"), cellWidth, cellHeight);
+            if (expectedBottom < cellHeight) {
+                continue;
+            }
+            ++checkedSizes;
+
+            // More lines than fit, so the pane has scrolled and drawForeground()
+            // is on its cached-pixmap path.
+            runLua(host, qsl("clearWindow()"));
+            runLua(host, qsl("cecho('<white>' .. string.rep('%1\\n', %2))").arg(QString(kUnderscoreCount, QLatin1Char('_'))).arg(pane->getScreenHeight() * 2));
+            pane->forceUpdate();
+            QApplication::processEvents();
+
+            // What the user sees after a partial repaint: the previous frame,
+            // with the damaged band erased to the console background by Qt and
+            // then painted over by the widget.
+            QImage rendered = renderPane(host);
+            const int row = pane->getScreenHeight() / 2;
+            const QRect damaged(0, row * cellHeight, pane->width(), cellHeight * 2);
+            QPainter eraser(&rendered);
+            eraser.fillRect(damaged, host->mpConsole->getConsoleBgColor());
+            eraser.end();
+            pane->render(&rendered, damaged.topLeft(), QRegion(damaged), QWidget::DrawChildren);
+
+            const int actualBottom = inkBottom(collectInk(rendered, (row - 1) * cellHeight, cellHeight, cellWidth));
+            QVERIFY2(actualBottom == expectedBottom,
+                     qPrintable(qsl("%1pt: after a partial repaint the line above the dirty region ends %2 rows below its cell top, expected %3").arg(size).arg(actualBottom).arg(expectedBottom)));
+        }
+
+        QVERIFY2(checkedSizes > 0, "No font size produced an overflowing line, so this test proves nothing");
+    }
+
+    void cleanup()
+    {
+        const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        delete mudlet::self();
+        delete mpServer;
+        mpServer = nullptr;
+        deleteDirectory(profilePath);
+    }
+
+private:
+    // The pane paints its cells onto whatever the parent widget is showing, so
+    // start from the console background rather than letting render() lay down
+    // the default palette colour where no cell was filled.
+    static QImage renderPane(Host* host)
+    {
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QImage image(pane->size(), QImage::Format_ARGB32_Premultiplied);
+        image.fill(host->mpConsole->getConsoleBgColor());
+        pane->render(&image, QPoint(), QRegion(), QWidget::DrawChildren);
+        return image;
+    }
+
+    static int cellHeightOf(const TTextEdit* pane) { return QFontMetrics(pane->font()).height(); }
+    static int cellWidthOf(const TTextEdit* pane) { return QFontMetrics(pane->font()).averageCharWidth(); }
+
+    static int inkBottom(const QVector<QPoint>& ink)
+    {
+        int bottom = -1;
+        for (const QPoint& point : ink) {
+            bottom = qMax(bottom, point.y());
+        }
+        return bottom;
+    }
+
+    void applyFont(Host* host, const QString& family, int size)
+    {
+        QFont font(family, size);
+        font.setFixedPitch(true);
+        const auto result = host->setDisplayFont(font);
+        QVERIFY2(result.first, qPrintable(qsl("Could not set the display font to %1 %2pt: %3").arg(family).arg(size).arg(result.second)));
+        QApplication::processEvents();
+    }
+
+    // Prints a line of underscores followed by a filler line dressed up as the
+    // given underlay, repaints, and returns the ink of the underscore line.
+    QVector<QPoint> renderAndCollectInk(Host* host, const Underlay& underlay)
+    {
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        runLua(host, qsl("clearWindow()"));
+        runLua(host, qsl("cecho('<white>%1\\n')").arg(QString(kUnderscoreCount, QLatin1Char('_'))));
+        runLua(host, qsl("cecho('%1%2\\n')").arg(underlay.colourTag, QString(kFillerCount, QLatin1Char(' '))));
+
+        const int underscoreLine = findLine(host, QString(kUnderscoreCount, QLatin1Char('_')));
+        if (underscoreLine < 0) {
+            return {};
+        }
+        if (underlay.selected) {
+            auto& below = host->mpConsole->buffer.buffer.at(underscoreLine + 1);
+            for (TChar& character : below) {
+                character.select();
+            }
+        }
+        pane->forceUpdate();
+        QApplication::processEvents();
+
+        const QImage rendered = renderPane(host);
+        const int cellHeight = cellHeightOf(pane);
+        return collectInk(rendered, (underscoreLine - pane->imageTopLine()) * cellHeight, cellHeight, cellWidthOf(pane));
+    }
+
+    static int findLine(Host* host, const QString& text)
+    {
+        TBuffer& buffer = host->mpConsole->buffer;
+        for (int i = 0; i <= buffer.getLastLineNumber(); ++i) {
+            if (buffer.line(i) == text) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // Every pixel of the underscore run that differs from what its own pixel row
+    // looks like away from the glyphs, as offsets from the cell's top left.
+    // Reaches a few rows past the bottom of the cell so overflow is included
+    // without picking up the glyphs of the line below.
+    static QVector<QPoint> collectInk(const QImage& image, int cellTop, int cellHeight, int cellWidth)
+    {
+        QVector<QPoint> ink;
+        const int sampleX = kBackgroundSampleColumn * cellWidth + cellWidth / 2;
+        if (sampleX >= image.width() || cellTop < 0) {
+            return ink;
+        }
+        const int lastX = qMin(kUnderscoreCount * cellWidth, image.width()) - 1;
+        const int lastY = qMin(cellTop + cellHeight + kOverflowScanRows, image.height()) - 1;
+        for (int y = cellTop; y <= lastY; ++y) {
+            const QRgb background = image.pixel(sampleX, y);
+            for (int x = 0; x <= lastX; ++x) {
+                if (pixelIsInk(image.pixel(x, y), background)) {
+                    ink.append(QPoint(x, y - cellTop));
+                }
+            }
+        }
+        return ink;
+    }
+
+    // Where the glyph's ink ends relative to the top of its cell when drawn the
+    // way TTextEdit::paintGraphemeForeground() draws it.
+    static int referenceInkBottom(const QFont& font, const QString& grapheme, int cellWidth, int cellHeight)
+    {
+        QImage image(cellWidth, cellHeight * 3, QImage::Format_ARGB32_Premultiplied);
+        image.fill(Qt::black);
+        QPainter painter(&image);
+        painter.setFont(font);
+        painter.setPen(Qt::white);
+        painter.drawText(QRect(0, cellHeight, cellWidth, cellHeight), Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
+        painter.end();
+
+        int bottom = -1;
+        for (int y = 0; y < image.height(); ++y) {
+            for (int x = 0; x < image.width(); ++x) {
+                if (pixelIsInk(image.pixel(x, y), qRgb(0, 0, 0))) {
+                    bottom = y;
+                    break;
+                }
+            }
+        }
+        return bottom - cellHeight;
+    }
+
+    void runLua(Host* host, const QString& script) { host->getLuaInterpreter()->compileAndExecuteScript(script); }
+
+    Host* startOfflineProfile()
+    {
+        startProfile(mHostname, mLocalhost, mPort);
+        auto* host = mudlet::self()->getActiveHost();
+        host->mEchoLuaErrors = true;
+
+        mudlet::self()->resize(1400, 900);
+        QApplication::processEvents();
+
+        // cecho() into a live connection would race with the stub's traffic
+        host->mTelnet.disconnectIt();
+        if (!QTest::qWaitFor(
+                    [host]() {
+                        return host->mTelnet.getConnectionState() == QAbstractSocket::UnconnectedState;
+                    },
+                    5000)) {
+            qWarning() << "Profile did not go offline in time; stub traffic may interleave with the printed lines";
+        }
+        return host;
+    }
+
+    // Starts a profile the way a user would via the GUI (mirrors the helper in
+    // TelnetTextDisplayedTest).
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        if (!mudlet::self()->getActiveHost()) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mudlet::self()->getActiveHost()->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName) { deleteDirectory(mudlet::getMudletPath(enums::profileHomePath, profileName)); }
+
+    void deleteDirectory(const QString& path)
+    {
+        QDir dir(path);
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "GlyphOverflowTest.moc"
+QTEST_MAIN(GlyphOverflowTest)

--- a/test/functional_tests/GlyphOverflowTest.cpp
+++ b/test/functional_tests/GlyphOverflowTest.cpp
@@ -97,6 +97,9 @@ private slots:
     void initTestCase()
     {
         initializeQRCResources();
+#ifndef INCLUDE_FONTS
+        QSKIP("Built with WITH_FONTS=NO, so the fonts whose metrics this measures are not available");
+#else
         // src/main.cpp extracts the bundled fonts into the config directory and
         // FontManager picks them up from there, but QTEST_MAIN never runs
         // main(), so on a machine that has not run Mudlet before there is
@@ -110,6 +113,7 @@ private slots:
         for (const QString& family : kTestFamilies) {
             QVERIFY2(QFontDatabase::families().contains(family), qPrintable(qsl("'%1' is missing from the font database after registering the bundled files").arg(family)));
         }
+#endif
     }
 
     void init()

--- a/test/functional_tests/GlyphOverflowTest.cpp
+++ b/test/functional_tests/GlyphOverflowTest.cpp
@@ -17,6 +17,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QFontDatabase>
 #include <QPainter>
 #include <QtTest/QtTest>
 
@@ -83,6 +84,7 @@ private:
     static constexpr int kInkThreshold = 24;
     // How far past the bottom of a cell to look for ink that overflowed out of it
     static constexpr int kOverflowScanRows = 4;
+    static const inline QStringList kTestFamilies = {qsl("Bitstream Vera Sans Mono"), qsl("Ubuntu Mono")};
     static constexpr int kFirstSize = 9;
     static constexpr int kLastSize = 30;
 
@@ -92,7 +94,23 @@ private:
     }
 
 private slots:
-    void initTestCase() { initializeQRCResources(); }
+    void initTestCase()
+    {
+        initializeQRCResources();
+        // src/main.cpp extracts the bundled fonts into the config directory and
+        // FontManager picks them up from there, but QTEST_MAIN never runs
+        // main(), so on a machine that has not run Mudlet before there is
+        // nothing on disk to pick up and Qt quietly substitutes another family.
+        for (const QString& file : {qsl(":/fonts/ttf-bitstream-vera-1.10/VeraMono.ttf"),
+                                    qsl(":/fonts/ttf-bitstream-vera-1.10/VeraMoBd.ttf"),
+                                    qsl(":/fonts/ubuntu-font-family-0.83/UbuntuMono-R.ttf"),
+                                    qsl(":/fonts/ubuntu-font-family-0.83/UbuntuMono-B.ttf")}) {
+            QVERIFY2(QFontDatabase::addApplicationFont(file) != -1, qPrintable(qsl("Could not register the bundled font %1").arg(file)));
+        }
+        for (const QString& family : kTestFamilies) {
+            QVERIFY2(QFontDatabase::families().contains(family), qPrintable(qsl("'%1' is missing from the font database after registering the bundled files").arg(family)));
+        }
+    }
 
     void init()
     {
@@ -121,7 +139,7 @@ private slots:
         QVERIFY2(pane, "No upper pane available");
 
         int sizesWithOverflow = 0;
-        for (const QString& family : {qsl("Bitstream Vera Sans Mono"), qsl("Ubuntu Mono")}) {
+        for (const QString& family : kTestFamilies) {
             for (int size = kFirstSize; size <= kLastSize; ++size) {
                 applyFont(host, family, size);
                 QVERIFY2(pane->getColumnCount() > kBackgroundSampleColumn,
@@ -167,7 +185,7 @@ private slots:
 
         int checkedSizes = 0;
         for (int size = kFirstSize; size <= kLastSize; ++size) {
-            applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
+            applyFont(host, kTestFamilies.first(), size);
             const int cellHeight = cellHeightOf(pane);
             const int cellWidth = cellWidthOf(pane);
             const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
@@ -211,7 +229,7 @@ private slots:
 
         int checkedSizes = 0;
         for (int size = kFirstSize; size <= kLastSize; ++size) {
-            applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
+            applyFont(host, kTestFamilies.first(), size);
             const int cellHeight = cellHeightOf(pane);
             const int cellWidth = cellWidthOf(pane);
             const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
@@ -264,7 +282,7 @@ private slots:
 
         int checkedSizes = 0;
         for (int size = kFirstSize; size <= kLastSize; ++size) {
-            applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
+            applyFont(host, kTestFamilies.first(), size);
             const int cellHeight = cellHeightOf(pane);
             const int cellWidth = cellWidthOf(pane);
             const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
@@ -330,8 +348,13 @@ private slots:
 
         int checkedSizes = 0;
         for (int size = kFirstSize; size <= kLastSize; ++size) {
+            runLua(host, qsl("setFont('overflowMini', '%1')").arg(kTestFamilies.first()));
             runLua(host, qsl("setMiniConsoleFontSize('overflowMini', %1)").arg(size));
             QApplication::processEvents();
+            // this one goes through the miniconsole API rather than applyFont(),
+            // so it needs its own check that the family was not substituted
+            QVERIFY2(QFontInfo(pane->font()).family() == kTestFamilies.first(),
+                     qPrintable(qsl("The miniconsole resolved to '%1' rather than '%2', so this would measure the wrong glyph").arg(QFontInfo(pane->font()).family(), kTestFamilies.first())));
             const int cellHeight = cellHeightOf(pane);
             const int cellWidth = cellWidthOf(pane);
             const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
@@ -482,16 +505,21 @@ private:
         return ink;
     }
 
-    // Where the glyph's ink starts and ends relative to the top of its cell when
-    // drawn the way TTextEdit::paintGraphemeForeground() draws it.
+    // Where the ink of a run of graphemes starts and ends relative to the top of
+    // its cell, drawn cell by cell the way TTextEdit::paintGraphemeForeground()
+    // draws it. The whole run is rendered rather than a single glyph because
+    // neighbouring cells' antialiasing overlaps at the cell boundaries, which
+    // moves the faintest row of the ink.
     static QPair<int, int> referenceInkExtent(const QFont& font, const QString& grapheme, int cellWidth, int cellHeight)
     {
-        QImage image(cellWidth, cellHeight * 3, QImage::Format_ARGB32_Premultiplied);
+        QImage image(kUnderscoreCount * cellWidth, cellHeight * 3, QImage::Format_ARGB32_Premultiplied);
         image.fill(Qt::black);
         QPainter painter(&image);
         painter.setFont(font);
         painter.setPen(Qt::white);
-        painter.drawText(QRect(0, cellHeight, cellWidth, cellHeight), Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
+        for (int cell = 0; cell < kUnderscoreCount; ++cell) {
+            painter.drawText(QRect(cell * cellWidth, cellHeight, cellWidth, cellHeight), Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
+        }
         painter.end();
 
         int top = -1;

--- a/test/functional_tests/GlyphOverflowTest.cpp
+++ b/test/functional_tests/GlyphOverflowTest.cpp
@@ -39,8 +39,8 @@ void initializeQRCResources();
 
 // TTextEdit lays text out in cells of QFontMetrics::height(), which is a
 // typographic measure rather than the glyph ink box. At a good number of font
-// sizes the ink of "_gjpqy$@()" reaches a pixel past the bottom of its cell, so
-// those glyphs only render completely if nothing paints over that pixel
+// sizes the ink of a glyph such as "_" reaches a pixel past the bottom of its
+// cell, so it only renders completely if nothing paints over that pixel
 // afterwards. #9070 and #9719 are both reports of underscores vanishing because
 // something did.
 class GlyphOverflowTest : public QObject
@@ -50,11 +50,11 @@ class GlyphOverflowTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mHostname = "Test-GlyphOverflow";
-    QString mPort; // assigned the stub's actual loopback port in init()
+    QString mPort;
     const QString mLocalhost = "localhost";
 
-    // What the line below the underscores looks like. Each of these used to
-    // paint over the overflow pixel of the line above it.
+    // What the line below the underscores looks like. Each one takes a different
+    // branch of the background fill in layoutGrapheme().
     struct Underlay
     {
         QString name;
@@ -75,7 +75,8 @@ private:
     static constexpr int kUnderscoreCount = 40;
     static constexpr int kFillerCount = 60;
     // Column used to sample what a pixel row looks like where no glyph was
-    // drawn: past the underscores, still inside the filler line.
+    // drawn; whatever the line below paints there is the reference for its own
+    // pixel row.
     static constexpr int kBackgroundSampleColumn = 50;
     // How far a channel has to move from its row's background before the pixel
     // counts as glyph ink rather than antialiasing noise.
@@ -110,11 +111,12 @@ private slots:
     }
 
     // A line has to render all of its ink whatever the line below it looks like,
-    // and that ink has to match the glyph drawn on its own with the same font,
-    // cell geometry and painter flags.
+    // and that ink has to match the same glyph drawn on its own with the same
+    // font, cell geometry and painter flags.
     void test_lineBelowDoesNotEraseOverflowingInk()
     {
         Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
         TTextEdit* pane = host->mpConsole->mUpperPane;
         QVERIFY2(pane, "No upper pane available");
 
@@ -122,9 +124,15 @@ private slots:
         for (const QString& family : {qsl("Bitstream Vera Sans Mono"), qsl("Ubuntu Mono")}) {
             for (int size = kFirstSize; size <= kLastSize; ++size) {
                 applyFont(host, family, size);
+                QVERIFY2(pane->getColumnCount() > kBackgroundSampleColumn,
+                         qPrintable(qsl("%1 %2pt narrowed the pane to %3 columns, too few for the background sample at column %4")
+                                            .arg(family)
+                                            .arg(size)
+                                            .arg(pane->getColumnCount())
+                                            .arg(kBackgroundSampleColumn)));
                 const int cellHeight = cellHeightOf(pane);
-                const int expectedBottom = referenceInkBottom(pane->font(), qsl("_"), cellWidthOf(pane), cellHeight);
-                if (expectedBottom >= cellHeight) {
+                const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidthOf(pane), cellHeight);
+                if (expected.second >= cellHeight) {
                     ++sizesWithOverflow;
                 }
 
@@ -133,25 +141,27 @@ private slots:
                     const QString where = qsl("%1 %2pt below %3").arg(family).arg(size).arg(underlay.name);
                     QVERIFY2(!ink.isEmpty(), qPrintable(qsl("%1: no underscore ink rendered at all").arg(where)));
 
-                    int actualBottom = ink.first().y();
-                    for (const QPoint& point : ink) {
-                        actualBottom = qMax(actualBottom, point.y());
-                    }
-                    QVERIFY2(actualBottom == expectedBottom,
-                             qPrintable(qsl("%1: underscore ink ends %2 rows below the cell top, expected %3 (cell is %4 tall)").arg(where).arg(actualBottom).arg(expectedBottom).arg(cellHeight)));
+                    const QPair<int, int> actual = inkExtent(ink);
+                    QVERIFY2(actual == expected,
+                             qPrintable(qsl("%1: underscore ink occupies %2 of its cell, expected %3 (cell is %4 tall)").arg(where, describeExtent(actual), describeExtent(expected)).arg(cellHeight)));
                 }
             }
         }
 
-        QVERIFY2(sizesWithOverflow > 0, "None of the tested font sizes overflow their cell, so this test proves nothing - pick different sizes");
+        if (sizesWithOverflow == 0) {
+            // The comparisons above all ran and passed, so this is a coverage
+            // warning rather than a skip
+            QWARN("None of the tested font sizes overflow their cell on this platform, so the overflow case went unexercised");
+        }
     }
 
     // The screen is rendered into a pixmap sized from the number of whole
-    // character cells that fit, so the bottom line's overflow used to be cut off
-    // by the edge of that pixmap regardless of what was painted afterwards.
+    // character cells that fit, so the bottom line's overflow only survives if
+    // that pixmap has somewhere to put it.
     void test_bottomLineOverflowSurvivesThePixmapEdge()
     {
         Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
         TTextEdit* pane = host->mpConsole->mUpperPane;
         QVERIFY2(pane, "No upper pane available");
 
@@ -160,8 +170,8 @@ private slots:
             applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
             const int cellHeight = cellHeightOf(pane);
             const int cellWidth = cellWidthOf(pane);
-            const int expectedBottom = referenceInkBottom(pane->font(), qsl("_"), cellWidth, cellHeight);
-            if (expectedBottom < cellHeight) {
+            const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
+            if (expected.second < cellHeight) {
                 continue; // this size keeps its ink inside the cell, nothing to check
             }
             // A pane whose height is an exact multiple of the cell height has no
@@ -179,12 +189,14 @@ private slots:
 
             const QImage rendered = renderPane(host);
             const int cellTop = (screenHeight - 1) * cellHeight;
-            const int actualBottom = inkBottom(collectInk(rendered, cellTop, cellHeight, cellWidth));
-            QVERIFY2(actualBottom == expectedBottom,
-                     qPrintable(qsl("%1pt: the bottom line's underscore ink ends %2 rows below the cell top, expected %3").arg(size).arg(actualBottom).arg(expectedBottom)));
+            const QPair<int, int> actual = inkExtent(collectInk(rendered, cellTop, cellHeight, cellWidth));
+            QVERIFY2(actual == expected,
+                     qPrintable(qsl("%1pt: the bottom line's underscore ink occupies %2 of its cell, expected %3").arg(QString::number(size), describeExtent(actual), describeExtent(expected))));
         }
 
-        QVERIFY2(checkedSizes > 0, "No font size produced an overflowing bottom line, so this test proves nothing");
+        if (checkedSizes == 0) {
+            QSKIP("No font size produced an overflowing bottom line on this platform, so nothing here is being proved");
+        }
     }
 
     // Repainting part of the pane clears whole character cells, which takes the
@@ -193,6 +205,7 @@ private slots:
     void test_partialRepaintKeepsTheLineAboveIntact()
     {
         Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
         TTextEdit* pane = host->mpConsole->mUpperPane;
         QVERIFY2(pane, "No upper pane available");
 
@@ -201,22 +214,23 @@ private slots:
             applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
             const int cellHeight = cellHeightOf(pane);
             const int cellWidth = cellWidthOf(pane);
-            const int expectedBottom = referenceInkBottom(pane->font(), qsl("_"), cellWidth, cellHeight);
-            if (expectedBottom < cellHeight) {
+            const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
+            if (expected.second < cellHeight) {
                 continue;
             }
             ++checkedSizes;
 
-            // More lines than fit, so the pane has scrolled and drawForeground()
-            // is on its cached-pixmap path.
+            // More lines than fit, so imageTopLine() is past zero - the
+            // precondition for the partial repaint below to reach
+            // drawForeground()'s cached-pixmap path.
             runLua(host, qsl("clearWindow()"));
             runLua(host, qsl("cecho('<white>' .. string.rep('%1\\n', %2))").arg(QString(kUnderscoreCount, QLatin1Char('_'))).arg(pane->getScreenHeight() * 2));
             pane->forceUpdate();
             QApplication::processEvents();
+            QVERIFY2(pane->imageTopLine() > 0, "The pane did not scroll, so the partial repaint would not reach the cached-pixmap path");
 
-            // What the user sees after a partial repaint: the previous frame,
-            // with the damaged band erased to the console background by Qt and
-            // then painted over by the widget.
+            // Simulate a partial repaint: the previous frame, the damaged band
+            // reset to the console background, then only that band re-rendered.
             QImage rendered = renderPane(host);
             const int row = pane->getScreenHeight() / 2;
             const QRect damaged(0, row * cellHeight, pane->width(), cellHeight * 2);
@@ -225,12 +239,125 @@ private slots:
             eraser.end();
             pane->render(&rendered, damaged.topLeft(), QRegion(damaged), QWidget::DrawChildren);
 
-            const int actualBottom = inkBottom(collectInk(rendered, (row - 1) * cellHeight, cellHeight, cellWidth));
-            QVERIFY2(actualBottom == expectedBottom,
-                     qPrintable(qsl("%1pt: after a partial repaint the line above the dirty region ends %2 rows below its cell top, expected %3").arg(size).arg(actualBottom).arg(expectedBottom)));
+            // Only the bottom of the ink can be pinned here: every line is
+            // underscores, so the top rows of the cell hold the overflow of the
+            // line above it rather than this line's own glyph.
+            const QPair<int, int> actual = inkExtent(collectInk(rendered, (row - 1) * cellHeight, cellHeight, cellWidth));
+            QVERIFY2(actual.second == expected.second,
+                     qPrintable(qsl("%1pt: after a partial repaint the line above the dirty region ends at row %2 of its cell, expected %3").arg(size).arg(actual.second).arg(expected.second)));
         }
 
-        QVERIFY2(checkedSizes > 0, "No font size produced an overflowing line, so this test proves nothing");
+        if (checkedSizes == 0) {
+            QSKIP("No font size produced an overflowing line on this platform, so nothing here is being proved");
+        }
+    }
+
+    // Scrolling reuses the cached screen by blitting it a whole number of cells
+    // up or down, which lands a complete line of text in the strip below the
+    // last one. Only the bottom line's own overflow belongs there.
+    void test_scrollingLeavesNoGhostLineBelowTheBottomOne()
+    {
+        Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY2(pane, "No upper pane available");
+
+        int checkedSizes = 0;
+        for (int size = kFirstSize; size <= kLastSize; ++size) {
+            applyFont(host, qsl("Bitstream Vera Sans Mono"), size);
+            const int cellHeight = cellHeightOf(pane);
+            const int cellWidth = cellWidthOf(pane);
+            const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
+            const int spareTop = pane->getScreenHeight() * cellHeight;
+            if (expected.second < cellHeight || pane->height() - spareTop <= kOverflowScanRows) {
+                continue;
+            }
+            ++checkedSizes;
+
+            // Underscores for the overflow, letters past them so that a whole
+            // ghost line would be unmistakable in the strip.
+            const QString line = QString(kUnderscoreCount, QLatin1Char('_')) + QString(20, QLatin1Char('M'));
+            runLua(host, qsl("clearWindow()"));
+            runLua(host, qsl("cecho('<white>' .. string.rep('%1\\n', %2))").arg(line).arg(pane->getScreenHeight() * 4));
+            pane->forceUpdate();
+            QApplication::processEvents();
+            // primes the cached screen the scroll below is blitted from
+            renderPane(host);
+
+            // drawForeground() ignores the cache entirely below ten scrolled-off
+            // lines, so there has to be more scrollback than that
+            const int topLineBeforeScroll = pane->imageTopLine();
+            QVERIFY2(topLineBeforeScroll >= 10, "Not enough scrollback for drawForeground() to take its scrolling path");
+
+            // Render straight after the scroll so the frame under test is the
+            // one drawForeground() builds from the shifted cache.
+            pane->scrollUp(3);
+            QVERIFY2(pane->imageTopLine() < topLineBeforeScroll, "The pane did not scroll back, so the frame below is not built from a shifted cache");
+            const QImage rendered = renderPane(host);
+
+            for (int y = spareTop + kOverflowScanRows; y < pane->height(); ++y) {
+                int litPixels = 0;
+                for (int x = 0; x < rendered.width(); ++x) {
+                    if (pixelIsInk(rendered.pixel(x, y), consoleBackground(host))) {
+                        ++litPixels;
+                    }
+                }
+                QVERIFY2(litPixels == 0, qPrintable(qsl("%1pt: %2 stray pixels %3 rows below the last character cell after scrolling back").arg(size).arg(litPixels).arg(y - spareTop)));
+            }
+
+            // As above, the top of the cell holds the previous line's overflow
+            const QPair<int, int> actual = inkExtent(collectInk(rendered, spareTop - cellHeight, cellHeight, cellWidth));
+            QVERIFY2(actual.second == expected.second,
+                     qPrintable(qsl("%1pt: after scrolling back the bottom line's underscore ink ends at row %2 of its cell, expected %3").arg(size).arg(actual.second).arg(expected.second)));
+        }
+
+        if (checkedSizes == 0) {
+            QSKIP("No font size produced an overflowing bottom line on this platform, so nothing here is being proved");
+        }
+    }
+
+    // Miniconsoles keep the fill rule the main console does not, so check the
+    // paint order protects their overflow too.
+    void test_miniConsoleKeepsOverflowingInk()
+    {
+        Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
+        runLua(host, qsl("createMiniConsole('overflowMini', 0, 0, 800, 400)"));
+        auto* mini = host->mpConsole->mSubConsoleMap.value(qsl("overflowMini"));
+        QVERIFY2(mini, "The miniconsole was not created");
+        TTextEdit* pane = mini->mUpperPane;
+        QVERIFY2(pane, "The miniconsole has no pane");
+
+        int checkedSizes = 0;
+        for (int size = kFirstSize; size <= kLastSize; ++size) {
+            runLua(host, qsl("setMiniConsoleFontSize('overflowMini', %1)").arg(size));
+            QApplication::processEvents();
+            const int cellHeight = cellHeightOf(pane);
+            const int cellWidth = cellWidthOf(pane);
+            const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
+            if (expected.second < cellHeight || pane->getColumnCount() <= kBackgroundSampleColumn) {
+                continue;
+            }
+            ++checkedSizes;
+
+            runLua(host, qsl("clearWindow('overflowMini')"));
+            runLua(host, qsl("cecho('overflowMini', '<white>%1\\n')").arg(QString(kUnderscoreCount, QLatin1Char('_'))));
+            runLua(host, qsl("cecho('overflowMini', '<white:blue>%1\\n')").arg(QString(kFillerCount, QLatin1Char(' '))));
+            pane->forceUpdate();
+            QApplication::processEvents();
+
+            QImage rendered(pane->size(), QImage::Format_ARGB32_Premultiplied);
+            rendered.fill(mini->getConsoleBgColor());
+            pane->render(&rendered, QPoint(), QRegion(), QWidget::DrawChildren);
+
+            const QPair<int, int> actual = inkExtent(collectInk(rendered, 0, cellHeight, cellWidth));
+            QVERIFY2(actual == expected,
+                     qPrintable(qsl("%1pt: a miniconsole's underscore ink occupies %2 of its cell, expected %3").arg(QString::number(size), describeExtent(actual), describeExtent(expected))));
+        }
+
+        if (checkedSizes == 0) {
+            QSKIP("No font size produced an overflowing line in a miniconsole on this platform, so nothing here is being proved");
+        }
     }
 
     void cleanup()
@@ -255,22 +382,35 @@ private:
         return image;
     }
 
+    static QRgb consoleBackground(Host* host) { return host->mpConsole->getConsoleBgColor().rgb(); }
+
     static int cellHeightOf(const TTextEdit* pane) { return QFontMetrics(pane->font()).height(); }
     static int cellWidthOf(const TTextEdit* pane) { return QFontMetrics(pane->font()).averageCharWidth(); }
 
-    static int inkBottom(const QVector<QPoint>& ink)
+    // First and last pixel row of a set of ink, as offsets from the cell top.
+    // Empty ink reports {-1, -1} so a completely erased glyph never matches a
+    // real reference extent.
+    static QPair<int, int> inkExtent(const QVector<QPoint>& ink)
     {
-        int bottom = -1;
+        if (ink.isEmpty()) {
+            return {-1, -1};
+        }
+        int top = ink.first().y();
+        int bottom = top;
         for (const QPoint& point : ink) {
+            top = qMin(top, point.y());
             bottom = qMax(bottom, point.y());
         }
-        return bottom;
+        return {top, bottom};
     }
+
+    static QString describeExtent(const QPair<int, int>& extent) { return qsl("rows %1..%2").arg(extent.first).arg(extent.second); }
 
     void applyFont(Host* host, const QString& family, int size)
     {
         QFont font(family, size);
         font.setFixedPitch(true);
+        QVERIFY2(QFontInfo(font).family() == family, qPrintable(qsl("Qt substituted '%1' for the requested '%2', so this would measure the wrong glyph").arg(QFontInfo(font).family(), family)));
         const auto result = host->setDisplayFont(font);
         QVERIFY2(result.first, qPrintable(qsl("Could not set the display font to %1 %2pt: %3").arg(family).arg(size).arg(result.second)));
         QApplication::processEvents();
@@ -290,6 +430,9 @@ private:
             return {};
         }
         if (underlay.selected) {
+            if (underscoreLine + 1 >= static_cast<int>(host->mpConsole->buffer.buffer.size())) {
+                return {};
+            }
             auto& below = host->mpConsole->buffer.buffer.at(underscoreLine + 1);
             for (TChar& character : below) {
                 character.select();
@@ -316,8 +459,9 @@ private:
 
     // Every pixel of the underscore run that differs from what its own pixel row
     // looks like away from the glyphs, as offsets from the cell's top left.
-    // Reaches a few rows past the bottom of the cell so overflow is included
-    // without picking up the glyphs of the line below.
+    // Reaches a few rows past the bottom of the cell so overflow is included.
+    // That only avoids picking up the line below because every caller leaves it
+    // blank or puts underscores on it, whose ink sits at the bottom of a cell.
     static QVector<QPoint> collectInk(const QImage& image, int cellTop, int cellHeight, int cellWidth)
     {
         QVector<QPoint> ink;
@@ -338,9 +482,9 @@ private:
         return ink;
     }
 
-    // Where the glyph's ink ends relative to the top of its cell when drawn the
-    // way TTextEdit::paintGraphemeForeground() draws it.
-    static int referenceInkBottom(const QFont& font, const QString& grapheme, int cellWidth, int cellHeight)
+    // Where the glyph's ink starts and ends relative to the top of its cell when
+    // drawn the way TTextEdit::paintGraphemeForeground() draws it.
+    static QPair<int, int> referenceInkExtent(const QFont& font, const QString& grapheme, int cellWidth, int cellHeight)
     {
         QImage image(cellWidth, cellHeight * 3, QImage::Format_ARGB32_Premultiplied);
         image.fill(Qt::black);
@@ -350,24 +494,31 @@ private:
         painter.drawText(QRect(0, cellHeight, cellWidth, cellHeight), Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
         painter.end();
 
+        int top = -1;
         int bottom = -1;
         for (int y = 0; y < image.height(); ++y) {
             for (int x = 0; x < image.width(); ++x) {
                 if (pixelIsInk(image.pixel(x, y), qRgb(0, 0, 0))) {
+                    if (top < 0) {
+                        top = y;
+                    }
                     bottom = y;
                     break;
                 }
             }
         }
-        return bottom - cellHeight;
+        return {top - cellHeight, bottom - cellHeight};
     }
 
-    void runLua(Host* host, const QString& script) { host->getLuaInterpreter()->compileAndExecuteScript(script); }
+    void runLua(Host* host, const QString& script) { QVERIFY2(host->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(qsl("Lua script failed: %1").arg(script))); }
 
     Host* startOfflineProfile()
     {
         startProfile(mHostname, mLocalhost, mPort);
         auto* host = mudlet::self()->getActiveHost();
+        if (!host) {
+            return nullptr;
+        }
         host->mEchoLuaErrors = true;
 
         mudlet::self()->resize(1400, 900);

--- a/test/functional_tests/GlyphOverflowTest.cpp
+++ b/test/functional_tests/GlyphOverflowTest.cpp
@@ -17,6 +17,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QClipboard>
 #include <QFontDatabase>
 #include <QPainter>
 #include <QtTest/QtTest>
@@ -387,6 +388,53 @@ private slots:
         }
     }
 
+    // Copy-as-image sizes its pixmap at exactly one cell per selected line, so
+    // the bottom line's overflow has nowhere to go unless the paint leaves room
+    // for it and the image is trimmed back afterwards.
+    void test_copyAsImageKeepsTheBottomLineOverflow()
+    {
+        Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY2(pane, "No upper pane available");
+
+        int checkedSizes = 0;
+        for (int size = kFirstSize; size <= kLastSize; ++size) {
+            applyFont(host, kTestFamilies.first(), size);
+            const int cellHeight = cellHeightOf(pane);
+            const int cellWidth = cellWidthOf(pane);
+            const QPair<int, int> expected = referenceInkExtent(pane->font(), qsl("_"), cellWidth, cellHeight);
+            if (expected.second < cellHeight) {
+                continue;
+            }
+            ++checkedSizes;
+
+            const int selectedLines = 5;
+            runLua(host, qsl("clearWindow()"));
+            runLua(host, qsl("cecho('<white>' .. string.rep('%1\\n', %2))").arg(QString(kUnderscoreCount, QLatin1Char('_'))).arg(selectedLines));
+            pane->forceUpdate();
+            QApplication::processEvents();
+
+            selectRows(pane, 0, selectedLines - 1, cellHeight, cellWidth);
+            QMetaObject::invokeMethod(pane, "slot_copySelectionToClipboardImage", Qt::DirectConnection);
+            QApplication::processEvents();
+
+            const QImage copied = QApplication::clipboard()->image();
+            QVERIFY2(!copied.isNull(), qPrintable(qsl("%1pt: copy as image produced nothing").arg(size)));
+            const QPair<int, int> actual = inkExtentOnFlat(copied, (selectedLines - 1) * cellHeight, cellHeight, consoleBackground(host));
+            QVERIFY2(actual.second == expected.second,
+                     qPrintable(qsl("%1pt: the copied image's bottom line ends at row %2 of its cell, expected %3").arg(size).arg(actual.second).arg(expected.second)));
+            // the spare row must not survive as blank padding, nor bring an
+            // extra line of text with it
+            QVERIFY2(copied.height() <= selectedLines * cellHeight + kOverflowScanRows,
+                     qPrintable(qsl("%1pt: the copied image is %2px tall for %3 lines of %4px").arg(size).arg(copied.height()).arg(selectedLines).arg(cellHeight)));
+        }
+
+        if (checkedSizes == 0) {
+            QSKIP("No font size produced an overflowing line on this platform, so nothing here is being proved");
+        }
+    }
+
     void cleanup()
     {
         const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
@@ -407,6 +455,26 @@ private:
         image.fill(host->mpConsole->getConsoleBgColor());
         pane->render(&image, QPoint(), QRegion(), QWidget::DrawChildren);
         return image;
+    }
+
+    // For images too narrow to carry a background sample column, such as the
+    // copy-as-image output, which is only as wide as the selected text.
+    static QPair<int, int> inkExtentOnFlat(const QImage& image, int cellTop, int cellHeight, QRgb background)
+    {
+        int top = -1;
+        int bottom = -1;
+        for (int y = qMax(0, cellTop); y < qMin(image.height(), cellTop + cellHeight + kOverflowScanRows); ++y) {
+            for (int x = 0; x < image.width(); ++x) {
+                if (pixelIsInk(image.pixel(x, y), background)) {
+                    if (top < 0) {
+                        top = y;
+                    }
+                    bottom = y;
+                    break;
+                }
+            }
+        }
+        return {top - cellTop, bottom - cellTop};
     }
 
     static QRgb consoleBackground(Host* host) { return host->mpConsole->getConsoleBgColor().rgb(); }
@@ -602,6 +670,21 @@ private:
         if (!spy2.wait(2000)) {
             QFAIL("Could not connect with the host.");
         }
+    }
+
+    // Drag-selects whole rows, which is the only way in from outside the class.
+    static void selectRows(TTextEdit* pane, int firstRow, int lastRow, int cellHeight, int cellWidth)
+    {
+        auto send = [pane](QEvent::Type type, Qt::MouseButton button, Qt::MouseButtons buttons, const QPointF& pos) {
+            QMouseEvent event(type, pos, pane->mapToGlobal(pos.toPoint()), button, buttons, Qt::NoModifier);
+            QApplication::sendEvent(pane, &event);
+        };
+        const QPointF start(2, firstRow * cellHeight + 2);
+        const QPointF end(kUnderscoreCount * cellWidth - 2, lastRow * cellHeight + cellHeight / 2);
+        send(QEvent::MouseButtonPress, Qt::LeftButton, Qt::LeftButton, start);
+        send(QEvent::MouseMove, Qt::NoButton, Qt::LeftButton, end);
+        send(QEvent::MouseButtonRelease, Qt::LeftButton, Qt::NoButton, end);
+        QApplication::processEvents();
     }
 
     void deleteProfileDirectory(const QString& profileName) { deleteDirectory(mudlet::getMudletPath(enums::profileHomePath, profileName)); }


### PR DESCRIPTION
**Not for 5.0 - please hold this for the release after 5.0.**

#### Brief overview of PR changes/additions

- `TTextEdit` lays text out in cells of `QFontMetrics::height()`, a typographic measure rather than the glyph ink box, so at many font sizes the ink of `_ g j p q y $ @ ( )` reaches a pixel past the bottom of its cell. On Bitstream Vera Sans Mono at 14pt the underscore is a 1px bar sitting entirely below the cell, so it disappears completely.
- The screen is now rendered with each line's cell backgrounds painted before the previous line's glyphs, the screen pixmap has a spare row for the bottom line's overflow, and partial repaints and scroll blits put back the overflow they would otherwise erase.
- With backgrounds no longer able to clobber overflow, the narrowed background-fill condition from #9288 goes back to what #8887 intended.

Measured with an offscreen A/B of the same scene: 15.0-15.2ms per frame against 16.5-16.9ms before, on both the full-repaint and the scrolling path (ASan build, so treat the absolute numbers as relative only).

#### Motivation for adding to Mudlet

#9288 tried to fix this by letting the overflow pixel survive into the next line's cell, but four separate things still erase it: the next line's background fill whenever the colour differs (coloured text, selection, search highlight, caret, background image, alpha), the partial-repaint clear, the bottom edge of the screen pixmap, and the scroll blit. That is why the reporter sees different `print`-style functions behave differently at the same size.

#### Other info (issues closed, discussion etc)

Fixes #9719. Completes #9070, which #9288 only partly addressed.

`GlyphOverflowTest` renders a real console offscreen across two bundled fonts and 22 font sizes and compares the underscore's ink against the same glyph drawn on its own. All five of its cases fail on `development` and pass here: the line below carrying a default, coloured, bright or selected background; the bottom visible line; a partial repaint; a scroll-back; and a miniconsole.

Copy-as-image is fixed too: its pixmap is exactly one cell per selected line, so the bottom line's ink was cut off every time.

Known limitations, both unchanged from before this PR:

- The topmost visible line's ink can overflow above the pixmap and be clipped. Fixing it would mean shifting the whole screen-pixmap coordinate system.
- When a pane's height is an exact multiple of the line height there is no leftover strip below the last line, so the bottom line's overflow has no pixel to live in. Measured at roughly 1 pane height in every 22 for both the main console and the split-screen lower pane. The only fix is to drop a row when there is no slack, and because rows are quantised that costs a whole line of text plus a blank line-height strip at the same ~4.5% of heights, which is a worse trade than the pixel it buys. Resizing the pane by one pixel restores it.

Test case: `ctest -R GlyphOverflowTest`, or set Bitstream Vera Sans Mono at 14pt and `cecho("<yellow>plain _underscore_\n<white:blue>coloured line\n")`.

Assisted-by: Claude:claude-opus-5



https://github.com/user-attachments/assets/cbda2288-1e3e-4f24-9763-7275d2f09134


