### PR TITLE
fix: a killed alias, key binding or timer can come back to life and fire again

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -361,7 +361,15 @@ bool AliasUnit::enableAlias(const QString& name)
     // mid-run and skip duplicates on some QMultiMap implementations
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
-        it.value()->setIsActive(true);
+        TAlias* pT = it.value();
+        // An alias queued for deletion stays in the lookup table until
+        // doCleanup() frees it - re-activating one resurrects a killAlias()ed
+        // alias, or one whose package a script uninstalled mid-pass, and it
+        // matches commands again.
+        if (mCleanupSet.contains(pT) || uninstallList.contains(pT)) {
+            continue;
+        }
+        pT->setIsActive(true);
         found = true;
     }
     return found;

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -213,10 +213,18 @@ bool KeyUnit::enableKey(const QString& name)
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
         TKey* pT = it.value();
-        // Unlike the TTriggerUnit version of this code we directly set
-        // the mActive flag (and it shows up in the editor) rather than the
-        // mUserActiveState one (which does not)
-        // So do not use pT->setIsActive(true) here:
+        // A key queued for deletion stays in the lookup table until doCleanup()
+        // frees it - re-activating one resurrects a killKey()ed key, or one
+        // whose package a script uninstalled mid-pass, and it matches the next
+        // key press.
+        if (mCleanupSet.contains(pT) || uninstallList.contains(pT)) {
+            continue;
+        }
+        // enableKey() sets pT active and then walks pT's children for the same
+        // name without re-checking the skip above. That is only safe while no
+        // child key is ever queued for deletion under a live parent: killKey()
+        // and removeAllTempKeys() take root nodes only, and _uninstall() queues
+        // whole subtrees, so a corpse never sits under a parent this loop keeps.
         pT->enableKey(name);
         found = true;
     }
@@ -231,10 +239,7 @@ bool KeyUnit::disableKey(const QString& name)
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
         TKey* pT = it.value();
-        // Unlike the TTriggerUnit version of this code we directly clear
-        // the mActive flag (and it shows up in the editor) rather than the
-        // mUserActiveState one (which does not)
-        // So do not use pT->setIsActive(false) here:
+        // Walks pT's children for the same name as well - see enableKey()
         pT->disableKey(name);
         found = true;
     }

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -310,6 +310,14 @@ bool TimerUnit::enableTimer(const QString& name)
     const auto [begin, end] = mLookupTable.equal_range(name);
     for (auto it = begin; it != end; ++it) {
         TTimer* pT = it.value();
+        // A timer queued for deletion stays in the lookup table until
+        // doCleanup() frees it - re-activating one restarts the QTimer that
+        // killTimer() stopped, that a spent one-shot stopped itself (see
+        // TTimer::execute(), which markCleanup()s without deactivating, so that
+        // corpse is still isActive()), or that an uninstall is waiting to free.
+        if (mCleanupSet.contains(pT) || uninstallList.contains(pT)) {
+            continue;
+        }
 
         if (!pT->isOffsetTimer()) {
             pT->setIsActive(true);
@@ -320,7 +328,11 @@ bool TimerUnit::enableTimer(const QString& name)
 
         if (pT->isFolder()) {
             // disable or enable all timers in the respective branch
-            // irrespective of the user defined state.
+            // irrespective of the user defined state - and without re-checking
+            // the skip above. That is only safe while no child timer is ever
+            // queued for deletion under a live parent: only temporary root
+            // timers are ever queued (doCleanup() relies on the same thing) and
+            // _uninstall() queues whole subtrees.
             if (pT->shouldBeActive()) {
                 pT->enableTimer();
             } else {

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -19,7 +19,7 @@
 
 /*
  * TriggerUnit, AliasUnit, KeyUnit and TimerUnit each defer the deletion of an
- * item until no script is on the call stack. Two properties of that machinery
+ * item until no script is on the call stack. Four properties of that machinery
  * are checked here for all four units:
  *
  * - freeing a temporary item must unlink only that item from the by-name lookup
@@ -29,6 +29,8 @@
  *   rather than report failure over the first one (#9649)
  * - the two deferred-delete containers, mCleanupSet and uninstallList, must never
  *   free the same object twice, whichever order it lands in them (#9650)
+ * - enabling by name must not reactivate an item that is only waiting to be
+ *   freed, while still reaching every live item filed under that name (#9877)
  *
  * The timer half of #9649 cannot be reached from the busted Lua suite - that runs
  * inside a tempTimer, so TimerUnit's cleanup stays deferred for the whole run -
@@ -41,9 +43,9 @@
  * functional tests always build with the address sanitizer on non-Windows
  * (test/functional_tests/CMakeLists.txt includes EnableSanitizers.cmake, whose
  * USE_SANITIZER defaults to "address"), but it does mean these four cases carry
- * no weight in a build with sanitizers switched off. The trigger and timer
- * variants are pure regression guards: those two units already had the guards on
- * development, and only AliasUnit and KeyUnit gain them here.
+ * no weight in a build with sanitizers switched off. Only AliasUnit and KeyUnit
+ * ever lacked those disjointness guards; the trigger and timer cases are there
+ * to keep the four units checked alike.
  *
  * Run with: ctest -R UnitDeferredDeleteTest -V
  */
@@ -577,6 +579,295 @@ private slots:
 
         unit->doCleanup();
         QVERIFY(!unit->getTrigger(tempId));
+    }
+
+    // #9877, the alias half. doCleanup() cannot run while the script that did
+    // the killing is on the call stack, so a script at depth 0 keeps the corpse
+    // reachable by name for the rest of its own run.
+    void test_aliasEnableByNameCannotReviveKilled()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        const int id = mpHost->mLuaInterpreter.startTempAlias(qsl("^resurrect_alias$"), QString());
+        QVERIFY(id > 0);
+        auto* pAlias = unit->getAlias(id);
+        QVERIFY(pAlias);
+        const QString name = QString::number(id);
+        QVERIFY(pAlias->isActive());
+
+        QVERIFY2(unit->killAlias(name), "the temporary alias should be killable by name");
+        QVERIFY2(!pAlias->isActive(), "killAlias() must deactivate as well as queue the delete");
+        QVERIFY2(unit->mCleanupSet.contains(pAlias), "the killed alias should be waiting to be freed");
+
+        QVERIFY2(!unit->enableAlias(name), "enableAlias() must not report success for an alias that is only waiting to be freed");
+        QVERIFY2(!pAlias->isActive(), "a killed alias must stay dead until it is freed");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getAlias(id), "the killed alias should still have been freed");
+    }
+
+    // As a user meets it: a script kills the alias, something else enables it by
+    // name, and the next command goes out before doCleanup() has run.
+    void test_aliasEnableByNameCannotReviveAKilledAliasOnTheNextCommand()
+    {
+        mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("aliasFires = 0\n"
+                                                            "local id = tempAlias('^RESURRECTME$', [[aliasFires = aliasFires + 1]])\n"
+                                                            "local name = tostring(id)\n"
+                                                            "expandAlias('RESURRECTME', false)\n"
+                                                            "firstFires = aliasFires\n"
+                                                            "killAlias(name)\n"
+                                                            "enableAliasReturned = enableAlias(name)\n"
+                                                            "expandAlias('RESURRECTME', false)\n"));
+
+        QCOMPARE(readGlobalInt(qsl("firstFires")), 1);
+        QCOMPARE(readGlobalInt(qsl("aliasFires")), 1);
+        QVERIFY2(!readGlobalBool(qsl("enableAliasReturned")), "enableAlias() must not report success for an alias that is only waiting to be freed");
+    }
+
+    void test_aliasEnableByNameCannotReviveAnUninstalledAlias()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        const int id = mpHost->mLuaInterpreter.startTempAlias(qsl("^uninstall_revive_alias$"), QString());
+        QVERIFY(id > 0);
+        auto* pAlias = unit->getAlias(id);
+        QVERIFY(pAlias);
+        const QString name = QString::number(id);
+
+        pAlias->setIsActive(false);
+        unit->uninstallList.append(pAlias);
+        QVERIFY2(!unit->mCleanupSet.contains(pAlias), "uninstall() keeps the two deferred-delete containers disjoint");
+
+        QVERIFY2(!unit->enableAlias(name), "enableAlias() must not report success for an alias an uninstall is waiting to free");
+        QVERIFY2(!pAlias->isActive(), "an alias whose package has been uninstalled must stay inactive");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getAlias(id), "the uninstalled alias should still have been freed");
+    }
+
+    void test_aliasEnableByNameStillReachesALiveSameNamedAlias()
+    {
+        auto* unit = mpHost->getAliasUnit();
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermAlias(qsl("mixed corpse alias placeholder"), QString(), qsl("^mixed_corpse_alias_perm$"), QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        const QString sharedName = QString::number(permId + 1);
+        unit->getAlias(permId)->setName(sharedName);
+
+        const int tempId = mpHost->mLuaInterpreter.startTempAlias(qsl("^mixed_corpse_alias_temp$"), QString());
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killAlias(sharedName), "the temporary alias should be the one killed");
+        unit->getAlias(permId)->setIsActive(false);
+
+        QVERIFY2(unit->enableAlias(sharedName), "enableAlias must walk past the corpse to the live alias filed under the same name");
+        QVERIFY2(unit->getAlias(permId)->isActive(), "the live same-named alias should have been enabled");
+        QVERIFY2(!unit->getAlias(tempId)->isActive(), "the killed alias must stay dead");
+
+        unit->doCleanup();
+        QVERIFY(!unit->getAlias(tempId));
+    }
+
+    // #9877, the key half. There is no cleanup() between slots, so a permanent
+    // key one case creates stays live and bound for every later one: F6 and F7
+    // are held by the cases above and F4 by the last one here, so a case that
+    // presses a key has to pick a code none of them uses.
+    void test_keyEnableByNameCannotReviveKilled()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        int modifier = Qt::NoModifier;
+        int keyCode = Qt::Key_F1;
+        const int id = mpHost->mLuaInterpreter.startTempKey(modifier, keyCode, emptyScript);
+        QVERIFY(id > 0);
+        auto* pKey = unit->getKey(id);
+        QVERIFY(pKey);
+        QString name = QString::number(id);
+        QVERIFY(pKey->isActive());
+
+        QVERIFY2(unit->killKey(name), "the temporary key should be killable by name");
+        QVERIFY2(!pKey->isActive(), "killKey() must deactivate as well as queue the delete");
+        QVERIFY2(unit->mCleanupSet.contains(pKey), "the killed key should be waiting to be freed");
+
+        QVERIFY2(!unit->enableKey(name), "enableKey() must not report success for a key that is only waiting to be freed");
+        QVERIFY2(!pKey->isActive(), "a killed key must stay dead until it is freed");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getKey(id), "the killed key should still have been freed");
+    }
+
+    // As a user meets it: a script kills the key, something else enables it by
+    // name, and the key is pressed before doCleanup() has run.
+    void test_keyEnableByNameCannotReviveAKilledKeyOnTheNextPress()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("keyFires = 0"));
+        QString script = qsl("keyFires = keyFires + 1");
+        int modifier = Qt::NoModifier;
+        int keyCode = Qt::Key_F2;
+        const int id = mpHost->mLuaInterpreter.startTempKey(modifier, keyCode, script);
+        QVERIFY(id > 0);
+        QString name = QString::number(id);
+
+        QVERIFY(unit->processDataStream(Qt::Key_F2, Qt::NoModifier));
+        QCOMPARE(readGlobalInt(qsl("keyFires")), 1);
+
+        QVERIFY2(unit->killKey(name), "the temporary key should be killable by name");
+        const bool enabled = unit->enableKey(name);
+
+        QVERIFY2(!unit->processDataStream(Qt::Key_F2, Qt::NoModifier), "a killed key must not match a later key press");
+        QCOMPARE(readGlobalInt(qsl("keyFires")), 1);
+        QVERIFY2(!enabled, "enableKey() must not report success for a key that is only waiting to be freed");
+        QVERIFY2(!unit->getKey(id), "the pass at depth 0 should have freed the killed key");
+    }
+
+    void test_keyEnableByNameCannotReviveAnUninstalledKey()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        int modifier = Qt::NoModifier;
+        int keyCode = Qt::Key_F3;
+        const int id = mpHost->mLuaInterpreter.startTempKey(modifier, keyCode, emptyScript);
+        QVERIFY(id > 0);
+        auto* pKey = unit->getKey(id);
+        QVERIFY(pKey);
+        QString name = QString::number(id);
+
+        pKey->setIsActive(false);
+        unit->uninstallList.append(pKey);
+        QVERIFY2(!unit->mCleanupSet.contains(pKey), "uninstall() keeps the two deferred-delete containers disjoint");
+
+        QVERIFY2(!unit->enableKey(name), "enableKey() must not report success for a key an uninstall is waiting to free");
+        QVERIFY2(!pKey->isActive(), "a key whose package has been uninstalled must stay inactive");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getKey(id), "the uninstalled key should still have been freed");
+    }
+
+    void test_keyEnableByNameStillReachesALiveSameNamedKey()
+    {
+        auto* unit = mpHost->getKeyUnit();
+        QString emptyScript;
+        QString parent;
+        QString placeholder = qsl("mixed corpse key placeholder");
+        int permModifier = Qt::NoModifier;
+        int permKeyCode = Qt::Key_F4;
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermKey(placeholder, parent, permKeyCode, permModifier, emptyScript);
+        QVERIFY2(permId > 0, qPrintable(message));
+        QString sharedName = QString::number(permId + 1);
+        unit->getKey(permId)->setName(sharedName);
+
+        int tempModifier = Qt::NoModifier;
+        int tempKeyCode = Qt::Key_F9;
+        const int tempId = mpHost->mLuaInterpreter.startTempKey(tempModifier, tempKeyCode, emptyScript);
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killKey(sharedName), "the temporary key should be the one killed");
+        unit->getKey(permId)->setIsActive(false);
+
+        QVERIFY2(unit->enableKey(sharedName), "enableKey must walk past the corpse to the live key filed under the same name");
+        QVERIFY2(unit->getKey(permId)->isActive(), "the live same-named key should have been enabled");
+        QVERIFY2(!unit->getKey(tempId)->isActive(), "the killed key must stay dead");
+
+        unit->doCleanup();
+        QVERIFY(!unit->getKey(tempId));
+    }
+
+    // #9877, the timer half. killTimer() stops the QTimer, so reviving one arms
+    // it again - remainingTime() reads that back straight from the QTimer.
+    void test_timerEnableByNameCannotReviveKilled()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [id, message] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(id > 0, qPrintable(message));
+        auto* pTimer = unit->getTimer(id);
+        QVERIFY(pTimer);
+        const QString name = QString::number(id);
+        QVERIFY(unit->remainingTime(id) > 0);
+
+        QVERIFY2(unit->killTimer(name), "the temporary timer should be killable by name");
+        QVERIFY2(unit->remainingTime(id) == -1, "killTimer() must stop the timer as well as queue the delete");
+        QVERIFY2(unit->mCleanupSet.contains(pTimer), "the killed timer should be waiting to be freed");
+
+        QVERIFY2(!unit->enableTimer(name), "enableTimer() must not report success for a timer that is only waiting to be freed");
+        QVERIFY2(unit->remainingTime(id) == -1, "a killed timer must stay stopped until it is freed");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getTimer(id), "the killed timer should still have been freed");
+    }
+
+    // A one-shot that has fired is the one corpse that is still isActive():
+    // TTimer::execute() queues a spent non-repeating temporary with
+    // mpQTimer->stop() + markCleanup() and no deactivate(), unlike killTimer().
+    // The guard therefore cannot be reduced to a state test - skipping merely
+    // inactive timers would let this one fire again.
+    //
+    // The two calls below are exactly what TTimer::execute() does, rather than a
+    // real wait: mudlet::slot_timerFires() runs doCleanup() as soon as execute()
+    // returns, so a fired one-shot is freed before a test could look at it.
+    void test_timerEnableByNameCannotReviveASpentOneShot()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [id, message] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(id > 0, qPrintable(message));
+        auto* pTimer = unit->getTimer(id);
+        QVERIFY(pTimer);
+        const QString name = QString::number(id);
+
+        pTimer->stop();
+        unit->markCleanup(pTimer);
+        QVERIFY2(pTimer->isActive(), "a spent one-shot is queued for cleanup without being deactivated");
+        QCOMPARE(unit->remainingTime(id), -1);
+
+        QVERIFY2(!unit->enableTimer(name), "enableTimer() must not report success for a spent one-shot waiting to be freed");
+        QVERIFY2(unit->remainingTime(id) == -1, "a spent one-shot must not be re-armed");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getTimer(id), "the spent one-shot should still have been freed");
+    }
+
+    void test_timerEnableByNameCannotReviveAnUninstalledTimer()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [id, message] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(id > 0, qPrintable(message));
+        auto* pTimer = unit->getTimer(id);
+        QVERIFY(pTimer);
+        const QString name = QString::number(id);
+
+        pTimer->setIsActive(false);
+        unit->uninstallList.append(pTimer);
+        QVERIFY2(!unit->mCleanupSet.contains(pTimer), "uninstall() keeps the two deferred-delete containers disjoint");
+
+        QVERIFY2(!unit->enableTimer(name), "enableTimer() must not report success for a timer an uninstall is waiting to free");
+        QVERIFY2(unit->remainingTime(id) == -1, "a timer whose package has been uninstalled must stay stopped");
+
+        unit->doCleanup();
+        QVERIFY2(!unit->getTimer(id), "the uninstalled timer should still have been freed");
+    }
+
+    void test_timerEnableByNameStillReachesALiveSameNamedTimer()
+    {
+        auto* unit = mpHost->getTimerUnit();
+        auto [permId, message] = mpHost->mLuaInterpreter.startPermTimer(qsl("mixed corpse timer placeholder"), QString(), 60.0, QString());
+        QVERIFY2(permId > 0, qPrintable(message));
+        const QString sharedName = QString::number(permId + 1);
+        unit->getTimer(permId)->setName(sharedName);
+
+        auto [tempId, tempMessage] = mpHost->mLuaInterpreter.startTempTimer(60.0, QString(), false);
+        QVERIFY2(tempId > 0, qPrintable(tempMessage));
+        QCOMPARE(tempId, permId + 1);
+        QCOMPARE(lookupCount(unit->mLookupTable.count(sharedName)), 2);
+
+        QVERIFY2(unit->killTimer(sharedName), "the temporary timer should be the one killed");
+        unit->getTimer(permId)->setIsActive(false);
+
+        QVERIFY2(unit->enableTimer(sharedName), "enableTimer must walk past the corpse to the live timer filed under the same name");
+        QVERIFY2(unit->getTimer(permId)->isActive(), "the live same-named timer should have been enabled");
+        QVERIFY2(unit->remainingTime(permId) > 0, "the live same-named timer should have been re-armed, not just flagged active");
+        QVERIFY2(!unit->getTimer(tempId)->isActive(), "the killed timer must stay dead");
+
+        unit->doCleanup();
+        QVERIFY(!unit->getTimer(tempId));
     }
 
     // Helpers (reused from the ResetProfileTest pattern)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `killAlias()`, `killKey()` and `killTimer()` only deactivate an item and queue it for a deferred free, so until `doCleanup()` runs it is still in the unit's by-name lookup table. `enableAlias()`, `enableKey()` and `enableTimer()` found it there and switched it back on, and it fired again. They now skip anything queued in `mCleanupSet`/`uninstallList`, which is the same guard `enableTrigger()` got in #9697, while still reaching every live item filed under the same name.
- Corrects two comments in `KeyUnit.cpp` that claimed `pT->enableKey(name)`/`pT->disableKey(name)` avoid touching the user-active state: both reach `Tree<T>::setIsActive()`, which sets it. They now record what the calls really do - they also walk the key's children without re-checking the guard, which is safe only because no child is ever queued for deletion under a live parent.
- 12 new cases in `UnitDeferredDeleteTest`, all verified to fail against unfixed source: a killed item, an uninstalled one, a spent one-shot timer (the only corpse still `isActive()`), and, for each unit, that a live same-named item is still reached.

#### Motivation for adding to Mudlet

A one-shot that has been used up, or anything a script has deliberately killed, should stay dead - instead any later `enableX()` on its name brought it back.

#### Other info (issues closed, discussion etc)

Closes #9877. Pre-existing, not a 5.0 regression: 4.22.0 behaves identically. Triggers were the only one of the four units already fixed, by #9697; aliases, keys and timers were all still affected.

Found while checking that fix's siblings, and left for a follow-up: `reenableAllTriggers()` re-arms a killed temporary timer the same way (#9887). Only the timer unit is exposed there, because `TTimer::killTimer()` uses `deactivate()` and so leaves `mUserActiveState` set, where the other three kill paths clear it.

**Test case:** run `qaFires = 0 local id = tempAlias("^BOOM$", [[qaFires = qaFires + 1]]) local n = tostring(id) expandAlias("BOOM", false) killAlias(n) enableAlias(n) expandAlias("BOOM", false) echo(qaFires)` - on development it echoes 2, here 1.

Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>