### PR TITLE
Fix: Crash on macOS 12 shortly after startup

### DIFF
--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -40,9 +40,19 @@ if(APPLE)
         set(ARCH_LIST "arm64;x86_64")
     endif()
 
+    # ExternalProject does not inherit the parent build's cache, so without this
+    # the sentry-native/crashpad sub-build gets no -mmacosx-version-min at all
+    # and clang silently targets the *build machine's* macOS version. That makes
+    # __builtin_available(macOS 14.4, *) inside sentry_sync.h fold to a constant
+    # true and turns os_sync_wait_on_address_with_timeout() into a strong import,
+    # so the batcher thread called a symbol that does not exist on the macOS 12
+    # we still ship for and dyld aborted with "missing symbol called".
+    # Passing our deployment target down restores the weak import plus the real
+    # runtime check, so older releases take sentry's poll-wait fallback instead.
     list(APPEND SENTRY_COMMON_ARGS
         "-DCMAKE_OSX_ARCHITECTURES=${ARCH_LIST}"
         "-DCMAKE_OSX_SYSROOT=${MACOSX_SYSROOT}"
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
     )
 endif()
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Forward `CMAKE_OSX_DEPLOYMENT_TARGET` into the sentry-native/crashpad `ExternalProject_Add` sub-builds in `src/cmake/WithSentry.cmake`.

#### Motivation for adding to Mudlet

`ExternalProject_Add` starts a fresh CMake cache, so sentry-native compiled against the CI runner's own macOS (14/15) instead of Mudlet's macOS 12 minimum — at a target ≥ 14.4 clang folds sentry's `__builtin_available(macOS 14.4, *)` guard to constant true and strong-links `os_sync_wait_on_address_with_timeout`, which does not exist on Monterey, so Mudlet aborts there with dyld's "missing symbol called" the first time sentry's batcher thread waits (Sentry issue [MUDLET-3W](https://mudlet.sentry.io/issues/MUDLET-3W)). With the target forwarded, the symbols weak-link and macOS < 14.4 takes sentry's poll fallback, as upstream intends.

#### Other info (issues closed, discussion etc)

Closes #9942.

Verified on Linux: sentry-native builds standalone at the current pin with Mudlet's options (470/470 targets), and a minimal two-`ExternalProject_Add` reproduction confirmed the sub-build sees an empty deployment target before this change and `12.0` after. What only a macOS build can confirm: `nm -m` on the built `libsentry.a` or final binary should now show `_os_sync_wait_on_address_with_timeout` as `weak external`, never a plain undefined external — and ideally a smoke test on a real macOS 12 machine.

Behaviour note for macOS 12–14.3 users: sentry's batcher falls back to its 10 ms poll loop instead of a kernel wait — upstream's intended fallback path, not a regression.

**Test case:** build on macOS, run `nm -m build/3rdparty/sentry-native/.../libsentry.a | grep os_sync_wait` and confirm the symbol is a weak import; launch Mudlet on macOS 12.x and confirm no immediate "missing symbol called" abort.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXg7UzGfLS6oxd3Ysb6xgR)_