### PR TITLE
fix: game text no longer breaks into one character per line with GA forced off

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -5348,6 +5348,7 @@ Some data loss is likely - please mention this problem to the game admins.)",
                 cleandata = "";
             } else {
                 cleandata.push_back('\n');
+                recvdGA = false;
             }
         }
     } //for

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -193,6 +193,41 @@ private slots:
         }
     }
 
+    // With "Force telnet GA signal interpretation off" the GA branch appended a
+    // newline without clearing recvdGA, so every remaining byte of the read
+    // re-entered it and got its own newline. One buffer is fed here because that
+    // guarantees the GA and the text after it share a read, which is the condition
+    // - a socket write could in principle be split. mFORCE_GA_OFF is set directly
+    // because that is what the preference does: cTelnet copies it from the Host at
+    // connect time.
+    void forcedGaOffKeepsTheRestOfTheReadOnOneLine()
+    {
+        const bool savedForceGaOff = mpHost->mTelnet.mFORCE_GA_OFF;
+        const bool savedGaDriver = mpHost->mTelnet.mGA_Driver;
+        auto restoreFlags = qScopeGuard([this, savedForceGaOff, savedGaDriver]() {
+            mpHost->mTelnet.mFORCE_GA_OFF = savedForceGaOff;
+            mpHost->mTelnet.mGA_Driver = savedGaDriver;
+        });
+        mpHost->mTelnet.mFORCE_GA_OFF = true;
+
+        const QString trailing = qsl("AFTER-THE-GA this must stay on one line");
+        // A leading newline commits any partial line an earlier test left behind,
+        // so the prompt below cannot be glued onto residue.
+        QByteArray data("\r\nHP:100 MP:50 > ");
+        data += TN_IAC;
+        data += TN_GA;
+        data += trailing.toUtf8();
+        data += "\r\n";
+
+        mpHost->mTelnet.processSocketData(data.data(), data.size(), true);
+
+        // Pre-fix every byte after the GA became its own line, so no single line
+        // could hold the whole string: this assertion is the regression guard.
+        QVERIFY2(bufferContains(trailing),
+                 "the text following a GA was split up - recvdGA was not cleared in the "
+                 "mFORCE_GA_OFF branch, so every byte after the GA got its own newline");
+    }
+
     // The production route from Lua: feedTelnet() -> loopbackTest() ->
     // processSocketData(). loopbackTest() takes a non-const QByteArray and calls
     // data(), which detaches, so the allocation shape is Qt's choice rather than


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The `MAIN_LOOP_END` block that reacts to a received GA sits **inside** the per-byte loop of `processSocketData()`. The normal path clears `recvdGA` before handing the line to `gotPrompt()`; the `mFORCE_GA_OFF` path only appended a newline and left the flag set.
- So once a GA arrived, every remaining byte of that read re-entered the block and appended another newline: the rest of the read was emitted one character per line, and each of those lines ran the full trigger set.
- Clear `recvdGA` in that branch too.

#### Motivation for adding to Mudlet
With this option enabled, a single GA turned the remainder of the read into a vertical column of single characters and made the client crawl, since every character was processed as its own line.

#### Other info (issues closed, discussion etc)
Only reachable with "Force telnet GA signal interpretation off" enabled (Settings -> Special Options). That flag is copied into `cTelnet` at connect time (`ctelnet.cpp:497`), so it applies from the next connection - which is also why the group box is labelled as needing a restart.

The option exists so Mudlet ignores GA signalling from older game drivers, and ignoring the signal is precisely what this branch is for; it simply never consumed the flag.

**Test case:** with a server that sends text, then `IAC GA`, then more text **in a single write** so they arrive in one read, and with the option enabled before connecting: before this change everything after the GA appears one character per line; after it, the trailing text renders on one line as expected. `cTelnetBufferTest`, `TelnetSgrDefaultColorTest`, `TelnetStringSequenceRecoveryTest`, `GMCPCharLoginTest` and `TriggerSameLineMatchTest` all pass.