### PR TITLE
fix: preloading a sound no longer plays it, and IRC settings stop losing your password

### DIFF
--- a/CI/http-fixture-server.py
+++ b/CI/http-fixture-server.py
@@ -5,6 +5,11 @@ Serves the sibling ``http-fixtures/`` directory over localhost so the Lua test
 suite can exercise getHTTP/downloadFile against a real, local endpoint instead
 of the public internet.
 
+Requests below ``/media`` are answered with a generated WAV rather than from
+disk: the media specs need a file long enough that playback is still running
+when they look, and generating silence keeps an 80KB binary out of the
+repository.
+
 Requests below ``/echo`` are answered by an echo endpoint instead of from disk:
 it accepts GET and every verb this handler has no method of its own for
 (postHTTP/putHTTP/deleteHTTP/customHTTP all need one) and reports the method,
@@ -22,10 +27,29 @@ forward it to Mudlet as ``MUDLET_TEST_HTTP_PORT``.
 import http.server
 import os
 import socketserver
+import struct
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "http-fixtures")
 
 ECHO_PATH = "/echo"
+
+MEDIA_PATH = "/media/"
+
+# Long enough that a spec which starts playback still has it running when it
+# asks what is playing, and that one which expects no playback would have seen
+# it by then.
+MEDIA_SECONDS = 10
+
+
+def silent_wav(seconds):
+    """A WAV of the given length: 8 bit, 8kHz mono silence, which any decoder takes."""
+    sample_rate = 8000
+    # 128 is silence for unsigned 8 bit samples
+    samples = b"\x80" * (sample_rate * seconds)
+    header = b"fmt " + struct.pack("<IHHIIHH", 16, 1, 1, sample_rate, sample_rate, 1, 8)
+    data = b"data" + struct.pack("<I", len(samples)) + samples
+    body = b"WAVE" + header + data
+    return b"RIFF" + struct.pack("<I", len(body)) + body
 
 
 class QuietHandler(http.server.SimpleHTTPRequestHandler):
@@ -48,7 +72,21 @@ class QuietHandler(http.server.SimpleHTTPRequestHandler):
         if self.echo_requested():
             self.echo()
             return
+        if self.media_requested():
+            self.serve_media()
+            return
         super().do_GET()
+
+    def media_requested(self):
+        return self.path.startswith(MEDIA_PATH) and self.path.endswith(".wav")
+
+    def serve_media(self):
+        payload = silent_wav(MEDIA_SECONDS)
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
 
     def __getattr__(self, name):
         # BaseHTTPRequestHandler dispatches "VERB /path" to a do_VERB method and

--- a/CI/http-fixture-server.py
+++ b/CI/http-fixture-server.py
@@ -5,10 +5,10 @@ Serves the sibling ``http-fixtures/`` directory over localhost so the Lua test
 suite can exercise getHTTP/downloadFile against a real, local endpoint instead
 of the public internet.
 
-Requests below ``/media`` are answered with a generated WAV rather than from
-disk: the media specs need a file long enough that playback is still running
-when they look, and generating silence keeps an 80KB binary out of the
-repository.
+A GET below ``/media`` for a ``.wav`` is answered with a generated WAV rather
+than from disk (GET only, as with ``/echo`` below): the media specs need a file
+long enough to still be playing when they look, whether they expect that or not,
+and generating silence keeps an 80KB binary out of the repository.
 
 Requests below ``/echo`` are answered by an echo endpoint instead of from disk:
 it accepts GET and every verb this handler has no method of its own for
@@ -42,10 +42,11 @@ MEDIA_SECONDS = 10
 
 
 def silent_wav(seconds):
-    """A WAV of the given length: 8 bit, 8kHz mono silence, which any decoder takes."""
+    """A WAV of the given length: 8 bit, 8kHz mono silence, which needs no codec beyond PCM."""
     sample_rate = 8000
     # 128 is silence for unsigned 8 bit samples
     samples = b"\x80" * (sample_rate * seconds)
+    # chunk size, PCM format, channels, sample rate, byte rate, block align, bits
     header = b"fmt " + struct.pack("<IHHIIHH", 16, 1, 1, sample_rate, sample_rate, 1, 8)
     data = b"data" + struct.pack("<I", len(samples)) + samples
     body = b"WAVE" + header + data

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -854,8 +854,8 @@ private:
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     static void pushMapLabelPropertiesToLua(lua_State*, const TMapLabel& label);
     static std::pair<int, TAction*> getTActionFromIdOrName(lua_State*, const int, const char*);
-    static int loadMediaFileAsOrderedArguments(lua_State*, const char*);
-    static int loadMediaFileAsTableArgument(lua_State*, const char*);
+    static int loadMediaFileAsOrderedArguments(lua_State*, const char*, const TMediaData::MediaType);
+    static int loadMediaFileAsTableArgument(lua_State*, const char*, const TMediaData::MediaType);
     static int playMusicFileAsOrderedArguments(lua_State*, const char*);
     static int playMusicFileAsTableArgument(lua_State*, const char*);
     static int playSoundFileAsOrderedArguments(lua_State*, const char*);

--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -60,7 +60,7 @@ int TLuaInterpreter::receiveMSP(lua_State* L)
 }
 
 // Private
-int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L, const char* func)
+int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L, const char* func, const TMediaData::MediaType mediaType)
 {
     const Host& host = getHostFromLua(L);
     const int numArgs = lua_gettop(L);
@@ -110,6 +110,7 @@ int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L, const char* f
             }
 
             mediaData.setMediaProtocol(TMediaData::MediaProtocolAPI);
+            mediaData.setMediaType(mediaType);
             mediaData.setMediaVolume(TMediaData::MediaVolumePreload);
 
             host.mpMedia->playMedia(mediaData);
@@ -125,7 +126,7 @@ int TLuaInterpreter::loadMediaFileAsOrderedArguments(lua_State* L, const char* f
 }
 
 // Private
-int TLuaInterpreter::loadMediaFileAsTableArgument(lua_State* L, const char* func)
+int TLuaInterpreter::loadMediaFileAsTableArgument(lua_State* L, const char* func, const TMediaData::MediaType mediaType)
 {
     const Host& host = getHostFromLua(L);
 
@@ -178,6 +179,7 @@ int TLuaInterpreter::loadMediaFileAsTableArgument(lua_State* L, const char* func
                 errorPushed = true;
             } else {
                 mediaData.setMediaProtocol(TMediaData::MediaProtocolAPI);
+                mediaData.setMediaType(mediaType);
                 mediaData.setMediaVolume(TMediaData::MediaVolumePreload);
 
                 host.mpMedia->playMedia(mediaData);
@@ -202,10 +204,10 @@ int TLuaInterpreter::loadMusicFile(lua_State* L)
     }
 
     if (lua_istable(L, 1)) {
-        return loadMediaFileAsTableArgument(L, __func__);
+        return loadMediaFileAsTableArgument(L, __func__, TMediaData::MediaTypeMusic);
     }
 
-    return loadMediaFileAsOrderedArguments(L, __func__);
+    return loadMediaFileAsOrderedArguments(L, __func__, TMediaData::MediaTypeMusic);
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadSoundFile
@@ -217,10 +219,10 @@ int TLuaInterpreter::loadSoundFile(lua_State* L)
     }
 
     if (lua_istable(L, 1)) {
-        return loadMediaFileAsTableArgument(L, __func__);
+        return loadMediaFileAsTableArgument(L, __func__, TMediaData::MediaTypeSound);
     }
 
-    return loadMediaFileAsOrderedArguments(L, __func__);
+    return loadMediaFileAsOrderedArguments(L, __func__, TMediaData::MediaTypeSound);
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadVideoFile
@@ -236,7 +238,7 @@ int TLuaInterpreter::loadVideoFile(lua_State* L)
         return lua_error(L);
     }
 
-    return loadMediaFileAsTableArgument(L, __func__);
+    return loadMediaFileAsTableArgument(L, __func__, TMediaData::MediaTypeVideo);
 }
 
 // Private

--- a/src/TLuaInterpreterMedia.cpp
+++ b/src/TLuaInterpreterMedia.cpp
@@ -174,7 +174,7 @@ int TLuaInterpreter::loadMediaFileAsTableArgument(lua_State* L, const char* func
 
         if (!errorPushed) {
             if (mediaData.mediaFileName().isEmpty()) {
-                lua_pushstring(L, R"(loadMusicFile: missing name (add name = "file to play"))");
+                lua_pushfstring(L, R"(%s: missing name (add name = "file to play"))", func);
                 errorPushed = true;
             } else {
                 mediaData.setMediaProtocol(TMediaData::MediaProtocolAPI);
@@ -302,7 +302,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L, const char* f
                 intValue = static_cast<int>(lua_tointeger(L, i));
 
                 if (intValue < 0) {
-                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadein", intValue);
+                    lua_pushfstring(L, "%s: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", func, "fadein", intValue);
                     errorPushed = true;
                     break;
                 }
@@ -318,7 +318,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L, const char* f
                 intValue = static_cast<int>(lua_tointeger(L, i));
 
                 if (intValue < 0) {
-                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "fadeout", intValue);
+                    lua_pushfstring(L, "%s: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", func, "fadeout", intValue);
                     errorPushed = true;
                     break;
                 }
@@ -334,7 +334,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L, const char* f
                 intValue = static_cast<int>(lua_tointeger(L, i));
 
                 if (intValue < 0) {
-                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "start", intValue);
+                    lua_pushfstring(L, "%s: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", func, "start", intValue);
                     errorPushed = true;
                     break;
                 }
@@ -396,7 +396,7 @@ int TLuaInterpreter::playMusicFileAsOrderedArguments(lua_State* L, const char* f
                 intValue = static_cast<int>(lua_tointeger(L, i));
 
                 if (intValue < 0) {
-                    lua_pushfstring(L, "playSoundFile: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", "finish", intValue);
+                    lua_pushfstring(L, "%s: bad argument range for %s (values must be greater than or equal to 0, got value: %d)", func, "finish", intValue);
                     errorPushed = true;
                     break;
                 }

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -55,6 +55,7 @@
 #include "glwidget_integration.h"
 #endif
 
+#include <algorithm>
 #include <limits>
 #include <math.h>
 
@@ -543,6 +544,17 @@ int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
     return 1;
 }
 
+// An IRC channel name holds neither of the two characters its list is taken apart
+// on: the stored list is space-joined (dlgIRC::writeIrcChannels) and the JOIN
+// command is comma-joined, so a name carrying either would come back as two
+// channels.
+static bool ircChannelNameHasSeparator(const QString& channel)
+{
+    return std::any_of(channel.cbegin(), channel.cend(), [](const QChar character) {
+        return character.isSpace() || character == QLatin1Char(',');
+    });
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcChannels
 int TLuaInterpreter::setIrcChannels(lua_State* L)
 {
@@ -556,7 +568,7 @@ int TLuaInterpreter::setIrcChannels(lua_State* L)
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
             const QString c = lua_tostring(L, -1);
-            if (!c.isEmpty() && (c.startsWith(QLatin1String("#")) || c.startsWith(QLatin1String("&")) || c.startsWith(QLatin1String("+")))) {
+            if (!c.isEmpty() && (c.startsWith(QLatin1String("#")) || c.startsWith(QLatin1String("&")) || c.startsWith(QLatin1String("+"))) && !ircChannelNameHasSeparator(c)) {
                 newchannels << c;
             }
         }

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -598,7 +598,6 @@ int TLuaInterpreter::setIrcNick(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcServer
 int TLuaInterpreter::setIrcServer(lua_State* L)
 {
-    const int args = lua_gettop(L);
     int secure = false;
     int port = 6667;
     if (!checkStringArg(L, __func__, 1, "hostname")) {
@@ -614,14 +613,15 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
             return warnArgumentValue(L, __func__, qsl("invalid port number %1 given, if supplied it must be in range 1 to 65535").arg(port));
         }
     }
-    if (args > 2) {
+    if (!lua_isnoneornil(L, 3)) {
         secure = getVerifiedBool(L, __func__, 3, "secure {default = false}", true);
     }
 
-    // An omitted password leaves the stored one alone: there is no getter for
-    // it, so a script changing the host or the port could not put it back.
+    // An omitted password - and a nil one, which every optional argument here
+    // treats the same way - leaves the stored password alone: there is no getter
+    // for it, so a script changing the host or the port could not put it back.
     // Clearing one is asking for it, by passing an empty string.
-    const bool passwordGiven = args > 3;
+    const bool passwordGiven = !lua_isnoneornil(L, 4);
     if (passwordGiven && !checkStringArg(L, __func__, 4, "server password", true)) {
         return lua_error(L);
     }

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -617,12 +617,17 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
     if (args > 2) {
         secure = getVerifiedBool(L, __func__, 3, "secure {default = false}", true);
     }
-    if (args > 3 && !checkStringArg(L, __func__, 4, "server password", true)) {
+
+    // An omitted password leaves the stored one alone: there is no getter for
+    // it, so a script changing the host or the port could not put it back.
+    // Clearing one is asking for it, by passing an empty string.
+    const bool passwordGiven = args > 3;
+    if (passwordGiven && !checkStringArg(L, __func__, 4, "server password", true)) {
         return lua_error(L);
     }
 
     QString password;
-    if (args > 3) {
+    if (passwordGiven) {
         password = lua_tostring(L, 4);
     }
 
@@ -642,9 +647,11 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("unable to save secure, reason: %1").arg(result.second));
     }
 
-    result = dlgIRC::writeIrcPassword(pHost, password);
-    if (!result.first) {
-        return warnArgumentValue(L, __func__, qsl("unable to save password, reason: %1").arg(result.second));
+    if (passwordGiven) {
+        result = dlgIRC::writeIrcPassword(pHost, password);
+        if (!result.first) {
+            return warnArgumentValue(L, __func__, qsl("unable to save password, reason: %1").arg(result.second));
+        }
     }
 
     lua_pushboolean(L, true);

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -547,7 +547,8 @@ int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
 // An IRC channel name holds neither of the two characters its list is taken apart
 // on: the stored list is space-joined (dlgIRC::writeIrcChannels) and the JOIN
 // command is comma-joined, so a name carrying either would come back as two
-// channels.
+// channels. Every kind of whitespace is refused rather than only the space it is
+// joined on, because an IRC channel name may hold none of it.
 static bool ircChannelNameHasSeparator(const QString& channel)
 {
     return std::any_of(channel.cbegin(), channel.cend(), [](const QChar character) {
@@ -630,9 +631,9 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
     }
 
     // An omitted password - and a nil one, which every optional argument here
-    // treats the same way - leaves the stored password alone: there is no getter
-    // for it, so a script changing the host or the port could not put it back.
-    // Clearing one is asking for it, by passing an empty string.
+    // treats the same way - leaves the stored password alone: a call that only
+    // changes the host or the port must not drop a credential it was never
+    // given. Clearing one is asking for it, by passing an empty string.
     const bool passwordGiven = !lua_isnoneornil(L, 4);
     if (passwordGiven && !checkStringArg(L, __func__, 4, "server password", true)) {
         return lua_error(L);

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -221,7 +221,7 @@ int TLuaInterpreter::getIrcConnectedHost(lua_State* L)
     lua_pushboolean(L, true);
     lua_pushstring(L, cHostName.toUtf8().constData());
 
-    return 1;
+    return 2;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getIrcNick

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1094,7 +1094,12 @@ void TMedia::slot_writeFile(QNetworkReply* reply)
                 reply->deleteLater();
                 mpHost->raiseEvent(event);
 
-                TMedia::play(mediaData);
+                // A preload (volume 0) asked for the file to be in the cache, not to be
+                // heard: playMedia() returns before playing one it already has, so a
+                // download must not play the copy it has just made either.
+                if (mediaData.mediaVolume() != TMediaData::MediaVolumePreload) {
+                    TMedia::play(mediaData);
+                }
             } else {
                 event.mArgumentList << QLatin1String("sysDownloadError");
                 event.mArgumentTypeList << ARGUMENT_TYPE_STRING;

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -22,7 +22,7 @@ end
 local function assertArgError(fn, needle)
   local ok, err = pcall(fn)
   assert.is_false(ok)
-  assert.is_true(contains(err, needle))
+  assert.is_true(contains(err, needle), tostring(err))
 end
 
 describe("Media playback functions validate their parameters", function()
@@ -199,8 +199,7 @@ describe("Media load functions validate their parameters", function()
   end)
 
   it("the table form raises a Lua error naming the load that was called", function()
-    -- #9785: the shared table parser reported every one of them as
-    -- loadMusicFile, which sent anyone debugging a script to the wrong call
+    -- the three share one table parser, so each has to name its own caller
     assertArgError(function() loadSoundFile({}) end, "loadSoundFile: missing name")
     assertArgError(function() loadMusicFile({}) end, "loadMusicFile: missing name")
     assertArgError(function() loadVideoFile({}) end, "loadVideoFile: missing name")
@@ -464,9 +463,10 @@ describe("Media playback effects with a generated sound file", function()
 
   -- The fixture server of CI/http-fixture-server.py, when the harness started
   -- one and handed its ephemeral port over. A preload's observable effect is
-  -- the fetch it starts for a file the profile does not have, so the load specs
-  -- below are the media ones that need a server to talk to. Anything asked of
-  -- it below /media is answered with generated silence rather than from disk.
+  -- the fetch it starts for a file the profile does not have, so the specs
+  -- below that name a url are the media ones that need a server to talk to. A
+  -- GET below /media for a .wav is answered with generated silence rather than
+  -- from disk.
   local httpPort = os.getenv("MUDLET_TEST_HTTP_PORT")
   local requireFixture = os.getenv("MUDLET_TEST_REQUIRE_HTTP_FIXTURE")
   -- the file CI/http-fixtures/ serves, and its contents
@@ -996,8 +996,8 @@ describe("Media playback effects with a generated sound file", function()
       return
     end
     -- #9783: the download's completion played what it had just written. The
-    -- fixture server generates ten seconds of silence for this path, so a
-    -- playback that started would still be running when this looks.
+    -- fixture server answers this path with MEDIA_SECONDS of silence, long
+    -- enough that a playback which started would still be running here.
     local downloadName = "busted-media-download.wav"
     local downloaded = mediaDirectory .. "/" .. downloadName
     lfs.mkdir(mediaDirectory)
@@ -1018,7 +1018,6 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(0, #getPlayingMusic())
     assert.equals(0, #getPlayingVideos())
 
-    -- and the file is in the media directory, which is what the preload was for
     assert.is_not_nil(lfs.attributes(downloaded, "mode"), "the preload did not keep the file it downloaded")
   end)
 
@@ -1029,18 +1028,48 @@ describe("Media playback effects with a generated sound file", function()
     -- #9784: what a load is filed as decides which players it can reach.
     -- playMedia() looks for a paused player to resume before it does anything
     -- else, among the players of the type the request carries - and a load that
-    -- set no type at all searched every list this profile has, so a sound
+    -- carried no type at all searched all three of the API lists, so a sound
     -- preload took over music.
+    local paused = {}
+    collect("sysMediaPaused", paused)
+
     writeSoundFiles()
     assert.is_true(playMusicFile({name = longSoundFile, key = "busted-load-typed"}))
     assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
     assert.is_true(pauseMusic())
+    waitForCount("sysMediaPaused", paused, 1)
     assert.equals(1, #getPausedMusic())
 
+    -- both parsers stamp the type, and each has its own copy of that line
     assert.is_true(loadSoundFile({name = longSoundFile}))
+    assert.is_true(loadSoundFile(longSoundFile))
     assert.equals(1, #getPausedMusic())
     assert.equals(0, #getPlayingMusic())
     assert.equals(0, #getPlayingSounds())
+  end)
+
+  it("a play with a url plays the file once the download lands", function()
+    if noFixtureServer() then
+      return
+    end
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- the other half of #9783's guard: a request that is not a preload still
+    -- has to play what it fetched, or the fix would have taken playback away
+    -- from every play*File() that names a url
+    local downloadName = "busted-media-play.wav"
+    local downloaded = mediaDirectory .. "/" .. downloadName
+    lfs.mkdir(mediaDirectory)
+    os.remove(downloaded)
+    onCleanup(function() os.remove(downloaded) end)
+
+    assert.is_true(playSoundFile({name = downloadName, url = fixtureUrl() .. "/media", volume = 60, key = "busted-media-played"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 10000)))
+
+    local playing = getPlayingSounds()
+    assert.equals(1, #playing)
+    assert.equals(downloadName, playing[1].name)
   end)
 
   it("loadVideoFile reports a download error for a url it cannot fetch from", function()

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -171,6 +171,124 @@ describe("Media playback functions validate their parameters", function()
   end)
 end)
 
+describe("Media load functions validate their parameters", function()
+  -- loadMusicFile/loadSoundFile/loadVideoFile are the same preload request with
+  -- three different media types, and they share one pair of parsers with the
+  -- play family. Nothing here names a file that exists, so no preload gets as
+  -- far as the media engine.
+  it("each raises a Lua error when called with no arguments", function()
+    assertArgError(function() loadMusicFile() end, "loadMusicFile: need at least one argument")
+    assertArgError(function() loadSoundFile() end, "loadSoundFile: need at least one argument")
+    assertArgError(function() loadVideoFile() end, "loadVideoFile: need at least one argument")
+  end)
+
+  it("loadVideoFile raises a Lua error when its argument is not a table", function()
+    -- the video calls take the table form only
+    assertArgError(function() loadVideoFile("busted-media-absent.mkv") end, "loadVideoFile: needs to be a table")
+  end)
+
+  it("the ordered form returns nil when it is given no file name", function()
+    local ok, err = loadSoundFile(nil)
+    assert.is_nil(ok)
+    assert.is_true(contains(err, "missing argument 1"), tostring(err))
+
+    ok, err = loadMusicFile("")
+    assert.is_nil(ok)
+    assert.is_true(contains(err, "missing argument 1"), tostring(err))
+  end)
+
+  it("the table form raises a Lua error when it is given no name", function()
+    -- Only the tail of the message: all three loads report this one as
+    -- loadMusicFile, whichever was called, and pinning that here would hold
+    -- that in place.
+    assertArgError(function() loadSoundFile({}) end, "missing name")
+  end)
+
+  it("the ordered form raises a Lua error when the url is not a string", function()
+    assertArgError(function() loadSoundFile("busted-media-absent.wav", {}) end, "url as string expected, got table!")
+  end)
+
+  it("the table form raises a Lua error for a wrongly typed name or url", function()
+    assertArgError(function() loadMusicFile({name = {}}) end, "value for name as string expected, got table!")
+    assertArgError(function() loadMusicFile({name = "busted-media-absent.mp3", url = {}}) end, "value for url as string expected, got table!")
+  end)
+end)
+
+describe("Media query and stop functions validate their parameters", function()
+  -- The video calls, the pause calls and the paused-media queries take a table
+  -- and nothing else; the sound and music queries and stops take either form.
+  -- pauseSounds and pauseMusic have this same refusal checked above
+  local tableOnly = {
+    "getPlayingVideos", "getPausedSounds", "getPausedMusic", "getPausedVideos",
+    "pauseVideos", "stopVideos",
+  }
+
+  for _, fnName in ipairs(tableOnly) do
+    it(fnName .. " raises a Lua error when its argument is not a table", function()
+      assertArgError(function() _G[fnName](5) end, fnName .. ": needs to be a table")
+    end)
+  end
+
+  it("the ordered query forms raise a Lua error for a wrongly typed filter", function()
+    assertArgError(function() getPlayingSounds("busted-media-absent.wav", {}) end, "key as string expected, got table!")
+    assertArgError(function() getPlayingSounds("busted-media-absent.wav", "k", {}) end, "tag as string expected, got table!")
+    assertArgError(function() getPlayingSounds("busted-media-absent.wav", "k", "t", "loud") end, "priority as number expected, got string!")
+    assertArgError(function() getPlayingMusic("busted-media-absent.mp3", {}) end, "key as string expected, got table!")
+  end)
+
+  it("the table query forms raise a Lua error for a wrongly typed filter", function()
+    assertArgError(function() getPlayingMusic({name = {}}) end, "value for name as string expected, got table!")
+    assertArgError(function() getPausedSounds({key = {}}) end, "value for key as string expected, got table!")
+    assertArgError(function() getPausedMusic({tag = {}}) end, "value for tag as string expected, got table!")
+    assertArgError(function() getPausedVideos({name = {}}) end, "value for name as string expected, got table!")
+    assertArgError(function() getPlayingVideos({key = {}}) end, "value for key as string expected, got table!")
+  end)
+
+  it("the ordered stop forms raise a Lua error for a wrongly typed argument", function()
+    assertArgError(function() stopSounds("busted-media-absent.wav", "k", "t", "loud") end, "priority as number expected, got string!")
+    assertArgError(function() stopSounds("busted-media-absent.wav", "k", "t", 10, "yes") end, "fadeaway as boolean expected, got string!")
+    assertArgError(function() stopMusic("busted-media-absent.mp3", "k", "t", "yes") end, "fadeaway as boolean expected, got string!")
+    assertArgError(function() stopMusic("busted-media-absent.mp3", "k", "t", true, -1) end, "bad argument range for fadeout")
+  end)
+
+  it("the table pause and stop forms raise a Lua error for a wrongly typed filter", function()
+    assertArgError(function() pauseSounds({name = {}}) end, "value for name as string expected, got table!")
+    assertArgError(function() pauseMusic({key = {}}) end, "value for key as string expected, got table!")
+    assertArgError(function() pauseVideos({tag = {}}) end, "value for tag as string expected, got table!")
+    assertArgError(function() stopVideos({name = {}}) end, "value for name as string expected, got table!")
+  end)
+
+  it("the ordered play forms raise a Lua error for a wrongly typed argument", function()
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", {}) end, "volume as number expected, got table!")
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, 0, 0, 0, 1, {}) end, "key as string expected, got table!")
+    assertArgError(function() playSoundFile("busted-media-absent.wav", 50, 0, 0, 0, 1, "k", {}) end, "tag as string expected, got table!")
+  end)
+
+  it("the ordered play forms refuse a negative fade", function()
+    -- Only the range refusal, not the whole message: the music parser's fade
+    -- messages name playSoundFile, and pinning that here would hold it in
+    -- place.
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, -1) end, "bad argument range for fadein")
+    assertArgError(function() playSoundFile("busted-media-absent.wav", 50, 0, -1) end, "bad argument range for fadeout")
+  end)
+
+  it("every query returns an empty table while nothing is playing", function()
+    -- with everything stopped, each of the six queries answers with a table
+    -- rather than with nil or a false-plus-message pair
+    assert.is_true(stopSounds())
+    assert.is_true(stopMusic())
+    assert.is_true(stopVideos())
+
+    for _, query in ipairs({getPlayingSounds, getPlayingMusic, getPlayingVideos, getPausedSounds, getPausedMusic, getPausedVideos}) do
+      local result = query()
+      assert.is_table(result)
+      assert.equals(0, #result)
+      -- and the same with a filter that matches nothing
+      assert.same({}, query({key = "busted-media-no-such-key"}))
+    end
+  end)
+end)
+
 describe("Media playback effects with a generated sound file", function()
   -- The API media functions play files out of the profile's own media
   -- directory, so instead of shipping a binary fixture these specs write a
@@ -317,9 +435,63 @@ describe("Media playback effects with a generated sound file", function()
     return true
   end
 
+  -- The fixture server of CI/http-fixture-server.py, when the harness started
+  -- one and handed its ephemeral port over. A preload's only observable effect
+  -- is the fetch it starts for a file the profile does not have, so the two
+  -- load specs below are the media ones that need a server to talk to.
+  local httpPort = os.getenv("MUDLET_TEST_HTTP_PORT")
+  local requireFixture = os.getenv("MUDLET_TEST_REQUIRE_HTTP_FIXTURE")
+  -- the file CI/http-fixtures/ serves, and its contents
+  local fixtureFile = "fixture.txt"
+  local fixtureBody = "Mudlet self-test HTTP fixture.\n"
+
+  local function noFixtureServer()
+    if httpPort then
+      return false
+    end
+    if requireFixture then
+      assert.is_true(false, "MUDLET_TEST_REQUIRE_HTTP_FIXTURE is set but MUDLET_TEST_HTTP_PORT is not - the fixture server was not started")
+    end
+    pending("no local HTTP fixture server (set MUDLET_TEST_HTTP_PORT)")
+    return true
+  end
+
+  -- The url a media request is given is a directory: TMedia appends the file
+  -- name to it.
+  local function fixtureUrl()
+    return "http://127.0.0.1:" .. httpPort
+  end
+
+  local function readFile(path)
+    local handle = io.open(path, "rb")
+    if not handle then
+      return nil
+    end
+    local contents = handle:read("*a")
+    handle:close()
+    return contents
+  end
+
+  -- Video playback draws into a widget the request names with its key:
+  -- TMainConsole::setupVideoOutput() looks that key up among the profile's
+  -- labels and user windows, and refuses the request when it finds neither. The
+  -- label is left in place afterwards rather than deleted, because the player
+  -- that was handed its video widget outlives the spec.
+  local videoLabel = "busted-media-video-label"
+  local videoLabelReady
+
+  local function withVideoLabel()
+    if not videoLabelReady then
+      createLabel(videoLabel, 0, 0, 40, 40, 1)
+      assert.equals("label", windowType(videoLabel))
+      videoLabelReady = true
+    end
+  end
+
   after_each(function()
     stopSounds()
     stopMusic()
+    stopVideos()
   end)
 
   it("playSoundFile plays the file and reports it from start to finish", function()
@@ -713,6 +885,232 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(1, #errors)
     assert.is_true(contains(errors[1].message, "http"), tostring(errors[1].message))
     assert.is_true(contains(errors[1].path, "busted-media-absent-scheme.wav"), tostring(errors[1].path))
+  end)
+
+  it("loadSoundFile fetches a file the media directory does not have and keeps it", function()
+    if noFixtureServer() then
+      return
+    end
+    local downloaded = mediaDirectory .. "/" .. fixtureFile
+    lfs.mkdir(mediaDirectory)
+    os.remove(downloaded)
+    finally(function() os.remove(downloaded) end)
+
+    local done = {}
+    collect("sysDownloadDone", done)
+    assert.is_true(loadSoundFile({name = fixtureFile, url = fixtureUrl()}))
+    waitForCount("sysDownloadDone", done, 1)
+
+    assert.equals(1, #done)
+    assert.equals(fixtureBody, readFile(downloaded))
+  end)
+
+  it("loadMusicFile fetches from the url given in the ordered argument form", function()
+    if noFixtureServer() then
+      return
+    end
+    -- name[,url]: the ordered form has a parser of its own
+    local downloaded = mediaDirectory .. "/" .. fixtureFile
+    lfs.mkdir(mediaDirectory)
+    os.remove(downloaded)
+    finally(function() os.remove(downloaded) end)
+
+    local done = {}
+    collect("sysDownloadDone", done)
+    assert.is_true(loadMusicFile(fixtureFile, fixtureUrl()))
+    waitForCount("sysDownloadDone", done, 1)
+
+    assert.equals(1, #done)
+    assert.equals(fixtureBody, readFile(downloaded))
+  end)
+
+  it("loadVideoFile reports a download error for a url it cannot fetch from", function()
+    -- The preload reaches the same fetch as a play would, so the refusal of a
+    -- url that is not http(s) is where a spec can see a load act on its url
+    -- without a server to answer it.
+    local errors = {}
+    collect("sysDownloadError", errors)
+
+    assert.is_true(loadVideoFile({name = "busted-media-absent-load.mkv", url = "ftp://example.invalid/videos"}))
+    waitForCount("sysDownloadError", errors, 1)
+    assert.equals(1, #errors)
+    assert.is_true(contains(errors[1].path, "busted-media-absent-load.mkv"), tostring(errors[1].path))
+  end)
+
+  it("playMusicFile starts a track given in the ordered argument form", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+    -- name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag]
+    assert.is_true(playMusicFile(longSoundFile, 70, 0, 0, 0, 1, "busted-music-ordered", "busted-music-ordered-tag"))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    local music = getPlayingMusic()
+    assert.equals(1, #music)
+    assert.equals(longSoundFile, music[1].name)
+    assert.equals(70, music[1].volume)
+    assert.equals("busted-music-ordered", music[1].key)
+    assert.equals("busted-music-ordered-tag", music[1].tag)
+  end)
+
+  it("getPlayingMusic filters by name in both argument forms", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+    assert.is_true(playMusicFile({name = longSoundFile, key = "busted-music-filter"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    -- name[,key][,tag] as ordered arguments
+    assert.equals(1, #getPlayingMusic(longSoundFile))
+    assert.equals(1, #getPlayingMusic(longSoundFile, "busted-music-filter"))
+    assert.equals(0, #getPlayingMusic(otherLongSoundFile))
+    -- and the same filters as a table
+    assert.equals(1, #getPlayingMusic({name = longSoundFile}))
+    assert.equals(0, #getPlayingMusic({key = "busted-music-elsewhere"}))
+  end)
+
+  it("getPlayingSounds filters by name, key and tag in the ordered argument form", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-ordered-key", tag = "busted-ordered-tag"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    -- name[,key][,tag][,priority]
+    assert.equals(1, #getPlayingSounds(longSoundFile))
+    assert.equals(1, #getPlayingSounds(longSoundFile, "busted-ordered-key", "busted-ordered-tag"))
+    assert.equals(0, #getPlayingSounds(longSoundFile, "busted-ordered-key", "busted-other-tag"))
+    assert.equals(0, #getPlayingSounds(otherLongSoundFile))
+  end)
+
+  it("stopSounds stops only the sound named in the ordered argument form", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local started = {}
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-stop-named"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(playSoundFile({name = otherLongSoundFile, key = "busted-stop-spared"}))
+    waitForCount("sysMediaStarted", started, 2)
+    assert.equals(2, #getPlayingSounds())
+
+    -- name[,key][,tag][,priority][,fadeaway][,fadeout]
+    assert.is_true(stopSounds(longSoundFile))
+    local playing = getPlayingSounds()
+    assert.equals(1, #playing)
+    assert.equals(otherLongSoundFile, playing[1].name)
+  end)
+
+  it("stopMusic stops only the track named in the ordered argument form", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local started = {}
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playMusicFile({name = longSoundFile, key = "busted-music-stop-named"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(playMusicFile({name = otherLongSoundFile, key = "busted-music-stop-spared"}))
+    waitForCount("sysMediaStarted", started, 2)
+    assert.equals(2, #getPlayingMusic())
+
+    -- name[,key][,tag][,fadeaway][,fadeout]
+    assert.is_true(stopMusic(longSoundFile))
+    local music = getPlayingMusic()
+    assert.equals(1, #music)
+    assert.equals(otherLongSoundFile, music[1].name)
+  end)
+
+  it("pauseMusic and getPausedMusic take the same key filter", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local started = {}
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playMusicFile({name = longSoundFile, key = "busted-music-parked-key"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(playMusicFile({name = otherLongSoundFile, key = "busted-music-playing-key"}))
+    waitForCount("sysMediaStarted", started, 2)
+
+    assert.is_true(pauseMusic({key = "busted-music-parked-key"}))
+    assert.equals(1, #getPlayingMusic())
+    local paused = getPausedMusic()
+    assert.equals(1, #paused)
+    assert.equals(longSoundFile, paused[1].name)
+    assert.equals(1, #getPausedMusic({key = "busted-music-parked-key"}))
+    assert.equals(0, #getPausedMusic({key = "busted-music-playing-key"}))
+  end)
+
+  it("getPausedSounds takes the same key filter as the sound that was paused", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local started = {}
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = longSoundFile, key = "busted-sound-parked-key"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(pauseSounds({key = "busted-sound-parked-key"}))
+
+    assert.equals(1, #getPausedSounds({key = "busted-sound-parked-key"}))
+    assert.equals(0, #getPausedSounds({key = "busted-sound-never-played"}))
+    assert.equals(0, #getPausedSounds({name = otherLongSoundFile}))
+  end)
+
+  it("playVideoFile plays into the label its key names and the video family reports it", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- The file is the same silent WAV the sound specs use: what makes this a
+    -- video request is the type it is made as, which is what decides the widget
+    -- setup, the list it is tracked in and the media type its events carry. A
+    -- decodable picture would only change what the video widget draws.
+    withVideoLabel()
+    writeSoundFiles()
+    assert.equals(0, #getPlayingVideos())
+
+    assert.is_true(playVideoFile({name = longSoundFile, key = videoLabel, tag = "busted-video-tag"}))
+    local event, file, _, mediaType, key, tag = waitForEvent("sysMediaStarted", 5000)
+    assert.equals("sysMediaStarted", event)
+    assert.equals(longSoundFile, file)
+    assert.equals("video", mediaType)
+    assert.equals(videoLabel, key)
+    assert.equals("busted-video-tag", tag)
+
+    local playing = getPlayingVideos()
+    assert.equals(1, #playing)
+    assert.equals(longSoundFile, playing[1].name)
+    assert.equals(videoLabel, playing[1].key)
+    -- videos are tracked apart from sounds and music
+    assert.equals(0, #getPlayingSounds())
+    assert.equals(0, #getPlayingMusic())
+    assert.equals(1, #getPlayingVideos({key = videoLabel}))
+    assert.equals(0, #getPlayingVideos({key = "busted-video-other-key"}))
+
+    assert.is_true(pauseVideos())
+    assert.equals(0, #getPlayingVideos())
+    local paused = getPausedVideos()
+    assert.equals(1, #paused)
+    assert.equals(longSoundFile, paused[1].name)
+    assert.equals(1, #getPausedVideos({name = longSoundFile}))
+
+    -- resumed by playing the same file again, like sounds and music are
+    assert.is_true(playVideoFile({name = longSoundFile, key = videoLabel}))
+    assert.equals(1, #getPlayingVideos())
+    assert.equals(0, #getPausedVideos())
+
+    assert.is_true(stopVideos())
+    assert.equals(0, #getPlayingVideos())
   end)
 end)
 

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -505,6 +505,26 @@ describe("Media playback effects with a generated sound file", function()
   local videoLabel = "busted-media-video-label"
   local videoLabelReady
 
+  -- Handing a player that widget is the only thing this suite does that brings
+  -- a GL context up: Qt loads its XCB GL integration, and Mesa initialises and
+  -- then - at shutdown, with the context - unloads a driver. On the leak job's
+  -- Mesa that driver initialisation leaks around 240 bytes, and by the time
+  -- LeakSanitizer looks, the library holding the allocating frame is gone, so
+  -- no leak: line in asan-suppressions.txt can name it. That file asks for
+  -- exactly this: keep the context from being created test-side, which is also
+  -- why Other_spec leaves show3dMapView alone. The refusal spec below needs no
+  -- widget and no context, and every leg without leak checking - Windows CI and
+  -- a developer's own run - still plays the video.
+  local leakChecked = (os.getenv("ASAN_OPTIONS") or ""):find("detect_leaks=1", 1, true) ~= nil
+
+  local function videoWidgetUnavailable()
+    if leakChecked then
+      pending("a video widget's GL context leaks in this job's GL driver, where nothing is left to suppress by name")
+      return true
+    end
+    return false
+  end
+
   local function withVideoLabel()
     if not videoLabelReady then
       createLabel(videoLabel, 0, 0, 40, 40, 1)
@@ -1121,7 +1141,7 @@ describe("Media playback effects with a generated sound file", function()
   end)
 
   it("playVideoFile plays into the label its key names and the video family reports it", function()
-    if mediaPlaybackUnavailable() then
+    if videoWidgetUnavailable() or mediaPlaybackUnavailable() then
       return
     end
     -- The file is the same silent WAV the sound specs use: what makes this a

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -927,6 +927,9 @@ describe("Media playback effects with a generated sound file", function()
     end
     local downloaded = mediaDirectory .. "/" .. fixtureFile
     lfs.mkdir(mediaDirectory)
+    -- the download has to be the only file of that name, and a reused profile
+    -- may well have one of its own already
+    preserveMediaDirectory()
     os.remove(downloaded)
     onCleanup(function() os.remove(downloaded) end)
 
@@ -946,6 +949,9 @@ describe("Media playback effects with a generated sound file", function()
     -- name[,url]: the ordered form has a parser of its own
     local downloaded = mediaDirectory .. "/" .. fixtureFile
     lfs.mkdir(mediaDirectory)
+    -- the download has to be the only file of that name, and a reused profile
+    -- may well have one of its own already
+    preserveMediaDirectory()
     os.remove(downloaded)
     onCleanup(function() os.remove(downloaded) end)
 

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -172,10 +172,11 @@ describe("Media playback functions validate their parameters", function()
 end)
 
 describe("Media load functions validate their parameters", function()
-  -- loadMusicFile/loadSoundFile/loadVideoFile are the same preload request with
-  -- three different media types, and they share one pair of parsers with the
-  -- play family. Nothing here names a file that exists, so no preload gets as
-  -- far as the media engine.
+  -- loadMusicFile/loadSoundFile/loadVideoFile are one preload request behind
+  -- three names: they share a pair of parsers which set no media type at all,
+  -- so what actually differs between them is the name in their error messages
+  -- and loadVideoFile taking the table form only. Nothing here names a file
+  -- that exists, so no preload gets as far as the media engine.
   it("each raises a Lua error when called with no arguments", function()
     assertArgError(function() loadMusicFile() end, "loadMusicFile: need at least one argument")
     assertArgError(function() loadSoundFile() end, "loadSoundFile: need at least one argument")
@@ -264,6 +265,17 @@ describe("Media query and stop functions validate their parameters", function()
     assertArgError(function() playSoundFile("busted-media-absent.wav", 50, 0, 0, 0, 1, "k", {}) end, "tag as string expected, got table!")
   end)
 
+  it("a numeric key in a table argument does not stop the rest of it being read", function()
+    -- Reading a numeric key with lua_tostring() converts it in place, and the
+    -- step of the iteration that follows then refuses the key it is handed, so
+    -- every table parser reads its keys from a copy. Lua walks a table's array
+    -- part first, which puts the numeric key ahead of the named ones here.
+    assert.is_true(playSoundFile({[1] = "junk", name = "busted-media-absent.wav"}))
+    assert.is_true(stopSounds({[1] = "junk", key = "busted-media-no-such-key"}))
+    assert.is_table(getPlayingMusic({[1] = "junk", name = "busted-media-absent.mp3"}))
+    assert.is_table(getPausedVideos({[1] = "junk", key = "busted-media-no-such-key"}))
+  end)
+
   it("the ordered play forms refuse a negative fade", function()
     -- Only the range refusal, not the whole message: the music parser's fade
     -- messages name playSoundFile, and pinning that here would hold it in
@@ -347,6 +359,18 @@ describe("Media playback effects with a generated sound file", function()
     writeMediaFile(otherLongSoundFile, 10000)
   end
 
+  -- Cleanups to run at the end of the current spec. busted's finally() holds
+  -- one function rather than a list (busted/init.lua: `env.finally =
+  -- function(fn) finally = fn end`), so a spec that has two things to undo -
+  -- and several here do - would keep only the last of them. after_each drains
+  -- this instead, in reverse, and runs whatever a failed spec got as far as
+  -- registering.
+  local cleanups = {}
+
+  local function onCleanup(undo)
+    cleanups[#cleanups + 1] = undo
+  end
+
   -- purgeMediaCache() empties the whole media directory, not just the fixtures
   -- these specs wrote, and the self-test profile persists between runs on a
   -- developer's machine. Anything else already in there is moved aside for the
@@ -366,7 +390,7 @@ describe("Media playback effects with a generated sound file", function()
     for _, entry in ipairs(preserved) do
       os.rename(mediaDirectory .. "/" .. entry, stash .. "/" .. entry)
     end
-    finally(function()
+    onCleanup(function()
       lfs.mkdir(mediaDirectory)
       for _, entry in ipairs(preserved) do
         os.rename(stash .. "/" .. entry, mediaDirectory .. "/" .. entry)
@@ -383,7 +407,7 @@ describe("Media playback effects with a generated sound file", function()
     local handler = registerAnonymousEventHandler(eventName, function(_, file, path, mediaType, key, tag)
       into[#into + 1] = {file = file, path = path, mediaType = mediaType, key = key, tag = tag}
     end)
-    finally(function() killAnonymousEventHandler(handler) end)
+    onCleanup(function() killAnonymousEventHandler(handler) end)
   end
 
   -- Waits until collected holds count entries. A media event can be raised
@@ -475,8 +499,9 @@ describe("Media playback effects with a generated sound file", function()
   -- Video playback draws into a widget the request names with its key:
   -- TMainConsole::setupVideoOutput() looks that key up among the profile's
   -- labels and user windows, and refuses the request when it finds neither. The
-  -- label is left in place afterwards rather than deleted, because the player
-  -- that was handed its video widget outlives the spec.
+  -- label is not deleted afterwards, because the player that was handed its
+  -- video widget outlives the spec - it is only hidden again, so it does not
+  -- sit over the main console for every spec that runs later.
   local videoLabel = "busted-media-video-label"
   local videoLabelReady
 
@@ -486,9 +511,18 @@ describe("Media playback effects with a generated sound file", function()
       assert.equals("label", windowType(videoLabel))
       videoLabelReady = true
     end
+    onCleanup(function() hideWindow(videoLabel) end)
   end
 
   after_each(function()
+    -- before the stops below, not after: a spec's own event handlers have to
+    -- be gone before anything raises sysMediaFinished at them, or a handler
+    -- that starts a sound of its own leaves one playing into the next spec
+    for index = #cleanups, 1, -1 do
+      cleanups[index]()
+    end
+    cleanups = {}
+
     stopSounds()
     stopMusic()
     stopVideos()
@@ -736,7 +770,7 @@ describe("Media playback effects with a generated sound file", function()
       reentered = reentered + 1
       playSoundFile({name = otherLongSoundFile, key = "busted-handler-sound"})
     end)
-    finally(function() killAnonymousEventHandler(handler) end)
+    onCleanup(function() killAnonymousEventHandler(handler) end)
 
     assert.is_true(playSoundFile({name = longSoundFile, key = "busted-quiet", priority = 10}))
     -- stops the sound above while it is still loading, which raises
@@ -854,7 +888,7 @@ describe("Media playback effects with a generated sound file", function()
     handle:write("pinned")
     handle:close()
     os.execute("chmod 500 '" .. lockedDirectory .. "'")
-    finally(function()
+    onCleanup(function()
       os.execute("chmod 700 '" .. lockedDirectory .. "'")
       os.remove(pinnedFile)
       lfs.rmdir(lockedDirectory)
@@ -877,7 +911,7 @@ describe("Media playback effects with a generated sound file", function()
     local handler = registerAnonymousEventHandler("sysDownloadError", function(_, message, path)
       errors[#errors + 1] = {message = message, path = path}
     end)
-    finally(function() killAnonymousEventHandler(handler) end)
+    onCleanup(function() killAnonymousEventHandler(handler) end)
 
     -- a file the media directory does not have, so the url is the only way to get it
     assert.is_true(playSoundFile({name = "busted-media-absent-scheme.wav", url = "ftp://example.invalid/sounds"}))
@@ -894,7 +928,7 @@ describe("Media playback effects with a generated sound file", function()
     local downloaded = mediaDirectory .. "/" .. fixtureFile
     lfs.mkdir(mediaDirectory)
     os.remove(downloaded)
-    finally(function() os.remove(downloaded) end)
+    onCleanup(function() os.remove(downloaded) end)
 
     local done = {}
     collect("sysDownloadDone", done)
@@ -913,7 +947,7 @@ describe("Media playback effects with a generated sound file", function()
     local downloaded = mediaDirectory .. "/" .. fixtureFile
     lfs.mkdir(mediaDirectory)
     os.remove(downloaded)
-    finally(function() os.remove(downloaded) end)
+    onCleanup(function() os.remove(downloaded) end)
 
     local done = {}
     collect("sysDownloadDone", done)
@@ -929,12 +963,24 @@ describe("Media playback effects with a generated sound file", function()
     -- url that is not http(s) is where a spec can see a load act on its url
     -- without a server to answer it.
     local errors = {}
-    collect("sysDownloadError", errors)
+    local handler = registerAnonymousEventHandler("sysDownloadError", function(_, message, path)
+      errors[#errors + 1] = {message = message, path = path}
+    end)
+    onCleanup(function() killAnonymousEventHandler(handler) end)
 
     assert.is_true(loadVideoFile({name = "busted-media-absent-load.mkv", url = "ftp://example.invalid/videos"}))
     waitForCount("sysDownloadError", errors, 1)
-    assert.equals(1, #errors)
-    assert.is_true(contains(errors[1].path, "busted-media-absent-load.mkv"), tostring(errors[1].path))
+
+    -- picked out by name rather than by position: the collector sees every
+    -- download error, not only this one's
+    local reported
+    for _, failure in ipairs(errors) do
+      if contains(failure.path, "busted-media-absent-load.mkv") then
+        reported = failure
+      end
+    end
+    assert.is_not_nil(reported, "no download error named the file the load asked for")
+    assert.is_true(contains(reported.message, "http"), tostring(reported.message))
   end)
 
   it("playMusicFile starts a track given in the ordered argument form", function()
@@ -965,6 +1011,7 @@ describe("Media playback effects with a generated sound file", function()
     -- name[,key][,tag] as ordered arguments
     assert.equals(1, #getPlayingMusic(longSoundFile))
     assert.equals(1, #getPlayingMusic(longSoundFile, "busted-music-filter"))
+    assert.equals(0, #getPlayingMusic(longSoundFile, "busted-music-elsewhere"))
     assert.equals(0, #getPlayingMusic(otherLongSoundFile))
     -- and the same filters as a table
     assert.equals(1, #getPlayingMusic({name = longSoundFile}))
@@ -1112,6 +1159,19 @@ describe("Media playback effects with a generated sound file", function()
     assert.is_true(stopVideos())
     assert.equals(0, #getPlayingVideos())
   end)
+
+  it("playVideoFile starts nothing when its key names no widget to draw into", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+    -- The request is understood, so it reports success; the widget lookup then
+    -- turns up nothing and the playback never starts. Nothing but the video
+    -- list says so, which is why this is worth holding to.
+    assert.is_true(playVideoFile({name = longSoundFile, key = "busted-media-no-such-widget"}))
+    assert.equals(0, #getPlayingVideos())
+    assert.equals(0, #getPausedVideos())
+  end)
 end)
 
 describe("receiveMSP reports MSP is not enabled while offline", function()
@@ -1181,6 +1241,15 @@ describe("Tests the text-to-speech Lua API", function()
         return true
       end
 
+      -- Undone at the end of the current spec, for the same reason the media
+      -- specs above keep a list: busted's finally() holds one function, not a
+      -- list, and these specs have several things to put back.
+      local cleanups = {}
+
+      local function onCleanup(undo)
+        cleanups[#cleanups + 1] = undo
+      end
+
       -- Collects every occurrence of an event for the duration of one spec.
       -- The mock engine changes state inside the ttsSpeak()/ttsSkip() call
       -- itself, so the matching event is raised before a waitForEvent() could
@@ -1189,7 +1258,7 @@ describe("Tests the text-to-speech Lua API", function()
         local handler = registerAnonymousEventHandler(eventName, function(_, first)
           into[#into + 1] = first == nil and true or first
         end)
-        finally(function() killAnonymousEventHandler(handler) end)
+        onCleanup(function() killAnonymousEventHandler(handler) end)
       end
 
       -- The mock engine speaks in real time at roughly a tenth of a second per
@@ -1201,6 +1270,10 @@ describe("Tests the text-to-speech Lua API", function()
           ttsClearQueue()
           ttsSkip()
         end
+        for index = #cleanups, 1, -1 do
+          cleanups[index]()
+        end
+        cleanups = {}
       end)
 
       it("ttsSpeak rejects whitespace-only text", function()
@@ -1490,7 +1563,7 @@ describe("Tests the text-to-speech Lua API", function()
         collect("ttsPitchChanged", pitches)
         collect("ttsVolumeChanged", volumes)
         local rate, pitch, volume = ttsGetRate(), ttsGetPitch(), ttsGetVolume()
-        finally(function()
+        onCleanup(function()
           ttsSetRate(rate)
           ttsSetPitch(pitch)
           ttsSetVolume(volume)
@@ -1530,7 +1603,7 @@ describe("Tests the text-to-speech Lua API", function()
         local changes = {}
         local originalVoice = ttsGetCurrentVoice()
         collect("ttsVoiceChanged", changes)
-        finally(function() ttsSetVoiceByName(originalVoice) end)
+        onCleanup(function() ttsSetVoiceByName(originalVoice) end)
 
         assert.is_true(ttsSetVoiceByName(voices[2]))
         assert.equals(voices[2], ttsGetCurrentVoice())
@@ -1637,7 +1710,7 @@ describe("Tests the text-to-speech Lua API", function()
         local changes = {}
         collect("ttsVoiceChanged", changes)
         local originalVoice = ttsGetCurrentVoice()
-        finally(function() ttsSetVoiceByName(originalVoice) end)
+        onCleanup(function() ttsSetVoiceByName(originalVoice) end)
 
         assert.is_true(ttsSetVoiceByName(voices[2]))
         assert.equals(voices[2], ttsGetCurrentVoice())

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -173,10 +173,10 @@ end)
 
 describe("Media load functions validate their parameters", function()
   -- loadMusicFile/loadSoundFile/loadVideoFile are one preload request behind
-  -- three names: they share a pair of parsers which set no media type at all,
-  -- so what actually differs between them is the name in their error messages
-  -- and loadVideoFile taking the table form only. Nothing here names a file
-  -- that exists, so no preload gets as far as the media engine.
+  -- three names: they share a pair of parsers, each call stamping its own media
+  -- type on the request, and loadVideoFile takes the table form only. Nothing
+  -- here names a file that exists, so no preload gets as far as the media
+  -- engine.
   it("each raises a Lua error when called with no arguments", function()
     assertArgError(function() loadMusicFile() end, "loadMusicFile: need at least one argument")
     assertArgError(function() loadSoundFile() end, "loadSoundFile: need at least one argument")
@@ -985,6 +985,27 @@ describe("Media playback effects with a generated sound file", function()
 
     assert.equals(1, #done)
     assert.equals(fixtureBody, readFile(downloaded))
+  end)
+
+  it("a sound preload leaves paused music of the same name paused", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- #9784: what a load is filed as decides which players it can reach.
+    -- playMedia() looks for a paused player to resume before it does anything
+    -- else, among the players of the type the request carries - and a load that
+    -- set no type at all searched every list this profile has, so a sound
+    -- preload took over music.
+    writeSoundFiles()
+    assert.is_true(playMusicFile({name = longSoundFile, key = "busted-load-typed"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+    assert.is_true(pauseMusic())
+    assert.equals(1, #getPausedMusic())
+
+    assert.is_true(loadSoundFile({name = longSoundFile}))
+    assert.equals(1, #getPausedMusic())
+    assert.equals(0, #getPlayingMusic())
+    assert.equals(0, #getPlayingSounds())
   end)
 
   it("loadVideoFile reports a download error for a url it cannot fetch from", function()

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -198,11 +198,12 @@ describe("Media load functions validate their parameters", function()
     assert.is_true(contains(err, "missing argument 1"), tostring(err))
   end)
 
-  it("the table form raises a Lua error when it is given no name", function()
-    -- Only the tail of the message: all three loads report this one as
-    -- loadMusicFile, whichever was called, and pinning that here would hold
-    -- that in place.
-    assertArgError(function() loadSoundFile({}) end, "missing name")
+  it("the table form raises a Lua error naming the load that was called", function()
+    -- #9785: the shared table parser reported every one of them as
+    -- loadMusicFile, which sent anyone debugging a script to the wrong call
+    assertArgError(function() loadSoundFile({}) end, "loadSoundFile: missing name")
+    assertArgError(function() loadMusicFile({}) end, "loadMusicFile: missing name")
+    assertArgError(function() loadVideoFile({}) end, "loadVideoFile: missing name")
   end)
 
   it("the ordered form raises a Lua error when the url is not a string", function()
@@ -276,12 +277,14 @@ describe("Media query and stop functions validate their parameters", function()
     assert.is_table(getPausedVideos({[1] = "junk", key = "busted-media-no-such-key"}))
   end)
 
-  it("the ordered play forms refuse a negative fade", function()
-    -- Only the range refusal, not the whole message: the music parser's fade
-    -- messages name playSoundFile, and pinning that here would hold it in
-    -- place.
-    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, -1) end, "bad argument range for fadein")
-    assertArgError(function() playSoundFile("busted-media-absent.wav", 50, 0, -1) end, "bad argument range for fadeout")
+  it("the ordered play forms refuse a negative fade, start or finish and name the call", function()
+    -- #9785: the music parser's four range messages all named playSoundFile
+    -- name[,volume][,fadein][,fadeout][,start][,loops][,key][,tag][,continue][,url][,finish]
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, -1) end, "playMusicFile: bad argument range for fadein")
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, 0, -1) end, "playMusicFile: bad argument range for fadeout")
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, 0, 0, -1) end, "playMusicFile: bad argument range for start")
+    assertArgError(function() playMusicFile("busted-media-absent.mp3", 50, 0, 0, 0, 1, "k", "t", false, nil, -1) end, "playMusicFile: bad argument range for finish")
+    assertArgError(function() playSoundFile("busted-media-absent.wav", 50, 0, -1) end, "playSoundFile: bad argument range for fadeout")
   end)
 
   it("every query returns an empty table while nothing is playing", function()

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -463,9 +463,10 @@ describe("Media playback effects with a generated sound file", function()
   end
 
   -- The fixture server of CI/http-fixture-server.py, when the harness started
-  -- one and handed its ephemeral port over. A preload's only observable effect
-  -- is the fetch it starts for a file the profile does not have, so the two
-  -- load specs below are the media ones that need a server to talk to.
+  -- one and handed its ephemeral port over. A preload's observable effect is
+  -- the fetch it starts for a file the profile does not have, so the load specs
+  -- below are the media ones that need a server to talk to. Anything asked of
+  -- it below /media is answered with generated silence rather than from disk.
   local httpPort = os.getenv("MUDLET_TEST_HTTP_PORT")
   local requireFixture = os.getenv("MUDLET_TEST_REQUIRE_HTTP_FIXTURE")
   -- the file CI/http-fixtures/ serves, and its contents
@@ -985,6 +986,40 @@ describe("Media playback effects with a generated sound file", function()
 
     assert.equals(1, #done)
     assert.equals(fixtureBody, readFile(downloaded))
+  end)
+
+  it("a preload from a url keeps the file without playing it", function()
+    if noFixtureServer() then
+      return
+    end
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- #9783: the download's completion played what it had just written. The
+    -- fixture server generates ten seconds of silence for this path, so a
+    -- playback that started would still be running when this looks.
+    local downloadName = "busted-media-download.wav"
+    local downloaded = mediaDirectory .. "/" .. downloadName
+    lfs.mkdir(mediaDirectory)
+    os.remove(downloaded)
+    onCleanup(function() os.remove(downloaded) end)
+
+    local done = {}
+    collect("sysDownloadDone", done)
+    assert.is_true(loadSoundFile({name = downloadName, url = fixtureUrl() .. "/media"}))
+    waitForCount("sysDownloadDone", done, 1)
+    assert.equals(1, #done)
+
+    -- the playback this must not start would begin after the event above, and a
+    -- preloaded one raises no sysMediaStarted to wait for, so give the player
+    -- the turns it would need to reach the playing state
+    pumpEvents(1000)
+    assert.equals(0, #getPlayingSounds())
+    assert.equals(0, #getPlayingMusic())
+    assert.equals(0, #getPlayingVideos())
+
+    -- and the file is in the media directory, which is what the preload was for
+    assert.is_not_nil(lfs.attributes(downloaded, "mode"), "the preload did not keep the file it downloaded")
   end)
 
   it("a sound preload leaves paused music of the same name paused", function()

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -2013,10 +2013,16 @@ describe("The IRC configuration functions round-trip through the profile", funct
     -- Both of these read whether the profile has an IRC dialog, and nothing in
     -- the suite creates one - see the openIRC spec below for why. Should
     -- something start doing so, these are where it shows up first.
+    --
+    -- Which is also why only the failure half of getIrcConnectedHost's pair is
+    -- checked here: the other half needs a connection to an IRC server that has
+    -- sent its welcome. #9788 was in that half - it pushed true and the host
+    -- name but returned only one of them.
     it("getIrcConnectedHost returns false and says there is no client", function()
       local ok, err = getIrcConnectedHost()
       assert.is_false(ok)
       assert.equals("no client active", err)
+      assert.equals(2, select("#", getIrcConnectedHost()))
     end)
 
     it("restartIrc returns false", function()

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -1940,6 +1940,39 @@ describe("The IRC configuration functions round-trip through the profile", funct
       assert.equals(6667, port)
       assert.is_false(secure)
     end)
+
+    it("takes an explicit nil for any optional argument, as leaving it off does", function()
+      -- #9787: a script forwarding optional variables passes nil for the ones
+      -- it has no value for, and only the port accepted that
+      local passwordFile = getMudletHomeDir() .. "/irc_password"
+      local nick = getIrcNick()
+      local hostName, port, secure = getIrcServer()
+      local channels = getIrcChannels()
+      local ownPassword = readBinaryFile(passwordFile)
+      finally(function()
+        setIrcNick(nick)
+        setIrcServer(hostName, port, secure)
+        setIrcChannels(channels)
+        if ownPassword then
+          writeBinaryFile(passwordFile, ownPassword)
+        else
+          os.remove(passwordFile)
+        end
+      end)
+
+      assert.is_true(setIrcServer("irc.busted-nil.invalid", 6697, true, "BustedNilSecret"))
+      local stored = readBinaryFile(passwordFile)
+      assert.is_true(contains(stored, utf16be("BustedNilSecret")))
+
+      assert.is_true(setIrcServer("irc.busted-nil.invalid", nil, nil, nil))
+      local storedHost, storedPort, storedSecure = getIrcServer()
+      assert.equals("irc.busted-nil.invalid", storedHost)
+      -- a nil optional is the default, the same as leaving it off
+      assert.equals(6667, storedPort)
+      assert.is_false(storedSecure)
+      -- except for the password, which an omitted argument keeps as it is
+      assert.equals(stored, readBinaryFile(passwordFile))
+    end)
   end)
 
   describe("setIrcChannels", function()

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -2007,6 +2007,25 @@ describe("The IRC configuration functions round-trip through the profile", funct
       assert.is_true(setIrcChannels({"#busted-good", "busted-bad", "&busted-also-good"}))
       assert.same({"#busted-good", "&busted-also-good"}, getIrcChannels())
     end)
+
+    it("drops a channel name carrying a space or a comma rather than storing two", function()
+      -- #9789: the stored list is space-joined and the JOIN command is
+      -- comma-joined, so a name holding either came back as two channels. An
+      -- IRC channel name can hold neither, which puts them with the other
+      -- unusable names above: dropped, and refused outright when nothing is
+      -- left.
+      restoreIrcConfiguration()
+      assert.is_true(setIrcChannels({"#busted-spaced one", "#busted-plain"}))
+      assert.same({"#busted-plain"}, getIrcChannels())
+
+      assert.is_true(setIrcChannels({"#busted-a,#busted-b", "#busted-plain-two"}))
+      assert.same({"#busted-plain-two"}, getIrcChannels())
+
+      local ok, err = setIrcChannels({"#busted only spaced"})
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "no (valid) channel names provided"), tostring(err))
+      assert.same({"#busted-plain-two"}, getIrcChannels())
+    end)
   end)
 
   describe("getIrcConnectedHost and restartIrc without a client", function()

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -1744,16 +1744,14 @@ describe("The IRC configuration functions round-trip through the profile", funct
   -- connection anywhere in sight.
   --
   -- The profile's own IRC configuration is put back afterwards, because the
-  -- self-test profile is reused between runs. Two things the restore cannot
-  -- reach, both of which matter to a developer running the suite against a
-  -- config root that is not a throwaway one:
-  --
-  -- - the IRC password. setIrcServer() writes it on every call and blanks it
-  --   when none is passed, and no getter reads it back, so any password the
-  --   profile had is gone either way.
-  -- - the last-used nick, which setIrcNick() also writes to a file shared by
-  --   every profile (mudlet's data directory, not the profile's). Putting the
-  --   profile's nick back writes that file again rather than restoring it.
+  -- self-test profile is reused between runs. One thing the restore cannot
+  -- reach, which matters to a developer running the suite against a config root
+  -- that is not a throwaway one: the last-used nick, which setIrcNick() also
+  -- writes to a file shared by every profile (mudlet's data directory, not the
+  -- profile's). Putting the profile's nick back writes that file again rather
+  -- than restoring it. The password is left alone by every call below that does
+  -- not pass one, and the spec that does pass one puts the profile's own back
+  -- byte for byte.
   local function restoreIrcConfiguration()
     local nick = getIrcNick()
     local hostName, port, secure = getIrcServer()
@@ -1763,6 +1761,34 @@ describe("The IRC configuration functions round-trip through the profile", funct
       setIrcServer(hostName, port, secure)
       setIrcChannels(channels)
     end)
+  end
+
+  -- The password is the one setting with no getter, so the spec for it works on
+  -- the profile's own file: read and written as bytes, never parsed.
+  local function readBinaryFile(path)
+    local handle = io.open(path, "rb")
+    if not handle then
+      return nil
+    end
+    local contents = handle:read("*a")
+    handle:close()
+    return contents
+  end
+
+  local function writeBinaryFile(path, contents)
+    local handle = io.open(path, "wb")
+    assert.is_not_nil(handle, "could not write " .. path)
+    handle:write(contents)
+    handle:close()
+  end
+
+  -- How a QDataStream carries the characters of an ASCII QString
+  local function utf16be(text)
+    local encoded = {}
+    for index = 1, #text do
+      encoded[#encoded + 1] = "\0" .. text:sub(index, index)
+    end
+    return table.concat(encoded)
   end
 
   describe("getIrcNick, getIrcServer and getIrcChannels", function()
@@ -1865,6 +1891,43 @@ describe("The IRC configuration functions round-trip through the profile", funct
       assert.equals("irc.busted-two.invalid", hostName)
       assert.equals(6668, port)
       assert.is_false(secure)
+    end)
+
+    it("leaves the stored password alone when it is not passed", function()
+      -- #9786: every call rewrote the password, so changing the host or the
+      -- port blanked it - and with no getter for it, no script could put it
+      -- back. The file the profile keeps it in is where a spec can see it: a
+      -- QDataStream-serialised QString, compared as bytes rather than read.
+      local passwordFile = getMudletHomeDir() .. "/irc_password"
+      local nick = getIrcNick()
+      local hostName, port, secure = getIrcServer()
+      local channels = getIrcChannels()
+      local ownPassword = readBinaryFile(passwordFile)
+      finally(function()
+        setIrcNick(nick)
+        setIrcServer(hostName, port, secure)
+        setIrcChannels(channels)
+        if ownPassword then
+          writeBinaryFile(passwordFile, ownPassword)
+        else
+          os.remove(passwordFile)
+        end
+      end)
+
+      assert.is_true(setIrcServer("irc.busted-password.invalid", 6667, false, "BustedSecret"))
+      local stored = readBinaryFile(passwordFile)
+      assert.is_not_nil(stored, "setIrcServer stored no password file at all")
+      -- QDataStream writes a QString as a length and then UTF-16, big endian
+      assert.is_true(contains(stored, utf16be("BustedSecret")), "the password given was not the one stored")
+
+      -- the same server on another port, with the password argument left off
+      assert.is_true(setIrcServer("irc.busted-password.invalid", 6668))
+      assert.equals(6668, select(2, getIrcServer()))
+      assert.equals(stored, readBinaryFile(passwordFile))
+
+      -- and an empty string is how a script asks for the password to go
+      assert.is_true(setIrcServer("irc.busted-password.invalid", 6668, false, ""))
+      assert.is_false(contains(readBinaryFile(passwordFile), utf16be("BustedSecret")))
     end)
 
     it("falls back to port 6667 and an insecure connection when only a hostname is given", function()

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -1743,10 +1743,17 @@ describe("The IRC configuration functions round-trip through the profile", funct
   -- setters write to. So the round trip is testable with no IRC server and no
   -- connection anywhere in sight.
   --
-  -- Everything written here is put back afterwards, because the self-test
-  -- profile is reused between runs. The one thing the restore cannot put back
-  -- is the IRC password: setIrcServer() writes it on every call and blanks it
-  -- when none is passed, so any password the profile had is gone either way.
+  -- The profile's own IRC configuration is put back afterwards, because the
+  -- self-test profile is reused between runs. Two things the restore cannot
+  -- reach, both of which matter to a developer running the suite against a
+  -- config root that is not a throwaway one:
+  --
+  -- - the IRC password. setIrcServer() writes it on every call and blanks it
+  --   when none is passed, and no getter reads it back, so any password the
+  --   profile had is gone either way.
+  -- - the last-used nick, which setIrcNick() also writes to a file shared by
+  --   every profile (mudlet's data directory, not the profile's). Putting the
+  --   profile's nick back writes that file again rather than restoring it.
   local function restoreIrcConfiguration()
     local nick = getIrcNick()
     local hostName, port, secure = getIrcServer()
@@ -1907,6 +1914,9 @@ describe("The IRC configuration functions round-trip through the profile", funct
   end)
 
   describe("getIrcConnectedHost and restartIrc without a client", function()
+    -- Both of these read whether the profile has an IRC dialog, and nothing in
+    -- the suite creates one - see the openIRC spec below for why. Should
+    -- something start doing so, these are where it shows up first.
     it("getIrcConnectedHost returns false and says there is no client", function()
       local ok, err = getIrcConnectedHost()
       assert.is_false(ok)
@@ -1916,7 +1926,7 @@ describe("The IRC configuration functions round-trip through the profile", funct
     it("restartIrc returns false", function()
       -- there is no client to restart, and it says so by returning false
       -- rather than by opening one
-      assert.is_false(restartIrc())
+      assert.is_false(restartIrc(), "something in this run opened an IRC client")
     end)
   end)
 
@@ -1944,12 +1954,13 @@ describe("The IRC configuration functions round-trip through the profile", funct
 end)
 
 describe("getNetworkLatency", function()
-  it("reports the last measured latency as a number", function()
-    -- nothing has been timed on the self-test profile's socket, so what this
-    -- holds to is the type and that it is not negative; a meaningful value
-    -- needs a game server answering a command
+  it("reports zero on a profile whose game socket has never been timed", function()
+    -- The latency is measured between a command going out and the prompt that
+    -- answers it, and nothing in the suite connects the game socket - so the
+    -- untouched value is what this reads, which is also what pins it to the
+    -- right member. A meaningful reading needs a game server.
     local latency = getNetworkLatency()
     assert.is_number(latency)
-    assert.is_true(latency >= 0, tostring(latency))
+    assert.equals(0, latency)
   end)
 end)

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -1736,3 +1736,220 @@ describe("Discord Lua API availability contract", function()
     end)
   end)
 end)
+
+describe("The IRC configuration functions round-trip through the profile", function()
+  -- While a profile has no IRC dialog - none of these specs opens one - the
+  -- getters read the profile's own configuration off disk, which is what the
+  -- setters write to. So the round trip is testable with no IRC server and no
+  -- connection anywhere in sight.
+  --
+  -- Everything written here is put back afterwards, because the self-test
+  -- profile is reused between runs. The one thing the restore cannot put back
+  -- is the IRC password: setIrcServer() writes it on every call and blanks it
+  -- when none is passed, so any password the profile had is gone either way.
+  local function restoreIrcConfiguration()
+    local nick = getIrcNick()
+    local hostName, port, secure = getIrcServer()
+    local channels = getIrcChannels()
+    finally(function()
+      setIrcNick(nick)
+      setIrcServer(hostName, port, secure)
+      setIrcChannels(channels)
+    end)
+  end
+
+  describe("getIrcNick, getIrcServer and getIrcChannels", function()
+    it("report a nick, a server and a channel list without an IRC client", function()
+      -- with nothing configured each getter falls back to a built-in default
+      -- rather than to nil, which is what makes them safe to read before
+      -- anything has been set
+      local nick = getIrcNick()
+      assert.is_string(nick)
+      assert.is_true(#nick > 0)
+
+      local hostName, port, secure = getIrcServer()
+      assert.is_string(hostName)
+      assert.is_true(#hostName > 0)
+      assert.is_number(port)
+      assert.is_true(port >= 1 and port <= 65535, tostring(port))
+      assert.is_boolean(secure)
+
+      local channels = getIrcChannels()
+      assert.is_table(channels)
+      assert.is_true(#channels > 0)
+      for _, channel in ipairs(channels) do
+        assert.is_string(channel)
+      end
+    end)
+  end)
+
+  describe("setIrcNick", function()
+    it("raises a Lua error when the nick is missing or not a string", function()
+      assertArgError(function() setIrcNick() end, "setIrcNick: bad argument #1 type (nick as string expected")
+      assertArgError(function() setIrcNick({}) end, "setIrcNick: bad argument #1 type (nick as string expected, got table!)")
+    end)
+
+    it("returns nil and a message for an empty nick, leaving the stored one alone", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcNick("BustedKeptNick"))
+
+      local ok, err = setIrcNick("")
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "nick must not be empty"), tostring(err))
+      assert.equals("BustedKeptNick", getIrcNick())
+    end)
+
+    it("stores the nick where getIrcNick reads it back", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcNick("BustedNickOne"))
+      assert.equals("BustedNickOne", getIrcNick())
+
+      assert.is_true(setIrcNick("BustedNickTwo"))
+      assert.equals("BustedNickTwo", getIrcNick())
+    end)
+  end)
+
+  describe("setIrcServer", function()
+    it("raises a Lua error when the hostname or an optional argument is wrongly typed", function()
+      assertArgError(function() setIrcServer() end, "setIrcServer: bad argument #1 type (hostname as string expected")
+      assertArgError(function() setIrcServer({}) end, "setIrcServer: bad argument #1 type (hostname as string expected, got table!)")
+      assertArgError(function() setIrcServer("irc.busted.invalid", {}) end, "port number")
+      assertArgError(function() setIrcServer("irc.busted.invalid", 6667, "yes") end, "secure")
+      assertArgError(function() setIrcServer("irc.busted.invalid", 6667, false, {}) end, "server password")
+    end)
+
+    it("returns nil and a message for an empty hostname or an out-of-range port", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcServer("irc.busted-kept.invalid", 6690))
+
+      local ok, err = setIrcServer("")
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "hostname must not be empty"), tostring(err))
+
+      ok, err = setIrcServer("irc.busted.invalid", 70000)
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "invalid port number 70000"), tostring(err))
+
+      ok, err = setIrcServer("irc.busted.invalid", 0)
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "invalid port number 0"), tostring(err))
+
+      -- a refused call stored nothing
+      local hostName, port = getIrcServer()
+      assert.equals("irc.busted-kept.invalid", hostName)
+      assert.equals(6690, port)
+    end)
+
+    it("stores the hostname, port and secure flag where getIrcServer reads them back", function()
+      restoreIrcConfiguration()
+      -- it reports success as true plus a nil second value
+      local ok, extra = setIrcServer("irc.busted-one.invalid", 6697, true)
+      assert.is_true(ok)
+      assert.is_nil(extra)
+
+      local hostName, port, secure = getIrcServer()
+      assert.equals("irc.busted-one.invalid", hostName)
+      assert.equals(6697, port)
+      assert.is_true(secure)
+
+      -- the secure flag is stored, not merely defaulted: turn it back off
+      assert.is_true(setIrcServer("irc.busted-two.invalid", 6668, false))
+      hostName, port, secure = getIrcServer()
+      assert.equals("irc.busted-two.invalid", hostName)
+      assert.equals(6668, port)
+      assert.is_false(secure)
+    end)
+
+    it("falls back to port 6667 and an insecure connection when only a hostname is given", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcServer("irc.busted-secure.invalid", 6697, true))
+
+      assert.is_true(setIrcServer("irc.busted-default.invalid"))
+      local hostName, port, secure = getIrcServer()
+      assert.equals("irc.busted-default.invalid", hostName)
+      assert.equals(6667, port)
+      assert.is_false(secure)
+    end)
+  end)
+
+  describe("setIrcChannels", function()
+    it("raises a Lua error when the channels are not a table", function()
+      assertArgError(function() setIrcChannels("#mudlet") end, "setIrcChannels: bad argument #1 type (channels as table expected, got string!)")
+      assertArgError(function() setIrcChannels() end, "setIrcChannels: bad argument #1 type (channels as table expected, got no value!)")
+    end)
+
+    it("returns nil and a message when no entry is a usable channel name", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcChannels({"#busted-kept"}))
+
+      local ok, err = setIrcChannels({})
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "no (valid) channel names provided"), tostring(err))
+
+      -- a channel name has to start with #, & or +, and only strings are read
+      ok, err = setIrcChannels({"mudlet", 42, ""})
+      assert.is_nil(ok)
+      assert.is_true(contains(err, "no (valid) channel names provided"), tostring(err))
+      assert.same({"#busted-kept"}, getIrcChannels())
+    end)
+
+    it("stores the channel list where getIrcChannels reads it back", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcChannels({"#busted-one", "&busted-two", "+busted-three"}))
+      assert.same({"#busted-one", "&busted-two", "+busted-three"}, getIrcChannels())
+    end)
+
+    it("keeps the usable channel names out of a mixed list and drops the rest", function()
+      restoreIrcConfiguration()
+      assert.is_true(setIrcChannels({"#busted-good", "busted-bad", "&busted-also-good"}))
+      assert.same({"#busted-good", "&busted-also-good"}, getIrcChannels())
+    end)
+  end)
+
+  describe("getIrcConnectedHost and restartIrc without a client", function()
+    it("getIrcConnectedHost returns false and says there is no client", function()
+      local ok, err = getIrcConnectedHost()
+      assert.is_false(ok)
+      assert.equals("no client active", err)
+    end)
+
+    it("restartIrc returns false", function()
+      -- there is no client to restart, and it says so by returning false
+      -- rather than by opening one
+      assert.is_false(restartIrc())
+    end)
+  end)
+
+  describe("sendIrc", function()
+    -- Both arguments are checked before the IRC dialog would be created, so
+    -- these calls open no client. A well-formed sendIrc() does create one,
+    -- which is why there is no spec here for the delivery path.
+    it("raises a Lua error when the target or the message is missing or wrongly typed", function()
+      assertArgError(function() sendIrc() end, "sendIrc: bad argument #1 type (target as string expected")
+      assertArgError(function() sendIrc("#mudlet") end, "sendIrc: bad argument #2 type (message as string expected")
+      assertArgError(function() sendIrc({}, "hello") end, "sendIrc: bad argument #1 type (target as string expected, got table!)")
+      assertArgError(function() sendIrc("#mudlet", {}) end, "sendIrc: bad argument #2 type (message as string expected, got table!)")
+    end)
+  end)
+
+  describe("openIRC", function()
+    it("opens the IRC client window", function()
+      pending("openIRC creates the profile's IRC dialog and nothing in the Lua API closes it again. "
+        .. "From then on the getters answer out of the copy the dialog read when it was constructed - "
+        .. "a setIrcNick() while it is open is not seen by getIrcNick() until restartIrc() - so the "
+        .. "round trips above would stop working for the rest of the run, and the dialog dials the "
+        .. "configured server and raises a window over the specs that follow")
+    end)
+  end)
+end)
+
+describe("getNetworkLatency", function()
+  it("reports the last measured latency as a number", function()
+    -- nothing has been timed on the self-test profile's socket, so what this
+    -- holds to is the type and that it is not negative; a meaningful value
+    -- needs a game server answering a command
+    local latency = getNetworkLatency()
+    assert.is_number(latency)
+    assert.is_true(latency >= 0, tostring(latency))
+  end)
+end)

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -27,7 +27,7 @@ end
 local function assertArgError(fn, needle)
   local ok, err = pcall(fn)
   assert.is_false(ok)
-  assert.is_true(contains(err, needle))
+  assert.is_true(contains(err, needle), tostring(err))
 end
 
 describe("Networking send functions honour their disconnected/offline contracts", function()
@@ -1750,8 +1750,8 @@ describe("The IRC configuration functions round-trip through the profile", funct
   -- writes to a file shared by every profile (mudlet's data directory, not the
   -- profile's). Putting the profile's nick back writes that file again rather
   -- than restoring it. The password is left alone by every call below that does
-  -- not pass one, and the spec that does pass one puts the profile's own back
-  -- byte for byte.
+  -- not pass one, and the specs that do pass one put the profile's own back
+  -- through setConfig().
   local function restoreIrcConfiguration()
     local nick = getIrcNick()
     local hostName, port, secure = getIrcServer()
@@ -1763,32 +1763,20 @@ describe("The IRC configuration functions round-trip through the profile", funct
     end)
   end
 
-  -- The password is the one setting with no getter, so the spec for it works on
-  -- the profile's own file: read and written as bytes, never parsed.
-  local function readBinaryFile(path)
-    local handle = io.open(path, "rb")
-    if not handle then
-      return nil
-    end
-    local contents = handle:read("*a")
-    handle:close()
-    return contents
-  end
-
-  local function writeBinaryFile(path, contents)
-    local handle = io.open(path, "wb")
-    assert.is_not_nil(handle, "could not write " .. path)
-    handle:write(contents)
-    handle:close()
-  end
-
-  -- How a QDataStream carries the characters of an ASCII QString
-  local function utf16be(text)
-    local encoded = {}
-    for index = 1, #text do
-      encoded[#encoded + 1] = "\0" .. text:sub(index, index)
-    end
-    return table.concat(encoded)
+  -- setIrcServer takes a password but no getter of its own reads one back, so
+  -- the specs for it go through the configuration option the same file is
+  -- behind: getConfig("ircPassword") and setConfig("ircPassword", ...).
+  local function restoreIrcConfigurationWithPassword()
+    local nick = getIrcNick()
+    local hostName, port, secure = getIrcServer()
+    local channels = getIrcChannels()
+    local password = getConfig("ircPassword")
+    finally(function()
+      setIrcNick(nick)
+      setIrcServer(hostName, port, secure)
+      setIrcChannels(channels)
+      setConfig("ircPassword", password)
+    end)
   end
 
   describe("getIrcNick, getIrcServer and getIrcChannels", function()
@@ -1894,40 +1882,27 @@ describe("The IRC configuration functions round-trip through the profile", funct
     end)
 
     it("leaves the stored password alone when it is not passed", function()
-      -- #9786: every call rewrote the password, so changing the host or the
-      -- port blanked it - and with no getter for it, no script could put it
-      -- back. The file the profile keeps it in is where a spec can see it: a
-      -- QDataStream-serialised QString, compared as bytes rather than read.
-      local passwordFile = getMudletHomeDir() .. "/irc_password"
-      local nick = getIrcNick()
-      local hostName, port, secure = getIrcServer()
-      local channels = getIrcChannels()
-      local ownPassword = readBinaryFile(passwordFile)
-      finally(function()
-        setIrcNick(nick)
-        setIrcServer(hostName, port, secure)
-        setIrcChannels(channels)
-        if ownPassword then
-          writeBinaryFile(passwordFile, ownPassword)
-        else
-          os.remove(passwordFile)
-        end
-      end)
+      -- #9786: every call rewrote the password, so a script that changed the
+      -- host or the port destroyed a credential it was never given.
+      restoreIrcConfigurationWithPassword()
 
       assert.is_true(setIrcServer("irc.busted-password.invalid", 6667, false, "BustedSecret"))
-      local stored = readBinaryFile(passwordFile)
-      assert.is_not_nil(stored, "setIrcServer stored no password file at all")
-      -- QDataStream writes a QString as a length and then UTF-16, big endian
-      assert.is_true(contains(stored, utf16be("BustedSecret")), "the password given was not the one stored")
+      assert.equals("BustedSecret", getConfig("ircPassword"))
 
       -- the same server on another port, with the password argument left off
       assert.is_true(setIrcServer("irc.busted-password.invalid", 6668))
       assert.equals(6668, select(2, getIrcServer()))
-      assert.equals(stored, readBinaryFile(passwordFile))
+      assert.equals("BustedSecret", getConfig("ircPassword"))
 
-      -- and an empty string is how a script asks for the password to go
-      assert.is_true(setIrcServer("irc.busted-password.invalid", 6668, false, ""))
-      assert.is_false(contains(readBinaryFile(passwordFile), utf16be("BustedSecret")))
+      -- and it is kept across a change of server too, because an argument that
+      -- was not passed says nothing about the credential
+      assert.is_true(setIrcServer("irc.busted-other.invalid", 6667))
+      assert.equals("irc.busted-other.invalid", (getIrcServer()))
+      assert.equals("BustedSecret", getConfig("ircPassword"))
+
+      -- an empty string is how a script asks for the password to go
+      assert.is_true(setIrcServer("irc.busted-other.invalid", 6667, false, ""))
+      assert.equals("", getConfig("ircPassword"))
     end)
 
     it("falls back to port 6667 and an insecure connection when only a hostname is given", function()
@@ -1944,25 +1919,10 @@ describe("The IRC configuration functions round-trip through the profile", funct
     it("takes an explicit nil for any optional argument, as leaving it off does", function()
       -- #9787: a script forwarding optional variables passes nil for the ones
       -- it has no value for, and only the port accepted that
-      local passwordFile = getMudletHomeDir() .. "/irc_password"
-      local nick = getIrcNick()
-      local hostName, port, secure = getIrcServer()
-      local channels = getIrcChannels()
-      local ownPassword = readBinaryFile(passwordFile)
-      finally(function()
-        setIrcNick(nick)
-        setIrcServer(hostName, port, secure)
-        setIrcChannels(channels)
-        if ownPassword then
-          writeBinaryFile(passwordFile, ownPassword)
-        else
-          os.remove(passwordFile)
-        end
-      end)
+      restoreIrcConfigurationWithPassword()
 
       assert.is_true(setIrcServer("irc.busted-nil.invalid", 6697, true, "BustedNilSecret"))
-      local stored = readBinaryFile(passwordFile)
-      assert.is_true(contains(stored, utf16be("BustedNilSecret")))
+      assert.equals("BustedNilSecret", getConfig("ircPassword"))
 
       assert.is_true(setIrcServer("irc.busted-nil.invalid", nil, nil, nil))
       local storedHost, storedPort, storedSecure = getIrcServer()
@@ -1970,8 +1930,8 @@ describe("The IRC configuration functions round-trip through the profile", funct
       -- a nil optional is the default, the same as leaving it off
       assert.equals(6667, storedPort)
       assert.is_false(storedSecure)
-      -- except for the password, which an omitted argument keeps as it is
-      assert.equals(stored, readBinaryFile(passwordFile))
+      -- except for the password, which a nil argument keeps as it is
+      assert.equals("BustedNilSecret", getConfig("ircPassword"))
     end)
   end)
 
@@ -2018,7 +1978,7 @@ describe("The IRC configuration functions round-trip through the profile", funct
       assert.is_true(setIrcChannels({"#busted-spaced one", "#busted-plain"}))
       assert.same({"#busted-plain"}, getIrcChannels())
 
-      assert.is_true(setIrcChannels({"#busted-a,#busted-b", "#busted-plain-two"}))
+      assert.is_true(setIrcChannels({"#busted-a,#busted-b", "#busted-tabbed\tname", "#busted-plain-two"}))
       assert.same({"#busted-plain-two"}, getIrcChannels())
 
       local ok, err = setIrcChannels({"#busted only spaced"})
@@ -2034,9 +1994,9 @@ describe("The IRC configuration functions round-trip through the profile", funct
     -- something start doing so, these are where it shows up first.
     --
     -- Which is also why only the failure half of getIrcConnectedHost's pair is
-    -- checked here: the other half needs a connection to an IRC server that has
-    -- sent its welcome. #9788 was in that half - it pushed true and the host
-    -- name but returned only one of them.
+    -- checked here, arity included: the other half needs a client connected far
+    -- enough for the server's RPL_YOURHOST, which is where #9788 was - it pushed
+    -- true and the host name but returned only one of them.
     it("getIrcConnectedHost returns false and says there is no client", function()
       local ok, err = getIrcConnectedHost()
       assert.is_false(ok)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- **Media**: a preload that has to fetch its file now keeps it without playing it (#9783 - the same guard covers GMCP `Client.Media.Load`, which preloads the same way), each `load*File()` stamps its own media type so a load can only reach players of its own kind (#9784), and the load/play errors name the function that was actually called instead of always `loadMusicFile`/`playSoundFile` (#9785).
- **IRC**: `setIrcServer()` keeps a stored password it was not given - an empty string still clears it - and takes an explicit `nil` for any optional argument the way an omitted one is taken (#9786, #9787); `getIrcConnectedHost()` returns the documented `true, host` pair instead of dropping the boolean (#9788); `setIrcChannels()` drops a name carrying whitespace or a comma rather than storing one channel that reads back as two (#9789).
- Specs for six of the seven ship with them; the fixture server answers a GET below `/media` for a `.wav` with generated silence, so a preload spec has a real file to fetch. `getIrcConnectedHost()`'s success path needs a client connected far enough for the server's `RPL_YOURHOST`, which this suite deliberately never opens, so that one was checked with temporary instrumentation (before: 1 value, the host name; after: `true` plus the host name) rather than left to a spec that could not reach it.

#### Motivation for adding to Mudlet

All seven were found while writing the IRC and media specs in #9772 and filed from there. The two with teeth: a preload occupies a player and reports itself as playing, and a script that adjusts the IRC server destroys the saved password as a side effect.

#### Other info (issues closed, discussion etc)

Keeping an unmentioned password means it now survives a change of server too, which the spec pins; `setConfig("ircPassword", "")` and the empty string both clear it. No `mmcp*` code or Networking_spec MMCP region is touched, so #9744 stays clear.

**Test case:** `lua loadSoundFile({name = "x.wav", url = "http://127.0.0.1:PORT"})` - after `sysDownloadDone` the file is in the profile's media directory and `getPlayingSounds()` is empty, while `playSoundFile()` with the same url still plays.

Closes #9783
Closes #9784
Closes #9785
Closes #9786
Closes #9787
Closes #9788
Closes #9789

Assisted-by: Claude:claude-opus-5
