### PR TITLE
fix: gauges no longer make every line of game text expensive

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserColor.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserColor.lua
@@ -103,9 +103,13 @@ function Geyser.Color.parse(red, green, blue, alpha)
       elseif string.find(red, "^<") then
         next_num = string.gmatch(red, "%d+")
 
+      else
         -- fourth case is a named string
-      elseif Geyser.Color.find_color_name(red) then
         local col = Geyser.Color.find_color_name(red)
+        if not col then
+          -- finally, no matches, do nothing
+          return
+        end
         local i = 0
         local n = #color_table[col]
         next_num = function()
@@ -116,10 +120,6 @@ function Geyser.Color.parse(red, green, blue, alpha)
           else return nil
           end
         end
-
-      else
-        -- finally, no matches, do nothing
-        return
       end
     end
 
@@ -147,6 +147,20 @@ function Geyser.Color.parse(red, green, blue, alpha)
   return r, g, b, a
 end
 
+-- Lower cased name -> the name as color_table spells it. color_table holds
+-- around 500 entries and a lookup runs on every echo that carries a named
+-- colour, so scanning it is the single most expensive thing a Geyser label does.
+local colorNamesByLowerCase
+
+local function indexColorNames()
+  local index = {}
+  for name in pairs(color_table) do
+    index[name:lower()] = name
+  end
+  colorNamesByLowerCase = index
+  return index
+end
+
 --- Searches for a close match to 'color' in the color_table
 --  Returns the color found, or false if it can't find one
 -- @param color the color name you're trying to find
@@ -154,11 +168,23 @@ function Geyser.Color.find_color_name(color)
   if type(color) ~= "string" then
     return false
   end
-  color = color:lower()
-  color = color:gsub("_", "")
-  for color_name,_ in pairs(color_table) do
-    if color_name:lower() == color then
-      return color_name
+  -- underscores are stripped from what is asked for but not from what
+  -- color_table holds, so "light_blue" finds "lightblue" and not "light_blue"
+  local wanted = color:lower():gsub("_", "")
+  local index = colorNamesByLowerCase or indexColorNames()
+  local found = index[wanted]
+  if found and color_table[found] then
+    return found
+  end
+  -- either the index has never seen this name or color_table no longer holds
+  -- what it points at, so the index predates a change to the table. Scan for the
+  -- answer, which costs what the whole lookup used to, and rebuild the index
+  -- only when there was one to find - a name that is not a colour at all is the
+  -- answer a script asking "is this a colour?" wants, not a reason to reindex.
+  for name in pairs(color_table) do
+    if name:lower() == wanted then
+      indexColorNames()
+      return name
     end
   end
   return false

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -170,6 +170,91 @@ local function extractCSSSpacing(css, property)
   return spacing.left, spacing.right, spacing.top, spacing.bottom, unreadable
 end
 
+-- Reads the back label's margin, border and padding as one set of offsets, kept
+-- against the stylesheet they were read from: setValue runs on every prompt in
+-- most UIs and these three readings cost more than everything else it does,
+-- while the stylesheet behind them changes about once a session.
+-- @return left, right, top, bottom, and the first declaration that held a
+--         length with no pixel reading
+local function backSpacing(gauge)
+  local css = gauge.backCSS
+  local cached = gauge.backSpacingCache
+  -- read is its own flag because a gauge with no back stylesheet at all has a
+  -- css of nil, which is a reading in its own right
+  if cached.read and cached.css == css then
+    return cached.left, cached.right, cached.top, cached.bottom, cached.unreadable
+  end
+
+  local left, right, top, bottom, unreadable = 0, 0, 0, 0, nil
+  if css then
+    local ml, mr, mt, mb, marginUnreadable = extractCSSSpacing(css, "margin")
+    local bl, br, bt, bb, borderUnreadable = extractCSSSpacing(css, "border")
+    local pl, pr, pt, pb, paddingUnreadable = extractCSSSpacing(css, "padding")
+    left, right, top, bottom = ml + bl + pl, mr + br + pr, mt + bt + pt, mb + bb + pb
+    unreadable = marginUnreadable or borderUnreadable or paddingUnreadable
+  end
+
+  cached.read, cached.css = true, css
+  cached.left, cached.right, cached.top, cached.bottom, cached.unreadable = left, right, top, bottom, unreadable
+  return left, right, top, bottom, unreadable
+end
+
+-- Gives the front label the constraints for one orientation. They are functions
+-- rather than "<n>px" because a negative pixel constraint is measured from the
+-- opposite edge, which is not what a negative margin asks for, and they read the
+-- gauge's fill table rather than closing over its numbers, so that a new value
+-- costs a layout pass and not a fresh set of constraints. Only the back label's
+-- spacing is compensated for: Qt lays the front label's own border and padding
+-- outside its content area, and setStyleSheet strips its margins.
+local function setFrontConstraints(gauge)
+  local fill = gauge.frontFill
+  local front = gauge.front
+  local orientation = gauge.orientation
+
+  if orientation == "horizontal" then
+    front.x = function() return fill.left end
+    front.y = function() return fill.top end
+    front.width = function()
+      return math.floor((gauge.back.get_width() - fill.left - fill.right) * (fill.value / 100) + 0.5)
+    end
+    front.height = function() return math.floor(gauge.back.get_height() - fill.top - fill.bottom + 0.5) end
+  elseif orientation == "vertical" then
+    -- bottom to top, so an emptier gauge starts further down
+    front.x = function() return fill.left end
+    front.y = function()
+      return fill.top + math.floor((gauge.back.get_height() - fill.top - fill.bottom) * (1 - fill.value / 100) + 0.5)
+    end
+    front.width = function() return math.floor(gauge.back.get_width() - fill.left - fill.right + 0.5) end
+    front.height = function()
+      return math.floor((gauge.back.get_height() - fill.top - fill.bottom) * (fill.value / 100) + 0.5)
+    end
+  elseif orientation == "goofy" then
+    -- right to left, so an emptier gauge starts further right
+    front.x = function()
+      return fill.left + math.floor((gauge.back.get_width() - fill.left - fill.right) * (1 - fill.value / 100) + 0.5)
+    end
+    front.y = function() return fill.top end
+    front.width = function()
+      return math.floor((gauge.back.get_width() - fill.left - fill.right) * (fill.value / 100) + 0.5)
+    end
+    front.height = function() return math.floor(gauge.back.get_height() - fill.top - fill.bottom + 0.5) end
+  else -- batty (top to bottom), and anything the gauge cannot make sense of
+    front.x = function() return fill.left end
+    front.y = function() return fill.top end
+    front.width = function() return math.floor(gauge.back.get_width() - fill.left - fill.right + 0.5) end
+    front.height = function()
+      return math.floor((gauge.back.get_height() - fill.top - fill.bottom) * (fill.value / 100) + 0.5)
+    end
+  end
+
+  -- the constraints as installed, so that anything that replaces one of them -
+  -- an autoAdjustSize on the front label, a script moving it by hand - is
+  -- noticed and undone on the next update rather than sticking for good
+  fill.orientation = orientation
+  fill.x, fill.y, fill.width, fill.height = front.x, front.y, front.width, front.height
+  front:set_constraints(front)
+end
+
 --- Sets the gauge amount.
 -- @param currentValue Current numeric value, or if maxValue is omitted, then
 --        it is assumed that currentValue is a value between 0 and 100 and is
@@ -206,88 +291,41 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
 -- prevent the gauge from overflowing its borders if currentValue > maxValue if gauge is set to be strict
   if self.strict and self.value > 100 then self.value = 100 end
   
-  -- Calculate spacing from the back label's CSS (margins, borders, padding)
-  -- This fixes issue #5344: gauges with margins were misaligned
-  local leftOffset, rightOffset, topOffset, bottomOffset = 0, 0, 0, 0
-  
-  if self.backCSS then
-    local ml, mr, mt, mb, marginUnreadable = extractCSSSpacing(self.backCSS, "margin")
-    local bl, br, bt, bb, borderUnreadable = extractCSSSpacing(self.backCSS, "border")
-    local pl, pr, pt, pb, paddingUnreadable = extractCSSSpacing(self.backCSS, "padding")
+  -- the constructor makes both of these; a gauge that got here without them is
+  -- given them rather than made to error
+  self.frontFill = self.frontFill or {}
+  self.backSpacingCache = self.backSpacingCache or {}
 
-    leftOffset = ml + bl + pl
-    rightOffset = mr + br + pr
-    topOffset = mt + bt + pt
-    bottomOffset = mb + bb + pb
+  -- Spacing from the back label's CSS (margins, borders, padding), so that a
+  -- gauge with margins is not misaligned (issue #5344)
+  local leftOffset, rightOffset, topOffset, bottomOffset, unreadable = backSpacing(self)
 
-    -- Qt still applies a spacing Geyser cannot measure, so the fill bar ends up
-    -- laid out against the wrong box and spills past the gauge's frame. Say so
-    -- rather than leave it looking like a Geyser bug - latched, because setValue
-    -- runs on every prompt.
-    local unreadable = marginUnreadable or borderUnreadable or paddingUnreadable
-    if unreadable and not self.warnedUnreadableCSS then
-      self.warnedUnreadableCSS = true
-      debugc(string.format(
-        "Geyser.Gauge: gauge '%s' has a stylesheet spacing Geyser cannot measure in pixels (%s), so it is left out of the fill bar's position - use px or unitless lengths",
-        self.name, unreadable))
-    end
+  -- Qt still applies a spacing Geyser cannot measure, so the fill bar ends up
+  -- laid out against the wrong box and spills past the gauge's frame. Say so
+  -- rather than leave it looking like a Geyser bug - latched, because setValue
+  -- runs on every prompt.
+  if unreadable and not self.warnedUnreadableCSS then
+    self.warnedUnreadableCSS = true
+    debugc(string.format(
+      "Geyser.Gauge: gauge '%s' has a stylesheet spacing Geyser cannot measure in pixels (%s), so it is left out of the fill bar's position - use px or unitless lengths",
+      self.name, unreadable))
   end
-  
-  -- Update gauge in the requested orientation
-  -- Note: We use function-based constraints for dynamic sizing that accounts for margins
-  -- The front label can have its own borders and padding (margins are stripped in setStyleSheet)
-  -- Qt applies border/padding outside the widget's content area, so we don't need to compensate for them
-  -- The offsets are given as functions rather than as "<n>px": a negative pixel
-  -- constraint is measured from the opposite edge, which is not what a negative
-  -- margin asks for
 
-  if self.orientation == "horizontal" then
-    -- Position the front label inside the back's content area
-    self.front:move(function() return leftOffset end, function() return topOffset end)
-    -- For width: we want value% of the CONTENT width (back label's content area)
-    -- Content width = back_label_width - leftOffset - rightOffset
-    local totalBackOffset = leftOffset + rightOffset
-    local gaugeValue = self.value
-    self.front:resize(
-      function() return math.floor((self.back.get_width() - totalBackOffset) * (gaugeValue / 100) + 0.5) end,
-      function() return math.floor(self.back.get_height() - topOffset - bottomOffset + 0.5) end
-    )
-  elseif self.orientation == "vertical" then
-    -- For vertical (bottom-to-top), position needs to be calculated based on remaining space
-    -- At 100%: y = topOffset (fills from top to bottom of content area)
-    -- At 0%: y = topOffset + contentHeight (zero height at bottom)
-    local totalBackOffset = topOffset + bottomOffset
-    local gaugeValue = self.value
-    self.front:move(
-      function() return leftOffset end,
-      function() return topOffset + math.floor((self.back.get_height() - totalBackOffset) * (1 - gaugeValue / 100) + 0.5) end
-    )
-    self.front:resize(
-      function() return math.floor(self.back.get_width() - leftOffset - rightOffset + 0.5) end,
-      function() return math.floor((self.back.get_height() - totalBackOffset) * (gaugeValue / 100) + 0.5) end
-    )
-  elseif self.orientation == "goofy" then
-    -- For goofy (right-to-left), position needs to be calculated based on remaining space
-    -- At 100%: x = leftOffset (fills from left to right edge)
-    -- At 0%: x = leftOffset + contentWidth (zero width at right edge)
-    local totalBackOffset = leftOffset + rightOffset
-    local gaugeValue = self.value
-    self.front:move(
-      function() return leftOffset + math.floor((self.back.get_width() - totalBackOffset) * (1 - gaugeValue / 100) + 0.5) end,
-      function() return topOffset end
-    )
-    self.front:resize(
-      function() return math.floor((self.back.get_width() - totalBackOffset) * (gaugeValue / 100) + 0.5) end,
-      function() return math.floor(self.back.get_height() - topOffset - bottomOffset + 0.5) end
-    )
-  else -- batty (top to bottom)
-    self.front:move(function() return leftOffset end, function() return topOffset end)
-    local totalBackOffset = topOffset + bottomOffset
-    local gaugeValue = self.value
-    self.front:resize(
-      function() return math.floor(self.back.get_width() - leftOffset - rightOffset + 0.5) end,
-      function() return math.floor((self.back.get_height() - totalBackOffset) * (gaugeValue / 100) + 0.5) end
-    )
+  local fill = self.frontFill
+  local moved = fill.value ~= self.value or fill.left ~= leftOffset or fill.right ~= rightOffset
+                or fill.top ~= topOffset or fill.bottom ~= bottomOffset
+  fill.value, fill.left, fill.right, fill.top, fill.bottom = self.value, leftOffset, rightOffset, topOffset, bottomOffset
+
+  -- The constraints read the fill table, so a new value only needs the front
+  -- label laid out again, and a gauge sitting on the value it already has -
+  -- which the gauges a UI repaints wholesale on every prompt usually are - does
+  -- not even need that.
+  local front = self.front
+  if fill.orientation ~= self.orientation or front.x ~= fill.x or front.y ~= fill.y
+     or front.width ~= fill.width or front.height ~= fill.height then
+    setFrontConstraints(self)
+  elseif moved then
+    front:reposition()
   end
 
   if text then
@@ -472,6 +510,11 @@ function Geyser.Gauge:new (cons, container)
   setmetatable(me, self)
   self.__index = self
   me.windowname = me.windowname or me.container.windowname or "main"
+
+  -- what the front label was last laid out against, and the reading taken off
+  -- the back label's stylesheet
+  me.frontFill = {}
+  me.backSpacingCache = {}
 
   -- Now create the Gauge using primitives and tastey classes
 

--- a/src/mudlet-lua/tests/GeyserColor_spec.lua
+++ b/src/mudlet-lua/tests/GeyserColor_spec.lua
@@ -1,0 +1,90 @@
+describe("Tests functionality of Geyser.Color", function()
+  describe("Geyser.Color.find_color_name", function()
+    it("finds a colour however it is capitalised", function()
+      assert.are.equal("white", Geyser.Color.find_color_name("white"))
+      assert.are.equal("white", Geyser.Color.find_color_name("WHITE"))
+      assert.are.equal("white", Geyser.Color.find_color_name("White"))
+    end)
+
+    -- underscores come out of what is asked for but not out of what color_table
+    -- holds, so an underscored name only finds an unspaced entry
+    it("strips underscores from the name it is given", function()
+      assert.are.equal("LightBlue", Geyser.Color.find_color_name("light_blue"))
+      assert.are.equal("LightBlue", Geyser.Color.find_color_name("lightblue"))
+    end)
+
+    it("answers false for anything that is not a colour name", function()
+      assert.is_false(Geyser.Color.find_color_name("no_such_colour_at_all"))
+      assert.is_false(Geyser.Color.find_color_name(nil))
+      assert.is_false(Geyser.Color.find_color_name(42))
+      assert.is_false(Geyser.Color.find_color_name({}))
+    end)
+
+    -- the lookup is indexed rather than scanned, so an index built before a
+    -- script added its own colour has to notice it
+    it("finds a colour added to color_table after the first lookup", function()
+      assert.is_false(Geyser.Color.find_color_name("gcsAddedColour"))
+      finally(function() color_table.gcsAddedColour = nil end)
+      color_table.gcsAddedColour = {12, 34, 56}
+      assert.are.equal("gcsAddedColour", Geyser.Color.find_color_name("gcsaddedcolour"))
+      assert.are.same({12, 34, 56, 255}, {Geyser.Color.parse("gcsAddedColour")})
+    end)
+
+    it("stops finding a colour taken back out of color_table", function()
+      local restore = color_table.white
+      finally(function() color_table.white = restore end)
+      assert.are.equal("white", Geyser.Color.find_color_name("white"))
+      color_table.white = nil
+      assert.is_false(Geyser.Color.find_color_name("white"))
+      -- and putting it back finds it again, so nothing later in the suite
+      -- inherits a lookup that has lost white
+      color_table.white = restore
+      assert.are.equal("white", Geyser.Color.find_color_name("white"))
+    end)
+  end)
+
+  describe("Geyser.Color.parse", function()
+    it("reads a named colour", function()
+      assert.are.same({255, 255, 255, 255}, {Geyser.Color.parse("white")})
+    end)
+
+    it("reads hex, hecho, 0x and decho forms", function()
+      assert.are.same({170, 0, 255, 255}, {Geyser.Color.parse("#AA00FF")})
+      assert.are.same({170, 0, 255, 255}, {Geyser.Color.parse("|cAA00FF")})
+      assert.are.same({170, 0, 255, 255}, {Geyser.Color.parse("0xAA00FF")})
+      assert.are.same({190, 0, 255, 255}, {Geyser.Color.parse("<190,0,255>")})
+      assert.are.same({190, 0, 255, 128}, {Geyser.Color.parse("<190,0,255,128>")})
+    end)
+
+    it("reads discrete components and a table", function()
+      assert.are.same({1, 2, 3, 255}, {Geyser.Color.parse(1, 2, 3)})
+      assert.are.same({1, 2, 3, 4}, {Geyser.Color.parse(1, 2, 3, 4)})
+      assert.are.same({1, 2, 3, 4}, {Geyser.Color.parse({r = 1, g = 2, b = 3, a = 4})})
+    end)
+
+    -- only the names are looked up, never the components behind them: Mudlet
+    -- rewrites color_table's entries in place when the ANSI palette changes
+    it("gives the current value of a colour whose entry changed", function()
+      local restore = color_table.white
+      finally(function() color_table.white = restore end)
+      assert.are.same({255, 255, 255, 255}, {Geyser.Color.parse("white")})
+      color_table.white = {1, 2, 3}
+      assert.are.same({1, 2, 3, 255}, {Geyser.Color.parse("white")})
+    end)
+
+    it("gives nothing for a colour it cannot read", function()
+      assert.is_nil(Geyser.Color.parse("no_such_colour_at_all"))
+      assert.is_nil(Geyser.Color.parse(nil))
+    end)
+  end)
+
+  describe("Geyser.Color formatting", function()
+    it("formats a named colour every way round", function()
+      assert.are.equal("#ffffff", Geyser.Color.hex("white"))
+      assert.are.equal("#ffffffff", Geyser.Color.hexa("white"))
+      assert.are.equal("|cffffff", Geyser.Color.hhex("white"))
+      assert.are.equal("<255,255,255>", Geyser.Color.hdec("white"))
+      assert.are.equal("<255,255,255,255>", Geyser.Color.hdeca("white"))
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/GeyserGauge_spec.lua
+++ b/src/mudlet-lua/tests/GeyserGauge_spec.lua
@@ -145,6 +145,174 @@ describe("Tests functionality of Geyser.Gauge", function()
       -- a good reading has to be distinguishable from those refusals
       assert.is_true(gauge:setValue(50, 100))
     end)
+
+    -- a gauge only lays its front label out again when something about the fill
+    -- moved, so that a UI repainting every gauge on every prompt costs nothing
+    -- for the ones sitting still
+    it("lays the front label out once per update and not at all for a repeat", function()
+      gauge:setValue(50)
+      local move = spy.on(_G, "moveWindow")
+      local resize = spy.on(_G, "resizeWindow")
+      finally(function() move:revert() resize:revert() end)
+      gauge:setValue(60)
+      assert.spy(move).was.called(1)
+      assert.spy(resize).was.called(1)
+      gauge:setValue(60)
+      gauge:setValue(60)
+      assert.spy(move).was.called(1)
+      assert.spy(resize).was.called(1)
+      -- and the skipped repeats left it where the update put it
+      assert.are.equal(120, geometry("ggsValue_front").width)
+    end)
+
+    -- the geometry is the gauge's answer, not something a later event-loop turn
+    -- makes true, so a script may read it straight back
+    it("has the new geometry ready by the time it returns", function()
+      for _, value in ipairs({10, 20, 30, 40}) do
+        gauge:setValue(value)
+        assert.are.equal(value * 2, geometry("ggsValue_front").width)
+      end
+    end)
+
+    -- the front label's constraints are only rebuilt when they need to be, so a
+    -- gauge whose front label was resized out from under it has to notice
+    it("takes the front label back after something else resized it", function()
+      gauge:setValue(50)
+      gauge.front:resize(30, 10)
+      assert.are.same({x = 0, y = 0, width = 30, height = 10}, geometry("ggsValue_front"))
+      gauge:setValue(50)
+      assert.are.same({x = 0, y = 0, width = 100, height = 40}, geometry("ggsValue_front"))
+      gauge.front:move(7, 9)
+      gauge:setValue(60)
+      assert.are.same({x = 0, y = 0, width = 120, height = 40}, geometry("ggsValue_front"))
+    end)
+
+    it("keeps a format change made between two identical updates", function()
+      gauge:setValue(50, 100, "HP 50")
+      gauge:setBold(true)
+      gauge:setFontSize(18)
+      gauge:setValue(50, 100, "HP 50")
+      local shown = getLabelText("ggsValue_text")
+      assert.is_truthy(shown:find("<b>HP 50</b>", 1, true))
+      assert.is_truthy(shown:find("font%-size: 18pt"))
+    end)
+
+    it("puts its own text back after something else wrote to the label", function()
+      gauge:setValue(50, 100, "HP 50")
+      gauge.text:rawEcho("something else")
+      gauge:setValue(50, 100, "HP 50")
+      assert.is_truthy(getLabelText("ggsValue_text"):find("HP 50", 1, true))
+    end)
+
+    it("stays full over repeated overflow and comes back down", function()
+      local strict = track(Geyser.Gauge:new({name = "ggsStrictRepeat", x = 0, y = 0, width = 200, height = 40, strict = true}))
+      strict:setValue(150)
+      strict:setValue(300)
+      assert.are.equal(200, geometry("ggsStrictRepeat_front").width)
+      strict:setValue(50)
+      assert.are.equal(100, geometry("ggsStrictRepeat_front").width)
+    end)
+
+    it("follows a resize that happens between two identical updates", function()
+      gauge:setValue(50)
+      assert.are.equal(100, geometry("ggsValue_front").width)
+      gauge:resize(100, 40)
+      gauge:setValue(50)
+      assert.are.equal(50, geometry("ggsValue_front").width)
+    end)
+
+    it("follows a stylesheet that changes between two identical updates", function()
+      gauge:setValue(50)
+      gauge:setStyleSheet("margin: 10px;", "margin: 10px;")
+      gauge:setValue(50)
+      assert.are.same({x = 10, y = 10, width = 90, height = 20}, geometry("ggsValue_front"))
+    end)
+
+    it("keeps one gauge's spacing out of another's", function()
+      local plain = track(Geyser.Gauge:new({name = "ggsPlain", x = 0, y = 0, width = 200, height = 40}))
+      local inset = track(Geyser.Gauge:new({name = "ggsInset", x = 0, y = 0, width = 200, height = 40}))
+      inset:setStyleSheet("padding: 5px;", "padding: 5px;")
+      for _ = 1, 3 do
+        plain:setValue(50)
+        inset:setValue(50)
+      end
+      assert.are.same({x = 0, y = 0, width = 100, height = 40}, geometry("ggsPlain_front"))
+      assert.are.same({x = 5, y = 5, width = 95, height = 30}, geometry("ggsInset_front"))
+    end)
+
+    it("updates a gauge that is hidden, so showing it again is right", function()
+      gauge:hide()
+      gauge:setValue(25)
+      gauge:show()
+      assert.are.same({x = 0, y = 0, width = 50, height = 40}, geometry("ggsValue_front"))
+      assert.is_true(windowVisible("ggsValue_front"))
+    end)
+
+    -- the front label's constraints outlive the update that installed them, so
+    -- everything that lays a gauge out without going through setValue has to
+    -- keep working: the container cascade, and the reposition every window
+    -- resize runs
+    it("follows its container being moved, resized and repositioned", function()
+      local box = track(Geyser.Container:new({name = "ggsBoxMove", x = 100, y = 100, width = 400, height = 100}))
+      local gauge = track(Geyser.Gauge:new({name = "ggsInMove", x = 0, y = 0, width = "50%", height = "100%"}, box))
+      gauge:setValue(50)
+      assert.are.same({x = 100, y = 100, width = 100, height = 100}, geometry("ggsInMove_front"))
+      box:move(300, 200)
+      box:resize(200, 50)
+      assert.are.same({x = 300, y = 200, width = 50, height = 50}, geometry("ggsInMove_front"))
+      -- the value it already sits on must not undo that
+      gauge:setValue(50)
+      assert.are.same({x = 300, y = 200, width = 50, height = 50}, geometry("ggsInMove_front"))
+      box:reposition()
+      assert.are.same({x = 300, y = 200, width = 50, height = 50}, geometry("ggsInMove_front"))
+    end)
+
+    it("lays a whole row of gauges out in one go", function()
+      local row = {}
+      for i = 1, 5 do
+        row[i] = track(Geyser.Gauge:new({name = "ggsRow" .. i, x = 0, y = 0, width = 200, height = 40}))
+      end
+      for i = 1, 5 do
+        row[i]:setValue(i * 10, 100, "row " .. i)
+      end
+      for i = 1, 5 do
+        assert.are.equal(i * 20, geometry("ggsRow" .. i .. "_front").width)
+        assert.is_truthy(getLabelText("ggsRow" .. i .. "_text"):find("row " .. i, 1, true))
+      end
+    end)
+
+    -- each orientation wires the offsets into its own branch, so a gauge with
+    -- back spacing has to come out right in every one of them and on the way back
+    it("changes orientation on the next update, spacing and all", function()
+      local gauge = track(Geyser.Gauge:new({name = "ggsTurn", x = 0, y = 0, width = 200, height = 100}))
+      gauge:setStyleSheet("margin: 5px;", "margin: 5px;")
+      gauge:setValue(25)
+      assert.are.same({x = 5, y = 5, width = 48, height = 90}, geometry("ggsTurn_front"))
+      gauge.orientation = "vertical"
+      gauge:setValue(25)
+      assert.are.same({x = 5, y = 73, width = 190, height = 23}, geometry("ggsTurn_front"))
+      gauge.orientation = "goofy"
+      gauge:setValue(25)
+      assert.are.same({x = 148, y = 5, width = 48, height = 90}, geometry("ggsTurn_front"))
+      gauge.orientation = "batty"
+      gauge:setValue(25)
+      assert.are.same({x = 5, y = 5, width = 190, height = 23}, geometry("ggsTurn_front"))
+      gauge.orientation = "horizontal"
+      gauge:setValue(25)
+      assert.are.same({x = 5, y = 5, width = 48, height = 90}, geometry("ggsTurn_front"))
+    end)
+
+    -- pixel offsets against a container-relative size are where a memoised
+    -- spacing would drift, because the size is a fraction and the offsets are not
+    it("combines a percentage size with a pixel spacing", function()
+      local box = track(Geyser.Container:new({name = "ggsPctBox", x = 0, y = 0, width = 400, height = 100}))
+      local gauge = track(Geyser.Gauge:new({name = "ggsPct", x = 0, y = 0, width = "33%", height = "100%"}, box))
+      gauge:setStyleSheet("margin: 3px;", "margin: 3px;")
+      gauge:setValue(50)
+      assert.are.same({x = 3, y = 3, width = 63, height = 94}, geometry("ggsPct_front"))
+      box:resize(800, 100)
+      assert.are.same({x = 3, y = 3, width = 129, height = 94}, geometry("ggsPct_front"))
+    end)
   end)
 
   describe("Geyser.Gauge orientations", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `Geyser.Gauge:setValue` keeps the reading it takes off the back label's stylesheet instead of re-parsing margin, border and padding on every call, installs the front label's constraints once per orientation instead of rebuilding them per value, and lays the front label out once rather than twice - and not at all when nothing about the fill moved.
- `Geyser.Color.find_color_name` answers from an index instead of scanning all ~500 `color_table` entries, and `Geyser.Color.parse` calls it once instead of twice. That is 52 us off every Geyser label echo that carries a named colour, gauge or not.
- 25 new busted specs, including the staleness cases the two memos invite: the container moving under a gauge, a format change between two identical updates, a front label resized from outside, and a colour added to or taken out of `color_table` at runtime.

#### Motivation for adding to Mudlet
A new profile with the shipped starter UI processed game text 4.5x slower than 4.22.0 and nearly all of it was `setValue` running on every prompt line (#9761); this is in Geyser rather than the package, so every UI with a gauge gets it.

#### Other info (issues closed, discussion etc)
Fixes #9761.

One non-ASan RelWithDebInfo build, Lua swapped between runs, `test/compare-perf-baseline.py` as the arbiter:

| metric | before | after |
| --- | --- | --- |
| `defaults_text_lines_per_sec` | 16 600 | 27 049 (+62.9%) |
| `defaults_text_best_pass_ms` | 1506 ms | 924 ms |
| `text_lines_per_sec` / `trigger_lines_per_sec` | - | flat, within noise |

Three A/B pairs: +62.1%, +64.3%, +62.9%. Per call, on a starter-UI gauge: `setValue(v, max, text)` 115.0 us -> 5.8 us, `Geyser.Label:echo` with a named colour 55.7 us -> 2.7 us. Stubbing `setValue` out completely now only buys another 39 ms of the 924, so gauges are no longer what the starter UI spends its time on; the rest is the chat dock, which #9761 calls the floor.

Nothing is deferred: `getWindowGeometry` and `getLabelText` still answer with the new value in the same tick. Coalescing the repaint onto the next event-loop turn was tried and breaks 8 pre-existing gauge specs that read both back immediately, so it is left out.

Busted suite: 2437 successes / 0 failures / 0 errors / 129 pending. ctest: 95/95.

**Test case:** on a fresh profile with the starter UI, paste a few thousand lines of game text at a game that sends vitals - the gauges keep up instead of the client falling behind. `Geyser.Gauge:new{name="g", x=0, y=0, width=300, height=20}` then `g:setValue(50, 100, "HP 50/100")` behaves exactly as before.

Assisted-by: Claude:claude-opus-5