### PR TITLE
infrastructure: fix two tests still opting in with an empty XDG config dir

### DIFF
--- a/test/functional_tests/ConnectionDialogCrashTest.cpp
+++ b/test/functional_tests/ConnectionDialogCrashTest.cpp
@@ -170,7 +170,7 @@ private slots:
 
         mSavedXdg = qgetenv("XDG_CONFIG_HOME");
         QVERIFY(mXdgDir.isValid());
-        QVERIFY(QDir().mkpath(qsl("%1/mudlet").arg(mXdgDir.path()))); // empty dir = XDG opt-in
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mXdgDir.path()))); // profiles/ = XDG opt-in
         qputenv("XDG_CONFIG_HOME", mXdgDir.path().toUtf8());
 
         mudlet::start();

--- a/test/functional_tests/ProfileDeletionSafetyTest.cpp
+++ b/test/functional_tests/ProfileDeletionSafetyTest.cpp
@@ -149,9 +149,9 @@ private slots:
         initializeQRCResourcesForProfileDeletionSafetyTest();
 
         QVERIFY(mConfigDir.isValid());
-        // an existing $XDG_CONFIG_HOME/mudlet makes setupConfig() adopt it, so
-        // the test never goes near the user's own profiles
-        QVERIFY(QDir().mkpath(qsl("%1/mudlet").arg(mConfigDir.path())));
+        // $XDG_CONFIG_HOME/mudlet/profiles is the opt-in that makes setupConfig()
+        // adopt it, so the test never goes near the user's own profiles
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
         mSavedXdg = qgetenv("XDG_CONFIG_HOME");
         qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `61c2afd40` (#9712) made `$XDG_CONFIG_HOME/mudlet/profiles` the opt-in marker for an isolated config root, and an empty `$XDG_CONFIG_HOME/mudlet` no longer qualifies. It updated three functional tests to the new recipe and missed two, so `ProfileDeletionSafetyTest` and `ConnectionDialogCrashTest` resolved to the real `~/.config/mudlet` and failed in `initTestCase()` on every leg (run 31428353403). Every open PR inherits that red, because PR builds merge the dev tip.
- Both now pre-create `mudlet/profiles`, matching the ten sibling tests and `src/mudlet-lua/tests/README.md`. Product code is untouched.
- An empty `profiles/` still reads as a fresh install (`anyProfilesExist()` counts subdirectories), so neither test's first-launch expectations move.

Test case: `ctest -R "ProfileDeletionSafetyTest|ConnectionDialogCrashTest"` against a `~/.config/mudlet` that holds profiles - both fail on `development`, both pass here; the full functional suite is otherwise unchanged.

Assisted-by: Claude:claude-opus-5