### PR TITLE
fix: undoing the game's line wrapping no longer merges list entries

### DIFF
--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -146,7 +146,9 @@ jobs:
         MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK: 1
 
     - name: (Windows) Run Lua tests
-      timeout-minutes: 2
+      # Matches the other platforms: the suite alone can run past two minutes
+      # on a slow runner.
+      timeout-minutes: 3
       shell: msys2 {0}
       env:
         AUTORUN_BUSTED_TESTS: 'true'

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -146,8 +146,7 @@ jobs:
         MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK: 1
 
     - name: (Windows) Run Lua tests
-      # Matches the other platforms: the suite alone can run past two minutes
-      # on a slow runner.
+      # The suite alone can run past two minutes on a slow runner, as on the other platforms.
       timeout-minutes: 3
       shell: msys2 {0}
       env:

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -117,7 +117,9 @@ jobs:
         ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
 
     - name: (Windows) Run Lua tests
-      timeout-minutes: 2
+      # Matches the other platforms: the suite alone can run past two minutes
+      # on a slow runner.
+      timeout-minutes: 3
       shell: msys2 {0}
       env:
         AUTORUN_BUSTED_TESTS: 'true'

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -117,8 +117,7 @@ jobs:
         ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
 
     - name: (Windows) Run Lua tests
-      # Matches the other platforms: the suite alone can run past two minutes
-      # on a slow runner.
+      # The suite alone can run past two minutes on a slow runner, as on the other platforms.
       timeout-minutes: 3
       shell: msys2 {0}
       env:

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1801,9 +1801,9 @@ bool TBuffer::looksLikeWrappedProse(const QString& line) const
 }
 
 // A list entry reads exactly like wrapped prose: a sentence that can end
-// right at the wrap column. Only its "[1364]", "(3)", "2." or bullet tells
-// the list apart from a paragraph, so every form accepted here has to be one
-// that word wrap would not itself produce at the start of a continuation.
+// right at the wrap column. Only its marker tells the list apart from a
+// paragraph, so every form accepted here has to be one that word wrap would
+// not itself produce at the start of a continuation.
 // The ambiguous ones are left out on purpose: a spaced dash opens a
 // continuation whenever the wrap lands on it, and a parenthesised number is
 // as often an aside as a label, so it is capped like a bare one.

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1595,13 +1595,17 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
         // prompts ('\xff' from GA/EOR), timer-flushed fragments ('\r'),
         // MXP <br> breaks and blank lines - is a real line boundary.
         const bool proseSegment = looksLikeWrappedProse(mMudLine);
-        if (!mServerWrapPendingLine.isEmpty() && ((mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace()) || !proseSegment)) {
+        if (!mServerWrapPendingLine.isEmpty()) {
             // A continuation of wrapped prose starts with a word - or with
             // the single space some games move the break to instead of
-            // swallowing it. Deeper indentation or a symbol-heavy line
-            // instead belongs to centered ASCII art, menu columns, dividers
-            // and the like, so the held line was complete after all:
-            flushPendingServerWrapJoin();
+            // swallowing it. Deeper indentation, a symbol-heavy line or a
+            // line opening with its own list marker instead belongs to
+            // centered ASCII art, menu columns, dividers, help indexes and
+            // the like, so the held line was complete after all:
+            const bool indentedContinuation = mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace();
+            if (indentedContinuation || !proseSegment || startsWithListMarker(mMudLine)) {
+                flushPendingServerWrapJoin();
+            }
         }
         // Deliberately judged before the pending line is joined on: ending at
         // the game's wrap column is a property of the segment as the game
@@ -1796,6 +1800,47 @@ bool TBuffer::looksLikeWrappedProse(const QString& line) const
         }
     }
     return nonSpace > 0 && letters * 10 >= nonSpace * 6;
+}
+
+// Games list help entries, shop stock and menu choices one per line, each
+// opening with its own "[1364]", "(3)", "2." or bullet. Such an entry reads
+// exactly like wrapped prose - it is a sentence that can end right at the
+// wrap column - so the marker is the only thing that tells the list apart
+// from a paragraph. Word wrap does not put one at the start of a
+// continuation, so a segment that has one begins a new line of its own:
+bool TBuffer::startsWithListMarker(const QString& line)
+{
+    qsizetype start = 0;
+    while (start < line.size() && line.at(start).isSpace()) {
+        ++start;
+    }
+    if (start >= line.size()) {
+        return false;
+    }
+
+    static const QString bullets = qsl("*+-•·●◦");
+    if (bullets.contains(line.at(start))) {
+        return start + 1 < line.size() && line.at(start + 1) == QChar::Space;
+    }
+
+    static const QString openers = qsl("[(");
+    static const QString closers = qsl("])");
+    const qsizetype bracket = openers.indexOf(line.at(start));
+    const qsizetype labelStart = (bracket < 0) ? start : start + 1;
+    qsizetype labelEnd = labelStart;
+    while (labelEnd < line.size() && line.at(labelEnd).isDigit()) {
+        ++labelEnd;
+    }
+    const qsizetype digits = labelEnd - labelStart;
+    if (!digits || labelEnd >= line.size()) {
+        return false;
+    }
+    if (bracket >= 0) {
+        return digits <= csmServerWrapMaxListLabelDigits && line.at(labelEnd) == closers.at(bracket);
+    }
+    // Nothing marks off an unbracketed label but the punctuation and the
+    // space after it, so insist on both:
+    return digits <= csmServerWrapMaxBareListLabelDigits && (line.at(labelEnd) == QChar('.') || line.at(labelEnd) == QChar(')')) && labelEnd + 1 < line.size() && line.at(labelEnd + 1) == QChar::Space;
 }
 
 void TBuffer::joinPendingServerWrapOntoCurrent()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1598,12 +1598,10 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
         if (!mServerWrapPendingLine.isEmpty()) {
             // A continuation of wrapped prose starts with a word - or with
             // the single space some games move the break to instead of
-            // swallowing it. Deeper indentation, a symbol-heavy line or a
-            // line opening with its own list marker instead belongs to
-            // centered ASCII art, menu columns, dividers, help indexes and
-            // the like, so the held line was complete after all:
-            const bool indentedContinuation = mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace();
-            if (indentedContinuation || !proseSegment || startsWithListMarker(mMudLine)) {
+            // swallowing it. Anything else means the held line was complete
+            // after all:
+            const bool deeplyIndented = mMudLine.at(0).isSpace() && mMudLine.size() > 1 && mMudLine.at(1).isSpace();
+            if (deeplyIndented || !proseSegment || startsWithListMarker(mMudLine)) {
                 flushPendingServerWrapJoin();
             }
         }
@@ -1802,12 +1800,13 @@ bool TBuffer::looksLikeWrappedProse(const QString& line) const
     return nonSpace > 0 && letters * 10 >= nonSpace * 6;
 }
 
-// Games list help entries, shop stock and menu choices one per line, each
-// opening with its own "[1364]", "(3)", "2." or bullet. Such an entry reads
-// exactly like wrapped prose - it is a sentence that can end right at the
-// wrap column - so the marker is the only thing that tells the list apart
-// from a paragraph. Word wrap does not put one at the start of a
-// continuation, so a segment that has one begins a new line of its own:
+// A list entry reads exactly like wrapped prose: a sentence that can end
+// right at the wrap column. Only its "[1364]", "(3)", "2." or bullet tells
+// the list apart from a paragraph, so every form accepted here has to be one
+// that word wrap would not itself produce at the start of a continuation.
+// The ambiguous ones are left out on purpose: a spaced dash opens a
+// continuation whenever the wrap lands on it, and a parenthesised number is
+// as often an aside as a label, so it is capped like a bare one.
 bool TBuffer::startsWithListMarker(const QString& line)
 {
     qsizetype start = 0;
@@ -1818,7 +1817,7 @@ bool TBuffer::startsWithListMarker(const QString& line)
         return false;
     }
 
-    static const QString bullets = qsl("*+-•·●◦");
+    static const QString bullets = qsl("*+•·●◦");
     if (bullets.contains(line.at(start))) {
         return start + 1 < line.size() && line.at(start + 1) == QChar::Space;
     }
@@ -1835,12 +1834,9 @@ bool TBuffer::startsWithListMarker(const QString& line)
     if (!digits || labelEnd >= line.size()) {
         return false;
     }
-    if (bracket >= 0) {
-        return digits <= csmServerWrapMaxListLabelDigits && line.at(labelEnd) == closers.at(bracket);
-    }
-    // Nothing marks off an unbracketed label but the punctuation and the
-    // space after it, so insist on both:
-    return digits <= csmServerWrapMaxBareListLabelDigits && (line.at(labelEnd) == QChar('.') || line.at(labelEnd) == QChar(')')) && labelEnd + 1 < line.size() && line.at(labelEnd + 1) == QChar::Space;
+    const bool labelFitsAList = digits <= csmServerWrapMaxListLabelDigits || line.at(start) == QChar('[');
+    const bool closed = (bracket >= 0) ? line.at(labelEnd) == closers.at(bracket) : (line.at(labelEnd) == QChar('.') || line.at(labelEnd) == QChar(')'));
+    return labelFitsAList && closed && labelEnd + 1 < line.size() && line.at(labelEnd + 1) == QChar::Space;
 }
 
 void TBuffer::joinPendingServerWrapOntoCurrent()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1803,10 +1803,10 @@ bool TBuffer::looksLikeWrappedProse(const QString& line) const
 // A list entry reads exactly like wrapped prose: a sentence that can end
 // right at the wrap column. Only its marker tells the list apart from a
 // paragraph, so every form accepted here has to be one that word wrap would
-// not itself produce at the start of a continuation.
-// The ambiguous ones are left out on purpose: a spaced dash opens a
-// continuation whenever the wrap lands on it, and a parenthesised number is
-// as often an aside as a label, so it is capped like a bare one.
+// not itself produce at the start of a continuation. The ambiguous ones are
+// left out on purpose: a spaced dash opens a continuation whenever the wrap
+// lands on it, and a parenthesised number is as often an aside as a label,
+// so it is capped like a bare one.
 bool TBuffer::startsWithListMarker(const QString& line)
 {
     qsizetype start = 0;
@@ -1825,18 +1825,18 @@ bool TBuffer::startsWithListMarker(const QString& line)
     static const QString openers = qsl("[(");
     static const QString closers = qsl("])");
     const qsizetype bracket = openers.indexOf(line.at(start));
-    const qsizetype labelStart = (bracket < 0) ? start : start + 1;
-    qsizetype labelEnd = labelStart;
-    while (labelEnd < line.size() && line.at(labelEnd).isDigit()) {
-        ++labelEnd;
+    const qsizetype numberStart = (bracket < 0) ? start : start + 1;
+    qsizetype numberEnd = numberStart;
+    while (numberEnd < line.size() && line.at(numberEnd).isDigit()) {
+        ++numberEnd;
     }
-    const qsizetype digits = labelEnd - labelStart;
-    if (!digits || labelEnd >= line.size()) {
+    const qsizetype digits = numberEnd - numberStart;
+    if (!digits || numberEnd >= line.size()) {
         return false;
     }
-    const bool labelFitsAList = digits <= csmServerWrapMaxListLabelDigits || line.at(start) == QChar('[');
-    const bool closed = (bracket >= 0) ? line.at(labelEnd) == closers.at(bracket) : (line.at(labelEnd) == QChar('.') || line.at(labelEnd) == QChar(')'));
-    return labelFitsAList && closed && labelEnd + 1 < line.size() && line.at(labelEnd + 1) == QChar::Space;
+    const bool numberFitsAList = digits <= csmMaxListNumberDigits || line.at(start) == QChar('[');
+    const bool closed = (bracket >= 0) ? line.at(numberEnd) == closers.at(bracket) : (line.at(numberEnd) == QChar('.') || line.at(numberEnd) == QChar(')'));
+    return numberFitsAList && closed && numberEnd + 1 < line.size() && line.at(numberEnd + 1) == QChar::Space;
 }
 
 void TBuffer::joinPendingServerWrapOntoCurrent()

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -618,8 +618,8 @@ private:
     // it really was complete:
     static constexpr int csmServerWrapFlushDelayMs = 300;
     // A longer number opening a line is likelier a year or a price ending a
-    // wrapped sentence than a list label; only "[...]" is trusted past it:
-    static constexpr qsizetype csmServerWrapMaxListLabelDigits = 3;
+    // wrapped sentence than a list number; only "[...]" is trusted past it:
+    static constexpr qsizetype csmMaxListNumberDigits = 3;
     // Wrap detection hint: how many lines ending within 8 characters of a
     // stable ceiling column are needed before suggesting mUndoServerWrap:
     static constexpr int csmWrapDetectThreshold = 40;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -419,6 +419,7 @@ private:
     void commitLineData(QString line, std::deque<TChar> chars, char ch);
     bool endsAtServerWrapColumn() const;
     bool looksLikeWrappedProse(const QString& line) const;
+    static bool startsWithListMarker(const QString& line);
     void joinPendingServerWrapOntoCurrent();
     void startServerWrapFlushTimer();
     void recordLineLengthForWrapDetection(qsizetype length);
@@ -616,6 +617,11 @@ private:
     // How long to hold a full-width line for its continuation before deciding
     // it really was complete:
     static constexpr int csmServerWrapFlushDelayMs = 300;
+    // Longest number accepted inside a "[1364]" style list marker, and - for
+    // the unbracketed "3." style - the longest that is more likely to be a
+    // list label than a year or an amount of gold in mid-sentence:
+    static constexpr qsizetype csmServerWrapMaxListLabelDigits = 6;
+    static constexpr qsizetype csmServerWrapMaxBareListLabelDigits = 3;
     // Wrap detection hint: how many lines ending within 8 characters of a
     // stable ceiling column are needed before suggesting mUndoServerWrap:
     static constexpr int csmWrapDetectThreshold = 40;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -617,11 +617,9 @@ private:
     // How long to hold a full-width line for its continuation before deciding
     // it really was complete:
     static constexpr int csmServerWrapFlushDelayMs = 300;
-    // Longest number accepted inside a "[1364]" style list marker, and - for
-    // the unbracketed "3." style - the longest that is more likely to be a
-    // list label than a year or an amount of gold in mid-sentence:
-    static constexpr qsizetype csmServerWrapMaxListLabelDigits = 6;
-    static constexpr qsizetype csmServerWrapMaxBareListLabelDigits = 3;
+    // A longer number opening a line is likelier a year or a price ending a
+    // wrapped sentence than a list label; only "[...]" is trusted past it:
+    static constexpr qsizetype csmServerWrapMaxListLabelDigits = 3;
     // Wrap detection hint: how many lines ending within 8 characters of a
     // stable ceiling column are needed before suggesting mUndoServerWrap:
     static constexpr int csmWrapDetectThreshold = 40;

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -248,8 +248,7 @@ private slots:
 
         // Every entry ends at the wrap column and reads as a sentence, so
         // only the marker tells the list from a wrapped paragraph. The last
-        // one is short enough to commit on its own and carries the single
-        // leading space a game may indent an index by:
+        // carries the single leading space a game may indent an index by:
         const QString entry1 = heldLine(qsl("[581] Stat Fury - a viking only stat that grants bonuses"));
         const QString entry2 = heldLine(qsl("(3) Viking Default: what you get if you do not customise"));
         const QString entry3 = heldLine(qsl("1. Viking Specializations lists the class specialisations"));
@@ -293,8 +292,7 @@ private slots:
                 2000));
 
         // Every one of these continuations opens with something a list
-        // marker could be mistaken for, and every one of them is ordinary
-        // prose the game merely wrapped:
+        // marker could be mistaken for:
         const QString dash = heldLine(qsl("The Grand Bazaar sells everything you could want in this"));
         const QString aside = heldLine(qsl("You gain a large amount of experience for your daring"));
         const QString price = heldLine(qsl("The merchant paid for the whole shipment in advance, all"));
@@ -363,15 +361,14 @@ private:
     }
 
     // Only a line inside the join band - the wrap column of 80 less
-    // csmServerWrapSlack - is ever held back for a continuation, so pad the
-    // ones that have to be held to a fixed width well inside it:
+    // csmServerWrapSlack - is ever held back for a continuation. Lines that
+    // have to be held are padded to a fixed width inside it and checked,
+    // because one that drifted out would never be held, leaving every
+    // assertion after it passing without the code under test having run:
     static constexpr qsizetype smHeldLineLength = 70;
 
     static QString heldLine(const QString& text) { return text + QChar::Space + QString(smHeldLineLength - text.size() - 1, QChar('x')); }
 
-    // A held line that drifted out of the band would never be held, leaving
-    // the assertions that follow it passing without the code under test
-    // having run at all:
     void verifyHeldLines(const QList<QString>& lines)
     {
         for (const QString& line : lines) {

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -246,9 +246,8 @@ private slots:
                 },
                 2000));
 
-        // Every entry ends at the wrap column and reads as a sentence, so
-        // only the marker tells the list from a wrapped paragraph. The last
-        // carries the single leading space a game may indent an index by:
+        // Only the marker tells these entries from a wrapped paragraph; the
+        // last carries the single leading space a game may indent an index by:
         const QString entry1 = heldLine(qsl("[581] Stat Fury - a viking only stat that grants bonuses"));
         const QString entry2 = heldLine(qsl("(3) Viking Default: what you get if you do not customise"));
         const QString entry3 = heldLine(qsl("1. Viking Specializations lists the class specialisations"));

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -246,18 +246,21 @@ private slots:
                 },
                 2000));
 
-        // A help index. Every entry is a sentence and the long ones end
-        // right at the wrap column, so nothing but the "[1364]" marker
-        // distinguishes the list from a wrapped paragraph:
-        const QString entry1 = qsl("[581] Stat Fury - a viking only stat that grants bonuses to their ") + QString(10, QChar('x')) + qsl(".");
-        const QString entry2 = qsl("[1364] Viking Default: if you chose not to customize your viking ") + QString(10, QChar('y')) + qsl(".");
-        const QString entry3 = qsl("3) Vikings: a barbaric fighter class.");
-        mpServer->sendRaw(entry1.toUtf8() + "\r\n" + entry2.toUtf8() + "\r\n" + entry3.toUtf8() + "\r\n");
+        // Every entry ends at the wrap column and reads as a sentence, so
+        // only the marker tells the list from a wrapped paragraph. The last
+        // one is short enough to commit on its own and carries the single
+        // leading space a game may indent an index by:
+        const QString entry1 = heldLine(qsl("[581] Stat Fury - a viking only stat that grants bonuses"));
+        const QString entry2 = heldLine(qsl("(3) Viking Default: what you get if you do not customise"));
+        const QString entry3 = heldLine(qsl("1. Viking Specializations lists the class specialisations"));
+        const QString entry4 = qsl(" [1366] Vikings: a barbaric fighter class.");
+        verifyHeldLines({entry1, entry2, entry3});
+        mpServer->sendRaw(entry1.toUtf8() + "\r\n" + entry2.toUtf8() + "\r\n" + entry3.toUtf8() + "\r\n" + entry4.toUtf8() + "\r\n");
 
-        QVERIFY2(waitForLineInBuffer(entry1), "full-width list entry was joined onto the entry below it");
-        QVERIFY2(waitForLineInBuffer(entry2), "full-width list entry was joined onto the entry below it");
-        QVERIFY2(waitForLineInBuffer(entry3), "numbered list entry was joined onto the entry above it");
-        QVERIFY2(!bufferHasLine(entry1 + QChar::Space + entry2), "consecutive list entries were joined into one line");
+        QVERIFY2(waitForLineInBuffer(entry1), "bracketed list entry was joined onto the entry below it");
+        QVERIFY2(waitForLineInBuffer(entry2), "parenthesised list entry was joined onto the entry below it");
+        QVERIFY2(waitForLineInBuffer(entry3), "numbered list entry was joined onto the entry below it");
+        QVERIFY2(waitForLineInBuffer(entry4), "indented list entry was joined onto the entry above it");
     }
 
     void test_wrappedListEntryStillJoins()
@@ -270,12 +273,45 @@ private slots:
                 },
                 2000));
 
-        // A list entry too long for one line still wraps like any other
-        // prose - its continuation carries no marker of its own:
-        const QString entry = qsl("[1364] Viking Default: if you chose not to customize your viking ") + QString(10, QChar('z'));
-        mpServer->sendRaw(entry.toUtf8() + "\r\nthis is what is included.\r\n");
+        // The marker is looked for on the continuation only, so an entry too
+        // long for one line still wraps like any other prose:
+        const QString entry = heldLine(qsl("[1364] Viking Default: if you chose not to customise your"));
+        verifyHeldLines({entry});
+        mpServer->sendRaw(entry.toUtf8() + "\r\nviking this is what is included.\r\n");
 
-        QVERIFY2(waitForLineInBuffer(entry + qsl(" this is what is included.")), "a wrapped list entry was no longer joined back together");
+        QVERIFY2(waitForLineInBuffer(entry + qsl(" viking this is what is included.")), "a wrapped list entry was no longer joined back together");
+    }
+
+    void test_proseIsNotMistakenForAList()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // Every one of these continuations opens with something a list
+        // marker could be mistaken for, and every one of them is ordinary
+        // prose the game merely wrapped:
+        const QString dash = heldLine(qsl("The Grand Bazaar sells everything you could want in this"));
+        const QString aside = heldLine(qsl("You gain a large amount of experience for your daring"));
+        const QString price = heldLine(qsl("The merchant paid for the whole shipment in advance, all"));
+        const QString reference = heldLine(qsl("More detail about the viking class can be found over"));
+        verifyHeldLines({dash, aside, price, reference});
+
+        mpServer->sendRaw(dash.toUtf8() + "\r\n- weapons, armour and rope - at a very fair price.\r\n");
+        QVERIFY2(waitForLineInBuffer(dash + qsl(" - weapons, armour and rope - at a very fair price.")), "a spaced dash opening a continuation was mistaken for a bullet");
+
+        mpServer->sendRaw(aside.toUtf8() + "\r\n(2500) and the whole town cheers for you.\r\n");
+        QVERIFY2(waitForLineInBuffer(aside + qsl(" (2500) and the whole town cheers for you.")), "a parenthesised number too long to be a label was mistaken for one");
+
+        mpServer->sendRaw(price.toUtf8() + "\r\n1364. gold was a fair price for it.\r\n");
+        QVERIFY2(waitForLineInBuffer(price + qsl(" 1364. gold was a fair price for it.")), "a number too long to be a list label was mistaken for one");
+
+        mpServer->sendRaw(reference.toUtf8() + "\r\n(see help vikings) for the full list.\r\n");
+        QVERIFY2(waitForLineInBuffer(reference + qsl(" (see help vikings) for the full list.")), "a parenthesised phrase carrying no number was mistaken for a list marker");
     }
 
     void test_wrapDetectionRaisesHint()
@@ -324,6 +360,23 @@ private:
         // Keep Mudlet's own display wrap out of the way so that logical
         // lines can be compared with buffer lines verbatim:
         host->mpConsole->buffer.mWrapAt = 500;
+    }
+
+    // Only a line inside the join band - the wrap column of 80 less
+    // csmServerWrapSlack - is ever held back for a continuation, so pad the
+    // ones that have to be held to a fixed width well inside it:
+    static constexpr qsizetype smHeldLineLength = 70;
+
+    static QString heldLine(const QString& text) { return text + QChar::Space + QString(smHeldLineLength - text.size() - 1, QChar('x')); }
+
+    // A held line that drifted out of the band would never be held, leaving
+    // the assertions that follow it passing without the code under test
+    // having run at all:
+    void verifyHeldLines(const QList<QString>& lines)
+    {
+        for (const QString& line : lines) {
+            QVERIFY2(line.size() == smHeldLineLength, qPrintable(qsl("test line is %1 characters, not the %2 that put it inside the join band").arg(line.size()).arg(smHeldLineLength)));
+        }
     }
 
     // Utility function to manually start a profile like a user would do via the

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -236,6 +236,48 @@ private slots:
         QVERIFY2(waitForLineInBuffer(sentencePadded), "sentence-final line padded with several spaces was not committed on its own");
     }
 
+    void test_listEntriesAreNotJoined()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // A help index. Every entry is a sentence and the long ones end
+        // right at the wrap column, so nothing but the "[1364]" marker
+        // distinguishes the list from a wrapped paragraph:
+        const QString entry1 = qsl("[581] Stat Fury - a viking only stat that grants bonuses to their ") + QString(10, QChar('x')) + qsl(".");
+        const QString entry2 = qsl("[1364] Viking Default: if you chose not to customize your viking ") + QString(10, QChar('y')) + qsl(".");
+        const QString entry3 = qsl("3) Vikings: a barbaric fighter class.");
+        mpServer->sendRaw(entry1.toUtf8() + "\r\n" + entry2.toUtf8() + "\r\n" + entry3.toUtf8() + "\r\n");
+
+        QVERIFY2(waitForLineInBuffer(entry1), "full-width list entry was joined onto the entry below it");
+        QVERIFY2(waitForLineInBuffer(entry2), "full-width list entry was joined onto the entry below it");
+        QVERIFY2(waitForLineInBuffer(entry3), "numbered list entry was joined onto the entry above it");
+        QVERIFY2(!bufferHasLine(entry1 + QChar::Space + entry2), "consecutive list entries were joined into one line");
+    }
+
+    void test_wrappedListEntryStillJoins()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        enableUndoServerWrap();
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return mpServer->clientConnected();
+                },
+                2000));
+
+        // A list entry too long for one line still wraps like any other
+        // prose - its continuation carries no marker of its own:
+        const QString entry = qsl("[1364] Viking Default: if you chose not to customize your viking ") + QString(10, QChar('z'));
+        mpServer->sendRaw(entry.toUtf8() + "\r\nthis is what is included.\r\n");
+
+        QVERIFY2(waitForLineInBuffer(entry + qsl(" this is what is included.")), "a wrapped list entry was no longer joined back together");
+    }
+
     void test_wrapDetectionRaisesHint()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A line opening with a list marker - `[1364]`, `(3)`, `2.`, `3)` or a bullet - is now treated as a new line rather than the continuation of the one above it, so help indexes, shop stock and menus survive the option being on.
- Only markers that word wrap could not itself produce at the start of a continuation count. A spaced dash and a parenthesised number over 3 digits are deliberately excluded, since both open genuine wrapped prose.
- 3 new functional tests, including negative controls proving ordinary prose still rejoins.

#### Motivation for adding to Mudlet

With "undo the game's word wrapping" enabled at 78 columns, a help index came out with entries glued together - each entry is a sentence that can end right at the wrap column, so nothing but its marker distinguished it from a wrapped paragraph.

#### Other info (issues closed, discussion etc)

Also raises the Windows Lua test step to the 3 minute budget Linux and macOS already have - it was left at 2 and timed out on a slow runner while the specs were still running. Folded in here rather than split out, by request.

Follow-up to #9455, which added the option. The check reads the continuation only, so the last entry of a list can still absorb a full-width prose line that follows it - left alone deliberately, as requiring a marker on both lines would stop the first entry of a list detaching from a header above it.

**Test case:** enable Settings -> Display -> "undo the game's own word wrapping" at 78, then on a game with a numbered help index (e.g. `help viking`) confirm each `[NNN]` entry stays on its own line. `ctest -R UndoServerWrapTest` covers it - 15/15 pass.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>

