### PR TITLE
fix: deleting a big Geyser layout no longer freezes Mudlet

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -382,6 +382,17 @@ function Geyser.Container:new(cons, container)
   return me
 end
 
+-- Internal function: deletes a container's children. A named function rather
+-- than an inline loop so that delete() can pcall it without allocating a closure
+-- @param container the container whose children are to be deleted
+local function deleteChildren(container)
+  for _, child in pairs(container.windowList) do
+    if child and child.delete then
+      child:delete()
+    end
+  end
+end
+
 --- Deletes this window and removes it from its container's tracking.
 -- Recursively deletes all child windows first.
 -- Properly unregisters from all tracking structures including:
@@ -389,13 +400,21 @@ end
 -- - Geyser.parentWindows (for UserWindows and ScrollBoxes)
 -- - Geyser.windowList (for top-level Geyser objects)
 function Geyser.Container:delete()
-  -- Delete all children first
-  for _, child in pairs(self.windowList) do
-    if child and child.delete then
-      child:delete()
-    end
+  -- An HBox/VBox lays itself out whenever a child unlinks, so deleting children
+  -- one at a time costs a layout pass per child, every one of them laying out
+  -- windows the same loop goes on to destroy. Only self needs the flag: each
+  -- container in the cascade defers itself when its own delete runs. rawget, so
+  -- a container inheriting the flag from Geyser goes back to inheriting it.
+  local wasDeferring = rawget(self, "defer_updates")
+  self.defer_updates = true
+  local ok, err = pcall(deleteChildren, self)
+  -- restored before the error is re-raised: a container whose cascade failed is
+  -- still in the tree, and one left deferring would never lay itself out again
+  self.defer_updates = wasDeferring
+  if not ok then
+    error(err, 0)
   end
-  
+
   -- Clear references
   self.windowList = {}
   self.windows = {}

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -408,10 +408,12 @@ function Geyser.Container:delete()
   local wasDeferring = rawget(self, "defer_updates")
   self.defer_updates = true
   local ok, err = pcall(deleteChildren, self)
-  -- restored before the error is re-raised: a container whose cascade failed is
-  -- still in the tree, and one left deferring would never lay itself out again
   self.defer_updates = wasDeferring
   if not ok then
+    -- a container whose cascade failed stays in the tree, holding whatever
+    -- children the cascade did not reach - and they are still laid out for the
+    -- child count it started with, so it owes them the pass that was deferred
+    self:reposition()
     error(err, 0)
   end
 

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -10,7 +10,8 @@ Geyser.HBox = Geyser.Container:new({
 
 -- Internal function: lays the box out, or remembers that it still has to be laid
 -- out when updates are being deferred, so that the reposition end_update() runs
--- picks the work up again
+-- picks the work up again. A box being deleted defers as well and never gets
+-- that reposition, which is deliberate - it has no layout left worth doing.
 -- @param box the HBox to organize
 local function organizeOrDefer(box)
   if box.defer_updates then

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -10,7 +10,8 @@ Geyser.VBox = Geyser.Container:new({
 
 -- Internal function: lays the box out, or remembers that it still has to be laid
 -- out when updates are being deferred, so that the reposition end_update() runs
--- picks the work up again
+-- picks the work up again. A box being deleted defers as well and never gets
+-- that reposition, which is deliberate - it has no layout left worth doing.
 -- @param box the VBox to organize
 local function organizeOrDefer(box)
   if box.defer_updates then

--- a/src/mudlet-lua/tests/GeyserContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserContainer_spec.lua
@@ -378,6 +378,25 @@ describe("Tests functionality of Geyser.Container", function()
       assert.is_nil(table.index_of(Geyser.windows, "gcsDeleteRoot"))
     end)
 
+    -- the deferral is per container rather than per cascade, so a box nested
+    -- inside the container being deleted has to go quiet on its own account
+    it("holds the layout of a box it is deleting back", function()
+      local container = track(Geyser.Container:new({name = "gcsDeleteCost", x = 0, y = 0, width = 400, height = 100}))
+      local box = track(Geyser.HBox:new({name = "gcsDeleteCostBox", width = 400, height = 100}, container))
+      for i = 1, 5 do
+        track(Geyser.Label:new({name = "gcsDeleteCostChild" .. i}, box))
+      end
+      local organizes = 0
+      local organize = box.organize
+      box.organize = function(...)
+        organizes = organizes + 1
+        return organize(...)
+      end
+      container:delete()
+      assert.are.equal(0, organizes)
+      assert.is_nil(getWindowGeometry("gcsDeleteCostChild1"))
+    end)
+
     it("unregisters a child from its parent", function()
       local container = track(Geyser.Container:new({name = "gcsDeleteParent", x = 0, y = 0, width = 100, height = 100}))
       local child = track(Geyser.Label:new({name = "gcsDeleteMe"}, container))
@@ -649,6 +668,23 @@ describe("Tests functionality of Geyser.Container", function()
       Geyser:end_update()
       assert.are.same({x = 0, y = 0, width = 200, height = 100}, geometry("gcsRootDeferredA"))
       assert.are.same({x = 0, y = 100, width = 200, height = 100}, geometry("gcsRootDeferredB"))
+    end)
+
+    -- delete() defers the box it is emptying, and that borrowed deferral must
+    -- not end a deferral the caller asked for: the box has to stay held back
+    -- until end_update, and then still catch up on the layout it skipped
+    it("leaves a root deferral running when a box loses a child to delete", function()
+      -- leaving the flag set would stop every later spec repositioning
+      finally(function() Geyser.defer_updates = false end)
+      local box = track(Geyser.HBox:new({name = "gcsRootDelete", x = 0, y = 0, width = 400, height = 100}))
+      track(Geyser.Label:new({name = "gcsRootDeleteKeep"}, box))
+      local doomed = track(Geyser.Container:new({name = "gcsRootDeleteGone"}, box))
+      Geyser:begin_update()
+      doomed:delete()
+      assert.is_true(Geyser.defer_updates)
+      assert.are.equal(200, geometry("gcsRootDeleteKeep").width)
+      Geyser:end_update()
+      assert.are.equal(400, geometry("gcsRootDeleteKeep").width)
     end)
 
     it("repositions every window when Geyser:reposition is called directly", function()

--- a/src/mudlet-lua/tests/GeyserHBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserHBox_spec.lua
@@ -177,6 +177,58 @@ describe("Tests functionality of Geyser.HBox", function()
       assert.is_nil(getWindowGeometry("ghbShrinkB"))
       assert.is_nil(Geyser.windowList.ghbShrink)
     end)
+
+    -- one layout pass per child is what makes tearing a box down quadratic. The
+    -- fixed child is here because contains_fixed short circuits reposition()'s
+    -- check of the deferral, which could let the cost back in for boxes like it
+    it("does not lay the row out again for each child it deletes", function()
+      track(Geyser.Label:new({name = "ghbShrinkCostFixed", width = 100, h_policy = Geyser.Fixed}, box))
+      for i = 1, 3 do
+        track(Geyser.Label:new({name = "ghbShrinkCost" .. i}, box))
+      end
+      local organizes = 0
+      local organize = box.organize
+      box.organize = function(...)
+        organizes = organizes + 1
+        return organize(...)
+      end
+      box:delete()
+      assert.are.equal(0, organizes)
+      assert.is_nil(getWindowGeometry("ghbShrinkA"))
+      assert.is_nil(getWindowGeometry("ghbShrinkCost1"))
+    end)
+
+    -- the deferral belongs to the container being deleted, so a box losing a
+    -- whole subtree - one that defers itself on the way out - still re-splits
+    it("re-splits the row when a nested box of its own is deleted", function()
+      local nested = track(Geyser.VBox:new({name = "ghbShrinkNested"}, box))
+      track(Geyser.Label:new({name = "ghbShrinkNestedA"}, nested))
+      track(Geyser.Label:new({name = "ghbShrinkNestedB"}, nested))
+      nested:delete()
+      assert.are.same({"ghbShrinkA", "ghbShrinkB"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 300, height = 50}, geometry("ghbShrinkA"))
+      assert.are.same({x = 300, y = 0, width = 300, height = 50}, geometry("ghbShrinkB"))
+    end)
+
+    -- a cascade that raises leaves the box in the tree, so a box left holding
+    -- the cascade's deferral would silently never lay itself out again
+    it("stops deferring the row when a child's delete raises", function()
+      local doomed = box.windowList.ghbShrinkB
+      local ownDelete = rawget(doomed, "delete")
+      -- put the real delete back before after_each tries to clean the box up
+      finally(function() doomed.delete = ownDelete end)
+      doomed.delete = function() error("delete blew up") end
+      assert.has_error(function() box:delete() end)
+      assert.is_nil(rawget(box, "defer_updates"))
+      local organizes = 0
+      local organize = box.organize
+      box.organize = function(...)
+        organizes = organizes + 1
+        return organize(...)
+      end
+      track(Geyser.Label:new({name = "ghbShrinkAfterRaise"}, box))
+      assert.is_true(organizes > 0)
+    end)
   end)
 
   describe("Geyser.HBox:reposition", function()

--- a/src/mudlet-lua/tests/GeyserHBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserHBox_spec.lua
@@ -229,6 +229,28 @@ describe("Tests functionality of Geyser.HBox", function()
       track(Geyser.Label:new({name = "ghbShrinkAfterRaise"}, box))
       assert.is_true(organizes > 0)
     end)
+
+    -- the children the cascade did get through are gone, so the survivors are
+    -- left holding the widths worked out for the child count it started with
+    it("re-splits the row a half finished delete left behind", function()
+      local ownRemove = rawget(box, "remove")
+      -- restored so that after_each can still tear the box down
+      finally(function() box.remove = ownRemove end)
+      -- raising on the second unlink is what puts one child through and strands
+      -- the other, whichever order the cascade happens to walk them in
+      local removals = 0
+      local remove = box.remove
+      box.remove = function(...)
+        removals = removals + 1
+        if removals == 2 then
+          error("remove blew up")
+        end
+        return remove(...)
+      end
+      assert.has_error(function() box:delete() end)
+      assert.are.equal(1, #box.windows)
+      assert.are.same({x = 0, y = 0, width = 600, height = 50}, geometry(box.windows[1]))
+    end)
   end)
 
   describe("Geyser.HBox:reposition", function()

--- a/src/mudlet-lua/tests/GeyserVBox_spec.lua
+++ b/src/mudlet-lua/tests/GeyserVBox_spec.lua
@@ -189,6 +189,38 @@ describe("Tests functionality of Geyser.VBox", function()
       assert.is_nil(getWindowGeometry("gvbShrinkB"))
       assert.is_nil(Geyser.windowList.gvbShrink)
     end)
+
+    -- one layout pass per child is what makes tearing a box down quadratic. The
+    -- fixed child is here because contains_fixed short circuits reposition()'s
+    -- check of the deferral, which could let the cost back in for boxes like it
+    it("does not stack the column again for each child it deletes", function()
+      track(Geyser.Label:new({name = "gvbShrinkCostFixed", height = 100, v_policy = Geyser.Fixed}, box))
+      for i = 1, 3 do
+        track(Geyser.Label:new({name = "gvbShrinkCost" .. i}, box))
+      end
+      local organizes = 0
+      local organize = box.organize
+      box.organize = function(...)
+        organizes = organizes + 1
+        return organize(...)
+      end
+      box:delete()
+      assert.are.equal(0, organizes)
+      assert.is_nil(getWindowGeometry("gvbShrinkA"))
+      assert.is_nil(getWindowGeometry("gvbShrinkCost1"))
+    end)
+
+    -- the deferral belongs to the container being deleted, so a box losing a
+    -- whole subtree - one that defers itself on the way out - still re-stacks
+    it("re-stacks the column when a nested box of its own is deleted", function()
+      local nested = track(Geyser.HBox:new({name = "gvbShrinkNested"}, box))
+      track(Geyser.Label:new({name = "gvbShrinkNestedA"}, nested))
+      track(Geyser.Label:new({name = "gvbShrinkNestedB"}, nested))
+      nested:delete()
+      assert.are.same({"gvbShrinkA", "gvbShrinkB"}, box.windows)
+      assert.are.same({x = 0, y = 0, width = 50, height = 300}, geometry("gvbShrinkA"))
+      assert.are.same({x = 0, y = 300, width = 50, height = 300}, geometry("gvbShrinkB"))
+    end)
   end)
 
   describe("Geyser.VBox:reposition", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `Geyser.Container:delete()` now defers the layout of the container it is emptying for the length of its child loop, so tearing down an `HBox`/`VBox` no longer lays the box out once per child.
- The deferral is restored even if a child's delete raises, so a container that survives a failed cascade still lays itself out.
- Seven busted specs, counting layout passes rather than timing them.

#### Motivation for adding to Mudlet
`HBox:remove`/`VBox:remove` lay the box out on every removal (#9680, right on its own) and `Container:delete()` removes children one at a time, so a cascading delete re-laid-out the whole box once per child; Mudlet is single-threaded, so a UI package unloading or rebuilding a large layout froze the main thread for seconds. Every one of those passes was laying out windows the same loop went on to destroy.

Building a box is unaffected and unchanged: `HBox:add` has always organized per add, and the documented `begin_update`/`end_update` idiom already makes a bulk build linear.

#### Other info (issues closed, discussion etc)
Closes #9756.

One RelWithDebInfo build, Lua swapped between runs, `organize` = layout passes:

| case | before | after |
| --- | --- | --- |
| hbox100 | 0.2228 s, 100 passes | 0.0009 s, 0 |
| hbox200 | 0.9851 s, 200 | 0.0017 s, 0 |
| hbox400 | 4.1680 s, 400 | 0.0076 s, 0 |
| vbox200 | 0.9978 s, 200 | 0.0018 s, 0 |
| plain Container 200 (control) | 0.0035 s, 0 | 0.0017 s, 0 |

Busted suite: 2507 successes / 0 failures / 0 errors / 41 pending.

**Test case:** run `local box = Geyser.HBox:new({name = "b", x = 0, y = 0, width = 600, height = 400}) for i = 1, 400 do Geyser.Label:new({name = "l" .. i}, box) end box:delete()` - the delete is instant instead of a multi-second freeze.

Assisted-by: Claude:claude-opus-5