### PR TITLE
Fix: Crash when an update download is requested twice in quick succession

### DIFF
--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -32,6 +32,8 @@
 #include <QRegularExpression>
 #include <QTemporaryFile>
 
+#include <utility>
+
 namespace dblsqd {
 
 Feed::Feed(QObject* parent)
@@ -154,7 +156,13 @@ bool Feed::isReady() const
 
 bool Feed::isDownloading() const
 {
-    return mDownloadReply != nullptr && !mDownloadReply->isFinished();
+    // The checksums are fetched before the download request is made, so a
+    // download that has only got that far has no mDownloadReply yet. Counting
+    // that window as downloading is what stops a second downloadRelease() -
+    // the update dialog's automatic download and the twice-daily check both
+    // answer the same ready() - from starting a parallel run of the same
+    // download (#9938)
+    return mChecksumsReply != nullptr || (mDownloadReply != nullptr && !mDownloadReply->isFinished());
 }
 
 void Feed::load()
@@ -258,7 +266,9 @@ void Feed::fetchChecksums(const QUrl& checksumsUrl)
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     request.setTransferTimeout(30000);
     auto* reply = mNam.get(request);
+    mChecksumsReply = reply;
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        mChecksumsReply = nullptr;
         if (reply->error() != QNetworkReply::NoError) {
             if (mRequireChecksums) {
                 qWarning() << "Failed to fetch checksums:" << reply->errorString() << "- refusing to install an unverifiable download";
@@ -302,19 +312,23 @@ void Feed::makeDownloadRequest(const QUrl& url)
 {
     mDownloadFilePath.clear();
 
-    if (mDownloadReply != nullptr) {
-        if (!mDownloadReply->isFinished()) {
-            disconnect(mDownloadReply);
-            mDownloadReply->abort();
+    // Take the previous reply out of the member before touching it. abort()
+    // delivers finished() synchronously, so handleDownloadFinished() runs
+    // inside the call below and its cleanupDownloadReply() deletes the reply
+    // and clears the member - after which reading mDownloadReply again would
+    // call deleteLater() on a null pointer (#9938). Disconnecting the reply
+    // from this Feed first also keeps that handler, and the download error it
+    // emits, out of an abort this function asked for. The old
+    // disconnect(mDownloadReply) resolved to QObject::disconnect(receiver),
+    // which unhooks signals sent *to* the reply - of which there are none.
+    if (auto* previousReply = std::exchange(mDownloadReply, nullptr)) {
+        previousReply->disconnect(this);
+        if (!previousReply->isFinished()) {
+            previousReply->abort();
         }
-        mDownloadReply->deleteLater();
-        mDownloadReply = nullptr;
+        previousReply->deleteLater();
     }
-    if (mDownloadFile != nullptr) {
-        mDownloadFile->close();
-        mDownloadFile->deleteLater();
-        mDownloadFile = nullptr;
-    }
+    cleanupDownloadFile();
 
     QNetworkRequest request(url);
     request.setRawHeader("User-Agent", "Mudlet-Updater");

--- a/src/updater/Feed.h
+++ b/src/updater/Feed.h
@@ -96,6 +96,7 @@ private:
 
     QNetworkAccessManager mNam;
     QNetworkReply* mFeedReply{nullptr};
+    QNetworkReply* mChecksumsReply{nullptr};
     Release mCurrentDownload;
     QNetworkReply* mDownloadReply{nullptr};
     QTemporaryFile* mDownloadFile{nullptr};

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -87,6 +87,11 @@ if(USE_UPDATER AND NOT APPLE)
     list(APPEND FUNCTIONAL_TEST_SOURCES NewReleaseDialogTeardownTest.cpp)
 endif()
 
+# dblsqd::Feed itself is built on every platform that has the updater
+if(USE_UPDATER)
+    list(APPEND FUNCTIONAL_TEST_SOURCES FeedChecksumRaceTest.cpp)
+endif()
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp

--- a/test/functional_tests/FeedChecksumRaceTest.cpp
+++ b/test/functional_tests/FeedChecksumRaceTest.cpp
@@ -1,0 +1,206 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vperetokin@mudlet.org         *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "updater/Feed.h"
+#include "updater/Release.h"
+#include "utils.h"
+
+#include <QtTest/QtTest>
+
+#include <QHash>
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTimer>
+
+/*
+ * Regression test for https://github.com/Mudlet/Mudlet/issues/9938 (Sentry
+ * MUDLET-4M): EXCEPTION_ACCESS_VIOLATION_READ at address 0x8 inside
+ * Feed::makeDownloadRequest(), reached from the lambda Feed::fetchChecksums()
+ * connects to the checksum reply.
+ *
+ * Feed::isDownloading() only looked at the download reply, which does not
+ * exist yet while the checksums are being fetched - so a second
+ * downloadRelease() during that window sailed past the guard and started a
+ * second checksum fetch. The update dialog's automatic download and the
+ * twice-daily update check both answer the same Feed::ready(), so the second
+ * call is an ordinary consequence of leaving automatic updates on.
+ *
+ * When the second checksum fetch finished, makeDownloadRequest() found the
+ * first download already in flight and aborted it. abort() delivers finished()
+ * synchronously, so handleDownloadFinished() ran nested inside it and its
+ * cleanupDownloadReply() deleted the reply and set mDownloadReply to nullptr -
+ * the disconnect() meant to prevent that used the wrong overload and unhooked
+ * nothing. makeDownloadRequest() then went on to call
+ * mDownloadReply->deleteLater() on that null pointer, and QObject::deleteLater()
+ * reads d_ptr at offset 8 of `this`: a read of address 0x8.
+ *
+ * The stub server answers the second checksum request late on purpose, so the
+ * first download is guaranteed to be in flight by the time the second lambda
+ * runs. Without the fix this test does not fail an assertion, it segfaults.
+ */
+
+namespace {
+const auto assetName = qsl("Mudlet-9.9.9-linux-x64.AppImage.tar");
+const auto checksumsName = qsl("SHA256SUMS.txt");
+} // namespace
+
+// A minimum-viable HTTP server: it serves the checksum file, and answers the
+// download request with a Content-Length it never satisfies, so that download
+// stays unfinished for the whole test
+class StubFeedServer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit StubFeedServer(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        connect(&mServer, &QTcpServer::newConnection, this, &StubFeedServer::acceptConnections);
+    }
+
+    bool listen() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    quint16 port() const { return mServer.serverPort(); }
+
+    int checksumRequests() const { return mChecksumRequests; }
+    int downloadRequests() const { return mDownloadRequests; }
+
+private:
+    void acceptConnections()
+    {
+        while (auto* socket = mServer.nextPendingConnection()) {
+            connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
+                readRequest(socket);
+            });
+            connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+        }
+    }
+
+    void readRequest(QTcpSocket* socket)
+    {
+        QByteArray& buffer = mBuffers[socket];
+        buffer.append(socket->readAll());
+        const int headerEnd = buffer.indexOf("\r\n\r\n");
+        if (headerEnd < 0) {
+            return;
+        }
+        const QByteArray requestLine = buffer.left(buffer.indexOf("\r\n"));
+        mBuffers.remove(socket);
+
+        if (requestLine.contains(checksumsName.toLatin1())) {
+            ++mChecksumRequests;
+            // The first answer is immediate so its download is running before
+            // any second one lands; a later one is held back to guarantee that
+            const int delayMs = mChecksumRequests == 1 ? 0 : 300;
+            QTimer::singleShot(delayMs, socket, [socket]() {
+                sendChecksums(socket);
+            });
+            return;
+        }
+
+        if (requestLine.contains(assetName.toLatin1())) {
+            ++mDownloadRequests;
+            sendUnfinishedDownload(socket);
+            return;
+        }
+
+        socket->write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        socket->disconnectFromHost();
+    }
+
+    static void sendChecksums(QTcpSocket* socket)
+    {
+        const QByteArray body = QByteArray(64, 'a') + "  " + assetName.toLatin1() + "\n";
+        socket->write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: " + QByteArray::number(body.size()) + "\r\nConnection: close\r\n\r\n");
+        socket->write(body);
+        socket->flush();
+        socket->disconnectFromHost();
+    }
+
+    static void sendUnfinishedDownload(QTcpSocket* socket)
+    {
+        socket->write("HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: 4194304\r\nConnection: close\r\n\r\n");
+        socket->write(QByteArray(16, 'x'));
+        socket->flush();
+    }
+
+    QTcpServer mServer;
+    QHash<QTcpSocket*, QByteArray> mBuffers;
+    int mChecksumRequests{0};
+    int mDownloadRequests{0};
+};
+
+class FeedChecksumRaceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void secondDownloadRequestDuringChecksumFetchDoesNotCrash();
+};
+
+void FeedChecksumRaceTest::secondDownloadRequestDuringChecksumFetchDoesNotCrash()
+{
+    StubFeedServer server;
+    QVERIFY2(server.listen(), "the stub update server could not listen on localhost");
+    const QString base = qsl("http://127.0.0.1:%1/").arg(server.port());
+
+    QJsonObject checksumsAsset;
+    checksumsAsset.insert(qsl("name"), checksumsName);
+    checksumsAsset.insert(qsl("browser_download_url"), base + checksumsName);
+    QJsonObject downloadAsset;
+    downloadAsset.insert(qsl("name"), assetName);
+    downloadAsset.insert(qsl("browser_download_url"), base + assetName);
+    downloadAsset.insert(qsl("size"), 4194304);
+
+    QJsonObject releaseInfo;
+    releaseInfo.insert(qsl("tag_name"), qsl("Mudlet-9.9.9"));
+    releaseInfo.insert(qsl("published_at"), qsl("2026-08-01T00:00:00Z"));
+    releaseInfo.insert(qsl("body"), qsl("stub release"));
+    releaseInfo.insert(qsl("assets"), QJsonArray({checksumsAsset, downloadAsset}));
+
+    const dblsqd::Release release(releaseInfo, qsl("linux"), qsl("x64"));
+    QCOMPARE(release.getDownloadUrl().toString(), base + assetName);
+    QCOMPARE(release.getChecksumsUrl().toString(), base + checksumsName);
+
+    dblsqd::Feed feed;
+    QStringList downloadErrors;
+    connect(&feed, &dblsqd::Feed::downloadError, this, [&downloadErrors](const QString& message) {
+        downloadErrors << message;
+    });
+
+    // What the update dialog's automatic download and the twice-daily check do
+    // when both answer the same ready(): the second call lands while the first
+    // is still fetching checksums
+    feed.downloadRelease(release, /*requireChecksums=*/true);
+    feed.downloadRelease(release, /*requireChecksums=*/true);
+
+    // Long enough for both checksum answers - including the deliberately late
+    // one - and the download requests they lead to
+    QTest::qWait(1500);
+
+    QCOMPARE(server.downloadRequests(), 1);
+    QCOMPARE(server.checksumRequests(), 1);
+    QVERIFY2(downloadErrors.isEmpty(), qPrintable(qsl("no download error was expected, got: %1").arg(downloadErrors.join(qsl("; ")))));
+    QVERIFY2(feed.isDownloading(), "the download started by the first request must still be running");
+}
+
+QTEST_MAIN(FeedChecksumRaceTest)
+#include "FeedChecksumRaceTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Feed::isDownloading()` now also reports true while the pre-download checksum fetch is in flight (new `mChecksumsReply` member), so a second `downloadRelease()` in that window is refused like every other duplicate.
- `makeDownloadRequest()` takes the previous reply out of the member with `std::exchange` and disconnects it with the correct overload (`previousReply->disconnect(this)`) **before** aborting, so the abort's synchronously-emitted `finished()` can no longer run `handleDownloadFinished()` underneath it and null the member it is about to use.
- Adds `FeedChecksumRaceTest`, a functional test with a local `QTcpServer` stub that makes the ordering deterministic — it segfaults without the fix and passes with it.

#### Motivation for adding to Mudlet

Windows crash `EXCEPTION_ACCESS_VIOLATION_READ / 0x8` (Sentry [MUDLET-4M](https://mudlet.sentry.io/issues/MUDLET-4M), frames verified to match this exact code): `UpdateDialog::handleFeedReady()` and the twice-daily update check both react to the same `Feed::ready()` and both call `downloadRelease()`, so the second call lands inside the checksum-fetch window where the old `isDownloading()` was blind. The second fetch's completion aborted the first download; `QNetworkReply::abort()` emits `finished()` synchronously; the old `disconnect(mDownloadReply)` resolved to the receiver overload and disconnected nothing, so the error path ran nested, called `deleteLater()` + nulled `mDownloadReply`, and control returned to `makeDownloadRequest()` which executed `mDownloadReply->deleteLater()` on null — `deleteLater()` reads `d_ptr` at `this + 8`, the exact reported fault address.

#### Other info (issues closed, discussion etc)

Closes #9938.

Empirical validation (Linux ASan build): without the fix the test reports `SEGV on unknown address 0x000000000008` in `QObject::deleteLater()` ← `Feed.cpp:310 makeDownloadRequest` ← `Feed.cpp:297 operator()` (the HEAD equivalents of the crash frames); with only the crash-site half of the fix it fails on a duplicate download request (proving the guard half is load-bearing); with the full fix it passes. Full Lua spec suite: 3112 successes / 0 failures / 0 errors. Behaviour note for reviewers: a `downloadRelease()` issued during the checksum fetch is now logged and ignored rather than starting a parallel download, and a superseded download's "Operation canceled" error is no longer surfaced to the user. Upstream `dblsqd/dblsqd-cpp` is gone (404), so nothing to report upstream; this code is Mudlet's own rewrite.

**Test case:** build the `FeedChecksumRaceTest` target with the default (ASan) Linux preset and run it — it passes; revert the `src/updater/Feed.cpp` hunks and it segfaults at address 0x8. In the app: with automatic updates enabled, trigger an update check and click Update while checksums are still being fetched — no crash, one download.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXg7UzGfLS6oxd3Ysb6xgR)_