### PR TITLE
fix: exact-match triggers no longer copy every line they check

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -841,7 +841,7 @@ void TTrigger::processPromptMatch(int patternNumber)
 
 bool TTrigger::match_exact_match(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber)
 {
-    QString text = haystack;
+    QStringView text(haystack);
     if (text.endsWith(QChar('\n'))) {
         text.chop(1);
     }

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -199,7 +199,7 @@ private:
         return out;
     }
 
-    // A realistic ~three-dozen always-active trigger mix. Some patterns never
+    // A realistic ~four-dozen always-active trigger mix. Some patterns never
     // match, so the miss path is costed too. Lua-code matchers are excluded and
     // every trigger carries an empty script, so a match runs the full regex +
     // capture path (the cost we want) but TTrigger::execute() returns before any
@@ -261,6 +261,23 @@ private:
 
         for (const QString& s : {qsl("You are"), qsl("The"), qsl("HP:"), qsl("You gain")}) {
             addKind({s}, REGEX_BEGIN_OF_LINE_SUBSTRING, false);
+        }
+
+        // Exact-match patterns cost the whole line on every call, so they are
+        // costed at the same count as the substring group.
+        for (const QString& s : {qsl("You are hungry."),
+                                 qsl("You are thirsty."),
+                                 qsl("It is pitch black."),
+                                 qsl("The door is closed."),
+                                 qsl("You have no keys."),
+                                 qsl("Nothing happens."),
+                                 qsl("You feel better."),
+                                 qsl("Your wounds close."),
+                                 qsl("The orc dies."),
+                                 qsl("You are hidden."),
+                                 qsl("A cool breeze blows."),
+                                 qsl("You cannot go that way.")}) {
+            addKind({s}, REGEX_EXACT_MATCH, false);
         }
 
         addColor(1, TTrigger::scmIgnored);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `match_exact_match()` did `QString text = haystack;` then chopped a trailing newline. The assignment is copy-on-write and cheap, but `chop()` mutates, forcing the detach: a heap allocation plus a full character copy of the line.
- The newline is always present - `TMainConsole::runTriggers()` appends one to every line before dispatch (`TMainConsole.cpp:1570`) - so the chop always fires and the copy always happens, once per exact-match pattern, per reachable trigger, per line of game text.
- Use a `QStringView`. Chopping a view moves only its own end pointer, so nothing is allocated, and the comparison against the needle is unchanged. Both chop one UTF-16 code unit, so behaviour is identical for every input.

#### Motivation for adding to Mudlet
Removes a per-line heap allocation and line copy from the trigger matching path, which runs for every line of game text.

#### Other info (issues closed, discussion etc)
Measured with `PipelineBenchmark` on macOS/arm64, Release, `-DUSE_SANITIZER=""`, two binaries from one toolchain run in 24 interleaved ABBA pairs so run-order effects cancel: trigger throughput **+3.28%** (t=6.41), trigger overhead **-6.37%** (t=-4.94). The text-only control moved +0.23% (t=-0.56, 12/24 paired wins), i.e. no effect, which is the check that the trigger deltas are real.

Worth stating plainly: the stock benchmark corpus contains **no** exact-match patterns, so `match_exact_match()` is never entered by it. Twelve were added locally purely to measure this. The gain therefore scales with how many exact-match patterns a profile actually has, and is zero for a profile with none.

**Test case:** behaviour-neutral, so the checks are for regressions around where the chop lands. Exact-match triggers fire correctly on a plain ASCII line, on a line with an accented character, on one with an em dash, and on one containing an emoji (a surrogate pair, i.e. two UTF-16 code units - the case most likely to expose a code-unit-based chop). A line with trailing whitespace before the newline correctly does *not* match. Verified against before/after builds on macOS, plus 5 trigger functional test suites.