### PR TITLE
infrastructure: rename the six tests Windows refuses to launch without elevation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,30 +90,30 @@ set_tests_properties(CMakeListsConsistencyTest PROPERTIES
 # Pairing of a release's assets with its SHA256SUMS.txt. Built from the updater
 # sources rather than linked against the Mudlet library, because the library only
 # contains them when configured with USE_UPDATER.
-add_executable(UpdaterChecksumTest
-    UpdaterChecksumTest.cpp
+add_executable(ReleaseChecksumPairingTest
+    ReleaseChecksumPairingTest.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/Feed.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/Release.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/SemVer.cpp
 )
-target_link_libraries(UpdaterChecksumTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
-add_test(NAME UpdaterChecksumTest COMMAND $<TARGET_FILE:UpdaterChecksumTest>)
-set_tests_properties(UpdaterChecksumTest PROPERTIES
+target_link_libraries(ReleaseChecksumPairingTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
+add_test(NAME ReleaseChecksumPairingTest COMMAND $<TARGET_FILE:ReleaseChecksumPairingTest>)
+set_tests_properties(ReleaseChecksumPairingTest PROPERTIES
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
 )
 
 # Which releases the updater offers as an update. Built from the updater sources
 # rather than linked against the Mudlet library, because the library only
 # contains them when configured with USE_UPDATER.
-add_executable(UpdaterPlatformAssetTest
-    UpdaterPlatformAssetTest.cpp
+add_executable(ReleasePlatformAssetTest
+    ReleasePlatformAssetTest.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/Feed.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/Release.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/SemVer.cpp
 )
-target_link_libraries(UpdaterPlatformAssetTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
-add_test(NAME UpdaterPlatformAssetTest COMMAND $<TARGET_FILE:UpdaterPlatformAssetTest>)
-set_tests_properties(UpdaterPlatformAssetTest PROPERTIES
+target_link_libraries(ReleasePlatformAssetTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
+add_test(NAME ReleasePlatformAssetTest COMMAND $<TARGET_FILE:ReleasePlatformAssetTest>)
+set_tests_properties(ReleasePlatformAssetTest PROPERTIES
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
 )
 
@@ -143,3 +143,66 @@ if(NOT WIN32)
 endif()
 
 add_subdirectory(functional_tests)
+
+# CI runners are elevated, so nothing there catches a test executable Windows
+# refuses to launch for looking like an installer (#9748) - hence this gate,
+# whose message spells the heuristic out.
+function(mudlet_reject_uac_installer_name name)
+    string(TOLOWER "${name}" lowercaseName)
+    if(lowercaseName MATCHES "install|setup|update|patch")
+        message(FATAL_ERROR
+            "'${name}' cannot be used as a test name: Windows takes an unsigned executable whose name "
+            "contains '${CMAKE_MATCH_0}' for an installer and refuses to launch it without elevation "
+            "(#9748), so ctest reports BAD_COMMAND for it in an ordinary developer shell. Rename the "
+            "source file and its target to describe what the test asserts, watching for install, setup, "
+            "update and patch as substrings - Dispatch carries one.")
+    endif()
+endfunction()
+
+function(mudlet_reject_uac_installer_target_names directory)
+    get_property(targets DIRECTORY "${directory}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(target ${targets})
+        get_target_property(targetType ${target} TYPE)
+        if(NOT targetType STREQUAL "EXECUTABLE")
+            continue()
+        endif()
+        set_property(GLOBAL APPEND PROPERTY mudletUacCheckedExecutables "${target}")
+        get_target_property(executableName ${target} OUTPUT_NAME)
+        if(NOT executableName)
+            set(executableName ${target})
+        endif()
+        mudlet_reject_uac_installer_name("${executableName}")
+    endforeach()
+
+    get_property(subdirectories DIRECTORY "${directory}" PROPERTY SUBDIRECTORIES)
+    foreach(subdirectory ${subdirectories})
+        mudlet_reject_uac_installer_target_names("${subdirectory}")
+    endforeach()
+endfunction()
+
+# Both passes are needed. Targets carry the name that actually reaches disk,
+# OUTPUT_NAME included, but only for the tests this configuration builds:
+# NewReleaseDialogTeardownTest, for one, is registered only under USE_UPDATER.
+# Source names are what the registration loops derive executable names from,
+# and are present whatever the configuration.
+function(mudlet_check_test_executable_names directory)
+    mudlet_reject_uac_installer_target_names("${directory}")
+
+    get_property(checkedExecutables GLOBAL PROPERTY mudletUacCheckedExecutables)
+    if(NOT checkedExecutables)
+        message(FATAL_ERROR "The test executable name check found no executables under ${directory}, so it is checking nothing.")
+    endif()
+
+    file(GLOB_RECURSE testSources "${directory}/*.cpp")
+    if(NOT testSources)
+        message(FATAL_ERROR "The test executable name check found no sources under ${directory}, so it is checking nothing.")
+    endif()
+    foreach(testSource ${testSources})
+        get_filename_component(sourceName "${testSource}" NAME_WE)
+        mudlet_reject_uac_installer_name("${sourceName}")
+    endforeach()
+endfunction()
+
+# Deferred rather than called outright, so that targets registered below this
+# line, and in subdirectories added below it, are checked as well
+cmake_language(DEFER CALL mudlet_check_test_executable_names "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/test/README.md
+++ b/test/README.md
@@ -79,7 +79,7 @@ QTEST_MAIN(MyComponentTest)
 
 ### Adding a New Test
 
-1. **Create Test File**: Create `YourTestName.cpp` in the `test/` directory
+1. **Create Test File**: Create `YourTestName.cpp` in the `test/` directory. Keep the words `install`, `uninstall`, `setup`, `update` and `patch` out of the name: Windows takes an unsigned executable named that way for an installer and will not start it from an ordinary, non-elevated Windows shell. CMake rejects such a name at configure time.
 
 2. **Implement Test Class**: Follow the structure above, inheriting from `QObject` and using `Q_OBJECT` macro
 

--- a/test/ReleaseChecksumPairingTest.cpp
+++ b/test/ReleaseChecksumPairingTest.cpp
@@ -95,7 +95,7 @@ QJsonObject releaseJson()
 }
 } // namespace
 
-class UpdaterChecksumTest : public QObject
+class ReleaseChecksumPairingTest : public QObject
 {
     Q_OBJECT
 
@@ -115,7 +115,7 @@ private slots:
 
 // The updater picks the first asset matching its platform, so this is the file
 // whose checksum has to be present
-void UpdaterChecksumTest::windowsDownloadIsThePlatformExe()
+void ReleaseChecksumPairingTest::windowsDownloadIsThePlatformExe()
 {
     const dblsqd::Release release(releaseJson(), QStringLiteral("win"), QStringLiteral("x86_64"));
 
@@ -124,21 +124,21 @@ void UpdaterChecksumTest::windowsDownloadIsThePlatformExe()
 }
 
 // The regression: this is why Windows auto-update failed
-void UpdaterChecksumTest::publishedChecksumsDoNotCoverTheWindowsDownload()
+void ReleaseChecksumPairingTest::publishedChecksumsDoNotCoverTheWindowsDownload()
 {
     const dblsqd::Release release(releaseJson(), QStringLiteral("win"), QStringLiteral("x86_64"));
 
     QVERIFY(dblsqd::Feed::findChecksum(publishedChecksums(), release.getDownloadUrl().fileName()).isEmpty());
 }
 
-void UpdaterChecksumTest::mergedChecksumsCoverTheWindowsDownload()
+void ReleaseChecksumPairingTest::mergedChecksumsCoverTheWindowsDownload()
 {
     const dblsqd::Release release(releaseJson(), QStringLiteral("win"), QStringLiteral("x86_64"));
 
     QCOMPARE(dblsqd::Feed::findChecksum(mergedChecksums(), release.getDownloadUrl().fileName()), windowsHash);
 }
 
-void UpdaterChecksumTest::everyOtherPlatformWasAlreadyCovered()
+void ReleaseChecksumPairingTest::everyOtherPlatformWasAlreadyCovered()
 {
     const dblsqd::Release linuxRelease(releaseJson(), QStringLiteral("linux"), QStringLiteral("x86_64"));
     QCOMPARE(linuxRelease.getDownloadUrl().fileName(), linuxAsset);
@@ -155,7 +155,7 @@ void UpdaterChecksumTest::everyOtherPlatformWasAlreadyCovered()
 
 // sha256sum writes two spaces in text mode and " *" in binary mode; the Windows
 // build produces the latter
-void UpdaterChecksumTest::binaryAndTextModeLinesBothParse()
+void ReleaseChecksumPairingTest::binaryAndTextModeLinesBothParse()
 {
     QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1 *%2").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
     QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1  %2").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
@@ -166,7 +166,7 @@ void UpdaterChecksumTest::binaryAndTextModeLinesBothParse()
 
 // The rebuilt installer's entry must not be accepted for a different file, or the
 // updater would check the download against the wrong hash
-void UpdaterChecksumTest::anotherBuildsEntryDoesNotCoverThisDownload()
+void ReleaseChecksumPairingTest::anotherBuildsEntryDoesNotCoverThisDownload()
 {
     const QString rebuiltOnly = QStringLiteral("%1 *%2\n").arg(rebuiltWindowsHash, rebuiltWindowsAsset);
 
@@ -177,7 +177,7 @@ void UpdaterChecksumTest::anotherBuildsEntryDoesNotCoverThisDownload()
 // SHA256SUMS.txt accumulates entries across builds, so a name that merely contains
 // the download's name must not hand back its hash - the updater would then reject a
 // perfectly good download as corrupt
-void UpdaterChecksumTest::aLongerNameContainingThisOneDoesNotCoverIt()
+void ReleaseChecksumPairingTest::aLongerNameContainingThisOneDoesNotCoverIt()
 {
     const QString longerName = QStringLiteral("old-%1").arg(windowsAsset);
 
@@ -186,12 +186,12 @@ void UpdaterChecksumTest::aLongerNameContainingThisOneDoesNotCoverIt()
     QVERIFY(dblsqd::Feed::findChecksum(QStringLiteral("%1  %2.tar\n").arg(rebuiltWindowsHash, linuxAsset), linuxAsset).isEmpty());
 }
 
-void UpdaterChecksumTest::aPathPrefixedEntryStillCoversTheDownload()
+void ReleaseChecksumPairingTest::aPathPrefixedEntryStillCoversTheDownload()
 {
     QCOMPARE(dblsqd::Feed::findChecksum(QStringLiteral("%1 *upload/%2\n").arg(windowsHash, windowsAsset), windowsAsset), windowsHash);
 }
 
-void UpdaterChecksumTest::malformedLinesAreIgnored()
+void ReleaseChecksumPairingTest::malformedLinesAreIgnored()
 {
     // too short, non-hex, and no separator respectively, then the real entry
     const QString data = QStringLiteral("abc123  %1\n"
@@ -203,7 +203,7 @@ void UpdaterChecksumTest::malformedLinesAreIgnored()
     QCOMPARE(dblsqd::Feed::findChecksum(data, windowsAsset), windowsHash);
 }
 
-void UpdaterChecksumTest::emptyInputsYieldNoChecksum()
+void ReleaseChecksumPairingTest::emptyInputsYieldNoChecksum()
 {
     QVERIFY(dblsqd::Feed::findChecksum(QString(), windowsAsset).isEmpty());
     QVERIFY(dblsqd::Feed::findChecksum(mergedChecksums(), QString()).isEmpty());
@@ -211,7 +211,7 @@ void UpdaterChecksumTest::emptyInputsYieldNoChecksum()
 
 // A release that forgot one platform and a payload that was never a checksum file
 // both yield no hash, but they need different messages
-void UpdaterChecksumTest::entriesParsedTellsAnUnreadableFileFromAMissingEntry()
+void ReleaseChecksumPairingTest::entriesParsedTellsAnUnreadableFileFromAMissingEntry()
 {
     int entriesParsed = -1;
     QVERIFY(dblsqd::Feed::findChecksum(publishedChecksums(), windowsAsset, &entriesParsed).isEmpty());
@@ -226,5 +226,5 @@ void UpdaterChecksumTest::entriesParsedTellsAnUnreadableFileFromAMissingEntry()
     QCOMPARE(entriesParsed, 5);
 }
 
-#include "UpdaterChecksumTest.moc"
-QTEST_MAIN(UpdaterChecksumTest)
+#include "ReleaseChecksumPairingTest.moc"
+QTEST_MAIN(ReleaseChecksumPairingTest)

--- a/test/ReleasePlatformAssetTest.cpp
+++ b/test/ReleasePlatformAssetTest.cpp
@@ -110,7 +110,7 @@ dblsqd::Release installedRelease()
 }
 } // namespace
 
-class UpdaterPlatformAssetTest : public QObject
+class ReleasePlatformAssetTest : public QObject
 {
     Q_OBJECT
 
@@ -128,7 +128,7 @@ private slots:
 };
 
 // The regression: this is the update that produced a red console error twice a day
-void UpdaterPlatformAssetTest::linuxIsNotOfferedTheReleaseWithoutALinuxAsset()
+void ReleasePlatformAssetTest::linuxIsNotOfferedTheReleaseWithoutALinuxAsset()
 {
     const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("linux"), QStringLiteral("x86_64")), installedRelease());
 
@@ -137,7 +137,7 @@ void UpdaterPlatformAssetTest::linuxIsNotOfferedTheReleaseWithoutALinuxAsset()
     QVERIFY(updates.first().getDownloadUrl().fileName().endsWith(linuxSuffix));
 }
 
-void UpdaterPlatformAssetTest::windowsIsStillOfferedIt()
+void ReleasePlatformAssetTest::windowsIsStillOfferedIt()
 {
     const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("win"), QStringLiteral("x86_64")), installedRelease());
 
@@ -146,7 +146,7 @@ void UpdaterPlatformAssetTest::windowsIsStillOfferedIt()
     QCOMPARE(updates.last().getVersion(), completeVersion);
 }
 
-void UpdaterPlatformAssetTest::intelMacIsNotOfferedTheReleaseWithoutADmg()
+void ReleasePlatformAssetTest::intelMacIsNotOfferedTheReleaseWithoutADmg()
 {
     const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("mac"), QStringLiteral("x86_64")), installedRelease());
 
@@ -155,7 +155,7 @@ void UpdaterPlatformAssetTest::intelMacIsNotOfferedTheReleaseWithoutADmg()
     QVERIFY(updates.first().getDownloadUrl().fileName().endsWith(intelMacSuffix));
 }
 
-void UpdaterPlatformAssetTest::appleSiliconIsNotOfferedTheReleaseWithoutADmg()
+void ReleasePlatformAssetTest::appleSiliconIsNotOfferedTheReleaseWithoutADmg()
 {
     const auto updates = dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("mac"), QStringLiteral("arm64")), installedRelease());
 
@@ -165,7 +165,7 @@ void UpdaterPlatformAssetTest::appleSiliconIsNotOfferedTheReleaseWithoutADmg()
 }
 
 // A release whose binaries are still uploading looks the same as one that lost a build job
-void UpdaterPlatformAssetTest::aReleaseWithOnlyItsChecksumsFileIsNotOffered()
+void ReleasePlatformAssetTest::aReleaseWithOnlyItsChecksumsFileIsNotOffered()
 {
     const QList<dblsqd::Release> releases{dblsqd::Release(releaseJson(windowsOnlyTag, QStringLiteral("2026-08-07T02:14:11Z"), {}), QStringLiteral("linux"), QStringLiteral("x86_64"))};
 
@@ -174,14 +174,14 @@ void UpdaterPlatformAssetTest::aReleaseWithOnlyItsChecksumsFileIsNotOffered()
 
 // The download refuses to install what it cannot verify, so a release whose
 // SHA256SUMS.txt is missing is as uninstallable as one missing its binary
-void UpdaterPlatformAssetTest::aReleaseWithoutChecksumsIsNotOffered()
+void ReleasePlatformAssetTest::aReleaseWithoutChecksumsIsNotOffered()
 {
     const QList<dblsqd::Release> releases{dblsqd::Release(unverifiableRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"))};
 
     QVERIFY(dblsqd::Feed::selectUpdates(releases, installedRelease()).isEmpty());
 }
 
-void UpdaterPlatformAssetTest::theVerifiableReleaseIsOfferedInsteadOfTheNewerUnverifiableOne()
+void ReleasePlatformAssetTest::theVerifiableReleaseIsOfferedInsteadOfTheNewerUnverifiableOne()
 {
     const QList<dblsqd::Release> releases{dblsqd::Release(unverifiableRelease(), QStringLiteral("linux"), QStringLiteral("x86_64")),
                                           dblsqd::Release(completeRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"))};
@@ -195,13 +195,13 @@ void UpdaterPlatformAssetTest::theVerifiableReleaseIsOfferedInsteadOfTheNewerUnv
 // Mudlet publishes no binaries for the platforms it is packaged for by others,
 // so those builds are told there is no update rather than shown a failure they
 // can do nothing about, twice a day, forever
-void UpdaterPlatformAssetTest::aPlatformWithNoAssetsAtAllIsOfferedNothing()
+void ReleasePlatformAssetTest::aPlatformWithNoAssetsAtAllIsOfferedNothing()
 {
     QVERIFY(dblsqd::Feed::selectUpdates(feedReleases(QStringLiteral("freebsd"), QStringLiteral("x86_64")), installedRelease()).isEmpty());
 }
 
 // What a Linux user on the previous PTB sees: no update, rather than an error
-void UpdaterPlatformAssetTest::nothingIsOfferedOnceTheOnlyNewerReleaseIsIncomplete()
+void ReleasePlatformAssetTest::nothingIsOfferedOnceTheOnlyNewerReleaseIsIncomplete()
 {
     const QList<dblsqd::Release> releases{dblsqd::Release(windowsOnlyRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"))};
     const dblsqd::Release installed(completeVersion, QDateTime::fromString(QStringLiteral("2026-08-06T02:11:47Z"), Qt::ISODate));
@@ -212,7 +212,7 @@ void UpdaterPlatformAssetTest::nothingIsOfferedOnceTheOnlyNewerReleaseIsIncomple
 // A release passed over here still has to carry its version and notes: the
 // changelog dialogs render the unfiltered release list
 // (UpdateDialog::generateChangelogDocument)
-void UpdaterPlatformAssetTest::thePassedOverReleaseStaysReadableForTheChangelog()
+void ReleasePlatformAssetTest::thePassedOverReleaseStaysReadableForTheChangelog()
 {
     const dblsqd::Release release(windowsOnlyRelease(), QStringLiteral("linux"), QStringLiteral("x86_64"));
 
@@ -221,5 +221,5 @@ void UpdaterPlatformAssetTest::thePassedOverReleaseStaysReadableForTheChangelog(
     QCOMPARE(release.getChangelog(), QStringLiteral("- fixed a thing\n"));
 }
 
-#include "UpdaterPlatformAssetTest.moc"
-QTEST_MAIN(UpdaterPlatformAssetTest)
+#include "ReleasePlatformAssetTest.moc"
+QTEST_MAIN(ReleasePlatformAssetTest)

--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -45,13 +45,13 @@ void initializeQRCResources();
 // free the very TAction that TAction::execute() was running on, which then read
 // this->mpHost after the Lua call returned (heap-use-after-free). ActionUnit now
 // defers that delete until execute() has unwound.
-class ActionSelfUninstallTest : public QObject
+class ActionSelfRemovalTest : public QObject
 {
     Q_OBJECT
 
 private:
     TelnetServerStub* mpServer = nullptr;
-    const QString mpHostname = "Test-ActionSelfUninstall";
+    const QString mpHostname = "Test-ActionSelfRemoval";
     const QString mpPort = "4009";
     const QString mpLocalhost = "localhost";
 
@@ -259,5 +259,5 @@ void initializeQRCResources()
     qInitResources_qm();
 }
 
-#include "ActionSelfUninstallTest.moc"
-QTEST_MAIN(ActionSelfUninstallTest)
+#include "ActionSelfRemovalTest.moc"
+QTEST_MAIN(ActionSelfRemovalTest)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -36,9 +36,9 @@ set(FUNCTIONAL_TEST_SOURCES
     LogRestartDuplicateLineTest.cpp
     ProfileRoundTripTest.cpp
     ProfileLoadTempFileTest.cpp
-    PackageSelfUninstallTest.cpp
+    PackageSelfRemovalTest.cpp
     UnitProcessingDepthTest.cpp
-    PackageUninstallSaveTeardownTest.cpp
+    PackageRemovalSaveTeardownTest.cpp
     ModuleSaveTeardownTest.cpp
     MapRoundTripTest.cpp
     MapProgressDialogSeamTest.cpp
@@ -47,7 +47,7 @@ set(FUNCTIONAL_TEST_SOURCES
     UndoServerWrapTest.cpp
     NarrowWindowWrapTest.cpp
     HostWidgetDecouplingTest.cpp
-    ActionSelfUninstallTest.cpp
+    ActionSelfRemovalTest.cpp
     ProfileFolderNameTest.cpp
     ProfileDeletionSafetyTest.cpp
     DialogTeardownTest.cpp
@@ -65,7 +65,7 @@ set(FUNCTIONAL_TEST_SOURCES
 # The updater sources are only built with USE_UPDATER, and on macOS the
 # Updater wraps Sparkle instead of creating an UpdateDialog
 if(USE_UPDATER AND NOT APPLE)
-    list(APPEND FUNCTIONAL_TEST_SOURCES UpdaterTeardownTest.cpp)
+    list(APPEND FUNCTIONAL_TEST_SOURCES NewReleaseDialogTeardownTest.cpp)
 endif()
 
 set(FUNCTIONAL_TEST_UTILS
@@ -103,11 +103,11 @@ endif()
 # These still leak and stay unchecked until their defects are fixed:
 # - dlgTriggerEditorUndoRedoTest: never destroys its dlgTriggerEditor, leaving
 #   ~3.4MB of tree-item QIcon/QPixmap behind
-# - UpdaterTeardownTest: Qt's one-time system CA-certificate store load on
-#   first TLS use, cached for the process lifetime
+# - NewReleaseDialogTeardownTest: Qt's one-time system CA-certificate store load
+#   on first TLS use, cached for the process lifetime
 set(leakCheckExcludedTests
     dlgTriggerEditorUndoRedoTest
-    UpdaterTeardownTest
+    NewReleaseDialogTeardownTest
 )
 
 # mudlet_lsan_hooks has to be linked explicitly, see src/CMakeLists.txt

--- a/test/functional_tests/NewReleaseDialogTeardownTest.cpp
+++ b/test/functional_tests/NewReleaseDialogTeardownTest.cpp
@@ -54,7 +54,7 @@
  * QTEST_APPLESS_MAIN is used because the test itself must own the
  * QApplication lifetime to walk it through quit and destruction.
  */
-class UpdaterTeardownTest : public QObject
+class NewReleaseDialogTeardownTest : public QObject
 {
     Q_OBJECT
 
@@ -62,7 +62,7 @@ private slots:
     void updateDialogDestroyedBeforeApplicationTeardown();
 };
 
-void UpdaterTeardownTest::updateDialogDestroyedBeforeApplicationTeardown()
+void NewReleaseDialogTeardownTest::updateDialogDestroyedBeforeApplicationTeardown()
 {
     // Keeps checkUpdatesOnStart() away from real user data - on Windows it
     // deletes stale installer files from the genuine GenericDataLocation
@@ -73,7 +73,7 @@ void UpdaterTeardownTest::updateDialogDestroyedBeforeApplicationTeardown()
     QSettings settings(settingsDir.filePath(qsl("updater-test.ini")), QSettings::IniFormat);
 
     int argc = 1;
-    char appName[] = "UpdaterTeardownTest";
+    char appName[] = "NewReleaseDialogTeardownTest";
     char* argv[] = {appName, nullptr};
     const auto app = std::make_unique<QApplication>(argc, argv);
 
@@ -118,5 +118,5 @@ void UpdaterTeardownTest::updateDialogDestroyedBeforeApplicationTeardown()
     QVERIFY2(dialog.isNull(), "UpdateDialog must be destroyed when the application quits: deleting it any later (from ~Updater, inside the application's destructor) corrupts the heap - see #9122");
 }
 
-QTEST_APPLESS_MAIN(UpdaterTeardownTest)
-#include "UpdaterTeardownTest.moc"
+QTEST_APPLESS_MAIN(NewReleaseDialogTeardownTest)
+#include "NewReleaseDialogTeardownTest.moc"

--- a/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
+++ b/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
@@ -40,7 +40,7 @@
  * contract the fix rests on, and a sanitizer run over the uninstall/close/
  * destroy/pump sequence itself.
  *
- * Run with: ctest -R PackageUninstallSaveTeardownTest -V
+ * Run with: ctest -R PackageRemovalSaveTeardownTest -V
  */
 
 #include <QtTest/QtTest>
@@ -64,16 +64,16 @@ extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForPackageUninstallSaveTeardownTest();
+void initializeQRCResourcesForPackageRemovalSaveTeardownTest();
 
-class PackageUninstallSaveTeardownTest : public QObject
+class PackageRemovalSaveTeardownTest : public QObject
 {
     Q_OBJECT
 
 private:
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
-    const QString mProfileName = qsl("PackageUninstallSaveTeardown-Test");
+    const QString mProfileName = qsl("PackageRemovalSaveTeardown-Test");
     const QString mLocalhost = qsl("localhost");
     QString mPort; // the stub's actual ephemeral port, assigned in initTestCase()
     // The refusal test below installs an archive that names itself ".." - that
@@ -177,7 +177,7 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForPackageUninstallSaveTeardownTest();
+        initializeQRCResourcesForPackageRemovalSaveTeardownTest();
 
         // Keep the test hermetic: point the config dir resolution at a temporary
         // directory instead of the user's real profiles - one of the tests below
@@ -384,7 +384,7 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForPackageUninstallSaveTeardownTest()
+void initializeQRCResourcesForPackageRemovalSaveTeardownTest()
 {
 #ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
     qInitResources_additional_splash_screens();
@@ -399,5 +399,5 @@ void initializeQRCResourcesForPackageUninstallSaveTeardownTest()
     qInitResources_qm();
 }
 
-#include "PackageUninstallSaveTeardownTest.moc"
-QTEST_MAIN(PackageUninstallSaveTeardownTest)
+#include "PackageRemovalSaveTeardownTest.moc"
+QTEST_MAIN(PackageRemovalSaveTeardownTest)

--- a/test/functional_tests/PackageSelfRemovalTest.cpp
+++ b/test/functional_tests/PackageSelfRemovalTest.cpp
@@ -42,7 +42,7 @@
  * is outstanding is still registered, and must not be written back into the
  * profile by a save taken before the unit goes idle.
  *
- * Run with: ctest -R PackageSelfUninstallTest -V
+ * Run with: ctest -R PackageSelfRemovalTest -V
  */
 
 #include <QtTest/QtTest>
@@ -85,7 +85,7 @@ extern void qInitResources_qm();
 extern void qInitResources_additional_splash_screens();
 extern void qInitResources_mudlet_fonts_common();
 extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForPackageSelfUninstallTest();
+void initializeQRCResourcesForPackageSelfRemovalTest();
 
 // TriggerUnit only holds its depth inside processDataStream(), so a save at
 // depth has to come from a trigger's own script. Stands in for the Lua
@@ -119,12 +119,12 @@ static int exportProfileMidPass(lua_State* L)
     return 0;
 }
 
-class PackageSelfUninstallTest : public QObject
+class PackageSelfRemovalTest : public QObject
 {
     Q_OBJECT
 
 private:
-    const QString mProfileName = qsl("PackageSelfUninstall-Test");
+    const QString mProfileName = qsl("PackageSelfRemoval-Test");
     QTemporaryDir mConfigDir;
     QByteArray mSavedXdg;
     Host* mpHost = nullptr;
@@ -132,7 +132,7 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForPackageSelfUninstallTest();
+        initializeQRCResourcesForPackageSelfRemovalTest();
 
         // Keep the test hermetic: point the config dir resolution at a
         // temporary directory instead of the user's real profiles.
@@ -655,7 +655,7 @@ private:
     }
 };
 
-void initializeQRCResourcesForPackageSelfUninstallTest()
+void initializeQRCResourcesForPackageSelfRemovalTest()
 {
 #ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
     qInitResources_additional_splash_screens();
@@ -670,5 +670,5 @@ void initializeQRCResourcesForPackageSelfUninstallTest()
     qInitResources_qm();
 }
 
-#include "PackageSelfUninstallTest.moc"
-QTEST_MAIN(PackageSelfUninstallTest)
+#include "PackageSelfRemovalTest.moc"
+QTEST_MAIN(PackageSelfRemovalTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Renames the six test executables whose filenames trip Windows' UAC installer detection: `UpdaterChecksumTest` to `ReleaseChecksumPairingTest`, `UpdaterPlatformAssetTest` to `ReleasePlatformAssetTest`, `UpdaterTeardownTest` to `NewReleaseDialogTeardownTest`, `PackageSelfUninstallTest` to `PackageSelfRemovalTest`, `PackageUninstallSaveTeardownTest` to `PackageRemovalSaveTeardownTest`, `ActionSelfUninstallTest` to `ActionSelfRemovalTest`. Assertions are untouched.
- Adds a configure-time gate in `test/CMakeLists.txt` that fails with an actionable message if any test executable name contains install, setup, update or patch. It checks both the targets a configuration builds and the test source filenames, so conditionally registered tests cannot slip past it.
- Documents the naming rule in `test/README.md`.

#### Motivation for adding to Mudlet
Windows treats an unsigned executable named that way as an installer and refuses to start it, so those six tests reported `BAD_COMMAND` for anyone running the suite from an ordinary Windows shell - and because CI runners are elevated, nothing caught it as more tests were added.

#### Other info (issues closed, discussion etc)
Fixes #9748

The gate was verified to fire on a target named after the guard statement, on one in a subdirectory, on `EventDispatcherTest` (the message names the offending substring, since "dispatch" contains "patch"), on a test registered only under `USE_UPDATER` when configuring with the updater off, and to fail loudly if the walk ever stops finding executables.

**Test case:** `cmake --build build && ctest --test-dir build` - 92/92 pass; adding a test named e.g. `FooUpdateTest` fails the configure with an explanation.

Assisted-by: Claude:claude-opus-5