### PR TITLE
fix: a profile save no longer blanks, drops or inflates saved variables

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -707,15 +707,21 @@ void LuaInterface::renameVar(TVar* var)
     var->clearNewName();
 }
 
-// returns the value for a string/number/boolean datatype, or an empty string otherwise
+// Returns the value for a string/number/boolean datatype, and an empty string for
+// everything else - including for a variable it cannot read, which it has no way
+// to report. Nothing that commits the answer where an empty string cannot be told
+// apart from a variable that really is empty may use it (#9769); the save reads
+// its values off the tree the walk built, see exportedValue() in XMLexport.cpp.
 QString LuaInterface::getValue(TVar* var)
 {
+    // this walks down to the variable a push at a time, so every way out owes
+    // the caller's Lua stack back
+    const int stackTop = lua_gettop(mL);
     if (setjmp(buf) == 0) {
         QList<TVar*> const vars = varOrder(var);
         if (vars.empty()) {
             return {};
         }
-        const int pCount = vars.size(); //how many things we need to pop from the stack at the end
         //load from _G first
         auto firstVariable = vars.constFirst();
         if (firstVariable->getKeyType() == LUA_TSTRING) {
@@ -730,10 +736,12 @@ QString LuaInterface::getValue(TVar* var)
         if (lua_isnoneornil(mL, lua_gettop(mL))) {
             qDebug() << "LuaInterface::getValue: Couldn't put root value" << firstVariable->getName() << "onto the Lua stack in order to get value of" << var->getName()
                      << ", perhaps the key type isn't supported?";
+            lua_settop(mL, stackTop);
             return {};
         }
         for (int i = 1; i < vars.size(); i++) {
             if (!loadValue(mL, vars.at(i), -2)) {
+                lua_settop(mL, stackTop);
                 return {};
             }
         }
@@ -744,9 +752,10 @@ QString LuaInterface::getValue(TVar* var)
         } else if (valueType == LUA_TNUMBER || valueType == LUA_TSTRING) {
             value = lua_tostring(mL, -1);
         }
-        lua_pop(mL, pCount);
+        lua_settop(mL, stackTop);
         return value;
     }
+    lua_settop(mL, stackTop);
     return {};
 }
 
@@ -816,9 +825,11 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
         var->setParent(tVar);
         var->hidden = hide;
         tVar->addChild(var);
-        const void* pKey = lua_topointer(L, -1);
+        // whatever branch named the key above left the stack as lua_next did,
+        // with the key at -2 and the value at -1
+        const void* pKey = lua_topointer(L, -2);
         var->pKey = pKey;
-        const void* pValue = lua_topointer(L, -2);
+        const void* pValue = lua_topointer(L, -1);
         var->pValue = pValue;
         // A table two names reach is walked only under the first, which suits
         // Mudlet's own API - but a saved variable reached second would be left
@@ -892,6 +903,11 @@ void LuaInterface::getVars(bool hide)
     }
     lua_pushnil(mL);
     TVar* global = resetVariableTree();
+    if (hide) {
+        // this walk is about to hide everything it finds, so it is also where
+        // the identities of what was hidden last time stop being worth keeping
+        varUnit->clearHiddenTables();
+    }
     iterateTable(mL, LUA_GLOBALSINDEX, global, hide);
     // FIXME: possible to keep and report? qDebug()<<"took"<<t.elapsed()<<"to get variables in";
 }
@@ -904,24 +920,9 @@ void LuaInterface::getVars(bool hide)
 // each saved global in its own dedup scope is what avoids that.
 void LuaInterface::getSavedVars()
 {
-    const int stackTop = lua_gettop(mL);
-    if (setjmp(buf) != 0) {
-        lua_settop(mL, stackTop);
-        // getVars() does not clear this itself, so a later walk on this same
-        // interface would inherit the filter
-        mSavedVarsOnly = false;
-        // the global the walk died inside was not read to the end, so nothing
-        // says it is one the save can carry whole
-        if (!mCurrentSavedRootName.isEmpty()) {
-            mSavedRootsHoldingUnsaveableValues.insert(mCurrentSavedRootName);
-        }
-        qWarning() << "LuaInterface::getSavedVars() WARNING - Lua panicked while reading the saved variables in; the variable tree is incomplete.";
-        return;
-    }
     mSavedRootNames.clear();
-    mTruncatedSavedTables.clear();
-    mSavedRootsHoldingUnsaveableValues.clear();
-    mCurrentSavedRootName.clear();
+    mUnreadableSavedRoots.clear();
+    mPanickedSavedRootName.clear();
     for (const QString& savedVarName : std::as_const(varUnit->savedVars)) {
         // savedVars holds dotted paths, but a global's own name may contain a
         // dot as well, so both readings count as a name to walk
@@ -929,15 +930,91 @@ void LuaInterface::getSavedVars()
         mSavedRootNames.insert(savedVarName.section(QChar('.'), 0, 0));
     }
 
-    TVar* global = resetVariableTree();
     if (mSavedRootNames.isEmpty()) {
+        resetVariableTree();
         return;
     }
 
     mSavedVarsOnly = true;
-    lua_pushnil(mL);
-    iterateTable(mL, LUA_GLOBALSINDEX, global, false);
+    bool gaveUp = false;
+    // A panic cannot be resumed from where it happened, so the global the walk
+    // died inside is dropped and the rest are read again from the top: an
+    // unreadable global then costs the save that one variable instead of every
+    // variable the walk had still to reach (#9769). Each pass drops one global,
+    // so this is bounded by how many the profile saves.
+    while (!readSavedVars()) {
+        const QString unreadableRoot = mPanickedSavedRootName;
+        mPanickedSavedRootName.clear();
+        // Without a global to point at, the next attempt would only die in the
+        // same place, so the walk stops and reports what it is short of instead.
+        if (unreadableRoot.isEmpty() || !mSavedRootNames.remove(unreadableRoot)) {
+            gaveUp = true;
+            break;
+        }
+        mUnreadableSavedRoots.append(unreadableRoot);
+    }
+    // getVars() does not clear this itself, so a later walk on this same
+    // interface would inherit the filter
     mSavedVarsOnly = false;
+
+    if (gaveUp) {
+        addSavedRootsMissingFromTheTree();
+    }
+    mUnreadableSavedRoots.sort();
+}
+
+// What a walk that stopped without naming its culprit is short of: every saved
+// global with no node in the tree. One the user has since deleted reads as
+// missing too, and it is just as true of that one that this save has not got it.
+void LuaInterface::addSavedRootsMissingFromTheTree()
+{
+    QSet<QString> readRoots;
+    TVar* base = varUnit->getBase();
+    const QList<TVar*> roots = base ? base->getChildren(false) : QList<TVar*>();
+    for (const TVar* root : roots) {
+        readRoots.insert(root->getName());
+    }
+
+    for (const QString& savedVarName : std::as_const(varUnit->savedVars)) {
+        const QString rootName = savedVarName.section(QChar('.'), 0, 0);
+        if (!readRoots.contains(rootName) && !mUnreadableSavedRoots.contains(rootName)) {
+            mUnreadableSavedRoots.append(rootName);
+        }
+    }
+}
+
+// One attempt at the walk. False means a Lua panic cut it short, leaving the
+// tree holding however much of it had been read - and each attempt starts from
+// an empty tree and empty findings, so nothing a failed one saw carries over.
+bool LuaInterface::readSavedVars()
+{
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) != 0) {
+        lua_settop(mL, stackTop);
+        // Past depth 1 the walk is inside the global it entered last, so that
+        // global is the one that died; at depth 1 it could equally have been
+        // naming a key of a global it has no interest in, and blaming the last
+        // one entered would drop a variable that reads perfectly well.
+        if (depth > 1) {
+            mPanickedSavedRootName = mCurrentSavedRootName;
+            // should the caller give up rather than go round again, this global
+            // stays in the tree holding however much of it was read, which must
+            // not be written out as if it were all of it
+            mSavedRootsHoldingUnsaveableValues.insert(mCurrentSavedRootName);
+        }
+        qWarning().noquote().nospace() << "LuaInterface::readSavedVars() WARNING - Lua panicked "
+                                       << (depth > 1 ? qsl("while reading the saved variable \"%1\"").arg(mCurrentSavedRootName) : qsl("before or between the saved variables"))
+                                       << "; the variable tree is incomplete.";
+        return false;
+    }
+
+    mTruncatedSavedTables.clear();
+    mSavedRootsHoldingUnsaveableValues.clear();
+    mCurrentSavedRootName.clear();
+    resetVariableTree();
+    lua_pushnil(mL);
+    iterateTable(mL, LUA_GLOBALSINDEX, varUnit->getBase(), false);
+    return true;
 }
 
 // Throws away whatever tree there was, along with the Lua registry references it

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -60,13 +60,18 @@ public:
     void getVars(bool);
     void getSavedVars();
     // the saved variables the last getSavedVars() had to cut short, for the
-    // caller to tell the user about - they are in no profile save it takes
+    // caller to tell the user about - a save holds them as empty tables
     QStringList truncatedSavedTables() const { return mTruncatedSavedTables; }
-    // the saved globals the last getSavedVars() found a value inside, at any
-    // depth, that a save cannot carry: anything but a table, string, number or
-    // boolean. A walk cut short by a panic or by scmMaxTableDepth answers only
-    // for what it reached.
+    // the saved globals the last getSavedVars() cannot vouch for having read
+    // whole: it found a value inside, at any depth, that a save cannot carry
+    // (anything but a table, string, number or boolean), or a Lua panic stopped
+    // it part way through one. A walk cut short answers only for what it reached.
     QSet<QString> savedRootsHoldingUnsaveableValues() const { return mSavedRootsHoldingUnsaveableValues; }
+    // the saved globals missing from the tree the last getSavedVars() built,
+    // because a Lua panic had to be got past by dropping them or stopped the
+    // walk reaching them at all - they are in no profile save taken from that
+    // tree, which is the caller's to tell the user about
+    QStringList unreadableSavedRoots() const { return mUnreadableSavedRoots; }
     QStringList varName(TVar* var);
     QList<TVar*> varOrder(TVar* var);
     QString getValue(TVar*);
@@ -92,6 +97,8 @@ public:
 
 private:
     TVar* resetVariableTree();
+    bool readSavedVars();
+    void addSavedRootsMissingFromTheTree();
 
     int depth = 0;
     lua_State* mL;
@@ -105,8 +112,13 @@ private:
     QSet<QString> mSavedRootNames;
     // which of those keys the walk is inside, meaningful only while one is running
     QString mCurrentSavedRootName;
+    // ...and the one a panic ended the last attempt inside, which outlives that
+    // attempt because it is what the next one has to leave out
+    QString mPanickedSavedRootName;
     // the keys it found a value under that the save cannot carry
     QSet<QString> mSavedRootsHoldingUnsaveableValues;
+    // ...and the ones missing from the tree it ended up with
+    QStringList mUnreadableSavedRoots;
     QStringList mTruncatedSavedTables;
 };
 

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -42,10 +42,48 @@ bool VarUnit::isHidden(TVar* var)
     if (var->getName() == qsl("_G")) { // we never hide global
         return false;
     }
-    if (hidden.contains(shortVarName(var).join(qsl(".")))) {
+    // By identity as well as by name: a saved variable holding one of Mudlet's
+    // or a package's tables reaches it under a name of the user's own, which no
+    // name-keyed lookup matches, and a profile save would then write out that
+    // table's contents (#9769).
+    if (var->pValue && hiddenTables.contains(var->pValue)) {
         return true;
     }
-    return hiddenByUser.contains(shortVarName(var).join(qsl(".")));
+    const QString fullName = shortVarName(var).join(qsl("."));
+    if (hidden.contains(fullName)) {
+        return true;
+    }
+    return hiddenByUser.contains(fullName);
+}
+
+// Thrown away at the start of every hiding walk, which is the only thing that
+// fills it: a Lua table's address is only an identity while that table is alive,
+// and Lua hands a freed one's address straight back out to the next table.
+void VarUnit::clearHiddenTables()
+{
+    hiddenTables.clear();
+    mHiddenTableByName.clear();
+}
+
+// Only tables are worth an identity: nothing else has contents for a saved
+// variable to drag into a profile save by holding it.
+void VarUnit::rememberHiddenTable(TVar* var, const QString& fullName)
+{
+    if (var->getValueType() != LUA_TTABLE || !var->pValue) {
+        return;
+    }
+    mHiddenTableByName.insert(fullName, var->pValue);
+    hiddenTables.insert(var->pValue);
+}
+
+void VarUnit::forgetHiddenTable(const QString& fullName)
+{
+    const auto it = mHiddenTableByName.constFind(fullName);
+    if (it == mHiddenTableByName.constEnd()) {
+        return;
+    }
+    hiddenTables.remove(it.value());
+    mHiddenTableByName.erase(it);
 }
 
 
@@ -259,21 +297,23 @@ QStringList VarUnit::shortVarName(TVar* var)
 
 void VarUnit::addVariable(TVar* var)
 {
-    const QString fullName = varName(var).join(qsl("."));
-    // pointers.insert(var->pointer);
-    variableSet.insert(fullName);
+    variableSet.insert(varName(var).join(qsl(".")));
     if (var->hidden) {
-        hidden.insert(shortVarName(var).join(qsl(".")));
+        const QString shortName = shortVarName(var).join(qsl("."));
+        hidden.insert(shortName);
+        rememberHiddenTable(var, shortName);
     }
 }
 
 void VarUnit::addHidden(TVar* var, int user)
 {
     var->hidden = true;
+    const QString shortName = shortVarName(var).join(qsl("."));
     if (user) {
-        hiddenByUser.insert(shortVarName(var).join(qsl(".")));
+        hiddenByUser.insert(shortName);
     } else {
-        hidden.insert(shortVarName(var).join(qsl(".")));
+        hidden.insert(shortName);
+        rememberHiddenTable(var, shortName);
     }
 }
 
@@ -287,6 +327,7 @@ void VarUnit::removeHidden(TVar* var)
     const QString fullName = shortVarName(var).join(qsl("."));
     hidden.remove(fullName);
     hiddenByUser.remove(fullName);
+    forgetHiddenTable(fullName);
     var->hidden = false;
 }
 
@@ -294,6 +335,7 @@ void VarUnit::removeHidden(const QString& name)
 {
     hidden.remove(name);
     hiddenByUser.remove(name);
+    forgetHiddenTable(name);
     // does not remove the reference from TVar, similar to addHidden()
 }
 

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 #include <QCoreApplication>
+#include <QHash>
 #include <QMap>
 #include <QSet>
 #include <QStringList>
@@ -71,13 +72,23 @@ public:
     bool isSaved(TVar*);
     void addPointer(const void*);
     void clearPointers();
+    void clearHiddenTables();
     QString getUnsaveableReason(TVar*);
     QSet<QString> hidden;
     QSet<QString> hiddenByUser;
+    // The identity half of `hidden`: the Lua tables behind those names, so that
+    // one of them reached under a name of the user's own is still recognised.
+    // Only good for as long as those tables live, hence clearHiddenTables() -
+    // and it travels with the private name map, so assigning it alone (as a
+    // save-time copy does, which never un-hides anything) leaves un-hiding a
+    // no-op on the copy.
+    QSet<const void*> hiddenTables;
     QSet<QString> savedVars;
 
 private:
     int countTableItems(TVar*);
+    void rememberHiddenTable(TVar*, const QString& fullName);
+    void forgetHiddenTable(const QString& fullName);
     std::unique_ptr<TVar> base;
     QSet<QString> variableSet;
     // ?? variables
@@ -85,6 +96,8 @@ private:
     // temporary variables
     QMap<QTreeWidgetItem*, TVar*> tVars;
     QSet<const void*> mPointers;
+    // what un-hiding a name has to hand back to hiddenTables
+    QHash<QString, const void*> mHiddenTableByName;
 };
 
 #endif // MUDLET_VARUNIT_H

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -78,10 +78,16 @@ public:
     QSet<QString> hiddenByUser;
     // The identity half of `hidden`: the Lua tables behind those names, so that
     // one of them reached under a name of the user's own is still recognised.
-    // Only good for as long as those tables live, hence clearHiddenTables() -
-    // and it travels with the private name map, so assigning it alone (as a
-    // save-time copy does, which never un-hides anything) leaves un-hiding a
-    // no-op on the copy.
+    // An address is only an identity while that table is alive, and Lua hands a
+    // collected one's address back out, so a hidden table dropped since the last
+    // hiding walk can name a live one - which is what clearHiddenTables() bounds
+    // to a single walk. What it costs if that does happen is one ride-along
+    // member of a saved table, since a name the profile saves is checked before
+    // hiding is. Pinning each table with a registry reference would make it
+    // exact, at the price of keeping an uninstalled package's tables alive for
+    // the session.
+    // Travels with the private name map: assigning it alone (as the save-time
+    // copy does, which never un-hides anything) leaves un-hiding a no-op.
     QSet<const void*> hiddenTables;
     QSet<QString> savedVars;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -780,12 +780,13 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     LuaInterface saveTimeInterface(lI->getState());
     VarUnit* saveTimeUnit = saveTimeInterface.getVarUnit();
     // A fresh tree carries no per-variable saved/hidden flags, so isSaved() and
-    // isHidden() have to answer from these name-keyed sets. savedVars has to be
-    // in place before the call below: it is what tells getSavedVars() which
-    // globals to read, so an empty one exports nothing.
+    // isHidden() have to answer from the bookkeeping the live unit holds.
+    // savedVars has to be in place before the call below: it is what tells
+    // getSavedVars() which globals to read, so an empty one exports nothing.
     saveTimeUnit->savedVars = vu->savedVars;
     saveTimeUnit->hidden = vu->hidden;
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
+    saveTimeUnit->hiddenTables = vu->hiddenTables;
     saveTimeInterface.getSavedVars();
 
     // A saved global with a value anywhere inside it that no save can carry (see
@@ -795,7 +796,8 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     // a global therefore exports only the members registered in savedVars, which
     // for a table registered while it was empty is an empty group: the state the
     // "it is empty, so rebuild it" guard packages carry needs to see (#9857).
-    // Only the value type counts. A member dropped for its size, for being a
+    // The same fence goes up around a global the walk died inside, which was
+    // not read to the end either. A member dropped for its size, for being a
     // second name for a table already written, or for being hidden still rides
     // along with its siblings, because those are limits on how much of a table
     // to write rather than on what a table can hold, and fencing the whole
@@ -805,10 +807,18 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
         QListIterator<TVar*> itVariable(base->getChildren(false));
         while (itVariable.hasNext()) {
             TVar* pVariable = itVariable.next();
-            writeVariable(pVariable, &saveTimeInterface, saveTimeUnit, variablePackage, false, !unsaveableRoots.contains(pVariable->getName()));
+            writeVariable(pVariable, saveTimeUnit, variablePackage, false, !unsaveableRoots.contains(pVariable->getName()));
         }
     }
     saveTimeInterface.releaseVariableReferences();
+
+    const QStringList unreadableRoots = saveTimeInterface.unreadableSavedRoots();
+    if (!unreadableRoots.isEmpty()) {
+        //: %1 is a comma separated list of Lua variable names
+        pHost->postMessage(tr("[ ALERT ] - Lua could not be read while these saved variables were being saved, so this save leaves them out: %1. "
+                              "Everything else in the profile was saved. An earlier save that still has them is under 'Connect - Options - Profile history'.")
+                                   .arg(unreadableRoots.join(qsl(", "))));
+    }
 
     const QStringList truncatedTables = saveTimeInterface.truncatedSavedTables();
     if (!truncatedTables.isEmpty()) {
@@ -895,7 +905,25 @@ void XMLexport::writeTriggerPackage(const Host* pHost, pugi::xml_node& mudletPac
     }
 }
 
-void XMLexport::writeVariable(TVar* pVar, LuaInterface* pLuaInterface, VarUnit* pVariableUnit, pugi::xml_node xmlParent, bool insideSavedTable, bool rideAlongAllowed)
+// The value the walk that built this node read out of Lua, rather than a second
+// read of it: LuaInterface::getValue() answers an empty string for a variable it
+// cannot read, which is also a value a variable can genuinely have, so a read
+// that fails here would blank the variable in the save with nothing to show for
+// it (#9769). Only these three types carry a value into the XML - a table's
+// members are written as its child nodes, and no other type survives a save.
+static QString exportedValue(const TVar* pVar)
+{
+    switch (pVar->getValueType()) {
+    case LUA_TSTRING:
+    case LUA_TNUMBER:
+    case LUA_TBOOLEAN:
+        return pVar->getValue();
+    default:
+        return {};
+    }
+}
+
+void XMLexport::writeVariable(TVar* pVar, VarUnit* pVariableUnit, pugi::xml_node xmlParent, bool insideSavedTable, bool rideAlongAllowed)
 {
     // a member of a saved table is saved with it even without its own
     // savedVars entry: a missing entry cannot be told apart from a member a
@@ -912,19 +940,19 @@ void XMLexport::writeVariable(TVar* pVar, LuaInterface* pLuaInterface, VarUnit* 
 
             variableGroup.append_child("name").text().set(pVar->getName().toUtf8().constData());
             variableGroup.append_child("keyType").text().set(QString::number(pVar->getKeyType()).toUtf8().constData());
-            variableGroup.append_child("value").text().set(pLuaInterface->getValue(pVar).toUtf8().constData());
+            variableGroup.append_child("value").text().set(exportedValue(pVar).toUtf8().constData());
             variableGroup.append_child("valueType").text().set(QString::number(pVar->getValueType()).toUtf8().constData());
 
             QListIterator<TVar*> itNestedVariable(pVar->getChildren(false));
             while (itNestedVariable.hasNext()) {
-                writeVariable(itNestedVariable.next(), pLuaInterface, pVariableUnit, variableGroup, true, rideAlongAllowed);
+                writeVariable(itNestedVariable.next(), pVariableUnit, variableGroup, true, rideAlongAllowed);
             }
         } else {
             auto variable = xmlParent.append_child("Variable");
 
             variable.append_child("name").text().set(pVar->getName().toUtf8().constData());
             variable.append_child("keyType").text().set(QString::number(pVar->getKeyType()).toUtf8().constData());
-            variable.append_child("value").text().set(pLuaInterface->getValue(pVar).toUtf8().constData());
+            variable.append_child("value").text().set(exportedValue(pVar).toUtf8().constData());
             variable.append_child("valueType").text().set(QString::number(pVar->getValueType()).toUtf8().constData());
         }
     }

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -34,7 +34,6 @@
 
 class QFile;
 class Host;
-class LuaInterface;
 class TAction;
 class TAlias;
 class TKey;
@@ -65,7 +64,7 @@ public:
     void writeAction(TAction*, pugi::xml_node xmlParent);
     void writeScript(TScript*, pugi::xml_node xmlParent);
     void writeKey(TKey*, pugi::xml_node xmlParent);
-    void writeVariable(TVar*, LuaInterface*, VarUnit*, pugi::xml_node xmlParent, bool insideSavedTable = false, bool rideAlongAllowed = true);
+    void writeVariable(TVar*, VarUnit*, pugi::xml_node xmlParent, bool insideSavedTable = false, bool rideAlongAllowed = true);
     void writeModuleXML(const QString& moduleName);
     std::shared_ptr<pugi::xml_document> takeExportDocument();
     static bool saveXmlDocToFile(const QString& fileName, const pugi::xml_document& doc);

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -20,8 +20,12 @@
 #include <LuaInterface.h>
 #include <TVar.h>
 #include <VarUnit.h>
+#include <utils.h>
 #include <QtTest/QtTest>
 
+#include <QRegularExpression>
+
+#include <cstdlib>
 #include <memory>
 
 extern "C" {
@@ -34,6 +38,28 @@ extern "C" {
 #include <lua.h>
 #include <lualib.h>
 #endif
+}
+
+// A Lua allocator that can be told to fail one allocation. Lua turns that into
+// the panic an out-of-memory raises, which is how a test written in C++ can stop
+// the variable walk part way through without the walk knowing it is a test.
+struct AllocationBudget
+{
+    qint64 allocations = 0;
+    qint64 failAt = -1;
+};
+
+static void* budgetedAllocator(void* userData, void* pointer, size_t /*oldSize*/, size_t newSize)
+{
+    auto* budget = static_cast<AllocationBudget*>(userData);
+    if (!newSize) {
+        free(pointer);
+        return nullptr;
+    }
+    if (++budget->allocations == budget->failAt) {
+        return nullptr;
+    }
+    return realloc(pointer, newSize);
 }
 
 
@@ -89,6 +115,149 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QCOMPARE(testVar->getName(), "test");
         QCOMPARE(testVar->getValue(), "1");
         QCOMPARE(testVar->getValueType(), LUA_TNUMBER);
+    }
+
+    // getValue() walks down to the variable a push at a time, so a variable it
+    // cannot reach leaves those pushes on the Lua stack of the profile's live
+    // interpreter, where every trigger, alias and timer is then charged for them.
+    void testGetValueOnAVariableThatIsGoneLeavesTheStackAsItFoundIt()
+    {
+        execLua("goneVar = 'here for now'");
+        interface->getVars(false);
+        TVar* goneVar = interface->getVarUnit()->getBase()->getChildren().first();
+        QCOMPARE(goneVar->getName(), "goneVar");
+        execLua("goneVar = nil");
+
+        const int stackBefore = lua_gettop(L);
+        for (int i = 0; i < 10; ++i) {
+            QCOMPARE(interface->getValue(goneVar), QString());
+        }
+        QCOMPARE(lua_gettop(L), stackBefore);
+    }
+
+    // ...and the same for the descent into a table, which pushes once per level
+    // and so leaves more behind the deeper the variable sits.
+    void testGetValueOnAMemberThatIsGoneLeavesTheStackAsItFoundIt()
+    {
+        execLua("goneTable = {inner = {member = 'here for now'}}");
+        interface->getVars(false);
+        TVar* goneTable = interface->getVarUnit()->getBase()->getChildren().first();
+        QCOMPARE(goneTable->getName(), "goneTable");
+        TVar* innerTable = goneTable->getChildren().first();
+        QCOMPARE(innerTable->getName(), "inner");
+        TVar* member = innerTable->getChildren().first();
+        QCOMPARE(member->getName(), "member");
+        execLua("goneTable.inner = nil");
+
+        const int stackBefore = lua_gettop(L);
+        for (int i = 0; i < 10; ++i) {
+            QCOMPARE(interface->getValue(member), QString());
+        }
+        QCOMPARE(lua_gettop(L), stackBefore);
+    }
+
+    // Which of the two pointers a variable node carries is which: the value's,
+    // which is what identity-based hiding matches on, and the key's.
+    void testVariableNodesCarryTheirValuesIdentity()
+    {
+        execLua("identityTable = {} aliasOfIdentityTable = identityTable");
+        // both, or the walk keeps only the name that reached the table first
+        interface->getVarUnit()->savedVars.insert(qsl("identityTable"));
+        interface->getVarUnit()->savedVars.insert(qsl("aliasOfIdentityTable"));
+        interface->getVars(false);
+
+        const QList<TVar*> globals = interface->getVarUnit()->getBase()->getChildren();
+        QCOMPARE(globals.size(), 2);
+        QVERIFY2(globals.at(0)->pValue == globals.at(1)->pValue, "two globals holding one table must carry that table as their value identity");
+        QVERIFY2(globals.at(0)->pValue, "a table has an address, so a node holding one has a value identity");
+        // lua_topointer() has none to give for a string, which is what a global's key is
+        QVERIFY2(!globals.at(0)->pKey, "a string-keyed node has no key identity");
+    }
+
+    // A Lua panic while the saved variables are being read cannot be resumed
+    // from, so the walk has to go round again without the global it died inside.
+    // Ending the walk there instead leaves a profile save holding the saved
+    // globals it had reached and quietly short of the rest.
+    void testAPanicInOneSavedGlobalStillLeavesTheOthersInTheTree()
+    {
+        // Six globals of number-keyed members, each key unique across the lot:
+        // naming one costs a fresh Lua string, and those are the allocations the
+        // failure below is aimed at, so it lands inside a global rather than
+        // between two of them.
+        const char* buildSavedGlobals = "for i = 1, 6 do "
+                                        "  local t = {} "
+                                        "  for j = 1, 60 do t[i * 1000 + j] = 'saved value ' .. i end "
+                                        "  _G['savedRoot' .. i] = t "
+                                        "end";
+
+        AllocationBudget budget;
+        lua_State* countingState = lua_newstate(&budgetedAllocator, &budget);
+        QVERIFY(countingState);
+        qint64 walkAllocations = 0;
+        {
+            luaL_openlibs(countingState);
+            LuaInterface countingInterface(countingState);
+            QCOMPARE(luaL_dostring(countingState, buildSavedGlobals), 0);
+            markSavedRoots(countingInterface);
+
+            const qint64 before = budget.allocations;
+            countingInterface.getSavedVars();
+            walkAllocations = budget.allocations - before;
+
+            QVERIFY2(countingInterface.unreadableSavedRoots().isEmpty(), "the walk with nothing failing must read every saved global");
+            QCOMPARE(savedRootsRead(countingInterface), 6);
+            QVERIFY2(walkAllocations > 100, "the walk is supposed to name a few hundred number keys, each of which costs an allocation");
+            countingInterface.releaseVariableReferences();
+        }
+        lua_close(countingState);
+
+        AllocationBudget failingBudget;
+        lua_State* failingState = lua_newstate(&budgetedAllocator, &failingBudget);
+        QVERIFY(failingState);
+        {
+            luaL_openlibs(failingState);
+            LuaInterface failingInterface(failingState);
+            QCOMPARE(luaL_dostring(failingState, buildSavedGlobals), 0);
+            markSavedRoots(failingInterface);
+
+            // half way through the walk: far enough in to be inside a global,
+            // far enough from the end that giving up there loses several more
+            failingBudget.failAt = failingBudget.allocations + walkAllocations / 2;
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("Lua panicked")));
+            failingInterface.getSavedVars();
+
+            // every saved global is either in the tree or named as missing from
+            // it - which of the six the failure lands in is Lua's business
+            const QStringList unreadable = failingInterface.unreadableSavedRoots();
+            QVERIFY2(!unreadable.isEmpty(), "a walk a panic cut short has to say what the save will be short of");
+            QCOMPARE(savedRootsRead(failingInterface), 6 - unreadable.size());
+            const QList<TVar*> readRoots = failingInterface.getVarUnit()->getBase()->getChildren(false);
+            for (TVar* root : readRoots) {
+                QVERIFY2(!unreadable.contains(root->getName()), "a global in the tree must not also be reported as missing from it");
+                QCOMPARE(root->getChildren(false).size(), 60);
+            }
+
+            // the saved-globals-only filter must not outlive the failed walk
+            // either, or the Variables view shows almost nothing afterwards
+            failingInterface.getVars(false);
+            QVERIFY2(savedRootsRead(failingInterface) > 6, "a getVars() after a panicked getSavedVars() must go back to reading the whole of _G");
+            failingInterface.releaseVariableReferences();
+        }
+        lua_close(failingState);
+    }
+
+private:
+    static void markSavedRoots(LuaInterface& luaInterface)
+    {
+        for (int i = 1; i <= 6; ++i) {
+            luaInterface.getVarUnit()->savedVars.insert(qsl("savedRoot%1").arg(i));
+        }
+    }
+
+    static int savedRootsRead(LuaInterface& luaInterface)
+    {
+        TVar* base = luaInterface.getVarUnit()->getBase();
+        return base ? base->getChildren(false).size() : 0;
     }
 };
 

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -29,7 +29,9 @@
  * Also covers a saved table that other globals reference, which must export in
  * full under every saved name that reaches it (issue #9755), and the boundary of
  * the fence that stops a table holding a function exporting in part (issue
- * #9857) - SavedVariableFenceTest covers that one in full.
+ * #9857) - SavedVariableFenceTest covers that one in full. Then the two halves
+ * of issue #9769 a save can show: a value the export cannot read a second time,
+ * and a saved table holding one of Mudlet's own.
  *
  * Run with: ctest -R XMLexportVariablesTest -V
  */
@@ -720,6 +722,96 @@ private slots:
         QCOMPARE(luaL_dostring(L, "deeplyNestedSavedTable = nil"), 0);
     }
 
+    // The walk names a number-keyed member by converting the key to text, and
+    // %.14g does not name every double exactly, so looking such a member up
+    // again by that name finds nothing. A member must be saved with the value
+    // the walk read rather than with what a second read makes of it: an empty
+    // value is one a member can genuinely have (#9769).
+    void test_memberWithAnImpreciseNumberKeyIsNotExportedBlank()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "impreciseKeyTable = {} impreciseKeyTable[1/3] = 'imprecise member value'"), 0);
+        vu->savedVars.insert(qsl("impreciseKeyTable"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("impreciseKeyTable")), "the saved table itself must be exported");
+        QVERIFY2(xml.contains(qsl("imprecise member value")), "a member the export cannot look up again must still be saved with the value the walk read");
+
+        vu->savedVars.remove(qsl("impreciseKeyTable"));
+        QCOMPARE(luaL_dostring(L, "impreciseKeyTable = nil"), 0);
+    }
+
+    // Mudlet's own tables are hidden by name at profile load, so a saved table
+    // holding one of them reaches it under a name of the user's own that
+    // nothing has hidden. Recognising it has to be by identity, or the whole of
+    // Mudlet's table goes into the profile save behind it (#9769).
+    void test_savedTableHoldingAHiddenTableDoesNotExportItsContents()
+    {
+        QVERIFY2(!mpEditor, "this test rebuilds the shared variable tree, so it must run before the Variables-view tests");
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "internalApiTable = {internalField = 'internal field value'}"), 0);
+
+        const QSet<QString> hiddenBefore = vu->hidden;
+        const QSet<const void*> hiddenTablesBefore = vu->hiddenTables;
+        // the hiding half of what Host::hideMudletsVariables() does at profile
+        // load: everything in _G at that moment is Mudlet's or a package's
+        lI->getVars(true);
+
+        QCOMPARE(luaL_dostring(L, "apiHolderTable = {plainMember = 'plain member value', api = internalApiTable}"), 0);
+        vu->savedVars.insert(qsl("apiHolderTable"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("plain member value")), "a plain member of a saved table must be exported");
+        QVERIFY2(!xml.contains(qsl("internal field value")), "a saved table holding a hidden table must not export that table's contents");
+
+        vu->savedVars.remove(qsl("apiHolderTable"));
+        vu->hidden = hiddenBefore;
+        vu->hiddenTables = hiddenTablesBefore;
+        QCOMPARE(luaL_dostring(L, "apiHolderTable, internalApiTable = nil"), 0);
+    }
+
+    // The other side of that: profile load hides every table in _G, the user's
+    // own included, and then un-hides the ones the profile saves. Un-hiding has
+    // to give a table its identity back as well as its name, or a saved table
+    // that another one holds stops being written out with it.
+    void test_unhiddenSavedTableStillRidesAlongInsideAnotherSavedTable()
+    {
+        QVERIFY2(!mpEditor, "this test rebuilds the shared variable tree, so it must run before the Variables-view tests");
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "unhiddenInnerTable = {member = 'unhidden member value'}"), 0);
+        // both names, as a restored profile has them: XMLimport registers every
+        // variable it reads back, members included
+        vu->savedVars.insert(qsl("unhiddenInnerTable"));
+        vu->savedVars.insert(qsl("unhiddenInnerTable.member"));
+
+        const QSet<QString> hiddenBefore = vu->hidden;
+        const QSet<const void*> hiddenTablesBefore = vu->hiddenTables;
+        mpHost->hideMudletsVariables();
+
+        // the holder comes after the hiding, as a package's would when it runs
+        QCOMPARE(luaL_dostring(L, "unhiddenHolderTable = {inner = unhiddenInnerTable}"), 0);
+        vu->savedVars.insert(qsl("unhiddenHolderTable"));
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QCOMPARE(xml.count(qsl("unhidden member value")), 2);
+
+        vu->savedVars.remove(qsl("unhiddenInnerTable"));
+        vu->savedVars.remove(qsl("unhiddenInnerTable.member"));
+        vu->savedVars.remove(qsl("unhiddenHolderTable"));
+        vu->hidden = hiddenBefore;
+        vu->hiddenTables = hiddenTablesBefore;
+        QCOMPARE(luaL_dostring(L, "unhiddenHolderTable, unhiddenInnerTable = nil"), 0);
+    }
+
     // A script adds to a saved table while the editor sits on the Variables
     // view. A session's last save is taken with whatever view was left on
     // screen, so quitting from there is enough to reach this.
@@ -742,8 +834,8 @@ private slots:
         const QString xml = exportProfileXml();
         QVERIFY(!xml.isEmpty());
         QVERIFY2(xml.contains(qsl("late member value")), "a member added while the Variables view was open must still be saved");
-        // secondary: writeVariable() re-reads values from Lua, so a stale tree
-        // writes this one out empty rather than with its old value
+        // secondary: the save reads a fresh tree, so a member that is gone by
+        // then has no node in it to be written from
         QVERIFY2(!xml.contains(qsl("seed member value")), "a member a script removed while the Variables view was open must not be saved back");
 
         auto* pVariablesTree = mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_variables"));
@@ -844,6 +936,51 @@ private slots:
             vu->savedVars.remove(name);
         }
         QCOMPARE(luaL_dostring(L, "reloadSavedTable = nil"), 0);
+    }
+
+    // The session after the one test_savedTableReachedByAnotherGlobalSurvivesAReload
+    // covers. Profile load hides everything in _G once the variables are back in
+    // it, so the user's own tables go through the hiding as well, and the save
+    // that follows only holds them because loading un-hides every name the
+    // profile saves. Declared after the Variables-view tests because the hiding
+    // walk rebuilds the tree their items point into.
+    void test_savedTableSurvivesTheSaveAfterALoad()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "secondSessionTable = {member = 'second session value', nest = {deep = 'second session deep value'}}"), 0);
+        vu->savedVars.insert(qsl("secondSessionTable"));
+
+        const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/second-session-test.xml");
+        auto writer = std::make_shared<XMLexport>(mpHost);
+        QVERIFY2(writer->exportPackage(xmlPath, true, false), "the profile could not be exported");
+        QCOMPARE(luaL_dostring(L, "secondSessionTable = nil"), 0);
+
+        QFile file(xmlPath);
+        QVERIFY2(file.open(QFile::ReadOnly | QFile::Text), qPrintable(file.errorString()));
+        XMLimport importer(mpHost);
+        auto [imported, importError] = importer.importPackage(&file);
+        file.close();
+        QFile::remove(xmlPath);
+        QVERIFY2(imported, qPrintable(importError));
+
+        const QSet<QString> hiddenBefore = vu->hidden;
+        const QSet<const void*> hiddenTablesBefore = vu->hiddenTables;
+        // where profile load runs it: after the import has put the variables back
+        mpHost->hideMudletsVariables();
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("second session value")), "a saved table's member must still be in the save the session after it was loaded");
+        QVERIFY2(xml.contains(qsl("second session deep value")), "a saved table's nested member must still be in the save the session after it was loaded");
+
+        vu->hidden = hiddenBefore;
+        vu->hiddenTables = hiddenTablesBefore;
+        for (const auto& name : {qsl("secondSessionTable"), qsl("secondSessionTable.member"), qsl("secondSessionTable.nest"), qsl("secondSessionTable.nest.deep")}) {
+            vu->savedVars.remove(name);
+        }
+        QCOMPARE(luaL_dostring(L, "secondSessionTable = nil"), 0);
     }
 
 private:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- A Lua panic while the saved variables were being read ended the walk there, and the save committed whatever tree it had. The walk now drops the global it died inside, reads the rest again, and the save names in-game what it is short of.
- A value the export could not read a second time was written as an empty string, which the next load cannot tell from a variable that really is empty. The save now writes the value the walk already read - one Lua round trip per variable less, too.
- Hiding was matched by name, so a saved table holding one of Mudlet's or a package's tables exported that table's contents. Hidden tables are now matched by identity as well, so an alias of one is recognised.

#### Motivation for adding to Mudlet
Three pre-existing defects (none a 5.0 regression) that between them let a variable export come out both larger and smaller than the truth, quietly.

#### Other info (issues closed, discussion etc)
Closes #9769. Composes with #9704, #9762 and #9860 - the fence and the per-global dedup scope are untouched.

Two side effects worth knowing: `LuaInterface::getValue()` used to leave a Lua stack slot behind per failed read, on the profile's live interpreter, and no longer does; and `iterateTable()` was filling `TVar::pKey` from the value and `pValue` from the key, which only `varExists()` read and only symmetrically.

**Test case:** `lua qaHolder = {api = mudlet, mine = "kept"}`, tick `qaHolder` in the editor's Variables view, quit and reopen - `qaHolder.mine` is back and Mudlet's own table is not in the profile XML. `ctest -R 'XMLexportVariablesTest|TLuaInterfaceTest'` covers all three defects; 6 of the 8 new cases were verified to fail against the unfixed source; the other 2 guard against the fix over-reaching.

Assisted-by: Claude:claude-opus-5

Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>