### PR TITLE
fix: the main window restore baseline the map dock invalidates

### DIFF
--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -5177,15 +5177,24 @@ describe("Main window size and saved layout", function()
   end
 
   setup(function()
-    originalWidth, originalHeight = getMainWindowSize()
-    measurable = testMode and originalWidth > 0 and originalHeight > 0
+    local firstWidth, firstHeight = getMainWindowSize()
+    measurable = testMode and firstWidth > 0 and firstHeight > 0
     if not measurable then
       return
     end
-    setMainWindowSize(originalWidth + 300, originalHeight + 300)
+    setMainWindowSize(firstWidth + 300, firstHeight + 300)
     pumpEvents(200)
     local width, height = getMainWindowSize()
-    resizable = width > originalWidth and height > originalHeight
+    resizable = width > firstWidth and height > firstHeight
+
+    -- A dock another spec file left open - the map widget is the one that does
+    -- this - only takes its width out of the console at the next re-layout,
+    -- which is the resize just above. So the size to put the window back to is
+    -- read after asking for the first one again rather than before: a size the
+    -- window has actually been is a size it can be put back to.
+    setMainWindowSize(firstWidth, firstHeight)
+    pumpEvents(200)
+    originalWidth, originalHeight = getMainWindowSize()
     restoreMainWindowSize()
   end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The "Main window size and saved layout" specs read the size to put the window back to before the first resize of the run. A dock another spec file leaves open - the map widget - only takes its width out of the console at the next re-layout, which is that resize, so the baseline is a size the window can no longer be put back to and `restoreMainWindowSize()` never converges.
- The baseline is now read after asking for the original size again, so it is a size the window has actually been.
- This is the failure development's ubuntu Lua leg is red on: `UI_spec.lua @ 5228 the main window can be put back the size it was`.

**Test case:** running `Mapper_spec` and `UI_spec` together reproduces the CI failure exactly and this clears it; `UI_spec` on its own and a second run over the same profile are unaffected.

Assisted-by: Claude:claude-opus-5
