### PR TITLE
infrastructure: MXP frame placement test no longer depends on the startup window size

### DIFF
--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -102,6 +102,14 @@ private slots:
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
         mudlet::self()->init();
         mudlet::self()->setStorePasswordsSecurely(false);
+        // Sized before the profile, so before there is a TMainConsole to resize:
+        // getMainWindowSize() ignores a shrink of more than half and goes on
+        // reporting the size from before it, and every later report is measured
+        // against that kept size, so it never catches up. Whatever the platform
+        // picks for a main window nobody has sized is not ours to rely on - under
+        // the offscreen plugin it is over 16000 pixels wide on some machines, and
+        // coming down from that to 1200 is exactly the drop that gets ignored.
+        mudlet::self()->resize(1200, 800);
 
         QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
 
@@ -139,6 +147,17 @@ private slots:
 
         mudlet::self()->resize(1200, 800);
         QTest::qWait(100ms);
+
+        // Frames are placed against getMainWindowSize(), so a run where that has
+        // stopped tracking the window would fail every placement assertion with
+        // numbers that say nothing about frame placement. It only ever subtracts
+        // from the console's own size, so anything bigger means it is reporting a
+        // size the window no longer has - say so here instead.
+        const QSize reported = mpHost->mpConsole->getMainWindowSize();
+        const QSize consoleSize = mpHost->mpConsole->size();
+        QVERIFY2(reported.width() <= consoleSize.width() && reported.height() <= consoleSize.height(),
+                 qPrintable(qsl("getMainWindowSize() reports %1x%2 inside a console that is only %3x%4")
+                                    .arg(QString::number(reported.width()), QString::number(reported.height()), QString::number(consoleSize.width()), QString::number(consoleSize.height()))));
     }
 
     void cleanupTestCase()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `MxpFramePlacementTest` sized the main window to 1200x800 *after* the profile loaded. `TConsole::getMainWindowSize()` ignores a shrink of more than half and goes on reporting the size from before it - and since every later report is measured against that kept size, it never catches up. Size the window before the profile exists instead, so the console is only ever born at 1200x800.
- Under the offscreen plugin an unsized main window comes up over 16000px wide on some machines, so 1200 was a 93% drop and the guard latched; on CI the startup size is small enough that it never tripped, which is why this only failed locally.
- `initTestCase()` now asserts the reported size fits inside the console, so a future latch says so directly instead of surfacing as three placement assertions comparing frame geometry against numbers the window does not have.

#### Motivation for adding to Mudlet
The test failed on developer machines while passing in CI, for a reason that had nothing to do with what it covers.

#### Other info (issues closed, discussion etc)
Found while merging development into #9773 - unrelated to that PR, the same 3 slots fail on pristine `development`.

The guard itself looks like a real defect rather than only a test hazard: once it fires, `resizeEvent()` stores the kept size back into `mOldSize`, so every subsequent report is compared against it and the stale value never clears. In the failing run the console sat at 1200px wide while `getMainWindowSize()` reported 16301 across ~16 further resizes. Left alone here; worth a separate look, since Geyser layouts and MXP frames are both placed off that number.

**Test case:** `ctest --preset linux-debug -R MxpFramePlacementTest` - 16 slots pass. Verified the new precondition assertion fires by stripping the early resize back out: it fails with `getMainWindowSize() reports 16301x825 inside a console that is only 1200x778` instead of the three placement failures.