### PR TITLE
fix: trigger matching no longer allocates memory for every pattern on every line

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -29,6 +29,11 @@
 #include "TDebug.h"
 #include "mudlet.h"
 
+static void pcre2_match_data_deleter(pcre2_match_data* pointer)
+{
+    pcre2_match_data_free(pointer);
+}
+
 TAlias::TAlias(TAlias* parent, Host* pHost)
 : Tree<TAlias>(parent)
 , mpHost(pHost)
@@ -124,7 +129,10 @@ bool TAlias::match(const QString& haystack)
         goto MUD_ERROR;
     }
 
-    match_data = pcre2_match_data_create_from_pattern(re.data(), nullptr);
+    if (!mpMatchData) {
+        mpMatchData.reset(pcre2_match_data_create_from_pattern(re.data(), nullptr), pcre2_match_data_deleter);
+    }
+    match_data = mpMatchData.data();
     if (!match_data) {
         goto MUD_ERROR;
     }
@@ -132,7 +140,6 @@ bool TAlias::match(const QString& haystack)
     rc = pcre2_match(re.data(), reinterpret_cast<PCRE2_SPTR>(haystackC), haystackCLength, 0, 0, match_data, nullptr);
 
     if (rc < 0) {
-        pcre2_match_data_free(match_data);
         goto MUD_ERROR;
     }
 
@@ -237,10 +244,6 @@ END: {
     pL->clearCaptureGroups();
 }
 
-    if (match_data) {
-        pcre2_match_data_free(match_data);
-    }
-
 MUD_ERROR:
     for (auto childAlias : *mpMyChildrenList) {
         if (childAlias->match(haystack)) {
@@ -289,6 +292,7 @@ void TAlias::compileRegex()
     }
 
     mpRegex = re;
+    mpMatchData.reset();
 }
 
 bool TAlias::registerAlias()

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -76,6 +76,7 @@ public:
     QString mCommand;
     QString mRegexCode;
     QSharedPointer<pcre2_code> mpRegex;
+    QSharedPointer<pcre2_match_data> mpMatchData;
     QString mScript;
     QPointer<Host> mpHost;
     bool mModuleMember = false;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -94,12 +94,18 @@ static void pcre2_code_deleter(pcre2_code* pointer)
     pcre2_code_free(pointer);
 }
 
+static void pcre2_match_data_deleter(pcre2_match_data* pointer)
+{
+    pcre2_match_data_free(pointer);
+}
+
 //FIXME: lock if code *OR* regex doesn't compile
 bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, bool existingTrigger)
 {
     patterns.replaceInStrings("\n", "");
     mPatterns.clear();
     mRegexMap.clear();
+    mMatchDataMap.clear();
     mPatternKinds.clear();
     mLuaConditionMap.clear();
     mColorPatternList.clear();
@@ -229,21 +235,23 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
 
     const int haystackCLength = strlen(haystackC);
 
-    pcre2_match_data* match_data = pcre2_match_data_create_from_pattern(re.data(), nullptr);
-    if (!match_data) {
-        return false;
+    QSharedPointer<pcre2_match_data>& matchData = mMatchDataMap[patternNumber];
+    if (!matchData) {
+        matchData.reset(pcre2_match_data_create_from_pattern(re.data(), nullptr), pcre2_match_data_deleter);
+        if (!matchData) {
+            return false;
+        }
     }
+    pcre2_match_data* match_data = matchData.data();
 
     int rc = pcre2_match(re.data(), reinterpret_cast<PCRE2_SPTR>(haystackC), haystackCLength, 0, 0, match_data, nullptr);
 
     if (rc < 0) {
-        pcre2_match_data_free(match_data);
         return false;
     }
 
     processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, haystackCLength, match_data, rc, lineNumber);
 
-    pcre2_match_data_free(match_data);
     return true;
 }
 

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -210,6 +210,7 @@ private:
 
     QList<int> mPatternKinds;
     QMap<int, QSharedPointer<pcre2_code>> mRegexMap;
+    QMap<int, QSharedPointer<pcre2_match_data>> mMatchDataMap;
 
     // Lua code as a string to run
     QString mScript;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `match_perl()` called `pcre2_match_data_create_from_pattern()` + `pcre2_match_data_free()` on every call: one heap allocation and free per Perl-regex pattern, per reachable trigger, per line of game text.
- Cache one `match_data` per compiled pattern and reuse it across lines, in a `QSharedPointer` with a deleter to match how `mRegexMap` already owns its `pcre2_code`. Cleared alongside `mRegexMap` when patterns are recompiled, since each block is sized from its pattern's capture count.
- Reuse is safe under re-entrancy: `processRegexMatch()` copies every capture out of the ovector into `captureList` before calling `execute()`, so a script that calls `feedTriggers()` and re-enters `match_perl()` on the same pattern cannot clobber an ovector still being read.

#### Motivation for adding to Mudlet
This is a regression, not a missed optimisation: before #8533 migrated the regex engine to PCRE2 the match results went into a stack array (`int ovector[MAX_CAPTURE_GROUPS]`), and the per-call heap allocation arrived unnoticed with PCRE2's API style.

#### Other info (issues closed, discussion etc)
Measured with `PipelineBenchmark` on macOS/arm64, Release, `-DUSE_SANITIZER=""`, using two binaries from one toolchain run in 24 interleaved ABBA pairs (alternating order, so run-order effects cancel): trigger throughput **+3.11%** (t=3.00), trigger overhead **-5.51%** (t=-2.13). The text-only control moved -0.92% (t=-0.26, 12/24 paired wins) i.e. no effect, which is the check that the trigger deltas are real. ASan must be off for this measurement since it instruments every malloc.

**Test case:** behaviour-neutral, so the checks are for regressions. Perl-regex triggers with 2 and 3 capture groups firing on one line both return correct captures; editing a saved trigger's pattern to one with a different capture count then re-firing still returns correct captures (exercises cache invalidation); a trigger whose script calls `feedTriggers()` into a second Perl trigger still fires correctly (exercises re-entrancy). Verified against before/after builds on macOS, plus 6 trigger functional test suites.