### PR TITLE
fix: update notes no longer skip releases your platform never got

### DIFF
--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -118,6 +118,30 @@ QList<Release> Feed::selectUpdates(const QList<Release>& releases, const Release
     return updates;
 }
 
+QList<Release> Feed::selectReleasesBetween(const QList<Release>& releases, const Release& after, const Release& upTo)
+{
+    QList<Release> selected;
+    // With nothing on offer upTo is a default-constructed Release, which no
+    // release is older than or equal to
+    if (upTo.getVersion().isEmpty()) {
+        return selected;
+    }
+    for (const auto& release : releases) {
+        // The release being run is in the feed as well, and its own notes were
+        // read when it was installed. Matched by version like selectUpdates
+        // does: a version SemVer cannot read is ordered by date instead, and
+        // the date the running release carries is when it was built rather than
+        // when it was published, so it can sort as older than itself
+        if (after.getVersion().compare(release.getVersion(), Qt::CaseInsensitive) == 0) {
+            continue;
+        }
+        if (after < release && release <= upTo) {
+            selected << release;
+        }
+    }
+    return selected;
+}
+
 QString Feed::getDownloadFilePath() const
 {
     return mDownloadFilePath;

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -46,7 +46,7 @@ public:
     QUrl getUrl() const;
 
     void load();
-    void downloadRelease(const Release& release, bool requireChecksums = false);
+    void downloadRelease(const Release& release, bool requireChecksums = true);
 
     // Returns the SHA256 that sha256sum-style output lists for downloadFilename,
     // comparing the whole filename case-insensitively, or an empty string when no

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -64,6 +64,12 @@ public:
     QList<Release> getUpdates(const Release& currentRelease) const;
     static QList<Release> selectUpdates(const QList<Release>& releases, const Release& currentRelease);
 
+    // The releases in (after, upTo] - everything installing upTo brings with it.
+    // Pass the unfiltered release list: a release getUpdates() passed over for
+    // want of an asset for this platform is still part of what a later release
+    // delivers, so its notes belong in the changelog for it.
+    static QList<Release> selectReleasesBetween(const QList<Release>& releases, const Release& after, const Release& upTo);
+
     QList<Release> getReleases() const;
     QString getDownloadFilePath() const;
     bool isReady() const;

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -554,7 +554,13 @@ QString UpdateDialog::generateChangelogDocument()
     QString changelog;
     QList<Release> changelogReleases;
     if (mMinVersion.isEmpty() && mMaxVersion.isEmpty()) {
-        changelogReleases = mUpdates;
+        // Everything the offered release brings with it, off the unfiltered
+        // list: a release left out of mUpdates because it published no asset
+        // for this platform still ships its changes inside the one being
+        // offered, so the user is about to receive them either way. Bounded by
+        // the same release getUpdates() measures against, so what is listed and
+        // what is offered cannot disagree.
+        changelogReleases = Feed::selectReleasesBetween(mReleases, Release::getCurrentRelease(), mLatestRelease);
     } else {
         Release minRelease(mMinVersion.isEmpty() ? QApplication::applicationVersion() : mMinVersion);
         Release maxRelease(mMaxVersion);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,21 @@ endif()
 # somebody running the binary by hand on a bare X server is allowed the skip.
 set_property(TEST TKeySequenceEditTest APPEND PROPERTY ENVIRONMENT "MUDLET_REQUIRE_WINDOW_ACTIVATION=1")
 
+# Which releases' notes the update offer shows. Built from the updater sources
+# rather than linked against the Mudlet library, because the library only
+# contains them when configured with USE_UPDATER.
+add_executable(ReleaseChangelogSpanTest
+    ReleaseChangelogSpanTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/Feed.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/Release.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/SemVer.cpp
+)
+target_link_libraries(ReleaseChangelogSpanTest PRIVATE Qt6::Test Qt6::Network Qt6::Widgets)
+add_test(NAME ReleaseChangelogSpanTest COMMAND $<TARGET_FILE:ReleaseChangelogSpanTest>)
+set_tests_properties(ReleaseChangelogSpanTest PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
+)
+
 # DiscordTest checks the Lua API permission gating contract by scanning the source
 target_compile_definitions(DiscordTest PRIVATE MUDLET_SRC_DIR="${CMAKE_SOURCE_DIR}/src")
 

--- a/test/ReleaseChangelogSpanTest.cpp
+++ b/test/ReleaseChangelogSpanTest.cpp
@@ -1,0 +1,205 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "../src/updater/Feed.h"
+#include "../src/updater/Release.h"
+
+#include <QtTest/QtTest>
+
+#include <QJsonArray>
+#include <QJsonObject>
+
+/*
+ * Covers which releases' notes the update offer shows
+ * (UpdateDialog::generateChangelogDocument).
+ *
+ * The offer used to list the notes of the releases it could offer, which is not
+ * the same set as the releases the user is about to receive: the 2026-08-07 PTB
+ * published a Windows installer only, so a Linux user offered the 08-08 build
+ * was never told what the 08-07 one changed, even though installing 08-08 hands
+ * it to them. The span is therefore taken from the unfiltered release list,
+ * bounded by what is running and what is on offer.
+ */
+
+namespace {
+const auto aug06Tag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-06-1a2b3c4d");
+const auto aug07Tag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-07-eaa991b9");
+const auto aug08Tag = QStringLiteral("Mudlet-4.22.0-ptb-2026-08-08-7c6b5a49");
+const auto aug06Version = QStringLiteral("4.22.0-ptb-2026-08-06-1a2b3c4d");
+const auto aug07Version = QStringLiteral("4.22.0-ptb-2026-08-07-eaa991b9");
+const auto aug08Version = QStringLiteral("4.22.0-ptb-2026-08-08-7c6b5a49");
+
+const auto windowsSuffix = QStringLiteral("-windows-64.exe");
+const auto linuxSuffix = QStringLiteral("-linux-x64.AppImage.tar");
+
+const auto linuxOs = QStringLiteral("linux");
+const auto x64Arch = QStringLiteral("x86_64");
+
+QJsonObject makeAsset(const QString& tag, const QString& name)
+{
+    QJsonObject asset;
+    asset.insert(QStringLiteral("name"), name);
+    asset.insert(QStringLiteral("browser_download_url"), QStringLiteral("https://github.com/Mudlet/Mudlet/releases/download/%1/%2").arg(tag, name));
+    asset.insert(QStringLiteral("size"), 137252032);
+    return asset;
+}
+
+QJsonObject releaseJson(const QString& tag, const QString& publishedAt, const QStringList& assetSuffixes, bool prerelease = true)
+{
+    QJsonArray assets;
+    for (const auto& suffix : assetSuffixes) {
+        assets.append(makeAsset(tag, QStringLiteral("%1%2").arg(tag, suffix)));
+    }
+    assets.append(makeAsset(tag, QStringLiteral("SHA256SUMS.txt")));
+
+    QJsonObject release;
+    release.insert(QStringLiteral("tag_name"), tag);
+    release.insert(QStringLiteral("published_at"), publishedAt);
+    release.insert(QStringLiteral("prerelease"), prerelease);
+    release.insert(QStringLiteral("draft"), false);
+    release.insert(QStringLiteral("body"), QStringLiteral("- %1 changed a thing\n").arg(tag));
+    release.insert(QStringLiteral("assets"), assets);
+    return release;
+}
+
+dblsqd::Release linuxRelease(const QJsonObject& json)
+{
+    return dblsqd::Release(json, linuxOs, x64Arch);
+}
+
+// Newest first, the order Feed sorts its releases into. Only the 08-07 build
+// published a Windows installer, as the real one did.
+QList<dblsqd::Release> feedReleases()
+{
+    return {linuxRelease(releaseJson(aug08Tag, QStringLiteral("2026-08-08T02:12:36Z"), {windowsSuffix, linuxSuffix})),
+            linuxRelease(releaseJson(aug07Tag, QStringLiteral("2026-08-07T02:14:11Z"), {windowsSuffix})),
+            linuxRelease(releaseJson(aug06Tag, QStringLiteral("2026-08-06T02:11:47Z"), {windowsSuffix, linuxSuffix}))};
+}
+
+// Release::getCurrentRelease() dates the running release by when it was built,
+// which is always before the release carrying it was published
+dblsqd::Release runningRelease(const QString& version, const QString& buildDate)
+{
+    return dblsqd::Release(version, QDateTime::fromString(buildDate, Qt::ISODate));
+}
+
+QStringList versionsOf(const QList<dblsqd::Release>& releases)
+{
+    QStringList versions;
+    for (const auto& release : releases) {
+        versions << release.getVersion();
+    }
+    return versions;
+}
+} // namespace
+
+class ReleaseChangelogSpanTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void theNotesOfAReleaseThisPlatformWasNotOfferedAreStillShown();
+    void whatIsAlreadyRunningAndOlderIsLeftOut();
+    void theOfferedReleaseIsShownAndAnythingNewerIsNot();
+    void nothingIsShownWhenNothingIsOffered();
+    void releasesAreSpannedBySemVerOrder();
+    void aVersionSemVerCannotReadIsSpannedByDateWithoutRepeatingItself();
+};
+
+// The regression: on Linux the 08-07 build is not offerable, but 08-08 carries
+// its changes, so its notes have to appear alongside 08-08's
+void ReleaseChangelogSpanTest::theNotesOfAReleaseThisPlatformWasNotOfferedAreStillShown()
+{
+    const auto releases = feedReleases();
+    const auto running = runningRelease(aug06Version, QStringLiteral("2026-08-06T01:49:20Z"));
+    const auto updates = dblsqd::Feed::selectUpdates(releases, running);
+    QCOMPARE(versionsOf(updates), QStringList{aug08Version});
+
+    const auto span = dblsqd::Feed::selectReleasesBetween(releases, running, updates.first());
+
+    QCOMPARE(versionsOf(span), QStringList({aug08Version, aug07Version}));
+    QVERIFY(span.at(1).getChangelog().contains(aug07Tag));
+}
+
+// The running release is in the feed too, and its notes were read long ago
+void ReleaseChangelogSpanTest::whatIsAlreadyRunningAndOlderIsLeftOut()
+{
+    const auto releases = feedReleases();
+    const auto running = runningRelease(aug07Version, QStringLiteral("2026-08-07T01:52:04Z"));
+
+    const auto span = dblsqd::Feed::selectReleasesBetween(releases, running, releases.constFirst());
+
+    QCOMPARE(versionsOf(span), QStringList{aug08Version});
+}
+
+// A release newer than the one on offer is not being installed, so promising
+// its changes would be a lie - it can be newer because this platform has no
+// asset in it, which is how the offer comes to be an older release. The offer
+// itself is what the user is about to get, so it is shown.
+void ReleaseChangelogSpanTest::theOfferedReleaseIsShownAndAnythingNewerIsNot()
+{
+    const auto releases = feedReleases();
+    const auto running = runningRelease(QStringLiteral("4.22.0-ptb-2026-08-05-9f8e7d6c"), QStringLiteral("2026-08-05T01:47:31Z"));
+    const auto offered = releases.constLast();
+    QCOMPARE(offered.getVersion(), aug06Version);
+
+    const auto span = dblsqd::Feed::selectReleasesBetween(releases, running, offered);
+
+    QCOMPARE(versionsOf(span), QStringList{aug06Version});
+}
+
+void ReleaseChangelogSpanTest::nothingIsShownWhenNothingIsOffered()
+{
+    const auto running = runningRelease(aug06Version, QStringLiteral("2026-08-06T01:49:20Z"));
+
+    QVERIFY(dblsqd::Feed::selectReleasesBetween(feedReleases(), running, dblsqd::Release()).isEmpty());
+}
+
+// Both stable and PTB versions are valid SemVer - the PTB date lives in the
+// prerelease identifier - so the version, not the publication date, orders them
+void ReleaseChangelogSpanTest::releasesAreSpannedBySemVerOrder()
+{
+    const QList<dblsqd::Release> releases{linuxRelease(releaseJson(QStringLiteral("Mudlet-4.22.0"), QStringLiteral("2026-07-06T09:00:00Z"), {linuxSuffix}, /*prerelease=*/false)),
+                                          linuxRelease(releaseJson(QStringLiteral("Mudlet-4.21.1"), QStringLiteral("2026-05-11T09:00:00Z"), {linuxSuffix}, /*prerelease=*/false)),
+                                          linuxRelease(releaseJson(QStringLiteral("Mudlet-4.21.0"), QStringLiteral("2026-04-27T09:00:00Z"), {linuxSuffix}, /*prerelease=*/false))};
+    const dblsqd::Release running(QStringLiteral("4.21.0"));
+
+    const auto span = dblsqd::Feed::selectReleasesBetween(releases, running, releases.constFirst());
+
+    QCOMPARE(versionsOf(span), QStringList({QStringLiteral("4.22.0"), QStringLiteral("4.21.1")}));
+}
+
+// A two-component version is not SemVer, so these fall back to being ordered by
+// date - and the running one is dated when it was built, which is before the
+// release carrying it was published, so it looks newer than itself. Such a
+// version never reaches a release (CI/check-release-tag.sh rejects it), but the
+// span has to answer for one rather than replay notes the user already has.
+void ReleaseChangelogSpanTest::aVersionSemVerCannotReadIsSpannedByDateWithoutRepeatingItself()
+{
+    const QList<dblsqd::Release> releases{linuxRelease(releaseJson(QStringLiteral("Mudlet-5.0-ptb-2026-08-08-7c6b5a49"), QStringLiteral("2026-08-08T02:12:36Z"), {linuxSuffix})),
+                                          linuxRelease(releaseJson(QStringLiteral("Mudlet-5.0-ptb-2026-08-07-eaa991b9"), QStringLiteral("2026-08-07T02:14:11Z"), {linuxSuffix}))};
+    const auto running = runningRelease(QStringLiteral("5.0-ptb-2026-08-07-eaa991b9"), QStringLiteral("2026-08-07T01:52:04Z"));
+
+    const auto span = dblsqd::Feed::selectReleasesBetween(releases, running, releases.constFirst());
+
+    QCOMPARE(versionsOf(span), QStringList{QStringLiteral("5.0-ptb-2026-08-08-7c6b5a49")});
+}
+
+#include "ReleaseChangelogSpanTest.moc"
+QTEST_MAIN(ReleaseChangelogSpanTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The update window now builds its release notes from all releases between your current version and the offered one, so a release that skipped your platform (e.g. a partial PTB) still shows its notes when the next complete build arrives
- `Feed::downloadRelease` now verifies checksums by default instead of opting in
- New `ReleaseChangelogSpanTest` covering the note span bounds (6 cases)

#### Motivation for adding to Mudlet
Follow-up to #9735: filtering asset-less releases out of the update offer silently dropped their notes from the "what's new" text, and the unsafe checksum default was a trap for future callers.

#### Other info (issues closed, discussion etc)
The same-version guard matters because the running release is dated from `__DATE__` (build time, not publish time), so a non-SemVer version could replay its own notes.

**Test case:** with a PTB feed where the previous PTB lacks your platform's asset, open the update offer dialog - the skipped PTB's notes appear; `ctest -R ReleaseChangelogSpan` passes.

Assisted-by: Claude:claude-opus-5

Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>