### PR TITLE
fix: Mudlet no longer copies the whole screen an extra time on every repaint

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1317,7 +1317,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
     painter.drawPixmap(0, 0, pixmap);
     if (!noCopy) {
-        mScreenMap = pixmap.copy();
+        mScreenMap = pixmap;
     }
     mScrollVector = 0;
     mLastRenderedOffset = lineOffset;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `drawForeground()` ended with `mScreenMap = pixmap.copy()`. The local `pixmap` is freshly allocated on entry, last used by the `drawPixmap()` two lines above, and dead afterwards, so the deep copy serves no purpose.
- `mScreenMap` is only ever read as a `drawPixmap()` source (lines 1211 and 1226) plus size guards. No `QPainter` is constructed on it and it is never passed by non-const reference, so copy-on-write can never be forced to detach - plain assignment shares the buffer safely.
- Wasted work removed: a full-frame allocation plus blit per repaint, roughly 15 MB each on a 1200x800 logical pane at devicePixelRatio 2, alongside the three other full-frame operations in the same function.

#### Motivation for adding to Mudlet
Every repaint allocated and copied an entire screen-sized pixmap that nothing ever read from or wrote to.

#### Other info (issues closed, discussion etc)
Present since the first version of `drawForeground()` in 2009. #9743 already removed two other `mScreenMap.copy()` sub-rect copies from this same function in favour of an offset `drawPixmap()`, so trimming copies here is an accepted direction that stopped one line short.

Plain assignment is used rather than `std::move(pixmap)`: both are zero-copy since neither pixmap is written again, but assignment leaves the local non-null, so a later edit that adds a use after this line fails safe instead of operating on a null pixmap.

No benchmark figure is quoted deliberately. `PipelineBenchmark` is headless and its header states the display path is out of scope, with the live-GUI companion being the separate Stressinator package. The argument here is that the removed work is provably dead, not that a measurement improved.

**Test case:** `GlyphOverflowTest` passes - it compares rendered pixels through both `mScreenMap` reuse paths, the scroll-reuse offset draw and the partial-repaint draw. `CopyAsImageTest`, `WindowBackgroundTest` and `WindowStateGettersTest` also pass. Manually on macOS against before/after builds: scrolling through scrollback shows no tearing, ghost lines or stale rows; drag-selection across the upper/lower pane split behaves correctly; copy-as-image produces correct output; text stays crisp on a HiDPI display (devicePixelRatio survives the assignment).