### PR TITLE
Infra: Guide AI assistants to prefer Lua specs over C++ functional tests

### DIFF
--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -132,6 +132,14 @@ Don't add comments for obvious code as that increases cognitive load on the read
 - Follow Qt's Model-View pattern
 - Use Qt's signal/slot mechanism for communication
 
+## Tests
+
+Two harnesses: Lua specs in `src/mudlet-lua/tests/*_spec.lua` (busted, run in the self-test profile), and C++ functional tests in `test/functional_tests/` (ctest).
+
+Prefer a spec. Each functional test is its own executable statically linking `mudlet_core`, so it adds ~290MB to every build tree plus a link step, while a spec is ~30KB and needs no rebuild at all because `mudlet-lua` loads from disk. Write a functional test when a spec genuinely cannot reach the behaviour: private C++ state, a path with no Lua entry point, or something that happens before Lua exists. Sanitiser coverage is not one of those reasons, as the spec run exercises the same instrumented binary.
+
+Both harnesses fail silently rather than red when the setup is wrong, so confirm a new test fails without the fix before trusting it.
+
 ## Demo videos
 
 To demonstrate a bug fix or UI change with a screen recording, follow the before & after video workflow in `docs/demo-videos.md` (Linux/Xvfb; records headlessly, then trims and labels the result for attaching to a PR).


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Adds a `## Tests` section to `docs/ai-instructions.md` (which `CLAUDE.md` symlinks to), naming the two harnesses and when each is warranted.
- Records the cost asymmetry behind the choice: 240-292MB per functional test binary against 1.2MB for all 40 specs combined.
- Notes that both harnesses can pass silently when misconfigured, so a new test should be confirmed to fail without its fix.

#### Motivation for adding to Mudlet

AI assistants default to a C++ functional test where a Lua spec would do, and each one costs ~290MB in every build tree plus a link on the ASan tail.

#### Other info (issues closed, discussion etc)

Documentation only. Written to the Claude 5 context-engineering guidance: guidance rather than prohibition, repo-specific facts only, no examples.

**Test case:** open `CLAUDE.md`; the new `## Tests` section sits between "Common patterns" and "Demo videos".

Assisted-by: Claude:claude-opus-5