### PR TITLE
fix: a script connecting while the profile is still connecting no longer leaves it connected to nothing

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -521,12 +521,27 @@ void cTelnet::sendGMCPSupportsRemove(const QString& package)
     socketOutRaw(data);
 }
 
+// Stops waiting on the name lookup in progress, if there is one. Aborting does
+// not always stop a result that is already on its way, so the id is cleared as
+// well and slot_socketHostFound() drops anything that does not match it.
+void cTelnet::abandonHostLookup()
+{
+    if (mHostLookupId != -1) {
+        QHostInfo::abortHostLookup(mHostLookupId);
+        mHostLookupId = -1;
+    }
+}
+
 void cTelnet::connectIt(const QString& address, int port)
 {
     // Set early - before the recursion-on-busy-socket block below - so the
     // QCoreApplication::processEvents() call there cannot leave the indicator
     // briefly showing Disconnected during a reconnect.
     mLookingUpHost = true;
+
+    // Done before the processEvents() below so that call cannot deliver a
+    // result for a server this one has already replaced.
+    abandonHostLookup();
 
     if (mpHost) {
         mUSE_IRE_DRIVER_BUGFIX = mpHost->mUSE_IRE_DRIVER_BUGFIX;
@@ -596,7 +611,7 @@ void cTelnet::connectIt(const QString& address, int port)
     // We can now use a compile-time slot for this as:
     // https://bugreports.qt.io/browse/QTBUG-67646 was (finally) fixed in
     // Qt 5.12.5:
-    QHostInfo::lookupHost(address, this, &cTelnet::slot_socketHostFound);
+    mHostLookupId = QHostInfo::lookupHost(address, this, &cTelnet::slot_socketHostFound);
 }
 
 void cTelnet::reconnect()
@@ -614,6 +629,10 @@ void cTelnet::disconnectIt()
 {
     mDontReconnect = true;
     mLookingUpHost = false;
+    // There is no socket yet while the name lookup is outstanding, so without
+    // this a Disconnect during the lookup is followed by the connection being
+    // made anyway when the result arrives.
+    abandonHostLookup();
     if (mpSocket) {
         // This will write out any pending data before it disconnects...
         mpSocket->disconnectFromHost();
@@ -628,6 +647,7 @@ void cTelnet::abortConnection()
     // lingering until the (asynchronous) disconnect signal arrives.
     mLookingUpHost = false;
     mDontReconnect = true;
+    abandonHostLookup();
     if (mpSocket) {
         // One socket is probably active - and has signals connected - but will
         // close immediately, dropping any pending output:
@@ -1010,7 +1030,23 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 #if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
     qDebug().noquote() << "cTelnet::slot_socketHostFound(QHostInfo) INFO - called.";
 #endif
+    // A result for a connect that has been replaced or called off: its address
+    // belongs with a port that has already been overwritten, so acting on it
+    // would dial the old host on the new port and leave the wanted connection
+    // unmade. mLookingUpHost is deliberately left alone - the lookup that is
+    // being waited on is still outstanding.
+    if (hostInfo.lookupId() != mHostLookupId) {
+#if defined(DEBUG_TELNET) && (DEBUG_TELNET & 4)
+        qDebug().noquote().nospace() << "cTelnet::slot_socketHostFound(QHostInfo) INFO - ignoring the result of lookup " << hostInfo.lookupId() << " for \"" << hostInfo.hostName()
+                                     << "\", waiting on lookup " << mHostLookupId << ".";
+#endif
+        return;
+    }
+    mHostLookupId = -1;
     mLookingUpHost = false;
+    if (!mpHost || mpHost->isClosingDown()) {
+        return;
+    }
     QStringList addressList_ipV4;
     QStringList addressList_ipV6;
     for (const QHostAddress& address : hostInfo.addresses()) {

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -350,6 +350,8 @@ private:
     void abortLosingSocket(QSslSocket* losingSocket);
 #endif
 
+    void abandonHostLookup();
+
     // loopbackTesting is for internal testing whilst OFF-LINE using the
     // feedTelnet(...) Lua function.
     void processSocketData(char* data, int size, const bool loopbackTesting = false);
@@ -460,6 +462,10 @@ private:
     // True between connectIt() and slot_socketHostFound, so
     // getConnectionState() reports HostLookupState during DNS lookup.
     bool mLookingUpHost = false;
+    // The lookup connectIt() is waiting on, or -1. mHostUrl and mHostPort move
+    // on with every connectIt(), so a callback from a lookup a later call
+    // superseded would pair its own host name with the newer port.
+    int mHostLookupId = -1;
     int mLoopbackProcessingDepth = 0;
     std::queue<int> mCommandQueue;
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(FUNCTIONAL_TEST_SOURCES
     StarterUiSectionsTest.cpp
     TtsInterruptingSpeakTest.cpp
     UndoServerWrapTest.cpp
+    TelnetConnectLookupRaceTest.cpp
     NarrowWindowWrapTest.cpp
     HostWidgetDecouplingTest.cpp
     ActionSelfRemovalTest.cpp
@@ -193,6 +194,10 @@ set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 # TelnetReconnectStateTest creates a fresh profile per test method and reconnects it several
 # times per method, so it needs a longer timeout
 set_tests_properties(TelnetReconnectStateTest PROPERTIES TIMEOUT 300)
+
+# TelnetConnectLookupRaceTest creates a fresh profile per test method and waits out a connect to
+# an address nothing answers on, so it needs a longer timeout
+set_tests_properties(TelnetConnectLookupRaceTest PROPERTIES TIMEOUT 300)
 
 # GlyphOverflowTest creates a fresh profile per test method and sweeps two font
 # families across 22 sizes, so it needs a longer timeout

--- a/test/functional_tests/TelnetConnectLookupRaceTest.cpp
+++ b/test/functional_tests/TelnetConnectLookupRaceTest.cpp
@@ -1,0 +1,328 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// A connect starts with an asynchronous name lookup, and the server it is for lives in members
+// that the next connect overwrites. These drive a second connect in while the first one's lookup
+// is still outstanding - what a script calling connectToServer() during the profile's own connect
+// does - and assert that the connection lands on the server that was asked for last.
+
+#include <QtTest/QtTest>
+#include <QtNetwork/QTcpServer>
+#include <QtNetwork/QHostInfo>
+#include <QtNetwork/QTcpSocket>
+#include <limits>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+static void initializeQRCResources();
+
+// A game that says nothing and only counts who reaches it. Bound to 127.0.0.1 by name rather
+// than to every interface, so the test can name a loopback address that is not this one and know
+// that nothing there will answer.
+class ConnectionCountingServer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ConnectionCountingServer(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        connect(&mServer, &QTcpServer::newConnection, this, &ConnectionCountingServer::onNewConnection);
+    }
+
+    // Ephemeral port so parallel worktree runs never collide.
+    bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    quint16 serverPort() const { return mServer.serverPort(); }
+    int connectionCount() const { return mConnectionCount; }
+
+private slots:
+    void onNewConnection()
+    {
+        auto* client = mServer.nextPendingConnection();
+        if (!client) {
+            return;
+        }
+        ++mConnectionCount;
+        connect(client, &QTcpSocket::disconnected, client, &QObject::deleteLater);
+    }
+
+private:
+    QTcpServer mServer;
+    int mConnectionCount = 0;
+};
+
+class TelnetConnectLookupRaceTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    ConnectionCountingServer* mpServer = nullptr;
+    const QString mHostname = qsl("Test-TelnetConnectLookupRace");
+    const QString mLocalhost = qsl("localhost");
+    // A loopback address the stub is not listening on. Naming it rather than 127.0.0.1 is what
+    // makes a connect meant for it distinguishable from one meant for the stub; whether the
+    // platform can route to it does not matter, because either way nothing answers there.
+    const QString mOtherLoopback = qsl("127.0.0.2");
+    // TEST-NET-1, reserved for documentation and so routed nowhere. A connect aimed here hangs in
+    // ConnectingState rather than being refused, which is what makes acting on a lookup nobody is
+    // waiting on tell against a build that does act on it.
+    const QString mBlackhole = qsl("192.0.2.1");
+    quint16 mPort = 0;
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mpServer = new ConnectionCountingServer(qApp);
+        QVERIFY2(mpServer->start(), "ConnectionCountingServer failed to bind a loopback port");
+        mPort = mpServer->serverPort();
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    // The event a superseded connect leaves behind: its lookup is answered after a later connect
+    // has moved the server on, so it names a host nobody asked for any more while the port beside
+    // it has already changed. Acted on, it dials that pairing and the connect that was actually
+    // wanted is refused for a socket that is already busy. Injected rather than raced for, since
+    // which of two outstanding lookups is answered first is up to the resolver.
+    void test_aLookupASecondConnectSupersededIsNotActedOn()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(disconnectProfile(host));
+
+        QVERIFY2(waitForConnection(host,
+                                   [&]() {
+                                       host->mTelnet.connectIt(mLocalhost, mPort);
+                                       host->mTelnet.slot_socketHostFound(supersededLookup());
+                                   }),
+                 "a lookup left over from a superseded connect took the connection with it");
+        // The drop deliberately leaves the "still looking up" flag alone, which the tab's
+        // connection indicator reads, so it has to have been cleared by the wanted result.
+        QCOMPARE(host->mTelnet.getConnectionState(), QAbstractSocket::ConnectedState);
+    }
+
+    // The same result arriving when there is no connect outstanding at all. Nothing is waiting on
+    // it, so acting on it would dial a game the profile has finished with.
+    void test_aLookupThatOutlivesTheConnectEntirelyIsNotActedOn()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(disconnectProfile(host));
+
+        const int before = mpServer->connectionCount();
+        host->mTelnet.slot_socketHostFound(supersededLookup());
+        QTest::qWait(2000);
+        QCOMPARE(mpServer->connectionCount(), before);
+        QCOMPARE(host->mTelnet.getConnectionState(), QAbstractSocket::UnconnectedState);
+    }
+
+    // Disconnecting while the name lookup is outstanding has no socket to close, so the result
+    // arriving afterwards is the only thing left that could still make the connection.
+    void test_disconnectingDuringTheLookupCallsTheConnectOff()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(disconnectProfile(host));
+
+        const int before = mpServer->connectionCount();
+        host->mTelnet.connectIt(mLocalhost, mPort);
+        host->mTelnet.disconnectIt();
+        QTest::qWait(2000);
+        QCOMPARE(mpServer->connectionCount(), before);
+    }
+
+    // Two connects in one turn of the event loop leave two lookups outstanding at once, which is
+    // what a script calling connectToServer() during the profile's own connect does.
+    void test_aSecondConnectDuringTheFirstsLookupStillConnects()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(disconnectProfile(host));
+
+        QVERIFY2(waitForConnection(host,
+                                   [&]() {
+                                       host->mTelnet.connectIt(mOtherLoopback, mPort);
+                                       host->mTelnet.connectIt(mLocalhost, mPort);
+                                   }),
+                 "the connect issued while the first lookup was outstanding never reached the game");
+    }
+
+    // The guard that drops the superseded lookup must not be left standing, or the connect after
+    // it is dropped as well and the profile can never connect again.
+    void test_anOrdinaryConnectStillWorksAfterASupersededOne()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(disconnectProfile(host));
+
+        QVERIFY2(waitForConnection(host,
+                                   [&]() {
+                                       host->mTelnet.connectIt(mOtherLoopback, mPort);
+                                       host->mTelnet.connectIt(mLocalhost, mPort);
+                                   }),
+                 "the racing pair never connected, so this proves nothing about what follows");
+
+        QVERIFY(disconnectProfile(host));
+        QVERIFY2(waitForConnection(host,
+                                   [&]() {
+                                       host->mTelnet.connectIt(mLocalhost, mPort);
+                                   }),
+                 "a plain connect after a superseded lookup never reached the game");
+    }
+
+private:
+    // What the resolver hands back for a connect that a later one has replaced: a good answer,
+    // for the wrong server, carrying the id of a lookup nobody is waiting on any more.
+    QHostInfo supersededLookup() const
+    {
+        QHostInfo lookup;
+        lookup.setLookupId(std::numeric_limits<int>::max());
+        lookup.setHostName(mBlackhole);
+        lookup.setAddresses({QHostAddress(mBlackhole)});
+        return lookup;
+    }
+
+    // Answers rather than asserting: a QVERIFY here would only return from this helper, leaving
+    // the test slot to run on and bury the real failure under timeouts.
+    [[nodiscard]] bool disconnectProfile(Host* host)
+    {
+        QSignalSpy disconnected(&host->mTelnet, &cTelnet::signal_disconnected);
+        host->mTelnet.disconnectIt();
+        const bool done = QTest::qWaitFor(
+                [&]() {
+                    return !disconnected.isEmpty();
+                },
+                8000);
+        if (!done) {
+            qWarning("the profile never disconnected from the stub");
+        }
+        return done;
+    }
+
+    // Both ends have to agree the connection is up: asking Mudlet about one it has not made yet
+    // gets answers that are about not being connected.
+    [[nodiscard]] bool waitForConnection(Host* host, const std::function<void()>& connectAction = {})
+    {
+        const int before = mpServer->connectionCount();
+        QSignalSpy connected(&host->mTelnet, &cTelnet::signal_connected);
+        if (connectAction) {
+            connectAction();
+        }
+        const bool made = QTest::qWaitFor(
+                [&]() {
+                    return mpServer->connectionCount() > before && !connected.isEmpty();
+                },
+                15000);
+        if (!made) {
+            qWarning("the profile did not connect to the stub");
+        }
+        return made;
+    }
+
+    // Mirrors the helper the other functional tests use.
+    Host* startProfile()
+    {
+        const QString port = QString::number(mPort);
+        QTimer::singleShot(0, qApp, [this, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy loaded(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!loaded.wait(5000)) {
+            qWarning("the profile took too long to load");
+            return nullptr;
+        }
+        Host* host = mudlet::self()->getActiveHost();
+        if (!host) {
+            qWarning("no active host available for the test");
+            return nullptr;
+        }
+        QSignalSpy connected(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!connected.wait(5000)) {
+            qWarning("could not connect to the stub");
+            return nullptr;
+        }
+        host->mEchoLuaErrors = true;
+        return host;
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+};
+
+static void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "TelnetConnectLookupRaceTest.moc"
+QTEST_MAIN(TelnetConnectLookupRaceTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A connect starts an asynchronous name lookup and records the server in `mHostUrl`/`mHostPort`, which the next `connectIt()` overwrites. Answered late, the superseded lookup paired **its own host name** with the **newer port** - a server that does not exist - and the connect that was actually wanted was then refused by Qt for a socket already busy on that misdial. The profile ended up connected to nothing, with nothing reported.
- The lookup in progress is now identified by its id, abandoned when a new connect replaces it, and any result that is not the one being waited on is dropped rather than acted on. Aborting alone is not enough: a result already posted cannot be unposted, so the id check is what does the work.
- `disconnectIt()` and `abortConnection()` abandon it too - there is no socket to close during the lookup, so before this a Disconnect pressed while "Looking up the details of server..." was on screen was followed by the connection being made anyway.

#### Motivation for adding to Mudlet

`connectToServer()` from a script during the profile's own connect - and a Disconnect during a slow DNS lookup - could leave the profile silently connected to nothing.

#### Other info (issues closed, discussion etc)

Closes #9889

Pre-existing, not a 5.0 regression: reproduced identically on 4.22.0 and current `development`.

**Test case:** new `TelnetConnectLookupRaceTest`, 5 test functions; 4 of them fail against unfixed source and all 5 pass with the fix, 3/3 runs. `TelnetReconnectStateTest` 10/10, `GMCPCharLoginTest` 31/31 and `TelnetSgrDefaultColorTest` 11/11 alongside it.

Assisted-by: Claude:claude-opus-5

Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>