### PR TITLE
fix: saved variables holding functions come back empty again instead of half-filled

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -750,6 +750,14 @@ QString LuaInterface::getValue(TVar* var)
     return {};
 }
 
+// The value types a profile save can write and an import can read back. A member
+// of any other type is dropped from the save, which is what XMLexport has to
+// know about to keep the ride-along export honest (#9857).
+static bool serializableValueType(const int valueType)
+{
+    return valueType == LUA_TTABLE || valueType == LUA_TSTRING || valueType == LUA_TNUMBER || valueType == LUA_TBOOLEAN;
+}
+
 void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
 {
     depth++;
@@ -783,14 +791,21 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
             lua_pop(L, 1);
             continue;
         }
-        if (mSavedVarsOnly && depth == 1) {
-            if (!mSavedRootNames.contains(keyName)) {
-                lua_pop(L, 1);
-                continue;
+        if (mSavedVarsOnly) {
+            if (depth == 1) {
+                if (!mSavedRootNames.contains(keyName)) {
+                    lua_pop(L, 1);
+                    continue;
+                }
+                // each saved global is walked in its own dedup scope, so two of them
+                // that reference the same table both get a complete subtree
+                varUnit->clearPointers();
+                mCurrentSavedRootName = keyName;
+            } else if (!serializableValueType(vType)) {
+                // against the global rather than the table the value sits in:
+                // what a script reads back is the whole variable
+                mSavedRootsHoldingUnsaveableValues.insert(mCurrentSavedRootName);
             }
-            // each saved global is walked in its own dedup scope, so two of them
-            // that reference the same table both get a complete subtree
-            varUnit->clearPointers();
         }
         auto var = new TVar();
         var->setReference(keyIsReference);
@@ -898,6 +913,8 @@ void LuaInterface::getSavedVars()
     }
     mSavedRootNames.clear();
     mTruncatedSavedTables.clear();
+    mSavedRootsHoldingUnsaveableValues.clear();
+    mCurrentSavedRootName.clear();
     for (const QString& savedVarName : std::as_const(varUnit->savedVars)) {
         // savedVars holds dotted paths, but a global's own name may contain a
         // dot as well, so both readings count as a name to walk

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -750,9 +750,10 @@ QString LuaInterface::getValue(TVar* var)
     return {};
 }
 
-// The value types a profile save can write and an import can read back. A member
-// of any other type is dropped from the save, which is what XMLexport has to
-// know about to keep the ride-along export honest (#9857).
+// The value types a variable can survive a save as: XMLimport hands every element
+// it reads to setValue(), which can rebuild nothing else. A value of any other
+// type is lost across the save, so a saved global holding one anywhere inside it
+// cannot be exported whole (#9857).
 static bool serializableValueType(const int valueType)
 {
     return valueType == LUA_TTABLE || valueType == LUA_TSTRING || valueType == LUA_TNUMBER || valueType == LUA_TBOOLEAN;
@@ -802,8 +803,9 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
                 varUnit->clearPointers();
                 mCurrentSavedRootName = keyName;
             } else if (!serializableValueType(vType)) {
-                // against the global rather than the table the value sits in:
-                // what a script reads back is the whole variable
+                // the whole global, not just the table this value sits in: a
+                // script gets the global back as one object, so one member the
+                // save cannot carry makes all of it untrustworthy
                 mSavedRootsHoldingUnsaveableValues.insert(mCurrentSavedRootName);
             }
         }
@@ -908,6 +910,11 @@ void LuaInterface::getSavedVars()
         // getVars() does not clear this itself, so a later walk on this same
         // interface would inherit the filter
         mSavedVarsOnly = false;
+        // the global the walk died inside was not read to the end, so nothing
+        // says it is one the save can carry whole
+        if (!mCurrentSavedRootName.isEmpty()) {
+            mSavedRootsHoldingUnsaveableValues.insert(mCurrentSavedRootName);
+        }
         qWarning() << "LuaInterface::getSavedVars() WARNING - Lua panicked while reading the saved variables in; the variable tree is incomplete.";
         return;
     }

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -62,8 +62,10 @@ public:
     // the saved variables the last getSavedVars() had to cut short, for the
     // caller to tell the user about - they are in no profile save it takes
     QStringList truncatedSavedTables() const { return mTruncatedSavedTables; }
-    // the saved globals the last getSavedVars() found a value under that no
-    // save can carry: a function, userdata or coroutine
+    // the saved globals the last getSavedVars() found a value inside, at any
+    // depth, that a save cannot carry: anything but a table, string, number or
+    // boolean. A walk cut short by a panic or by scmMaxTableDepth answers only
+    // for what it reached.
     QSet<QString> savedRootsHoldingUnsaveableValues() const { return mSavedRootsHoldingUnsaveableValues; }
     QStringList varName(TVar* var);
     QList<TVar*> varOrder(TVar* var);
@@ -101,9 +103,9 @@ private:
     bool mSavedVarsOnly = false;
     // ...and these are the top-level keys such a walk may keep
     QSet<QString> mSavedRootNames;
-    // which of those keys the walk is inside at the moment, and the ones it
-    // found a value under that the save has to drop
+    // which of those keys the walk is inside, meaningful only while one is running
     QString mCurrentSavedRootName;
+    // the keys it found a value under that the save cannot carry
     QSet<QString> mSavedRootsHoldingUnsaveableValues;
     QStringList mTruncatedSavedTables;
 };

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -62,6 +62,9 @@ public:
     // the saved variables the last getSavedVars() had to cut short, for the
     // caller to tell the user about - they are in no profile save it takes
     QStringList truncatedSavedTables() const { return mTruncatedSavedTables; }
+    // the saved globals the last getSavedVars() found a value under that no
+    // save can carry: a function, userdata or coroutine
+    QSet<QString> savedRootsHoldingUnsaveableValues() const { return mSavedRootsHoldingUnsaveableValues; }
     QStringList varName(TVar* var);
     QList<TVar*> varOrder(TVar* var);
     QString getValue(TVar*);
@@ -98,6 +101,10 @@ private:
     bool mSavedVarsOnly = false;
     // ...and these are the top-level keys such a walk may keep
     QSet<QString> mSavedRootNames;
+    // which of those keys the walk is inside at the moment, and the ones it
+    // found a value under that the save has to drop
+    QString mCurrentSavedRootName;
+    QSet<QString> mSavedRootsHoldingUnsaveableValues;
     QStringList mTruncatedSavedTables;
 };
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -788,13 +788,18 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
     saveTimeInterface.getSavedVars();
 
-    // A saved global holding a function, userdata or coroutine cannot be written
-    // out as it stands, and exporting the rest of it hands the next session a
-    // table its own scripts no longer recognise - a cron job without its
-    // command, say. Mudlet up to 4.22 wrote such a variable as an empty group,
-    // which is what the "if it is empty, rebuild it" guard packages carry keys
-    // off, so those variables go on being exported the way they were: registered
-    // members only, no ride-along (#9857).
+    // A saved global with a value anywhere inside it that no save can carry (see
+    // serializableValueType() in LuaInterface.cpp) cannot come back whole, and
+    // writing out the parts that can be saved hands the next session a table its
+    // own scripts no longer recognise - a cron job without its command, say. Such
+    // a global therefore exports only the members registered in savedVars, which
+    // for a table registered while it was empty is an empty group: the state the
+    // "it is empty, so rebuild it" guard packages carry needs to see (#9857).
+    // Only the value type counts. A member dropped for its size, for being a
+    // second name for a table already written, or for being hidden still rides
+    // along with its siblings, because those are limits on how much of a table
+    // to write rather than on what a table can hold, and fencing the whole
+    // variable on one of them would lose more than it saved.
     const QSet<QString> unsaveableRoots = saveTimeInterface.savedRootsHoldingUnsaveableValues();
     if (TVar* base = saveTimeUnit->getBase()) {
         QListIterator<TVar*> itVariable(base->getChildren(false));
@@ -898,8 +903,8 @@ void XMLexport::writeVariable(TVar* pVar, LuaInterface* pLuaInterface, VarUnit* 
     // silently dropped (#9517). The ride-along skips hidden variables
     // (Mudlet's internals and ones the user hid) and unsaveable ones
     // (functions, references, oversized tables), and it is off altogether for a
-    // variable the save cannot carry whole, see writeVariablePackage(); an
-    // explicitly saved variable exports as it always has.
+    // variable the save cannot carry whole, see writeVariablePackage(). A
+    // variable with its own savedVars entry exports either way.
     const bool exportable = pVariableUnit->isSaved(pVar) || (insideSavedTable && rideAlongAllowed && pVariableUnit->shouldSave(pVar) && !pVariableUnit->isHidden(pVar));
     if (exportable) {
         if (pVar->getValueType() == LUA_TTABLE) {

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -788,10 +788,19 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
     saveTimeInterface.getSavedVars();
 
+    // A saved global holding a function, userdata or coroutine cannot be written
+    // out as it stands, and exporting the rest of it hands the next session a
+    // table its own scripts no longer recognise - a cron job without its
+    // command, say. Mudlet up to 4.22 wrote such a variable as an empty group,
+    // which is what the "if it is empty, rebuild it" guard packages carry keys
+    // off, so those variables go on being exported the way they were: registered
+    // members only, no ride-along (#9857).
+    const QSet<QString> unsaveableRoots = saveTimeInterface.savedRootsHoldingUnsaveableValues();
     if (TVar* base = saveTimeUnit->getBase()) {
         QListIterator<TVar*> itVariable(base->getChildren(false));
         while (itVariable.hasNext()) {
-            writeVariable(itVariable.next(), &saveTimeInterface, saveTimeUnit, variablePackage);
+            TVar* pVariable = itVariable.next();
+            writeVariable(pVariable, &saveTimeInterface, saveTimeUnit, variablePackage, false, !unsaveableRoots.contains(pVariable->getName()));
         }
     }
     saveTimeInterface.releaseVariableReferences();
@@ -881,16 +890,17 @@ void XMLexport::writeTriggerPackage(const Host* pHost, pugi::xml_node& mudletPac
     }
 }
 
-void XMLexport::writeVariable(TVar* pVar, LuaInterface* pLuaInterface, VarUnit* pVariableUnit, pugi::xml_node xmlParent, bool insideSavedTable)
+void XMLexport::writeVariable(TVar* pVar, LuaInterface* pLuaInterface, VarUnit* pVariableUnit, pugi::xml_node xmlParent, bool insideSavedTable, bool rideAlongAllowed)
 {
     // a member of a saved table is saved with it even without its own
     // savedVars entry: a missing entry cannot be told apart from a member a
     // script added after the table was marked saved, and those must not be
     // silently dropped (#9517). The ride-along skips hidden variables
     // (Mudlet's internals and ones the user hid) and unsaveable ones
-    // (functions, references, oversized tables); an explicitly saved
-    // variable exports as it always has.
-    const bool exportable = pVariableUnit->isSaved(pVar) || (insideSavedTable && pVariableUnit->shouldSave(pVar) && !pVariableUnit->isHidden(pVar));
+    // (functions, references, oversized tables), and it is off altogether for a
+    // variable the save cannot carry whole, see writeVariablePackage(); an
+    // explicitly saved variable exports as it always has.
+    const bool exportable = pVariableUnit->isSaved(pVar) || (insideSavedTable && rideAlongAllowed && pVariableUnit->shouldSave(pVar) && !pVariableUnit->isHidden(pVar));
     if (exportable) {
         if (pVar->getValueType() == LUA_TTABLE) {
             auto variableGroup = xmlParent.append_child("VariableGroup");
@@ -902,7 +912,7 @@ void XMLexport::writeVariable(TVar* pVar, LuaInterface* pLuaInterface, VarUnit* 
 
             QListIterator<TVar*> itNestedVariable(pVar->getChildren(false));
             while (itNestedVariable.hasNext()) {
-                writeVariable(itNestedVariable.next(), pLuaInterface, pVariableUnit, variableGroup, true);
+                writeVariable(itNestedVariable.next(), pLuaInterface, pVariableUnit, variableGroup, true, rideAlongAllowed);
             }
         } else {
             auto variable = xmlParent.append_child("Variable");

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -65,7 +65,7 @@ public:
     void writeAction(TAction*, pugi::xml_node xmlParent);
     void writeScript(TScript*, pugi::xml_node xmlParent);
     void writeKey(TKey*, pugi::xml_node xmlParent);
-    void writeVariable(TVar*, LuaInterface*, VarUnit*, pugi::xml_node xmlParent, bool insideSavedTable = false);
+    void writeVariable(TVar*, LuaInterface*, VarUnit*, pugi::xml_node xmlParent, bool insideSavedTable = false, bool rideAlongAllowed = true);
     void writeModuleXML(const QString& moduleName);
     std::shared_ptr<pugi::xml_document> takeExportDocument();
     static bool saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(FUNCTIONAL_TEST_SOURCES
     UnitDeferredDeleteTest.cpp
     ProfileLifecycleTest.cpp
     MxpFramePlacementTest.cpp
+    SavedVariableFenceTest.cpp
     ColorTriggerFilterChildTest.cpp
     CopyAsImageTest.cpp
     GlyphOverflowTest.cpp

--- a/test/functional_tests/SavedVariableFenceTest.cpp
+++ b/test/functional_tests/SavedVariableFenceTest.cpp
@@ -1,0 +1,447 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Issue #9857. A saved table holding a function, userdata or coroutine cannot be
+ * written out in full: the save drops those members and the next session gets a
+ * table its own scripts no longer recognise - a cron job without its command,
+ * say. Mudlet up to 4.22 wrote such a table as an empty group, and packages key
+ * "if it is empty, rebuild it" off exactly that, so it goes on being written the
+ * way it was: the members registered in savedVars and no others.
+ *
+ * The shapes below are the ones measured on 4.22.0 and on the 5.0 release
+ * candidate, each ticked as a saved variable while empty and filled by a script
+ * afterwards - which is the state a package that rebuilds its own tables is
+ * always in, and the only one that regressed. Tables that hold nothing but data
+ * keep the full save.
+ *
+ * Run with: ctest -R SavedVariableFenceTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "LuaInterface.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "VarUnit.h"
+#include "XMLexport.h"
+#include "XMLimport.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include <QXmlStreamReader>
+
+#include <optional>
+
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
+}
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForSavedVariableFenceTest();
+
+struct SavedShape
+{
+    // what the shape is called in the measurements this pins
+    const char* description = nullptr;
+    QString globalName;
+    // Lua that builds the shape, standing in for the script that fills a table
+    // the user ticked while it was empty
+    QString setup;
+    // the member names the save has to write inside the variable, so an empty
+    // list means the variable is written as an empty group
+    QStringList exportedMembers;
+    // what the next session has to see
+    QString restoreCheck;
+};
+
+class SavedVariableFenceTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "SavedVarFence-Test";
+    const QString mLocalhost = "localhost";
+
+    // An existing but empty table is what the "rebuild it if it is empty" guard
+    // in cron-daemon and every package like it needs to see.
+    static QString emptyTableCheck(const QString& globalName)
+    {
+        return qsl("assert(type(%1) == 'table', 'the saved variable did not come back as a table') "
+                   "assert(next(%1) == nil, 'the saved variable came back partially filled')")
+                .arg(globalName);
+    }
+
+    static QVector<SavedShape> shapes()
+    {
+        return {
+                {"flat data", qsl("qaFlatData"), qsl("qaFlatData = {a = 1, b = 'x'}"), {qsl("a"), qsl("b")}, qsl("assert(qaFlatData.a == 1 and qaFlatData.b == 'x')")},
+                {"clean nested",
+                 qsl("qaCleanNested"),
+                 qsl("qaCleanNested = {a = 1, sub = {b = 2, c = 'deep'}}"),
+                 {qsl("a"), qsl("sub")},
+                 qsl("assert(qaCleanNested.a == 1 and qaCleanNested.sub.b == 2 and qaCleanNested.sub.c == 'deep')")},
+                {"two globals on one data table",
+                 qsl("qaTwoGlobals"),
+                 qsl("qaTwoGlobals = {a = 1, b = 'x'} qaTwoGlobalsAlias = qaTwoGlobals"),
+                 {qsl("a"), qsl("b")},
+                 qsl("assert(qaTwoGlobals.a == 1 and qaTwoGlobals.b == 'x')")},
+                {"flat mixed", qsl("qaFlatMixed"), qsl("qaFlatMixed = {a = 1, f = function() end}"), {}, emptyTableCheck(qsl("qaFlatMixed"))},
+                {"two globals on one table holding a function",
+                 qsl("qaTwoGlobalsMixed"),
+                 qsl("qaTwoGlobalsMixed = {a = 1, f = function() end} qaTwoGlobalsMixedAlias = qaTwoGlobalsMixed"),
+                 {},
+                 emptyTableCheck(qsl("qaTwoGlobalsMixed"))},
+                {"cron-daemon's shape",
+                 qsl("qaCron"),
+                 qsl("qaCron = {otherdata = 1, joblist = {{command = function() end, spec = '*', name = 'j1'}, {command = function() end, spec = '*', name = 'j2'}}}"),
+                 {},
+                 emptyTableCheck(qsl("qaCron"))},
+                {"function only", qsl("qaFunctionOnly"), qsl("qaFunctionOnly = {f = function() end}"), {}, emptyTableCheck(qsl("qaFunctionOnly"))},
+                {"callbacks in a deeper table", qsl("qaDeepCallbacks"), qsl("qaDeepCallbacks = {data = {a = 1}, callbacks = {f = function() end}}"), {}, emptyTableCheck(qsl("qaDeepCallbacks"))},
+                {"userdata", qsl("qaUserdata"), qsl("qaUserdata = {a = 1, ud = io.stdout}"), {}, emptyTableCheck(qsl("qaUserdata"))},
+                {"coroutine", qsl("qaCoroutine"), qsl("qaCoroutine = {a = 1, co = coroutine.create(function() end)}"), {}, emptyTableCheck(qsl("qaCoroutine"))},
+                {"array and hash with a function", qsl("qaArrayHash"), qsl("qaArrayHash = {1, 2, function() end, x = 1}"), {}, emptyTableCheck(qsl("qaArrayHash"))},
+        };
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForSavedVariableFenceTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        // port 0 asks the OS for an ephemeral port, so parallel test runs
+        // (and other worktrees) cannot collide on a fixed one
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->serverPort() != 0, "TelnetServerStub failed to bind a loopback port");
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+
+        startProfile(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY2(mpHost, "No active host after profile creation");
+
+        // the userdata shape is built out of io.stdout, and a test that quietly
+        // stopped covering userdata would still pass
+        QCOMPARE(runLua(qsl("assert(type(io.stdout) == 'userdata')")), QString());
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    void test_savedShapeExportsWhatItAlwaysDid_data()
+    {
+        QTest::addColumn<QString>("globalName");
+        QTest::addColumn<QString>("setup");
+        QTest::addColumn<QStringList>("exportedMembers");
+
+        for (const SavedShape& shape : shapes()) {
+            QTest::newRow(shape.description) << shape.globalName << shape.setup << shape.exportedMembers;
+        }
+    }
+
+    // Each shape ticked while empty and filled by a script afterwards, so the
+    // variable is registered in savedVars and none of its members are.
+    void test_savedShapeExportsWhatItAlwaysDid()
+    {
+        QFETCH(QString, globalName);
+        QFETCH(QString, setup);
+        QFETCH(QStringList, exportedMembers);
+
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        QCOMPARE(runLua(setup), QString());
+        vu->savedVars.insert(globalName);
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        const std::optional<QStringList> written = exportedMembersOf(xml, globalName);
+        QVERIFY2(written.has_value(),
+                 "the saved variable itself must be on disk whatever it holds - the next session seeing an empty table "
+                 "rather than nil is what a package's rebuild guard keys off");
+
+        QStringList expected = exportedMembers;
+        expected.sort();
+        QStringList got = written.value();
+        got.sort();
+        QCOMPARE(got, expected);
+
+        vu->savedVars.remove(globalName);
+        QCOMPARE(runLua(qsl("_G['%1'] = nil _G['%1Alias'] = nil").arg(globalName)), QString());
+    }
+
+    // The fallback is per saved variable, so one variable holding a function
+    // cannot cost an unrelated one its full save.
+    void test_aTableHoldingAFunctionDoesNotAffectItsSiblings()
+    {
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        QCOMPARE(runLua(qsl("siblingDirtyTable = {a = 1, f = function() end} siblingCleanTable = {a = 'sibling clean value'}")), QString());
+        vu->savedVars.insert(qsl("siblingDirtyTable"));
+        vu->savedVars.insert(qsl("siblingCleanTable"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QCOMPARE(exportedMembersOf(xml, qsl("siblingDirtyTable")).value_or(QStringList{qsl("missing")}), QStringList());
+        QCOMPARE(exportedMembersOf(xml, qsl("siblingCleanTable")).value_or(QStringList{qsl("missing")}), QStringList{qsl("a")});
+
+        vu->savedVars.remove(qsl("siblingDirtyTable"));
+        vu->savedVars.remove(qsl("siblingCleanTable"));
+        QCOMPARE(runLua(qsl("siblingDirtyTable, siblingCleanTable = nil")), QString());
+    }
+
+    // The upgrade path: a profile saved by 4.22 while the table was populated
+    // carries a savedVars entry per member, and those keep being written whatever
+    // else the table holds. Only the ride-along export of unregistered members
+    // falls back.
+    void test_registeredMembersOfATableHoldingAFunctionStillExport()
+    {
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        QCOMPARE(runLua(qsl("registeredMixedTable = {a = 'registered member value', later = 'unregistered member value', f = function() end}")), QString());
+        vu->savedVars.insert(qsl("registeredMixedTable"));
+        vu->savedVars.insert(qsl("registeredMixedTable.a"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QCOMPARE(exportedMembersOf(xml, qsl("registeredMixedTable")).value_or(QStringList{qsl("missing")}), QStringList{qsl("a")});
+        QVERIFY2(xml.contains(qsl("registered member value")), "a member registered in savedVars must be exported whatever else its table holds");
+        QVERIFY2(!xml.contains(qsl("unregistered member value")), "an unregistered member of a table holding a function must not be exported");
+
+        vu->savedVars.remove(qsl("registeredMixedTable"));
+        vu->savedVars.remove(qsl("registeredMixedTable.a"));
+        QCOMPARE(runLua(qsl("registeredMixedTable = nil")), QString());
+    }
+
+    // What the user is left with next session. Declared last: the import puts a
+    // whole profile package back into the live one, which the tests above would
+    // then be sharing.
+    void test_savedShapesRestoreAsTheyAlwaysDid()
+    {
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        const QVector<SavedShape> savedShapes = shapes();
+        // all of them in one profile, which is also how a save proves it treats
+        // the variables one by one
+        for (const SavedShape& shape : savedShapes) {
+            QCOMPARE(runLua(shape.setup), QString());
+            vu->savedVars.insert(shape.globalName);
+        }
+
+        const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/saved-variable-fence-test.xml");
+        QVERIFY2(exportProfileTo(xmlPath), "the profile could not be exported");
+
+        for (const SavedShape& shape : savedShapes) {
+            vu->savedVars.remove(shape.globalName);
+            QCOMPARE(runLua(qsl("_G['%1'] = nil _G['%1Alias'] = nil").arg(shape.globalName)), QString());
+        }
+
+        QFile file(xmlPath);
+        QVERIFY2(file.open(QFile::ReadOnly | QFile::Text), qPrintable(file.errorString()));
+        XMLimport importer(mpHost);
+        auto [imported, importError] = importer.importPackage(&file);
+        file.close();
+        QFile::remove(xmlPath);
+        QVERIFY2(imported, qPrintable(importError));
+
+        for (const SavedShape& shape : savedShapes) {
+            const QString failure = runLua(shape.restoreCheck);
+            QVERIFY2(failure.isEmpty(), qPrintable(qsl("%1: %2").arg(QLatin1String(shape.description), failure)));
+        }
+
+        for (const SavedShape& shape : savedShapes) {
+            vu->savedVars.remove(shape.globalName);
+            QCOMPARE(runLua(qsl("_G['%1'] = nil").arg(shape.globalName)), QString());
+        }
+    }
+
+private:
+    // Empty on success, the Lua error otherwise.
+    QString runLua(const QString& code)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        if (luaL_dostring(L, code.toUtf8().constData()) == 0) {
+            return {};
+        }
+        const QString error = QString::fromUtf8(lua_tostring(L, -1));
+        lua_pop(L, 1);
+        return error;
+    }
+
+    // Consumes the Variable or VariableGroup element the reader is on, handing
+    // back the names of the member nodes written inside it.
+    static QStringList readVariableNode(QXmlStreamReader& reader, QString& name)
+    {
+        QStringList members;
+        while (reader.readNextStartElement()) {
+            if (reader.name() == qsl("name")) {
+                name = reader.readElementText();
+            } else if (reader.name() == qsl("Variable") || reader.name() == qsl("VariableGroup")) {
+                QString memberName;
+                // the call consumes the member's own element, nested members and all
+                readVariableNode(reader, memberName);
+                members << memberName;
+            } else {
+                reader.skipCurrentElement();
+            }
+        }
+        return members;
+    }
+
+    // The members the export wrote inside the variable called globalName, or
+    // nothing at all when it wrote no such variable.
+    static std::optional<QStringList> exportedMembersOf(const QString& xml, const QString& globalName)
+    {
+        QXmlStreamReader reader(xml);
+        while (!reader.atEnd()) {
+            if (reader.readNext() != QXmlStreamReader::StartElement || reader.name() != qsl("VariablePackage")) {
+                continue;
+            }
+            while (reader.readNextStartElement()) {
+                if (reader.name() != qsl("Variable") && reader.name() != qsl("VariableGroup")) {
+                    reader.skipCurrentElement();
+                    continue;
+                }
+                QString name;
+                const QStringList members = readVariableNode(reader, name);
+                if (name == globalName) {
+                    return members;
+                }
+            }
+        }
+        return std::nullopt;
+    }
+
+    // The save runs on a worker thread, so the file is only there once its
+    // future is.
+    bool exportProfileTo(const QString& xmlPath)
+    {
+        auto writer = std::make_shared<XMLexport>(mpHost);
+        if (!writer->exportPackage(xmlPath, true, false)) {
+            return false;
+        }
+        for (QFuture<bool>& save : writer->saveFutures) {
+            save.waitForFinished();
+        }
+        return true;
+    }
+
+    QString exportProfileXml()
+    {
+        const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/saved-variable-fence-export.xml");
+        if (!exportProfileTo(xmlPath)) {
+            return {};
+        }
+        QFile file(xmlPath);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return {};
+        }
+        const QString xml = QString::fromUtf8(file.readAll());
+        file.close();
+        QFile::remove(xmlPath);
+        return xml;
+    }
+
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(2000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(1000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForSavedVariableFenceTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "SavedVariableFenceTest.moc"
+QTEST_MAIN(SavedVariableFenceTest)

--- a/test/functional_tests/SavedVariableFenceTest.cpp
+++ b/test/functional_tests/SavedVariableFenceTest.cpp
@@ -19,17 +19,16 @@
 
 /*
  * Issue #9857. A saved table holding a function, userdata or coroutine cannot be
- * written out in full: the save drops those members and the next session gets a
- * table its own scripts no longer recognise - a cron job without its command,
- * say. Mudlet up to 4.22 wrote such a table as an empty group, and packages key
- * "if it is empty, rebuild it" off exactly that, so it goes on being written the
- * way it was: the members registered in savedVars and no others.
+ * written out in full: those members cannot be restored, and a table that comes
+ * back with only some of its contents is one its own scripts no longer recognise
+ * - a cron job without its command, say. Packages guard against that by
+ * rebuilding a saved table when they find it empty, so a table registered while
+ * empty has to come back empty rather than half-filled.
  *
- * The shapes below are the ones measured on 4.22.0 and on the 5.0 release
- * candidate, each ticked as a saved variable while empty and filled by a script
- * afterwards - which is the state a package that rebuilds its own tables is
- * always in, and the only one that regressed. Tables that hold nothing but data
- * keep the full save.
+ * Each shape below is registered as a saved variable and filled by a script
+ * afterwards, so the variable has a savedVars entry and none of its members do,
+ * which is the state a package that rebuilds its own tables is always in. Tables
+ * that hold nothing but data keep the full save.
  *
  * Run with: ctest -R SavedVariableFenceTest -V
  */
@@ -55,11 +54,9 @@ extern "C" {
 #if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lauxlib.h>
 #include <lua5.1/lua.h>
-#include <lua5.1/lualib.h>
 #else
 #include <lauxlib.h>
 #include <lua.h>
-#include <lualib.h>
 #endif
 }
 
@@ -72,7 +69,7 @@ void initializeQRCResourcesForSavedVariableFenceTest();
 
 struct SavedShape
 {
-    // what the shape is called in the measurements this pins
+    // the QTest row name, and the prefix on a restore failure
     const char* description = nullptr;
     QString globalName;
     // Lua that builds the shape, standing in for the script that fills a table
@@ -85,6 +82,13 @@ struct SavedShape
     QString restoreCheck;
 };
 
+struct ExportedVariable
+{
+    QString name;
+    int valueType = 0;
+    QStringList members;
+};
+
 class SavedVariableFenceTest : public QObject
 {
     Q_OBJECT
@@ -94,6 +98,8 @@ private:
     Host* mpHost = nullptr;
     const QString mHostname = "SavedVarFence-Test";
     const QString mLocalhost = "localhost";
+    QSet<QString> mSavedVarsBefore;
+    bool mHasImported = false;
 
     // An existing but empty table is what the "rebuild it if it is empty" guard
     // in cron-daemon and every package like it needs to see.
@@ -107,7 +113,13 @@ private:
     static QVector<SavedShape> shapes()
     {
         return {
-                {"flat data", qsl("qaFlatData"), qsl("qaFlatData = {a = 1, b = 'x'}"), {qsl("a"), qsl("b")}, qsl("assert(qaFlatData.a == 1 and qaFlatData.b == 'x')")},
+                // one member of each type a save can carry, so a change to what
+                // LuaInterface::setValue() rebuilds fails here
+                {"flat data",
+                 qsl("qaFlatData"),
+                 qsl("qaFlatData = {a = 1, b = 'x', c = true, d = {e = 'nested'}}"),
+                 {qsl("a"), qsl("b"), qsl("c"), qsl("d")},
+                 qsl("assert(qaFlatData.a == 1 and qaFlatData.b == 'x' and qaFlatData.c == true and qaFlatData.d.e == 'nested')")},
                 {"clean nested",
                  qsl("qaCleanNested"),
                  qsl("qaCleanNested = {a = 1, sub = {b = 2, c = 'deep'}}"),
@@ -129,6 +141,8 @@ private:
                  qsl("qaCron = {otherdata = 1, joblist = {{command = function() end, spec = '*', name = 'j1'}, {command = function() end, spec = '*', name = 'j2'}}}"),
                  {},
                  emptyTableCheck(qsl("qaCron"))},
+                // a boundary rather than fence coverage: a table whose every
+                // member is unsaveable exported empty before the fence too
                 {"function only", qsl("qaFunctionOnly"), qsl("qaFunctionOnly = {f = function() end}"), {}, emptyTableCheck(qsl("qaFunctionOnly"))},
                 {"callbacks in a deeper table", qsl("qaDeepCallbacks"), qsl("qaDeepCallbacks = {data = {a = 1}, callbacks = {f = function() end}}"), {}, emptyTableCheck(qsl("qaDeepCallbacks"))},
                 {"userdata", qsl("qaUserdata"), qsl("qaUserdata = {a = 1, ud = io.stdout}"), {}, emptyTableCheck(qsl("qaUserdata"))},
@@ -158,8 +172,9 @@ private slots:
         mpHost = mudlet::self()->getActiveHost();
         QVERIFY2(mpHost, "No active host after profile creation");
 
-        // the userdata shape is built out of io.stdout, and a test that quietly
-        // stopped covering userdata would still pass
+        // io.stdout is the only userdata to hand: if a Lua build ever stopped
+        // providing it the userdata row would turn into a data-only table and
+        // fail for a reason nobody would guess from the row name
         QCOMPARE(runLua(qsl("assert(type(io.stdout) == 'userdata')")), QString());
     }
 
@@ -172,7 +187,20 @@ private slots:
         delete mudlet::self();
     }
 
-    void test_savedShapeExportsWhatItAlwaysDid_data()
+    void init() { mSavedVarsBefore = mpHost->getLuaInterface()->getVarUnit()->savedVars; }
+
+    // QTest runs this after every test function and every data row, failed ones
+    // included, so a row that fails part way cannot leave a global behind for the
+    // next one to trip over. Every global these tests create is named qa*.
+    void cleanup()
+    {
+        mpHost->getLuaInterface()->getVarUnit()->savedVars = mSavedVarsBefore;
+        // setting an existing field to nil mid-traversal is the one mutation
+        // Lua's next() allows
+        QCOMPARE(runLua(qsl("for name in pairs(_G) do if type(name) == 'string' and name:find('^qa') then _G[name] = nil end end")), QString());
+    }
+
+    void test_savedShapeExportsItsExpectedMembers_data()
     {
         QTest::addColumn<QString>("globalName");
         QTest::addColumn<QString>("setup");
@@ -185,11 +213,12 @@ private slots:
 
     // Each shape ticked while empty and filled by a script afterwards, so the
     // variable is registered in savedVars and none of its members are.
-    void test_savedShapeExportsWhatItAlwaysDid()
+    void test_savedShapeExportsItsExpectedMembers()
     {
         QFETCH(QString, globalName);
         QFETCH(QString, setup);
         QFETCH(QStringList, exportedMembers);
+        QVERIFY2(!mHasImported, "a test that imports a profile was declared before the ones that must run without it");
 
         VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
         QCOMPARE(runLua(setup), QString());
@@ -197,66 +226,102 @@ private slots:
 
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
-        const std::optional<QStringList> written = exportedMembersOf(xml, globalName);
+        const std::optional<ExportedVariable> written = exportedVariable(xml, globalName);
         QVERIFY2(written.has_value(),
                  "the saved variable itself must be on disk whatever it holds - the next session seeing an empty table "
                  "rather than nil is what a package's rebuild guard keys off");
+        // only a table node makes the import recreate the table, so an empty
+        // group of any other type would restore as nil
+        QCOMPARE(written->valueType, LUA_TTABLE);
 
         QStringList expected = exportedMembers;
         expected.sort();
-        QStringList got = written.value();
+        QStringList got = written->members;
         got.sort();
         QCOMPARE(got, expected);
-
-        vu->savedVars.remove(globalName);
-        QCOMPARE(runLua(qsl("_G['%1'] = nil _G['%1Alias'] = nil").arg(globalName)), QString());
     }
 
     // The fallback is per saved variable, so one variable holding a function
     // cannot cost an unrelated one its full save.
     void test_aTableHoldingAFunctionDoesNotAffectItsSiblings()
     {
+        QVERIFY2(!mHasImported, "a test that imports a profile was declared before the ones that must run without it");
         VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
-        QCOMPARE(runLua(qsl("siblingDirtyTable = {a = 1, f = function() end} siblingCleanTable = {a = 'sibling clean value'}")), QString());
-        vu->savedVars.insert(qsl("siblingDirtyTable"));
-        vu->savedVars.insert(qsl("siblingCleanTable"));
+        QCOMPARE(runLua(qsl("qaSiblingDirty = {a = 1, f = function() end} qaSiblingClean = {a = 'sibling clean value'}")), QString());
+        vu->savedVars.insert(qsl("qaSiblingDirty"));
+        vu->savedVars.insert(qsl("qaSiblingClean"));
 
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
-        QCOMPARE(exportedMembersOf(xml, qsl("siblingDirtyTable")).value_or(QStringList{qsl("missing")}), QStringList());
-        QCOMPARE(exportedMembersOf(xml, qsl("siblingCleanTable")).value_or(QStringList{qsl("missing")}), QStringList{qsl("a")});
-
-        vu->savedVars.remove(qsl("siblingDirtyTable"));
-        vu->savedVars.remove(qsl("siblingCleanTable"));
-        QCOMPARE(runLua(qsl("siblingDirtyTable, siblingCleanTable = nil")), QString());
+        QCOMPARE(exportedMemberNames(xml, qsl("qaSiblingDirty")), QStringList());
+        QCOMPARE(exportedMemberNames(xml, qsl("qaSiblingClean")), QStringList{qsl("a")});
     }
 
-    // The upgrade path: a profile saved by 4.22 while the table was populated
-    // carries a savedVars entry per member, and those keep being written whatever
-    // else the table holds. Only the ride-along export of unregistered members
-    // falls back.
-    void test_registeredMembersOfATableHoldingAFunctionStillExport()
+    // Two saved globals that are the same table holding a function. Both have to
+    // fence: the walk reads the table again under each saved name, and a fix that
+    // read it once would leave whichever name Lua yielded second exporting empty
+    // and the other exporting in full, by hash order.
+    void test_bothSavedGlobalsSharingATableHoldingAFunctionFence()
     {
+        QVERIFY2(!mHasImported, "a test that imports a profile was declared before the ones that must run without it");
         VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
-        QCOMPARE(runLua(qsl("registeredMixedTable = {a = 'registered member value', later = 'unregistered member value', f = function() end}")), QString());
-        vu->savedVars.insert(qsl("registeredMixedTable"));
-        vu->savedVars.insert(qsl("registeredMixedTable.a"));
+        QCOMPARE(runLua(qsl("qaSharedMixed = {a = 1, f = function() end} qaSharedMixedOther = qaSharedMixed")), QString());
+        vu->savedVars.insert(qsl("qaSharedMixed"));
+        vu->savedVars.insert(qsl("qaSharedMixedOther"));
 
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
-        QCOMPARE(exportedMembersOf(xml, qsl("registeredMixedTable")).value_or(QStringList{qsl("missing")}), QStringList{qsl("a")});
+        QCOMPARE(exportedMemberNames(xml, qsl("qaSharedMixed")), QStringList());
+        QCOMPARE(exportedMemberNames(xml, qsl("qaSharedMixedOther")), QStringList());
+    }
+
+    // A table that was already populated when the profile was saved comes back
+    // with a savedVars entry per member - the import registers every element it
+    // reads - and those keep being written whatever else the table holds. Only
+    // the ride-along export of unregistered members falls back.
+    void test_registeredMembersOfATableHoldingAFunctionStillExport()
+    {
+        QVERIFY2(!mHasImported, "a test that imports a profile was declared before the ones that must run without it");
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        QCOMPARE(runLua(qsl("qaRegisteredMixed = {a = 'registered member value', later = 'unregistered member value', f = function() end}")), QString());
+        vu->savedVars.insert(qsl("qaRegisteredMixed"));
+        vu->savedVars.insert(qsl("qaRegisteredMixed.a"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QCOMPARE(exportedMemberNames(xml, qsl("qaRegisteredMixed")), QStringList{qsl("a")});
         QVERIFY2(xml.contains(qsl("registered member value")), "a member registered in savedVars must be exported whatever else its table holds");
         QVERIFY2(!xml.contains(qsl("unregistered member value")), "an unregistered member of a table holding a function must not be exported");
+    }
 
-        vu->savedVars.remove(qsl("registeredMixedTable"));
-        vu->savedVars.remove(qsl("registeredMixedTable.a"));
-        QCOMPARE(runLua(qsl("registeredMixedTable = nil")), QString());
+    // Where the fence stops. A member the export drops for any reason other than
+    // its value type still rides along, and its siblings with it: the 10,000-item
+    // cap and the one-copy-per-saved-name rule are deliberate size limits, not
+    // "this cannot be saved at all", and turning them into whole-variable
+    // fallbacks would lose more data than they save. XMLexportVariablesTest pins
+    // the drops themselves.
+    void test_theFenceCoversValueTypesOnly()
+    {
+        QVERIFY2(!mHasImported, "a test that imports a profile was declared before the ones that must run without it");
+        VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
+        QCOMPARE(runLua(qsl("qaReferenceKey = {a = 1} qaReferenceKey[{}] = 'reference member value' "
+                            "qaSharedMember = {first = {b = 2}} qaSharedMember.second = qaSharedMember.first")),
+                 QString());
+        vu->savedVars.insert(qsl("qaReferenceKey"));
+        vu->savedVars.insert(qsl("qaSharedMember"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QCOMPARE(exportedMemberNames(xml, qsl("qaReferenceKey")), QStringList{qsl("a")});
+        // whichever of the two names for that one table pairs() reaches first is
+        // the one written, so only its count is deterministic
+        QCOMPARE(exportedMemberNames(xml, qsl("qaSharedMember")).size(), 1);
     }
 
     // What the user is left with next session. Declared last: the import puts a
     // whole profile package back into the live one, which the tests above would
     // then be sharing.
-    void test_savedShapesRestoreAsTheyAlwaysDid()
+    void test_savedShapesRestoreWholeOrEmpty()
     {
         VarUnit* vu = mpHost->getLuaInterface()->getVarUnit();
         const QVector<SavedShape> savedShapes = shapes();
@@ -270,6 +335,8 @@ private slots:
         const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/saved-variable-fence-test.xml");
         QVERIFY2(exportProfileTo(xmlPath), "the profile could not be exported");
 
+        // nothing of the seeding may survive into the checks below, or they would
+        // be reading what this session left in _G rather than what came back
         for (const SavedShape& shape : savedShapes) {
             vu->savedVars.remove(shape.globalName);
             QCOMPARE(runLua(qsl("_G['%1'] = nil _G['%1Alias'] = nil").arg(shape.globalName)), QString());
@@ -278,6 +345,7 @@ private slots:
         QFile file(xmlPath);
         QVERIFY2(file.open(QFile::ReadOnly | QFile::Text), qPrintable(file.errorString()));
         XMLimport importer(mpHost);
+        mHasImported = true;
         auto [imported, importError] = importer.importPackage(&file);
         file.close();
         QFile::remove(xmlPath);
@@ -286,11 +354,6 @@ private slots:
         for (const SavedShape& shape : savedShapes) {
             const QString failure = runLua(shape.restoreCheck);
             QVERIFY2(failure.isEmpty(), qPrintable(qsl("%1: %2").arg(QLatin1String(shape.description), failure)));
-        }
-
-        for (const SavedShape& shape : savedShapes) {
-            vu->savedVars.remove(shape.globalName);
-            QCOMPARE(runLua(qsl("_G['%1'] = nil").arg(shape.globalName)), QString());
         }
     }
 
@@ -308,28 +371,29 @@ private:
     }
 
     // Consumes the Variable or VariableGroup element the reader is on, handing
-    // back the names of the member nodes written inside it.
-    static QStringList readVariableNode(QXmlStreamReader& reader, QString& name)
+    // back what was written inside it.
+    static ExportedVariable readVariableNode(QXmlStreamReader& reader)
     {
-        QStringList members;
+        ExportedVariable written;
         while (reader.readNextStartElement()) {
             if (reader.name() == qsl("name")) {
-                name = reader.readElementText();
+                written.name = reader.readElementText();
+            } else if (reader.name() == qsl("valueType")) {
+                written.valueType = reader.readElementText().toInt();
             } else if (reader.name() == qsl("Variable") || reader.name() == qsl("VariableGroup")) {
-                QString memberName;
                 // the call consumes the member's own element, nested members and all
-                readVariableNode(reader, memberName);
-                members << memberName;
+                written.members << readVariableNode(reader).name;
             } else {
                 reader.skipCurrentElement();
             }
         }
-        return members;
+        return written;
     }
 
-    // The members the export wrote inside the variable called globalName, or
-    // nothing at all when it wrote no such variable.
-    static std::optional<QStringList> exportedMembersOf(const QString& xml, const QString& globalName)
+    // What the export wrote for the variable called globalName; std::nullopt when
+    // it wrote no such variable at all, which an empty member list does not mean
+    // - that is a variable written as an empty group.
+    static std::optional<ExportedVariable> exportedVariable(const QString& xml, const QString& globalName)
     {
         QXmlStreamReader reader(xml);
         while (!reader.atEnd()) {
@@ -341,28 +405,27 @@ private:
                     reader.skipCurrentElement();
                     continue;
                 }
-                QString name;
-                const QStringList members = readVariableNode(reader, name);
-                if (name == globalName) {
-                    return members;
+                const ExportedVariable written = readVariableNode(reader);
+                if (written.name == globalName) {
+                    return written;
                 }
             }
         }
         return std::nullopt;
     }
 
-    // The save runs on a worker thread, so the file is only there once its
-    // future is.
+    // A variable the export did not write at all comes back naming that, so a
+    // QCOMPARE against the expected members reports it instead of passing.
+    static QStringList exportedMemberNames(const QString& xml, const QString& globalName)
+    {
+        const std::optional<ExportedVariable> written = exportedVariable(xml, globalName);
+        return written ? written->members : QStringList{qsl("<the export wrote no such variable>")};
+    }
+
     bool exportProfileTo(const QString& xmlPath)
     {
         auto writer = std::make_shared<XMLexport>(mpHost);
-        if (!writer->exportPackage(xmlPath, true, false)) {
-            return false;
-        }
-        for (QFuture<bool>& save : writer->saveFutures) {
-            save.waitForFinished();
-        }
-        return true;
+        return writer->exportPackage(xmlPath, true, false);
     }
 
     QString exportProfileXml()

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -367,8 +367,11 @@ private slots:
         QCOMPARE(luaL_dostring(L, "explicitHiddenTable = nil"), 0);
     }
 
-    // Function members cannot be saved, so they must not ride along either.
-    void test_functionMemberOfSavedTableIsNotExported()
+    // Function members cannot be saved, and a table holding one therefore cannot
+    // be written out as it stands: the ride-along is off for the whole variable,
+    // which for a table ticked while empty leaves an empty group, exactly as
+    // Mudlet wrote it before (#9857). SavedVariableFenceTest covers that in full.
+    void test_functionMemberBlocksTheRideAlong()
     {
         LuaInterface* lI = mpHost->getLuaInterface();
         VarUnit* vu = lI->getVarUnit();
@@ -379,7 +382,8 @@ private slots:
 
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
-        QVERIFY2(xml.contains(qsl("data member value")), "a plain member of a saved table must be exported");
+        QVERIFY2(xml.contains(qsl("callableHolderTable")), "the saved table itself must still be exported");
+        QVERIFY2(!xml.contains(qsl("data member value")), "a table holding a function exports the members registered in savedVars and no others");
         QVERIFY2(!xml.contains(qsl("callableMember")), "a function member must not ride along with its saved table");
 
         vu->savedVars.remove(qsl("callableHolderTable"));

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -27,7 +27,9 @@
  * runtime: they have no savedVars entry of their own but must be saved with
  * the table (issue #9517), while hidden and unsaveable members must not be.
  * Also covers a saved table that other globals reference, which must export in
- * full under every saved name that reaches it (issue #9755).
+ * full under every saved name that reaches it (issue #9755), and the boundary of
+ * the fence that stops a table holding a function exporting in part (issue
+ * #9857) - SavedVariableFenceTest covers that one in full.
  *
  * Run with: ctest -R XMLexportVariablesTest -V
  */
@@ -369,8 +371,8 @@ private slots:
 
     // Function members cannot be saved, and a table holding one therefore cannot
     // be written out as it stands: the ride-along is off for the whole variable,
-    // which for a table ticked while empty leaves an empty group, exactly as
-    // Mudlet wrote it before (#9857). SavedVariableFenceTest covers that in full.
+    // which for a table ticked while empty leaves an empty group (#9857).
+    // SavedVariableFenceTest covers that in full.
     void test_functionMemberBlocksTheRideAlong()
     {
         LuaInterface* lI = mpHost->getLuaInterface();
@@ -382,8 +384,8 @@ private slots:
 
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
-        QVERIFY2(xml.contains(qsl("callableHolderTable")), "the saved table itself must still be exported");
-        QVERIFY2(!xml.contains(qsl("data member value")), "a table holding a function exports the members registered in savedVars and no others");
+        QVERIFY2(xml.contains(qsl("<name>callableHolderTable</name>")), "the saved table itself must still be exported, or the next session sees nil rather than an empty table");
+        QVERIFY2(!xml.contains(qsl("dataMember")), "a table holding a function exports the members registered in savedVars and no others");
         QVERIFY2(!xml.contains(qsl("callableMember")), "a function member must not ride along with its saved table");
 
         vu->savedVars.remove(qsl("callableHolderTable"));


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A saved variable with a function, userdata or coroutine anywhere inside it now exports only the members registered in `savedVars`, which for a table ticked while empty is an empty group. Tables holding nothing but data keep the full save added in #9762.
- The save-time walk records which saved globals hold such a value; `XMLexport` turns the ride-along off for those variables only. Silent, and it costs nothing outside a save.
- New `SavedVariableFenceTest` pins all 11 measured shapes, on disk and after a reload.

#### Motivation for adding to Mudlet

A half-restored table defeats the `if next(t) == nil then rebuild() end` guard packages carry, which kills cron-daemon's scheduler permanently on its first minute wake after a restart.

#### Other info (issues closed, discussion etc)

Fixes #9857

**Test case:** install cron-daemon, tick `cron` in the Variables view, add a job with a `command` function, restart and wait for the minute rollover - the daemon keeps running (measured 2/2 canary fires, against 0/2 before).

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>