### PR TITLE
improve: the ISO 8859-1 decoder no longer allocates a string for every character

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1317,7 +1317,7 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                 mMudLine.append(encodingLookupTable.at(index - 128));
             }
         } else if (mEncoding == "ISO 8859-1") {
-            mMudLine.append(QString(QChar::fromLatin1(ch)));
+            mMudLine.append(QChar::fromLatin1(ch));
         } else if (mEncoding == "GBK") {
             if (!processGBSequence(localBuffer, isFromServer, false, localBufferLength, localBufferPosition, isTwoTCharsNeeded)) {
                 // We have run out of bytes and we have stored the unprocessed

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -383,6 +383,27 @@ private slots:
         emitMetric("text_best_pass_ms", seconds * 1000.0);
     }
 
+    // ISO 8859-1 has no lookup table, so every received byte takes the single-byte
+    // branch of the decoder - unlike the default encoding, which never enters it.
+    // Decoding the UTF-8 corpus as Latin-1 yields mojibake, which is irrelevant:
+    // the byte count through that branch is what is being timed.
+    void benchLatin1Decode()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+
+        const auto result = host->mTelnet.setEncoding("ISO 8859-1", false);
+        QVERIFY2(result.first, qPrintable(result.second));
+
+        const double seconds = feedCorpusBestPass(host, kFeedPasses);
+        const int bufferedLines = host->mpConsole->buffer.getLastLineNumber();
+        QVERIFY2(bufferedLines > 1000, qPrintable(qsl("console buffer only holds %1 lines - the pipeline did not process the corpus").arg(bufferedLines)));
+
+        emitMetric("latin1_lines_per_sec", mCorpusLines / seconds);
+        emitMetric("latin1_mb_per_sec", (mCorpusBytes / 1.0e6) / seconds);
+        emitMetric("latin1_best_pass_ms", seconds * 1000.0);
+    }
+
     void benchTriggerEngine()
     {
         Host* host = startProfile();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The `ISO 8859-1` branch of `translateToPlainTextInner()` wrapped each decoded character in a temporary `QString` before appending it, costing one heap allocation per character on the per-character decode path.
- Append the bare `QChar` instead, which is what the adjacent branch five lines above (bytes below 128 for table-based encodings) already does.
- Second commit adds a `latin1_*` phase to `PipelineBenchmark`, which previously set no server encoding and so never entered this branch at all.

#### Motivation for adding to Mudlet
Removes a heap allocation per character of received text for every profile using ISO 8859-1 — worth about **23% more throughput** on that decode path.

#### Other info (issues closed, discussion etc)
**Measured** with the new `latin1_*` phase on macOS/arm64, Release, `-DUSE_SANITIZER=""`, two binaries from one toolchain run in 12 interleaved ABBA pairs so run-order effects cancel:

| metric | before | after | delta | pairs favouring | t |
|---|---|---|---|---|---|
| `latin1_lines_per_sec` | 79,629 | 98,322 | **+23.47%** | 12/12 | +28.61 |
| `latin1_best_pass_ms` | 314.0 | 254.3 | **-19.01%** | 12/12 | -25.58 |
| `text_best_pass_ms` (control) | 294.9 | 296.2 | +0.42% | 4/12 | +0.13 |

ISO 8859-1 has no lookup table, so **every** byte takes the changed line — roughly 2.4 million heap allocations removed per pass over the 2.4 MB corpus. The control metric not moving is the check that the delta is real.

Note the first commit's message says "No benchmark figure is quoted"; that statement is superseded by the second commit and the table above.

Caution when reading the phases: do not compare `latin1_*` against `text_*` directly. Latin-1 decoding is intrinsically cheaper than UTF-8, so that phase reads faster regardless of this change. Only the before/after of the same metric is meaningful.

This is an inconsistency rather than a deliberate choice: both branches were written in the same commit (#969), five lines apart, and the ISO 8859-1 one was never revisited. `git log -L` over these lines shows only incidental touches since — CP437 support in #3579, the GBK/GB18030 decoder, a comment typo fix in #1495, a signed/unsigned cast pass, and the brace-formatting pass in #1115.

Behaviour is unchanged by construction: both forms evaluate the same `QChar::fromLatin1(ch)` and hand the identical `QChar` to `QString::append()`; only the temporary `QString` disappears.

**Test case:** `lua setServerEncoding("ISO 8859-1")` then `lua feedTriggers("caf\233 na\239ve \253\254 \160\176\191\208\247\n", false)` renders `café naïve ýþ  °¿Ð÷`, exercising bytes 0xE9, 0xEF, 0xFD, 0xFE, 0xA0, 0xB0, 0xBF, 0xD0 and 0xF7 through the changed line. Output is byte-identical before and after, verified against before/after builds on macOS.

Note for anyone testing: do not use byte 0xFF. `CHAR_END_OF_FILE '\xff'` (`TStringUtils.h:32`) is Mudlet's internal line-commit and prompt marker — `CHAR_IS_COMMIT_CHAR` lists it beside `\n` and `\r`, and `TBuffer.cpp:1668`/`:1684` use it to set `promptBuffer` — so it can never arrive as displayable text regardless of this change.

`GlyphOverflowTest`, `CopyAsImageTest`, `WindowBackgroundTest`, `ProfileRoundTripTest`, `TriggerSameLineMatchTest`, `cTelnetBufferTest`, `TelnetSgrDefaultColorTest` and `TelnetStringSequenceRecoveryTest` all pass.