### PR TITLE
fix: Mudlet no longer crashes when a multiline trigger's script feeds text back

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -35,6 +35,7 @@
 
 #include <cassert>
 #include <sstream>
+#include <vector>
 
 // Some extraordinary numbers outside of the range (0-255) used for ANSI colors:
 // Changing them WILL modify the Lua API of TLuaInterpreter::tempColorTrigger

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1017,58 +1017,55 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
 
         // in the case of multiline triggers: check our state
         if (mIsMultiline) {
-            int k = 0;
             conditionMet = false; //invalidate conditionMet as it has no meaning for multiline triggers
-            std::list<TMatchState*> removeList;
 
-            for (auto& matchStatePair : mConditionMap) {
-                k++;
-                if (matchStatePair.second->isComplete()) {
-                    mKeepFiring = mStayOpen;
-                    if (mudlet::smDebugMode) {
-                        TDebug(Qt::yellow, Qt::darkMagenta) << "multiline trigger name=" << mName << " *FIRES* all conditions are fulfilled. Executing script.\n" >> mpHost;
-                    }
-                    removeList.push_back(matchStatePair.first);
-                    conditionMet = true;
-                    TLuaInterpreter* pL = mpHost->getLuaInterpreter();
-                    pL->setMultiCaptureGroups(matchStatePair.second->multiCaptureList, matchStatePair.second->multiCapturePosList, matchStatePair.second->nameCaptures);
-                    execute();
-                    pL->clearCaptureGroups();
-                    if (mFilterTrigger) {
-                        std::list<std::list<std::string>> multiCaptureList;
-                        multiCaptureList = matchStatePair.second->multiCaptureList;
-                        if (!multiCaptureList.empty()) {
-                            for (auto mit = multiCaptureList.begin(); mit != multiCaptureList.end(); mit++, k++) {
-                                const int total = (*mit).size();
-                                auto its = (*mit).begin();
-                                for (int i = 1; its != (*mit).end(); ++its, i++) {
-                                    std::string s = *its;
-                                    int p = 0;
-                                    // multiline captures may come from earlier lines, so no
-                                    // single line number applies here
-                                    if (total > 1) {
-                                        if (i % total != 1) {
-                                            filter(s, p, -1);
-                                        }
-                                    } else {
-                                        filter(s, p, -1);
-                                    }
+            // A firing script can feed text back through the pipeline, which
+            // re-enters this function on the same trigger. Completed states are
+            // taken out of mConditionMap before any script runs, so a nested pass
+            // can neither fire one again nor destroy one still being read here.
+            std::vector<std::unique_ptr<TMatchState>> completedStates;
+            for (auto it = mConditionMap.begin(); it != mConditionMap.end();) {
+                if (it->second->isComplete()) {
+                    completedStates.push_back(std::move(it->second));
+                } else if (it->second->newLine()) {
+                    ++it;
+                    continue;
+                }
+                if (mudlet::smDebugMode) {
+                    TDebug(Qt::darkBlue, Qt::black) << "removing condition from condition table.\n" >> mpHost;
+                }
+                it = mConditionMap.erase(it);
+            }
+
+            for (auto& matchState : completedStates) {
+                mKeepFiring = mStayOpen;
+                if (mudlet::smDebugMode) {
+                    TDebug(Qt::yellow, Qt::darkMagenta) << "multiline trigger name=" << mName << " *FIRES* all conditions are fulfilled. Executing script.\n" >> mpHost;
+                }
+                conditionMet = true;
+                TLuaInterpreter* pL = mpHost->getLuaInterpreter();
+                pL->setMultiCaptureGroups(matchState->multiCaptureList, matchState->multiCapturePosList, matchState->nameCaptures);
+                execute();
+                pL->clearCaptureGroups();
+                if (mFilterTrigger) {
+                    const std::list<std::list<std::string>>& multiCaptureList = matchState->multiCaptureList;
+                    for (const auto& captures : multiCaptureList) {
+                        const int total = captures.size();
+                        auto its = captures.begin();
+                        for (int i = 1; its != captures.end(); ++its, i++) {
+                            std::string s = *its;
+                            int p = 0;
+                            // multiline captures may come from earlier lines, so no
+                            // single line number applies here
+                            if (total > 1) {
+                                if (i % total != 1) {
+                                    filter(s, p, -1);
                                 }
+                            } else {
+                                filter(s, p, -1);
                             }
                         }
                     }
-                }
-
-                if (!matchStatePair.second->newLine()) {
-                    removeList.push_back(matchStatePair.first);
-                }
-            }
-            for (auto& matchState : removeList) {
-                if (mConditionMap.find(matchState) != mConditionMap.end()) {
-                    if (mudlet::smDebugMode) {
-                        TDebug(Qt::darkBlue, Qt::black) << "removing condition from condition table.\n" >> mpHost;
-                    }
-                    mConditionMap.erase(matchState);
                 }
             }
         }

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TriggerEditorTest.cpp
     TFeedTriggersRecursionTest.cpp
     TriggerSameLineMatchTest.cpp
+    MultilineTriggerReentrancyTest.cpp
     dlgTriggerEditorUndoRedoTest.cpp
     EditorBannerViewSwitchTest.cpp
     TDiscordModeTest.cpp

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -184,6 +184,8 @@ set_tests_properties(dlgTriggerEditorUndoRedoTest PROPERTIES TIMEOUT 300)
 # grows the heap by ~110MB/s: the RSS ceiling and the timeout are what turn that
 # into a reported failure. ENVIRONMENT replaces the loop's, hence QT_QPA_PLATFORM
 # again, and the lost detect_leaks is why the test is in leakCheckExcludedTests.
+set_tests_properties(MultilineTriggerReentrancyTest PROPERTIES TIMEOUT 300)
+
 set_tests_properties(TriggerSameLineMatchTest PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen;ASAN_OPTIONS=detect_leaks=0:hard_rss_limit_mb=3000"
     TIMEOUT 300)

--- a/test/functional_tests/MultilineTriggerReentrancyTest.cpp
+++ b/test/functional_tests/MultilineTriggerReentrancyTest.cpp
@@ -43,9 +43,11 @@ void initializeQRCResources();
 // state. Against the unfixed code the first case here does not merely fail, it
 // takes the process down with SIGSEGV.
 //
-// tempComplexRegexTrigger() is the only Lua route to this: called twice under
-// one name it accumulates patterns into a single trigger, and it is the only
-// function that also sets the multiline flag and the condition line delta.
+// tempComplexRegexTrigger() is the only Lua function that can set the condition
+// line delta, which conditions arriving on separate lines need. The perm*Trigger
+// variants do make a multiline trigger - they pass (patterns.size() > 1) as the
+// flag - but leave the delta at 0, so their conditions must all match one line.
+// Called twice under one name it also accumulates patterns into a single trigger.
 class MultilineTriggerReentrancyTest : public QObject
 {
     Q_OBJECT
@@ -53,7 +55,7 @@ class MultilineTriggerReentrancyTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-MultilineTriggerReentrancy";
-    const QString mpPort = "4003";
+    QString mpPort; // assigned the stub's actual ephemeral port in init()
     const QString mpLocalhost = "localhost";
 
 private slots:
@@ -62,7 +64,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mpServer->start(mpLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mpPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
@@ -155,7 +158,8 @@ private slots:
 
     // A state whose window closes without completing must still be dropped, so
     // the same lines arriving later start a fresh state rather than completing
-    // the stale one.
+    // the stale one. Both sides are asserted: a count of zero alone would also be
+    // what a silently broken setup produces.
     void test_expiredStateIsStillDiscarded()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -163,19 +167,23 @@ private slots:
         QVERIFY(host);
         host->mEchoLuaErrors = true;
 
-        // A delta of 0 keeps the state alive only for the line that created it,
-        // so the second condition arriving later must not complete it:
+        // A delta of 1 lets the state survive exactly one further line, so the
+        // consecutive pair completes it and the padded pair must not:
         host->getLuaInterpreter()->compileAndExecuteScript(qsl("expiredFires = 0\n"
                                                                "local code = [=[expiredFires = expiredFires + 1]=]\n"
-                                                               "tempComplexRegexTrigger('MLE', [[^first$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)\n"
-                                                               "tempComplexRegexTrigger('MLE', [[^second$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)\n"
+                                                               "tempComplexRegexTrigger('MLE', [[^first$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1)\n"
+                                                               "tempComplexRegexTrigger('MLE', [[^second$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1)\n"
+                                                               "feedTriggers('first\\n')\n"
+                                                               "feedTriggers('second\\n')\n"
+                                                               "echo('CONSECUTIVE=' .. expiredFires .. '#\\n')\n"
                                                                "feedTriggers('first\\n')\n"
                                                                "feedTriggers('padding\\n')\n"
                                                                "feedTriggers('second\\n')\n"
-                                                               "echo('EXPIRED=' .. expiredFires .. '#\\n')\n"));
+                                                               "echo('PADDED=' .. expiredFires .. '#\\n')\n"));
 
         QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
-        QVERIFY2(bufferContains(qsl("EXPIRED=0#")), "a match state outlived its line delta, so a much later line completed it");
+        QVERIFY2(bufferContains(qsl("CONSECUTIVE=1#")), "a multiline state within its line delta did not complete, so the case proves nothing about expiry");
+        QVERIFY2(bufferContains(qsl("PADDED=1#")), "a match state outlived its line delta, so a padded second condition completed it");
     }
 
     void cleanup()

--- a/test/functional_tests/MultilineTriggerReentrancyTest.cpp
+++ b/test/functional_tests/MultilineTriggerReentrancyTest.cpp
@@ -1,0 +1,268 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Jay Howard - jay.patrick.howard@gmail.com       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TriggerUnit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResources();
+
+// A multiline trigger's completed TMatchState used to stay in mConditionMap
+// while its script ran. Feeding text from that script re-enters trigger
+// processing on the same trigger, which found the state still complete, fired it
+// a second time, and erased it - leaving the outer frame reading a destroyed
+// state. Against the unfixed code the first case here does not merely fail, it
+// takes the process down with SIGSEGV.
+//
+// tempComplexRegexTrigger() is the only Lua route to this: called twice under
+// one name it accumulates patterns into a single trigger, and it is the only
+// function that also sets the multiline flag and the condition line delta.
+class MultilineTriggerReentrancyTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    const QString mpHostname = "Test-MultilineTriggerReentrancy";
+    const QString mpPort = "4003";
+    const QString mpLocalhost = "localhost";
+
+private slots:
+    void initTestCase() { initializeQRCResources(); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mpHostname);
+    }
+
+    // The completed state must fire exactly once even though its own script
+    // feeds text back through the pipeline.
+    void test_completedStateFiresOnceWhenItsScriptFeedsText()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("fireCount = 0\n"
+                                                               "fed = false\n"
+                                                               "local code = [=[\n"
+                                                               "  fireCount = fireCount + 1\n"
+                                                               "  if not fed then\n"
+                                                               "    fed = true\n"
+                                                               "    feedTriggers('zzz filler\\n')\n"
+                                                               "  end\n"
+                                                               "]=]\n"
+                                                               "tempComplexRegexTrigger('MLR', [[^alpha$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 3)\n"
+                                                               "tempComplexRegexTrigger('MLR', [[^beta$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 3)\n"
+                                                               "feedTriggers('alpha\\n')\n"
+                                                               "feedTriggers('beta\\n')\n"
+                                                               "echo('FIRECOUNT=' .. fireCount .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("FIRECOUNT=1#")), "the completed multiline state fired more than once because the nested pass could still see it in mConditionMap");
+    }
+
+    // The filter branch re-reads the state's captures after execute() has
+    // returned, so it is the second place a destroyed state was dereferenced.
+    void test_filterTriggerSurvivesANestedFeed()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("filterFires = 0\n"
+                                                               "filterFed = false\n"
+                                                               "local code = [=[\n"
+                                                               "  filterFires = filterFires + 1\n"
+                                                               "  if not filterFed then\n"
+                                                               "    filterFed = true\n"
+                                                               "    feedTriggers('zzz filler\\n')\n"
+                                                               "  end\n"
+                                                               "]=]\n"
+                                                               "tempComplexRegexTrigger('MLF', [[^gamma (\\w+)$]], code, 1, 0, 0, 1, 0, 0, 0, 0, 0, 3)\n"
+                                                               "tempComplexRegexTrigger('MLF', [[^delta (\\w+)$]], code, 1, 0, 0, 1, 0, 0, 0, 0, 0, 3)\n"
+                                                               "feedTriggers('gamma one\\n')\n"
+                                                               "feedTriggers('delta two\\n')\n"
+                                                               "echo('FILTERFIRES=' .. filterFires .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("FILTERFIRES=1#")), "a filtering multiline trigger did not fire exactly once across a nested feed");
+    }
+
+    // Guards the other direction: moving the state out of mConditionMap before
+    // the script runs must not disturb ordinary multiline matching, and the
+    // captures gathered across the earlier lines must still reach the script.
+    void test_ordinaryMultilineTriggerStillFiresWithItsCaptures()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("plainFires = 0\n"
+                                                               "caps = ''\n"
+                                                               "local code = [=[\n"
+                                                               "  plainFires = plainFires + 1\n"
+                                                               "  caps = multimatches[1][2] .. ',' .. multimatches[2][2]\n"
+                                                               "]=]\n"
+                                                               "tempComplexRegexTrigger('MLP', [[^one (\\w+)$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 3)\n"
+                                                               "tempComplexRegexTrigger('MLP', [[^two (\\w+)$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 3)\n"
+                                                               "feedTriggers('one aaa\\n')\n"
+                                                               "feedTriggers('two bbb\\n')\n"
+                                                               "echo('PLAIN=' .. plainFires .. '/' .. caps .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("PLAIN=1/aaa,bbb#")), "an ordinary multiline trigger no longer fires once with the captures from both of its lines");
+    }
+
+    // A state whose window closes without completing must still be dropped, so
+    // the same lines arriving later start a fresh state rather than completing
+    // the stale one.
+    void test_expiredStateIsStillDiscarded()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        host->mEchoLuaErrors = true;
+
+        // A delta of 0 keeps the state alive only for the line that created it,
+        // so the second condition arriving later must not complete it:
+        host->getLuaInterpreter()->compileAndExecuteScript(qsl("expiredFires = 0\n"
+                                                               "local code = [=[expiredFires = expiredFires + 1]=]\n"
+                                                               "tempComplexRegexTrigger('MLE', [[^first$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)\n"
+                                                               "tempComplexRegexTrigger('MLE', [[^second$]], code, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)\n"
+                                                               "feedTriggers('first\\n')\n"
+                                                               "feedTriggers('padding\\n')\n"
+                                                               "feedTriggers('second\\n')\n"
+                                                               "echo('EXPIRED=' .. expiredFires .. '#\\n')\n"));
+
+        QCOMPARE(host->getTriggerUnit()->processingDepth(), 0);
+        QVERIFY2(bufferContains(qsl("EXPIRED=0#")), "a match state outlived its line delta, so a much later line completed it");
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mpHostname);
+        delete mudlet::self();
+    }
+
+private:
+    // Starts a profile the way a user would via the GUI (mirrors the helper in
+    // TriggerSameLineMatchTest).
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    // Joins every physical buffer line and normalises whitespace before
+    // matching, so a needle the console word-wraps across lines is still found.
+    QString joinedBuffer()
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        QString allText;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            allText.append(console->buffer.line(i)).append(QChar::Space);
+        }
+        return allText.simplified();
+    }
+
+    bool bufferContains(const QString& needle) { return joinedBuffer().contains(needle); }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "MultilineTriggerReentrancyTest.moc"
+QTEST_MAIN(MultilineTriggerReentrancyTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A multiline trigger's completed match state stayed in `mConditionMap` while its script ran, so feeding text from that script re-entered processing on the same trigger, fired the state a second time and freed it under the outer loop. Completed states are now moved out of the map before any script runs.
- The expiry check moves into the same walk, using an explicit iterator — erasing during the old range-for invalidated it, which was the other half of the crash.
- Adds `MultilineTriggerReentrancyTest` (4 cases). Nothing in the suite fired a multiline trigger with a script before, so this was completely unguarded.

#### Motivation for adding to Mudlet

**What a player sees.** It needs a multiline trigger whose own script calls `feedTriggers()`/`feedTelnet()` — an ordinary shape, e.g. a trigger spanning a multi-line combat report or a `who` list that feeds the captured text back so sub-triggers can parse it.

- **The script's action happens twice.** Two identical commands sent to the game, two quaffs, a counter climbing by two, a sound played twice. In combat that is a wasted round.
- **Mudlet crashes**, mid-session, no warning.
- **The crash blames the wrong thing.** Reading freed memory does not reliably crash at that moment — it crashes when the heap is reused. Mudlet may die a second later while scrolling, or on the next line, or while opening a dialog. Nothing points at the trigger, so it reads as "Mudlet crashes randomly" while the real cause ran ten lines earlier.
- It can equally surface as **garbled captures** — `multimatches` holding text from the wrong line — rather than a crash, because a nested pass overwrites the Lua-side capture copies.

Nothing is logged in any of these cases, so from the outside it just looks flaky.

#### Other info (issues closed, discussion etc)

Fixes #9910

**Why this shape and not something smaller.** Erasing inside the loop before `execute()` destroys the captures that `setMultiCaptureGroups()`, the filter branch and `newLine()` still read — that trades one use-after-free for another, so ownership has to *move* rather than drop. Firing inside the same walk does not work either: a nested pass can erase the node the iterator has advanced to.

The deep copy of `multiCaptureList` in the filter branch becomes a reference. That copy *was* load-bearing before — the state was still in the map during `filter()`, so a nested pass could destroy it mid-iteration — and moving ownership out supersedes it. The `int k` counter is gone; it was incremented twice and never read.

**Two deliberate behaviour changes.** A state inserted by a nested pass during `execute()` is no longer visited by the outer pass — previously that depended on heap addresses, so this makes it deterministic. And in debug mode the "removing condition from condition table" line now prints before the fire rather than after: same messages, different order.

Related but untouched: the recursion cap (`scmMaxProcessingDepth = 50`) bounds how deep nesting can go, and the deferred-cleanup machinery from #9682/#9697 defers *trigger* deletion — neither protects a match state inside a live trigger, which is why this survived both.

**Test case:** `ctest -R MultilineTriggerReentrancyTest` — 4 cases: the nested-feed case, the filter branch that re-reads captures after `execute()`, ordinary multiline matching with captures from both lines intact, and the expiry path. Verified in both directions on hash-verified builds: against development's `TTrigger.cpp` the first case does not merely fail, the process dies with `SIGSEGV` (`SEGV_ACCERR`, accessing `0x50`); on this branch all four pass, and pass again under AddressSanitizer with no report. `TFeedTriggersRecursionTest` and the `Trigger_spec` suite are unaffected.