### PR TITLE
Fix: keep the selected room when right-clicking elsewhere on the map

### DIFF
--- a/src/RoomContextMenuHandler.cpp
+++ b/src/RoomContextMenuHandler.cpp
@@ -131,10 +131,10 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
             selectionChanged = true;
         }
     }
-    // A right-click that hits no room leaves the selection alone, whatever its
-    // size: mappers select a room (or box-select one from a stack) and then
-    // right-click on empty space to edit it, because hitting the room itself is
-    // hard when zoomed out (#9915).
+    // Deliberately no else branch: a right-click that hits no room leaves the
+    // selection alone, whatever its size. Mappers select a room (or box-select
+    // one from a stack) and then right-click on empty space to edit it, because
+    // hitting the room itself is hard when zoomed out (#9915).
 
     context.multiSelectionSet = &mMapWidget.mMultiSelectionSet;
     context.hasMultiSelection = !mMapWidget.mMultiSelectionSet.isEmpty();

--- a/src/RoomContextMenuHandler.cpp
+++ b/src/RoomContextMenuHandler.cpp
@@ -130,12 +130,11 @@ bool RoomContextMenuHandler::handle(T2DMap::MapInteractionContext& context)
             mMapWidget.mMultiSelectionHighlightRoomId = context.clickedRoomId;
             selectionChanged = true;
         }
-    } else if (previousSelectionSize <= 1 && previousSelectionSize > 0) {
-        mMapWidget.clearSelection();
-        mMapWidget.mMultiSelectionSet.clear();
-        mMapWidget.mMultiSelectionHighlightRoomId = 0;
-        selectionChanged = true;
     }
+    // A right-click that hits no room leaves the selection alone, whatever its
+    // size: mappers select a room (or box-select one from a stack) and then
+    // right-click on empty space to edit it, because hitting the room itself is
+    // hard when zoomed out (#9915).
 
     context.multiSelectionSet = &mMapWidget.mMultiSelectionSet;
     context.hasMultiSelection = !mMapWidget.mMultiSelectionSet.isEmpty();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Removes the branch in `RoomContextMenuHandler` that cleared the room selection when a right-click landed on empty map space with exactly one room selected. A right-click that hits no room now leaves the selection alone whatever its size — the same thing the pre-#8356 `T2DMap::mousePressEvent` did. Closes #9915.

#### Motivation for adding to Mudlet

Mappers select a room — often box-selected out of a stack of overlapping rooms and trimmed via the selection list — and then right-click somewhere easier to hit than the room itself, especially at far zoom levels. Since 4.20.0 that discarded the selection and offered to create a new room instead of editing the selected one.

#### Other info (issues closed, discussion etc)

Regression traced to 35ec2767 (#8356), first shipped in 4.20.0; 4.19.1 behaved correctly. Verified by reproducing before and after on a headless build: one room selected + right-click on empty space now shows the room-edit menu (including Set exits and Create exit line), while the no-selection and multi-selection menus are unchanged. Reviewers also confirmed `mMultiSelectionHighlightRoomId` stays consistent on every path that can leave the set at size 1, so the highlight-dependent menu items act on the right room.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHLpgjE72BEvHHw9MgUzuq)_