### PR TITLE
improve: moving or resizing a Geyser layout no longer lays it out several times over

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -357,12 +357,14 @@ function Adjustable.Container:onMove (label, event)
             end
             tx = make_percent(tx/winw)
             ty = make_percent(ty/winh)
-            self:move(tx, ty)
             local minw, minh = 0,0
             if self.container == Geyser and not self.noLimit then minw, minh = 75,25 end
             tw,th = max(minw,tw), max(minh,th)
             tw,th = make_percent(tw/winw), make_percent(th/winh)
-            self:resize(tw, th)
+            -- one pass over the subtree per drag event, where move() then resize()
+            -- took two; neither runs here, so an override of either is not invoked
+            self.x, self.y, self.width, self.height = tx, ty, tw, th
+            self:set_constraints(self)
             if self.connectedContainers then
                 self:adjustConnectedContainers()
             end
@@ -1022,8 +1024,8 @@ end
 --- Event: "AdjustableContainerReposition" passed values (name, width, height, x, y, isMouseAction)
 --- (the isMouseAction property is true if the reposition is an effect of user dragging/resizing the window,
 --- and false if the reposition event comes as effect of external action, such as resizing of main window)
-function Adjustable.Container:reposition()
-    Geyser.Container.reposition(self)
+function Adjustable.Container:reposition(skipChildren)
+    Geyser.Container.reposition(self, skipChildren)
     raiseEvent(
       "AdjustableContainerReposition",
       self.name,

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -104,16 +104,19 @@ end
 
 --- Responsible for placing/moving/resizing this window to the correct place/size.
 -- Called on window resize events.
-function Geyser.Container:reposition ()
-  local x, y, w, h = self:get_x(), self:get_y(), self:get_width(), self:get_height()
+-- @param skipChildren If true, place only this window, for a caller that walks
+--                     the children itself.
+function Geyser.Container:reposition (skipChildren)
   if self.type ~= "userwindow" then
     moveWindow(self.name, self:get_x(), self:get_y())
     resizeWindow(self.name, self:get_width(), self:get_height())
   end
   -- deal with all children of this container
-  for k, v in pairs(self.windowList) do
-    if k ~= self and not v.nestLabels then
-      v:reposition()
+  if not skipChildren then
+    for k, v in pairs(self.windowList) do
+      if k ~= self and not v.nestLabels then
+        v:reposition()
+      end
     end
   end
 
@@ -278,7 +281,11 @@ end
 -- @param cons Any Lua table that contains appropriate constraint entries.
 function Geyser.Container:set_constraints (cons)
   cons = cons or self
-  Geyser.set_constraints(self, cons, self.container)
+  -- this walk already reaches every descendant, so letting reposition() recurse
+  -- too placed each one again for every ancestor. Self first: ScrollBox:reposition
+  -- zeroes its own origin once placed, and its children are relative to that.
+  Geyser.calc_constraints(self, cons, self.container)
+  self:reposition(true)
   for k, v in pairs(self.windowList) do
     v:set_constraints(v)
   end

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -86,8 +86,8 @@ function Geyser.HBox:organize()
   end
 end
 
-function Geyser.HBox:reposition()
-  Geyser.Container.reposition(self)
+function Geyser.HBox:reposition(skipChildren)
+  Geyser.Container.reposition(self, skipChildren)
   -- contains_fixed prevents gaps when items have fixed size and is deliberately
   -- not deferred, pending_organize
   -- flushes a layout that was skipped while updates were deferred. Clearing it

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -11,8 +11,8 @@ Geyser.MiniConsole = Geyser.Window:new({
   wrapAt = 300, })
 
 --- Override reposition to reset autowrap
-function Geyser.MiniConsole:reposition()
-  self.parent.reposition(self)
+function Geyser.MiniConsole:reposition(skipChildren)
+  self.parent.reposition(self, skipChildren)
   if self.autoWrap then
     self:resetAutoWrap()
   end

--- a/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserScrollBox.lua
@@ -10,16 +10,18 @@ Geyser.ScrollBox = Geyser.Window:new({
 })
 
 -- Overridden reposition for special coordination handling
-function Geyser.ScrollBox:reposition()
+function Geyser.ScrollBox:reposition(skipChildren)
     Geyser.calc_constraints(self, self, self.container)
     moveWindow(self.name, self:get_x(), self:get_y())
     resizeWindow(self.name, self:get_width(), self:get_height())
     self.get_x = function() return 0 end
     self.get_y = function() return 0 end
       -- deal with all children of this container
-    for k, v in pairs(self.windowList) do
-        if k ~= self and not v.nestLabels then
-        v:reposition()
+    if not skipChildren then
+        for k, v in pairs(self.windowList) do
+            if k ~= self and not v.nestLabels then
+            v:reposition()
+            end
         end
     end
 end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -87,8 +87,8 @@ function Geyser.VBox:organize()
   end
 end
 
-function Geyser.VBox:reposition()
-  Geyser.Container.reposition(self)
+function Geyser.VBox:reposition(skipChildren)
+  Geyser.Container.reposition(self, skipChildren)
   -- contains_fixed prevents gaps when items have fixed size and is deliberately
   -- not deferred, pending_organize
   -- flushes a layout that was skipped while updates were deferred. Clearing it

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -1226,3 +1226,78 @@ describe("Tests dragging an Adjustable.Container out of its parent", function()
     assert.are.equal(x, child:get_x())
   end)
 end)
+
+-- Dragging an edge used to set the position and then the size, laying the whole
+-- subtree out twice for one mouse-move.
+describe("Tests the cost of resizing an Adjustable.Container by its edge", function()
+  local container
+  local containerName = "gadEdge"
+
+  before_each(function()
+    container = Adjustable.Container:new({
+      name = containerName,
+      x = 50, y = 50, width = 300, height = 200,
+      autoLoad = false,
+      autoSave = false,
+    })
+    Geyser.Label:new({name = containerName .. "Leaf", x = 0, y = 0, width = "50%", height = "50%"},
+      container.Inside or container)
+  end)
+
+  after_each(function()
+    if container and Adjustable.Container.all[containerName] == container then
+      container:deleteSaveFile()
+      container:delete()
+    end
+    container = nil
+  end)
+
+  -- as with getMousePosition above, Geyser looks moveWindow up in its own globals
+  local function placements(work)
+    local geyser = getfenv(Geyser.Container.reposition)
+    local count = 0
+    local realMoveWindow = geyser.moveWindow
+    geyser.moveWindow = function(...)
+      count = count + 1
+      return realMoveWindow(...)
+    end
+    local ok, err = pcall(work)
+    geyser.moveWindow = realMoveWindow
+    assert.is_true(ok, tostring(err))
+    assert.is_true(count > 0, "nothing was placed, so the counter is not hooked up")
+    return count
+  end
+
+  it("lays the container out once per mouse-move rather than twice", function()
+    local geyser = getfenv(Adjustable.Container.onMove)
+    local realGetMousePosition = geyser.getMousePosition
+    local pointerX, pointerY = 500, 400
+    geyser.getMousePosition = function() return pointerX, pointerY end
+    finally(function() geyser.getMousePosition = realGetMousePosition end)
+
+    -- grabbing within ten pixels of the far edge is what adjust_Info reads as a
+    -- resize rather than a move, and it takes a click for onClick to see that
+    local grabX = container.adjLabel:get_width() - 2
+    local grabY = container.adjLabel:get_height() - 2
+    local event = {button = "LeftButton", buttons = {"LeftButton"},
+                   x = grabX, y = grabY, globalX = pointerX, globalY = pointerY}
+    container:onRelease(container.adjLabel, event)
+    container:onClick(container.adjLabel, event)
+    container:onClick(container.adjLabel, event)
+    finally(function() container:onRelease(container.adjLabel, event) end)
+
+    -- one geometry update over this container and its child is the yardstick, so
+    -- the spec holds whatever the machine's window size makes the subtree cost
+    local oneUpdate = placements(function() container:set_constraints(container) end)
+    local steps = 3
+    local wholeDrag = placements(function()
+      for _ = 1, steps do
+        pointerX, pointerY = pointerX - 5, pointerY - 5
+        container:onMove(container.adjLabel, event)
+      end
+    end)
+
+    assert.is_true(container:get_width() < 300, "the drag has to have resized the container")
+    assert.are.equal(oneUpdate * steps, wholeDrag)
+  end)
+end)

--- a/src/mudlet-lua/tests/GeyserContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserContainer_spec.lua
@@ -204,6 +204,107 @@ describe("Tests functionality of Geyser.Container", function()
       -- middle spans x 300..500, y 50..250, so the leaf starts halfway into it
       assert.are.same({x = 400, y = 150, width = 100, height = 100}, geometry("gcsLeaf"))
     end)
+
+    -- set_constraints walks every descendant itself, and reposition() walks them
+    -- again, so each window used to be placed once per ancestor it had. The three
+    -- specs below pin the single pass and the two kinds of child that only the
+    -- walk reaches, which a top-down reposition on its own would leave behind.
+    -- Geyser looks moveWindow up in the globals of the file it lives in, which are
+    -- not the globals a spec file writes to, so the counter has to go into its
+    -- environment rather than ours
+    local function countPlacements(work)
+      local geyser = getfenv(Geyser.Container.reposition)
+      local placements = 0
+      local realMoveWindow = geyser.moveWindow
+      geyser.moveWindow = function(...)
+        placements = placements + 1
+        return realMoveWindow(...)
+      end
+      local ok, err = pcall(work)
+      geyser.moveWindow = realMoveWindow
+      assert.is_true(ok, tostring(err))
+      -- a count of zero would make every comparison below trivially true
+      assert.is_true(placements > 0, "nothing was placed, so the counter is not hooked up")
+      return placements
+    end
+
+    -- every class that overrides reposition has to hand skipChildren on, or its
+    -- subtree keeps being placed once per ancestor. Boxes inside an adjustable
+    -- container is what a real layout is built from, so each class is covered
+    -- rather than only the plain container the base implementation serves.
+    for _, class in ipairs({"Container", "HBox", "VBox", "ScrollBox"}) do
+      it(("places each window once for one set_constraints, for a %s"):format(class), function()
+        local constructor = Geyser[class]
+        local root = track(constructor:new({name = "gcsOnce" .. class, x = 0, y = 0, width = "60%", height = "60%"}))
+        local parents = {root}
+        for depth = 1, 3 do
+          local nextParents = {}
+          for index, parent in ipairs(parents) do
+            for child = 1, 2 do
+              nextParents[#nextParents + 1] = track(constructor:new({
+                name = ("gcsOnce%s_%d_%d_%d"):format(class, depth, index, child),
+                x = 0, y = 0, width = "100%", height = "100%"}, parent))
+            end
+          end
+          parents = nextParents
+        end
+
+        -- reposition() reaches every window in the tree exactly once, so it is the
+        -- count set_constraints has to match rather than a hardcoded total
+        local onePass = countPlacements(function() root:reposition() end)
+        local viaConstraints = countPlacements(function() root:set_constraints(root) end)
+        assert.are.equal(onePass, viaConstraints)
+      end)
+    end
+
+    it("places each window once for one set_constraints, for an adjustable container", function()
+      local root = Adjustable.Container:new({name = "gcsOnceAdj", x = 20, y = 20,
+        width = 300, height = 200, autoLoad = false, autoSave = false})
+      finally(function()
+        if Adjustable.Container.all[root.name] == root then
+          root:deleteSaveFile()
+          root:delete()
+        end
+      end)
+      local box = track(Geyser.VBox:new({name = "gcsOnceAdjBox", x = 0, y = 0,
+        width = "100%", height = "100%"}, root.Inside or root))
+      track(Geyser.MiniConsole:new({name = "gcsOnceAdjConsole", autoWrap = true}, box))
+      track(Geyser.Label:new({name = "gcsOnceAdjLabel"}, box))
+
+      local onePass = countPlacements(function() root:reposition() end)
+      local viaConstraints = countPlacements(function() root:set_constraints(root) end)
+      assert.are.equal(onePass, viaConstraints)
+    end)
+
+    it("lays out a child of a container whose reposition does not recurse", function()
+      local root = track(Geyser.Container:new({name = "gcsMapRoot", x = 0, y = 0, width = "60%", height = "60%"}))
+      -- Geyser.Mapper:reposition places the map widget and stops, so its children
+      -- are laid out only because set_constraints visits them
+      local mapper = track(Geyser.Mapper:new({name = "gcsMapper", x = 0, y = 0,
+        width = "100%", height = "50%", embedded = false}, root))
+      track(Geyser.Label:new({name = "gcsMapLabel", x = 0, y = 0, width = "50%", height = "50%"}, mapper))
+
+      local before = geometry("gcsMapLabel")
+      root:move(root:get_x() + 40, root:get_y() + 30)
+      local after = geometry("gcsMapLabel")
+      assert.are.equal(before.x + 40, after.x)
+      assert.are.equal(before.y + 30, after.y)
+    end)
+
+    it("lays out the children of a container that nests its labels", function()
+      local root = track(Geyser.Container:new({name = "gcsNestRoot", x = 0, y = 0, width = "60%", height = "60%"}))
+      local nester = track(Geyser.Container:new({name = "gcsNester", x = 0, y = 0, width = "100%", height = "100%"}, root))
+      -- reposition() skips a child that nests its labels, so again only the
+      -- set_constraints walk reaches what is under it
+      nester.nestLabels = true
+      track(Geyser.Label:new({name = "gcsNestLabel", x = 0, y = 0, width = "50%", height = "50%"}, nester))
+
+      local before = geometry("gcsNestLabel")
+      root:move(root:get_x() + 40, root:get_y() + 30)
+      local after = geometry("gcsNestLabel")
+      assert.are.equal(before.x + 40, after.x)
+      assert.are.equal(before.y + 30, after.y)
+    end)
   end)
 
   describe("Geyser.Container:move/resize", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Geyser.Container:set_constraints()` walks every descendant itself, and the `reposition()` it triggered walked them again, so **each window was placed once for every ancestor it had**. `reposition()` now takes a `skipChildren` argument so the walk does not re-recurse.
- **Every class that overrides `reposition()` hands the argument on** — `HBox`, `VBox`, `ScrollBox`, `MiniConsole`, `Adjustable.Container`. Without this the change would have reached plain containers only; boxes inside an adjustable container, which is what real layouts are built from, kept the old cost.
- `Adjustable.Container:onMove()` set the position and then the size while an edge was dragged, laying the subtree out twice per mouse-move. It now sets the four constraints and reflows once.
- `Geyser.Container:reposition()` computed four getters into locals it never used; removed.
- Eight specs.

#### Motivation for adding to Mudlet

A GUI package felt heavy for the wrong reason: the cost of moving or resizing a layout grew with how deeply it was **nested** rather than with how many windows it had. Dragging an adjustable container by an edge paid it twice per mouse-move event.

#### Measurements

A layout shaped like a real GUI package — an adjustable container holding a `VBox` with a row of gauges, a chat miniconsole, an embedded mapper and a row of buttons; 26 windows, four deep. Hash-verified builds, ABBA-interleaved across separate launches, medians of 7 rounds.

| operation | placements | | wall clock | | |
|---|---|---|---|---|---|
| | before | after | before | after | |
| script `move()` | 116 | **26** | 2.07 ms | **0.41 ms** | 5.0× |
| script `resize()` | 116 | **26** | 2.07 ms | **0.45 ms** | 4.6× |
| one mouse-move of a resize drag | 232 | **26** | 2.06 ms | **0.20 ms** | 10.3× |
| main-window resize | 41 | 41 | 0.202 ms | **0.118 ms** | 1.7× |

26 is one placement per window. A "placement" is one `moveWindow` call into Mudlet.

The old multiplier tracked depth rather than size — 1.8× at depth 1, 2.6× at 2, 3.5× at 3, 4.5× at 4, 5.1× at 5.

Main-window resize keeps an identical placement count because `GeyserReposition` was already single-pass; its whole gain is the four dead getter calls, confirmed with a third build carrying only that deletion (0.202 → 0.114 ms, versus 0.118 for the full patch). Those getters are not cheap: a percentage getter walks up the ancestor chain and the root's calls `getMainWindowSize()`.

Placement counts are exact. The millisecond figures come from an offscreen Release build using `os.clock()`, so they measure Lua and Qt call overhead without real painting.

#### Other info (issues closed, discussion etc)

Fixes #9917

**Two traps this had to avoid, both of which pass CI green if you get them wrong.**

The tempting shape — calc the subtree, then reposition once from the top — **silently stops laying out two kinds of child**: a child of a container whose `reposition()` does not recurse (a label inside a `Geyser.Mapper`, since `Geyser.Mapper:reposition()` places the map widget and stops), and everything under a container with `nestLabels` set, which `Container:reposition()` skips while the `set_constraints` walk does not. Both depend on the redundant walk existing. Measured on that shape: the label in the mapper went from 1 placement to 0, and a `nestLabels` subtree from 2 to 0. Nothing in the suite covered either case, so two of the new specs do.

Ordering also matters: the window is placed **before** its children are walked, because `Geyser.ScrollBox:reposition()` zeroes its own origin once it has placed itself and its children are relative to that.

**One behaviour change.** The intermediate `AdjustableContainerReposition` raise during a resize drag is gone — two raises per mouse-move become one. The raise that disappears is the one that carried the **new position with the stale size**; the surviving raise is byte-identical to the one that followed it, so a script mirroring geometry stops receiving a transient half-updated notification. `AdjustableContainerRepositionFinish`, which the specs do pin, is untouched. Also, neither `move()` nor `resize()` runs on the drag path now, so an override of either is not invoked while an edge is being dragged; `Adjustable.Container` overrides neither, and there are no in-repo subclasses.

**Known limitation, filed separately as #9918:** `HBox`/`VBox:organize()` still moves every child unconditionally, so a box with one `Geyser.Fixed` child re-lays out its children on every reposition — about 1.67× on a 9-node box. The fix used in `onMove` is not safe there, because `organize`'s receivers are arbitrary children and `Geyser.Mapper`/`Geyser.UserWindow` override `move`/`resize` with essential work.

**Test case:** `Geyser.calc_constraints/set_constraints` in `GeyserContainer_spec.lua` gains six specs — one per container class plus the adjustable container asserting each window is placed exactly once per `set_constraints`, and the two child-kind cases above — and `GeyserAdjustableContainer_spec.lua` gains one asserting a drag event costs one layout pass rather than two, driving a real resize drag through `onMove`. Each count-based spec calibrates against a single geometry update measured in the same run, so no window size is hardcoded, and each asserts its counter is non-zero so it cannot pass vacuously. Verified three ways: all eight pass with the patch (suite 2873 → 2881, pre-existing failures unchanged); six fail against `development`; the two child-kind specs fail against the coverage-dropping shape. Manually tested on macOS against before/after builds — layout geometry identical across all 14 widgets, drags smoother.