### PR TITLE
Fix: Rare crash if a profile closes while an MXP tag is stalled

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -223,6 +223,9 @@ TBuffer::TBuffer(Host* pH, TConsole* pConsole)
 TBuffer::~TBuffer()
 {
     if (mTagWatchdog) {
+        // The timeout lambda captures 'this', and so does the deferred
+        // continuation the watchdog queues against this timer. Destroying the
+        // timer with the buffer, just below, drops both:
         mTagWatchdog->stop();
     }
     if (mpServerWrapFlushTimer) {
@@ -2004,8 +2007,17 @@ void TBuffer::processMxpWatchdogCallback()
             const TChar style(mForeGroundColor, mBackGroundColor, computeCurrentAttributeFlags());
             QPointer<Host> hostGuard = mpHost;
             QPointer<TConsole> consoleGuard = mpConsole;
-            QTimer::singleShot(0ms, mpConsole, [this, style, hostGuard, consoleGuard]() {
-                if (!hostGuard || !consoleGuard) {
+            // The continuation writes into this buffer through the captured
+            // 'this', so what has to cancel it is this buffer going away - not
+            // the console going away, which is a different and longer life. The
+            // watchdog timer is owned by the buffer, so naming it as the context
+            // object ties the two together: destroying the buffer destroys the
+            // timer, and that drops any continuation still queued against it.
+            QTimer::singleShot(0ms, mTagWatchdog.get(), [this, style, hostGuard, consoleGuard]() {
+                // commitLine() and finalize() below both reach the main console
+                // through the host, and that pointer empties on its own when the
+                // profile's console goes:
+                if (!hostGuard || !consoleGuard || !hostGuard->mpConsole) {
                     return;
                 }
                 QString lastEntityValue = hostGuard->mMxpProcessor.getEntityValue();

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(FUNCTIONAL_TEST_SOURCES
     UnitDeferredDeleteTest.cpp
     ProfileLifecycleTest.cpp
     MxpFramePlacementTest.cpp
+    MxpWatchdogBufferLifetimeTest.cpp
     TelnetReconnectStateTest.cpp
     SavedVariableFenceTest.cpp
     ColorTriggerFilterChildTest.cpp

--- a/test/functional_tests/MxpWatchdogBufferLifetimeTest.cpp
+++ b/test/functional_tests/MxpWatchdogBufferLifetimeTest.cpp
@@ -1,0 +1,207 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QElapsedTimer>
+#include <QSignalSpy>
+#include <QtTest/QtTest>
+#include <chrono>
+#include <string>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TBuffer.h"
+#include "TMainConsole.h"
+#include "TMxpProcessor.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+void initializeQRCResourcesForMxpWatchdogBufferLifetimeTest();
+
+// Covers issue #9934, the return of #8784: the MXP tag watchdog unfreezes a
+// stalled tag from a deferred continuation that captures a raw TBuffer 'this'.
+// #8785 gave that continuation QPointer guards for the Host and the TConsole,
+// but tied its lifetime to the console rather than to the buffer it writes
+// into, so a buffer that names a console it is not a member of leaves the
+// continuation to run over freed memory. Under the sanitisers a regression is
+// a use-after-free report rather than a failed assertion.
+class MxpWatchdogBufferLifetimeTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "MxpWatchdogBufferLifetime-Test-Host";
+    QString mPort;
+    const QString mLocalhost = "localhost";
+
+    // A single pass of the loop, so that a timer armed from inside a timeout
+    // handler - which is exactly what the watchdog's continuation is - does not
+    // get dispatched in the same pass that armed it.
+    void pumpOnce() { QCoreApplication::processEvents(QEventLoop::AllEvents); }
+
+private slots:
+    void initTestCase()
+    {
+        initializeQRCResourcesForMxpWatchdogBufferLifetimeTest();
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        mudlet::self()->resize(1200, 800);
+
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        delete mudlet::self();
+        QDir(path).removeRecursively();
+    }
+
+    void init()
+    {
+        QVERIFY(mpHost);
+        QVERIFY(mpHost->mpConsole);
+        // The games this matters for do not negotiate MXP, they assume it, so
+        // this is how the processor is turned on for them - secure mode included
+        mpHost->setForceMXPProcessorOn(true);
+        mpHost->mMxpProcessor.enable();
+        mpHost->mMxpProcessor.setMode(MXP_MODE_CODE_LOCK_SECURE);
+        mpHost->mMxpProcessor.getMxpTagBuilder().reset();
+        mpHost->mMxpProcessor.setLastEntityValue(QString());
+    }
+
+    void cleanup()
+    {
+        mpHost->mMxpProcessor.getMxpTagBuilder().reset();
+        mpHost->mMxpProcessor.setLastEntityValue(QString());
+        mpHost->setForceMXPProcessorOn(false);
+    }
+
+    // A tag that never closes arms the watchdog; two timeouts later the
+    // unfreeze phase queues a continuation that appends the literal text into
+    // the buffer. Destroying the buffer in that window has to take the
+    // continuation with it - it writes through a captured raw pointer.
+    void test_destroyedBufferCancelsTheWatchdogContinuation()
+    {
+        // Connecting can leave the main console's own watchdog counting down over
+        // the MXP state this shares with it, and that would reset the tag builder
+        // out from under the buffer below. Let it run itself out first.
+        QTest::qWait(2 * 1300ms + 400ms);
+        mpHost->mMxpProcessor.getMxpTagBuilder().reset();
+        mpHost->mMxpProcessor.setLastEntityValue(QString());
+
+        auto* pBuffer = new TBuffer(mpHost, mpHost->mpConsole);
+        std::string stalledTag{"<send"};
+        pBuffer->translateToPlainText(stalledTag, true);
+        QVERIFY2(mpHost->mMxpProcessor.getMxpTagBuilder().isInsideTag(), "the feed left no tag open, so no watchdog was armed");
+
+        // The unfreeze phase publishes the literal text as the last entity
+        // value immediately before it queues the continuation, so that is the
+        // signal that the continuation is pending but has not run yet.
+        QElapsedTimer elapsed;
+        elapsed.start();
+        while (elapsed.elapsed() < 8000 && mpHost->mMxpProcessor.getEntityValue().isEmpty()) {
+            pumpOnce();
+            QThread::usleep(200);
+        }
+        QVERIFY2(!mpHost->mMxpProcessor.getEntityValue().isEmpty(), "the watchdog never reached its unfreeze phase, so nothing was queued to test");
+
+        delete pBuffer;
+
+        // Runs the queued continuation, if the destructor left one behind
+        QTest::qWait(250ms);
+
+        // Under the sanitisers the regression already showed up above, as a
+        // use-after-free inside the continuation. Where they are not compiled in,
+        // resetting the tag builder is the continuation's last visible act, so a
+        // builder still holding the stalled tag is how a cancelled continuation
+        // reads.
+        QCOMPARE(QString::fromStdString(mpHost->mMxpProcessor.getMxpTagBuilder().getRawTagContent()), qsl("send"));
+    }
+};
+
+void initializeQRCResourcesForMxpWatchdogBufferLifetimeTest()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "MxpWatchdogBufferLifetimeTest.moc"
+QTEST_MAIN(MxpWatchdogBufferLifetimeTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The MXP watchdog's deferred continuation (added in #8785) is now scheduled against the buffer-owned watchdog timer instead of `mpConsole`, so destroying the `TBuffer` cancels the queued lambda that captures raw `this` — the same pattern `~TBuffer()` already uses for `mpServerWrapFlushTimer`.
- The continuation also null-checks `hostGuard->mpConsole` before `commitLine()`/`finalize()` dereference it.
- Adds `MxpWatchdogBufferLifetimeTest`, which under AddressSanitizer is red without the fix (heap-use-after-free, 776 bytes inside a freed 2680-byte region — exactly `sizeof(TBuffer)` — at the continuation's `mMudBuffer.push_back`) and green with it.

#### Motivation for adding to Mudlet

#8785's `QPointer` guards prove the Host and console are alive, but they are read *out of* the raw captured `this` — they can never prove the buffer itself is alive, and the continuation's cancellation was tied to `mpConsole`, an object with a longer lifetime than the buffer. A `TBuffer` destroyed between the watchdog unfreeze and the queued continuation running is a use-after-free.

Honest scope note: with today's `TBuffer` usage the hole is latent rather than a confirmed production crasher — every buffer that arms the watchdog currently belongs to the console the continuation was parented to. This completes #8785 and removes a trap for any future `TBuffer` user, proven by the ASan test.

#### Other info (issues closed, discussion etc)

Investigation of #9934 / Sentry [MUDLET-1D](https://mudlet.sentry.io/issues/MUDLET-1D) found the reported "regression" of #8785 does not exist: every event with the signature fault address 0xbb8 (a constant null-`Host` member offset, not heap garbage) comes from pre-#8785 binaries, and the events on "fixed" releases are unrelated system-only minidumps (GPU driver, CRT thunks) that Sentry mis-grouped under a generic `basic_string::size` hash. Details in the issue thread. Full Lua spec suite passes unchanged (3112 successes / 0 failures / 0 errors; the ±2 vs baseline is an environmental pending-split, identical pre-fix).

**Test case:** build the `MxpWatchdogBufferLifetimeTest` target with the default (ASan) Linux preset and run it — it passes; revert the `src/TBuffer.cpp` hunks and it reports a heap-use-after-free in the watchdog continuation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXg7UzGfLS6oxd3Ysb6xgR)_