### PR TITLE
fix: your interface no longer stays laid out for the size the window used to be

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2339,18 +2339,19 @@ QSize TConsole::getMainWindowSize() const
     const int commandLineHeight = mpCommandLine->height();
     QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
 
-    // Reject obviously invalid or suspiciously small sizes during profile switch transitions
-    const int minValidWidth = 50;
-    if (mainWindowSize.width() < minValidWidth && mOldSize.width() >= minValidWidth) {
+    // A profile being switched to gets its geometry over several events, so in
+    // between the console can be a few pixels wide, or shorter than the command
+    // line it has to subtract - which leaves nothing to lay anything out in, so
+    // hand back the last size it really had. Only a size that small is refused:
+    // refusing one that has merely changed a lot would make this the yardstick
+    // every later size is measured against, and since resizeEvent() stores what
+    // this returns, a window shrunk to under half its width could never be
+    // reported again.
+    const int minValidLength = 50;
+    const bool measurementUsable = mainWindowSize.width() >= minValidLength && mainWindowSize.height() >= minValidLength;
+    const bool oldSizeUsable = mOldSize.width() >= minValidLength && mOldSize.height() >= minValidLength;
+    if (!measurementUsable && oldSizeUsable) {
         return mOldSize;
-    }
-
-    // Reject suspicious shrinkage (more than 50% reduction) - geometry may not have settled yet
-    if (mOldSize.width() > 0) {
-        const double shrinkageRatio = static_cast<double>(mainWindowSize.width()) / mOldSize.width();
-        if (shrinkageRatio < 0.5) {
-            return mOldSize;
-        }
     }
 
     return mainWindowSize;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2330,31 +2330,30 @@ void TConsole::slot_searchBufferDown()
 
 QSize TConsole::getMainWindowSize() const
 {
-    if (isHidden()) {
-        return mOldSize;
+    if (isHidden() && mLastMeasuredSize.isValid()) {
+        return mLastMeasuredSize;
     }
     const QSize consoleSize = size();
     const int toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
     const int toolbarHeight = mpTopToolBar->height();
     const int commandLineHeight = mpCommandLine->height();
-    QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
+    const QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
 
     // A profile being switched to gets its geometry over several events, so in
     // between the console can be a few pixels wide, or so short that the command
     // line and toolbars taken off it come to more than its whole height, which
     // leaves nothing at all. Hand back the last size it really had for those, and
-    // for nothing else: since resizeEvent() stores whatever this returns, refusing
-    // a size for merely having changed a lot would make the refused answer the
-    // yardstick every later size is measured against, and a window shrunk to under
-    // half its width could never be reported again. A window that is genuinely
-    // only 48 pixels tall inside is reported as that, however little use it is.
+    // for nothing else: refusing a size for merely having changed a lot would make
+    // the refused answer the yardstick every later size is measured against, and a
+    // window shrunk to under half its width could never be reported again. A
+    // window that is genuinely only 48 pixels tall inside is reported as that,
+    // however little use it is.
     const int minValidWidth = 50;
-    const bool measurementUsable = mainWindowSize.width() >= minValidWidth && mainWindowSize.height() > 0;
-    const bool oldSizeUsable = mOldSize.width() >= minValidWidth && mOldSize.height() > 0;
-    if (!measurementUsable && oldSizeUsable) {
-        return mOldSize;
+    if (mainWindowSize.width() < minValidWidth || mainWindowSize.height() <= 0) {
+        return mLastMeasuredSize.isValid() ? mLastMeasuredSize : mainWindowSize;
     }
 
+    mLastMeasuredSize = mainWindowSize;
     return mainWindowSize;
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2340,16 +2340,17 @@ QSize TConsole::getMainWindowSize() const
     QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
 
     // A profile being switched to gets its geometry over several events, so in
-    // between the console can be a few pixels wide, or shorter than the command
-    // line it has to subtract - which leaves nothing to lay anything out in, so
-    // hand back the last size it really had. Only a size that small is refused:
-    // refusing one that has merely changed a lot would make this the yardstick
-    // every later size is measured against, and since resizeEvent() stores what
-    // this returns, a window shrunk to under half its width could never be
-    // reported again.
-    const int minValidLength = 50;
-    const bool measurementUsable = mainWindowSize.width() >= minValidLength && mainWindowSize.height() >= minValidLength;
-    const bool oldSizeUsable = mOldSize.width() >= minValidLength && mOldSize.height() >= minValidLength;
+    // between the console can be a few pixels wide, or so short that the command
+    // line and toolbars taken off it come to more than its whole height, which
+    // leaves nothing at all. Hand back the last size it really had for those, and
+    // for nothing else: since resizeEvent() stores whatever this returns, refusing
+    // a size for merely having changed a lot would make the refused answer the
+    // yardstick every later size is measured against, and a window shrunk to under
+    // half its width could never be reported again. A window that is genuinely
+    // only 48 pixels tall inside is reported as that, however little use it is.
+    const int minValidWidth = 50;
+    const bool measurementUsable = mainWindowSize.width() >= minValidWidth && mainWindowSize.height() > 0;
+    const bool oldSizeUsable = mOldSize.width() >= minValidWidth && mOldSize.height() > 0;
     if (!measurementUsable && oldSizeUsable) {
         return mOldSize;
     }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -490,7 +490,12 @@ private:
     std::unique_ptr<THyperlinkVisibilityManager> mpHyperlinkVisibilityManager;
 
     ConsoleType mType = UnknownType;
+    // the size the last resize reported to Lua
     QSize mOldSize;
+    // only ever written from a size that was really measured, so what
+    // getMainWindowSize() falls back to while the console is hidden or too small
+    // to measure cannot be a size the window never had
+    mutable QSize mLastMeasuredSize;
     SearchOptions mSearchOptions = SearchOptionNone;
     QAction* mpAction_searchOptions = nullptr;
     QIcon mIcon_searchOptions;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1230,22 +1230,16 @@ QSize TMainConsole::getUserWindowSize(const QString& windowname) const
         const QSize windowSize = pW->widget()->size();
         const int minValidWidth = 50;
 
-        // Reject obviously invalid sizes
+        // Mid-switch the dock can be a few pixels wide, which nothing can be laid
+        // out in - hand back the last size it really had. Only a size this small
+        // is refused: refusing one that has merely changed a lot would leave the
+        // cache as the yardstick for every size after it, and a window shrunk to
+        // under half its width could never be reported again.
         if (windowSize.width() < minValidWidth) {
             if (mCachedWindowSizes.contains(windowname)) {
                 return mCachedWindowSizes.value(windowname);
             }
             return windowSize;
-        }
-
-        // Reject suspicious shrinkage (more than 50% reduction suggests profile
-        // is transitioning and geometry isn't settled yet)
-        if (mCachedWindowSizes.contains(windowname)) {
-            const QSize cachedSize = mCachedWindowSizes.value(windowname);
-            const double shrinkageRatio = static_cast<double>(windowSize.width()) / cachedSize.width();
-            if (shrinkageRatio < 0.5) {
-                return cachedSize;
-            }
         }
 
         // Size looks valid, cache and return it

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -5303,6 +5303,35 @@ describe("Main window size and saved layout", function()
     assert.is_true(tallHeight <= smallHeight + 300)
   end)
 
+  it("a main window that loses more than half its width is reported at the width it has", function()
+    if not resizableWindowAvailable() then
+      return
+    end
+    finally(restoreMainWindowSize)
+    setMainWindowSize(1600, 700)
+    pumpEvents(200)
+    local wideWidth = getMainWindowSize()
+    local wideColumns = getColumnCount("main")
+
+    setMainWindowSize(300, 700)
+    pumpEvents(200)
+    local narrowWidth = getMainWindowSize()
+    local narrowColumns = getColumnCount("main")
+
+    -- the main window has a minimum width of its own, so how narrow it really
+    -- became is read off the column count rather than assumed; that and
+    -- getMainWindowSize() have to tell the same story
+    if narrowColumns * 2 >= wideColumns then
+      pending("this display would not take the main window below half its width")
+      return
+    end
+    -- the console holds fewer than half the columns it did, so the width it
+    -- reports has to have more than halved with them; merely falling would also
+    -- be true of a size that only got part of the way down
+    assert.is_true(narrowWidth * 2 < wideWidth,
+      ("getMainWindowSize reported %d, down from %d, while the console went from %d to %d columns"):format(narrowWidth, wideWidth, wideColumns, narrowColumns))
+  end)
+
   it("the main window can be put back the size it was", function()
     if not resizableWindowAvailable() then
       return

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(FUNCTIONAL_TEST_SOURCES
     InsertTextCapTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
     SetScriptCallbackTest.cpp
+    MainWindowSizeReportTest.cpp
     ClearWindowLogTest.cpp
     ProfileSaveShutdownRaceTest.cpp
     XMLexportVariablesTest.cpp

--- a/test/functional_tests/MainWindowSizeReportTest.cpp
+++ b/test/functional_tests/MainWindowSizeReportTest.cpp
@@ -235,16 +235,23 @@ private slots:
         runLua(qsl("hideWindow('%1')").arg(userWindow));
     }
 
-    // the same for the main window: 800x100 is a window a player can drag Mudlet
-    // down to, and what is left inside it after the command line and toolbars is
-    // under 50 pixels. Small is not the same as not settled yet.
+    // the same for the main window: a player can drag Mudlet down to a window
+    // with well under 50 pixels left inside it once the command line and toolbars
+    // have had their share. Small is not the same as not settled yet.
     void test_aMainWindowTooShortToBeUsefulIsStillReported()
     {
+        // how much of the window never reaches the console differs with the
+        // platform's chrome, so the height to ask for is worked out from a window
+        // that fits rather than assumed
         resizeWindow(800, 200);
-        resizeWindow(800, 100);
+        const int consumedByChrome = 200 - measuredMainWindowSize().height();
+        const int wantedInside = 30;
+        resizeWindow(800, consumedByChrome + wantedInside);
 
         const QSize measured = measuredMainWindowSize();
-        QVERIFY2(measured.height() > 0 && measured.height() < 50, qPrintable(qsl("expected a positive height under 50 to test with, got %1").arg(measured.height())));
+        if (measured.height() <= 0 || measured.height() >= 50) {
+            QSKIP(qPrintable(qsl("the window would not go short enough to test with - %1 pixels inside").arg(measured.height())));
+        }
         QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measured, qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measured)));
     }
 

--- a/test/functional_tests/MainWindowSizeReportTest.cpp
+++ b/test/functional_tests/MainWindowSizeReportTest.cpp
@@ -1,0 +1,247 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QSignalSpy>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForMainWindowSizeReportTest();
+
+// getMainWindowSize() is what Geyser, the Lua function of the same name and MXP
+// frame placement all measure against, so a report that stops following the
+// window puts every one of them in the wrong place. It declines to report a
+// shrink of more than half - geometry mid-profile-switch is not to be trusted -
+// and the danger in that is the report becoming self-referential: if what it
+// declined to report is what it compares the next size against, one large shrink
+// makes it decline forever.
+class MainWindowSizeReportTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "MainWindowSizeReport-Test-Host";
+    QString mPort;
+    const QString mLocalhost = "localhost";
+
+    // resizes are answered from a zero timer
+    void settle() { QTest::qWait(50ms); }
+
+    void resizeWindow(const int width, const int height)
+    {
+        mudlet::self()->resize(width, height);
+        settle();
+    }
+
+    // What the console really has to hand out, from its own geometry rather than
+    // from the reporting path under test.
+    QSize measuredMainWindowSize() const
+    {
+        TMainConsole* pConsole = mpHost->mpConsole;
+        return {pConsole->width() - (pConsole->mpLeftToolBar->width() + pConsole->mpRightToolBar->width()),
+                pConsole->height() - (pConsole->mpCommandLine->height() + pConsole->mpTopToolBar->height())};
+    }
+
+    int luaInt(const QString& global) const
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, global.toUtf8().constData());
+        const int value = static_cast<int>(lua_tointeger(L, -1));
+        lua_pop(L, 1);
+        return value;
+    }
+
+    QString mismatch(const QSize& reported, const QSize& measured) const
+    {
+        return qsl("getMainWindowSize() reports %1x%2 for a console that measures %3x%4")
+                .arg(QString::number(reported.width()), QString::number(reported.height()), QString::number(measured.width()), QString::number(measured.height()));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForMainWindowSizeReportTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        // sized before the console exists, so the shrink under test is the one
+        // each case performs and not one left over from however wide the platform
+        // makes a main window nobody has sized
+        mudlet::self()->resize(1200, 800);
+
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+        settle();
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        delete mudlet::self();
+        QDir(path).removeRecursively();
+    }
+
+    // leaves the window at a size no case has to shrink into to get started
+    void cleanup() { resizeWindow(1200, 800); }
+
+    // dragging an edge inwards arrives in small steps, so the report has never
+    // had trouble following it
+    void test_aGradualShrinkIsReported()
+    {
+        resizeWindow(1200, 800);
+
+        for (int width = 1150; width >= 900; width -= 50) {
+            resizeWindow(width, 800);
+            QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measuredMainWindowSize(), qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measuredMainWindowSize())));
+        }
+    }
+
+    // the same shrink arriving in one step, which is what unmaximising or moving
+    // the window to a smaller screen does
+    void test_aShrinkOfMoreThanHalfIsReported()
+    {
+        resizeWindow(2000, 1200);
+        QCOMPARE(mpHost->mpConsole->getMainWindowSize(), measuredMainWindowSize());
+
+        resizeWindow(800, 600);
+
+        QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measuredMainWindowSize(), qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measuredMainWindowSize())));
+    }
+
+    // a report that declined once must not go on measuring every later size
+    // against what it declined to report, or nothing the window does afterwards
+    // can bring it back
+    void test_theReportKeepsUpAfterAShrinkOfMoreThanHalf()
+    {
+        resizeWindow(2000, 1200);
+        resizeWindow(800, 600);
+
+        for (const QSize& size : {QSize(900, 650), QSize(1100, 700), QSize(1200, 800)}) {
+            resizeWindow(size.width(), size.height());
+            QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measuredMainWindowSize(), qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measuredMainWindowSize())));
+        }
+    }
+
+    // the shrink a player performs rather than one the test dials in: restoring a
+    // maximised window drops it to well under half the screen's width in one go
+    void test_restoringAMaximisedWindowReportsTheRestoredSize()
+    {
+        resizeWindow(800, 600);
+        mudlet::self()->showMaximized();
+        QTest::qWait(200ms);
+        const int maximisedWidth = mpHost->mpConsole->width();
+
+        mudlet::self()->showNormal();
+        resizeWindow(800, 600);
+
+        if (maximisedWidth < 2 * mpHost->mpConsole->width()) {
+            QSKIP("no window manager here to maximise against, so this is not the shrink under test");
+        }
+        QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measuredMainWindowSize(), qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measuredMainWindowSize())));
+    }
+
+    // the number Lua hands scripts is the same one, so a stale report is what
+    // every Geyser layout is built against
+    void test_luaSeesTheSizeTheWindowHasAfterAShrink()
+    {
+        resizeWindow(2000, 1200);
+        resizeWindow(800, 600);
+
+        QVERIFY(mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("mainWindowWidth, mainWindowHeight = getMainWindowSize()")));
+
+        const QSize measured = measuredMainWindowSize();
+        QCOMPARE(luaInt(qsl("mainWindowWidth")), measured.width());
+        QCOMPARE(luaInt(qsl("mainWindowHeight")), measured.height());
+    }
+};
+
+void initializeQRCResourcesForMainWindowSizeReportTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "MainWindowSizeReportTest.moc"
+QTEST_MAIN(MainWindowSizeReportTest)

--- a/test/functional_tests/MainWindowSizeReportTest.cpp
+++ b/test/functional_tests/MainWindowSizeReportTest.cpp
@@ -24,6 +24,7 @@
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
 #include "TLuaInterpreter.h"
+#include "TDockWidget.h"
 #include "TMainConsole.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
@@ -75,6 +76,14 @@ private:
                 pConsole->height() - (pConsole->mpCommandLine->height() + pConsole->mpTopToolBar->height())};
     }
 
+    void runLua(const QString& script) { QVERIFY2(mpHost->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(script)); }
+
+    QSize dockSize(const QString& name) const
+    {
+        TDockWidget* pDock = mpHost->mpConsole->mDockWidgetMap.value(name);
+        return (pDock && pDock->widget()) ? pDock->widget()->size() : QSize();
+    }
+
     int luaInt(const QString& global) const
     {
         lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
@@ -86,7 +95,7 @@ private:
 
     QString mismatch(const QSize& reported, const QSize& measured) const
     {
-        return qsl("getMainWindowSize() reports %1x%2 for a console that measures %3x%4")
+        return qsl("reported as %1x%2 for a widget that measures %3x%4")
                 .arg(QString::number(reported.width()), QString::number(reported.height()), QString::number(measured.width()), QString::number(measured.height()));
     }
 
@@ -193,6 +202,50 @@ private slots:
             resizeWindow(size.width(), size.height());
             QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measuredMainWindowSize(), qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measuredMainWindowSize())));
         }
+    }
+
+    // user windows are reported through a cache of their own, which used to keep
+    // the same "not less than half" rule and so kept the same way of getting stuck
+    void test_aUserWindowShrunkByMoreThanHalfIsReported()
+    {
+        const QString userWindow = qsl("mwsrUserWindow");
+        runLua(qsl("openUserWindow('%1', false)").arg(userWindow));
+        settle();
+        QVERIFY2(mpHost->mpConsole->mDockWidgetMap.contains(userWindow), "the user window was not created");
+
+        runLua(qsl("resizeWindow('%1', 600, 400)").arg(userWindow));
+        settle();
+        QCOMPARE(mpHost->mpConsole->getUserWindowSize(userWindow), dockSize(userWindow));
+
+        runLua(qsl("resizeWindow('%1', 200, 150)").arg(userWindow));
+        settle();
+        QVERIFY2(mpHost->mpConsole->getUserWindowSize(userWindow) == dockSize(userWindow), qPrintable(mismatch(mpHost->mpConsole->getUserWindowSize(userWindow), dockSize(userWindow))));
+
+        // a script may ask for a user window this short and Mudlet gives it one,
+        // so a size below any "too small to be real" bar is still the size to
+        // report - refusing it would leave the cache answering for it instead
+        runLua(qsl("resizeWindow('%1', 300, 40)").arg(userWindow));
+        settle();
+        // how much of the 40 the dock keeps is up to the window manager, so only
+        // that it ended up under the bar is pinned, not the exact height
+        const QSize shortDock = dockSize(userWindow);
+        QVERIFY2(shortDock.height() > 0 && shortDock.height() < 50, qPrintable(qsl("expected a positive height under 50 to test with, got %1").arg(shortDock.height())));
+        QVERIFY2(mpHost->mpConsole->getUserWindowSize(userWindow) == shortDock, qPrintable(mismatch(mpHost->mpConsole->getUserWindowSize(userWindow), shortDock)));
+
+        runLua(qsl("hideWindow('%1')").arg(userWindow));
+    }
+
+    // the same for the main window: 800x100 is a window a player can drag Mudlet
+    // down to, and what is left inside it after the command line and toolbars is
+    // under 50 pixels. Small is not the same as not settled yet.
+    void test_aMainWindowTooShortToBeUsefulIsStillReported()
+    {
+        resizeWindow(800, 200);
+        resizeWindow(800, 100);
+
+        const QSize measured = measuredMainWindowSize();
+        QVERIFY2(measured.height() > 0 && measured.height() < 50, qPrintable(qsl("expected a positive height under 50 to test with, got %1").arg(measured.height())));
+        QVERIFY2(mpHost->mpConsole->getMainWindowSize() == measured, qPrintable(mismatch(mpHost->mpConsole->getMainWindowSize(), measured)));
     }
 
     // the shrink a player performs rather than one the test dials in: restoring a


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `getMainWindowSize()` refused to report a width less than half the last one it reported. `resizeEvent()` stores what it reports, so the refused answer became the yardstick the next size was measured against - and a window shrunk by more than half was never reported again until it was widened back past half of the old size.
- Restoring a maximised window is exactly that shrink, so everything placed off that number - every Geyser layout, MXP frames, the Lua `getMainWindowSize()` - went on building for the maximised window. `getUserWindowSize()` cached the same way, for user windows.
- Only a size too small to lay anything out in is refused now, which is what the guard was added for, and that check covers the height as well as the width. What it falls back to is a size of its own that is only ever written from a real measurement, the way `getUserWindowSize()` has always used `mCachedWindowSizes`, so the fallback can never be a size the window never had.

#### Motivation for adding to Mudlet
Un-maximise Mudlet and your UI keeps being laid out for the full-screen window, with elements sitting off the right-hand edge, until you make the window big again.

#### Other info (issues closed, discussion etc)
The refusal came in with #8853 (Fix: Miniconsole text cutoff after switching profiles, closing #8273) as an "extra safeguard" beside that PR's actual fix - the deferred `refreshSubconsoles()`, which is untouched here.

Found while fixing #9876, where the same latch made `MxpFramePlacementTest` fail locally.

#9830 had the same fix as one of its nine; it is out of there now and this PR carries it, along with the busted spec it had. #9830 keeps `ProfileSwitchMiniconsoleTest`, which pins the #8273 invariant the safeguard nominally protected and passes either way.

**Test case:** maximise Mudlet, then restore it, and check `getMainWindowSize()` against the window - before this it reports the maximised size. Covered by the new `MainWindowSizeReportTest`; on `development` 4 of its 7 slots fail, including `restoringAMaximisedWindowReportsTheRestoredSize`, which reported 2560x1366 for an 800x547 console under a real window manager. All 111 ctest tests pass, and the busted suite is identical to `development` over three runs each (2964 successes / 2 failures / 7 errors both ways, same items).

Closes #9796

Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>