### PR TITLE
fix: ProfileLifecycleTest running against the real config directory

### DIFF
--- a/test/functional_tests/ProfileLifecycleTest.cpp
+++ b/test/functional_tests/ProfileLifecycleTest.cpp
@@ -312,9 +312,9 @@ private slots:
         initializeQRCResourcesForProfileLifecycleTest();
 
         QVERIFY(mConfigDir.isValid());
-        // an existing $XDG_CONFIG_HOME/mudlet makes setupConfig() adopt it, so
-        // the profiles these tests enumerate are only ever their own
-        QVERIFY(QDir().mkpath(qsl("%1/mudlet").arg(mConfigDir.path())));
+        // $XDG_CONFIG_HOME/mudlet/profiles is the opt-in that makes setupConfig()
+        // adopt it, so the profiles these tests enumerate are only ever their own
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
         mSavedXdgConfigHome = qgetenv("XDG_CONFIG_HOME");
         qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`ProfileLifecycleTest` (#9776) seeds `$XDG_CONFIG_HOME/mudlet` without the `profiles/` subdirectory that #9712 made the opt-in, so `setupConfig()` keeps a populated `~/.config/mudlet` and `initTestCase()` fails its own line 331 assertion. It fails the C++ test step on all four legs of every open PR, which inherit it through the merged development tip - #9813, #9815, #9816 and #9799 are all red on `60 - ProfileLifecycleTest`. #9776's build legs finished on 10 Aug 13:52-14:55 UTC and #9712 merged at 22:17 that evening, so it was merged 16 hours later on green CI that predates the rule it breaks. Same bug class as #9810, third instance; the one-line fix is the recipe from there.

Test case: with a `~/.config/mudlet` that holds profiles, `ProfileLifecycleTest` is 19/19 here and fails `initTestCase()` without the change; the real config directory is left alone either way.

Assisted-by: Claude:claude-opus-5