### PR TITLE
improve: text and trigger throughput, and a CSI sequence that read freed memory

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -979,7 +979,9 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                     // Needed for mud.durismud.com see forum message topic:
                     // https://forums.mudlet.org/viewtopic.php?f=9&t=22887
                     const int dataLength = spanEnd - spanStart;
-                    const QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
+                    // fromRawData() has to point into localBuffer itself: a substr()
+                    // temporary is gone by the time temp is read
+                    const QByteArray temp = QByteArray::fromRawData(localBuffer.data() + localBufferPosition, dataLength);
                     bool isOk = false;
                     const int spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
@@ -1011,7 +1013,9 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                      *   scrollback buffer - which is again a NWIH for us...!
                      */
                     const int dataLength = spanEnd - spanStart;
-                    const QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
+                    // fromRawData() has to point into localBuffer itself: a substr()
+                    // temporary is gone by the time temp is read
+                    const QByteArray temp = QByteArray::fromRawData(localBuffer.data() + localBufferPosition, dataLength);
                     bool isOk = false;
                     const int argValue = temp.toInt(&isOk);
                     if (isOk) {
@@ -6656,7 +6660,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
 
         QString codePoint;
         if (TEncodingHelper::isEncodingAvailable(mEncoding)) {
-            codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.substr(pos, gbSequenceLength).c_str(), gbSequenceLength), mEncoding);
+            codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.data() + pos, gbSequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
                 Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
@@ -6770,7 +6774,7 @@ bool TBuffer::processBig5Sequence(const std::string& bufferData, const bool isFr
 
         QString codePoint;
         if (TEncodingHelper::isEncodingAvailable(mEncoding)) {
-            codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.substr(pos, big5SequenceLength).c_str(), big5SequenceLength), mEncoding);
+            codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.data() + pos, big5SequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
                 Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
@@ -6891,7 +6895,7 @@ bool TBuffer::processEUC_KRSequence(const std::string& bufferData, const bool is
 
         QString codePoint;
         if (TEncodingHelper::isEncodingAvailable(mEncoding)) {
-            codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.substr(pos, eucSequenceLength).c_str(), eucSequenceLength), mEncoding);
+            codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.data() + pos, eucSequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
                 Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5122,8 +5122,7 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
             continue;
         }
         const int nextBoundary = boundaryFinder.toNextBoundary();
-        const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
-        const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
+        const uint unicode = graphemeInfo::getBaseCharacter(QStringView(lineText).mid(indexOfChar, nextBoundary - indexOfChar));
         // Safety check: during destruction, mpHost might be null
         const int charWidth = mpHost ? graphemeInfo::getWidth(unicode, mpHost->wideAmbiguousEAsianGlyphs()) : graphemeInfo::getWidth(unicode, false);
         const int indentationHere = isNewline ? indent : hangingIndent;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -979,8 +979,8 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                     // Needed for mud.durismud.com see forum message topic:
                     // https://forums.mudlet.org/viewtopic.php?f=9&t=22887
                     const int dataLength = spanEnd - spanStart;
-                    // fromRawData() has to point into localBuffer itself: a substr()
-                    // temporary is gone by the time temp is read
+                    // fromRawData() does not copy, so the bytes have to outlive temp:
+                    // point it into localBuffer rather than at any temporary
                     const QByteArray temp = QByteArray::fromRawData(localBuffer.data() + localBufferPosition, dataLength);
                     bool isOk = false;
                     const int spacesNeeded = temp.toInt(&isOk);
@@ -1013,8 +1013,8 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                      *   scrollback buffer - which is again a NWIH for us...!
                      */
                     const int dataLength = spanEnd - spanStart;
-                    // fromRawData() has to point into localBuffer itself: a substr()
-                    // temporary is gone by the time temp is read
+                    // fromRawData() does not copy, so the bytes have to outlive temp:
+                    // point it into localBuffer rather than at any temporary
                     const QByteArray temp = QByteArray::fromRawData(localBuffer.data() + localBufferPosition, dataLength);
                     bool isOk = false;
                     const int argValue = temp.toInt(&isOk);
@@ -6662,7 +6662,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.data() + pos, gbSequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
-                Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
+                Q_UNREACHABLE(); // This can't happen, unless we got pos or gbSequenceLength wrong
                 qWarning().nospace() << "TBuffer::processGBSequence(...) " << gbSequenceLength << "-byte " << (isGB18030 ? "GB18030" : "GB2312/GBK") << " sequence accepted, and it encoded to "
                                      << codePoint.size() << " QChars which does not make sense!!!";
                 isValid = false;
@@ -6776,7 +6776,7 @@ bool TBuffer::processBig5Sequence(const std::string& bufferData, const bool isFr
             codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.data() + pos, big5SequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
-                Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
+                Q_UNREACHABLE(); // This can't happen, unless we got pos or big5SequenceLength wrong
                 qWarning().nospace() << "TBuffer::processBig5Sequence(...) " << big5SequenceLength << "-byte Big5 sequence accepted, and it encoded to " << codePoint.size()
                                      << " QChars which does not make sense!!!";
                 isValid = false;
@@ -6897,7 +6897,7 @@ bool TBuffer::processEUC_KRSequence(const std::string& bufferData, const bool is
             codePoint = TEncodingHelper::decode(QByteArray::fromRawData(bufferData.data() + pos, eucSequenceLength), mEncoding);
             switch (codePoint.size()) {
             default:
-                Q_UNREACHABLE(); // This can't happen, unless we got start or length wrong in std::string::substr()
+                Q_UNREACHABLE(); // This can't happen, unless we got pos or eucSequenceLength wrong
                 qWarning().nospace() << "TBuffer::processEUC_KRSequence(...) " << eucSequenceLength << "-byte EUC-KR sequence accepted, and it encoded to " << codePoint.size()
                                      << " QChars which does not make sense!!!";
                 isValid = false;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1724,7 +1724,7 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bo
             int charWidth = 0;
             // This could contain a surrogate pair (i.e. pair of QChars) and/or
             // include suffixed combining diacritical marks (additional QChars):
-            const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
+            const QStringView grapheme = QStringView(lineText).mid(indexOfChar, nextBoundary - indexOfChar);
             const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
             if (unicode == '\t') {
                 charWidth = mTabStopwidth - (column % mTabStopwidth);
@@ -2285,8 +2285,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
             auto nextBoundary{boundaryFinder.toNextBoundary()};
             // Width in "normal" width equivalent of this grapheme:
             int charWidth{};
-            const QString grapheme = lineText.mid(indexOfChar, nextBoundary - indexOfChar);
-            const uint unicode = graphemeInfo::getBaseCharacter(grapheme);
+            const uint unicode = graphemeInfo::getBaseCharacter(QStringView(lineText).mid(indexOfChar, nextBoundary - indexOfChar));
             if (unicode == '\t') {
                 charWidth = mTabStopwidth - (column % mTabStopwidth);
             } else {

--- a/src/TTextProperties.h
+++ b/src/TTextProperties.h
@@ -27,6 +27,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QStringView>
+
 #include <string>
 #include "widechar_width.h"
 
@@ -70,12 +72,11 @@ inline int getWidth(uint unicode, bool mWideAmbigousWidthGlyphs)
 }
 
 
-
 // Extract the base (first) part which will be one or two QChars
 // and if they ARE a surrogate pair convert them back to the single
 // Unicode codepoint (needs around 21 bits, can be contained in a
 // 32bit unsigned integer) value:
-inline uint getBaseCharacter(const QString& str)
+inline uint getBaseCharacter(QStringView str)
 {
     if (str.isEmpty()) {
         return 0;
@@ -89,7 +90,8 @@ inline uint getBaseCharacter(const QString& str)
         }
 
         if (Q_UNLIKELY(first.isLowSurrogate() && second.isHighSurrogate())) {
-            qDebug().noquote().nospace() << "TTextEdit::getGraphemeBaseCharacter(\"str\") INFO - passed a QString comprising a Low followed by a High surrogate QChar, this is not expected, they will be swapped around to try and recover but if this causes mojibake (text corrupted into meaningless symbols) please report this to the developers!";
+            qDebug().noquote().nospace() << "TTextEdit::getGraphemeBaseCharacter(\"str\") INFO - passed a QString comprising a Low followed by a High surrogate QChar, this is not expected, they will "
+                                            "be swapped around to try and recover but if this causes mojibake (text corrupted into meaningless symbols) please report this to the developers!";
             return QChar::surrogateToUcs4(second, first);
         }
 

--- a/src/TTextProperties.h
+++ b/src/TTextProperties.h
@@ -90,7 +90,7 @@ inline uint getBaseCharacter(QStringView str)
         }
 
         if (Q_UNLIKELY(first.isLowSurrogate() && second.isHighSurrogate())) {
-            qDebug().noquote().nospace() << "TTextEdit::getGraphemeBaseCharacter(\"str\") INFO - passed a QString comprising a Low followed by a High surrogate QChar, this is not expected, they will "
+            qDebug().noquote().nospace() << "graphemeInfo::getBaseCharacter() INFO - passed a grapheme comprising a Low followed by a High surrogate QChar, this is not expected, they will "
                                             "be swapped around to try and recover but if this causes mojibake (text corrupted into meaningless symbols) please report this to the developers!";
             return QChar::surrogateToUcs4(second, first);
         }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -220,7 +220,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
     return state;
 }
 
-bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternNumber, int posOffset, int lineNumber)
+bool TTrigger::match_perl(const char* haystackC, const int haystackCLength, const QString& haystack, int patternNumber, int posOffset, int lineNumber)
 {
     assert(mRegexMap.contains(patternNumber));
 
@@ -235,8 +235,6 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         }
         return false; //regex compile error
     }
-
-    const int haystackCLength = strlen(haystackC);
 
     QSharedPointer<pcre2_match_data>& matchData = mMatchDataMap[patternNumber];
     if (!matchData) {
@@ -561,8 +559,10 @@ void TTrigger::filter(std::string& capture, int& posOffset, int lineNumber)
         return;
     }
     const QString text = QString::fromStdString(capture);
+    // Perl patterns see the capture only as far as its first NUL byte
+    const int captureLength = static_cast<int>(qstrnlen(capture.data(), capture.size()));
     for (auto& trigger : *mpMyChildrenList) {
-        trigger->match(capture.data(), text, lineNumber, posOffset);
+        trigger->match(capture.data(), captureLength, text, lineNumber, posOffset);
     }
 }
 
@@ -915,11 +915,12 @@ void TTrigger::processExactMatch(const QString& needle, int patternNumber, int p
     }
 }
 
-// haystackC: string to match as a char*
+// haystackC: string to match as a char*, UTF-8 encoded
+// haystackCLength: how much of haystackC perl patterns are offered, in bytes
 // haystack: string to match as a QString
 // line: line number in the buffer
 // posOffset: position in the line to start matching from; used by child triggers
-bool TTrigger::match(char* haystackC, const QString& haystack, int line, int posOffset)
+bool TTrigger::match(const char* haystackC, const int haystackCLength, const QString& haystack, int line, int posOffset)
 {
     // Guard against re-entrancy: cleanup may have deleted this trigger while
     // match() was still on the call stack
@@ -971,7 +972,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                 break;
 
             case REGEX_PERL:
-                ret = match_perl(haystackC, haystack, patternNumber, posOffset, line);
+                ret = match_perl(haystackC, haystackCLength, haystack, patternNumber, posOffset, line);
                 break;
 
             case REGEX_BEGIN_OF_LINE_SUBSTRING:
@@ -1083,7 +1084,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
         if (!mFilterTrigger) {
             if (conditionMet || (mPatterns.empty())) {
                 for (auto trigger : *mpMyChildrenList) {
-                    ret = trigger->match(haystackC, haystack, line, posOffset);
+                    ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset);
                     if (ret) {
                         conditionMet = true;
                     }
@@ -1097,7 +1098,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                 execute();
             }
             for (auto trigger : *mpMyChildrenList) {
-                ret = trigger->match(haystackC, haystack, line, posOffset);
+                ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset);
                 if (ret) {
                     conditionMet = true;
                 }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -559,7 +559,8 @@ void TTrigger::filter(std::string& capture, int& posOffset, int lineNumber)
         return;
     }
     const QString text = QString::fromStdString(capture);
-    // Perl patterns see the capture only as far as its first NUL byte
+    // pcre2 takes an explicit subject length: cut it at the first NUL, so perl
+    // patterns stop there while the QString-based ones still see the whole capture
     const int captureLength = static_cast<int>(qstrnlen(capture.data(), capture.size()));
     for (auto& trigger : *mpMyChildrenList) {
         trigger->match(capture.data(), captureLength, text, lineNumber, posOffset);
@@ -916,7 +917,9 @@ void TTrigger::processExactMatch(const QString& needle, int patternNumber, int p
 }
 
 // haystackC: string to match as a char*, UTF-8 encoded
-// haystackCLength: how much of haystackC perl patterns are offered, in bytes
+// haystackCLength: bytes of haystackC offered to perl patterns; it stops at the
+//   first NUL, so it can be shorter than the buffer. Nothing here copies
+//   haystackC, so it has to stay alive for the whole call
 // haystack: string to match as a QString
 // line: line number in the buffer
 // posOffset: position in the line to start matching from; used by child triggers

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -107,7 +107,7 @@ public:
     QString getScript() const { return mScript; }
     bool setScript(const QString& script);
     bool compileScript();
-    bool match(char*, const QString&, int line, int posOffset = 0);
+    bool match(const char* haystackC, int haystackCLength, const QString&, int line, int posOffset = 0);
     bool checkIfNew();
     void unmarkAsNew();
 
@@ -123,7 +123,7 @@ public:
     void disableTrigger(const QString&);
     TTrigger* killTrigger(const QString&);
     bool match_substring(const QString&, const QString&, int, int posOffset, int lineNumber);
-    bool match_perl(char*, const QString&, int, int posOffset, int lineNumber);
+    bool match_perl(const char* haystackC, int haystackCLength, const QString&, int, int posOffset, int lineNumber);
     bool match_exact_match(const QString&, const QString&, int, int posOffset, int lineNumber);
     bool match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber);
     bool match_lua_code(int);
@@ -261,7 +261,7 @@ inline QDebug& operator<<(QDebug& debug, const TTrigger* trigger)
     debug.nospace() << ", isMultiline=" << trigger->isMultiline();
     debug.nospace() << ", patterns=" << trigger->getPatternsList();
     debug.nospace() << ", regexCodes=" << trigger->getRegexCodePropertyList();
-    debug.nospace() << ", script is in: " << (trigger->mRegisteredAnonymousLuaFunction ? "string": "Lua function");
+    debug.nospace() << ", script is in: " << (trigger->mRegisteredAnonymousLuaFunction ? "string" : "Lua function");
     debug.nospace() << ", script=" << trigger->getScript();
     debug.nospace() << ')';
     return debug;

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -401,16 +401,12 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         return;
     }
 
+    // utf8Data has to outlive every match() call below, which reads through
+    // subject. Perl patterns see the line only as far as its first NUL byte,
+    // so this is qstrnlen() rather than the byte count.
     const QByteArray utf8Data = data.toUtf8();
-    const char* utf8Ptr = utf8Data.constData();
-    const size_t utf8Length = utf8Data.size();
-
-    char* subject = static_cast<char*>(malloc(utf8Length + 1));
-    if (!subject) {
-        return;
-    }
-    memcpy(subject, utf8Ptr, utf8Length);
-    subject[utf8Length] = '\0';
+    const char* subject = utf8Data.constData();
+    const int subjectLength = static_cast<int>(qstrnlen(subject, utf8Data.size()));
 
     mProcessingDepth++;
     const auto processingGuard = qScopeGuard([this] {
@@ -450,7 +446,7 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         if (!trigger->isActive()) {
             continue;
         }
-        trigger->match(subject, data, line);
+        trigger->match(subject, subjectLength, data, line);
     }
     // A match here can register more triggers, which also get a shot at the
     // current line - so the list grows in front of the loop, and a trigger that
@@ -475,9 +471,8 @@ void TriggerUnit::processDataStream(const QString& data, int line)
             stopSameLineCreationLoop(trigger->sameLineChainId());
             continue;
         }
-        trigger->match(subject, data, line);
+        trigger->match(subject, subjectLength, data, line);
     }
-    free(subject);
 }
 
 void TriggerUnit::compileAll()

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -401,9 +401,9 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         return;
     }
 
-    // utf8Data has to outlive every match() call below, which reads through
-    // subject. Perl patterns see the line only as far as its first NUL byte,
-    // so this is qstrnlen() rather than the byte count.
+    // subject points into utf8Data, so utf8Data has to outlive every match()
+    // call below. Perl patterns see the line only as far as its first NUL
+    // byte, so this is qstrnlen() rather than the byte count.
     const QByteArray utf8Data = data.toUtf8();
     const char* subject = utf8Data.constData();
     const int subjectLength = static_cast<int>(qstrnlen(subject, utf8Data.size()));

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -297,6 +297,48 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
+    -- The subject handed to PCRE is measured in UTF-8 bytes, not in the UTF-16
+    -- code units a QString counts: a length taken from the wrong one cuts a
+    -- multibyte line short and the end anchor then matches in the wrong place
+    it("matches a multibyte line right through to its end anchor", function()
+        local send = spy.on(_G, "send")
+        local snapshot = {}
+        local pattern = "^(\\w+) (\\w+) (\\w+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            send("match")
+            snapshot = matches
+        end, 1)
+
+        feedTriggers("\nЗдравствуй уважаемый Mudlet\n")
+
+        assert.spy(send).was.called(1)
+        assert.are.equal("Здравствуй уважаемый Mudlet", snapshot[1])
+        assert.are.equal("Здравствуй", snapshot[2])
+        assert.are.equal("уважаемый", snapshot[3])
+        assert.are.equal("Mudlet", snapshot[4])
+        killTrigger(id)
+    end)
+
+    -- A capture's position comes back from PCRE as a byte offset and has to be
+    -- converted to the character position the console selects by. The dragon is
+    -- outside the BMP, so it is four UTF-8 bytes but two of those characters
+    it("selectCaptureGroup lands on the right characters after multibyte text", function()
+        local selection
+        local pattern = "^Цель: (\\S+) Оружие: (?<wpn>\\w+)$"
+
+        local id = tempRegexTrigger(pattern, function()
+            selectCaptureGroup("wpn")
+            selection = getSelection()
+            deselect()
+        end, 1)
+
+        feedTriggers("\nЦель: 🐉 Оружие: меч\n")
+
+        assert.are.equal("меч", selection)
+        killTrigger(id)
+    end)
+
     -- selectCaptureGroup by name selects correct text
     it("selectCaptureGroup by name selects the right text", function()
         local selection_first, selection_second

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(FUNCTIONAL_TEST_SOURCES
     TelnetReconnectStateTest.cpp
     SavedVariableFenceTest.cpp
     ColorTriggerFilterChildTest.cpp
+    CsiCursorForwardTest.cpp
     CopyAsImageTest.cpp
     GlyphOverflowTest.cpp
     GMCPCharLoginTest.cpp

--- a/test/functional_tests/ColorTriggerFilterChildTest.cpp
+++ b/test/functional_tests/ColorTriggerFilterChildTest.cpp
@@ -26,6 +26,10 @@
  * the filter-child case, and that the child only scans the parent's capture
  * rather than the whole line.
  *
+ * A perl child of a filter parent is measured rather than scanned - it is
+ * handed the capture as UTF-8 bytes plus a length - so there is a case for that
+ * here too, over text where a byte count and a character count differ.
+ *
  * Run with: ctest -R ColorTriggerFilterChildTest -V
  */
 
@@ -97,6 +101,28 @@ private:
         pT->mFilterTrigger = true;
         pT->registerTrigger();
         pT->setScript(QString());
+        pT->setName(name);
+        pT->setIsActive(true);
+        return pT;
+    }
+
+    QString luaGlobalString(const char* name)
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, name);
+        const QString value = QString::fromUtf8(lua_tostring(L, -1));
+        lua_pop(L, 1);
+        return value;
+    }
+
+    TTrigger* makePerlChild(TTrigger* pParent, const QString& name, const QString& pattern, const QString& script)
+    {
+        auto* pT = new TTrigger(pParent, mpHost);
+        pT->setIsFolder(false);
+        pT->setTemporary(true);
+        pT->setRegexCodeList({pattern}, {REGEX_PERL});
+        pT->registerTrigger();
+        pT->setScript(script);
         pT->setName(name);
         pT->setIsActive(true);
         return pT;
@@ -180,6 +206,23 @@ private slots:
 
         runLua(qsl("feedTriggers('hello \\27[33mworld\\27[0m\\n')"));
         QVERIFY2(luaGlobalTrue("captureChildFired"), "color child should fire when the parent's capture is yellow");
+
+        pParent->setIsActive(false);
+        pChild->setIsActive(false);
+    }
+
+    // The child's pattern is anchored at both ends, so it only matches if the
+    // capture it is offered runs to the end. The dragon is four UTF-8 bytes but
+    // two characters, and the Cyrillic two bytes each, so a length taken in
+    // characters would stop the child short of its own end anchor.
+    void test_perlChildUnderFilterParentIsOfferedTheWholeCapture()
+    {
+        auto* pParent = makeFilterParent(qsl("multibyte filter parent"), qsl("^Цель: (.+)$"));
+        auto* pChild = makePerlChild(pParent, qsl("perl filter child"), qsl("^(\\S+) Оружие: (\\w+)$"), qsl("perlChildWeapon = matches[3]"));
+
+        runLua(qsl("perlChildWeapon = ''"));
+        runLua(qsl("feedTriggers('Цель: 🐉 Оружие: меч\\n')"));
+        QCOMPARE(luaGlobalString("perlChildWeapon"), qsl("меч"));
 
         pParent->setIsActive(false);
         pChild->setIsActive(false);

--- a/test/functional_tests/CsiCursorForwardTest.cpp
+++ b/test/functional_tests/CsiCursorForwardTest.cpp
@@ -22,19 +22,20 @@
  * argument out of: CUF (ESC[nC, emulated as n spaces) and ED (ESC[nJ, reported
  * and ignored). Both are live on mud.durismud.com.
  *
- * The long_* rows pad the argument past std::string's small-string
- * optimisation on purpose. The parser built its QByteArray over a substr()
- * temporary with QByteArray::fromRawData(), so it parsed bytes that had already
- * been freed; only an argument long enough to have been heap allocated makes
- * that read land somewhere the allocator has really taken back, and the
- * sequence then fails to parse at all. AddressSanitizer stays silent on it
- * either way, because QByteArray::toInt() reads those bytes inside Qt rather
- * than inside instrumented Mudlet code.
+ * Both handlers point a QByteArray at the argument's bytes without copying
+ * them, so the rows here guard against those bytes being gone by the time the
+ * argument is parsed and logged. Keep the long_* arguments long: a short one is
+ * inside whatever holds it, so a stale read of it can quietly succeed. Assert on
+ * what Mudlet does with the argument rather than on AddressSanitizer, which
+ * stays silent here - QByteArray::toInt() reads the bytes inside Qt, which is
+ * not instrumented.
  *
  * Run with: ctest -R CsiCursorForwardTest -V
  */
 
 #include <QtTest/QtTest>
+
+#include <QRegularExpression>
 
 #include "MudletInstanceCoordinator.h"
 #include "TBuffer.h"
@@ -61,6 +62,21 @@ private:
     const QString mHostname = qsl("CSI-Cursor-Forward-Test-Host");
     const QString mLocalhost = qsl("localhost");
     QString mPort;
+
+    // Leading zeros do not change the value parsed out of an argument, but they
+    // do carry it past the small-string optimisation of every standard library
+    // the project builds against - libstdc++ inlines up to 15 bytes, libc++ up
+    // to 22 - so a stale read lands in memory the allocator really has taken back
+    static QByteArray padded(const char* digits) { return QByteArray("000000000000000000000000") + digits; }
+
+    // Every branch that rejects a sequence logs the argument it parsed, as
+    // "<argument><final byte> received". For the sequences Mudlet does not act
+    // on that log is the only visible read of those bytes, so a stale one
+    // reports something else and leaves this expectation unfulfilled.
+    static void expectTheArgumentIsReadBack(const QByteArray& argument, char finalByte)
+    {
+        QTest::ignoreMessage(QtDebugMsg, QRegularExpression(QRegularExpression::escape(QString::fromUtf8(argument) + QLatin1Char(finalByte) + qsl(" received"))));
+    }
 
     void injectData(const QByteArray& payload)
     {
@@ -155,10 +171,8 @@ private slots:
 
         QTest::newRow("short_5") << QByteArray("5") << 5;
         QTest::newRow("short_1") << QByteArray("1") << 1;
-        // Leading zeros only pad the argument past the small-string optimisation;
-        // they do not change the value parsed out of it
-        QTest::newRow("long_5") << QByteArray("0000000000000000005") << 5;
-        QTest::newRow("long_12") << QByteArray("000000000000000000000000012") << 12;
+        QTest::newRow("long_5") << padded("5") << 5;
+        QTest::newRow("long_12") << padded("12") << 12;
     }
 
     void test_cursorForwardInsertsSpaces()
@@ -171,32 +185,36 @@ private slots:
         QCOMPARE(injectedLine(), qsl("AB%1CD").arg(QString(expectedSpaces, QChar::Space)));
     }
 
-    // A CUF argument that makes no sense leaves the line untouched. The parser
-    // reports it, which is what reads the argument a second time.
+    // A CUF argument that makes no sense leaves the line alone, so only the
+    // diagnostic can tell a good read from a bad one here.
     void test_nonsenseCursorForwardIsIgnored()
     {
-        injectData(QByteArray("AB\x1b[00000000000000000009999999999999999999CCD"));
+        const QByteArray argument = padded("9999999999999999999");
+
+        expectTheArgumentIsReadBack(argument, 'C');
+        injectData(QByteArray("AB\x1b[") + argument + QByteArray("CCD"));
 
         QCOMPARE(injectedLine(), qsl("ABCD"));
     }
 
-    // Every ED variant is incompatible with a scrollback buffer, so all Mudlet
-    // does is report the argument - and reporting it is the whole exposure.
+    // Mudlet acts on no ED variant, it only logs the argument, so as with the
+    // nonsense CUF above the diagnostic is the only thing that can discriminate.
     void test_eraseInDisplayIsIgnored_data()
     {
         QTest::addColumn<QByteArray>("argument");
 
         QTest::newRow("short_0") << QByteArray("0");
         QTest::newRow("short_2") << QByteArray("2");
-        QTest::newRow("long_2") << QByteArray("0000000000000000002");
-        QTest::newRow("long_out_of_range") << QByteArray("0000000000000000009");
-        QTest::newRow("long_nonsense") << QByteArray("00000000000000000099999999999999999999");
+        QTest::newRow("long_2") << padded("2");
+        QTest::newRow("long_out_of_range") << padded("9");
+        QTest::newRow("long_nonsense") << padded("9999999999999999999");
     }
 
     void test_eraseInDisplayIsIgnored()
     {
         QFETCH(QByteArray, argument);
 
+        expectTheArgumentIsReadBack(argument, 'J');
         injectData(QByteArray("AB\x1b[") + argument + QByteArray("JCD"));
 
         QCOMPARE(injectedLine(), qsl("ABCD"));

--- a/test/functional_tests/CsiCursorForwardTest.cpp
+++ b/test/functional_tests/CsiCursorForwardTest.cpp
@@ -1,0 +1,222 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Tests the two CSI sequences TBuffer::translateToPlainText() reads a numeric
+ * argument out of: CUF (ESC[nC, emulated as n spaces) and ED (ESC[nJ, reported
+ * and ignored). Both are live on mud.durismud.com.
+ *
+ * The long_* rows pad the argument past std::string's small-string
+ * optimisation on purpose. The parser built its QByteArray over a substr()
+ * temporary with QByteArray::fromRawData(), so it parsed bytes that had already
+ * been freed; only an argument long enough to have been heap allocated makes
+ * that read land somewhere the allocator has really taken back, and the
+ * sequence then fails to parse at all. AddressSanitizer stays silent on it
+ * either way, because QByteArray::toInt() reads those bytes inside Qt rather
+ * than inside instrumented Mudlet code.
+ *
+ * Run with: ctest -R CsiCursorForwardTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "MudletInstanceCoordinator.h"
+#include "TBuffer.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+static void initializeQRCResources();
+
+class CsiCursorForwardTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("CSI-Cursor-Forward-Test-Host");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort;
+
+    void injectData(const QByteArray& payload)
+    {
+        QByteArray data = payload;
+        data.append("\r\n");
+        mpHost->mTelnet.loopbackTest(data);
+        QTest::qWait(50);
+    }
+
+    // The buffer's last line is the empty one waiting for the next output, so
+    // look for the line the payload actually landed on
+    QString injectedLine() const
+    {
+        TBuffer& buffer = mpHost->mpConsole->buffer;
+        for (int line = buffer.getLastLineNumber(); line >= 0; --line) {
+            const QString& text = buffer.lineBuffer.at(line);
+            if (text.startsWith(qsl("AB"))) {
+                return text;
+            }
+        }
+        return QString();
+    }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResources();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        QTimer::singleShot(0, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy loaded(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!loaded.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+        QSignalSpy connected(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!connected.wait(3000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+        delete mudlet::self();
+    }
+
+    void init()
+    {
+        QVERIFY(mpHost);
+        QVERIFY(mpHost->mpConsole);
+        mpHost->mpConsole->buffer.clear();
+    }
+
+    void test_cursorForwardInsertsSpaces_data()
+    {
+        QTest::addColumn<QByteArray>("argument");
+        QTest::addColumn<int>("expectedSpaces");
+
+        QTest::newRow("short_5") << QByteArray("5") << 5;
+        QTest::newRow("short_1") << QByteArray("1") << 1;
+        // Leading zeros only pad the argument past the small-string optimisation;
+        // they do not change the value parsed out of it
+        QTest::newRow("long_5") << QByteArray("0000000000000000005") << 5;
+        QTest::newRow("long_12") << QByteArray("000000000000000000000000012") << 12;
+    }
+
+    void test_cursorForwardInsertsSpaces()
+    {
+        QFETCH(QByteArray, argument);
+        QFETCH(int, expectedSpaces);
+
+        injectData(QByteArray("AB\x1b[") + argument + QByteArray("CCD"));
+
+        QCOMPARE(injectedLine(), qsl("AB%1CD").arg(QString(expectedSpaces, QChar::Space)));
+    }
+
+    // A CUF argument that makes no sense leaves the line untouched. The parser
+    // reports it, which is what reads the argument a second time.
+    void test_nonsenseCursorForwardIsIgnored()
+    {
+        injectData(QByteArray("AB\x1b[00000000000000000009999999999999999999CCD"));
+
+        QCOMPARE(injectedLine(), qsl("ABCD"));
+    }
+
+    // Every ED variant is incompatible with a scrollback buffer, so all Mudlet
+    // does is report the argument - and reporting it is the whole exposure.
+    void test_eraseInDisplayIsIgnored_data()
+    {
+        QTest::addColumn<QByteArray>("argument");
+
+        QTest::newRow("short_0") << QByteArray("0");
+        QTest::newRow("short_2") << QByteArray("2");
+        QTest::newRow("long_2") << QByteArray("0000000000000000002");
+        QTest::newRow("long_out_of_range") << QByteArray("0000000000000000009");
+        QTest::newRow("long_nonsense") << QByteArray("00000000000000000099999999999999999999");
+    }
+
+    void test_eraseInDisplayIsIgnored()
+    {
+        QFETCH(QByteArray, argument);
+
+        injectData(QByteArray("AB\x1b[") + argument + QByteArray("JCD"));
+
+        QCOMPARE(injectedLine(), qsl("ABCD"));
+    }
+};
+
+static void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "CsiCursorForwardTest.moc"
+QTEST_MAIN(CsiCursorForwardTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `TBuffer::getWrapInfo()` and the two `TTextEdit` measuring loops built a whole QString per grapheme with `QString::mid()` just to read its first codepoint. Qt 6's `mid()` on a const lvalue deep-copies, so that was one malloc per character of every line received, every console resize and every mouse move over the console. `graphemeInfo::getBaseCharacter()` takes a `QStringView` now.
- `TriggerUnit::processDataStream()` no longer malloc/memcpy/frees a copy of each line for the pattern matchers, and works its length out once per line instead of once per perl pattern per trigger.
- CUF (`ESC[nC`) and ED (`ESC[nJ`) parsed their argument out of freed memory: `QByteArray::fromRawData()` was pointed at the `c_str()` of a `substr()` temporary that is destroyed at the end of that statement.

#### Motivation for adding to Mudlet
Mudlet is mostly a text-processing application, and this is the allocation traffic sitting inside its per-character loops - halving it is worth ~11% of raw text throughput for every user, and the freed-memory read is reachable from any server that sends those cursor sequences (mud.durismud.com does).

#### Other info (issues closed, discussion etc)
Closes #9924 (the freed-memory read, filed separately so the analysis is on record).

Measured with the existing `test/functional_tests/PipelineBenchmark` (the #9011 perf gate) on a RelWithDebInfo build, median of 7 runs each against 634a5025b, 25 000 lines fed 6 times. Ranges did not overlap on any row.

| | before | after | |
|---|---|---|---|
| text throughput | 117 055 lines/s | 130 408 lines/s | +11.4% |
| latin-1 text throughput | 139 916 lines/s | 158 962 lines/s | +13.6% |
| 46-trigger throughput | 75 530 lines/s | 80 468 lines/s | +6.5% |
| new-user profile (starter UI) | 26 236 lines/s | 28 128 lines/s | +7.2% |
| allocations, text pass | 26.1M | 12.7M | -51.4% |
| allocations, trigger pass | 30.9M | 17.5M | -43.3% |

Two candidates were measured and dropped rather than shipped: a hand-rolled UTF-8 to UTF-16 length counter to replace `QString::fromUtf8(...).length()` on the capture path came out ~1% **slower** than Qt's vectorised decoder, and converting the paint layout loop only moves its allocation into `layoutGrapheme()`, which has to materialise the grapheme for `drawText()` anyway. The `substr()` in the CJK decode loops is small-string-optimised, so removing it there is neutral - those three sites are in only because they use the same non-copying idiom as the bug above.

AddressSanitizer does not report the freed read, because `QByteArray::toInt()` reads those bytes inside uninstrumented libQt6Core; verified with a standalone reproducer. The behaviour is visible instead: with the fix reverted, 6 of the 12 new `CsiCursorForwardTest` rows fail.

**Test case:** connect to any game and check text still renders and wraps normally, including CJK/accented lines; `lua feedTriggers("\27[0000000000000000000000005Chello\n")` should print "hello" indented by five spaces.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
