### PR TITLE
fix: profile saves silently dropping saved variables that a second global references

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -759,11 +759,11 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
         lua_pushvalue(L, -2); //we do this because extracting the key with tostring changes it
         QString keyName;
         QString valueName;
-        auto var = new TVar();
+        bool keyIsReference = false;
         if (kType == LUA_TTABLE) {
             keyName = QString::number(luaL_ref(L, LUA_REGISTRYINDEX)); //this function pops the top item
             lrefs.append(keyName.toInt());
-            var->setReference(true);
+            keyIsReference = true;
         } else if (kType == LUA_TBOOLEAN) {
             //lua_tostring() returns NULL for booleans, name the key ourselves
             keyName = lua_toboolean(L, -1) ? qsl("true") : qsl("false");
@@ -774,17 +774,26 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
                 //we lost the reference
                 keyName = QString::number(luaL_ref(L, LUA_REGISTRYINDEX));
                 lrefs.append(keyName.toInt());
-                var->setReference(true);
+                keyIsReference = true;
             } else {
                 lua_pop(L, 1);
             }
         }
         if (keyName == "package" && depth == 1) { //don't load in the 'package' table
             lua_pop(L, 1);
-            tVar->removeChild(var);
-            delete var;
             continue;
         }
+        if (mSavedVarsOnly && depth == 1) {
+            if (!mSavedRootNames.contains(keyName)) {
+                lua_pop(L, 1);
+                continue;
+            }
+            // each saved global is walked in its own dedup scope, so two of them
+            // that reference the same table both get a complete subtree
+            varUnit->clearPointers();
+        }
+        auto var = new TVar();
+        var->setReference(keyIsReference);
         var->setName(keyName, kType);
         var->setValueType(vType);
         var->setParent(tVar);
@@ -794,7 +803,11 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
         var->pKey = pKey;
         const void* pValue = lua_topointer(L, -2);
         var->pValue = pValue;
-        if (varUnit->varExists(var) || keyName == qsl("_G")) {
+        // A table two names reach is walked only under the first, which suits
+        // Mudlet's own API - but a saved variable reached second would be left
+        // with no node to export from, so it is exempt (#9755). _G reaches
+        // itself, hence the name test.
+        if (keyName == qsl("_G") || (varUnit->varExists(var) && !varUnit->isSaved(var))) {
             lua_pop(L, 1);
             tVar->removeChild(var);
             delete var;
@@ -806,12 +819,21 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
 
         varUnit->addPointer(pValue);
         if (vType == LUA_TTABLE) {
-            if (depth <= 99 && lua_checkstack(L, 3)) { //depth is historical now
+            var->setValue("{}", LUA_TTABLE);
+            const bool tooDeep = depth > scmMaxTableDepth;
+            if (!tooDeep && lua_checkstack(L, 3)) {
                 //put the table on top
                 lua_pushnil(L);
-                var->setValue("{}", LUA_TTABLE);
                 iterateTable(L, -2, var, hide);
                 depth--;
+            } else {
+                const QString variableName = varUnit->shortVarName(var).join(qsl("."));
+                qWarning().noquote().nospace() << "LuaInterface::iterateTable() WARNING - not reading the contents of the table \"" << variableName
+                                               << "\": " << (tooDeep ? qsl("it is nested more than %1 tables deep").arg(scmMaxTableDepth) : qsl("the Lua stack could not be grown"))
+                                               << ". It is being treated as an empty table.";
+                if (mSavedVarsOnly) {
+                    mTruncatedSavedTables.append(variableName);
+                }
             }
         } else if (vType == LUA_TSTRING || vType == LUA_TNUMBER) {
             lua_pushvalue(L, -1);
@@ -843,19 +865,68 @@ void LuaInterface::getVars(bool hide)
     // onPanic() longjmp()s to the shared buf, so without a setjmp of our own
     // that jump lands in whichever frame set it last - usually one that has
     // already returned, taking the caller's scope down with it.
+    const int stackTop = lua_gettop(mL);
     if (setjmp(buf) != 0) {
+        // the panic jumped out of iterateTable() with its working values still
+        // on the stack of the profile's live interpreter
+        lua_settop(mL, stackTop);
         qWarning() << "LuaInterface::getVars() WARNING - Lua panicked while reading the variables in; the variable tree is incomplete.";
         return;
     }
     lua_pushnil(mL);
+    TVar* global = resetVariableTree();
+    iterateTable(mL, LUA_GLOBALSINDEX, global, hide);
+    // FIXME: possible to keep and report? qDebug()<<"took"<<t.elapsed()<<"to get variables in";
+}
+
+// The tree a profile save needs: the globals the profile saves, read fresh out
+// of Lua. Reading all of _G instead costs the size of _G on every save, and the
+// dedup in iterateTable() then only spares a saved table itself - table members
+// riding along with it under #9517 have no savedVars entry to be spared by, so
+// whichever unrelated global reached them first would keep them (#9755). Walking
+// each saved global in its own dedup scope is what avoids that.
+void LuaInterface::getSavedVars()
+{
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) != 0) {
+        lua_settop(mL, stackTop);
+        // getVars() does not clear this itself, so a later walk on this same
+        // interface would inherit the filter
+        mSavedVarsOnly = false;
+        qWarning() << "LuaInterface::getSavedVars() WARNING - Lua panicked while reading the saved variables in; the variable tree is incomplete.";
+        return;
+    }
+    mSavedRootNames.clear();
+    mTruncatedSavedTables.clear();
+    for (const QString& savedVarName : std::as_const(varUnit->savedVars)) {
+        // savedVars holds dotted paths, but a global's own name may contain a
+        // dot as well, so both readings count as a name to walk
+        mSavedRootNames.insert(savedVarName);
+        mSavedRootNames.insert(savedVarName.section(QChar('.'), 0, 0));
+    }
+
+    TVar* global = resetVariableTree();
+    if (mSavedRootNames.isEmpty()) {
+        return;
+    }
+
+    mSavedVarsOnly = true;
+    lua_pushnil(mL);
+    iterateTable(mL, LUA_GLOBALSINDEX, global, false);
+    mSavedVarsOnly = false;
+}
+
+// Throws away whatever tree there was, along with the Lua registry references it
+// held, and returns the _G node a fresh walk hangs off.
+TVar* LuaInterface::resetVariableTree()
+{
     depth = 0;
     auto global = new TVar();
-    global->setName("_G", LUA_TSTRING);
-    global->setValue("{}", LUA_TTABLE);
+    global->setName(qsl("_G"), LUA_TSTRING);
+    global->setValue(qsl("{}"), LUA_TTABLE);
     releaseVariableReferences();
     varUnit->clear();
     varUnit->setBase(global);
     varUnit->addVariable(global);
-    iterateTable(mL, LUA_GLOBALSINDEX, global, hide);
-    // FIXME: possible to keep and report? qDebug()<<"took"<<t.elapsed()<<"to get variables in";
+    return global;
 }

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -49,10 +49,19 @@ class QTreeWidgetItem;
 class LuaInterface
 {
 public:
+    // the deepest table level whose contents are read; anything below that is
+    // recorded as an empty table, which for a saved variable means its contents
+    // do not get saved
+    static constexpr int scmMaxTableDepth = 99;
+
     explicit LuaInterface(lua_State*);
     ~LuaInterface();
     void iterateTable(lua_State*, int, TVar*, bool);
     void getVars(bool);
+    void getSavedVars();
+    // the saved variables the last getSavedVars() had to cut short, for the
+    // caller to tell the user about - they are in no profile save it takes
+    QStringList truncatedSavedTables() const { return mTruncatedSavedTables; }
     QStringList varName(TVar* var);
     QList<TVar*> varOrder(TVar* var);
     QString getValue(TVar*);
@@ -77,11 +86,19 @@ public:
     static int onPanic(lua_State*);
 
 private:
+    TVar* resetVariableTree();
+
     int depth = 0;
     lua_State* mL;
     QSet<TVar> hiddenVars;
     QScopedPointer<VarUnit> varUnit;
     QList<int> lrefs;
+    // makes iterateTable() a saved-globals-only walk that starts a fresh dedup
+    // scope per global...
+    bool mSavedVarsOnly = false;
+    // ...and these are the top-level keys such a walk may keep
+    QSet<QString> mSavedRootNames;
+    QStringList mTruncatedSavedTables;
 };
 
 #endif // MUDLET_LUAINTERFACE_H

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -65,6 +65,14 @@ void VarUnit::addPointer(const void* pointer)
     mPointers.insert(pointer);
 }
 
+// Resets the seen-pointer set varExists() answers from. iterateTable() does this
+// per saved root so a table two roots share is walked in full under each; within
+// one walk that set is the cycle guard, with the depth cap as the backstop.
+void VarUnit::clearPointers()
+{
+    mPointers.clear();
+}
+
 bool VarUnit::shouldSave(QTreeWidgetItem* pWidgetItem)
 {
     auto var = getWVar(pWidgetItem);

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -70,6 +70,7 @@ public:
     void removeHidden(const QString& name);
     bool isSaved(TVar*);
     void addPointer(const void*);
+    void clearPointers();
     QString getUnsaveableReason(TVar*);
     QSet<QString> hidden;
     QSet<QString> hiddenByUser;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -780,11 +780,13 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     LuaInterface saveTimeInterface(lI->getState());
     VarUnit* saveTimeUnit = saveTimeInterface.getVarUnit();
     // A fresh tree carries no per-variable saved/hidden flags, so isSaved() and
-    // isHidden() have to answer from these name-keyed sets.
+    // isHidden() have to answer from these name-keyed sets. savedVars has to be
+    // in place before the call below: it is what tells getSavedVars() which
+    // globals to read, so an empty one exports nothing.
     saveTimeUnit->savedVars = vu->savedVars;
     saveTimeUnit->hidden = vu->hidden;
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
-    saveTimeInterface.getVars(false);
+    saveTimeInterface.getSavedVars();
 
     if (TVar* base = saveTimeUnit->getBase()) {
         QListIterator<TVar*> itVariable(base->getChildren(false));
@@ -793,6 +795,14 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
         }
     }
     saveTimeInterface.releaseVariableReferences();
+
+    const QStringList truncatedTables = saveTimeInterface.truncatedSavedTables();
+    if (!truncatedTables.isEmpty()) {
+        //: %1 is how many levels of nested tables Mudlet reads, %2 is a comma separated list of Lua variable names
+        pHost->postMessage(tr("[ WARN ]  - These saved variables are nested more than %1 tables deep, so this save holds them as empty tables: %2. "
+                              "Store data that deep with table.save() and table.load() instead.")
+                                   .arg(QString::number(LuaInterface::scmMaxTableDepth), truncatedTables.join(qsl(", "))));
+    }
 }
 
 // A unit busy executing an item of a package being uninstalled can only

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -26,6 +26,8 @@
  * profile saves. Also covers members a script adds to a saved table at
  * runtime: they have no savedVars entry of their own but must be saved with
  * the table (issue #9517), while hidden and unsaveable members must not be.
+ * Also covers a saved table that other globals reference, which must export in
+ * full under every saved name that reaches it (issue #9755).
  *
  * Run with: ctest -R XMLexportVariablesTest -V
  */
@@ -38,11 +40,13 @@
 #include "TelnetServerStub.h"
 #include "VarUnit.h"
 #include "XMLexport.h"
+#include "XMLimport.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "dlgTriggerEditor.h"
 #include "mudlet.h"
 
+#include <QRegularExpression>
 #include <QTreeWidget>
 
 extern "C" {
@@ -424,9 +428,13 @@ private slots:
     // registry would grow by that many slots on every save.
     void test_exportDoesNotLeakLuaRegistryReferences()
     {
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
         lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
-        // several reference-keyed members, so a leak grows the registry visibly
+        // several reference-keyed members, so a leak grows the registry visibly.
+        // The table has to be saved for the export to read it at all, and each
+        // of those keys costs a registry reference while it does
         QCOMPARE(luaL_dostring(L, "refKeyLeakTable = {} for i = 1, 20 do refKeyLeakTable[{}] = i end"), 0);
+        vu->savedVars.insert(qsl("refKeyLeakTable"));
 
         // freed slots go on a free list and come straight back out, so the
         // number stops climbing once the registry fits one pass's worth.
@@ -448,7 +456,262 @@ private slots:
         QVERIFY2(refAfterSix < refAfterOne + 20,
                  qPrintable(qsl("the exports pinned Lua registry slots: a reference taken after one export was %1, one taken after six was %2").arg(refAfterOne).arg(refAfterSix)));
 
+        vu->savedVars.remove(qsl("refKeyLeakTable"));
         QCOMPARE(luaL_dostring(L, "refKeyLeakTable = nil"), 0);
+    }
+
+    // A saved table other globals also reference exports in full, whichever of
+    // the names anything else happens to reach it by (issue #9755).
+    void test_savedTableReachedByAnotherGlobalIsExported()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "aliasedSavedTable = {member = 'aliased member value'}"), 0);
+        vu->savedVars.insert(qsl("aliasedSavedTable"));
+        vu->savedVars.insert(qsl("aliasedSavedTable.member"));
+        // seven aliases, not one: should the export ever go back to walking all
+        // of _G, hash order picks which name wins, and one alias would then only
+        // fail this test some of the time
+        QCOMPARE(luaL_dostring(L,
+                               "aaaAliasOfSaved = aliasedSavedTable bAliasOfSaved = aliasedSavedTable m1AliasOfSaved = aliasedSavedTable "
+                               "xyzzyAliasOfSaved = aliasedSavedTable alphaAliasOfSaved = aliasedSavedTable ref1AliasOfSaved = aliasedSavedTable "
+                               "A_1AliasOfSaved = aliasedSavedTable"),
+                 0);
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("aliasedSavedTable")), "a saved table must be exported however many other globals also reference it");
+        QVERIFY2(xml.contains(qsl("aliased member value")), "the members of a saved table other globals reference must be exported too");
+        QVERIFY2(!xml.contains(qsl("AliasOfSaved")), "the other globals are not saved themselves, so they must not be exported");
+
+        vu->savedVars.remove(qsl("aliasedSavedTable"));
+        vu->savedVars.remove(qsl("aliasedSavedTable.member"));
+        QCOMPARE(luaL_dostring(L, "aliasedSavedTable, aaaAliasOfSaved, bAliasOfSaved, m1AliasOfSaved, xyzzyAliasOfSaved, alphaAliasOfSaved, ref1AliasOfSaved, A_1AliasOfSaved = nil"), 0);
+    }
+
+    // Two saved globals that are the same table. Neither may be reduced to an
+    // empty group by the other having been read first.
+    void test_twoSavedGlobalsSharingATableBothExport()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "sharedFirstTable = {member = 'shared member value'} sharedSecondTable = sharedFirstTable"), 0);
+        for (const auto& name : {qsl("sharedFirstTable"), qsl("sharedFirstTable.member"), qsl("sharedSecondTable"), qsl("sharedSecondTable.member")}) {
+            vu->savedVars.insert(name);
+        }
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("sharedFirstTable")), "the first of two saved globals sharing a table must be exported");
+        QVERIFY2(xml.contains(qsl("sharedSecondTable")), "the second of two saved globals sharing a table must be exported");
+        QCOMPARE(xml.count(qsl("shared member value")), 2);
+
+        for (const auto& name : {qsl("sharedFirstTable"), qsl("sharedFirstTable.member"), qsl("sharedSecondTable"), qsl("sharedSecondTable.member")}) {
+            vu->savedVars.remove(name);
+        }
+        QCOMPARE(luaL_dostring(L, "sharedFirstTable, sharedSecondTable = nil"), 0);
+    }
+
+    // The shape a stock profile hits without anyone aliasing anything: a saved
+    // table that a second saved table holds as a member, which is how the EMCO
+    // and AdjustableContainer packages reach each other's tables.
+    void test_savedTableHeldByAnotherSavedTableIsExported()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "innerSavedTable = {member = 'inner member value'} holderSavedTable = {inner = innerSavedTable}"), 0);
+        for (const auto& name : {qsl("innerSavedTable"), qsl("innerSavedTable.member"), qsl("holderSavedTable"), qsl("holderSavedTable.inner")}) {
+            vu->savedVars.insert(name);
+        }
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("innerSavedTable")), "a saved table another saved table holds must still be exported in its own right");
+        QCOMPARE(xml.count(qsl("inner member value")), 2);
+
+        for (const auto& name : {qsl("innerSavedTable"), qsl("innerSavedTable.member"), qsl("holderSavedTable"), qsl("holderSavedTable.inner")}) {
+            vu->savedVars.remove(name);
+        }
+        QCOMPARE(luaL_dostring(L, "innerSavedTable, holderSavedTable = nil"), 0);
+    }
+
+    // Design pin. Two members of one saved table that are the same Lua table
+    // are not both exported: the profile XML has no way to say "these two names
+    // are one table", so the export would have to write the subtree once per
+    // name. On a profile whose saved table holds a UI object that multiplies
+    // out - measured at 5.5x the file, and big enough for the 10,000-item limit
+    // to then drop whole branches - so the walk keeps one copy per saved name
+    // and no more. Members the user ticks individually are exported in full.
+    void test_twoMembersOfASavedTableSharingATableExportOnce()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "memberShareTable = {} memberShareTable.first = {member = 'member share value'} memberShareTable.second = memberShareTable.first"), 0);
+        vu->savedVars.insert(qsl("memberShareTable"));
+
+        QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QCOMPARE(xml.count(qsl("member share value")), 1);
+
+        // ticking a member in the Variables view (which is what savedVars holds)
+        // is what asks for it to be written under its own name as well
+        vu->savedVars.insert(qsl("memberShareTable.first"));
+        vu->savedVars.insert(qsl("memberShareTable.second"));
+        xml = exportProfileXml();
+        QCOMPARE(xml.count(qsl("member share value")), 2);
+
+        for (const auto& name : {qsl("memberShareTable"), qsl("memberShareTable.first"), qsl("memberShareTable.second")}) {
+            vu->savedVars.remove(name);
+        }
+        QCOMPARE(luaL_dostring(L, "memberShareTable = nil"), 0);
+    }
+
+    // A table that holds itself must not send the walk round for ever.
+    void test_selfReferencingSavedTableIsExported()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "cyclicSavedTable = {member = 'cyclic member value'} cyclicSavedTable.self = cyclicSavedTable"), 0);
+        vu->savedVars.insert(qsl("cyclicSavedTable"));
+        vu->savedVars.insert(qsl("cyclicSavedTable.self"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("cyclic member value")), "a table that references itself must still export its other members");
+
+        vu->savedVars.remove(qsl("cyclicSavedTable"));
+        vu->savedVars.remove(qsl("cyclicSavedTable.self"));
+        QCOMPARE(luaL_dostring(L, "cyclicSavedTable = nil"), 0);
+    }
+
+    // What keeps a save off the size of _G: the tree it builds holds the saved
+    // globals and nothing else, so a global a profile does not save costs a key
+    // conversion and a hash lookup instead of a walk of everything it reaches.
+    void test_saveTimeTreeHoldsOnlyTheSavedGlobals()
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L,
+                               "for i = 1, 500 do _G['walkNoiseTable' .. i] = {nested = {deeper = i}} end "
+                               "walkSavedRootTable = {member = 'walk member value'}"),
+                 0);
+
+        LuaInterface saveTimeInterface(L);
+        saveTimeInterface.getVarUnit()->savedVars.insert(qsl("walkSavedRootTable"));
+        saveTimeInterface.getSavedVars();
+
+        TVar* pBase = saveTimeInterface.getVarUnit()->getBase();
+        QVERIFY(pBase);
+        const QList<TVar*> roots = pBase->getChildren(false);
+        QCOMPARE(roots.size(), 1);
+        QCOMPARE(roots.constFirst()->getName(), qsl("walkSavedRootTable"));
+        QCOMPARE(roots.constFirst()->getChildren(false).size(), 1);
+
+        // the saved-globals-only mode must not outlive the call that asked for
+        // it, or the Variables view built from this interface would show almost
+        // nothing
+        saveTimeInterface.getVars(false);
+        QVERIFY2(saveTimeInterface.getVarUnit()->getBase()->getChildren(false).size() > 1, "a getVars() after getSavedVars() must go back to reading the whole of _G");
+        saveTimeInterface.releaseVariableReferences();
+
+        QCOMPARE(luaL_dostring(L, "for i = 1, 500 do _G['walkNoiseTable' .. i] = nil end walkSavedRootTable = nil"), 0);
+    }
+
+    // The export borrows the profile's live Lua state, so anything it leaves on
+    // the stack is charged to every trigger, alias and timer for the rest of the
+    // session. Covers the three ways out of the walk: nothing saved at all, a
+    // normal walk, and one cut short by the nesting limit.
+    void test_exportLeavesTheLuaStackAsItFoundIt()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+
+        const QSet<QString> savedVarsBefore = vu->savedVars;
+        vu->savedVars.clear();
+        const int stackWithNothingSaved = lua_gettop(L);
+        const QString emptyXml = exportProfileXml();
+        QVERIFY(!emptyXml.isEmpty());
+        QVERIFY2(!emptyXml.contains(qsl("<Variable>")), "with nothing marked as saved the VariablePackage must come out empty");
+        QCOMPARE(lua_gettop(L), stackWithNothingSaved);
+        vu->savedVars = savedVarsBefore;
+
+        QCOMPARE(luaL_dostring(L,
+                               "stackCheckTable = {member = 'stack check value', nested = {deeper = 'deeper stack value'}} "
+                               "local t = stackCheckTable "
+                               "for i = 1, 120 do t.nested = {} t = t.nested end"),
+                 0);
+        vu->savedVars.insert(qsl("stackCheckTable"));
+
+        const int stackBefore = lua_gettop(L);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("nested more than 99 tables deep")));
+        QVERIFY(!exportProfileXml().isEmpty());
+        QCOMPARE(lua_gettop(L), stackBefore);
+
+        vu->savedVars.remove(qsl("stackCheckTable"));
+        QCOMPARE(luaL_dostring(L, "stackCheckTable = nil"), 0);
+    }
+
+    // A table-keyed entry costs a Lua registry reference to name at all, and the
+    // walk takes that reference before it knows whether the global is saved. The
+    // ones it then skips still have to be handed back.
+    void test_skippedGlobalsDoNotPinLuaRegistryReferences()
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "for i = 1, 20 do _G[{}] = 'unsaved table-keyed global' end"), 0);
+
+        QVERIFY(!exportProfileXml().isEmpty());
+        lua_pushboolean(L, 1);
+        const int refAfterOne = luaL_ref(L, LUA_REGISTRYINDEX);
+        luaL_unref(L, LUA_REGISTRYINDEX, refAfterOne);
+
+        for (int i = 0; i < 5; ++i) {
+            QVERIFY(!exportProfileXml().isEmpty());
+        }
+
+        lua_pushboolean(L, 1);
+        const int refAfterSix = luaL_ref(L, LUA_REGISTRYINDEX);
+        luaL_unref(L, LUA_REGISTRYINDEX, refAfterSix);
+
+        QVERIFY2(refAfterSix < refAfterOne + 20,
+                 qPrintable(qsl("the exports pinned Lua registry slots for globals they skipped: a reference taken after one export was %1, one taken after six was %2")
+                                    .arg(refAfterOne)
+                                    .arg(refAfterSix)));
+
+        QCOMPARE(luaL_dostring(L,
+                               "local deadKeys = {} for k in pairs(_G) do if type(k) == 'table' then deadKeys[#deadKeys + 1] = k end end "
+                               "for _, k in ipairs(deadKeys) do _G[k] = nil end"),
+                 0);
+    }
+
+    // The walk stops at 99 levels of nesting and hands back an empty table,
+    // which for a saved variable means its contents are not in the save. That
+    // has to be said out loud rather than left to be discovered.
+    void test_tableNestedPastTheWalkLimitIsReportedNotSilentlyEmptied()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L,
+                               "deeplyNestedSavedTable = {shallow = 'shallow member value'} "
+                               "local t = deeplyNestedSavedTable "
+                               "for i = 1, 120 do t.nested = {} t = t.nested end "
+                               "t.deepest = 'past the limit value'"),
+                 0);
+        vu->savedVars.insert(qsl("deeplyNestedSavedTable"));
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("nested more than 99 tables deep")));
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("shallow member value")), "the members the walk did reach must still be exported");
+        QVERIFY2(!xml.contains(qsl("past the limit value")), "a member past the nesting limit is not exported - the warning above is what tells the user");
+
+        vu->savedVars.remove(qsl("deeplyNestedSavedTable"));
+        QCOMPARE(luaL_dostring(L, "deeplyNestedSavedTable = nil"), 0);
     }
 
     // A script adds to a saved table while the editor sits on the Variables
@@ -531,6 +794,50 @@ private slots:
         QVERIFY(!exportProfileXml().isEmpty());
 
         QVERIFY2(vu->getWVar(pVariableItem) == pMappedBefore, "a profile save must leave the Variables editor's items resolving to their variables");
+    }
+
+    // What the user actually cares about: the data is there again next session.
+    // Declared last because importing puts the whole package back into the live
+    // profile, which the other tests would then be sharing.
+    void test_savedTableReachedByAnotherGlobalSurvivesAReload()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        // as many aliases as test_savedTableReachedByAnotherGlobalIsExported
+        // uses, and for the same reason
+        QCOMPARE(luaL_dostring(L,
+                               "reloadSavedTable = {member = 'reload member value', nest = {deep = 'reload deep value'}} "
+                               "aaaAliasOfReload = reloadSavedTable bAliasOfReload = reloadSavedTable m1AliasOfReload = reloadSavedTable "
+                               "xyzzyAliasOfReload = reloadSavedTable alphaAliasOfReload = reloadSavedTable ref1AliasOfReload = reloadSavedTable "
+                               "A_1AliasOfReload = reloadSavedTable"),
+                 0);
+        for (const auto& name : {qsl("reloadSavedTable"), qsl("reloadSavedTable.member"), qsl("reloadSavedTable.nest"), qsl("reloadSavedTable.nest.deep")}) {
+            vu->savedVars.insert(name);
+        }
+
+        const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/reload-test.xml");
+        auto writer = std::make_shared<XMLexport>(mpHost);
+        QVERIFY2(writer->exportPackage(xmlPath, true, false), "the profile could not be exported");
+
+        QCOMPARE(luaL_dostring(L, "reloadSavedTable, aaaAliasOfReload, bAliasOfReload, m1AliasOfReload, xyzzyAliasOfReload, alphaAliasOfReload, ref1AliasOfReload, A_1AliasOfReload = nil"), 0);
+        QCOMPARE(luaL_dostring(L, "assert(reloadSavedTable == nil)"), 0);
+
+        QFile file(xmlPath);
+        QVERIFY2(file.open(QFile::ReadOnly | QFile::Text), qPrintable(file.errorString()));
+        XMLimport importer(mpHost);
+        auto [imported, importError] = importer.importPackage(&file);
+        file.close();
+        QFile::remove(xmlPath);
+        QVERIFY2(imported, qPrintable(importError));
+
+        QVERIFY2(luaL_dostring(L, "assert(reloadSavedTable.member == 'reload member value')") == 0, "the saved table did not come back with its member after a save and reload");
+        QVERIFY2(luaL_dostring(L, "assert(reloadSavedTable.nest.deep == 'reload deep value')") == 0, "the saved table's nested member did not come back after a save and reload");
+
+        for (const auto& name : {qsl("reloadSavedTable"), qsl("reloadSavedTable.member"), qsl("reloadSavedTable.nest"), qsl("reloadSavedTable.nest.deep")}) {
+            vu->savedVars.remove(name);
+        }
+        QCOMPARE(luaL_dostring(L, "reloadSavedTable = nil"), 0);
     }
 
 private:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- A profile save read a fresh variable tree by walking all of `_G` first-seen-wins, so a saved table another global name reached first was filed under that name and written nowhere. Saves now read only the globals the profile saves, each in its own dedup scope, and a name the user saves is never deduped away.
- Same change takes the save off the size of `_G`: 0.269 s -> 0.007 s per save at 20,000 globals, 0.013 s -> 0.001 s on a default profile (4.22.0 is 0.002 s).
- `iterateTable()` names the table when it stops at 99 levels of nesting instead of handing back an empty one, and the save tells the user which saved variables that leaves empty.

#### Motivation for adding to Mudlet
Silent, permanent data loss on every save with no user action: a stock 4.x profile with EMCO/AdjustableContainer packages lost 1416 of its 1444 saved variable entries on the first 5.0 session.

#### Other info (issues closed, discussion etc)
Fixes #9755. Keeps #9704's fix (quitting with the editor on the Variables tab) intact - the export still builds a throwaway tree, so the Variables editor's tree items are never stranded.

Measured on a real profile (`Pox`, fresh isolated HOME): 25 variables / 4 groups / 4.3 KB before, 2267 / 535 / 497 KB after, identical on a second session. 4.22.0 wrote 1163 / 281 / 258 KB. The difference above 4.22.0 is the live EMCO and AdjustableContainer objects the profile keeps inside its saved `demonnic` table, which the ride-along rule from #9517 says to save.

**Test case:** `lua qaShared = {a = "alpha"}`, tick `qaShared` in the editor's Variables view, then `lua aaaAliasOfShared = qaShared`, quit and reopen - `qaShared.a` is still there. `ctest -R XMLexportVariablesTest` covers it; 5 of the 8 new cases were verified to fail against the unfixed source.