### PR TITLE
infrastructure: stop the development ccache from going stale

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -1,5 +1,7 @@
 # DUPLICATE WORKFLOW: This file is paired with build-mudlet.yml
-# Changes here likely need to be mirrored there as well.
+# Changes here likely need to be mirrored there as well, apart from the ccache
+# handling: caches here are scoped to their own pull request ref and keyed per
+# commit, so there is never a key to delete before saving one.
 name: 🔨 Build Mudlet - PR
 on:
   pull_request:

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -1,5 +1,7 @@
 # DUPLICATE WORKFLOW: This file is paired with build-mudlet-win.yml
-# Changes here likely need to be mirrored there as well.
+# Changes here likely need to be mirrored there as well, apart from the ccache
+# handling: caches here are scoped to their own pull request ref and keyed per
+# commit, so there is never a key to delete before saving one.
 name: 🔨 Build Mudlet - PR (windows)
 on:
   pull_request:

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -1,5 +1,7 @@
 # DUPLICATE WORKFLOW: This file is paired with build-mudlet-win-pr.yml
-# Changes here likely need to be mirrored there as well.
+# Changes here likely need to be mirrored there as well, apart from the ccache
+# deletion below: pull request caches are scoped to their own ref and keyed per
+# commit, so nothing there ever holds a key it needs to reuse.
 name: 🔨 Build Mudlet (windows)
 on:
   push:
@@ -14,7 +16,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
-# Permissions required for SignPath trusted build verification
+# id-token and contents are what SignPath's trusted build verification needs;
+# actions: write is for deleting the branch's previous ccache entry before
+# saving the new one.
 permissions:
   id-token: write
   contents: read
@@ -178,6 +182,32 @@ jobs:
         then
           echo "Lua tests failed - see the action called 'Run Lua tests' above for detailed output."
           exit 1
+        fi
+
+    # Cache keys are immutable, so the save below is refused while the branch's
+    # previous entry still holds the key, and the branch cache only ever
+    # refreshes when GitHub's eviction happens to drop it first. Deleting by key
+    # rather than by id covers a key held by several entries at once, which is
+    # what cache version drift leaves behind. Two pushes overlapping here is
+    # fine - the loser's save is refused and the next push heals it - but the
+    # branch has no cache at all between this step and the save, so a run
+    # cancelled in between leaves the next build cold.
+    # Git bash rather than the msys2 shell the build steps use: gh ships with
+    # the runner image and is on the native PATH.
+    - name: Delete the previous ccache entry
+      if: always() && steps.restore-ccache.outputs.cache-primary-key != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CACHE_KEY: ${{ steps.restore-ccache.outputs.cache-primary-key }}
+      run: |
+        key="$(jq -rn --arg key "${CACHE_KEY}" '$key|@uri')"
+        if response="$(gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/caches?key=${key}" 2>&1)"; then
+          echo "deleted the previous ${CACHE_KEY} entry"
+        elif [[ "${response}" == *"HTTP 404"* ]]; then
+          echo "no ${CACHE_KEY} entry to delete yet"
+        else
+          echo "::warning::could not delete ${CACHE_KEY}, so the save below will be refused and this branch's ccache will go stale: ${response}"
         fi
 
     - name: Save ccache

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -1,5 +1,7 @@
 # DUPLICATE WORKFLOW: This file is paired with build-mudlet-pr.yml
-# Changes here likely need to be mirrored there as well.
+# Changes here likely need to be mirrored there as well, apart from the ccache
+# deletion below: pull request caches are scoped to their own ref and keyed per
+# commit, so nothing there ever holds a key it needs to reuse.
 name: 🔨 Build Mudlet
 on:
   push:
@@ -13,6 +15,12 @@ on:
         default: 'false'
   schedule:
     - cron: '0 2 * * *'
+
+# actions: write is for deleting the branch's previous ccache entry before
+# saving the new one; nothing here writes to the repository itself.
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   compile-mudlet:
@@ -352,13 +360,37 @@ jobs:
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+    # Cache keys are immutable, so the save below is refused while the branch's
+    # previous entry still holds the key, and the branch cache only ever
+    # refreshes when GitHub's eviction happens to drop it first. Deleting by key
+    # rather than by id covers a key held by several entries at once, which is
+    # what cache version drift leaves behind. Two pushes overlapping here is
+    # fine - the loser's save is refused and the next push heals it - but the
+    # branch has no cache at all between this step and the save, so a run
+    # cancelled in between leaves the next build cold.
+    - name: Delete the previous ccache entry
+      if: always() && steps.restore-ccache.outputs.cache-primary-key != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CACHE_KEY: ${{ steps.restore-ccache.outputs.cache-primary-key }}
+      run: |
+        key="$(jq -rn --arg key "${CACHE_KEY}" '$key|@uri')"
+        if response="$(gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/caches?key=${key}" 2>&1)"; then
+          echo "deleted the previous ${CACHE_KEY} entry"
+        elif [[ "${response}" == *"HTTP 404"* ]]; then
+          echo "no ${CACHE_KEY} entry to delete yet"
+        else
+          echo "::warning::could not delete ${CACHE_KEY}, so the save below will be refused and this branch's ccache will go stale: ${response}"
+        fi
+
     - name: Save ccache
       if: always()
       uses: actions/cache/save@v6
       with:
         path: ${{runner.workspace}}/ccache
         key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
-  
+
     - name: check ccache stats post build
       run: ccache --show-stats
 

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,99 @@
+# The repository shares a 10GB cache quota, and once it is full GitHub evicts
+# the least recently used entries - just as likely to be the branch ccache a
+# fresh pull request build falls back to as the per-commit entries left behind
+# by a pull request nobody will push to again.
+name: 🧹 Clean up caches
+on:
+  pull_request_target:
+    types: [closed]
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  closed-pull-request:
+    name: Delete a closed pull request's caches
+    if: github.event_name == 'pull_request_target' && github.repository_owner == 'Mudlet'
+    runs-on: ubuntu-latest
+    steps:
+    # Deliberately no checkout: pull_request_target hands the job a token that
+    # can write, so the pull request's own head must never be checked out here.
+    - name: Delete the caches scoped to this pull request
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CACHE_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+      run: |
+        ids="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100&ref=${CACHE_REF}" --jq '.actions_caches[].id')"
+        if [ -z "${ids}" ]; then
+          echo "no caches left for ${CACHE_REF}"
+          exit 0
+        fi
+        gone=0
+        failed=0
+        for id in ${ids}; do
+          # A 404 means the entry went away between the listing and here, which
+          # is the wanted end state: GitHub evicts constantly under this quota.
+          if response="$(gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${id}" 2>&1)" \
+            || [[ "${response}" == *"HTTP 404"* ]]; then
+            gone=$(( gone + 1 ))
+          else
+            echo "::warning::could not delete cache ${id}: ${response}"
+            failed=$(( failed + 1 ))
+          fi
+        done
+        echo "${gone} cache(s) gone for ${CACHE_REF}"
+        if [ "${failed}" -gt 0 ]; then
+          echo "::error::${failed} cache(s) survived deletion"
+          exit 1
+        fi
+
+  stale-per-commit-ccache:
+    name: Sweep stale per-commit ccache entries
+    if: github.event_name != 'pull_request_target' && github.repository_owner == 'Mudlet'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Delete per-commit ccache entries not used in 48 hours
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Only entries whose key ends in a 40 character commit hash qualify, so
+        # nothing keyed per branch or tag is ever touched, and neither is any
+        # cache that is not a ccache one. An open pull request left idle for two
+        # days does lose its own entry, and falls back to the branch entry its
+        # first build used.
+        cutoff="$(( $(date -u +%s) - 48 * 3600 ))"
+        entries="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" --jq '
+          .actions_caches[]
+          | select(.key | test("^ccache-.*-[0-9a-f]{40}$"))
+          | [.id, (.last_accessed_at | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)]
+          | @tsv')"
+        ids="$(printf '%s\n' "${entries}" | awk -v cutoff="${cutoff}" '$2 < cutoff {print $1}')"
+        # Both counts, so that a sweep with nothing to do reads differently from
+        # one whose filter has stopped matching anything at all.
+        echo "$(printf '%s' "${entries}" | grep -c '' || true) per-commit ccache entries, $(printf '%s' "${ids}" | grep -c '' || true) of them not used in 48 hours"
+        if [ -z "${ids}" ]; then
+          exit 0
+        fi
+        gone=0
+        failed=0
+        for id in ${ids}; do
+          # A 404 means the entry went away between the listing and here, which
+          # is the wanted end state: GitHub evicts constantly under this quota.
+          if response="$(gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${id}" 2>&1)" \
+            || [[ "${response}" == *"HTTP 404"* ]]; then
+            gone=$(( gone + 1 ))
+          else
+            echo "::warning::could not delete cache ${id}: ${response}"
+            failed=$(( failed + 1 ))
+          fi
+        done
+        echo "${gone} stale cache(s) gone"
+        if [ "${failed}" -gt 0 ]; then
+          echo "::error::${failed} cache(s) survived deletion"
+          exit 1
+        fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -118,7 +118,11 @@ jobs:
 
         # Install all required dependencies
         # liblua5.1-0-dev is needed for CMake to find Lua headers/library
-        sudo apt-get install libsecret-1-dev ccache pkg-config pcre2-utils expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
+        # No ccache here on purpose: CMake picks it up as a compiler launcher
+        # wherever it is installed, and a cache hit would hide the compilation
+        # from CodeQL's tracer. The runner images do not ship ccache, so leaving
+        # it out of this list is enough to keep it out of the build.
+        sudo apt-get install libsecret-1-dev pkg-config pcre2-utils expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
           libassimp-dev libpcre2-dev libpugixml-dev libsqlite3-dev libyajl-dev libhunspell-dev liblua5.1-0-dev libonig-dev libboost-dev qtkeychain-qt6-dev -y
 
         # switch to GCC that supports C++20 while retaining support for older OS's
@@ -126,8 +130,6 @@ jobs:
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
         sudo update-alternatives --set gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}}
         sudo update-alternatives --set g++ /usr/bin/g++-${{matrix.gcc_compiler_version}}
-
-        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics
         luarocks install --local lua-yajl


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Push builds delete the branch's previous ccache entry before saving the new one. Cache keys are immutable, so every save under `ccache-...-development` was being refused while the old entry held the key, and the branch cache only refreshed when GitHub's eviction happened to drop it first.
- New `cleanup-caches.yml` deletes a pull request's caches when it closes, and nightly sweeps per-commit `ccache-*` entries unused for 48h. The repo sits over its 10GB quota, and the resulting eviction churn is what kills the branch caches every pull request build falls back to.
- CodeQL no longer installs ccache: CMake auto-detects it as a compiler launcher, and a cache hit would hide compilations from CodeQL's tracer.

#### Motivation for adding to Mudlet
Pull request builds can only fall back to the development cache, so when that goes stale they compile from cold - one platform was down to a 59.5% hit rate against another's 98.8%.

#### Other info (issues closed, discussion etc)
The cache deletion is deliberately not mirrored into the two PR workflows: their caches are scoped to their own ref and keyed per commit, so there is never a key to delete. `actions: write` is new on `build-mudlet.yml`, which had no explicit `permissions:` block before; `build-mudlet-win.yml` already had it for SignPath.

**Test case:** The changed workflows only run from the base branch, so none of this executes until merge - after merging, a push to development should log `deleted the previous ccache-... entry` before "Save ccache", and the next PR build should restore a same-day development cache. The delete/list/delete-by-id API calls were exercised against this repo's live cache API beforehand, including the missing-key, missing-permission and already-evicted paths.

Assisted-by: Claude:claude-opus-5