### PR TITLE
Fix: Music stopped with a fade-away right after it starts no longer plays on

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -374,18 +374,24 @@ void TMedia::stopMedia(TMediaData& mediaData)
             const int fadeOut = pPlayer->mediaData().mediaFadeOut() ? pPlayer->mediaData().mediaFadeOut() : mediaData.mediaFadeOut();
             const int remainingDuration = (finishPosition != TMediaData::MediaFinishNotSet ? finishPosition : duration) - currentPosition;
             const int endDuration = fadeOut != TMediaData::MediaFadeNotSet ? std::min(remainingDuration, fadeOut) : std::min(remainingDuration, 5000);
-            const int endPosition = currentPosition + endDuration;
 
-            //: This word is part of a sentence like "Music fades" when the music is about to stop.
-            printClosedCaption(pPlayer->mediaData(), tr("fades"));
+            // Only a playing track can be faded out: the position changes a fade is applied from
+            // do not come for a player that is still loading or paused, and a track already past
+            // its finish position has no stretch left to fade over, which is what a non-positive
+            // endDuration says. Either way the stop is performed outright below, as a stop
+            // without a fade-away is, and there is nothing to announce as fading.
+            if (endDuration > 0 && pPlayer->getPlaybackState() == QMediaPlayer::PlayingState) {
+                //: This word is part of a sentence like "Music fades" when the music is about to stop.
+                printClosedCaption(pPlayer->mediaData(), tr("fades"));
 
-            TMediaData updateMediaData = pPlayer->mediaData();
-            updateMediaData.setMediaFadeOut(endDuration);
-            updateMediaData.setMediaEnd(endPosition);
-            pPlayer->setMediaData(updateMediaData);
-            TMedia::updateMediaPlayerList(std::move(pPlayer));
+                TMediaData updateMediaData = pPlayer->mediaData();
+                updateMediaData.setMediaFadeOut(endDuration);
+                updateMediaData.setMediaEnd(currentPosition + endDuration);
+                pPlayer->setMediaData(updateMediaData);
+                TMedia::updateMediaPlayerList(std::move(pPlayer));
 
-            continue;
+                continue;
+            }
         }
 
         // **Stop the player but keep it for reuse**

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -77,7 +77,9 @@ public:
 
     static constexpr int MediaFadeNotSet = 0;
     static constexpr int MediaStartDefault = 0;
-    static constexpr int MediaEndNotSet = 0;
+    // An end is a position in the track, and 0 is one of those, so unlike its neighbours this
+    // sentinel has to sit outside the range it stands in for.
+    static constexpr int MediaEndNotSet = -1;
     static constexpr int MediaFinishNotSet = 0;
 
     static constexpr const char* MediaWidgetLabel = "label";

--- a/test/functional_tests/TMediaLoopTest.cpp
+++ b/test/functional_tests/TMediaLoopTest.cpp
@@ -78,7 +78,9 @@ using namespace std::chrono_literals;
  *     continue=false restart of the same one, must keep the source it was given;
  *   - each of those endings must raise sysMediaFinished exactly once, since releasing the
  *     source alone leaves a script chaining its next track off that event waiting forever,
- *     and announcing twice re-enters any handler that stops the media it was told about.
+ *     and announcing twice re-enters any handler that stops the media it was told about;
+ *   - a fade-away stop must end the track whatever state it is in, a track that is not playing
+ *     being one it cannot fade over and so has to stop outright (issue #9902).
  *
  * Which of those a backend can demonstrate varies, so probeBackend() measures one up front and
  * each test skips with what it found. CMakeLists.txt pins QT_MEDIA_BACKEND on the platforms
@@ -99,6 +101,14 @@ private:
     // Length of the generated clip. Long enough that "still playing" cannot be an
     // artefact of start-up latency, short enough to loop several times quickly.
     static constexpr int clipMs = 400;
+
+    // For the fade-away tests. A fade of fadeOutMs has to be a small fraction of the clip, or a
+    // fade that never happened cannot be told from one that ran its course; and the clip has to
+    // outlast fadeStopDeadline, which is the budget a stop that was acted on has to end the
+    // track within.
+    static constexpr int longClipMs = 8000;
+    static constexpr int fadeOutMs = 800;
+    static constexpr std::chrono::milliseconds fadeStopDeadline{longClipMs / 2};
 
     QTemporaryDir mProbeDir;
     // Set when the backend never reaches PlayingState, so nothing below can even be started.
@@ -530,6 +540,210 @@ private slots:
         QVERIFY2(waitForPlaying(media, fileName, 2s), "A restarted track was cut off - the cleanup deferred by its own stop cleared the source it had just been given.");
     }
 
+    // A fade-away stop lands in the same window as test_stoppedTrackReleasesItsSource whenever a
+    // script plays a track and stops it from the same alias or handler, and it has nowhere to
+    // fade from: the position and duration the fade is worked out from are both still 0, which a
+    // player that has not reached PlayingState stands in for here. A fade over no time at all
+    // leaves the track running with no sysMediaFinished to chain anything off - hence a repeating
+    // track and a long clip, since one that simply ran out would release its source and announce
+    // itself, reading as a stop that worked.
+    void test_fadeAwayStopWhileStillLoadingStillStopsTheTrack()
+    {
+        SKIP_OR_FAIL_WITHOUT(mCannotStartReason);
+        SKIP_OR_FAIL_WITHOUT(mSynchronousStartReason);
+
+        auto* media = startProfileAndGetMedia();
+        QVERIFY(media);
+
+        watchMediaFinished();
+
+        const QString fileName = writeClip(qsl("fadeloading.wav"), wavBytes(longClipMs));
+        QVERIFY(!fileName.isEmpty());
+
+        TMediaData data = clipData(fileName);
+        data.setMediaLoops(TMediaData::MediaLoopsRepeat);
+        media->playMedia(data);
+
+        // A player that holds the source but has not started is what "still loading" means here.
+        // Without the first of these the stop could be landing on a track that has already
+        // started; without the second, on a play() that bailed out and left nothing to stop, and
+        // the assertions below would all be satisfied by a track that never played.
+        QCOMPARE(media->playersHoldingSource(), 1);
+        QVERIFY2(media->playersInPlayingState() == 0, "The track was already playing when the stop was issued, so the stop did not land while it was still loading.");
+
+        TMediaData stop = clipData(fileName);
+        stop.setMediaFadeAway(TMediaData::MediaFadeAwayEnabled);
+        media->stopMedia(stop);
+
+        const bool stopped = QTest::qWaitFor(
+                [&]() {
+                    return !playing(media, fileName);
+                },
+                QDeadlineTimer(fadeStopDeadline));
+
+        QVERIFY2(stopped, "A fade-away stop issued while the track was still loading was lost - the track started anyway and played on.");
+
+        const bool released = QTest::qWaitFor(
+                [&]() {
+                    return media->playersHoldingSource() == 0;
+                },
+                QDeadlineTimer(10s));
+
+        QVERIFY2(released, "A track stopped with a fade-away while it was still loading never released its media source.");
+
+        QVERIFY2(waitForMediaFinishedCount(1), "A track stopped with a fade-away while it was still loading raised no single sysMediaFinished.");
+        QVERIFY2(mediaFinishedHolds(qsl("mediaFinishedNames[1] == 'fadeloading.wav'")), "sysMediaFinished named the wrong file for a track stopped with a fade-away while it was loading.");
+
+        // The source outlives the event by a turn, so a backend that does report a state change
+        // for this player can still announce the same ending a second time.
+        QTest::qWait(clipMs);
+        QVERIFY2(mediaFinishedHolds(qsl("mediaFinishedCount == 1")), "A track stopped with a fade-away while it was still loading announced its ending more than once.");
+    }
+
+    // The same stop, on a track carrying a finish position. That position is what the fade is
+    // measured against when it is set, and it is known before the track has loaded, so this is
+    // the one mid-load stop that can work out a fade over a stretch of a track that is not
+    // playing yet.
+    void test_fadeAwayStopWhileStillLoadingStillStopsATrackWithAFinish()
+    {
+        SKIP_OR_FAIL_WITHOUT(mCannotStartReason);
+        SKIP_OR_FAIL_WITHOUT(mSynchronousStartReason);
+
+        auto* media = startProfileAndGetMedia();
+        QVERIFY(media);
+
+        watchMediaFinished();
+
+        const QString fileName = writeClip(qsl("fadefinish.wav"), wavBytes(longClipMs));
+        QVERIFY(!fileName.isEmpty());
+
+        TMediaData data = clipData(fileName);
+        data.setMediaLoops(TMediaData::MediaLoopsRepeat);
+        data.setMediaFinish(longClipMs);
+        media->playMedia(data);
+
+        QCOMPARE(media->playersHoldingSource(), 1);
+        QVERIFY2(media->playersInPlayingState() == 0, "The track was already playing when the stop was issued, so the stop did not land while it was still loading.");
+
+        TMediaData stop = clipData(fileName);
+        stop.setMediaFadeAway(TMediaData::MediaFadeAwayEnabled);
+        media->stopMedia(stop);
+
+        const bool stopped = QTest::qWaitFor(
+                [&]() {
+                    return !playing(media, fileName);
+                },
+                QDeadlineTimer(fadeStopDeadline));
+
+        QVERIFY2(stopped,
+                 "A fade-away stop issued while a track with a finish position was still loading left it playing - the finish position let a fade be worked out for a track that had not started.");
+        QVERIFY2(waitForMediaFinishedCount(1), "A track with a finish position stopped with a fade-away while it was still loading raised no single sysMediaFinished.");
+    }
+
+    // A paused track cannot be faded out either: the position changes a fade is applied from
+    // only come while a player is running, so an end scheduled for a paused one is never reached
+    // and it holds its source for good.
+    void test_fadeAwayStopOfAPausedTrackStopsIt()
+    {
+        SKIP_OR_FAIL_WITHOUT(mCannotStartReason);
+
+        auto* media = startProfileAndGetMedia();
+        QVERIFY(media);
+
+        watchMediaFinished();
+
+        const QString fileName = writeClip(qsl("fadepaused.wav"), wavBytes(longClipMs));
+        QVERIFY(!fileName.isEmpty());
+
+        TMediaData data = clipData(fileName);
+        data.setMediaLoops(TMediaData::MediaLoopsRepeat);
+        media->playMedia(data);
+
+        QVERIFY2(waitForPlaybackStarted(media, fileName), "The track never started playing.");
+
+        TMediaData pause = clipData(fileName);
+        media->pauseMedia(pause);
+
+        TMediaData pausedCriteria = clipData(fileName);
+        QVERIFY2(media->pausedMedia(pausedCriteria).size() == 1, "The track was not paused, so the stop below would land on a playing one.");
+
+        TMediaData stop = clipData(fileName);
+        stop.setMediaFadeAway(TMediaData::MediaFadeAwayEnabled);
+        media->stopMedia(stop);
+
+        const bool released = QTest::qWaitFor(
+                [&]() {
+                    return media->playersHoldingSource() == 0;
+                },
+                QDeadlineTimer(fadeStopDeadline));
+
+        QVERIFY2(released, "A fade-away stop of a paused track never released its media source - the fade it scheduled waits on position changes a paused player does not make.");
+        QVERIFY2(waitForMediaFinishedCount(1), "A paused track stopped with a fade-away raised no single sysMediaFinished.");
+    }
+
+    // The other half of test_fadeAwayStopWhileStillLoadingStillStopsTheTrack: a fade-away stop of
+    // a track that is really playing must still fade it rather than cut it off, and the fade must
+    // still end it. The clip is long enough that the fade is a fraction of it, so a track that
+    // plays to its own end reads as a fade that never happened. Assumes the backend knows the
+    // duration by the time it reports PlayingState, as the ones pinned in CMakeLists.txt do -
+    // one that did not would have no stretch to fade over and would stop the track outright.
+    void test_fadeAwayStopFadesAPlayingTrackOut()
+    {
+        SKIP_OR_FAIL_WITHOUT(mCannotPlayReason);
+
+        auto* media = startProfileAndGetMedia();
+        QVERIFY(media);
+
+        watchMediaFinished();
+
+        const QString fileName = writeClip(qsl("fadeplaying.wav"), wavBytes(longClipMs));
+        QVERIFY(!fileName.isEmpty());
+
+        TMediaData data = clipData(fileName);
+        media->playMedia(data);
+
+        QVERIFY2(waitForPlaybackStarted(media, fileName), "The track never started playing.");
+
+        TMediaData stop = clipData(fileName);
+        stop.setMediaFadeAway(TMediaData::MediaFadeAwayEnabled);
+        stop.setMediaFadeOut(fadeOutMs);
+        media->stopMedia(stop);
+
+        TMediaData criteria = clipData(fileName);
+        const QList<TMediaData> stillPlaying = media->playingMedia(criteria);
+        QVERIFY2(stillPlaying.size() == 1, "A fade-away stop cut the track off outright instead of fading it.");
+        QVERIFY2(stillPlaying.at(0).mediaEnd() != TMediaData::MediaEndNotSet, "A fade-away stop of a playing track scheduled no end for it, so nothing would ever end the fade.");
+
+        const bool stopped = QTest::qWaitFor(
+                [&]() {
+                    return !playing(media, fileName);
+                },
+                QDeadlineTimer(fadeStopDeadline));
+
+        QVERIFY2(stopped, "A faded-away track was still playing long after its fade should have ended it.");
+        QVERIFY2(waitForMediaFinishedCount(1), "A faded-away track raised no single sysMediaFinished.");
+        QVERIFY2(mediaFinishedHolds(qsl("mediaFinishedNames[1] == 'fadeplaying.wav'")), "sysMediaFinished named the wrong file for a faded-away track.");
+
+        QTest::qWait(clipMs);
+        QVERIFY2(mediaFinishedHolds(qsl("mediaFinishedCount == 1")), "A faded-away track announced its ending more than once.");
+    }
+
+    // The end a fade-away schedules is a position in the track, so an end of 0 has to stay
+    // distinguishable from no end having been scheduled at all. A sentinel taken from inside
+    // that range makes the two the same value, and a fade nothing acts on is what comes of it.
+    void test_anEndOfZeroIsNotTheSameAsNoEndAtAll()
+    {
+        TMediaData data;
+        QCOMPARE(data.mediaEnd(), TMediaData::MediaEndNotSet);
+
+        data.setMediaEnd(0);
+        QCOMPARE(data.mediaEnd(), 0);
+        QVERIFY2(data.mediaEnd() != TMediaData::MediaEndNotSet, "An end scheduled at position 0 reads back as no end having been scheduled, so nothing would ever act on it.");
+
+        data.setMediaEnd(-5);
+        QCOMPARE(data.mediaEnd(), TMediaData::MediaEndNotSet);
+    }
+
     void cleanup()
     {
         delete mpServer;
@@ -771,7 +985,7 @@ private:
     QString writeUnplayableClip(const QString& fileName) const { return writeClip(fileName, QByteArray("not a WAV file, and not decodable as anything else")); }
 
     // Writes a clip into the profile media directory, returning {} if that fails.
-    QString writeClip(const QString& fileName, const QByteArray& contents = wavBytes()) const
+    QString writeClip(const QString& fileName, const QByteArray& contents = wavBytes(clipMs)) const
     {
         const QString mediaPath = mudlet::getMudletPath(enums::profileMediaPath, mHostname);
         if (!QDir().mkpath(mediaPath)) {
@@ -791,11 +1005,11 @@ private:
 
     // A silent 16-bit mono PCM WAV. Silence is fine: the tests assert on playback state
     // transitions, not on what is heard.
-    static QByteArray wavBytes()
+    static QByteArray wavBytes(int durationMs = clipMs)
     {
         constexpr int sampleRate = 8000;
         constexpr int bytesPerSample = 2;
-        const int dataBytes = sampleRate * bytesPerSample * clipMs / 1000;
+        const int dataBytes = sampleRate * bytesPerSample * durationMs / 1000;
 
         QByteArray wav;
         QDataStream out(&wav, QIODevice::WriteOnly);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `TMedia::stopMedia()` only schedules a fade-away for a track that is actually playing; a stop that lands while the file is still loading, or on a paused track, is performed outright, as a stop without a fade-away already was.
- `TMediaData::MediaEndNotSet` moves out of the range of positions an end can be scheduled at, so a computed end can no longer read back as no end having been scheduled.
- Four new `TMediaLoopTest` slots: the mid-load stop, the same with a `finish` position set, the paused track, and the ordinary fade of a playing track. All four fail against the unfixed source.

#### Motivation for adding to Mudlet
A script that plays a track and stops it with `fadeaway` from the same alias, trigger or event handler lost the stop entirely - the track started anyway, played on, and raised no `sysMediaFinished` for anything waiting on it.

#### Other info (issues closed, discussion etc)
Closes #9902. Pre-existing rather than a 5.0 regression: 4.22.0 has the same fade branch and the same zero-valued sentinel.

**Test case:** run `playMusicFile({name = "song.wav", loops = -1}) stopMusic({fadeaway = true})` as one script - the music must not play on. `ctest -R TMediaLoopTest` covers that, the paused variant, and the ordinary fade.

Assisted-by: Claude:claude-opus-5