### PR TITLE
fix: the Variables editor no longer creates a junk copy of a variable it cannot name exactly

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include <QDebug>
+#include <QRegularExpression>
 
 #include "LuaInterface.h"
 #include "VarUnit.h"
@@ -351,6 +352,115 @@ QList<TVar*> LuaInterface::varOrder(TVar* var)
         pParent = pParent->getParent();
     }
     return vars;
+}
+
+// A name two members of the same table are both shown under says nothing about
+// which of them is meant, and whichever one a write reaches may well be the
+// other. Two keys can share a name: "%.14g" gives 1/3 and 0.33333333333333 the
+// same text, and a key ending at an embedded NUL is named by the part before it.
+static bool nameSharedWithASibling(TVar* var)
+{
+    TVar* parent = var->getParent();
+    if (!parent) {
+        return false;
+    }
+    // a number key and a string key that read the same are still distinct
+    // lookups, so the key type is part of the name here
+    const QString name = var->getName();
+    const int keyType = var->getKeyType();
+    int matches = 0;
+    for (const TVar* sibling : parent->getChildren(false)) {
+        if (sibling->getName() == name && sibling->getKeyType() == keyType && ++matches > 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// The write paths build Lua source out of these names - see setValue() - where a
+// string key goes inside a quoted literal and a root goes in bare. So a key
+// holding a backslash comes back out as an escape sequence, and a root that is
+// not an identifier either fails to parse or, with a dot in it, parses as an
+// index into some other global.
+static bool nameSurvivesGeneratedCode(TVar* var, const bool asRoot)
+{
+    const QString name = var->getName();
+    if (asRoot) {
+        static const QRegularExpression identifier(qsl("^[A-Za-z_][A-Za-z0-9_]*$"));
+        return var->getKeyType() == LUA_TSTRING && identifier.match(name).hasMatch();
+    }
+    if (var->getKeyType() != LUA_TSTRING) {
+        return true;
+    }
+    return !name.contains(QLatin1Char('\\')) && !name.contains(QLatin1Char('"')) && !name.contains(QLatin1Char('\n')) && !name.contains(QLatin1Char('\r'));
+}
+
+// Whether a variable can be written back through the name the variable tree gave
+// it, which is what every write path has to reach it by. Two things have to
+// hold, and neither is a given:
+//  - the name finds that same variable again. Lua names a number key with
+//    "%.14g", which a key of 1/3 does not survive, and names a string key
+//    through a C string, which ends at an embedded NUL - so the name is a key of
+//    its own, and writing through it leaves a second variable beside the real
+//    one (#9903). A variable a script has deleted since the tree was built is
+//    not found either.
+//  - the name is one the generated Lua source can carry back, which is a
+//    narrower thing than the C API can look up.
+// What the variable holds is not part of the question: a script is free to have
+// changed that since the tree was built, and the name still finds it.
+bool LuaInterface::writableByName(TVar* var)
+{
+    const QList<TVar*> vars = varOrder(var);
+    if (vars.isEmpty()) {
+        // _G, which nothing writes through a name
+        return false;
+    }
+    if (nameSharedWithASibling(var)) {
+        return false;
+    }
+    for (int i = 0; i < vars.size(); ++i) {
+        if (!nameSurvivesGeneratedCode(vars.at(i), i == 0)) {
+            return false;
+        }
+    }
+
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) == 0) {
+        // one slot per level of nesting - the key pushed for a level becomes
+        // that level's value - and one more for the last key, which is pushed
+        // while its own level's table is still on the stack
+        if (!lua_checkstack(mL, static_cast<int>(vars.size()) + 1)) {
+            qWarning().noquote().nospace() << "LuaInterface::writableByName() WARNING - could not grow the Lua stack to reach \"" << var->getName() << "\", so it is being treated as unwritable.";
+            return false;
+        }
+        lua_getglobal(mL, vars.constFirst()->getName().toUtf8().constData());
+        // down to the table the variable sits in, which loadValue() checks is
+        // still a table
+        for (int i = 1; i < vars.size() - 1; ++i) {
+            if (!loadValue(mL, vars.at(i), -2)) {
+                lua_settop(mL, stackTop);
+                return false;
+            }
+        }
+        if (vars.size() > 1) {
+            // the last step is loadValue() without its value-type test, which
+            // would answer for what the variable holds rather than for its name
+            const int topWithTable = lua_gettop(mL);
+            // loadKey() pushes nothing for a key type it does not handle, and
+            // says so only by leaving the top where it was
+            if (!lua_istable(mL, -1) || !loadKey(mL, vars.constLast()) || lua_gettop(mL) != topWithTable + 1) {
+                lua_settop(mL, stackTop);
+                return false;
+            }
+            lua_gettable(mL, -2);
+        }
+        const bool found = !lua_isnoneornil(mL, -1);
+        lua_settop(mL, stackTop);
+        return found;
+    }
+    lua_settop(mL, stackTop);
+    qWarning().noquote().nospace() << "LuaInterface::writableByName() WARNING - Lua panicked while looking \"" << var->getName() << "\" up, so it is being treated as unwritable.";
+    return false;
 }
 
 void LuaInterface::createVar(TVar* var)

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -387,7 +387,10 @@ static bool nameSurvivesGeneratedCode(TVar* var, const bool asRoot)
     const QString name = var->getName();
     if (asRoot) {
         static const QRegularExpression identifier(qsl("^[A-Za-z_][A-Za-z0-9_]*$"));
-        return var->getKeyType() == LUA_TSTRING && identifier.match(name).hasMatch();
+        static const QSet<QString> luaKeywords{qsl("and"),   qsl("break"), qsl("do"),  qsl("else"), qsl("elseif"), qsl("end"),    qsl("false"), qsl("for"),  qsl("function"), qsl("if"),   qsl("in"),
+                                               qsl("local"), qsl("nil"),   qsl("not"), qsl("or"),   qsl("repeat"), qsl("return"), qsl("then"),  qsl("true"), qsl("until"),    qsl("while")};
+        // a keyword reads as an identifier but parses as itself
+        return var->getKeyType() == LUA_TSTRING && identifier.match(name).hasMatch() && !luaKeywords.contains(name);
     }
     if (var->getKeyType() != LUA_TSTRING) {
         return true;
@@ -396,14 +399,15 @@ static bool nameSurvivesGeneratedCode(TVar* var, const bool asRoot)
 }
 
 // Whether a variable can be written back through the name the variable tree gave
-// it, which is what every write path has to reach it by. Two things have to
-// hold, and neither is a given:
+// it, which is what every write path has to reach it by. Three things have to
+// hold, and for the tables above the variable as much as for the variable:
 //  - the name finds that same variable again. Lua names a number key with
 //    "%.14g", which a key of 1/3 does not survive, and names a string key
 //    through a C string, which ends at an embedded NUL - so the name is a key of
 //    its own, and writing through it leaves a second variable beside the real
 //    one (#9903). A variable a script has deleted since the tree was built is
 //    not found either.
+//  - no other member of the same table is shown under that name too.
 //  - the name is one the generated Lua source can carry back, which is a
 //    narrower thing than the C API can look up.
 // What the variable holds is not part of the question: a script is free to have
@@ -415,48 +419,40 @@ bool LuaInterface::writableByName(TVar* var)
         // _G, which nothing writes through a name
         return false;
     }
-    if (nameSharedWithASibling(var)) {
-        return false;
-    }
     for (int i = 0; i < vars.size(); ++i) {
-        if (!nameSurvivesGeneratedCode(vars.at(i), i == 0)) {
+        if (nameSharedWithASibling(vars.at(i)) || !nameSurvivesGeneratedCode(vars.at(i), i == 0)) {
             return false;
         }
     }
 
     const int stackTop = lua_gettop(mL);
     if (setjmp(buf) == 0) {
-        // one slot per level of nesting - the key pushed for a level becomes
-        // that level's value - and one more for the last key, which is pushed
-        // while its own level's table is still on the stack
-        if (!lua_checkstack(mL, static_cast<int>(vars.size()) + 1)) {
+        // the table of the level being looked at, plus the key pushed into it,
+        // for as many levels as there are names
+        if (!lua_checkstack(mL, static_cast<int>(vars.size()) + 2)) {
             qWarning().noquote().nospace() << "LuaInterface::writableByName() WARNING - could not grow the Lua stack to reach \"" << var->getName() << "\", so it is being treated as unwritable.";
             return false;
         }
-        lua_getglobal(mL, vars.constFirst()->getName().toUtf8().constData());
-        // down to the table the variable sits in, which loadValue() checks is
-        // still a table
-        for (int i = 1; i < vars.size() - 1; ++i) {
-            if (!loadValue(mL, vars.at(i), -2)) {
-                lua_settop(mL, stackTop);
-                return false;
-            }
-        }
-        if (vars.size() > 1) {
-            // the last step is loadValue() without its value-type test, which
-            // would answer for what the variable holds rather than for its name
+        lua_pushvalue(mL, LUA_GLOBALSINDEX);
+        for (TVar* level : vars) {
             const int topWithTable = lua_gettop(mL);
-            // loadKey() pushes nothing for a key type it does not handle, and
-            // says so only by leaving the top where it was
-            if (!lua_istable(mL, -1) || !loadKey(mL, vars.constLast()) || lua_gettop(mL) != topWithTable + 1) {
+            // Raw, because the tree was built by iterating the tables, which is
+            // raw as well: a value an __index metamethod stands in with is not
+            // the variable the tree is showing. loadKey() also pushes nothing
+            // for a key type it does not handle, and says so only by leaving the
+            // top where it was.
+            if (!lua_istable(mL, -1) || !loadKey(mL, level) || lua_gettop(mL) != topWithTable + 1) {
                 lua_settop(mL, stackTop);
                 return false;
             }
-            lua_gettable(mL, -2);
+            lua_rawget(mL, -2);
+            if (lua_isnoneornil(mL, -1)) {
+                lua_settop(mL, stackTop);
+                return false;
+            }
         }
-        const bool found = !lua_isnoneornil(mL, -1);
         lua_settop(mL, stackTop);
-        return found;
+        return true;
     }
     lua_settop(mL, stackTop);
     qWarning().noquote().nospace() << "LuaInterface::writableByName() WARNING - Lua panicked while looking \"" << var->getName() << "\" up, so it is being treated as unwritable.";

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -78,6 +78,9 @@ public:
     void renameCVar(QList<TVar*>);
     void renameVar(TVar*);
     void createVar(TVar*);
+    // whether a variable can be written back through the name the tree gave it,
+    // which the editor asks before writing - the write paths themselves do not
+    bool writableByName(TVar*);
     VarUnit* getVarUnit();
     // Anything that builds a variable tree and throws it away owes this call:
     // ~LuaInterface cannot make it, see there.

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6900,6 +6900,14 @@ void dlgTriggerEditor::saveVar()
         slot_variableSelected(pItem);
         return;
     }
+    // Everything below reaches the variable by the name the tree gave it, and a
+    // write through a name that does not reach it lands on a key of its own,
+    // leaving a second variable beside the real one (#9903). Quietly, because
+    // selecting the variable already said so. A new variable is exempt: its name
+    // is the key about to be created, so there is nothing for it to find yet.
+    if (!newVar && !luaInterface->writableByName(variable)) {
+        return;
+    }
     mChangingVar = true;
     int uiNameType = mpVarsMainArea->comboBox_variable_key_type->itemData(mpVarsMainArea->comboBox_variable_key_type->currentIndex(), Qt::UserRole).toInt();
     int uiValueType = mpVarsMainArea->comboBox_variable_value_type->itemData(mpVarsMainArea->comboBox_variable_value_type->currentIndex(), Qt::UserRole).toInt();
@@ -8285,6 +8293,15 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     pItem->setData(0, Qt::UserRole, var->getValueType());
     pItem->setIcon(0, icon);
     mChangingVar = false;
+    // Said on selection rather than when the user tries to save: the value box
+    // filled in above is empty for the same reason, getValue() reaching the
+    // variable by this same name, and without this it reads as a real value.
+    if (!lI->writableByName(var)) {
+        //: Warning shown in the editor's Variables view for a variable it cannot write back to Lua. %1 is the name the variable is shown under.
+        showWarning(tr("\"%1\" cannot be changed here: Mudlet has no way to reach it in Lua under the name it is shown with, so anything saved for it would go somewhere else. "
+                       "Its value may show up blank for the same reason. A script can still change it.")
+                            .arg(var->getName().toHtmlEscaped()));
+    }
 }
 
 void dlgTriggerEditor::slot_actionSelected(QTreeWidgetItem* pItem)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -109,6 +109,7 @@ class dlgTriggerEditor : public QMainWindow, private Ui::trigger_editor
     friend class dlgTriggerEditorUndoRedoTest;
     friend class EditorBannerViewSwitchTest;
     friend class ScriptEventHandlerLifetimeTest;
+    friend class VariableEditorWriteBackTest;
 
     enum SearchDataRole {
         // Value is the ID of the item found MUST BE Qt::UserRole to avoid

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -903,6 +903,56 @@ private slots:
         QVERIFY(!interface->writableByName(var));
     }
 
+    // The tables above a variable are reached by name too, so an ambiguous name
+    // anywhere along the way puts the write somewhere else just as surely.
+    void testNotWritableByNameUnderATableSharingItsNameWithASibling()
+    {
+        execLua(qsl("testTbl = {} testTbl['before\\0after'] = {member = 'first'} testTbl['before'] = {member = 'second'}"));
+        interface->getVars(false);
+        TVar* table = findChild(interface->getVarUnit()->getBase(), qsl("testTbl"));
+        QVERIFY(table);
+        int checked = 0;
+        for (TVar* ambiguous : table->getChildren(false)) {
+            if (ambiguous->getName() != qsl("before")) {
+                continue;
+            }
+            TVar* member = findChild(ambiguous, qsl("member"));
+            QVERIFY(member);
+            QVERIFY(!interface->writableByName(member));
+            ++checked;
+        }
+        QCOMPARE(checked, 2);
+    }
+
+    // A keyword reads as an identifier but does not parse as one, so the source
+    // the write paths generate for it does not run.
+    void testNotWritableByNameForAGlobalNamedAfterALuaKeyword()
+    {
+        execLua(qsl("_G['end'] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("end"));
+        QVERIFY(var);
+        QVERIFY(!interface->writableByName(var));
+    }
+
+    // The tree is built by iterating the tables, which does not consult
+    // metamethods, so neither does the lookup: what an __index stands in with
+    // once a script removes the real key is a different variable.
+    void testNotWritableByNameWhenOnlyAMetamethodSuppliesTheTable()
+    {
+        execLua(qsl("fallbackTbl = {sub = {member = 'fallback value'}} "
+                    "testTbl = {sub = {member = 'real value'}} "
+                    "setmetatable(testTbl, {__index = fallbackTbl})"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("sub")), qsl("member"));
+        QVERIFY(member);
+        QVERIFY(interface->writableByName(member));
+
+        execLua(qsl("testTbl.sub = nil"));
+        QCOMPARE(getLuaValue(qsl("testTbl.sub.member")), qsl("fallback value"));
+        QVERIFY(!interface->writableByName(member));
+    }
+
     // it walks down to the variable a push at a time, and in the editor that is
     // the profile's own stack, where a slot left behind stays for the session
     void testWritableByNameLeavesTheStackAsItFoundIt()

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -20,6 +20,7 @@
 #include <LuaInterface.h>
 #include <TVar.h>
 #include <VarUnit.h>
+#include <utils.h>
 #include <QtTest/QtTest>
 
 #include <memory>
@@ -748,6 +749,181 @@ private slots:
         QVERIFY(var);
         execLua(QStringLiteral("testVar = 'after'"));
         QCOMPARE(interface->getValue(var), QStringLiteral("after"));
+    }
+
+    // ========================================================================
+    // writableByName - can a variable be written back under the name it is shown with?
+    // ========================================================================
+
+    void testWritableByNameForAGlobal()
+    {
+        execLua(qsl("testVar = 'hello'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("testVar"));
+        QVERIFY(var);
+        QVERIFY(interface->writableByName(var));
+    }
+
+    void testWritableByNameForANestedMember()
+    {
+        execLua(qsl("testTbl = {sub = {deep = 'value'}}"));
+        interface->getVars(false);
+        TVar* deep = findChild(findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("sub")), qsl("deep"));
+        QVERIFY(deep);
+        QVERIFY(interface->writableByName(deep));
+    }
+
+    // Lua names a number key with "%.14g", which is exact for an index
+    void testWritableByNameForAnIntegerKeyedMember()
+    {
+        execLua(qsl("testTbl = {[2] = 'value'}"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("2"));
+        QVERIFY(member);
+        QVERIFY(interface->writableByName(member));
+    }
+
+    // ...but not for one that needs more digits than that: the name is a
+    // different key, and a write through it would add a member (#9903)
+    void testNotWritableByNameForAFractionKeyedMember()
+    {
+        execLua(qsl("testTbl = {[1/3] = 'value'}"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("0.33333333333333"));
+        QVERIFY2(member, "the walk did not name the member the way Lua names its key");
+        QVERIFY(!interface->writableByName(member));
+    }
+
+    // a key is named through a C string, so it ends at an embedded NUL
+    void testNotWritableByNameForAMemberWithANulInItsKey()
+    {
+        execLua(qsl("testTbl = {['before\\0after'] = 'value'}"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("before"));
+        QVERIFY2(member, "the walk did not name the member the way Lua names its key");
+        QVERIFY(!interface->writableByName(member));
+    }
+
+    // the name of a member is only as good as the names above it
+    void testNotWritableByNameUnderAFractionKeyedTable()
+    {
+        execLua(qsl("testTbl = {[1/3] = {member = 'value'}}"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("0.33333333333333")), qsl("member"));
+        QVERIFY(member);
+        QVERIFY(!interface->writableByName(member));
+    }
+
+    void testNotWritableByNameForAGlobalAScriptRemoved()
+    {
+        execLua(qsl("testVar = 'hello'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("testVar"));
+        QVERIFY(var);
+        execLua(qsl("testVar = nil"));
+        QVERIFY(!interface->writableByName(var));
+    }
+
+    // What it holds is the script's business: the tree may be showing a value
+    // that is a type out of date, and the name still reaches the variable.
+    void testWritableByNameAfterAScriptChangedTheType()
+    {
+        execLua(qsl("testVar = 'hello'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("testVar"));
+        QVERIFY(var);
+        execLua(qsl("testVar = 42"));
+        QVERIFY(interface->writableByName(var));
+    }
+
+    // Both are shown as "before", so neither name says which member it means -
+    // and the one a write would reach is the other one.
+    void testNotWritableByNameWhenTwoMembersAreShownUnderOneName()
+    {
+        execLua(qsl("testTbl = {} testTbl['before\\0after'] = 'first' testTbl['before'] = 'second'"));
+        interface->getVars(false);
+        TVar* table = findChild(interface->getVarUnit()->getBase(), qsl("testTbl"));
+        QVERIFY(table);
+        int shownAsBefore = 0;
+        for (TVar* member : table->getChildren(false)) {
+            if (member->getName() == qsl("before")) {
+                ++shownAsBefore;
+                QVERIFY(!interface->writableByName(member));
+            }
+        }
+        QCOMPARE(shownAsBefore, 2);
+    }
+
+    // ...while a number key and a string key that read alike are different
+    // lookups, so both stay writable
+    void testWritableByNameForAStringKeyThatReadsLikeItsNumberSibling()
+    {
+        execLua(qsl("testTbl = {} testTbl[42] = 'number keyed' testTbl['42'] = 'string keyed'"));
+        interface->getVars(false);
+        TVar* table = findChild(interface->getVarUnit()->getBase(), qsl("testTbl"));
+        QVERIFY(table);
+        int shownAs42 = 0;
+        for (TVar* member : table->getChildren(false)) {
+            if (member->getName() == qsl("42")) {
+                ++shownAs42;
+                QVERIFY(interface->writableByName(member));
+            }
+        }
+        QCOMPARE(shownAs42, 2);
+    }
+
+    // The write paths put a string key into a quoted Lua literal, where a
+    // backslash starts an escape and reaches a key of its own instead.
+    void testNotWritableByNameForAMemberWithABackslashInItsKey()
+    {
+        execLua(qsl("testTbl = {} testTbl['C:\\\\temp'] = 'value'"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("C:\\temp"));
+        QVERIFY2(member, "the walk did not name the member after its key");
+        QVERIFY(!interface->writableByName(member));
+    }
+
+    // ...and a global goes into that source bare, so only an identifier gets
+    // there. One with a dot in it would parse as an index into another global.
+    void testNotWritableByNameForAGlobalWithADotInItsName()
+    {
+        execLua(qsl("_G['dotted.global'] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("dotted.global"));
+        QVERIFY(var);
+        QVERIFY(!interface->writableByName(var));
+    }
+
+    void testNotWritableByNameForANumberKeyedGlobal()
+    {
+        execLua(qsl("_G[7] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("7"));
+        QVERIFY(var);
+        QVERIFY(!interface->writableByName(var));
+    }
+
+    // it walks down to the variable a push at a time, and in the editor that is
+    // the profile's own stack, where a slot left behind stays for the session
+    void testWritableByNameLeavesTheStackAsItFoundIt()
+    {
+        execLua(qsl("testTbl = {writable = 'value', [1/3] = 'value'}"));
+        interface->getVars(false);
+        TVar* table = findChild(interface->getVarUnit()->getBase(), qsl("testTbl"));
+        QVERIFY(table);
+        TVar* writable = findChild(table, qsl("writable"));
+        TVar* unwritable = findChild(table, qsl("0.33333333333333"));
+        QVERIFY(writable);
+        QVERIFY(unwritable);
+
+        lua_pushstring(L, "sentinel");
+        const int stackBefore = lua_gettop(L);
+        QVERIFY(interface->writableByName(writable));
+        QCOMPARE(lua_gettop(L), stackBefore);
+        QVERIFY(!interface->writableByName(unwritable));
+        QCOMPARE(lua_gettop(L), stackBefore);
+        QCOMPARE(QString::fromUtf8(lua_tostring(L, -1)), qsl("sentinel"));
+        lua_pop(L, 1);
     }
 
     // ========================================================================

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(FUNCTIONAL_TEST_SOURCES
     CopyAsImageTest.cpp
     GlyphOverflowTest.cpp
     GMCPCharLoginTest.cpp
+    VariableEditorWriteBackTest.cpp
     InsertTextCapTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
     SetScriptCallbackTest.cpp

--- a/test/functional_tests/VariableEditorWriteBackTest.cpp
+++ b/test/functional_tests/VariableEditorWriteBackTest.cpp
@@ -1,0 +1,448 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Tests for what the Variables editor writes back to Lua when the user leaves a
+ * variable. The editor knows a variable by the name the variable tree gives it,
+ * and for a string or number key that name is the text Lua has for the key -
+ * which not every key comes back from. Lua names a number key with "%.14g", so
+ * a key of 1/3 is shown as "0.33333333333333", which is a different key, and a
+ * write made through the shown name lands beside the real variable instead of
+ * on it.
+ *
+ * Run with: ctest -R VariableEditorWriteBackTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "dlgTriggerEditor.h"
+#include "dlgVarsMainArea.h"
+#include "mudlet.h"
+
+#include <QTreeWidget>
+
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#include <lua5.1/lualib.h>
+#else
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#endif
+}
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForVariableEditorWriteBackTest();
+
+class VariableEditorWriteBackTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgTriggerEditor* mpEditor = nullptr;
+    QTreeWidget* mpVariablesTree = nullptr;
+    const QString mHostname = "VariableEditorWriteBack-Test";
+    const QString mLocalhost = "localhost";
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForVariableEditorWriteBackTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        // port 0 asks the OS for an ephemeral port, so parallel test runs
+        // (and other worktrees) cannot collide on a fixed one
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->serverPort() != 0, "TelnetServerStub failed to bind a loopback port");
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+
+        startProfile(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY2(mpHost, "No active host after profile creation");
+        QVERIFY2(showEditorOnVariablesView(), "the script editor could not be opened on the Variables view");
+        mpVariablesTree = mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_variables"));
+        QVERIFY2(mpVariablesTree, "the editor has no variables tree widget");
+    }
+
+    void cleanupTestCase()
+    {
+        mpVariablesTree = nullptr;
+        mpEditor = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory(mHostname);
+        delete mudlet::self();
+    }
+
+    // Selecting a member whose key the tree can only name approximately and
+    // then clicking away: the editor has nothing it can write, and must not put
+    // what it read under the name it has.
+    void test_leavingAFractionKeyedMemberAddsNoSecondMember()
+    {
+        execLua(qsl("fractionKeyTable = {[1/3] = 'fraction member value'} fractionKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("fractionKeyTable"), qsl("0.33333333333333")});
+        QVERIFY2(pMember, "the Variables view did not show the member under the name Lua gives its key");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("fractionKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        QVERIFY2(bannerShowing(), "selecting a variable the editor cannot write has to say so");
+        QVERIFY2(bannerText().contains(qsl("0.33333333333333")), "the message should name the variable it is about");
+
+        selectVariable(pDecoy);
+        QCOMPARE(luaMemberCount(qsl("fractionKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("fractionKeyTable[1/3]"), qsl("fraction member value")), "leaving the member changed the value it was showing");
+        QVERIFY2(!bannerShowing(), "the message belongs to the variable it is about, not to the next one");
+
+        execLua(qsl("fractionKeyTable = nil fractionKeyDecoy = nil"));
+    }
+
+    // ...and it stays out of Lua when the user does type something, rather than
+    // going to the key the name spells out.
+    void test_editingAFractionKeyedMemberChangesNothing()
+    {
+        execLua(qsl("editedKeyTable = {[1/3] = 'fraction member value'} editedKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("editedKeyTable"), qsl("0.33333333333333")});
+        QVERIFY2(pMember, "the Variables view did not show the member under the name Lua gives its key");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("editedKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited member value"));
+        selectVariable(pDecoy);
+
+        QCOMPARE(luaMemberCount(qsl("editedKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("editedKeyTable[1/3]"), qsl("fraction member value")), "the edit reached a variable it was not meant to reach");
+
+        execLua(qsl("editedKeyTable = nil editedKeyDecoy = nil"));
+    }
+
+    // Leaving the Variables view saves what is on screen as well, and that path
+    // does not go through clicking another variable.
+    void test_switchingViewsWithAnEditPendingChangesNothing()
+    {
+        execLua(qsl("viewSwitchTable = {[1/3] = 'fraction member value'}"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("viewSwitchTable"), qsl("0.33333333333333")});
+        QVERIFY2(pMember, "the Variables view did not show the member under the name Lua gives its key");
+
+        selectVariable(pMember);
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited member value"));
+        mpEditor->slot_showTriggers();
+        QTest::qWait(20);
+
+        QCOMPARE(luaMemberCount(qsl("viewSwitchTable")), 1);
+        QVERIFY2(luaHolds(qsl("viewSwitchTable[1/3]"), qsl("fraction member value")), "the edit reached a variable it was not meant to reach");
+
+        QVERIFY2(showEditorOnVariablesView(), "the editor could not be put back on the Variables view");
+        execLua(qsl("viewSwitchTable = nil"));
+    }
+
+    // A rename goes through the same name to find what it is renaming, so it is
+    // refused on the same terms - and the tree keeps the name it had.
+    void test_renamingAFractionKeyedMemberIsRefused()
+    {
+        execLua(qsl("renamedKeyTable = {[1/3] = 'fraction member value'} renamedKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("renamedKeyTable"), qsl("0.33333333333333")});
+        QVERIFY2(pMember, "the Variables view did not show the member under the name Lua gives its key");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("renamedKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        mpEditor->mpVarsMainArea->lineEdit_var_name->setText(qsl("renamedMember"));
+        selectVariable(pDecoy);
+
+        QCOMPARE(luaMemberCount(qsl("renamedKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("renamedKeyTable[1/3]"), qsl("fraction member value")), "the member did not survive the rename attempt");
+        QCOMPARE(pMember->text(0), qsl("0.33333333333333"));
+
+        execLua(qsl("renamedKeyTable = nil renamedKeyDecoy = nil"));
+    }
+
+    // The same for a table member under a string key that does not survive the
+    // trip through the C string the tree names it with.
+    void test_leavingAMemberWithANulInItsKeyAddsNoSecondMember()
+    {
+        execLua(qsl("nulKeyTable = {['before\\0after'] = 'nul member value'} nulKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("nulKeyTable"), qsl("before")});
+        QVERIFY2(pMember, "the Variables view did not show the member under the name Lua gives its key");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("nulKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        selectVariable(pDecoy);
+
+        QCOMPARE(luaMemberCount(qsl("nulKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("nulKeyTable['before\\0after']"), qsl("nul member value")), "leaving the member changed the value it was showing");
+
+        execLua(qsl("nulKeyTable = nil nulKeyDecoy = nil"));
+    }
+
+    // A global whose name is not an identifier is not reached by that name
+    // either: the write paths put a root into Lua source bare, so a dot in it
+    // reads as an index into whatever global comes before the dot.
+    void test_editingAGlobalWithADotInItsNameLeavesOtherTablesAlone()
+    {
+        execLua(qsl("dotted = {} _G['dotted.global'] = 'dotted global value' dottedDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pGlobal = findVariableItem({qsl("dotted.global")});
+        QVERIFY2(pGlobal, "the Variables view did not show the global");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("dottedDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pGlobal);
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited dotted value"));
+        selectVariable(pDecoy);
+
+        QCOMPARE(luaMemberCount(qsl("dotted")), 0);
+        QVERIFY2(luaHolds(qsl("_G['dotted.global']"), qsl("dotted global value")), "the global was changed under a name that does not reach it");
+
+        execLua(qsl("dotted = nil _G['dotted.global'] = nil dottedDecoy = nil"));
+    }
+
+    // The control: an integer key is named exactly, so this member is the
+    // editor's to write - both when it is left alone and when it is edited.
+    void test_anIntegerKeyedMemberIsStillEditable()
+    {
+        execLua(qsl("integerKeyTable = {[2] = 'integer member value'} integerKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("integerKeyTable"), qsl("2")});
+        QVERIFY2(pMember, "the Variables view did not show the member");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("integerKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        QVERIFY2(!bannerShowing(), "a variable the editor can write must not be reported as one it cannot");
+        selectVariable(pDecoy);
+        QCOMPARE(luaMemberCount(qsl("integerKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("integerKeyTable[2]"), qsl("integer member value")), "leaving the member alone changed its value");
+
+        selectVariable(pMember);
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited member value"));
+        selectVariable(pDecoy);
+        QCOMPARE(luaMemberCount(qsl("integerKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("integerKeyTable[2]"), qsl("edited member value")), "editing the member did not reach Lua");
+
+        execLua(qsl("integerKeyTable = nil integerKeyDecoy = nil"));
+    }
+
+    // ...and the same for a plain global, which the editor reaches without a
+    // key of its own to name.
+    void test_aStringKeyedGlobalIsStillEditable()
+    {
+        execLua(qsl("stringKeyGlobal = 'global value' stringKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pGlobal = findVariableItem({qsl("stringKeyGlobal")});
+        QVERIFY2(pGlobal, "the Variables view did not show the global");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("stringKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pGlobal);
+        QVERIFY2(!bannerShowing(), "a variable the editor can write must not be reported as one it cannot");
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited global value"));
+        selectVariable(pDecoy);
+        QVERIFY2(luaHolds(qsl("stringKeyGlobal"), qsl("edited global value")), "editing the global did not reach Lua");
+
+        execLua(qsl("stringKeyGlobal = nil stringKeyDecoy = nil"));
+    }
+
+private:
+    void execLua(const QString& code)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, code.toUtf8().constData()), 0);
+    }
+
+    // How many keys the table has, so that a member the editor added beside the
+    // real one is caught whatever it was named.
+    int luaMemberCount(const QString& tableName)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        const QString code = qsl("local n = 0 for _ in pairs(%1) do n = n + 1 end return n").arg(tableName);
+        if (luaL_dostring(L, code.toUtf8().constData()) != 0) {
+            lua_pop(L, 1);
+            return -1;
+        }
+        const int count = static_cast<int>(lua_tonumber(L, -1));
+        lua_pop(L, 1);
+        return count;
+    }
+
+    bool luaHolds(const QString& expression, const QString& value)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        const QString code = qsl("return %1").arg(expression);
+        if (luaL_dostring(L, code.toUtf8().constData()) != 0) {
+            // otherwise a typo in the expression reads as a product bug
+            qWarning().noquote().nospace() << "luaHolds() could not run \"" << code << "\": " << lua_tostring(L, -1);
+            lua_pop(L, 1);
+            return false;
+        }
+        const bool held = lua_isstring(L, -1) && QString::fromUtf8(lua_tostring(L, -1)) == value;
+        lua_pop(L, 1);
+        return held;
+    }
+
+    bool bannerShowing() const { return !mpEditor->mpSystemMessageArea->isHidden(); }
+
+    QString bannerText() const { return mpEditor->mpSystemMessageArea->notificationAreaMessageBox->text(); }
+
+    QTreeWidgetItem* findVariableItem(const QStringList& namePath)
+    {
+        QTreeWidgetItem* pItem = mpVariablesTree->topLevelItem(0);
+        for (const QString& name : namePath) {
+            QTreeWidgetItem* pNext = nullptr;
+            for (int i = 0; pItem && i < pItem->childCount(); ++i) {
+                if (pItem->child(i)->text(0) == name) {
+                    pNext = pItem->child(i);
+                    break;
+                }
+            }
+            if (!pNext) {
+                return nullptr;
+            }
+            pItem = pNext;
+        }
+        return pItem;
+    }
+
+    // What clicking an item in the Variables view does, which is also what saves
+    // whatever was selected before it. Both calls are deliberate: setting the
+    // current item already reaches slot_variableSelected() through
+    // itemSelectionChanged, and the explicit call stands in for the itemClicked
+    // that follows on the mouse release.
+    void selectVariable(QTreeWidgetItem* pItem)
+    {
+        mpVariablesTree->setCurrentItem(pItem);
+        mpEditor->slot_variableSelected(pItem);
+    }
+
+    // Returns false rather than asserting: QVERIFY expands to a bare return,
+    // which would leave the caller to dereference a null editor.
+    bool showEditorOnVariablesView()
+    {
+        if (!mpEditor) {
+            mudlet::self()->slot_showScriptDialog();
+            QTest::qWait(100);
+            mpEditor = mpHost->mpEditorDialog;
+            if (!mpEditor) {
+                return false;
+            }
+        }
+        mpEditor->slot_showVariables();
+        QTest::qWait(50);
+        return true;
+    }
+
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), hostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), address);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), port);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(2000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(1000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        QDir dir(path);
+
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+};
+
+void initializeQRCResourcesForVariableEditorWriteBackTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "VariableEditorWriteBackTest.moc"
+QTEST_MAIN(VariableEditorWriteBackTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The Variables tree names a variable with the text Lua has for its key, and `t[1/3]` gets `0.33333333333333` - a different key. Selecting that member and clicking away wrote an empty value through the shown name, leaving `t[0.33333333333333] = ""` next to the real member. Same family: a key cut short at an embedded NUL, a key holding a backslash (the write path builds Lua source, where it becomes an escape), and a global with a dot in its name (which lands inside some other global's table).
- `LuaInterface::writableByName()` answers whether a variable can be written back under the name the tree gave it: the name has to find that same variable again - raw, as the tree was built - it has to be the only member of its table shown under it, and it has to survive the Lua source the write paths generate. That holds for the tables above the variable as much as for the variable. `saveVar()` skips the write when it does not.
- Selecting such a variable now says so, which is also where the empty value box it shows gets explained.

#### Motivation for adding to Mudlet

Clicking through the Variables view quietly added junk members to players' tables, and saved tables carried them into the profile save.

#### Other info (issues closed, discussion etc)

Closes #9903. Pre-existing, not a 5.0 regression - the editor write-back logic dates from 2017/2018.

Touches `LuaInterface.cpp` alongside #9892 and #9895, in a different function; no behavioural overlap. Checked for over-refusal by running the new test against every variable of a live profile: 6779 variables, none of them refused.

**Test case:** `lua junk = {[1/3] = 'value'}`, open the editor's Variables view, click the `0.33333333333333` member, click another variable, then `lua display(junk)` - one member, unchanged.

Assisted-by: Claude:claude-opus-5