### PR TITLE
fix: replaceAll() replaces the wrong characters when a line has accents

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -655,15 +655,27 @@ function replaceAll(word, what, keepColor)
   assert(type(word) == 'string', 'replaceAll: bad argument #1 type (expected string, got '..type(word)..'!)')
   assert(type(what) == 'string', 'replaceAll: bad argument #2 type (expected string, got '..type(what)..'!)')
   local getCurrentLine, selectSection, replace = getCurrentLine, selectSection, replace
-  local startp, endp = 1, 1
+  local whatLength = utf8.len(what)
+  local resumeAt = 1
   while true do
-    startp, endp = getCurrentLine():find(word, endp)
+    -- utf8.find() reports character offsets, which is what selectSection() indexes by;
+    -- string.find() reported bytes, which any non-ASCII earlier in the line then shifted
+    local startp, endp = utf8.find(getCurrentLine(), word, resumeAt)
     if not startp then
       break
     end
-    selectSection(startp - 1, endp - startp + 1)
-    replace(what, keepColor)
-    endp = endp + (#what - #word) + 1 -- recalculate the new word ending to start search from there
+    if endp < startp then
+      -- an empty match replaces nothing, so stepping over it is the only way to advance
+      resumeAt = startp + 1
+    elseif not selectSection(startp - 1, endp - startp + 1) then
+      -- a refused selection would leave replace() splicing into line 0 column 0
+      break
+    else
+      replace(what, keepColor)
+      -- resume past what was written: advancing by the pattern's length instead can
+      -- land back inside the replacement and match it forever
+      resumeAt = startp + whatLength
+    end
   end
 end
 

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -2426,6 +2426,84 @@ describe("Tests UI functions", function()
       assert.is_nil(result:find("aaa", 1, true))
     end)
 
+    -- Echo a marked line, park the cursor on it, run replaceAll and hand back what
+    -- the line reads afterwards. A budget runs the call under an instruction-count
+    -- hook, so a replaceAll that fails to terminate fails the spec instead of
+    -- hanging the whole suite.
+    local function replaceOnMarkedLine(text, word, what, budget)
+      echo("main", "\n" .. text .. "\n")
+      local lineCount = getLineCount()
+      local target
+      for i = lineCount - 1, math.max(0, lineCount - 8), -1 do
+        moveCursor(0, i)
+        selectCurrentLine()
+        if getCurrentLine():find(text, 1, true) then
+          target = i
+          break
+        end
+      end
+      deselect()
+      assert.is_not_nil(target, "marked line not found in the main console")
+
+      moveCursor(0, target)
+      local terminated, err
+      if budget then
+        local runner = coroutine.create(function() replaceAll(word, what) end)
+        debug.sethook(runner, function() error("replaceAll did not terminate", 0) end, "", budget)
+        terminated, err = coroutine.resume(runner)
+      else
+        terminated, err = pcall(replaceAll, word, what)
+      end
+
+      -- replace() edits the line in place, so its index is still good
+      moveCursor(0, target)
+      selectCurrentLine()
+      local result = getCurrentLine()
+      deselect()
+      moveCursorEnd()
+      return result, terminated, err
+    end
+
+    -- string.find() reported byte offsets while selectSection() indexes characters,
+    -- so any non-ASCII earlier in the line slid the selection to the right
+    it("replaces the right characters when the line contains non-ASCII", function()
+      local result = replaceOnMarkedLine("uiReplaceAllAccent Der H\195\164ndler sagt: John kommt", "John", "Doe")
+      assert.is_truthy(result:find("uiReplaceAllAccent Der H\195\164ndler sagt: Doe kommt", 1, true), "got: " .. result)
+    end)
+
+    -- a three-byte character shifts it by two, and needs no non-English game
+    it("replaces the right characters after a three-byte character", function()
+      local result = replaceOnMarkedLine("uiReplaceAllQuote It\226\128\153s John here", "John", "Doe")
+      assert.is_truthy(result:find("uiReplaceAllQuote It\226\128\153s Doe here", 1, true), "got: " .. result)
+    end)
+
+    -- %a matches an accented letter for utf8.find but not for string.find, whose
+    -- classes are byte-wise and locale-bound
+    it("matches a pattern class against characters, not bytes", function()
+      local result = replaceOnMarkedLine("uiReplaceAllClass caf\195\169 done", "caf%a", "TEA")
+      assert.is_truthy(result:find("uiReplaceAllClass TEA done", 1, true), "got: " .. result)
+    end)
+
+    -- the search used to resume by the PATTERN's length rather than the match's,
+    -- so masking a digit landed back on the digit it had just written
+    it("terminates when the replacement still matches the pattern", function()
+      local result, terminated, err = replaceOnMarkedLine("uiReplaceAllDigits you have 42 gold", "%d", "0", 50000)
+      assert.is_true(terminated, tostring(err))
+      assert.is_truthy(result:find("uiReplaceAllDigits you have 00 gold", 1, true), "got: " .. result)
+    end)
+
+    -- a pattern that can match nothing never advances on its own
+    it("terminates on a pattern that can match the empty string", function()
+      local _, terminated, err = replaceOnMarkedLine("uiReplaceAllEmpty abc", "x*", "-", 50000)
+      assert.is_true(terminated, tostring(err))
+    end)
+
+    -- the shape a script hits when the needle it computed came back empty
+    it("terminates when the search string is empty", function()
+      local _, terminated, err = replaceOnMarkedLine("uiReplaceAllNoNeedle abc", "", "Z", 50000)
+      assert.is_true(terminated, tostring(err))
+    end)
+
     it("hard-errors on non-string arguments", function()
       assert.is_false(pcall(replaceAll, 5, "x"))
       assert.is_false(pcall(replaceAll, "x", 5))


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `replaceAll()` searched the line with `string.find()`, which reports **byte** offsets, then fed them to `selectSection()`, which indexes **characters** — so every non-ASCII character earlier in the line dragged the replacement one place left per extra byte. Searching with `utf8.find()` reports the offsets `selectSection()` already wants, so no arithmetic is needed to reconcile them.
- Fixes two pre-existing ways to **hang the client**, both from the same line of arithmetic: the search resumed by the *pattern's* length rather than the *match's* (so `replaceAll("%d", "0")` landed back on the digit it had just written and replaced it forever), and a pattern that can match the empty string never advanced at all.
- A refused `selectSection()` now breaks the loop instead of letting `replace()` splice into line 0 column 0.
- Six regression specs in `UI_spec.lua`.

#### Motivation for adding to Mudlet

Any player on a game that sends accented characters — or just a typographic apostrophe — gets their substitutions written into the wrong place, and a couple of ordinary-looking calls freeze the client outright.

#### What a user sees

Given `replaceAll("John", "Doe")` on a line the game sent:

| line | before | after |
|---|---|---|
| `Der Händler sagt: John kommt` | `Der Händler sagt: JDoekommt` | `Der Händler sagt: Doe kommt` |
| `It’s John here` | `It’s JoDoeere` | `It’s Doe here` |

One `ä` shifts the replacement by one character; the three-byte curly apostrophe that many games send instead of `'` shifts it by two. The further into the line the accent sits, the more mangled the result — and it only misbehaves for the players whose games aren't pure ASCII, which is what makes it easy to miss.

Pattern classes were affected too, because `string.find`'s `%a` is byte-wise and cannot see an accented letter as a letter:

| call | line | before | after |
|---|---|---|---|
| `replaceAll("caf%a", "TEA")` | `the café is open` | `the café is open` (no match at all) | `the TEA is open` |

And the freezes, which need no accents whatsoever:

| call | line | before | after |
|---|---|---|---|
| `replaceAll("%d", "0")` | `you have 42 gold` | client hangs permanently | `you have 00 gold` |
| `replaceAll("x*", "-")` | `abc` | client hangs permanently | returns |
| `replaceAll("", "Z")` | `abc` | client hangs permanently | returns |

Masking numbers out of a line is a perfectly ordinary thing to want, and `replaceAll("%d", "0")` is an unrecoverable freeze today — the only way out is to force-quit and lose the session. The empty-pattern case is the shape a script hits when the needle it computed came back empty.

#### Other info (issues closed, discussion etc)

Fixes #9913

**Testing hanging specs needed new code.** Three of the six specs assert that `replaceAll()` *terminates*, and on unpatched code it does not — a plain spec would have hung the entire busted suite rather than reporting a failure. Those three run `replaceAll()` inside a coroutine with a `debug.sethook` instruction-count budget attached, so exhausting the budget raises an error that the spec catches and reports as a normal failure. That is the only reason these are Lua specs and not C++ functional tests.

**One behaviour change beyond the fix.** `utf8.find()` applies Lua patterns per character rather than per byte, so on `café` the pattern `%a` now matches four characters where it matched three, and `.` matches four where it matched five. This is the change that makes case 3 above work; it is a fix rather than a regression, but it is a semantic difference worth noting for anyone whose script leaned on the byte-wise behaviour.

**A residual off-by-one remains for characters outside the Basic Multilingual Plane** (emoji, some CJK extensions, musical symbols). `selectSection()` indexes UTF-16 cells, where those characters occupy two, while `utf8.len()` counts codepoints, where they occupy one. Everything in the BMP — all accented Latin, Greek, Cyrillic, Hebrew, Arabic, and the common CJK ranges — is exact. Fixing the non-BMP case properly means either a `selectSection()` variant that accepts byte offsets or a codepoint-to-UTF-16 conversion in Lua, both of which are larger than this bug warrants.

Measured cost on the hot path is +58 ns per `replaceAll()` iteration versus the old arithmetic, which is unavoidable: deciding a character offset correctly requires inspecting the bytes before the match, and the original was cheap precisely because it skipped that. A `find("[\128-\255]")` pre-test to skip the work on pure-ASCII lines measured 6.9× **worse** and was dropped.

**Test case:**

1. Create an alias with pattern `^prf$` and this script:
   ```lua
   echo("\nDer Händler sagt: John kommt\n")
   moveCursor(0, getLineCount() - 2)
   replaceAll("John", "Doe")
   moveCursorEnd()
   ```
2. Type `prf`. Before: `Der Händler sagt: JDoekommt`. After: `Der Händler sagt: Doe kommt`.
3. For the freeze, swap the script body for `replaceAll("%d", "0")` on the line `you have 42 gold`. Before this PR that call never returns and the client must be force-quit; after it prints `you have 00 gold`.

The six specs live in the existing `describe("replaceAll on the main console", ...)` block. Verified in both directions on hash-verified builds: 593 passed / 0 failed with the patch, 587 passed / 6 failed without it (exactly the six new ones). Full Lua suite went from 2873 passed to 2879 with a byte-identical set of pre-existing failures.