### PR TITLE
add: adjustable containers can be dragged out of their parent

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -14,12 +14,59 @@ Adjustable.Container = Adjustable.Container or Geyser.Container:new({name = "Adj
 
 local adjustInfo = {}
 
+-- how far the mouse pointer has to be taken past a parent container before the
+-- container being dragged comes out of it, so that pushing a container flush
+-- into a corner of its parent and overshooting a little does not take it out
+local dragOutMargin = 20
+
 -- Internal function to add "%" to a value and round it
 -- Resulting percentage has five precision points to ensure accurate 
 -- representation in pixel space.
 -- @param num Any float. For 0-100% output, use 0.0-1.0
 local function make_percent(num)
     return string.format("%.5f%%", (num * 100))
+end
+
+-- Internal function: the container everything in a window is nested in, which is
+-- where a container dragged out of its parent ends up
+-- @param self the Adjustable.Container itself
+local function windowRoot(self)
+    local parentWindow = self.windowname and self.windowname ~= "main" and Geyser.parentWindows and Geyser.parentWindows[self.windowname]
+    return parentWindow or Geyser
+end
+
+-- Internal function: tells whether a container is still part of the layout. A
+-- deleted container is dropped from the one it was in but goes on existing for
+-- as long as anything holds a reference to it
+-- @param container the container to check
+local function stillInLayout(container)
+    local owner = container and container.container
+    return owner ~= nil and owner.windowList ~= nil and owner.windowList[container.name] == container
+end
+
+-- Internal function: tells whether a constraint means a different size once the
+-- container it belongs to is put somewhere else. A percentage is a share of the
+-- parent and a negative value is measured from the parent's far edge, while a
+-- plain pixel or character size means the same wherever the container ends up.
+-- @param constraint a Geyser size constraint
+local function relativeToParent(constraint)
+    if type(constraint) ~= "string" then
+        return false
+    end
+    return string.find(constraint, "%%") ~= nil or string.find(constraint, "-") ~= nil
+end
+
+-- Internal function: works out what a constraint measures in a given container,
+-- by letting Geyser compile it against that container rather than by parsing it
+-- @param self the Adjustable.Container itself
+-- @param constraint the constraint to measure
+-- @param dimension "width" or "height"
+-- @param container the container to measure the constraint in
+local function constraintInPixels(self, constraint, dimension, container)
+    local probe = {x = self.x, y = self.y, width = self.width, height = self.height, fontSize = self.fontSize}
+    probe[dimension] = constraint
+    Geyser.calc_constraints(probe, probe, container)
+    return probe["get_"..dimension](probe)
 end
 
 -- Internal function: checks where the mouse is at on the Label
@@ -51,7 +98,7 @@ local function adjust_Info(self, label, event)
         end
     end
 
-    adjustInfo = {name = adjustInfo.name, top = top, bottom = bottom, left = left, right = right, x = x, y = y, move = adjustInfo.move}
+    adjustInfo = {name = adjustInfo.name, top = top, bottom = bottom, left = left, right = right, x = x, y = y, move = adjustInfo.move, grabX = event.x, grabY = event.y}
 end
 
 --- function to give your adjustable container a new title
@@ -134,6 +181,95 @@ function Adjustable.Container:onRelease (label, event)
     end
 end
 
+-- internal function to tell if a drag has taken the mouse pointer out of the
+-- container this one is nested in.
+-- The pointer has to leave rather than the container: the container is held at
+-- its parent's edge while the drag carries on, so a test on the container's own
+-- position would take it out of its parent as soon as it is dragged flush
+-- against that edge.
+-- @param ux x position the drag asks for, relative to the parent and before the parent holds it back
+-- @param uy y position the drag asks for, relative to the parent and before the parent holds it back
+-- @param grabX x position within the container the drag grabbed it at
+-- @param grabY y position within the container the drag grabbed it at
+function Adjustable.Container:dragLeavesParent(ux, uy, grabX, grabY)
+    local parent = self.container
+    -- an attached container has a main window border sized to it rather than
+    -- being placed by its parent, and adjustBorder() detaches one that is dragged
+    -- away from that border, so this only holds it in while it is still attached
+    if not self.dragOut or self.attached or not parent or parent == windowRoot(self) then
+        return false
+    end
+    local left, top = 0, 0
+    local right, bottom = parent.get_width(), parent.get_height()
+    -- an Adjustable.Container keeps its children in an inside container which
+    -- leaves room for its title bar and border, and a pointer over those is still
+    -- over the parent however far outside that inside container it is
+    local owner = parent.container
+    if owner and owner.Inside == parent then
+        left, top = owner.get_x() - parent.get_x(), owner.get_y() - parent.get_y()
+        right, bottom = left + owner.get_width(), top + owner.get_height()
+    end
+    local pointerX, pointerY = ux + grabX, uy + grabY
+    return pointerX < left - dragOutMargin or pointerY < top - dragOutMargin
+        or pointerX > right + dragOutMargin or pointerY > bottom + dragOutMargin
+end
+
+-- internal function to take the container out of the container it is nested in
+-- and put it at the top level of the window it is in, at the position the drag
+-- asks for, which keeps the container under the mouse pointer so that the drag
+-- carries on from there
+-- @param ux x position the drag asks for, relative to the parent
+-- @param uy y position the drag asks for, relative to the parent
+function Adjustable.Container:dragOutOfParent(ux, uy)
+    local parent = self.container
+    local root = windowRoot(self)
+    if not parent or parent == root then
+        return false
+    end
+    local w, h = self:get_width(), self:get_height()
+    local rootw, rooth = root.get_width(), root.get_height()
+    local x, y = parent.get_x() + ux - root.get_x(), parent.get_y() + uy - root.get_y()
+    x, y = math.max(0, x), math.max(0, y)
+    -- a scrollBox scrolls to what does not fit into it rather than bounding it
+    if root.type ~= "scrollBox" then
+        x, y = math.min(x, rootw - w), math.min(y, rooth - h)
+    end
+    -- the height a minimized container restores to is measured in its parent as
+    -- well, so it has to be read while the parent still is the parent
+    local origh = self.minimized and relativeToParent(self.origh) and constraintInPixels(self, self.origh, "height", parent)
+    -- where it came from, so that settings saved before it was dragged out can
+    -- be loaded back into the parent they were saved for
+    self.dragOutParent = parent
+    self:changeContainer(root)
+    -- changeContainer turns down anything that is not a container, and geometry
+    -- for the window would be nonsense inside the parent it did not leave
+    if self.container ~= root then
+        return false
+    end
+    -- a size measured against the parent means a different size in the window
+    -- the container is in now, so it becomes the share of that window which
+    -- keeps the container the size it is
+    if relativeToParent(self.width) then self.width = make_percent(w/rootw) end
+    if relativeToParent(self.height) then self.height = make_percent(h/rooth) end
+    if origh then self.origh = make_percent(origh/rooth) end
+    self:move(make_percent(x/rootw), make_percent(y/rooth))
+    self.draggedOut = true
+    return true
+end
+
+-- overridden changeContainer which keeps track of a container dragged out of its
+-- parent, so that saved settings only take a container back out of a parent it was
+-- dragged out of, and not out of one a script has put it in since
+-- @param container the container to move into
+-- @return what Geyser:changeContainer returns: nothing when the container moved, nil and a message when it did not
+function Adjustable.Container:changeContainer(container)
+    local result, err = Geyser.changeContainer(self, container)
+    if self.container ~= windowRoot(self) then
+        self.draggedOut = false
+    end
+    return result, err
+end
+
 -- internal function to handle the onMove event of main Adjustable.Container Label
 -- @param label the main Adjustable.Container Label
 -- @param event the onMove event and its information
@@ -172,6 +308,18 @@ function Adjustable.Container:onMove (label, event)
         local hasScrollBox = self.windowname and Geyser.parentWindows and Geyser.parentWindows[self.windowname] and Geyser.parentWindows[self.windowname].type == "scrollBox"
         if adjustInfo.move and not self.connectedContainers then
             label:setCursor("ClosedHand")
+            if self.dragOut then
+                -- the parent holds the container at its edge while the drag carries
+                -- on, so where the drag asks for the container to be has to be kept
+                -- apart from where it is allowed to be to know where the pointer got to
+                adjustInfo.ux, adjustInfo.uy = (adjustInfo.ux or x1) - dx, (adjustInfo.uy or y1) - dy
+                if self:dragLeavesParent(adjustInfo.ux, adjustInfo.uy, adjustInfo.grabX or 0, adjustInfo.grabY or 0) then
+                    self:dragOutOfParent(adjustInfo.ux, adjustInfo.uy)
+                    adjustInfo.x, adjustInfo.y = x, y
+                    adjustInfo.ux, adjustInfo.uy = nil, nil
+                    return
+                end
+            end
             local tx, ty = max(0,x1-dx), max(0,y1-dy)
             -- get rid of move/size limits when in scrollbox (as it is scrollable)
             if not(hasScrollBox) then
@@ -766,6 +914,7 @@ function Adjustable.Container:save(slot, dir)
     mytable.connectedToBorder = self.connectedToBorder
     mytable.connectedContainers = self.connectedContainers
     mytable.windowname = self.windowname
+    mytable.draggedOut = self.draggedOut
     if not(io.exists(dir)) then lfs.mkdir(dir) end
     table.save(saveDir, mainTable)
     return true
@@ -806,6 +955,19 @@ function Adjustable.Container:load(slot, dir)
             self:changeContainer(Geyser)
         else
             self:changeContainer(Geyser.parentWindows[mytable.windowname])
+        end
+    end
+
+    -- a saved position is a position in whichever container the container was in,
+    -- and which container that was is not part of what gets saved. Only the drag
+    -- out itself is, so settings from before one go back into the parent and
+    -- settings from after it stay out of it
+    if self.dragOut then
+        if mytable.draggedOut then
+            self:changeContainer(windowRoot(self))
+            self.draggedOut = true
+        elseif self.draggedOut and stillInLayout(self.dragOutParent) then
+            self:changeContainer(self.dragOutParent)
         end
     end
 
@@ -1136,6 +1298,7 @@ end
 --@param[opt=true] cons.raiseOnClick  raise your container if you click on it with your left mouse button
 --@param[opt=true] cons.autoSave  saves your container settings on exit (sysExitEvent). If set to false it won't autoSave
 --@param[opt=true] cons.autoLoad  loads the container settings (if there are some to load) at creation of the container. If set to false it won't load the settings at creation
+--@param[opt=false] cons.dragOut  lets a container nested in another container be dragged out of it, into the window it is in. A nested container is otherwise held inside its parent. There is no dragging back in, use changeContainer for that
 
 function Adjustable.Container:new(cons,container)
     Adjustable.Container.Locale = Adjustable.Container.Locale or loadTranslations("AdjustableContainer")
@@ -1203,6 +1366,7 @@ function Adjustable.Container:new(cons,container)
     me:setTitle()
     me.lockStyle = me.lockStyle or "standard"
     me.noLimit = me.noLimit or false
+    me.dragOut = me.dragOut or false
     if not(me.raiseOnClick == false) then
         me.raiseOnClick = true
     end

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -229,11 +229,14 @@ function Adjustable.Container:dragOutOfParent(ux, uy)
     local w, h = self:get_width(), self:get_height()
     local rootw, rooth = root.get_width(), root.get_height()
     local x, y = parent.get_x() + ux - root.get_x(), parent.get_y() + uy - root.get_y()
-    x, y = math.max(0, x), math.max(0, y)
-    -- a scrollBox scrolls to what does not fit into it rather than bounding it
+    -- a scrollBox scrolls to what does not fit into it rather than bounding it.
+    -- The lower bound is applied last: a container too big for the window has a
+    -- negative upper bound, and a negative position is read as one measured from
+    -- the far edge, which would put the container's far corner at the origin
     if root.type ~= "scrollBox" then
         x, y = math.min(x, rootw - w), math.min(y, rooth - h)
     end
+    x, y = math.max(0, x), math.max(0, y)
     -- the height a minimized container restores to is measured in its parent as
     -- well, so it has to be read while the parent still is the parent
     local origh = self.minimized and relativeToParent(self.origh) and constraintInPixels(self, self.origh, "height", parent)

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -809,12 +809,16 @@ describe("Tests dragging an Adjustable.Container out of its parent", function()
   end
 
   before_each(function()
+    -- the window is whatever size the machine running the specs gives them, so
+    -- the container everything else nests in is sized to fit in it rather than
+    -- assumed to. Everything below goes by what it reads back, not by these
     local winWidth, winHeight = getMainWindowSize()
-    assert.is_true(winWidth >= 600 and winHeight >= 500,
-      string.format("these specs need room for a 400x300 container, the window is %dx%d", winWidth, winHeight))
+    local width, height = math.min(400, winWidth - 100), math.min(300, winHeight - 100)
+    assert.is_true(width >= 200 and height >= 150,
+      string.format("these specs need a window with room for a container in it, this one is %dx%d", winWidth, winHeight))
     dock = Adjustable.Container:new({
       name = dockName,
-      x = 100, y = 100, width = 400, height = 300,
+      x = 50, y = 50, width = width, height = height,
       autoLoad = false,
       autoSave = false,
     })
@@ -1063,7 +1067,7 @@ describe("Tests dragging an Adjustable.Container out of its parent", function()
   end)
 
   it("comes out into the user window it is in rather than into the main window", function()
-    local userWindow = Geyser.UserWindow:new({name = "gadUserWindow", x = 0, y = 0, width = 400, height = 400})
+    local userWindow = Geyser.UserWindow:new({name = "gadUserWindow", x = 0, y = 0, width = 200, height = 200})
     finally(function()
       -- the user window's own root container is what takes the window and
       -- everything left in it with it
@@ -1074,7 +1078,7 @@ describe("Tests dragging an Adjustable.Container out of its parent", function()
     end)
     local windowDock = Adjustable.Container:new({
       name = "gadWindowDock",
-      x = 0, y = 0, width = 300, height = 200,
+      x = 0, y = 0, width = 150, height = 150,
       autoLoad = false, autoSave = false,
     }, userWindow)
     local windowChild = Adjustable.Container:new({
@@ -1152,10 +1156,10 @@ describe("Tests dragging an Adjustable.Container out of its parent", function()
         box:delete()
       end
     end)
-    box = Geyser.ScrollBox:new({name = "gadScrollBox", x = 0, y = 0, width = 300, height = 300})
+    box = Geyser.ScrollBox:new({name = "gadScrollBox", x = 0, y = 0, width = 200, height = 200})
     local boxDock = Adjustable.Container:new({
       name = "gadBoxDock",
-      x = 0, y = 0, width = 200, height = 200,
+      x = 0, y = 0, width = 150, height = 150,
       autoLoad = false, autoSave = false,
     }, box)
     local boxChild = Adjustable.Container:new({

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -1121,10 +1121,27 @@ describe("Tests dragging an Adjustable.Container out of its parent", function()
       dragOut = true,
     }, middle)
     assert.are.equal(middle.Inside, deep.container)
+    local x, y = deep:get_x(), deep:get_y()
 
-    assert.is_true(deep:dragOutOfParent(0, 0))
+    assert.is_true(deep:dragOutOfParent(x - middle.Inside.get_x(), y - middle.Inside.get_y()))
 
     assert.are.equal(Geyser, deep.container)
+    -- the position of a container two levels down counts in every container it
+    -- is inside of, so it has to come out of all of them onto the same spot
+    assertNear(deep:get_x(), x, "x")
+    assertNear(deep:get_y(), y, "y")
+  end)
+
+  it("keeps a container bigger than the window at the window's corner", function()
+    local winWidth, winHeight = getMainWindowSize()
+    makeChild({dragOut = true, width = winWidth + 200, height = winHeight + 200})
+
+    child:dragOutOfParent(0, 0)
+
+    -- there is nowhere to put a container that does not fit that keeps all of it
+    -- on screen, so it goes at the corner rather than off the top left of it
+    assert.are.equal(0, child:get_x())
+    assert.are.equal(0, child:get_y())
   end)
 
   it("does not hold a container back at the edge of a scroll box", function()

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -755,3 +755,453 @@ describe("Tests the Adjustable.Container mouse handlers", function()
     end)
   end)
 end)
+
+-- Dragging a container out of the container it is nested in. onMove follows the
+-- real mouse pointer through getMousePosition(), which a headless run cannot
+-- drive, so these specs go at the two functions onMove hands a drag to: the
+-- decision that the pointer has left the parent, and the move out itself.
+describe("Tests dragging an Adjustable.Container out of its parent", function()
+  local dock, child
+  local dockName, childName = "gadDock", "gadChild"
+
+  local function makeChild(cons)
+    cons = cons or {}
+    cons.name = childName
+    cons.x, cons.y = cons.x or 20, cons.y or 20
+    cons.width, cons.height = cons.width or "50%", cons.height or "50%"
+    cons.autoLoad, cons.autoSave = false, false
+    child = Adjustable.Container:new(cons, dock)
+    return child
+  end
+
+  local function assertNear(actual, expected, what)
+    assert.is_true(math.abs(actual - expected) <= 1,
+      string.format("%s: expected %s, got %s", what, tostring(expected), tostring(actual)))
+  end
+
+  -- drives a drag through the handlers a mouse would call. The handlers ask
+  -- getMousePosition where the pointer is, and they look it up in the globals of
+  -- the file they live in, which is not the globals a spec file writes to, so the
+  -- stand-in for the mouse has to go into their own environment
+  local function drag(container, grabX, grabY, stepX, stepY, steps)
+    local geyser = getfenv(Adjustable.Container.onMove)
+    local realGetMousePosition = geyser.getMousePosition
+    local pointerX, pointerY = 500, 400
+    local event = {button = "LeftButton", buttons = {"LeftButton"}, x = grabX, y = grabY, globalX = pointerX, globalY = pointerY}
+    geyser.getMousePosition = function() return pointerX, pointerY end
+    local ok, err = pcall(function()
+      -- which edge is being dragged is kept in one table shared by every
+      -- container, and only a completed click empties it, so start from a
+      -- released mouse rather than from whatever the last spec left behind
+      container:onClick(container.adjLabel, event)
+      container:onRelease(container.adjLabel, event)
+      container:onClick(container.adjLabel, event)
+      for _ = 1, steps do
+        pointerX, pointerY = pointerX + stepX, pointerY + stepY
+        container:onMove(container.adjLabel, event)
+      end
+      container:onRelease(container.adjLabel, event)
+    end)
+    geyser.getMousePosition = realGetMousePosition
+    if not ok then
+      error(err, 0)
+    end
+  end
+
+  before_each(function()
+    local winWidth, winHeight = getMainWindowSize()
+    assert.is_true(winWidth >= 600 and winHeight >= 500,
+      string.format("these specs need room for a 400x300 container, the window is %dx%d", winWidth, winHeight))
+    dock = Adjustable.Container:new({
+      name = dockName,
+      x = 100, y = 100, width = 400, height = 300,
+      autoLoad = false,
+      autoSave = false,
+    })
+  end)
+
+  local function cleanUp(container)
+    if container and Adjustable.Container.all[container.name] == container then
+      container:deleteSaveFile()
+      container:delete()
+    end
+  end
+
+  after_each(function()
+    -- the child first: dragged out it is no longer the dock's to delete, and
+    -- still inside it the dock's cascade would have taken it along
+    cleanUp(child)
+    cleanUp(dock)
+    child, dock = nil, nil
+  end)
+
+  it("holds a nested container inside its parent by default", function()
+    makeChild()
+    -- a container puts its children in an inside container of its own, which is
+    -- the parent a nested container is held inside of
+    assert.are.equal(dock.Inside, child.container)
+    assert.is_false(child.dragOut)
+    assert.is_false(child:dragLeavesParent(-500, -500, 5, 5))
+  end)
+
+  it("stays inside while the pointer is still over the parent", function()
+    makeChild({dragOut = true})
+    local inside = child.container
+    assert.is_false(child:dragLeavesParent(0, 0, 5, 5))
+    assert.is_false(child:dragLeavesParent(inside.get_width() - 50, inside.get_height() - 50, 5, 5))
+  end)
+
+  it("puts up with a small overshoot at the parent's edge", function()
+    makeChild({dragOut = true})
+    -- pushing a container flush into the corner of its parent and going a little
+    -- too far, which is not what asking for it to come out looks like
+    assert.is_false(child:dragLeavesParent(-25, 0, 5, 5))
+  end)
+
+  it("stays in while the pointer is over the parent's own title bar", function()
+    makeChild({dragOut = true})
+    -- a container holds its children below its title bar, so a pointer over that
+    -- title bar is already outside the area the children are placed in
+    dock:setPadding(30)
+    assert.is_false(child:dragLeavesParent(-40, -40, 5, 5))
+    assert.is_true(child:dragLeavesParent(-40, -120, 5, 5))
+  end)
+
+  it("goes by where the pointer is rather than by where the container was pushed to", function()
+    makeChild({dragOut = true, width = "80%"})
+    local inside = child.container
+    local grabX = child:get_width() - 20
+
+    -- the drag asking for far to the left of the parent, but the container was
+    -- grabbed near its right hand end, so the pointer is still over the parent
+    assert.is_false(child:dragLeavesParent(-100, 10, grabX, 5))
+    -- and the other way about: the container barely past the right hand edge,
+    -- but the pointer that dragged it there is well clear of the parent
+    assert.is_true(child:dragLeavesParent(inside.get_width() - 50, 10, grabX, 5))
+  end)
+
+  it("comes out once the pointer is dragged clear of the parent", function()
+    makeChild({dragOut = true})
+    local inside = child.container
+    assert.is_true(child:dragLeavesParent(-100, 0, 5, 5))
+    assert.is_true(child:dragLeavesParent(0, -100, 5, 5))
+    assert.is_true(child:dragLeavesParent(inside.get_width() + 100, 0, 5, 5))
+    assert.is_true(child:dragLeavesParent(0, inside.get_height() + 100, 5, 5))
+  end)
+
+  it("leaves a container that is not nested in another one alone", function()
+    makeChild({dragOut = true})
+    child:changeContainer(Geyser)
+    assert.is_false(child:dragLeavesParent(-500, -500, 5, 5))
+  end)
+
+  it("holds on to an attached container", function()
+    makeChild({dragOut = true})
+    -- set rather than attached for real: attachToBorder only takes a container
+    -- near enough to a border, which depends on the size of the window the tests
+    -- happen to run in, and it reserves a main window border and registers a
+    -- resize handler that a failing spec would leave behind
+    finally(function() child.attached = false end)
+    child.attached = "left"
+    assert.is_false(child:dragLeavesParent(-500, -500, 5, 5))
+    child.attached = false
+    assert.is_true(child:dragLeavesParent(-500, -500, 5, 5))
+  end)
+
+  it("stays where it is on screen when it comes out of its parent", function()
+    makeChild({dragOut = true})
+    local inside = child.container
+    local x, y = child:get_x(), child:get_y()
+    local width, height = child:get_width(), child:get_height()
+
+    -- the position the drag asks for is the one the container is already at
+    assert.is_true(child:dragOutOfParent(x - inside.get_x(), y - inside.get_y()))
+
+    assert.are.equal(Geyser, child.container)
+    assert.are.equal(child, Geyser.windowList[childName])
+    assert.is_true(child.draggedOut)
+    assertNear(child:get_x(), x, "x")
+    assertNear(child:get_y(), y, "y")
+    assertNear(child:get_width(), width, "width")
+    assertNear(child:get_height(), height, "height")
+    -- and the widget went with it rather than only the bookkeeping
+    local widgetX, widgetY = getWindowGeometry(childName .. "adjLabel")
+    assertNear(widgetX, x, "widget x")
+    assertNear(widgetY, y, "widget y")
+  end)
+
+  it("follows the drag out to where the pointer took it", function()
+    makeChild({dragOut = true})
+    local inside = child.container
+    local insideX, insideY = inside.get_x(), inside.get_y()
+
+    child:dragOutOfParent(-50, 10)
+
+    assertNear(child:get_x(), insideX - 50, "x")
+    assertNear(child:get_y(), insideY + 10, "y")
+  end)
+
+  it("keeps the size it had, whether that was a share of the parent or pixels", function()
+    makeChild({dragOut = true, width = "50%", height = 100})
+    local width = child:get_width()
+
+    child:dragOutOfParent(0, 0)
+
+    assert.is_truthy(tostring(child.width):find("%%$"))
+    assertNear(child:get_width(), width, "width")
+    assert.are.equal("100px", child.height)
+    assert.are.equal(100, child:get_height())
+  end)
+
+  it("keeps the size of a container measured from its parent's far edge", function()
+    -- a negative size is the parent's, less that many pixels, so it means a
+    -- different size in the window the container comes out into
+    makeChild({dragOut = true, width = "-100"})
+    local width = child:get_width()
+
+    child:dragOutOfParent(0, 0)
+
+    assert.is_truthy(tostring(child.width):find("%%$"))
+    assertNear(child:get_width(), width, "width")
+  end)
+
+  it("keeps a container that comes out at the edge inside the window", function()
+    makeChild({dragOut = true})
+    local winWidth, winHeight = getMainWindowSize()
+
+    child:dragOutOfParent(-100000, -100000)
+    assert.are.equal(0, child:get_x())
+    assert.are.equal(0, child:get_y())
+
+    child:changeContainer(dock.Inside)
+    child:dragOutOfParent(100000, 100000)
+    assertNear(child:get_x(), winWidth - child:get_width(), "x")
+    assertNear(child:get_y(), winHeight - child:get_height(), "y")
+  end)
+
+  it("restores a minimized container to the height it had", function()
+    makeChild({dragOut = true})
+    local height = child:get_height()
+    child:minimize()
+
+    child:dragOutOfParent(0, 0)
+    child:restore()
+
+    assert.is_false(child.minimized)
+    -- the height it restores to was a share of the parent it has left
+    assertNear(child:get_height(), height, "restored height")
+  end)
+
+  it("does nothing for a container that is not nested in another one", function()
+    makeChild({dragOut = true})
+    child:changeContainer(Geyser)
+    local x = child:get_x()
+
+    assert.is_false(child:dragOutOfParent(-500, -500))
+
+    assert.are.equal(x, child:get_x())
+  end)
+
+  it("is not dragged out any more once a script puts it back in a container", function()
+    makeChild({dragOut = true})
+    child:dragOutOfParent(0, 0)
+    assert.is_true(child.draggedOut)
+
+    child:changeContainer(dock.Inside)
+
+    assert.are.equal(dock.Inside, child.container)
+    assert.is_false(child.draggedOut)
+  end)
+
+  it("comes back out of its parent when its saved settings are loaded", function()
+    makeChild({dragOut = true})
+    child:dragOutOfParent(-50, 10)
+    local x, y = child:get_x(), child:get_y()
+    child:save()
+    child:delete()
+
+    local reloaded = makeChild({dragOut = true})
+    assert.are.equal(dock.Inside, reloaded.container)
+    reloaded:load()
+
+    assert.are.equal(Geyser, reloaded.container)
+    assert.is_true(reloaded.draggedOut)
+    assertNear(reloaded:get_x(), x, "x")
+    assertNear(reloaded:get_y(), y, "y")
+  end)
+
+  it("restores a minimized container that was dragged out to the height it had", function()
+    makeChild({dragOut = true})
+    local height = child:get_height()
+    child:minimize()
+    child:dragOutOfParent(-50, 10)
+    child:save()
+    child:delete()
+
+    local reloaded = makeChild({dragOut = true})
+    reloaded:load()
+    reloaded:restore()
+
+    assert.are.equal(Geyser, reloaded.container)
+    assertNear(reloaded:get_height(), height, "restored height")
+  end)
+
+  it("goes back into its parent for settings that were saved before it was dragged out", function()
+    makeChild({dragOut = true})
+    local x, y = child:get_x(), child:get_y()
+    child:save()
+
+    child:dragOutOfParent(-50, 10)
+    child:load()
+
+    -- those settings are a position inside the parent, which is only that
+    -- position while the container is back inside the parent
+    assert.are.equal(dock.Inside, child.container)
+    assert.is_false(child.draggedOut)
+    assertNear(child:get_x(), x, "x")
+    assertNear(child:get_y(), y, "y")
+  end)
+
+  it("comes out into the user window it is in rather than into the main window", function()
+    local userWindow = Geyser.UserWindow:new({name = "gadUserWindow", x = 0, y = 0, width = 400, height = 400})
+    finally(function()
+      -- the user window's own root container is what takes the window and
+      -- everything left in it with it
+      local root = Geyser.windowList.gadUserWindowContainer
+      if root then
+        root:delete()
+      end
+    end)
+    local windowDock = Adjustable.Container:new({
+      name = "gadWindowDock",
+      x = 0, y = 0, width = 300, height = 200,
+      autoLoad = false, autoSave = false,
+    }, userWindow)
+    local windowChild = Adjustable.Container:new({
+      name = "gadWindowChild",
+      x = 10, y = 10, width = 100, height = 60,
+      autoLoad = false, autoSave = false,
+      dragOut = true,
+    }, windowDock)
+    assert.are.equal(windowDock.Inside, windowChild.container)
+
+    assert.is_true(windowChild:dragOutOfParent(0, 0))
+
+    assert.are.equal(userWindow, windowChild.container)
+    assert.are.equal("gadUserWindow", windowChild.windowname)
+  end)
+
+  it("leaves a container without dragOut where the package that made it put it", function()
+    makeChild({dragOut = true})
+    child:dragOutOfParent(-50, 10)
+    child:save()
+    child:delete()
+
+    local reloaded = makeChild()
+    reloaded:load()
+
+    assert.are.equal(dock.Inside, reloaded.container)
+  end)
+
+  it("comes out to the window rather than to the container in between", function()
+    local middle, deep
+    finally(function()
+      cleanUp(deep)
+      cleanUp(middle)
+    end)
+    middle = Adjustable.Container:new({
+      name = "gadMiddle",
+      x = 10, y = 10, width = "80%", height = "80%",
+      autoLoad = false, autoSave = false,
+    }, dock)
+    deep = Adjustable.Container:new({
+      name = "gadDeep",
+      x = 5, y = 5, width = 60, height = 40,
+      autoLoad = false, autoSave = false,
+      dragOut = true,
+    }, middle)
+    assert.are.equal(middle.Inside, deep.container)
+
+    assert.is_true(deep:dragOutOfParent(0, 0))
+
+    assert.are.equal(Geyser, deep.container)
+  end)
+
+  it("does not hold a container back at the edge of a scroll box", function()
+    local box
+    finally(function()
+      -- deleting the box takes everything that was put in it with it
+      if box then
+        box:delete()
+      end
+    end)
+    box = Geyser.ScrollBox:new({name = "gadScrollBox", x = 0, y = 0, width = 300, height = 300})
+    local boxDock = Adjustable.Container:new({
+      name = "gadBoxDock",
+      x = 0, y = 0, width = 200, height = 200,
+      autoLoad = false, autoSave = false,
+    }, box)
+    local boxChild = Adjustable.Container:new({
+      name = "gadBoxChild",
+      x = 10, y = 10, width = 60, height = 40,
+      autoLoad = false, autoSave = false,
+      dragOut = true,
+    }, boxDock)
+    assert.are.equal("gadScrollBox", boxChild.windowname)
+
+    assert.is_true(boxChild:dragOutOfParent(400, 400))
+
+    assert.are.equal(box, boxChild.container)
+    -- a scroll box is scrolled to what does not fit into it, so a container
+    -- dragged out beyond its edge is not pulled back to it
+    assert.is_true(boxChild:get_x() > box.get_width() - boxChild:get_width())
+  end)
+
+  it("hands back what Geyser makes of a container it will not move into", function()
+    makeChild({dragOut = true})
+
+    local moved, message = child:changeContainer(nil)
+
+    assert.is_nil(moved)
+    assert.is_string(message)
+    assert.are.equal(dock.Inside, child.container)
+  end)
+
+  it("carries a drag that keeps pushing past the parent out of it", function()
+    makeChild({dragOut = true})
+    local inside = child.container
+
+    -- grabbed 60 pixels in and dragged 200 to the left, which is far enough for
+    -- the pointer to leave the parent long after the container stopped at its edge
+    drag(child, 60, 30, -10, 0, 20)
+
+    assert.are.equal(Geyser, child.container)
+    assert.is_true(child.draggedOut)
+    assert.is_true(child:get_x() < inside.get_x(), "the container ended up outside its old parent")
+  end)
+
+  it("holds a drag inside the parent when the container was not given dragOut", function()
+    makeChild()
+    local inside = child.container
+
+    drag(child, 60, 30, -10, 0, 20)
+
+    assert.are.equal(inside, child.container)
+    -- held against the inside of its parent, which is what a drag out is opting
+    -- out of and every container without the constraint still does
+    assertNear(child:get_x(), inside.get_x(), "x")
+    assert.is_truthy(tostring(child.x):find("%%$"))
+  end)
+
+  it("does not take a locked container out of its parent", function()
+    makeChild({dragOut = true})
+    local inside = child.container
+    local x = child:get_x()
+    child:lockContainer()
+
+    drag(child, 60, 30, -10, 0, 20)
+
+    assert.are.equal(inside, child.container)
+    assert.are.equal(x, child:get_x())
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- new `dragOut` constraint for `Adjustable.Container`: taking the mouse pointer past the parent container takes the container out of it, into the window it is in, and the drag carries on from there
- the container keeps the size it had across the move out, and drag out state is saved with the container, so a container dragged out of its parent is still out after a restart
- off by default: a nested container without the constraint is held inside its parent exactly as before

#### Motivation for adding to Mudlet
A container nested in another one can never be pulled out of it, so a panel a package put in a dock stays in that dock whatever the user wants.

#### Other info (issues closed, discussion etc)
Opt in with `dragOut = true` at creation. With it off, a drag is bit for bit what it is today - checked by driving the same real drag against this branch and against development and comparing the positions. Dragging back in is deliberately not part of this, `changeContainer` does that from a script; the asymmetry is documented on the constraint. The base UI's gauge panel (#9840) could take this up later so its panels can be pulled out of the dock.

**Test case:** make an `Adjustable.Container` with `dragOut = true` inside another one, drag it past the parent's edge and it comes out under the pointer, while the same container without the constraint stays pinned at the parent's edge.

Assisted-by: Claude:claude-opus-5



https://github.com/user-attachments/assets/0dac73bc-8f34-4a66-be17-6f12e967a7df

