### PR TITLE
infrastructure: fix Windows CI losing the per-user luarocks tree

### DIFF
--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -132,8 +132,7 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
-        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
+        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
@@ -159,8 +158,7 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
-        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
+        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -132,9 +132,12 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        LUA_PATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-path)" )
+        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
+        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
+        # such a list, leaving the per-user rock tree unreachable.
+        LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
-        LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
+        LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
         export LUA_CPATH
 
         ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
@@ -157,9 +160,12 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        LUA_PATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-path)" )
+        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
+        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
+        # such a list, leaving the per-user rock tree unreachable.
+        LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
-        LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
+        LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
         export LUA_CPATH
 
         # Linux and macOS start the fixture HTTP server in a step of their own,

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -132,9 +132,8 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
-        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
-        # such a list, leaving the per-user rock tree unreachable.
+        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
+        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
@@ -160,9 +159,8 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
-        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
-        # such a list, leaving the per-user rock tree unreachable.
+        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
+        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -132,7 +132,6 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
@@ -158,7 +157,6 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -109,7 +109,6 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
@@ -130,7 +129,6 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -109,9 +109,12 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        LUA_PATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-path)" )
+        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
+        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
+        # such a list, leaving the per-user rock tree unreachable.
+        LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
-        LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
+        LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
         export LUA_CPATH
 
         ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
@@ -129,9 +132,12 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        LUA_PATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-path)" )
+        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
+        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
+        # such a list, leaving the per-user rock tree unreachable.
+        LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
-        LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
+        LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
         export LUA_CPATH
 
         # Linux and macOS start the fixture HTTP server in a step of their own,

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -109,9 +109,8 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
-        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
-        # such a list, leaving the per-user rock tree unreachable.
+        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
+        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
@@ -132,9 +131,8 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        # Keep luarocks' output as-is: Lua here is a native Windows binary and wants
-        # Windows-form, ';'-separated paths. cygpath converts only the first entry of
-        # such a list, leaving the per-user rock tree unreachable.
+        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
+        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -109,8 +109,7 @@ jobs:
     - name: (Windows) Run QTest
       shell: msys2 {0}
       run: |
-        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
-        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
+        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
@@ -131,8 +130,7 @@ jobs:
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
         QUIT_MUDLET_AFTER_TESTS: 'true'
       run: |
-        # Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
-        # leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
+        # Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
         LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
         export LUA_PATH
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -112,10 +112,9 @@ mkdir -p "build-${MSYSTEM}"
 cd "${GITHUB_WORKSPACE}"/build-"${MSYSTEM}" || exit 1
 
 #### Lua environment setup ####
-# Set up Lua 5.1 paths for translation processing and runtime.
-# Keep luarocks' output as-is: Lua here is a native Windows binary and wants
-# Windows-form, ';'-separated paths. cygpath converts only the first entry of
-# such a list, leaving the per-user rock tree unreachable.
+# Set up Lua 5.1 paths so the build's translation-stats script finds its rocks.
+# Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
+# leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
 LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
 export LUA_PATH
 LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -112,10 +112,13 @@ mkdir -p "build-${MSYSTEM}"
 cd "${GITHUB_WORKSPACE}"/build-"${MSYSTEM}" || exit 1
 
 #### Lua environment setup ####
-# Set up Lua 5.1 paths for translation processing and runtime
-LUA_PATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-path)" )
+# Set up Lua 5.1 paths for translation processing and runtime.
+# Keep luarocks' output as-is: Lua here is a native Windows binary and wants
+# Windows-form, ';'-separated paths. cygpath converts only the first entry of
+# such a list, leaving the per-user rock tree unreachable.
+LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
 export LUA_PATH
-LUA_CPATH=$(cygpath -u "$(luarocks --lua-version 5.1 path --lr-cpath)" )
+LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
 export LUA_CPATH
 
 echo ""

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -112,8 +112,6 @@ mkdir -p "build-${MSYSTEM}"
 cd "${GITHUB_WORKSPACE}"/build-"${MSYSTEM}" || exit 1
 
 #### Lua environment setup ####
-# The build runs generate-translation-stats.lua, which needs its rocks on the path.
-# Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
 LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
 export LUA_PATH
 LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)

--- a/CI/build-mudlet-for-windows.sh
+++ b/CI/build-mudlet-for-windows.sh
@@ -112,9 +112,8 @@ mkdir -p "build-${MSYSTEM}"
 cd "${GITHUB_WORKSPACE}"/build-"${MSYSTEM}" || exit 1
 
 #### Lua environment setup ####
-# Set up Lua 5.1 paths so the build's translation-stats script finds its rocks.
-# Not via cygpath: it does not treat ';' as a list separator, so it rewrites only the
-# leading entry (the per-user rock tree) into a POSIX path native Windows Lua cannot open.
+# The build runs generate-translation-stats.lua, which needs its rocks on the path.
+# Not via cygpath: it does not split on ';', so only the first entry gets POSIX-ified.
 LUA_PATH=$(luarocks --lua-version 5.1 path --lr-path)
 export LUA_PATH
 LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Windows CI no longer pipes `luarocks path --lr-path/--lr-cpath` through `cygpath -u`; the raw Windows-form output is exported instead.
- Same 4-line block fixed in all 5 places: `CI/build-mudlet-for-windows.sh` and both Windows workflows (QTest + Lua tests steps in each).
- Added a short note at each site saying why cygpath must not be reintroduced.

#### Motivation for adding to Mudlet
`cygpath -u` does not know `;` delimits a list, so it rewrites only the leading entry into a POSIX path the native Windows Lua cannot open - which is exactly the per-user rock tree, so CI silently ran without those rocks.

#### Other info (issues closed, discussion etc)
Fixes #9750

Verified functionally in a real MSYS2 CLANG64 shell on a Windows 11 VM, with a canary module installed into `$HOME/.luarocks-CLANG64`:

Raw luarocks output:
```
C:\msys64\home\Bob\.luarocks-CLANG64\share\lua\5.1\?.lua;C:\msys64\home\Bob\...\?\init.lua;C:\msys64\clang64\share\lua\5.1\?.lua;...
```
After `cygpath -u` (what CI did):
```
/home/Bob/.luarocks-CLANG64/share/lua/5.1/?.lua;C:/msys64/home/Bob/...
```
Only element 1 is genuinely converted, and `C:\home` does not exist on the guest. Running the native `/clang64/bin/lua5.1`:

| `LUA_PATH` value | `require 'zzcanary'` |
| --- | --- |
| raw luarocks output | `true canary-ok` |
| `cygpath -u` output | fails: `no file '/home/Bob/.luarocks-CLANG64/share/lua/5.1/zzcanary.lua'` |
| `cygpath -u -p` output | worse: `:`-separated, Lua reads the whole list as one filename |

`LUA_CPATH` behaves the same (the per-user `.dll` is unreachable after `cygpath -u`, found before it). Also confirmed MSYS2 does not auto-convert these variables when spawning a native child, so nothing was masking the defect. `CI/setup-windows-sdk.sh` already prints the raw form as the recommended Qt Creator environment, so CI now matches its own setup advice.

Separately, #9749 (the functional tests never receiving `LUA_PATH`/`LUA_CPATH` at all) is a different root cause and is not addressed here.

**Test case:** Windows CI green; the QTest and Lua test steps log `LUA_PATH`/`LUA_CPATH` in `C:\...;C:\...` form and busted/lfs/rex_pcre2 load from the per-user tree.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
