### PR TITLE
infra: Auto-setup build environment for Claude Code web sessions

### DIFF
--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -89,9 +89,12 @@ The `.claude/hooks/session-start.sh` SessionStart hook provisions the remote Ubu
 apt dependencies, Qt 6.9.0 via aqtinstall under `/opt/qt` (Ubuntu's packaged Qt 6.4 is older
 than the 6.8.2 minimum), submodules, and a ccache warm-up build of the `linux-debug-nosan`
 preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the documented preset
-commands work unchanged. On a warm container the hook is a sub-second no-op and a full build is
+commands work unchanged. On a warm container the hook finishes in seconds and a full build is
 mostly ccache hits — measured 5m25s wall for all targets at 99% hit rate, most of it linking —
 versus ~25 minutes cold. If the container cache is cold the hook itself takes ~30 minutes, once.
+The hook also pre-configures `build-linux-debug-nosan/` with `-DUSE_ALTERNATE_LINKER=mold`:
+linking is the bulk of a warm rebuild and mold shrinks it dramatically (PR #9927 measured a CI
+link tail of 4m13s → 29s). Keep that flag if you reconfigure the tree from scratch.
 Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen`.
 
 Both test harnesses work in the remote container (validated: 112/112 ctest, 3202 busted

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -103,9 +103,12 @@ successes):
   `'rex'` errors.
 - **Lua specs (busted)**: `.claude/scripts/run-lua-tests.sh` — starts the HTTP/Discord/MMCP
   fixtures from `CI/` and runs the self-test profile under xvfb exactly like the
-  "(Linux) Run Lua tests" CI step. Always let it kill leftover fixture processes: stale MMCP
-  peers from an aborted run answer on old ports and fail ~38 Networking specs with
-  "Expected objects to be the same" at the `ensurePeer` assertion.
+  "(Linux) Run Lua tests" CI step. Concurrent runs are safe (one per worktree, or even the
+  same tree): fixtures bind ephemeral ports handed over via a per-run temp directory, cleanup
+  kills only that run's fixture PIDs, and each run gets a private HOME so no two Mudlets — nor
+  leftovers of an aborted run — share the self-test profile's saved state. Sharing a profile
+  tree is not survivable: stale state fails ~38 Networking specs with "Expected objects to be
+  the same" at the `ensurePeer` assertion.
 - The egress proxy blocks GitHub codeload tarballs (403), so `luarocks install` of rocks whose
   rockspecs point at tarballs fails; the hook falls back to `git clone` + `luarocks make`
   (git-protocol GitHub access is allowed). `LuaSQL-SQLite3` must stay pinned at 2.6.1 — 2.8.0

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -83,6 +83,21 @@ Sanitizers are not enabled on Windows, so there is no `-nosan` variant.
 Mudlet is a graphical desktop application; launching it opens a window. Variant presets put the
 binary under `build-<preset-name>/` instead. Allow up to 10 minutes for a full build.
 
+## Claude Code on the web (remote sessions)
+
+The `.claude/hooks/session-start.sh` SessionStart hook provisions the remote Ubuntu container:
+apt dependencies, Qt 6.9.0 via aqtinstall under `/opt/qt` (Ubuntu's packaged Qt 6.4 is older
+than the 6.8.2 minimum), submodules, and a ccache warm-up build of the `linux-debug-nosan`
+preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the documented preset
+commands work unchanged. On a warm container the hook is a fast no-op and a full build is
+mostly ccache hits (~2-4 minutes); if the container cache is cold the hook itself takes
+~25 minutes, once. Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen` and run tests
+with `QT_QPA_PLATFORM=offscreen ctest --preset linux-debug-nosan`.
+
+The `docker/` directory is a separate developer convenience (QtCreator-in-container); its
+Ubuntu 22.04 base only offers Qt 6.2 from apt, so it cannot build current Mudlet until it is
+modernised — do not reach for it in remote sessions.
+
 ## Pitfalls
 
 **Never pass `--parallel` without a job count on a Makefiles build.** `cmake --build . --parallel`

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -89,9 +89,9 @@ The `.claude/hooks/session-start.sh` SessionStart hook provisions the remote Ubu
 apt dependencies, Qt 6.9.0 via aqtinstall under `/opt/qt` (Ubuntu's packaged Qt 6.4 is older
 than the 6.8.2 minimum), submodules, and a ccache warm-up build of the `linux-debug-nosan`
 preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the documented preset
-commands work unchanged. On a warm container the hook is a fast no-op and a full build is
-mostly ccache hits (~2-4 minutes); if the container cache is cold the hook itself takes
-~25 minutes, once. Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen` and run tests
+commands work unchanged. On a warm container the hook is a sub-second no-op and a full build is
+mostly ccache hits — measured 5m25s wall for all targets at 99% hit rate, most of it linking —
+versus ~25 minutes cold. If the container cache is cold the hook itself takes ~30 minutes, once. Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen` and run tests
 with `QT_QPA_PLATFORM=offscreen ctest --preset linux-debug-nosan`.
 
 The `docker/` directory is a separate developer convenience (QtCreator-in-container); its

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -91,8 +91,25 @@ than the 6.8.2 minimum), submodules, and a ccache warm-up build of the `linux-de
 preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the documented preset
 commands work unchanged. On a warm container the hook is a sub-second no-op and a full build is
 mostly ccache hits — measured 5m25s wall for all targets at 99% hit rate, most of it linking —
-versus ~25 minutes cold. If the container cache is cold the hook itself takes ~30 minutes, once. Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen` and run tests
-with `QT_QPA_PLATFORM=offscreen ctest --preset linux-debug-nosan`.
+versus ~25 minutes cold. If the container cache is cold the hook itself takes ~30 minutes, once.
+Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen`.
+
+Both test harnesses work in the remote container (validated: 112/112 ctest, 3202 busted
+successes):
+
+- **C++ tests**: `QT_QPA_PLATFORM=offscreen ctest --preset linux-debug-nosan`. The functional
+  tests load `LuaGlobal.lua`, which needs the `--local` Lua rocks on `LUA_PATH`/`LUA_CPATH` —
+  the hook exports both; without them ~12 tests fail with `attempt to index global 'yajl'` or
+  `'rex'` errors.
+- **Lua specs (busted)**: `.claude/scripts/run-lua-tests.sh` — starts the HTTP/Discord/MMCP
+  fixtures from `CI/` and runs the self-test profile under xvfb exactly like the
+  "(Linux) Run Lua tests" CI step. Always let it kill leftover fixture processes: stale MMCP
+  peers from an aborted run answer on old ports and fail ~38 Networking specs with
+  "Expected objects to be the same" at the `ensurePeer` assertion.
+- The egress proxy blocks GitHub codeload tarballs (403), so `luarocks install` of rocks whose
+  rockspecs point at tarballs fails; the hook falls back to `git clone` + `luarocks make`
+  (git-protocol GitHub access is allowed). `LuaSQL-SQLite3` must stay pinned at 2.6.1 — 2.8.0
+  breaks `DB.lua`'s `PRAGMA table_info` handling and errors 8 DB specs.
 
 The `docker/` directory is a separate developer convenience (QtCreator-in-container); its
 Ubuntu 22.04 base only offers Qt 6.2 from apt, so it cannot build current Mudlet until it is

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -113,12 +113,22 @@ successes):
   rockspecs point at tarballs fails; the hook falls back to `git clone` + `luarocks make`
   (git-protocol GitHub access is allowed). `LuaSQL-SQLite3` must stay pinned at 2.6.1 — 2.8.0
   breaks `DB.lua`'s `PRAGMA table_info` handling and errors 8 DB specs.
-- **GUI automation without Mudlet changes**: the busted run's Xvfb is a real X server, so
-  `xdotool` (installed by the hook) can drive Mudlet from outside — a spec launches it in the
-  background with `os.execute("(xdotool mousemove --window $(xdotool search --class mudlet | head -1) X Y; xdotool click 1) &")`
-  and pumps `pumpEvents()` until the effect lands; `xdotool key`/`type` reach the focused
-  widget. Validated: a real XTEST click fires a `Geyser.Label` click callback. Linux/X11 only —
-  a repo spec using this needs a gate, since CI's macOS busted legs have no xdotool or X11.
+- **Seeing and driving the real UI**: to verify a feature or fix visually, run Mudlet on a
+  virtual display and work it like a user — the hook installs the whole toolchain from
+  `docs/demo-videos.md` (xvfb, openbox, xdotool, imagemagick, ffmpeg):
+
+  ```bash
+  export DISPLAY=:78
+  Xvfb :78 -screen 0 1280x800x24 & sleep 2; openbox & sleep 1
+  HOME=$(mktemp -d) ./build-linux-debug-nosan/src/mudlet & sleep 8
+  xdotool mousemove <x> <y> click 1        # or: xdotool key Return, xdotool type "text"
+  import -window root /tmp/shot.png        # screenshot; read it to verify, then iterate
+  ```
+
+  A throwaway `HOME` keeps the real profile tree untouched. Screenshot after every
+  interaction — coordinates come from looking at the previous shot, not from guessing. The
+  same display serves `docs/demo-videos.md`'s before/after recording workflow via ffmpeg.
+  All of this is Linux/X11-only, and XTEST events work headlessly on Xvfb only.
 
 The `docker/` directory is a separate developer convenience (QtCreator-in-container); its
 Ubuntu 22.04 base only offers Qt 6.2 from apt, so it cannot build current Mudlet until it is

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -113,6 +113,12 @@ successes):
   rockspecs point at tarballs fails; the hook falls back to `git clone` + `luarocks make`
   (git-protocol GitHub access is allowed). `LuaSQL-SQLite3` must stay pinned at 2.6.1 — 2.8.0
   breaks `DB.lua`'s `PRAGMA table_info` handling and errors 8 DB specs.
+- **GUI automation without Mudlet changes**: the busted run's Xvfb is a real X server, so
+  `xdotool` (installed by the hook) can drive Mudlet from outside — a spec launches it in the
+  background with `os.execute("(xdotool mousemove --window $(xdotool search --class mudlet | head -1) X Y; xdotool click 1) &")`
+  and pumps `pumpEvents()` until the effect lands; `xdotool key`/`type` reach the focused
+  widget. Validated: a real XTEST click fires a `Geyser.Label` click callback. Linux/X11 only —
+  a repo spec using this needs a gate, since CI's macOS busted legs have no xdotool or X11.
 
 The `docker/` directory is a separate developer convenience (QtCreator-in-container); its
 Ubuntu 22.04 base only offers Qt 6.2 from apt, so it cannot build current Mudlet until it is

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web: provision everything needed to
+# compile Mudlet natively on the Ubuntu 24.04 session container.
+#
+# The container filesystem is cached after this hook completes, so the
+# expensive steps (apt, Qt download, ccache warm-up build) only run when the
+# cache is cold; on a warm container every step short-circuits and the hook
+# finishes in well under a minute.
+set -euo pipefail
+
+# Local checkouts (desktop/CLI) manage their own toolchain - do nothing there.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+SUDO=""
+if [ "$(id -u)" != "0" ]; then
+  # -E keeps the proxy environment that downloads depend on in this container
+  SUDO="sudo -E"
+fi
+
+# Mudlet needs Qt >= 6.8.2 but Ubuntu 24.04 only packages 6.4, so Qt comes
+# from aqtinstall (same as .github/workflows/build-mudlet.yml) and everything
+# else from apt. qtkeychain-qt6-dev is built against the distro Qt 6.4, which
+# is fine: Qt guarantees binary compatibility across 6.x minor releases, and
+# CI relies on the same mix.
+QT_VERSION=6.9.0
+QT_DIR="/opt/qt/${QT_VERSION}/gcc_64"
+
+if ! dpkg -s qtkeychain-qt6-dev >/dev/null 2>&1; then
+  echo "Installing apt build dependencies..."
+  ${SUDO} apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y --no-install-recommends \
+    ccache \
+    g++ \
+    libassimp-dev \
+    libboost-dev \
+    libcurl4-openssl-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libhunspell-dev \
+    liblua5.1-0-dev \
+    libpcre2-dev \
+    libpugixml-dev \
+    libpulse-dev \
+    libsecret-1-dev \
+    libspeechd-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libxkbcommon-dev \
+    libxkbcommon-x11-0 \
+    libyajl-dev \
+    libzip-dev \
+    lua5.1 \
+    luarocks \
+    mesa-common-dev \
+    pkg-config \
+    qtkeychain-qt6-dev
+fi
+
+if [ ! -d "${QT_DIR}" ]; then
+  echo "Installing Qt ${QT_VERSION} via aqtinstall..."
+  if [ ! -x /opt/aqt-venv/bin/aqt ]; then
+    ${SUDO} mkdir -p /opt/aqt-venv /opt/qt
+    ${SUDO} chown "$(id -un)" /opt/aqt-venv /opt/qt
+    python3 -m venv /opt/aqt-venv
+    /opt/aqt-venv/bin/pip install --quiet aqtinstall
+  fi
+  # aqt drops aqtinstall.log in the current directory - keep it out of the repo
+  (cd /opt/qt && /opt/aqt-venv/bin/aqt install-qt linux desktop "${QT_VERSION}" \
+    linux_gcc_64 -O /opt/qt -m qt5compat qtmultimedia qtspeech)
+fi
+
+# Let every shell in the session find the aqt-installed Qt without extra flags.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export CMAKE_PREFIX_PATH=\"${QT_DIR}\${CMAKE_PREFIX_PATH:+:\$CMAKE_PREFIX_PATH}\"" >> "${CLAUDE_ENV_FILE}"
+fi
+
+# The repo is cloned fresh each session, so submodules are always missing even
+# on a warm container.
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+  git -C "${CLAUDE_PROJECT_DIR}" submodule update --init --recursive
+
+  # Warm the compiler cache once per container image. CMakeLists.txt wires
+  # ccache in automatically, so this one cold build (~20 min) makes every
+  # later session's build mostly cache hits (a few minutes including linking).
+  # The build tree itself is discarded with the session; only ccache persists.
+  CCACHE_DIR_PATH="$(ccache -k cache_dir 2>/dev/null || echo "${HOME}/.cache/ccache")"
+  CACHE_KB="$(du -sk "${CCACHE_DIR_PATH}" 2>/dev/null | cut -f1 || echo 0)"
+  if [ "${CACHE_KB:-0}" -lt 102400 ]; then
+    echo "Cold ccache - running warm-up build..."
+    cd "${CLAUDE_PROJECT_DIR}"
+    cmake --preset linux-debug-nosan -DCMAKE_PREFIX_PATH="${QT_DIR}"
+    cmake --build --preset linux-debug-nosan
+  fi
+fi
+
+echo "Mudlet build environment ready (Qt ${QT_VERSION} at ${QT_DIR})"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -85,7 +85,8 @@ if ! dpkg -s libxcb-shape0 >/dev/null 2>&1; then
     libxcb-keysyms1 \
     libxcb-render-util0 \
     libxcb-shape0 \
-    libxcb-xinerama0
+    libxcb-xinerama0 \
+    xdotool
 fi
 
 # Lua rocks that LuaGlobal.lua and the test harnesses load, mirroring the CI

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -94,5 +94,3 @@ if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
     cmake --build --preset linux-debug-nosan
   fi
 fi
-
-echo "Mudlet build environment ready (Qt ${QT_VERSION} at ${QT_DIR})"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -71,9 +71,11 @@ if [ ! -d "${QT_DIR}" ]; then
     linux_gcc_64 -O /opt/qt -m qt5compat qtmultimedia qtspeech)
 fi
 
-# Test-suite dependencies: xvfb and xcb libraries for the busted run (the aqt
-# Qt's xcb platform needs libxcb-cursor0 and libxcb-shape0, which Ubuntu's own
-# Qt would have pulled in), gstreamer for Qt Multimedia.
+# Test-suite and UI-driving dependencies: xvfb and xcb libraries for the
+# busted run (the aqt Qt's xcb platform needs libxcb-cursor0 and
+# libxcb-shape0, which Ubuntu's own Qt would have pulled in), gstreamer for
+# Qt Multimedia, and the docs/demo-videos.md toolchain (openbox, xdotool,
+# imagemagick, ffmpeg) for driving and recording the real UI headlessly.
 if ! dpkg -s libxcb-shape0 >/dev/null 2>&1; then
   echo "Installing test-suite apt dependencies..."
   DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y --no-install-recommends \
@@ -86,7 +88,10 @@ if ! dpkg -s libxcb-shape0 >/dev/null 2>&1; then
     libxcb-render-util0 \
     libxcb-shape0 \
     libxcb-xinerama0 \
-    xdotool
+    xdotool \
+    openbox \
+    imagemagick \
+    ffmpeg
 fi
 
 # Lua rocks that LuaGlobal.lua and the test harnesses load, mirroring the CI
@@ -134,6 +139,16 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     echo "export LUA_PATH='${LUA_PATH}'"
     echo "export LUA_CPATH='${LUA_CPATH}'"
   } >> "${CLAUDE_ENV_FILE}"
+fi
+
+# PR-review tooling for the agent. Installed at user scope, so it lands in
+# the cached container state like everything else. Non-fatal: a marketplace
+# outage must not block the session.
+if command -v claude >/dev/null 2>&1; then
+  if ! claude plugin list 2>/dev/null | grep -q 'pr-review-toolkit'; then
+    claude plugin marketplace add anthropics/claude-plugins-official || true
+    claude plugin install pr-review-toolkit@claude-plugins-official || true
+  fi
 fi
 
 # The repo is cloned fresh each session, so submodules are always missing even

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -54,6 +54,7 @@ if ! dpkg -s qtkeychain-qt6-dev >/dev/null 2>&1; then
     lua5.1 \
     luarocks \
     mesa-common-dev \
+    mold \
     pkg-config \
     qtkeychain-qt6-dev
 fi
@@ -156,6 +157,14 @@ fi
 if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
   git -C "${CLAUDE_PROJECT_DIR}" submodule update --init --recursive
 
+  # Configure the default tree every session (cheap) so it already exists
+  # with Qt and the mold linker wired in - linking dominates a warm rebuild,
+  # and mold cuts the link tail dramatically (see PR #9927; until its
+  # top-level set_alternate_linker() move merges, the flag only reaches the
+  # main mudlet binary, afterwards every target).
+  cd "${CLAUDE_PROJECT_DIR}"
+  cmake --preset linux-debug-nosan -DCMAKE_PREFIX_PATH="${QT_DIR}" -DUSE_ALTERNATE_LINKER=mold
+
   # Warm the compiler cache once per container image. CMakeLists.txt wires
   # ccache in automatically, so this one cold build (~20 min) makes every
   # later session's build mostly cache hits (a few minutes including linking).
@@ -164,8 +173,6 @@ if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
   CACHE_KB="$(du -sk "${CCACHE_DIR_PATH}" 2>/dev/null | cut -f1 || echo 0)"
   if [ "${CACHE_KB:-0}" -lt 102400 ]; then
     echo "Cold ccache - running warm-up build..."
-    cd "${CLAUDE_PROJECT_DIR}"
-    cmake --preset linux-debug-nosan -DCMAKE_PREFIX_PATH="${QT_DIR}"
     cmake --build --preset linux-debug-nosan
   fi
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -71,9 +71,68 @@ if [ ! -d "${QT_DIR}" ]; then
     linux_gcc_64 -O /opt/qt -m qt5compat qtmultimedia qtspeech)
 fi
 
-# Let every shell in the session find the aqt-installed Qt without extra flags.
+# Test-suite dependencies: xvfb and xcb libraries for the busted run (the aqt
+# Qt's xcb platform needs libxcb-cursor0 and libxcb-shape0, which Ubuntu's own
+# Qt would have pulled in), gstreamer for Qt Multimedia.
+if ! dpkg -s libxcb-shape0 >/dev/null 2>&1; then
+  echo "Installing test-suite apt dependencies..."
+  DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y --no-install-recommends \
+    xvfb \
+    libgstreamer-plugins-base1.0-0 \
+    libxcb-cursor0 \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-render-util0 \
+    libxcb-shape0 \
+    libxcb-xinerama0
+fi
+
+# Lua rocks that LuaGlobal.lua and the test harnesses load, mirroring the CI
+# list in .github/workflows/build-mudlet.yml. The egress proxy blocks GitHub
+# codeload tarballs (403) while git clones are allowed, so rocks whose
+# rockspecs point at tarballs are built from a git checkout instead.
+rock_from_git() {
+  local spec=$1 repo=$2 ref=$3 dir
+  dir="$(mktemp -d)"
+  git clone -q --depth 1 --branch "${ref}" "${repo}" "${dir}" || return 1
+  (cd "${dir}" && curl -fsS -O "https://luarocks.org/${spec}.rockspec" \
+    && luarocks --lua-version 5.1 make --local "${spec}.rockspec" >/dev/null)
+}
+
+ensure_rock() {
+  local rock=$1 version=${2:-}
+  luarocks --lua-version 5.1 show "${rock}" >/dev/null 2>&1 && return 0
+  local out url spec repo ref
+  for _ in 1 2 3 4 5; do
+    # shellcheck disable=SC2086
+    out=$(luarocks --lua-version 5.1 install --local "${rock}" ${version} 2>&1) && return 0
+    url=$(grep -oE 'https://github.com/[^ ]+/archive/[^ ]+\.tar\.gz' <<<"${out}" | head -1)
+    [ -n "${url}" ] || { echo "${out}" | tail -3; return 1; }
+    spec=$(grep -oE 'https://luarocks.org/[A-Za-z0-9_.-]+\.rockspec' <<<"${out}" | head -1 | sed 's|.*/||; s|\.rockspec$||')
+    repo="$(sed -E 's|(https://github.com/[^/]+/[^/]+)/archive/.*|\1|' <<<"${url}").git"
+    ref=$(sed -E 's|.*/archive/(.*)\.tar\.gz|\1|; s|^refs/tags/||' <<<"${url}")
+    rock_from_git "${spec:-${rock}}" "${repo}" "${ref}" || return 1
+  done
+  return 1
+}
+
+for rock in LuaFileSystem lpeg lua-zip lrexlib-pcre2 luautf8 lua-yajl argparse lunajson busted; do
+  ensure_rock "${rock}" || echo "WARNING: could not install rock ${rock}"
+done
+# CI pins this version; 2.8.0 breaks DB.lua's PRAGMA table_info handling
+ensure_rock LuaSQL-SQLite3 2.6.1 || echo "WARNING: could not install rock LuaSQL-SQLite3"
+
+# Let every shell in the session find the aqt-installed Qt without extra
+# flags, and the --local rocks (the C++ functional tests load LuaGlobal.lua,
+# which needs them on the Lua path).
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   echo "export CMAKE_PREFIX_PATH=\"${QT_DIR}\${CMAKE_PREFIX_PATH:+:\$CMAKE_PREFIX_PATH}\"" >> "${CLAUDE_ENV_FILE}"
+  eval "$(luarocks path --local --lua-version 5.1)"
+  {
+    echo "export LUA_PATH='${LUA_PATH}'"
+    echo "export LUA_CPATH='${LUA_CPATH}'"
+  } >> "${CLAUDE_ENV_FILE}"
 fi
 
 # The repo is cloned fresh each session, so submodules are always missing even

--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Runs the busted Lua specs the way CI's "(Linux) Run Lua tests" step does:
+# starts the HTTP, Discord IPC and MMCP peer fixtures, then drives the built
+# Mudlet through the "Mudlet self-test" profile under xvfb.
+#
+# Usage: .claude/scripts/run-lua-tests.sh [path-to-mudlet-binary]
+# Defaults to the linux-debug-nosan build. Needs the rocks and apt packages
+# that .claude/hooks/session-start.sh installs.
+set -euo pipefail
+
+WS="$(cd "$(dirname "$0")/../.." && pwd)"
+BINARY="${1:-$WS/build-linux-debug-nosan/src/mudlet}"
+TMP="$(mktemp -d /tmp/mudlet-luatests-XXXX)"
+
+[ -x "$BINARY" ] || { echo "no mudlet binary at $BINARY - build first"; exit 1; }
+
+# fixtures from a previous run would answer on stale ports and fail the MMCP
+# specs with peers the tests never scripted
+pkill -f 'CI/http-fixture-server.py' 2>/dev/null || true
+pkill -f 'CI/discord-ipc-fixture.py' 2>/dev/null || true
+pkill -f 'CI/mmcp-peer.py' 2>/dev/null || true
+sleep 1
+
+cleanup() {
+  pkill -f 'CI/http-fixture-server.py' 2>/dev/null || true
+  pkill -f 'CI/discord-ipc-fixture.py' 2>/dev/null || true
+  pkill -f 'CI/mmcp-peer.py' 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# the binary must sit in src/ so LuaGlobal.lua loads relative to it
+cp "$BINARY" "$WS/src/mudlet"
+
+port_file="$TMP/http-port"
+MUDLET_TEST_HTTP_PORT_FILE="$port_file" nohup python3 "$WS/CI/http-fixture-server.py" > "$TMP/http.log" 2>&1 &
+for _ in $(seq 1 50); do [ -s "$port_file" ] && break; sleep 0.1; done
+[ -s "$port_file" ] || { echo "http fixture failed"; cat "$TMP/http.log"; exit 1; }
+HTTP_PORT="$(cat "$port_file")"
+curl -fsS "http://127.0.0.1:${HTTP_PORT}/fixture.txt" > /dev/null
+
+# short runtime dir of its own: the discord-ipc-0 socket path has to fit into
+# sockaddr_un's 108-character sun_path
+runtime_dir="$(mktemp -d /tmp/mdxdg-XXXX)"
+ready_file="$TMP/discord-ready"
+nohup python3 "$WS/CI/discord-ipc-fixture.py" \
+  --runtime-dir "$runtime_dir" \
+  --capture-file "$TMP/discord-frames.jsonl" \
+  --ready-file "$ready_file" > "$TMP/discord.log" 2>&1 &
+for _ in $(seq 1 50); do [ -s "$ready_file" ] && break; sleep 0.1; done
+[ -s "$ready_file" ] && [ -S "$runtime_dir/discord-ipc-0" ] || { echo "discord fixture failed"; cat "$TMP/discord.log"; exit 1; }
+set -a; source "$ready_file"; set +a
+
+peer_dir="$TMP/mmcp-peer"
+mkdir -p "$peer_dir"
+MUDLET_TEST_MMCP_DIR="$peer_dir" nohup python3 "$WS/CI/mmcp-peer.py" > "$TMP/mmcp.log" 2>&1 &
+for _ in $(seq 1 50); do [ -s "$peer_dir/port" ] && break; sleep 0.1; done
+[ -s "$peer_dir/port" ] || { echo "mmcp fixture failed"; cat "$TMP/mmcp.log"; exit 1; }
+
+eval "$(luarocks path --local --lua-version 5.1)"
+export LUA_PATH LUA_CPATH
+
+export AUTORUN_BUSTED_TESTS=true
+export MUDLET_TEST_MODE=1
+export MUDLET_TEST_REQUIRE_TTS_MOCK=1
+export MUDLET_TEST_REQUIRE_HTTP_FIXTURE=1
+export MUDLET_TEST_REQUIRE_MMCP_PEER=1
+export MUDLET_TEST_REQUIRE_MEDIA=1
+export MUDLET_TEST_REQUIRE_DISCORD=1
+export MUDLET_TEST_HTTP_PORT="$HTTP_PORT"
+export MUDLET_TEST_MMCP_DIR="$peer_dir"
+export XDG_RUNTIME_DIR="${MUDLET_TEST_DISCORD_RUNTIME_DIR:-$runtime_dir}"
+export LD_LIBRARY_PATH="$WS/3rdparty/discord/rpc/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DBUS_SESSION_BUS_ADDRESS='disabled:'
+export TESTS_DIRECTORY="$WS/src/mudlet-lua/tests"
+export QUIT_MUDLET_AFTER_TESTS=true
+
+cd "$WS"
+rc=0
+timeout 360 xvfb-run --auto-servernum "$WS/src/mudlet" --profile "Mudlet self-test" --mirror || rc=$?
+exit $rc

--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -6,6 +6,11 @@
 # Usage: .claude/scripts/run-lua-tests.sh [path-to-mudlet-binary]
 # Defaults to the linux-debug-nosan build. Needs the rocks and apt packages
 # that .claude/hooks/session-start.sh installs.
+#
+# Safe to run concurrently (e.g. one run per worktree): every fixture binds an
+# ephemeral port handed over through this run's private temp directory, only
+# this run's fixture processes are cleaned up, and the profile tree lives in a
+# per-run HOME so simultaneous Mudlets never share saved state.
 set -euo pipefail
 
 WS="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -14,50 +19,62 @@ TMP="$(mktemp -d /tmp/mudlet-luatests-XXXX)"
 
 [ -x "$BINARY" ] || { echo "no mudlet binary at $BINARY - build first"; exit 1; }
 
-# fixtures from a previous run would answer on stale ports and fail the MMCP
-# specs with peers the tests never scripted
-pkill -f 'CI/http-fixture-server.py' 2>/dev/null || true
-pkill -f 'CI/discord-ipc-fixture.py' 2>/dev/null || true
-pkill -f 'CI/mmcp-peer.py' 2>/dev/null || true
-sleep 1
+# The binary is run in place; it locates mudlet-lua relative to itself, which
+# works for any build tree inside the repository (build*/src/mudlet).
+BINDIR="$(cd "$(dirname "$BINARY")" && pwd)"
+if [ ! -f "$BINDIR/../../src/mudlet-lua/lua/LuaGlobal.lua" ] && [ ! -f "$BINDIR/mudlet-lua/lua/LuaGlobal.lua" ]; then
+  echo "LuaGlobal.lua is not reachable relative to $BINARY - run a build tree that sits inside the repository"
+  exit 1
+fi
 
+FIXTURE_PIDS=()
 cleanup() {
-  pkill -f 'CI/http-fixture-server.py' 2>/dev/null || true
-  pkill -f 'CI/discord-ipc-fixture.py' 2>/dev/null || true
-  pkill -f 'CI/mmcp-peer.py' 2>/dev/null || true
+  for pid in "${FIXTURE_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
 }
 trap cleanup EXIT
 
-# the binary must sit in src/ so LuaGlobal.lua loads relative to it
-cp "$BINARY" "$WS/src/mudlet"
-
+# 1. HTTP fixture server
 port_file="$TMP/http-port"
 MUDLET_TEST_HTTP_PORT_FILE="$port_file" nohup python3 "$WS/CI/http-fixture-server.py" > "$TMP/http.log" 2>&1 &
+FIXTURE_PIDS+=($!)
 for _ in $(seq 1 50); do [ -s "$port_file" ] && break; sleep 0.1; done
 [ -s "$port_file" ] || { echo "http fixture failed"; cat "$TMP/http.log"; exit 1; }
 HTTP_PORT="$(cat "$port_file")"
 curl -fsS "http://127.0.0.1:${HTTP_PORT}/fixture.txt" > /dev/null
 
-# short runtime dir of its own: the discord-ipc-0 socket path has to fit into
-# sockaddr_un's 108-character sun_path
+# 2. fake Discord IPC server. A short runtime dir of its own: the whole
+# discord-ipc-0 socket path has to fit into sockaddr_un's 108-character
+# sun_path, so it cannot live under $TMP.
 runtime_dir="$(mktemp -d /tmp/mdxdg-XXXX)"
 ready_file="$TMP/discord-ready"
 nohup python3 "$WS/CI/discord-ipc-fixture.py" \
   --runtime-dir "$runtime_dir" \
   --capture-file "$TMP/discord-frames.jsonl" \
   --ready-file "$ready_file" > "$TMP/discord.log" 2>&1 &
+FIXTURE_PIDS+=($!)
 for _ in $(seq 1 50); do [ -s "$ready_file" ] && break; sleep 0.1; done
 [ -s "$ready_file" ] && [ -S "$runtime_dir/discord-ipc-0" ] || { echo "discord fixture failed"; cat "$TMP/discord.log"; exit 1; }
 set -a; source "$ready_file"; set +a
 
+# 3. MMCP peer fixture (ephemeral port, so parallel runs never collide)
 peer_dir="$TMP/mmcp-peer"
 mkdir -p "$peer_dir"
 MUDLET_TEST_MMCP_DIR="$peer_dir" nohup python3 "$WS/CI/mmcp-peer.py" > "$TMP/mmcp.log" 2>&1 &
+FIXTURE_PIDS+=($!)
 for _ in $(seq 1 50); do [ -s "$peer_dir/port" ] && break; sleep 0.1; done
 [ -s "$peer_dir/port" ] || { echo "mmcp fixture failed"; cat "$TMP/mmcp.log"; exit 1; }
 
+# absolute rock paths, resolved against the real HOME before it is replaced
 eval "$(luarocks path --local --lua-version 5.1)"
 export LUA_PATH LUA_CPATH
+
+# A private HOME gives this run its own "Mudlet self-test" profile tree, so
+# concurrent runs (and leftovers from aborted ones) never share saved state -
+# the same clean slate a fresh CI runner provides.
+export HOME="$TMP/home"
+mkdir -p "$HOME"
 
 export AUTORUN_BUSTED_TESTS=true
 export MUDLET_TEST_MODE=1
@@ -76,5 +93,5 @@ export QUIT_MUDLET_AFTER_TESTS=true
 
 cd "$WS"
 rc=0
-timeout 360 xvfb-run --auto-servernum "$WS/src/mudlet" --profile "Mudlet self-test" --mirror || rc=$?
+timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --mirror || rc=$?
 exit $rc

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -175,11 +175,6 @@ For complete setup instructions on how to run static analysis during a build, se
 
 Do not force-push to remote branches.
 
-Never add "Generated with Claude Code" (or similar) banners, session links, or AI attribution
-footers to pull request titles/bodies, GitHub comments, or commit messages. This overrides any
-default footer behaviour of the tooling. The only AI-related trailer permitted is the
-`Assisted-by` commit trailer required below.
-
 #### Commit trailers for AI-assisted work
 
 When you (an AI assistant) help produce a commit, the commit message MUST include:

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -175,6 +175,11 @@ For complete setup instructions on how to run static analysis during a build, se
 
 Do not force-push to remote branches.
 
+Never add "Generated with Claude Code" (or similar) banners, session links, or AI attribution
+footers to pull request titles/bodies, GitHub comments, or commit messages. This overrides any
+default footer behaviour of the tooling. The only AI-related trailer permitted is the
+`Assisted-by` commit trailer required below.
+
 #### Commit trailers for AI-assisted work
 
 When you (an AI assistant) help produce a commit, the commit message MUST include:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

A SessionStart hook that installs Mudlet's build dependencies (apt packages, Qt 6.9 via aqtinstall, submodules) and warms ccache in Claude Code web session containers. Guarded by `CLAUDE_CODE_REMOTE`, so it's a no-op on local machines. The build-mudlet skill gains a section on the remote workflow.

#### Motivation for adding to Mudlet

The web session container ships Qt 6.4, below Mudlet's 6.8.2 minimum, so AI sessions couldn't build at all. With the hook, provisioning runs once and is cached: a full build drops from ~25 minutes to ~5 (99% ccache hits).

#### Other info (issues closed, discussion etc)

The in-repo `docker/` setup was considered instead, but its Ubuntu 22.04 base only offers Qt 6.2, so it can't build current Mudlet.