### PR TITLE
fix: the last line of a paragraph no longer goes missing when undoing game wrapping

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1844,6 +1844,7 @@ void TBuffer::startServerWrapFlushTimer()
             mpHost->mpConsole->mTriggerEngineMode = true;
             flushPendingServerWrapJoin();
             mpHost->mpConsole->mTriggerEngineMode = false;
+            mpHost->mpConsole->finalize();
         });
     }
     mpServerWrapFlushTimer->start();

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1833,6 +1833,11 @@ void TBuffer::startServerWrapFlushTimer()
             return;
         }
         mpServerWrapFlushTimer = new QTimer(mpConsole);
+        // Named so that a test can find it on the console and observe the state
+        // it leaves behind, which no polling assertion can catch: the posting
+        // timer in cTelnet::slot_timerPosting() calls finalize() too and hides
+        // an unpainted line within a tick of it being committed
+        mpServerWrapFlushTimer->setObjectName(qsl("serverWrapFlushTimer"));
         mpServerWrapFlushTimer->setSingleShot(true);
         mpServerWrapFlushTimer->setInterval(csmServerWrapFlushDelayMs);
         QObject::connect(mpServerWrapFlushTimer, &QTimer::timeout, mpConsole, [this]() {

--- a/test/functional_tests/UndoServerWrapTest.cpp
+++ b/test/functional_tests/UndoServerWrapTest.cpp
@@ -115,6 +115,8 @@ private slots:
 
     void test_loneFullWidthLineIsFlushed()
     {
+        const QString welcome = qsl("Welcome to the test game.");
+        mpServer->setWelcomeMessage(welcome);
         startProfile(mpHostname, mpLocalhost, mpPort);
         enableUndoServerWrap();
         QVERIFY(QTest::qWaitFor(
@@ -123,11 +125,47 @@ private slots:
                 },
                 2000));
 
+        // The stub sends its welcome message 100ms after connecting. Letting it
+        // land first is what makes this test exercise the flush timer at all:
+        // otherwise it arrives as a following line and commits the held segment
+        // through the ordinary painted path before the timer ever fires.
+        QVERIFY(QTest::qWaitFor(
+                [&]() {
+                    return bufferHasLine(welcome);
+                },
+                2000));
+
         // Nothing follows, so the held line has to be committed by the
         // flush timer once the game goes quiet:
         mpServer->sendRaw(mSegment1.toUtf8() + "\r\n");
 
+        // The timer is created when the line is first held back:
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        QTimer* flushTimer = nullptr;
+        QVERIFY2(QTest::qWaitFor(
+                         [&]() {
+                             flushTimer = console->findChild<QTimer*>(qsl("serverWrapFlushTimer"));
+                             return flushTimer && flushTimer->isActive();
+                         },
+                         2000),
+                 "the full-width line was not held back for a continuation");
+
+        // Only showNewLines() advances buffer.mCursorY, so it having caught up
+        // with the buffer is what distinguishes a painted line from an appended
+        // one. It has to be read the moment the flush returns rather than
+        // polled for: cTelnet's posting timer calls finalize() as well and
+        // repaints within a tick, so any wait long enough to see the line
+        // appear is also long enough to lose the evidence.
+        int sizeAtFlush = -1;
+        int cursorAtFlush = -1;
+        connect(flushTimer, &QTimer::timeout, this, [&]() {
+            sizeAtFlush = console->buffer.size();
+            cursorAtFlush = console->buffer.mCursorY;
+        });
+
         QVERIFY2(waitForLineInBuffer(mSegment1), "held full-width line was not flushed after the game went quiet");
+        QVERIFY2(sizeAtFlush > 0, "the flush timer never fired, so the line was committed by some other path");
+        QCOMPARE(cursorAtFlush, sizeAtFlush);
     }
 
     void test_blankLineEndsParagraph()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- With "Undo the game's own wrapping at:" enabled, a full-width line is held back so a continuation can be joined onto it; when none arrives, a 300ms timer flushes it.
- That timer's lambda committed the held line through `flushPendingServerWrapJoin()` but never called `finalize()`, so the pane was never told to advance or repaint - the line reached the buffer and was never displayed.
- Nothing else could reveal it either: the pane's top line derives from a cursor only `showNewLines()` advances, so resizing or switching tabs leaves it hidden until unrelated output arrives.

#### Motivation for adding to Mudlet
The last line of a paragraph or spontaneous message simply never appeared on screen.

#### Other info (issues closed, discussion etc)
The lambda's own comment says it mimics `TMainConsole::printOnDisplay()`, which is followed by `finalize()` everywhere else, and the sibling MXP tag watchdog lambda in this same file already calls it - so this completes that mimicry rather than adding new behaviour.

Accepted side effect: the flushed line is now also announced to screen readers, since `finalize()` reaches `showNewLines()`'s accessibility branch. It was previously invisible to sighted and screen-reader users alike.

`UndoServerWrapTest::test_loneFullWidthLineIsFlushed` passes both before and after: it asserts only that the text reached the buffer via `waitForLineInBuffer()`, never that it was painted, which is how this went unnoticed. Extending it to assert the repaint would be a reasonable follow-up.

**Merge-order note:** please land this before or with any fix to the posting timer in `cTelnet::gotRest()` (the unconditional `mpPostingTimer->start()` in the non-GA branch). On non-GA profiles that timer is currently the only thing that repaints a wrap-held line, so removing it first would reintroduce this symptom for those profiles.

**Test case:** enable Settings -> Main display -> Word wrapping -> "Undo the game's own wrapping at:" with a width of 90, leave "Force telnet GA signal interpretation off" unchecked, and connect to a server that sends a prompt terminated by `IAC GA`, several ~90-character prose lines, another prompt, then one final full-width line followed by silence. Before this change that final line never appears; after it, it appears ~300ms later. Verified against before/after builds on macOS with a scripted local server. `UndoServerWrapTest`, `NarrowWindowWrapTest`, `GlyphOverflowTest`, `TriggerSameLineMatchTest` and `cTelnetBufferTest` all pass.