### PR TITLE
infrastructure: stop the telnet test stub losing data sent before a client connects

### DIFF
--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -31,7 +31,7 @@
 using namespace std::chrono_literals;
 
 TelnetServerStub::TelnetServerStub(QObject* parent)
-    : QTcpServer(parent)
+: QTcpServer(parent)
 {
     connect(this, &QTcpServer::newConnection, this, &TelnetServerStub::onNewConnection);
 }
@@ -47,10 +47,27 @@ void TelnetServerStub::start(const QString& host, quint16 port)
     }
 }
 
+TelnetServerStub::~TelnetServerStub()
+{
+    if (!mPendingData.isEmpty()) {
+        qWarning().noquote() << qsl("⚠️ TelnetServerStub destroyed with %1 undelivered queued bytes - no client was ever accepted.").arg(mPendingData.size());
+    }
+}
+
 void TelnetServerStub::sendRaw(const QByteArray& data)
 {
     if (!mpClient) {
-        qWarning() << "⚠️ sendRaw called without a connected client.";
+        if (mHadClient) {
+            // Between sessions there is no race to absorb, so queuing here
+            // would leak a dead session's bytes into the next connection:
+            qWarning() << "⚠️ sendRaw called without a connected client.";
+            return;
+        }
+        // Tests wait on the client-side connected signal, which can fire
+        // before this server side has accepted the connection - dropping the
+        // bytes here loses the payload on fast runners, so hold them until
+        // onNewConnection():
+        mPendingData.append(data);
         return;
     }
     mpClient->write(data);
@@ -66,25 +83,32 @@ void TelnetServerStub::onNewConnection()
         return;
     }
     mpClient = client;
+    mHadClient = true;
     qInfo().noquote() << qsl("🔌 Client connected: %1").arg(client->peerAddress().toString());
+
+    if (!mPendingData.isEmpty()) {
+        const auto bytesWritten = client->write(mPendingData);
+        client->flush();
+        if (bytesWritten <= 0) {
+            qWarning().noquote() << qsl("⚠️ Failed to deliver %1 queued bytes to %2").arg(QString::number(mPendingData.size()), client->peerAddress().toString());
+        }
+        mPendingData.clear();
+    }
 
     QPointer<QTcpSocket> safeClient = client;
 
-    QTimer::singleShot(100ms, [safeClient, welcomeMessage = mpWelcomeMessage]()
-    {
+    QTimer::singleShot(100ms, [safeClient, welcomeMessage = mpWelcomeMessage]() {
         if (!safeClient) {
             return;
         }
         const auto bytesWritten = safeClient->write(welcomeMessage.toUtf8() + "\r\n");
         safeClient->flush();
         if (bytesWritten <= 0) {
-            qWarning().noquote() << qsl("⚠️ Failed to send welcome message to %1")
-                                    .arg(safeClient->peerAddress().toString());
+            qWarning().noquote() << qsl("⚠️ Failed to send welcome message to %1").arg(safeClient->peerAddress().toString());
         }
     });
 
-    connect(client, &QTcpSocket::disconnected, [safeClient]()
-    {
+    connect(client, &QTcpSocket::disconnected, [safeClient]() {
         if (!safeClient) {
             return;
         }

--- a/test/functional_tests/TelnetServerStub.h
+++ b/test/functional_tests/TelnetServerStub.h
@@ -32,9 +32,12 @@ class TelnetServerStub : public QTcpServer
 
     QString mpWelcomeMessage = "";
     QPointer<QTcpSocket> mpClient;
+    QByteArray mPendingData;
+    bool mHadClient = false;
 
 public:
     explicit TelnetServerStub(QObject* parent = nullptr);
+    ~TelnetServerStub() override;
 
     // Bind to a caller-chosen port, or to an ephemeral OS-assigned port when port is 0 (the default).
     // Binding 0 lets concurrent test runs avoid colliding on a shared fixed port; the caller reads the


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- TelnetServerStub::sendRaw() now queues bytes sent before the server has accepted the client connection and flushes them on accept, instead of dropping them with only a warning
- Between sessions it still warns and drops, so a dead session's bytes cannot leak into the next connection; the destructor reports bytes that were never delivered
- The flush checks the write() return like the adjacent welcome-message path

#### Motivation for adding to Mudlet
Tests only wait on the client-side connected signal, which can fire before the stub's server side accepts - on fast runners the first payload was lost, failing TelnetStringSequenceRecoveryTest twice in a row on macOS arm64 in #9861's CI. The stub is shared by ~50 functional tests.

#### Other info (issues closed, discussion etc)
First validated on #9861 (run 31674918225 failed twice on arm64; run 31687605776 with the fix went green on all four platforms); it will be dropped from that PR once this merges.

**Test case:** TelnetStringSequenceRecoveryTest, TriggerSameLineMatchTest and UndoServerWrapTest pass (run twice each locally with the final version).

Assisted-by: Claude:claude-fable-5