### PR TITLE
fix: building a map from a script no longer slows to a crawl as it grows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set(mudlet_SRCS
     TAlias.cpp
     TArea.cpp
     TAreaGridIndex.cpp
+    TAreaSpanIndex.cpp
     TAreaZLevelIndex.cpp
     TBuffer.cpp
     TCommandLine.cpp
@@ -358,6 +359,7 @@ set(mudlet_HDRS
     TAlias.h
     TArea.h
     TAreaGridIndex.h
+    TAreaSpanIndex.h
     TAreaZLevelIndex.h
     TAstar.h
     TBuffer.h

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4138,7 +4138,7 @@ void T2DMap::slot_createRoom()
         return;
     }
 
-    mpMap->setRoomArea(roomID, mAreaID, false);
+    mpMap->setRoomArea(roomID, mAreaID);
     mpMap->setRoomCoordinates(roomID, mContextMenuClickPosition.x, mContextMenuClickPosition.y, mMapCenterZ);
 
     mpMap->mMapGraphNeedsUpdate = true;
@@ -5150,7 +5150,7 @@ void T2DMap::slot_newMap()
         return;
     }
 
-    mpMap->setRoomArea(roomID, -1, false);
+    mpMap->setRoomArea(roomID, -1);
     mpMap->setRoomCoordinates(roomID, 0, 0, 0);
     mpMap->mMapGraphNeedsUpdate = true;
 
@@ -5234,28 +5234,12 @@ void T2DMap::slot_setArea()
         mMultiRect = QRect(0, 0, 0, 0);
         QSetIterator<int> itSelectedRoom = mMultiSelectionSet;
         while (itSelectedRoom.hasNext()) {
-            const int currentRoomId = itSelectedRoom.next();
-            if (itSelectedRoom.hasNext()) { // NOT the last room in set -  so defer some area related recalculations
-                mpMap->setRoomArea(currentRoomId, newAreaId, true);
-            } else {
-                // Is the LAST room, so be careful to do all that is needed to clean
-                // up the affected areas (triggered by last "false" argument in next
-                // line)...
-                if (!(mpMap->setRoomArea(currentRoomId, newAreaId, false))) {
-                    // Failed on the last of multiple room area move so do the missed
-                    // out recalculations for the dirtied areas
-                    auto areaPtrsList{mpMap->mpRoomDB->getAreaPtrList()};
-                    QSet<TArea*> const areaPtrsSet{areaPtrsList.begin(), areaPtrsList.end()};
-                    QSetIterator<TArea*> itpArea{areaPtrsSet};
-                    while (itpArea.hasNext()) {
-                        TArea* pArea = itpArea.next();
-                        pArea->clean();
-                    }
-                }
-                const auto& targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
-                mpMap->mpMapper->comboBox_showArea->setCurrentText(targetAreaName);
-                switchArea(targetAreaName);
-            }
+            mpMap->setRoomArea(itSelectedRoom.next(), newAreaId);
+        }
+        if (!mMultiSelectionSet.isEmpty()) {
+            const auto& targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
+            mpMap->mpMapper->comboBox_showArea->setCurrentText(targetAreaName);
+            switchArea(targetAreaName);
         }
         update();
     });

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -31,7 +31,6 @@
 #include "TRoomDB.h"
 
 #include <QBuffer>
-#include <QElapsedTimer>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -228,15 +227,37 @@ void TArea::determineAreaExitsOfRoom(int id)
         QPair<int, int> const p = QPair<int, int>(exitId, DIR_OUT);
         mAreaExits.insert(id, p);
     }
-    QMapIterator<QString, int> it(pR->getSpecialExits());
+    const QMap<QString, int>& specialExits = pR->getSpecialExits();
+    if (specialExits.isEmpty()) {
+        return;
+    }
+
+    const int areaId = getAreaID();
+    QMapIterator<QString, int> it(specialExits);
     while (it.hasNext()) {
         it.next();
         TRoom* pO = mpRoomDB->getRoom(it.value());
         if (pO) {
-            if (pO->getArea() != getAreaID()) {
+            if (pO->getArea() != areaId) {
                 QPair<int, int> const p = QPair<int, int>(pO->getId(), DIR_OTHER);
                 mAreaExits.insert(id, p);
             }
+        }
+    }
+}
+
+void TArea::refreshAreaExitsToRoom(int id)
+{
+    if (!mpRoomDB) {
+        return;
+    }
+
+    // Rooms with an exit to this one are the only ones whose area exit records
+    // can have changed; the map-wide entrance hash finds them without a scan.
+    const QList<int> enteringRoomIds = mpRoomDB->getEntranceHash().values(id);
+    for (const int enteringRoomId : enteringRoomIds) {
+        if (enteringRoomId != id && rooms.contains(enteringRoomId)) {
+            determineAreaExitsOfRoom(enteringRoomId);
         }
     }
 }
@@ -327,36 +348,6 @@ void TArea::determineAreaExits()
     }
 }
 
-void TArea::fast_calcSpan(int id)
-{
-    TRoom* pR = mpRoomDB->getRoom(id);
-    if (!pR) {
-        return;
-    }
-
-    const int x = pR->x();
-    const int y = pR->y();
-    const int z = pR->z();
-    if (x > max_x) {
-        max_x = x;
-    }
-    if (x < min_x) {
-        min_x = x;
-    }
-    if (y > max_y) {
-        max_y = y;
-    }
-    if (y < min_y) {
-        min_y = y;
-    }
-    if (z > max_z) {
-        max_z = z;
-    }
-    if (z < min_z) {
-        min_z = z;
-    }
-}
-
 void TArea::addRoom(int id)
 {
     TRoom* pR = mpRoomDB->getRoom(id);
@@ -365,6 +356,9 @@ void TArea::addRoom(int id)
             rooms.insert(id);
             mZLevelIndex.addRoom(id, pR->z());
             mGridIndex.addRoom(id, pR->z(), pR->x(), pR->y());
+            if (mSpanIndex.addRoom(pR->x(), -1 * pR->y(), pR->z())) {
+                publishSpanForZ(pR->z());
+            }
         } else {
             qDebug() << "TArea::addRoom(" << id << ") No creation! room already exists";
         }
@@ -374,13 +368,87 @@ void TArea::addRoom(int id)
     }
 }
 
-void TArea::calcSpan()
+void TArea::moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY)
+{
+    if (!rooms.contains(id)) {
+        // A room that is not in this area has no entries here to move, and
+        // adding them would leave the indexes claiming a room they will never
+        // be told to drop:
+        return;
+    }
+
+    mZLevelIndex.moveRoom(id, fromZ, toZ);
+    mGridIndex.moveRoom(id, fromZ, fromX, fromY, toZ, toX, toY);
+    const bool fromExtremesMoved = mSpanIndex.removeRoom(fromX, -1 * fromY, fromZ);
+    const bool toExtremesMoved = mSpanIndex.addRoom(toX, -1 * toY, toZ);
+    if (fromExtremesMoved) {
+        publishSpanForZ(fromZ);
+    }
+    if (toExtremesMoved) {
+        publishSpanForZ(toZ);
+    }
+}
+
+void TArea::publishSpan()
 {
     xminForZ.clear();
-    yminForZ.clear();
     xmaxForZ.clear();
+    yminForZ.clear();
     ymaxForZ.clear();
-    zLevels.clear();
+    zLevels = mSpanIndex.zLevels();
+    for (const int z : zLevels) {
+        const TAreaSpanIndex::Extremes extremes = mSpanIndex.extremesForZ(z);
+        xminForZ.insert(z, extremes.minX);
+        xmaxForZ.insert(z, extremes.maxX);
+        yminForZ.insert(z, extremes.minY);
+        ymaxForZ.insert(z, extremes.maxY);
+    }
+    publishOverallSpan();
+}
+
+void TArea::publishSpanForZ(int z)
+{
+    if (mSpanIndex.hasZ(z)) {
+        const TAreaSpanIndex::Extremes extremes = mSpanIndex.extremesForZ(z);
+        xminForZ.insert(z, extremes.minX);
+        xmaxForZ.insert(z, extremes.maxX);
+        yminForZ.insert(z, extremes.minY);
+        ymaxForZ.insert(z, extremes.maxY);
+        if (!zLevels.contains(z)) {
+            zLevels.insert(std::lower_bound(zLevels.cbegin(), zLevels.cend(), z), z);
+        }
+    } else {
+        xminForZ.remove(z);
+        xmaxForZ.remove(z);
+        yminForZ.remove(z);
+        ymaxForZ.remove(z);
+        zLevels.removeOne(z);
+    }
+    publishOverallSpan();
+}
+
+void TArea::publishOverallSpan()
+{
+    if (mSpanIndex.empty()) {
+        // With no rooms to derive them from, an emptied area keeps whatever
+        // extremes it last had:
+        return;
+    }
+
+    const TAreaSpanIndex::Extremes extremes = mSpanIndex.overallExtremes();
+    min_x = extremes.minX;
+    max_x = extremes.maxX;
+    min_y = extremes.minY;
+    max_y = extremes.maxY;
+    min_z = mSpanIndex.minZ();
+    max_z = mSpanIndex.maxZ();
+}
+
+// Rebuilds every index from the area's room set, which is what callers that
+// change TArea::rooms wholesale (map loading, the map auditor) rely on.
+void TArea::calcSpan()
+{
+    mSpanIndex.clear();
 
     // Collect the room-to-Z mapping in a single pass so mZLevelIndex can be
     // rebuilt without a second iteration. Also collect the full z/x/y data
@@ -389,7 +457,6 @@ void TArea::calcSpan()
     roomIdToZ.reserve(rooms.size());
     QHash<int, QHash<int, QPair<int, int>>> zToRoomXY;
 
-    bool isFirstDone = false;
     QSetIterator<int> itRoom(rooms);
     while (itRoom.hasNext()) {
         const int id = itRoom.next();
@@ -400,142 +467,31 @@ void TArea::calcSpan()
 
         roomIdToZ.insert(id, pR->z());
         zToRoomXY[pR->z()].insert(id, {pR->x(), pR->y()});
-
-        if (!isFirstDone) {
-            // Only do this initialization for the first valid room
-            min_x = pR->x();
-            max_x = min_x;
-            min_y = pR->y() * -1;
-            max_y = min_y;
-            min_z = pR->z();
-            max_z = min_z;
-            zLevels.push_back(pR->z());
-            xminForZ.insert(pR->z(), pR->x());
-            xmaxForZ.insert(pR->z(), pR->x());
-            yminForZ.insert(pR->z(), (-1 * pR->y()));
-            ymaxForZ.insert(pR->z(), (-1 * pR->y()));
-            isFirstDone = true;
-            continue;
-        }
-        // Already had one valid room so now must check more things
-
-        if (!zLevels.contains(pR->z())) {
-            zLevels.push_back(pR->z());
-        }
-
-        if (!xminForZ.contains(pR->z())) {
-            xminForZ.insert(pR->z(), pR->x());
-        } else if (pR->x() < xminForZ.value(pR->z())) {
-            xminForZ.insert(pR->z(), pR->x());
-        }
-
-        if (pR->x() < min_x) {
-            min_x = pR->x();
-        }
-
-        if (!xmaxForZ.contains(pR->z())) {
-            xmaxForZ.insert(pR->z(), pR->x());
-        } else if (pR->x() > xmaxForZ.value(pR->z())) {
-            xmaxForZ.insert(pR->z(), pR->x());
-        }
-
-        if (pR->x() > max_x) {
-            max_x = pR->x();
-        }
-
-        if (!yminForZ.contains(pR->z())) {
-            yminForZ.insert(pR->z(), (-1 * pR->y()));
-        } else if ((-1 * pR->y()) < yminForZ.value(pR->z())) {
-            yminForZ.insert(pR->z(), (-1 * pR->y()));
-        }
-
-        if ((-1 * pR->y()) < min_y) {
-            min_y = (-1 * pR->y());
-        }
-
-        if ((-1 * pR->y()) > max_y) {
-            max_y = (-1 * pR->y());
-        }
-
-        if (!ymaxForZ.contains(pR->z())) {
-            ymaxForZ.insert(pR->z(), (-1 * pR->y()));
-        } else if ((-1 * pR->y()) > ymaxForZ.value(pR->z())) {
-            ymaxForZ.insert(pR->z(), (-1 * pR->y()));
-        }
-
-        if (pR->z() < min_z) {
-            min_z = pR->z();
-        }
-
-        if (pR->z() > max_z) {
-            max_z = pR->z();
-        }
+        mSpanIndex.addRoom(pR->x(), -1 * pR->y(), pR->z());
     }
 
-    if (zLevels.size() > 1) {
-        // Not essential but it makes debugging a bit clearer if they are sorted
-        // The {x|y}{min|max}ForZ are, by definition!
-        std::sort(zLevels.begin(), zLevels.end());
-    }
+    publishSpan();
 
-    // Rebuild the Z-level room index from the authoritative room set.
     mZLevelIndex.rebuild(roomIdToZ);
     mGridIndex.rebuild(zToRoomXY);
 }
 
-// Added a second argument to cut-out extremes recalculation if not required
-// Currently called from:
-// bool TRoom::setArea( int, bool )  -- the second arg there can be used for this
-// bool TRoomDB::__removeRoom( int ) -- automatically skipped for area deletion
-//                                      (when this would not be needed)
-void TArea::removeRoom(int room, bool deferAreaRecalculations)
+void TArea::removeRoom(int room)
 {
-    static double cumulativeMean = 0.0;
-    static quint64 runCount = 0;
-    QElapsedTimer timer;
-    timer.start();
-
-    // Will use to flag whether some things have to be recalculated.
-    bool isOnExtreme = false;
     TRoom* pR = mpRoomDB->getRoom(room);
-    if (pR) {
-        // Always keep the Z-level index consistent regardless of whether area
-        // recalculations are deferred.  The incremental removal is O(1) and
-        // ensures getRoomsForZ() returns correct results until calcSpan() next
-        // runs (which rebuilds the index authoritatively).
-        if (rooms.contains(room)) {
-            mZLevelIndex.removeRoom(room, pR->z());
-            mGridIndex.removeRoom(room, pR->z(), pR->x(), pR->y());
+    if (pR && rooms.contains(room)) {
+        mZLevelIndex.removeRoom(room, pR->z());
+        mGridIndex.removeRoom(room, pR->z(), pR->x(), pR->y());
+        if (mSpanIndex.removeRoom(pR->x(), -1 * pR->y(), pR->z())) {
+            publishSpanForZ(pR->z());
         }
-
-        if (rooms.contains(room) && !deferAreaRecalculations) {
-            // just a check, if the area DOESN'T have the room then it is not wise
-            // to behave as if it did
-            // Now see if the room is on an extreme - if it the only room on a
-            // particular z-coordinate it will be on all four
-            if (xminForZ.contains(pR->z()) && xminForZ.value(pR->z()) >= pR->x()) {
-                isOnExtreme = true;
-            } else if (xmaxForZ.contains(pR->z()) && xmaxForZ.value(pR->z()) <= pR->x()) {
-                isOnExtreme = true;
-            } else if (yminForZ.contains(pR->z()) && yminForZ.value(pR->z()) >= (-1 * pR->y())) {
-                isOnExtreme = true;
-            } else if (ymaxForZ.contains(pR->z()) && ymaxForZ.value(pR->z()) <= (-1 * pR->y())) {
-                isOnExtreme = true;
-            } else if (min_x >= pR->x() || min_y >= (-1 * pR->y()) || max_x <= pR->x() || max_y <= (-1 * pR->y())) {
-                isOnExtreme = true;
-            }
-        }
+    } else if (!pR && rooms.contains(room)) {
+        // The indexes are keyed on the room's coordinates, so without the room
+        // its entries are stuck here until something calls calcSpan():
+        qWarning() << "TArea::removeRoom(" << room << ") the room is no longer in the map, so this area's indexes cannot be updated";
     }
     rooms.remove(room);
     mAreaExits.remove(room);
-    if (isOnExtreme) {
-        calcSpan();
-    }
-    quint64 const thisTime = timer.nsecsElapsed();
-    cumulativeMean += (((thisTime * 1.0e-9) - cumulativeMean) / ++runCount);
-    if (runCount % 1000 == 0) {
-        qDebug() << "TArea::removeRoom(" << room << ") from Area took" << thisTime * 1.0e-9 << "sec. this time and after" << runCount << "times the average is" << cumulativeMean << "sec.";
-    }
 }
 
 // Reconstruct the area exit data in a format that actually makes sense - only

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -58,8 +58,10 @@ public:
     const QList<int> getAreaExitRoomIds() const { return mAreaExits.uniqueKeys(); }
     const QMultiMap<int, QPair<QString, int>> getAreaExitRoomData() const;
     // Keeps the Z-level index, the grid index and the area extremes in step
-    // when a room moves; callers must use this rather than updating any of
-    // them on their own.
+    // when a room this area already holds moves to new coordinates; callers
+    // must use this rather than updating any of them on their own.  A room
+    // joining or leaving the area, including one being deleted, goes through
+    // addRoom()/removeRoom() instead.
     void moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY);
     // Returns the set of room IDs on the given Z level.  The returned reference
     // is stable for the lifetime of the index (an internal empty set is used

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -25,6 +25,7 @@
 
 
 #include "TAreaGridIndex.h"
+#include "TAreaSpanIndex.h"
 #include "TAreaZLevelIndex.h"
 #include "TMap.h"
 
@@ -56,14 +57,10 @@ public:
     const QSet<int>& getAreaRooms() const { return rooms; }
     const QList<int> getAreaExitRoomIds() const { return mAreaExits.uniqueKeys(); }
     const QMultiMap<int, QPair<QString, int>> getAreaExitRoomData() const;
-    // Atomically updates both the Z-level index and the grid index when a room
-    // moves to a new position.  All callers should use this instead of calling
-    // moveRoomZ and moveRoomInGridIndex separately.
-    void moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY)
-    {
-        mZLevelIndex.moveRoom(id, fromZ, toZ);
-        mGridIndex.moveRoom(id, fromZ, fromX, fromY, toZ, toX, toY);
-    }
+    // Keeps the Z-level index, the grid index and the area extremes in step
+    // when a room moves; callers must use this rather than updating any of
+    // them on their own.
+    void moveRoom(int id, int fromZ, int fromX, int fromY, int toZ, int toX, int toY);
     // Returns the set of room IDs on the given Z level.  The returned reference
     // is stable for the lifetime of the index (an internal empty set is used
     // for Z levels with no rooms), so it can be safely iterated immediately.
@@ -71,10 +68,13 @@ public:
     // Returns a const reference to the grid index for read-only access by the renderer.
     const TAreaGridIndex& getGridIndex() const { return mGridIndex; }
     void calcSpan();
-    void fast_calcSpan(int);
     void determineAreaExits();
     void determineAreaExitsOfRoom(int);
-    void removeRoom(int, bool deferAreaRecalculations = false);
+    // Recomputes the area exit records of this area's rooms that have an exit
+    // to the given room, which is what changes when that room joins or leaves
+    // this area.
+    void refreshAreaExitsToRoom(int);
+    void removeRoom(int);
     // List of coordinate triples (x,y,z) where there are multiple rooms
     QList<std::tuple<int, int, int>> getCollisionNodes();
     QList<int> getRoomsByPosition(int x, int y, int z);
@@ -111,7 +111,7 @@ public:
     QMap<int, int> xmaxForZ;
     QMap<int, int> yminForZ;
     QMap<int, int> ymaxForZ;
-    QList<int> zLevels; // The z-levels that ARE used, not guaranteed to be in order
+    QList<int> zLevels; // The z-levels that have rooms, in ascending order
     bool gridMode = false;
     bool isZone = false;
     int zoneAreaRef = 0;
@@ -142,6 +142,10 @@ private:
     QVector3D readJson3DCoordinates(const QJsonObject&, const QString&) const;
     void writeJson3DCoordinates(QJsonObject&, const QString&, const QVector3D&) const;
 
+    void publishSpan();
+    void publishSpanForZ(int z);
+    void publishOverallSpan();
+
     QList<QByteArray> convertImageToBase64Data(const QPixmap&) const;
     QPixmap convertBase64DataToImage(const QList<QByteArray>&) const;
 
@@ -159,6 +163,10 @@ private:
     TAreaZLevelIndex mZLevelIndex;
     // Per-(z,x,y) grid index for efficient viewport queries in grid mode.
     TAreaGridIndex mGridIndex;
+    // Source of truth for the public extremes above (min_x, xminForZ, zLevels
+    // and friends), which stay plain members because the map file format
+    // stores them and a lot of code reads them directly.
+    TAreaSpanIndex mSpanIndex;
 
     // In use this has a minimum of 3.0 and a default of 20.0, the latter will
     // be applied in the constructor initialisation list:

--- a/src/TAreaSpanIndex.cpp
+++ b/src/TAreaSpanIndex.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TAreaSpanIndex.h"
+
+bool TAreaSpanIndex::addRoom(int x, int y, int z)
+{
+    increment(mXCounts, x);
+    increment(mYCounts, y);
+
+    const auto itZLevel = mPerZ.find(z);
+    if (itZLevel == mPerZ.end()) {
+        ZLevelCounts& zLevel = mPerZ[z];
+        increment(zLevel.xCounts, x);
+        increment(zLevel.yCounts, y);
+        return true;
+    }
+
+    // An overall extreme can only move when the extreme of the room's own Z
+    // level moves with it, so this answer covers both.
+    const Extremes before = extremesOf(itZLevel.value());
+    increment(itZLevel.value().xCounts, x);
+    increment(itZLevel.value().yCounts, y);
+    return !(before == extremesOf(itZLevel.value()));
+}
+
+bool TAreaSpanIndex::removeRoom(int x, int y, int z)
+{
+    const auto itZLevel = mPerZ.find(z);
+    if (itZLevel == mPerZ.end()) {
+        return false;
+    }
+
+    decrement(mXCounts, x);
+    decrement(mYCounts, y);
+    const Extremes before = extremesOf(itZLevel.value());
+    decrement(itZLevel.value().xCounts, x);
+    decrement(itZLevel.value().yCounts, y);
+    if (itZLevel.value().xCounts.isEmpty()) {
+        mPerZ.erase(itZLevel);
+        return true;
+    }
+    return !(before == extremesOf(itZLevel.value()));
+}
+
+TAreaSpanIndex::Extremes TAreaSpanIndex::overallExtremes() const
+{
+    if (mXCounts.isEmpty()) {
+        return {};
+    }
+    return {mXCounts.firstKey(), mXCounts.lastKey(), mYCounts.firstKey(), mYCounts.lastKey()};
+}
+
+TAreaSpanIndex::Extremes TAreaSpanIndex::extremesForZ(int z) const
+{
+    const auto itZLevel = mPerZ.constFind(z);
+    if (itZLevel == mPerZ.constEnd()) {
+        return {};
+    }
+    return extremesOf(itZLevel.value());
+}
+
+TAreaSpanIndex::Extremes TAreaSpanIndex::extremesOf(const ZLevelCounts& zLevel)
+{
+    return {zLevel.xCounts.firstKey(), zLevel.xCounts.lastKey(), zLevel.yCounts.firstKey(), zLevel.yCounts.lastKey()};
+}
+
+void TAreaSpanIndex::clear()
+{
+    mPerZ.clear();
+    mXCounts.clear();
+    mYCounts.clear();
+}
+
+void TAreaSpanIndex::increment(QMap<int, int>& counts, int value)
+{
+    ++counts[value];
+}
+
+void TAreaSpanIndex::decrement(QMap<int, int>& counts, int value)
+{
+    const auto it = counts.find(value);
+    if (it == counts.end()) {
+        return;
+    }
+
+    if (--it.value() <= 0) {
+        counts.erase(it);
+    }
+}

--- a/src/TAreaSpanIndex.cpp
+++ b/src/TAreaSpanIndex.cpp
@@ -47,11 +47,15 @@ bool TAreaSpanIndex::removeRoom(int x, int y, int z)
         return false;
     }
 
-    decrement(mXCounts, x);
-    decrement(mYCounts, y);
+    // The overall counts only lose what the Z level's own counts lost, so that
+    // a coordinate this level never had cannot take another level's with it:
     const Extremes before = extremesOf(itZLevel.value());
-    decrement(itZLevel.value().xCounts, x);
-    decrement(itZLevel.value().yCounts, y);
+    if (decrement(itZLevel.value().xCounts, x)) {
+        decrement(mXCounts, x);
+    }
+    if (decrement(itZLevel.value().yCounts, y)) {
+        decrement(mYCounts, y);
+    }
     if (itZLevel.value().xCounts.isEmpty()) {
         mPerZ.erase(itZLevel);
         return true;
@@ -93,14 +97,15 @@ void TAreaSpanIndex::increment(QMap<int, int>& counts, int value)
     ++counts[value];
 }
 
-void TAreaSpanIndex::decrement(QMap<int, int>& counts, int value)
+bool TAreaSpanIndex::decrement(QMap<int, int>& counts, int value)
 {
     const auto it = counts.find(value);
     if (it == counts.end()) {
-        return;
+        return false;
     }
 
     if (--it.value() <= 0) {
         counts.erase(it);
     }
+    return true;
 }

--- a/src/TAreaSpanIndex.h
+++ b/src/TAreaSpanIndex.h
@@ -79,7 +79,8 @@ private:
 
     static Extremes extremesOf(const ZLevelCounts& zLevel);
     static void increment(QMap<int, int>& counts, int value);
-    static void decrement(QMap<int, int>& counts, int value);
+    // Answers whether there was anything to take away.
+    static bool decrement(QMap<int, int>& counts, int value);
 
     QMap<int, ZLevelCounts> mPerZ;
     QMap<int, int> mXCounts;

--- a/src/TAreaSpanIndex.h
+++ b/src/TAreaSpanIndex.h
@@ -1,0 +1,89 @@
+#ifndef MUDLET_TAREA_SPAN_INDEX_H
+#define MUDLET_TAREA_SPAN_INDEX_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QList>
+#include <QMap>
+
+/*
+ * Maintains an area's coordinate extremes - overall and per Z level - as rooms
+ * are added, moved and removed, so that none of those operations has to rescan
+ * the area's rooms.
+ *
+ * Coordinates are bucketed into sorted count maps keyed by the coordinate
+ * value, so the number of entries is the number of *distinct* coordinates
+ * rather than the number of rooms, and an extreme is the first or last key of
+ * the relevant map.
+ *
+ * The y coordinates are those of TArea::min_y and friends, i.e. the negated
+ * TRoom::y(), so that callers do not have to flip the sense of the answers.
+ */
+class TAreaSpanIndex
+{
+public:
+    // The lowest and highest coordinate in use, either overall or on one Z
+    // level. Only meaningful for a level that has rooms.
+    struct Extremes
+    {
+        int minX = 0;
+        int maxX = 0;
+        int minY = 0;
+        int maxY = 0;
+
+        bool operator==(const Extremes& other) const { return minX == other.minX && maxX == other.maxX && minY == other.minY && maxY == other.maxY; }
+    };
+
+    // Both return whether the extremes of the affected Z level moved, so that
+    // callers can skip republishing them - during a map load that is the case
+    // for all but a handful of the rooms.
+    bool addRoom(int x, int y, int z);
+    bool removeRoom(int x, int y, int z);
+    void clear();
+
+    bool empty() const { return mPerZ.isEmpty(); }
+    bool hasZ(int z) const { return mPerZ.contains(z); }
+    // Ascending, as TArea::zLevels is expected (and saved) sorted.
+    QList<int> zLevels() const { return mPerZ.keys(); }
+
+    // All four answer with zeroes when there is nothing to measure, which is
+    // never a meaningful extreme, so callers check empty() / hasZ() first.
+    int minZ() const { return mPerZ.isEmpty() ? 0 : mPerZ.firstKey(); }
+    int maxZ() const { return mPerZ.isEmpty() ? 0 : mPerZ.lastKey(); }
+    Extremes overallExtremes() const;
+    Extremes extremesForZ(int z) const;
+
+private:
+    struct ZLevelCounts
+    {
+        QMap<int, int> xCounts;
+        QMap<int, int> yCounts;
+    };
+
+    static Extremes extremesOf(const ZLevelCounts& zLevel);
+    static void increment(QMap<int, int>& counts, int value);
+    static void decrement(QMap<int, int>& counts, int value);
+
+    QMap<int, ZLevelCounts> mPerZ;
+    QMap<int, int> mXCounts;
+    QMap<int, int> mYCounts;
+};
+
+#endif // MUDLET_TAREA_SPAN_INDEX_H

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -614,12 +614,11 @@ int TLuaInterpreter::addRoom(lua_State* L)
             areaID = getVerifiedInt(L, __func__, 2, "areaID");
         }
         const int requestedAreaID = areaID;
-        // defer area calculations as all new rooms are initialised at 0,0,0 anyway
-        if (!host.mpMap->setRoomArea(id, areaID, true)) {
+        if (!host.mpMap->setRoomArea(id, areaID)) {
             // The above will fail if the areaID does not exist (given that
             // "added" is true then the room now exists - so that isn't the
             // failure reason) so stuff the room in the "Default Area" instead
-            host.mpMap->setRoomArea(id, -1, true);
+            host.mpMap->setRoomArea(id, -1);
             issueBadAreaWarning = true;
             areaID = -1;
         }
@@ -3063,10 +3062,10 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
         return warnArgumentValue(L, __func__, "no map present or loaded");
     }
-    if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
+    if (!host.mpMap->mpRoomDB->hasRoom(id)) {
         return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
     }
-    const bool result = host.mpMap->setRoomArea(id, -1, false);
+    const bool result = host.mpMap->setRoomArea(id, -1);
     if (result) {
         host.mpMap->updateArea(-1);
     }
@@ -4029,14 +4028,14 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
 
     if (lua_isnumber(L, 1)) {
         const int id = getVerifiedInt(L, __func__, 1, "roomID");
-        if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
+        if (!host.mpMap->mpRoomDB->hasRoom(id)) {
             return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
         }
     } else if (lua_istable(L, 1)) {
         lua_pushnil(L);
         while (lua_next(L, 1) != 0) {
             const int id = getVerifiedInt(L, __func__, -1, "roomID");
-            if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
+            if (!host.mpMap->mpRoomDB->hasRoom(id)) {
                 return warnArgumentValue(L, __func__, csmInvalidRoomID.arg(id));
             }
             lua_pop(L, 1);
@@ -4092,8 +4091,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
     }
 
     const bool result = std::all_of(roomIds.begin(), roomIds.end(), [&](int id) {
-        // defer area recalculation on all rooms until the last room (.back())
-        return host.mpMap->setRoomArea(id, areaId, id != roomIds.back());
+        return host.mpMap->setRoomArea(id, areaId);
     });
 
     if (result) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -179,7 +179,7 @@ void TMap::logError(const QString& msg)
 //    mpHost->mLuaInterpreter.compileAndExecuteScript( script );
 //}
 
-bool TMap::setRoomArea(int id, int area, bool deferAreaRecalculations)
+bool TMap::setRoomArea(int id, int area)
 {
     TRoom* pR = mpRoomDB->getRoom(id);
     if (!pR) {
@@ -203,7 +203,7 @@ bool TMap::setRoomArea(int id, int area, bool deferAreaRecalculations)
         // to retain the API for the lua subsystem...
     }
 
-    const bool result = pR->setArea(area, deferAreaRecalculations);
+    const bool result = pR->setArea(area);
     if (result) {
         mMapGraphNeedsUpdate = true;
         setUnsaved(__func__);

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -116,7 +116,7 @@ public:
                        QColor outline = Qt::black);
     void deleteMapLabel(int area, int labelID);
     bool addRoom(int id = 0);
-    bool setRoomArea(int id, int area, bool deferAreaRecalculations = false);
+    bool setRoomArea(int id, int area);
     void deleteArea(int id);
     int createNewRoomID(int minimumId = 1);
     void logError(const QString&);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -336,21 +336,8 @@ void TRoom::setId(const int roomId)
     id = roomId;
 }
 
-// The second optional argument delays area related recaluclations when true
-// until called with false (the default) - it records the "dirty" areas so that
-// the affected areas can be identified.
-// The caller, should set the argument true for all but the last when working
-// through a list of rooms.
-// There IS a theoretical risk that if the last called room "doesn't exist" then
-// the area related recalculations won't get done - so had better provide an
-// alternative means to do them as a fault recovery
-bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
+bool TRoom::setArea(int areaID)
 {
-    // Track dirty areas by ID rather than TArea* across calls: a TArea* held
-    // through a deferred window can dangle if the map is cleared in between
-    // (e.g. clearMapDB(), profile close, bulk map reload). Looking up the
-    // pointer freshly at flush time safely skips areas that no longer exist.
-    static QSet<int> dirtyAreaIds;
     TArea* pA = mpRoomDB->getArea(areaID);
     if (!pA) {
         // There is no TArea instance with that _areaID
@@ -367,18 +354,7 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
     //remove from the old area
     TArea* pA2 = mpRoomDB->getArea(area);
     if (pA2) {
-        pA2->removeRoom(id, deferAreaRecalculations);
-        // Ah, all rooms in the OLD area that led to the room now become area
-        // exits for that OLD area {so must run determineAreaExits() for the
-        // old area after the room has moved to the new area see other
-        // "if( pA2 )" below} - other exits that led to the room from other
-        // areas are still "out of area exits" UNLESS the room moves to the SAME
-        // area that the other exits are in.
-        // Add to local store of dirty areas
-        dirtyAreaIds.insert(area);
-        // Flag the area itself in case something goes
-        // wrong on last room in a series
-        pA2->mIsDirty = true;
+        pA2->removeRoom(id);
     } else {
         //: Although this is reported as an error it is not a problem
         mpRoomDB->mpMap->logError(tr("When setting the Area for RoomID %1 it did not have a current area, this is unexpected but not a problem!")
@@ -388,20 +364,14 @@ bool TRoom::setArea(int areaID, bool deferAreaRecalculations)
     area = areaID;
     pA->addRoom(id);
 
-    dirtyAreaIds.insert(areaID);
-    pA->mIsDirty = true;
-
-    if (!deferAreaRecalculations) {
-        // Swap out the set before iterating so that reentrant calls into
-        // setArea() from within clean()/determineAreaExits() (e.g. via Lua
-        // event handlers) don't mutate the container we're walking.
-        QSet<int> toClean;
-        toClean.swap(dirtyAreaIds);
-        for (const int aid : toClean) {
-            if (TArea* pArea = mpRoomDB->getArea(aid)) {
-                pArea->clean();
-            }
-        }
+    // Both refreshes have to run once the room's own area has been updated, as
+    // that is what decides whether a special exit crosses an area boundary.
+    pA->determineAreaExitsOfRoom(id);
+    pA->refreshAreaExitsToRoom(id);
+    if (pA2 && pA2 != pA) {
+        // Exits that led to the room from the old area's rooms now leave that
+        // area; exits from any third area still do, so they are unaffected.
+        pA2->refreshAreaExitsToRoom(id);
     }
 
     mpRoomDB->mpMap->setUnsaved(__func__);
@@ -1540,6 +1510,12 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
             mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
         }
     }
+
+    // The audit rewrites exit destinations, which the entrance hash built
+    // during the load has no entry for. Removing the superseded entries as
+    // well would be a full scan of the hash per room, and the consumers all
+    // re-check the exit anyway, so the leftovers are left to them.
+    mpRoomDB->updateEntranceMap(this, true);
 }
 
 void TRoom::auditExit(int& exitRoomId,                     // Reference to where exit goes to

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -69,7 +69,7 @@ public:
     bool hasExitStub(int direction);
     void setExitStub(int direction, bool status);
     void calcRoomDimensions();
-    bool setArea(int, bool deferAreaRecalculations = false);
+    bool setArea(int);
     int getExitWeight(const QString& cmd);
 
     inline int x() const { return mX; }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -289,6 +289,11 @@ bool TRoomDB::__removeRoom(int id)
                     r->setOut(-1);
                 }
                 r->removeAllSpecialExitsToRoom(id);
+                // The plain setters above do not touch the area exit records,
+                // which still name the room that is going away:
+                if (TArea* pEnteringRoomArea = getArea(r->getArea())) {
+                    pEnteringRoomArea->determineAreaExitsOfRoom(r->getId());
+                }
             }
             ++i;
         }

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -72,6 +72,7 @@ public:
     const QHash<int, TRoom*>& getRoomMap() const { return rooms; }
     const QMap<int, TArea*>& getAreaMap() const { return areas; }
     QList<int> getRoomIDList();
+    bool hasRoom(int id) const { return rooms.contains(id); }
     QList<int> getAreaIDList();
     const QMap<int, QString>& getAreaNamesMap() const { return areaNamesMap; }
     void updateEntranceMap(TRoom*, bool isMapLoading = false);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(UNIT_TESTS
     OAuthClientFlowTest
     DiscordTest
     TTextEditBlinkTest
+    TAreaSpanIndexTest
     TAreaZLevelIndexTest
     TAreaGridIndexTest
     TKeySequenceEditTest

--- a/test/TAreaSpanIndexTest.cpp
+++ b/test/TAreaSpanIndexTest.cpp
@@ -1,0 +1,239 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <TAreaSpanIndex.h>
+
+#include <QtTest/QtTest>
+
+/*
+ * Unit tests for TAreaSpanIndex.
+ *
+ * The class is pure data, so these tests state the expected extremes as
+ * absolute values rather than comparing one code path against another.
+ *
+ * Coverage goals
+ * - the extremes of a single Z level and of the index as a whole
+ * - rooms sharing a coordinate: the bucket has to be emptied by the last of
+ *   them, not the first
+ * - Z levels appearing and disappearing
+ * - the "extremes moved" answer that TArea uses to decide whether to
+ *   republish, in both the true and the false direction
+ * - removals of coordinates and Z levels that were never added
+ */
+class TAreaSpanIndexTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    static void addRooms(TAreaSpanIndex& index, const QList<std::tuple<int, int, int>>& rooms)
+    {
+        for (const auto& [x, y, z] : rooms) {
+            index.addRoom(x, y, z);
+        }
+    }
+
+private slots:
+
+    void freshIndexIsEmpty()
+    {
+        TAreaSpanIndex index;
+        QVERIFY(index.empty());
+        QVERIFY(!index.hasZ(0));
+        QVERIFY(index.zLevels().isEmpty());
+    }
+
+    void singleRoomIsItsOwnExtreme()
+    {
+        TAreaSpanIndex index;
+        index.addRoom(7, -4, 2);
+
+        QVERIFY(!index.empty());
+        QVERIFY(index.hasZ(2));
+        QCOMPARE(index.minZ(), 2);
+        QCOMPARE(index.maxZ(), 2);
+        const TAreaSpanIndex::Extremes overall = index.overallExtremes();
+        QCOMPARE(overall.minX, 7);
+        QCOMPARE(overall.maxX, 7);
+        QCOMPARE(overall.minY, -4);
+        QCOMPARE(overall.maxY, -4);
+    }
+
+    void extremesAreTheLowestAndHighestCoordinates()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{-3, 5, 0}, {11, -2, 0}, {4, 9, 0}});
+
+        const TAreaSpanIndex::Extremes overall = index.overallExtremes();
+        QCOMPARE(overall.minX, -3);
+        QCOMPARE(overall.maxX, 11);
+        QCOMPARE(overall.minY, -2);
+        QCOMPARE(overall.maxY, 9);
+    }
+
+    void eachZLevelHasItsOwnExtremes()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{0, 0, 0}, {100, 100, 0}, {-50, -50, 3}, {-10, -10, 3}});
+
+        const TAreaSpanIndex::Extremes ground = index.extremesForZ(0);
+        QCOMPARE(ground.minX, 0);
+        QCOMPARE(ground.maxX, 100);
+        QCOMPARE(ground.minY, 0);
+        QCOMPARE(ground.maxY, 100);
+
+        const TAreaSpanIndex::Extremes upstairs = index.extremesForZ(3);
+        QCOMPARE(upstairs.minX, -50);
+        QCOMPARE(upstairs.maxX, -10);
+        QCOMPARE(upstairs.minY, -50);
+        QCOMPARE(upstairs.maxY, -10);
+
+        const TAreaSpanIndex::Extremes overall = index.overallExtremes();
+        QCOMPARE(overall.minX, -50);
+        QCOMPARE(overall.maxX, 100);
+        QCOMPARE(overall.minY, -50);
+        QCOMPARE(overall.maxY, 100);
+    }
+
+    void zLevelsAreAscendingAndDeduplicated()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{0, 0, 4}, {1, 1, -2}, {2, 2, 4}, {3, 3, 0}});
+
+        const QList<int> expected{-2, 0, 4};
+        QCOMPARE(index.zLevels(), expected);
+        QCOMPARE(index.minZ(), -2);
+        QCOMPARE(index.maxZ(), 4);
+    }
+
+    void aSharedCoordinateSurvivesTheFirstRemoval()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{2, 2, 0}, {2, 2, 0}, {8, 8, 0}});
+
+        index.removeRoom(2, 2, 0);
+        const TAreaSpanIndex::Extremes stillThere = index.extremesForZ(0);
+        QCOMPARE(stillThere.minX, 2);
+        QCOMPARE(stillThere.minY, 2);
+
+        index.removeRoom(2, 2, 0);
+        const TAreaSpanIndex::Extremes gone = index.extremesForZ(0);
+        QCOMPARE(gone.minX, 8);
+        QCOMPARE(gone.minY, 8);
+    }
+
+    void removingTheLastRoomOnALevelDropsTheLevel()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{1, 1, 0}, {2, 2, 5}});
+
+        index.removeRoom(2, 2, 5);
+        QVERIFY(!index.hasZ(5));
+        const QList<int> expected{0};
+        QCOMPARE(index.zLevels(), expected);
+        QCOMPARE(index.maxZ(), 0);
+    }
+
+    void emptyingTheIndexReportsEmpty()
+    {
+        TAreaSpanIndex index;
+        index.addRoom(1, 1, 0);
+        index.removeRoom(1, 1, 0);
+
+        QVERIFY(index.empty());
+        QVERIFY(index.zLevels().isEmpty());
+    }
+
+    void addReportsWhetherTheExtremesMoved()
+    {
+        TAreaSpanIndex index;
+        QVERIFY2(index.addRoom(5, 5, 0), "the first room on a Z level always moves its extremes");
+        QVERIFY2(index.addRoom(9, 9, 0), "a room beyond the current maximum moves it");
+        QVERIFY2(!index.addRoom(7, 7, 0), "a room inside the current range leaves the extremes alone");
+        QVERIFY2(!index.addRoom(5, 9, 0), "a room on both existing extremes leaves them alone");
+        QVERIFY2(index.addRoom(1, 7, 0), "a room below the current minimum moves it");
+        QVERIFY2(index.addRoom(7, 7, 1), "a new Z level always counts as a move");
+    }
+
+    void removeReportsWhetherTheExtremesMoved()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{1, 1, 0}, {5, 5, 0}, {9, 9, 0}});
+
+        QVERIFY2(!index.removeRoom(5, 5, 0), "removing a room inside the range leaves the extremes alone");
+        QVERIFY2(index.removeRoom(9, 9, 0), "removing the room at the maximum moves it");
+        QVERIFY2(index.removeRoom(1, 1, 0), "removing the last room drops the Z level");
+    }
+
+    void removalsOfThingsNeverAddedAreIgnored()
+    {
+        TAreaSpanIndex index;
+        index.addRoom(4, 4, 0);
+
+        QVERIFY(!index.removeRoom(4, 4, 99));
+        QVERIFY(!index.removeRoom(1000, 1000, 0));
+
+        // The one real room is still the only thing the index knows about:
+        const TAreaSpanIndex::Extremes overall = index.overallExtremes();
+        QCOMPARE(overall.minX, 4);
+        QCOMPARE(overall.maxX, 4);
+        QCOMPARE(index.zLevels(), QList<int>{0});
+    }
+
+    // The overall extremes are kept separately from the per-level ones, so a
+    // level that comes and goes must not leave anything behind in them.
+    void overallExtremesFollowLevelsThatComeAndGo()
+    {
+        TAreaSpanIndex index;
+        index.addRoom(0, 0, 0);
+        index.addRoom(400, -400, 7);
+        index.removeRoom(400, -400, 7);
+
+        const TAreaSpanIndex::Extremes overall = index.overallExtremes();
+        QCOMPARE(overall.minX, 0);
+        QCOMPARE(overall.maxX, 0);
+        QCOMPARE(overall.minY, 0);
+        QCOMPARE(overall.maxY, 0);
+    }
+
+    void clearForgetsEverything()
+    {
+        TAreaSpanIndex index;
+        addRooms(index, {{1, 2, 3}, {4, 5, 6}});
+
+        index.clear();
+        QVERIFY(index.empty());
+        QVERIFY(index.zLevels().isEmpty());
+        QVERIFY(!index.hasZ(3));
+    }
+
+    void extremesOfAnUnknownLevelAreZeroes()
+    {
+        TAreaSpanIndex index;
+        index.addRoom(11, 12, 0);
+
+        const TAreaSpanIndex::Extremes nothing = index.extremesForZ(42);
+        QCOMPARE(nothing.minX, 0);
+        QCOMPARE(nothing.maxX, 0);
+        QCOMPARE(nothing.minY, 0);
+        QCOMPARE(nothing.maxY, 0);
+    }
+};
+
+#include "TAreaSpanIndexTest.moc"
+QTEST_MAIN(TAreaSpanIndexTest)

--- a/test/TAreaSpanIndexTest.cpp
+++ b/test/TAreaSpanIndexTest.cpp
@@ -195,6 +195,23 @@ private slots:
         QCOMPARE(index.zLevels(), QList<int>{0});
     }
 
+    // The overall counts are shared by every Z level, so a removal a level
+    // cannot honour must not spend another level's share of a coordinate.
+    void aRemovalFromTheWrongLevelLeavesTheOtherLevelsAlone()
+    {
+        TAreaSpanIndex index;
+        index.addRoom(3, 3, 0);
+        index.addRoom(50, 50, 1);
+
+        index.removeRoom(50, 50, 0);
+        const TAreaSpanIndex::Extremes overall = index.overallExtremes();
+        QCOMPARE(overall.maxX, 50);
+        QCOMPARE(overall.maxY, 50);
+        const TAreaSpanIndex::Extremes upstairs = index.extremesForZ(1);
+        QCOMPARE(upstairs.maxX, 50);
+        QCOMPARE(upstairs.maxY, 50);
+    }
+
     // The overall extremes are kept separately from the per-level ones, so a
     // level that comes and goes must not leave anything behind in them.
     void overallExtremesFollowLevelsThatComeAndGo()

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TDiscordModeTest.cpp
     WindowStateGettersTest.cpp
     MainConsoleSelectionTest.cpp
+    MapAreaReassignmentTest.cpp
     EnableDisableByNameTest.cpp
     UnitDeferredDeleteTest.cpp
     MxpFramePlacementTest.cpp
@@ -176,6 +177,10 @@ endif()
 # The round-trip tests boot a full mudlet instance and save/reload profile and
 # map data, so they need a longer timeout
 set_tests_properties(ProfileRoundTripTest MapRoundTripTest MapProgressDialogSeamTest MapCloseDuringImportTest PROPERTIES TIMEOUT 300)
+
+# MapAreaReassignmentTest reports a cost curve built from thousands of rooms,
+# which takes minutes rather than milliseconds if the quadratic term returns
+set_tests_properties(MapAreaReassignmentTest PROPERTIES TIMEOUT 300)
 
 # HostWidgetDecouplingTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(HostWidgetDecouplingTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/EmbeddedMapperCreationTest.cpp
+++ b/test/functional_tests/EmbeddedMapperCreationTest.cpp
@@ -134,7 +134,7 @@ private slots:
         const int playerAreaId = pRoomDB->addArea(mPlayerAreaName);
         QVERIFY(playerAreaId > 0);
         QVERIFY(pMap->addRoom(1));
-        QVERIFY(pMap->setRoomArea(1, playerAreaId, false));
+        QVERIFY(pMap->setRoomArea(1, playerAreaId));
         pMap->mRoomIdHash[pMap->mProfileName] = 1;
         pMap->setDefaultAreaShown(false);
         QVERIFY2(!pRoomDB->isEmpty(), "the map has to be non-empty for this to be the returning-user path");

--- a/test/functional_tests/MapAreaReassignmentTest.cpp
+++ b/test/functional_tests/MapAreaReassignmentTest.cpp
@@ -1,0 +1,702 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Moving a room between areas keeps every per-area index up to date without
+ * rescanning the areas involved.
+ *
+ * Most of the tests here work the same way: drive the map through the
+ * incremental path (TMap::setRoomArea, TMap::setRoomCoordinates), then force
+ * the authoritative full rescan (TArea::calcSpan + determineAreaExits) and
+ * require that it changes nothing - including the bytes of the saved map file,
+ * which stores the area extents and the area exit records.
+ *
+ * assigningARoomDoesNotRescanTheArea() is the odd one out: it asserts that the
+ * rescan does not happen at all, which is what the issue was about.
+ *
+ * Run with: ctest -R MapAreaReassignmentTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QElapsedTimer>
+#include <QFile>
+#include <QSaveFile>
+#include <QTemporaryDir>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TArea.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForMapAreaReassignmentTest();
+
+namespace {
+// Sizes for the reported cost curve: a per-room cost that climbs with them is
+// what an assignment that rescans the area looks like.
+const QList<int> scmScalingRoomCounts{1000, 2000, 4000, 8000};
+
+// Bounds of the Z levels and coordinates the tests place rooms on, so that the
+// per-area indexes can be sampled over a fixed range.
+const int scmProbedZMinimum = -8;
+const int scmProbedZMaximum = 8;
+const int scmProbedCoordinateLimit = 100000;
+
+// Deterministic and self-contained, so that a failure reproduces exactly.
+class SmallRandom
+{
+public:
+    explicit SmallRandom(quint32 seed)
+    : mState(seed)
+    {
+    }
+    int next(int bound)
+    {
+        mState = mState * 1103515245u + 12345u;
+        return static_cast<int>((mState >> 16) % static_cast<quint32>(bound));
+    }
+
+private:
+    quint32 mState;
+};
+} // namespace
+
+class MapAreaReassignmentTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("MapAreaReassignment-Test");
+    QTemporaryDir mSaveDir;
+
+    // Everything a saved map records about an area's rooms, plus the derived
+    // data the mapper draws from:
+    struct AreaState
+    {
+        QSet<int> rooms;
+        QList<int> zLevels;
+        QMap<int, int> xminForZ;
+        QMap<int, int> xmaxForZ;
+        QMap<int, int> yminForZ;
+        QMap<int, int> ymaxForZ;
+        int minX = 0;
+        int maxX = 0;
+        int minY = 0;
+        int maxY = 0;
+        int minZ = 0;
+        int maxZ = 0;
+        QList<int> exitRoomIds;
+        QMultiMap<int, QPair<QString, int>> exitData;
+        QMap<int, QSet<int>> roomsForZ;
+        QMap<int, QList<int>> roomsInGrid;
+
+        bool operator==(const AreaState& other) const
+        {
+            return rooms == other.rooms && zLevels == other.zLevels && xminForZ == other.xminForZ && xmaxForZ == other.xmaxForZ && yminForZ == other.yminForZ && ymaxForZ == other.ymaxForZ
+                   && minX == other.minX && maxX == other.maxX && minY == other.minY && maxY == other.maxY && minZ == other.minZ && maxZ == other.maxZ && exitRoomIds == other.exitRoomIds
+                   && exitData == other.exitData && roomsForZ == other.roomsForZ && roomsInGrid == other.roomsInGrid;
+        }
+    };
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+    TRoomDB* roomDB() const { return mpHost->mpMap->mpRoomDB.get(); }
+
+    AreaState captureAreaState(TArea* pArea) const
+    {
+        AreaState state;
+        state.rooms = pArea->rooms;
+        state.zLevels = pArea->zLevels;
+        state.xminForZ = pArea->xminForZ;
+        state.xmaxForZ = pArea->xmaxForZ;
+        state.yminForZ = pArea->yminForZ;
+        state.ymaxForZ = pArea->ymaxForZ;
+        state.minX = pArea->min_x;
+        state.maxX = pArea->max_x;
+        state.minY = pArea->min_y;
+        state.maxY = pArea->max_y;
+        state.minZ = pArea->min_z;
+        state.maxZ = pArea->max_z;
+        state.exitRoomIds = pArea->getAreaExitRoomIds();
+        state.exitData = pArea->getAreaExitRoomData();
+        // Sampled over a fixed range rather than over the area's own zLevels,
+        // so that entries for a Z level the area does not admit to having are
+        // still visible:
+        for (int z = scmProbedZMinimum; z <= scmProbedZMaximum; ++z) {
+            const QSet<int> roomsForZ = pArea->getRoomsForZ(z);
+            if (!roomsForZ.isEmpty()) {
+                state.roomsForZ.insert(z, roomsForZ);
+            }
+            QList<int> roomsInGrid = pArea->getGridIndex().roomsInViewport(z, -scmProbedCoordinateLimit, scmProbedCoordinateLimit, -scmProbedCoordinateLimit, scmProbedCoordinateLimit);
+            if (!roomsInGrid.isEmpty()) {
+                std::sort(roomsInGrid.begin(), roomsInGrid.end());
+                state.roomsInGrid.insert(z, roomsInGrid);
+            }
+        }
+        return state;
+    }
+
+    // Both of these are what map loading and the map auditor run to rebuild an
+    // area from its room set, so they define the expected answers.
+    static void recalculateFully(TArea* pArea)
+    {
+        pArea->determineAreaExits();
+        pArea->calcSpan();
+    }
+
+    QString describeMismatch(int areaId) const { return qsl("area %1 differs from a full recalculation").arg(areaId); }
+
+    bool everyAreaMatchesFullRecalculation(QString& firstMismatch) const
+    {
+        const QList<int> areaIds = roomDB()->getAreaIDList();
+        for (const int areaId : areaIds) {
+            TArea* pArea = roomDB()->getArea(areaId);
+            if (!pArea) {
+                continue;
+            }
+
+            const AreaState incremental = captureAreaState(pArea);
+            recalculateFully(pArea);
+            if (!(incremental == captureAreaState(pArea))) {
+                firstMismatch = describeMismatch(areaId);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool saveMapToFile(const QString& fileName) const
+    {
+        QSaveFile file(fileName);
+        if (!file.open(QIODevice::WriteOnly)) {
+            return false;
+        }
+        QDataStream out(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            out.setVersion(mudlet::scmQDataStreamFormat_5_12);
+        }
+        if (!map()->serialize(out, map()->mDefaultVersion)) {
+            return false;
+        }
+        return file.commit();
+    }
+
+    static QByteArray fileContents(const QString& fileName)
+    {
+        QFile file(fileName);
+        if (!file.open(QIODevice::ReadOnly)) {
+            return {};
+        }
+        return file.readAll();
+    }
+
+    void clearMap()
+    {
+        map()->mapClear();
+        QVERIFY(roomDB()->getRoomIDList().isEmpty());
+    }
+
+    // Two areas of nine rooms each on two z levels, wired up with normal and
+    // special exits within and across the areas, plus a couple of exit stubs
+    // that no area bookkeeping should ever touch.
+    void buildTwoAreaMap(int& areaA, int& areaB)
+    {
+        clearMap();
+        areaA = roomDB()->addArea(qsl("area A"));
+        areaB = roomDB()->addArea(qsl("area B"));
+        QVERIFY(areaA > 0);
+        QVERIFY(areaB > 0);
+
+        for (int i = 0; i < 18; ++i) {
+            const int roomId = 100 + i;
+            QVERIFY(map()->addRoom(roomId));
+            QVERIFY(map()->setRoomArea(roomId, i < 9 ? areaA : areaB));
+            QVERIFY(map()->setRoomCoordinates(roomId, (i % 3) * 5, (i % 4) * -3, i % 2));
+        }
+
+        for (int i = 0; i < 17; ++i) {
+            QVERIFY(map()->setExit(100 + i, 101 + i, DIR_EAST));
+            QVERIFY(map()->setExit(101 + i, 100 + i, DIR_WEST));
+        }
+        // Across the area boundary in both directions, plus a special exit
+        // pair that only the area of the *target* room decides on:
+        QVERIFY(map()->setExit(102, 112, DIR_UP));
+        QVERIFY(map()->setExit(112, 102, DIR_DOWN));
+        roomDB()->getRoom(103)->setSpecialExit(115, qsl("teleport"));
+        roomDB()->getRoom(115)->setSpecialExit(103, qsl("return"));
+        roomDB()->getRoom(104)->setExitStub(DIR_NORTH, true);
+        roomDB()->getRoom(113)->setExitStub(DIR_SOUTHWEST, true);
+    }
+
+    // Four areas of rooms on three Z levels, sharing plenty of coordinates,
+    // wired up with a mix of normal and special exits.
+    void buildRandomMap(QList<int>& areaIds, QList<int>& roomIds)
+    {
+        clearMap();
+        for (int i = 0; i < 4; ++i) {
+            const int areaId = roomDB()->addArea(qsl("random area %1").arg(i));
+            QVERIFY(areaId > 0);
+            areaIds.append(areaId);
+        }
+
+        SmallRandom random(20260810u);
+        for (int i = 0; i < 60; ++i) {
+            const int roomId = 200 + i;
+            QVERIFY(map()->addRoom(roomId));
+            QVERIFY(map()->setRoomArea(roomId, areaIds.at(random.next(areaIds.count()))));
+            QVERIFY(map()->setRoomCoordinates(roomId, random.next(7) - 3, random.next(7) - 3, random.next(3) - 1));
+            roomIds.append(roomId);
+        }
+        for (int i = 0; i < 80; ++i) {
+            const int from = roomIds.at(random.next(roomIds.count()));
+            const int to = roomIds.at(random.next(roomIds.count()));
+            if (from == to) {
+                continue;
+            }
+            if (random.next(4) == 0) {
+                roomDB()->getRoom(from)->setSpecialExit(to, qsl("special%1").arg(i));
+            } else {
+                QVERIFY(map()->setExit(from, to, DIR_NORTH + (i % 8)));
+            }
+        }
+
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    void applyRandomOperation(SmallRandom& random, const QList<int>& areaIds, const QList<int>& roomIds, int step)
+    {
+        const int roomId = roomIds.at(random.next(roomIds.count()));
+        switch (random.next(3)) {
+        case 0:
+            QVERIFY(map()->setRoomArea(roomId, areaIds.at(random.next(areaIds.count()))));
+            break;
+        case 1:
+            QVERIFY(map()->setRoomCoordinates(roomId, random.next(9) - 4, random.next(9) - 4, random.next(3) - 1));
+            break;
+        default:
+            QVERIFY(map()->setExit(roomId, roomIds.at(random.next(roomIds.count())), DIR_NORTH + (step % 8)));
+            break;
+        }
+    }
+
+    // Returns the nanoseconds spent per room, or 0.0 if anything went wrong.
+    double buildRoomsIntoOneArea(int roomCount)
+    {
+        map()->mapClear();
+        const int areaId = roomDB()->addArea(qsl("bulk area"));
+        if (areaId <= 0) {
+            return 0.0;
+        }
+
+        QElapsedTimer timer;
+        timer.start();
+        for (int i = 0; i < roomCount; ++i) {
+            const int roomId = 1 + i;
+            if (!map()->addRoom(roomId) || !map()->setRoomCoordinates(roomId, i % 128, i / 128, 0) || !map()->setRoomArea(roomId, areaId)) {
+                return 0.0;
+            }
+        }
+        return static_cast<double>(timer.nsecsElapsed()) / roomCount;
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForMapAreaReassignmentTest();
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        QVERIFY(mSaveDir.isValid());
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+        QVERIFY(map());
+    }
+
+    void cleanupTestCase() { deleteProfileDirectory(mProfileName); }
+
+    // The room, its coordinates and its exits all end up where they should.
+    void roomChangesArea()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        TArea* pAreaA = roomDB()->getArea(areaA);
+        TArea* pAreaB = roomDB()->getArea(areaB);
+        QVERIFY(pAreaA);
+        QVERIFY(pAreaB);
+        TRoom* pRoom = roomDB()->getRoom(104);
+        QVERIFY(pRoom);
+        const int z = pRoom->z();
+
+        QVERIFY(pAreaA->getAreaRooms().contains(104));
+        QVERIFY(pAreaA->getRoomsForZ(z).contains(104));
+
+        QVERIFY(map()->setRoomArea(104, areaB));
+
+        QCOMPARE(pRoom->getArea(), areaB);
+        QVERIFY(!pAreaA->getAreaRooms().contains(104));
+        QVERIFY(!pAreaA->getRoomsForZ(z).contains(104));
+        QVERIFY(pAreaB->getAreaRooms().contains(104));
+        QVERIFY(pAreaB->getRoomsForZ(z).contains(104));
+        QVERIFY(pAreaB->getGridIndex().roomsAt(z, pRoom->x(), pRoom->y()).contains(104));
+
+        // The room's own exits and stubs are none of the area's business:
+        QCOMPARE(pRoom->getEast(), 105);
+        QCOMPARE(pRoom->getWest(), 103);
+        QVERIFY(pRoom->exitStubs.contains(DIR_NORTH));
+
+        // Its neighbours in the area it left now exit that area through it,
+        // and it exits its new area through them:
+        QVERIFY(pAreaA->getAreaExitRoomIds().contains(103));
+        QVERIFY(pAreaA->getAreaExitRoomIds().contains(105));
+        QVERIFY(pAreaB->getAreaExitRoomIds().contains(104));
+
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // Special exits are decided by the area of the room they lead to, so a
+    // move has to be reflected in the records of the rooms leading to it.
+    void specialExitsFollowTheMovedRoom()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        TArea* pAreaA = roomDB()->getArea(areaA);
+        QVERIFY(pAreaA);
+        // Room 103 (area A) has a special exit to room 115 (area B), so it is
+        // an area exit of A until 115 joins A too:
+        QVERIFY(pAreaA->getAreaExitRoomIds().contains(103));
+
+        QVERIFY(map()->setRoomArea(115, areaA));
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        QVERIFY(map()->setRoomArea(115, areaB));
+        QVERIFY(pAreaA->getAreaExitRoomIds().contains(103));
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // Emptying an area and moving every room back again.
+    void areaEmptiedAndRefilled()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        TArea* pAreaA = roomDB()->getArea(areaA);
+        QVERIFY(pAreaA);
+        const QList<int> areaARooms = pAreaA->getAreaRooms().values();
+        QVERIFY(areaARooms.count() > 1);
+        for (int i = 0; i < areaARooms.count() - 1; ++i) {
+            QVERIFY(map()->setRoomArea(areaARooms.at(i), areaB));
+        }
+
+        const int maxXOfTheLastRoom = pAreaA->max_x;
+        const int maxYOfTheLastRoom = pAreaA->max_y;
+        QVERIFY(map()->setRoomArea(areaARooms.constLast(), areaB));
+        QVERIFY(pAreaA->getAreaRooms().isEmpty());
+        QVERIFY(pAreaA->zLevels.isEmpty());
+        QVERIFY(pAreaA->xminForZ.isEmpty());
+        QVERIFY(pAreaA->ymaxForZ.isEmpty());
+        // The overall extents are the one thing an emptied area holds on to,
+        // and they are written into the map file, so they are pinned here
+        // rather than only compared against the rescan (which keeps them too):
+        QCOMPARE(pAreaA->max_x, maxXOfTheLastRoom);
+        QCOMPARE(pAreaA->max_y, maxYOfTheLastRoom);
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        for (const int roomId : areaARooms) {
+            QVERIFY(map()->setRoomArea(roomId, areaA));
+        }
+        QCOMPARE(pAreaA->getAreaRooms().count(), areaARooms.count());
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // The default area is the one every room starts out claiming to be in
+    // without ever being added to it, so it is the one most likely to collect
+    // rooms it does not hold.
+    void movesToAndFromTheDefaultArea()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        TArea* pDefaultArea = roomDB()->getArea(-1);
+        QVERIFY(pDefaultArea);
+        QVERIFY2(pDefaultArea->getAreaRooms().isEmpty(), "rooms that were never in the default area must not be recorded in it");
+        for (int z = scmProbedZMinimum; z <= scmProbedZMaximum; ++z) {
+            QVERIFY2(pDefaultArea->getRoomsForZ(z).isEmpty(), "the default area's Z index must not collect rooms it does not hold");
+            QVERIFY(pDefaultArea->getGridIndex().roomsInViewport(z, -scmProbedCoordinateLimit, scmProbedCoordinateLimit, -scmProbedCoordinateLimit, scmProbedCoordinateLimit).isEmpty());
+        }
+
+        QVERIFY(map()->setRoomArea(104, -1));
+        QCOMPARE(roomDB()->getRoom(104)->getArea(), -1);
+        QVERIFY(pDefaultArea->getAreaRooms().contains(104));
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        QVERIFY(map()->setRoomArea(104, areaA));
+        QVERIFY(pDefaultArea->getAreaRooms().isEmpty());
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // Moving a room to the area it is already in is a removal and an addition
+    // of the same room, which has to leave the coordinate refcounts as it
+    // found them.
+    void movingARoomToItsOwnArea()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        TArea* pAreaA = roomDB()->getArea(areaA);
+        QVERIFY(pAreaA);
+        const AreaState before = captureAreaState(pAreaA);
+
+        QVERIFY(map()->setRoomArea(104, areaA));
+        QVERIFY2(before == captureAreaState(pAreaA), "moving a room to its own area changed the area");
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // Coordinate changes and room deletions shrink the area extents as much as
+    // a rescan would.
+    void movedAndDeletedRoomsShrinkTheExtents()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        QVERIFY(map()->setRoomCoordinates(107, 4000, -4000, 7));
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        QVERIFY(map()->setRoomCoordinates(107, 1, 1, 0));
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        QSet<int> toRemove{106, 107};
+        roomDB()->removeRoom(toRemove);
+        QVERIFY(!roomDB()->getArea(areaA)->getAreaRooms().contains(106));
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        // Room 112 is in area B and is what room 102 in area A exits up to, so
+        // deleting it retires an area exit record as well as a room:
+        QVERIFY(roomDB()->getArea(areaA)->getAreaExitRoomIds().contains(102));
+        QVERIFY(roomDB()->removeRoom(112));
+        QVERIFY(!roomDB()->getArea(areaB)->getAreaRooms().contains(112));
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // A long random sequence of the operations that maintain the indexes,
+    // checked against a full recalculation after every step so that a failure
+    // says which step broke it.
+    void randomOperationsMatchFullRecalculation()
+    {
+        QList<int> areaIds;
+        QList<int> roomIds;
+        buildRandomMap(areaIds, roomIds);
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+
+        SmallRandom random(1234567u);
+        QString mismatch;
+        for (int step = 0; step < 300; ++step) {
+            applyRandomOperation(random, areaIds, roomIds, step);
+            if (QTest::currentTestFailed()) {
+                return;
+            }
+            QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(qsl("step %1: %2").arg(step).arg(mismatch)));
+        }
+    }
+
+    // The same sequence without the intermediate recalculations, which are a
+    // repair as much as a check: only this run can catch bookkeeping that
+    // drifts over many operations rather than in one.
+    void randomOperationsWithoutIntermediateRecalculation()
+    {
+        QList<int> areaIds;
+        QList<int> roomIds;
+        buildRandomMap(areaIds, roomIds);
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+
+        SmallRandom random(7654321u);
+        for (int step = 0; step < 300; ++step) {
+            applyRandomOperation(random, areaIds, roomIds, step);
+            if (QTest::currentTestFailed()) {
+                return;
+            }
+        }
+
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // The map file records the area extents and the area exits, so a map built
+    // by moving rooms around has to serialize to the same bytes as one whose
+    // areas were rebuilt from scratch.
+    void savedMapDoesNotDependOnHowTheAreasWereBuilt()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+        for (int i = 0; i < 9; i += 2) {
+            QVERIFY(map()->setRoomArea(100 + i, areaB));
+            QVERIFY(map()->setRoomArea(109 + i, areaA));
+        }
+
+        const QString incrementalFile = qsl("%1/incremental.dat").arg(mSaveDir.path());
+        QVERIFY(saveMapToFile(incrementalFile));
+
+        const QList<int> areaIds = roomDB()->getAreaIDList();
+        for (const int areaId : areaIds) {
+            if (TArea* pArea = roomDB()->getArea(areaId)) {
+                recalculateFully(pArea);
+            }
+        }
+
+        const QString recalculatedFile = qsl("%1/recalculated.dat").arg(mSaveDir.path());
+        QVERIFY(saveMapToFile(recalculatedFile));
+
+        const QByteArray incrementalBytes = fileContents(incrementalFile);
+        QVERIFY(!incrementalBytes.isEmpty());
+        QCOMPARE(incrementalBytes, fileContents(recalculatedFile));
+
+        map()->mapClear();
+        QVERIFY(map()->restore(incrementalFile));
+        map()->audit();
+        QCOMPARE(roomDB()->getRoomIDList().count(), 18);
+        QString mismatch;
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+
+        // A loaded map has to go on being maintained incrementally:
+        const int loadedAreaB = roomDB()->getAreaNamesMap().key(qsl("area B"));
+        QVERIFY(loadedAreaB > 0);
+        for (int i = 0; i < 18; i += 3) {
+            QVERIFY(map()->setRoomArea(100 + i, loadedAreaB));
+        }
+        QVERIFY2(everyAreaMatchesFullRecalculation(mismatch), qPrintable(mismatch));
+    }
+
+    // Assigning a room to an area must not rescan the area, whatever the
+    // machine's clock says. A room that the area's room set claims but that
+    // lives somewhere else is invisible to the incremental bookkeeping and
+    // impossible for a rescan to miss, so the extents say which one ran.
+    void assigningARoomDoesNotRescanTheArea()
+    {
+        int areaA = 0;
+        int areaB = 0;
+        buildTwoAreaMap(areaA, areaB);
+
+        TArea* pAreaA = roomDB()->getArea(areaA);
+        QVERIFY(pAreaA);
+        TRoom* pStranger = roomDB()->getRoom(117);
+        QVERIFY(pStranger);
+        QCOMPARE(pStranger->getArea(), areaB);
+        QVERIFY(map()->setRoomCoordinates(117, 6000, -6000, 0));
+
+        const int maxXBefore = pAreaA->max_x;
+        const int maxYBefore = pAreaA->max_y;
+        pAreaA->rooms.insert(117);
+
+        QVERIFY(map()->setRoomArea(105, areaB));
+        QVERIFY(map()->setRoomArea(105, areaA));
+        QCOMPARE(pAreaA->max_x, maxXBefore);
+        QCOMPARE(pAreaA->max_y, maxYBefore);
+
+        // ... and the same probe run through the rescan, to show that it does
+        // report the stranger and so could have failed above:
+        pAreaA->calcSpan();
+        QCOMPARE(pAreaA->max_x, 6000);
+        QCOMPARE(pAreaA->max_y, 6000);
+    }
+
+    // Reported rather than asserted on: a timing threshold is not dependable
+    // on a machine that is running the rest of the test suite at the same
+    // time. assigningARoomDoesNotRescanTheArea() is the check that has teeth.
+    void bulkAreaAssignmentCostPerRoom()
+    {
+        // Untimed, so that the first timed run is not the one that pays for
+        // warming the allocator up:
+        buildRoomsIntoOneArea(scmScalingRoomCounts.constFirst());
+
+        for (const int roomCount : scmScalingRoomCounts) {
+            double perRoom = 0.0;
+            for (int repeat = 0; repeat < 2; ++repeat) {
+                // The best of several runs is the one least disturbed by
+                // whatever else the machine is doing:
+                const double thisRun = buildRoomsIntoOneArea(roomCount);
+                QVERIFY2(thisRun > 0.0, "building the rooms failed");
+                perRoom = (repeat == 0) ? thisRun : qMin(perRoom, thisRun);
+            }
+            qInfo().nospace() << "built " << roomCount << " rooms in " << (perRoom * roomCount * 1.0e-9) << "s (" << (perRoom * 1.0e-3) << "us per room)";
+        }
+    }
+};
+
+void initializeQRCResourcesForMapAreaReassignmentTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "MapAreaReassignmentTest.moc"
+QTEST_MAIN(MapAreaReassignmentTest)

--- a/test/functional_tests/MapCloseDuringImportTest.cpp
+++ b/test/functional_tests/MapCloseDuringImportTest.cpp
@@ -96,7 +96,7 @@ private:
             QVERIFY(areaId > 0);
             for (int room = 0; room < 5; ++room, ++roomId) {
                 QVERIFY(pMap->addRoom(roomId));
-                QVERIFY(pMap->setRoomArea(roomId, areaId, false));
+                QVERIFY(pMap->setRoomArea(roomId, areaId));
                 QVERIFY(pMap->setRoomCoordinates(roomId, room, area, 0));
             }
         }

--- a/test/functional_tests/MapProgressDialogSeamTest.cpp
+++ b/test/functional_tests/MapProgressDialogSeamTest.cpp
@@ -78,7 +78,7 @@ private:
         for (const int areaId : {areaA, areaB}) {
             for (int i = 0; i < 3; ++i, ++id) {
                 QVERIFY(pMap->addRoom(id));
-                QVERIFY(pMap->setRoomArea(id, areaId, false));
+                QVERIFY(pMap->setRoomArea(id, areaId));
                 QVERIFY(pMap->setRoomCoordinates(id, i, i, 0));
             }
         }

--- a/test/functional_tests/MapRoundTripTest.cpp
+++ b/test/functional_tests/MapRoundTripTest.cpp
@@ -166,7 +166,7 @@ private:
 
         for (const int id : {scmRoom1, scmRoom2, scmRoom3, scmRoom4}) {
             QVERIFY(pMap->addRoom(id));
-            QVERIFY(pMap->setRoomArea(id, id == scmRoom4 ? mAreaB : mAreaA, false));
+            QVERIFY(pMap->setRoomArea(id, id == scmRoom4 ? mAreaB : mAreaA));
         }
         QVERIFY(pMap->setRoomCoordinates(scmRoom1, 0, 0, 0));
         QVERIFY(pMap->setRoomCoordinates(scmRoom2, -3, 7, 0));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `TArea` keeps its coordinate extents and its area-exit records up to date as rooms join, leave and move, instead of rebuilding both from every room in the area on each `setRoomArea()`
- new `TAreaSpanIndex` holds the extents as sorted counts of the distinct coordinates in use, so an extreme is a first/last key rather than a scan; `calcSpan()` stays the authoritative full rebuild that map loading and the auditor rely on
- two fixes found on the way: deleting a room left a stale area-exit record behind in every area that exited to it, and area extents did not shrink when a script moved a room with `setRoomCoordinates()`

#### Motivation for adding to Mudlet
Mudlet is single-threaded, so a mapper script importing a large area froze the client for minutes: 15,000 rooms took 66 s here (146 s as reported), and now takes 0.4 s.

#### Other info (issues closed, discussion etc)
Fixes #9759. Not a 5.0 regression - 4.22.0 behaves the same, measured against a 4.22-era build.

Cost of building a map room by room from Lua, same machine, before -> after:

| rooms | before | after |
|---|---|---|
| 1,000 | 0.23 s | 0.005 s |
| 2,000 | 0.89 s | 0.013 s |
| 4,000 | 3.57 s | 0.039 s |
| 8,000 | 14.4 s | 0.129 s |
| 15,000 | 66.6 s | 0.44 s |

The map file format is untouched: `MapRoundTripTest` still passes at every format version, and the new test saves a map built by moving rooms around and one whose areas were rebuilt from scratch and compares the two files byte for byte. What is left of the curve above is `createRoomID()`, which scans room ids from 1 upwards on every call - a separate defect, worth its own issue (with sequential ids the same run is flat at 3.2 us per room).

**Test case:** `ctest -R "MapAreaReassignmentTest|TAreaSpanIndexTest|MapRoundTripTest" -V`, or from a profile's command line: `local t=os.clock() for i=1,15000 do local id=createRoomID() addRoom(id) setRoomCoordinates(id,i%128,i//128,0) setRoomArea(id,1) end echo(os.clock()-t)`