### PR TITLE
infrastructure: link the Linux CI builds with mold

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -296,18 +296,22 @@ jobs:
         sudo ldconfig
 
     - name: (Linux) Install mold linker
+      timeout-minutes: 5
       if: runner.os == 'Linux'
       env:
         MOLD_VERSION: '2.41.0'
+        # mold publishes no checksum manifest, so this is the hash of the
+        # pinned asset as downloaded - re-verify it by hand when bumping
         MOLD_SHA256: 'a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d'
       run: |
         # Ubuntu 22.04 only packages mold 1.0.3, so take it from upstream
-        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 -o mold.tar.gz \
+        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 120 -o mold.tar.gz \
           "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"
         echo "${MOLD_SHA256}  mold.tar.gz" | sha256sum -c
         sudo tar xf mold.tar.gz -C /usr/local --strip-components=1
         rm mold.tar.gz
-        /usr/local/bin/mold --version
+        # not bin/mold: this is the GNU ld drop-in that -B has to resolve to
+        /usr/local/libexec/mold/ld --version
 
     - name: (Linux Clang) change compiler & disable optional components
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'
@@ -373,6 +377,7 @@ jobs:
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
+          -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}
           ${{ runner.os == 'macOS' && format('-DLUA_INCLUDE_DIR={0}/.lua/include -DLUA_LIBRARY={0}/.lua/lib/liblua.a', github.workspace) || '' }}
           -DWITH_SENTRY=ON
           -DSENTRY_SEND_DEBUG=${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}
@@ -381,11 +386,6 @@ jobs:
         NINJA_STATUS: '[%f/%t %o/sec] '
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # Link with mold: half of this build is linking, most of it the ~50
-        # sanitizer-instrumented test executables, and ccache cannot help there.
-        # -fuse-ld=mold needs GCC 12.1 and the oldest leg is on GCC 10, so point
-        # the compiler driver at mold's own ld instead - that works everywhere.
-        LDFLAGS: ${{ runner.os == 'Linux' && '-B/usr/local/libexec/mold' || '' }}
 
     - name: Save ccache
       if: always() && steps.restore-ccache.outputs.cache-hit != 'true'
@@ -396,6 +396,12 @@ jobs:
 
     - name: check ccache stats post build
       run: ccache --show-stats
+
+    # a mold that never got installed just makes the compiler fall back to the
+    # system ld, which builds fine and quietly costs three minutes a run
+    - name: (Linux) Confirm the build used mold
+      if: runner.os == 'Linux'
+      run: readelf -p .comment ${{runner.workspace}}/b/ninja/src/mudlet | grep -q mold
 
     - name: install dependencies for packaging/tests
       run: |

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -295,6 +295,20 @@ jobs:
         # Update library cache so linker finds new version
         sudo ldconfig
 
+    - name: (Linux) Install mold linker
+      if: runner.os == 'Linux'
+      env:
+        MOLD_VERSION: '2.41.0'
+        MOLD_SHA256: 'a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d'
+      run: |
+        # Ubuntu 22.04 only packages mold 1.0.3, so take it from upstream
+        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 -o mold.tar.gz \
+          "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"
+        echo "${MOLD_SHA256}  mold.tar.gz" | sha256sum -c
+        sudo tar xf mold.tar.gz -C /usr/local --strip-components=1
+        rm mold.tar.gz
+        /usr/local/bin/mold --version
+
     - name: (Linux Clang) change compiler & disable optional components
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'
       run: |
@@ -367,6 +381,11 @@ jobs:
         NINJA_STATUS: '[%f/%t %o/sec] '
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # Link with mold: half of this build is linking, most of it the ~50
+        # sanitizer-instrumented test executables, and ccache cannot help there.
+        # -fuse-ld=mold needs GCC 12.1 and the oldest leg is on GCC 10, so point
+        # the compiler driver at mold's own ld instead - that works everywhere.
+        LDFLAGS: ${{ runner.os == 'Linux' && '-B/usr/local/libexec/mold' || '' }}
 
     - name: Save ccache
       if: always() && steps.restore-ccache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -287,6 +287,20 @@ jobs:
         # Update library cache so linker finds new version
         sudo ldconfig
 
+    - name: (Linux) Install mold linker
+      if: runner.os == 'Linux'
+      env:
+        MOLD_VERSION: '2.41.0'
+        MOLD_SHA256: 'a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d'
+      run: |
+        # Ubuntu 22.04 only packages mold 1.0.3, so take it from upstream
+        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 -o mold.tar.gz \
+          "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"
+        echo "${MOLD_SHA256}  mold.tar.gz" | sha256sum -c
+        sudo tar xf mold.tar.gz -C /usr/local --strip-components=1
+        rm mold.tar.gz
+        /usr/local/bin/mold --version
+
     - name: (Linux Clang) change compiler & disable optional components
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'
       run: |
@@ -359,6 +373,11 @@ jobs:
         NINJA_STATUS: '[%f/%t %o/sec] '
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # Link with mold: half of this build is linking, most of it the ~50
+        # sanitizer-instrumented test executables, and ccache cannot help there.
+        # -fuse-ld=mold needs GCC 12.1 and the oldest leg is on GCC 10, so point
+        # the compiler driver at mold's own ld instead - that works everywhere.
+        LDFLAGS: ${{ runner.os == 'Linux' && '-B/usr/local/libexec/mold' || '' }}
 
     # Cache keys are immutable, so the save below is refused while the branch's
     # previous entry still holds the key, and the branch cache only ever

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -288,18 +288,22 @@ jobs:
         sudo ldconfig
 
     - name: (Linux) Install mold linker
+      timeout-minutes: 5
       if: runner.os == 'Linux'
       env:
         MOLD_VERSION: '2.41.0'
+        # mold publishes no checksum manifest, so this is the hash of the
+        # pinned asset as downloaded - re-verify it by hand when bumping
         MOLD_SHA256: 'a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d'
       run: |
         # Ubuntu 22.04 only packages mold 1.0.3, so take it from upstream
-        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 -o mold.tar.gz \
+        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 120 -o mold.tar.gz \
           "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"
         echo "${MOLD_SHA256}  mold.tar.gz" | sha256sum -c
         sudo tar xf mold.tar.gz -C /usr/local --strip-components=1
         rm mold.tar.gz
-        /usr/local/bin/mold --version
+        # not bin/mold: this is the GNU ld drop-in that -B has to resolve to
+        /usr/local/libexec/mold/ld --version
 
     - name: (Linux Clang) change compiler & disable optional components
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'
@@ -365,6 +369,7 @@ jobs:
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
+          -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}
           ${{ runner.os == 'macOS' && format('-DLUA_INCLUDE_DIR={0}/.lua/include -DLUA_LIBRARY={0}/.lua/lib/liblua.a', github.workspace) || '' }}
           -DWITH_SENTRY=ON
           -DSENTRY_SEND_DEBUG=${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}
@@ -373,11 +378,6 @@ jobs:
         NINJA_STATUS: '[%f/%t %o/sec] '
         MUDLET_SANITIZERS: ${{ github.event_name == 'pull_request' && 'address' || '' }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # Link with mold: half of this build is linking, most of it the ~50
-        # sanitizer-instrumented test executables, and ccache cannot help there.
-        # -fuse-ld=mold needs GCC 12.1 and the oldest leg is on GCC 10, so point
-        # the compiler driver at mold's own ld instead - that works everywhere.
-        LDFLAGS: ${{ runner.os == 'Linux' && '-B/usr/local/libexec/mold' || '' }}
 
     # Cache keys are immutable, so the save below is refused while the branch's
     # previous entry still holds the key, and the branch cache only ever
@@ -412,6 +412,12 @@ jobs:
 
     - name: check ccache stats post build
       run: ccache --show-stats
+
+    # a mold that never got installed just makes the compiler fall back to the
+    # system ld, which builds fine and quietly costs three minutes a run
+    - name: (Linux) Confirm the build used mold
+      if: runner.os == 'Linux'
+      run: readelf -p .comment ${{runner.workspace}}/b/ninja/src/mudlet | grep -q mold
 
     - name: install dependencies for packaging/tests
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,31 @@ if(CCACHE_FOUND)
   set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
 endif(CCACHE_FOUND)
 
+# credit to https://github.com/heavyai/heavydb/blob/72c90bc290b79dd30240da41c103a00720f6b050/CMakeLists.txt#L119
+macro(set_alternate_linker linker)
+  find_program(LINKER_EXECUTABLE ld.${USE_ALTERNATE_LINKER} ${USE_ALTERNATE_LINKER})
+  if(LINKER_EXECUTABLE)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 12.1.0 AND "${USE_ALTERNATE_LINKER}" STREQUAL "mold")
+      # LINKER_EXECUTABLE will be a full path to ld.mold, so we replace the end of the path, resulting in the relative
+      # libexec/mold dir, and tell GCC to look there first for an override version of executables, in this case, ld
+      string(REPLACE "bin/ld.mold" "libexec/mold" PATH_TO_LIBEXEC_MOLD ${LINKER_EXECUTABLE})
+      add_link_options("-B${PATH_TO_LIBEXEC_MOLD}")
+    else()
+      add_link_options("-fuse-ld=${USE_ALTERNATE_LINKER}")
+    endif()
+  else()
+    message(WARNING "USE_ALTERNATE_LINKER=${USE_ALTERNATE_LINKER} was asked for but no such linker is installed - using the system one")
+    set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker" FORCE)
+  endif()
+endmacro()
+
+# add_link_options() only reaches directories added after it, and most of the
+# link time is in test/, so this has to come before those subdirectories
+set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default; alternatives are 'gold', 'lld', 'bfd', 'mold'")
+if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
+  set_alternate_linker(${USE_ALTERNATE_LINKER})
+endif()
+
 add_subdirectory(3rdparty/edbee-lib/edbee-lib)
 add_subdirectory(3rdparty/communi)
 add_subdirectory(3rdparty/qt-tags-widget)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -497,28 +497,6 @@ if(USE_3DMAPPER)
   list(APPEND mudlet_SRCS glwidget_integration.cpp)
 endif(USE_3DMAPPER)
 
-# credit to https://github.com/heavyai/heavydb/blob/72c90bc290b79dd30240da41c103a00720f6b050/CMakeLists.txt#L119
-macro(set_alternate_linker linker)
-  find_program(LINKER_EXECUTABLE ld.${USE_ALTERNATE_LINKER} ${USE_ALTERNATE_LINKER})
-  if(LINKER_EXECUTABLE)
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 12.1.0 AND "${USE_ALTERNATE_LINKER}" STREQUAL "mold")
-      # LINKER_EXECUTABLE will be a full path to ld.mold, so we replace the end of the path, resulting in the relative
-      # libexec/mold dir, and tell GCC to look there first for an override version of executables, in this case, ld
-      string(REPLACE "bin/ld.mold" "libexec/mold" PATH_TO_LIBEXEC_MOLD ${LINKER_EXECUTABLE})
-      add_link_options("-B${PATH_TO_LIBEXEC_MOLD}")
-    else()
-      add_link_options("-fuse-ld=${USE_ALTERNATE_LINKER}")
-    endif()
-  else()
-    set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker" FORCE)
-  endif()
-endmacro()
-
-set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default; alternatives are 'gold', 'lld', 'bfd', 'mold'")
-if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
-  set_alternate_linker(${USE_ALTERNATE_LINKER})
-endif()
-
 if(NOT WIN32)
   include(cmake/EnableSanitizers.cmake)
 else()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The Linux CI legs install a pinned, checksummed mold 2.41.0 and build with `-DUSE_ALTERNATE_LINKER=mold`.
- Moved the repo's existing `set_alternate_linker()` from `src/CMakeLists.txt` to the top level: `add_link_options()` only reaches subdirectories added after it, so the option was reaching 1 of 110 link targets instead of all of them.
- Added a post-build check that fails the job unless the binary really is mold-linked - without mold the compiler silently falls back to the system `ld` and CI stays green at the old speed.

#### Motivation for adding to Mudlet
Half of every Linux build was linking - ~105 executables, ~50 of them AddressSanitizer-instrumented functional tests statically linked against mudlet_core - and ccache cannot shortcut a link.

**Measured on the `ubuntu / gcc / lua tests + leak detection` leg**, comparing this PR's run ([1975](https://github.com/Mudlet/Mudlet/actions/runs/31873609672)) against a same-morning baseline PR run ([1974](https://github.com/Mudlet/Mudlet/actions/runs/31873146137)) with a matched ccache state (72.75% vs 72.36% hit rate, 200 vs 204 misses of ~735 compilations), so the difference is the linker alone:

| Metric | system ld | mold | saved |
|---|---|---|---|
| Link tail after the last compile | 4m 13s | 29s | ~3m 45s |
| Full ninja build | 20m 42s | 17m 47s | ~2m 55s |
| Whole job wall-clock | 35m 24s | 32m 38s | ~2m 46s |

ctest passed 110/110 and all 3178 busted specs passed under AddressSanitizer with leak detection on the mold-linked output.

#### Other info (issues closed, discussion etc)
macOS keeps its default linker (mold has no maintained Mach-O support) and Windows is untouched; `USE_ALTERNATE_LINKER` stays empty by default, so a local build only changes if you ask for it. The ubuntu-22.04 leg is also the deploy leg, so PTB and release AppImages become mold-linked - kept deliberately, and this run's AppImage packaging plus the full test suite passed on that output. The `ubuntu / clang` leg only runs post-merge, so its `-fuse-ld=mold` path first executes on push to `development` - if anything is off there, the mold-confirmation guard fails that leg loudly rather than letting it fall back silently.

Assisted-by: Claude:claude-opus-5