### PR TITLE
Fix: Variables view no longer loses or corrupts variables in many edge cases

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -954,6 +954,12 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
         varUnit->addPointer(pValue);
         if (vType == LUA_TTABLE) {
             var->setValue("{}", LUA_TTABLE);
+            if (hide) {
+                // The identity addVariable() just remembered is only exact
+                // while this table is alive - anchor it weakly so isHidden()
+                // can tell a recycled address from the table itself.
+                varUnit->anchorHiddenTable(L, -1, pValue);
+            }
             const bool tooDeep = depth > scmMaxTableDepth;
             if (!tooDeep && lua_checkstack(L, 3)) {
                 //put the table on top

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -509,8 +509,10 @@ bool LuaInterface::pushOwningTable(const QList<TVar*>& vars)
     if (vars.isEmpty()) {
         return false;
     }
-    // the level being looked at, the key pushed into it, the value to write, and
-    // a copy of the key to look the current value up with
+    // headroom for what one level needs at once: the level being looked at, a
+    // key pushed into it, the value to write and a copy of the key to look the
+    // current value up with. Each level drops the one above it as it is entered,
+    // so the depth of the path does not add to this.
     if (!lua_checkstack(mL, 4)) {
         qWarning().noquote().nospace() << "LuaInterface::pushOwningTable() WARNING - the Lua stack could not be grown, so \"" << vars.constLast()->getName() << "\" cannot be written to.";
         return false;
@@ -535,10 +537,9 @@ bool LuaInterface::pushOwningTable(const QList<TVar*>& vars)
 // the long-bracket literal it was written into.
 bool LuaInterface::setValue(TVar* var)
 {
-    //This function assumes the var has been modified and then called
     const QList<TVar*> vars = varOrder(var);
     if (vars.isEmpty()) {
-        // _G itself, which is in no table to be written into
+        // a variable named _G - varOrder() gives it no path
         return false;
     }
 
@@ -564,7 +565,8 @@ bool LuaInterface::setValue(TVar* var)
         case LUA_TTABLE:
             // A table already there is left as it is: this is the call the
             // editor makes for a table it has just created, and the "= {}" the
-            // generated source used would empty one that is already in use.
+            // generated source used would replace one that is already in use
+            // with an empty one.
             lua_pushvalue(mL, -1);
             lua_gettable(mL, -3);
             if (lua_istable(mL, -1)) {
@@ -595,7 +597,7 @@ void LuaInterface::deleteVar(TVar* var)
 {
     const QList<TVar*> vars = varOrder(var);
     if (vars.isEmpty()) {
-        // _G itself, which the Variables view does not offer to delete
+        // a variable named _G - varOrder() gives it no path
         return;
     }
 
@@ -622,6 +624,10 @@ bool LuaInterface::renameCVar(QList<TVar*> vars)
     //and trash the stack
 
     TVar* var = vars.back();
+    // this walks down to the variable a push at a time, so every way out - the
+    // successful one included - owes the caller's Lua stack back. Left as it
+    // was, the leftovers stayed on the profile's live interpreter for good.
+    const int stackTop = lua_gettop(mL);
     //make the new stack
     lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
     if (setjmp(buf) == 0) {
@@ -641,7 +647,9 @@ bool LuaInterface::renameCVar(QList<TVar*> vars)
             lua_gettable(mL, -2);
             if (lua_isnil(mL, -1)) {
                 //value didn't exist, make it
-                lua_pop(mL, -1);
+                // that one nil, and not lua_pop(mL, -1) - which is
+                // lua_settop(mL, 0) and threw the whole stack away
+                lua_pop(mL, 1);
                 if (kType == LUA_TNUMBER) {
                     lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
                 } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
@@ -665,6 +673,7 @@ bool LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, or table.";
+            lua_settop(mL, stackTop);
             return false;
         }
 
@@ -694,6 +703,7 @@ bool LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when retrieving old value: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, table, or function.";
+            lua_settop(mL, stackTop);
             return false;
         }
         lua_gettable(mL, -2);
@@ -710,6 +720,7 @@ bool LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when setting new key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, or table.";
+            lua_settop(mL, stackTop);
             return false;
         }
         pushCount++;
@@ -727,13 +738,17 @@ bool LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when deleting old key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, table, or function.";
+            lua_settop(mL, stackTop);
             return false;
         }
         lua_pushnil(mL);
         lua_settable(mL, -3);
         var->clearNewName();
+        lua_settop(mL, stackTop);
         return true;
     }
+    lua_settop(mL, stackTop);
+    qWarning().noquote().nospace() << "LuaInterface::renameCVar() WARNING - Lua panicked while renaming \"" << var->getName() << "\"; it may be left under either name.";
     return false;
 }
 
@@ -791,8 +806,8 @@ bool LuaInterface::newNameIsFree(TVar* var)
     const int stackTop = lua_gettop(mL);
     if (setjmp(buf) == 0) {
         if (!pushOwningTable(varOrder(var)) || !pushKey(var, var->getNewName(), var->getNewKeyType())) {
-            // nothing here to be destroyed: the rename will fail to reach this
-            // table or this key as well, and say so in its own words
+            // nothing here to be destroyed - and the rename, reaching the same
+            // table by the same path, has as little chance of getting there
             lua_settop(mL, stackTop);
             return true;
         }
@@ -804,24 +819,42 @@ bool LuaInterface::newNameIsFree(TVar* var)
         lua_settop(mL, stackTop);
         return free;
     }
+    // Fails closed: the probe is what stands between a rename and a sibling's
+    // value, so a panic part way through it leaves the question unanswered, and
+    // the answer that cannot destroy anything is that the name is taken.
     lua_settop(mL, stackTop);
-    return true;
+    qWarning().noquote().nospace() << "LuaInterface::newNameIsFree() WARNING - Lua panicked while looking \"" << var->getNewName() << "\" up, so it is being treated as a name already in use.";
+    return false;
 }
 
-void LuaInterface::renameVar(TVar* var)
+bool LuaInterface::renameVar(TVar* var)
 {
     //this assumes anything like reparenting has been done
 
     QList<TVar*> vars = varOrder(var);
     if (vars.isEmpty()) {
-        // _G itself, which has no name to be renamed
-        return;
+        // a variable named _G - varOrder() gives it no path
+        var->abandonNewName();
+        return false;
+    }
+
+    if (var->isReference()) {
+        // A key that is a table or a function of its own is not a name, and the
+        // tree names such a member by the number of the registry reference
+        // holding the key. Renaming it to a string is not an operation that
+        // exists: what it did instead was write to a member named by that
+        // number - or, through renameCVar(), delete the member outright.
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - not renaming \"" << var->getName() << "\" to \"" << var->getNewName()
+                                       << "\": its key is a table or a function, which has no name to change.";
+        var->abandonNewName();
+        return false;
     }
 
     if (!newNameIsFree(var)) {
         qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - not renaming \"" << var->getName() << "\" to \"" << var->getNewName()
                                        << "\": another variable of that name is already there, and renaming onto it would destroy it.";
-        return;
+        var->abandonNewName();
+        return false;
     }
 
     // what the bookkeeping this variable is in has to follow it to, worked out
@@ -847,10 +880,17 @@ void LuaInterface::renameVar(TVar* var)
                 newName.append(qsl("[%1]").arg(vars[i]->getName()));
             }
         } else if (kType == LUA_TTABLE) {
+            // a table used as a key part way along the path - the leaf's own key
+            // cannot be one, that is refused above. Only the C API can put such
+            // a key back on the stack, so the whole rename goes through it.
             if (renameCVar(vars)) {
+                // where it goes, and why the bookkeeping moves here rather than
+                // once the rename is over: see the copying stage below
                 varUnit->renameVariableBookkeeping(oldFullName, newFullName);
+                return true;
             }
-            return;
+            var->abandonNewName();
+            return false;
         } else {
             // that leaves LUA_TSTRING
             oldVariable.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
@@ -877,20 +917,18 @@ void LuaInterface::renameVar(TVar* var)
     if (error) {
         qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << renameCode
                                        << "\".";
-        var->clearNewName();
-        return;
+        var->abandonNewName();
+        return false;
     }
     error = lua_pcall(mL, 0, LUA_MULTRET, 0);
     if (error) {
         qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
                                        << renameCode << "\".";
-        var->clearNewName();
-        return;
+        var->abandonNewName();
+        return false;
     }
-    // the variable is under its new name from here on, so what the profile
-    // remembers about it by name has to be under that name too - a saved or
-    // hidden mark left on the old name would go on to catch whichever unrelated
-    // variable is born there next
+    // here rather than at the end: the variable is under its new name from this
+    // point on, whatever the deleting stage below goes on to do
     varUnit->renameVariableBookkeeping(oldFullName, newFullName);
 
     //delete it
@@ -898,8 +936,10 @@ void LuaInterface::renameVar(TVar* var)
     if (error) {
         qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
                                        << renameCode << "\".";
+        // the copy landed, so the variable really is under its new name - only
+        // the old one is still there beside it, which this node does not name
         var->clearNewName();
-        return;
+        return true;
     }
     error = lua_pcall(mL, 0, LUA_MULTRET, 0);
     if (error) {
@@ -907,6 +947,7 @@ void LuaInterface::renameVar(TVar* var)
                                        << renameCode << "\".";
     }
     var->clearNewName();
+    return true;
 }
 
 // Returns the value for a string/number/boolean datatype, and an empty string for

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -615,7 +615,7 @@ void LuaInterface::deleteVar(TVar* var)
     qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Lua panicked while deleting \"" << var->getName() << "\"; it has not been deleted.";
 }
 
-void LuaInterface::renameCVar(QList<TVar*> vars)
+bool LuaInterface::renameCVar(QList<TVar*> vars)
 {
     //uses C Api to rename a variable.
     //dangerous function since you can get an api panic
@@ -665,7 +665,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, or table.";
-            return;
+            return false;
         }
 
         //put the old value on the stack
@@ -694,7 +694,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when retrieving old value: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, table, or function.";
-            return;
+            return false;
         }
         lua_gettable(mL, -2);
         pushCount++;
@@ -710,7 +710,7 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when setting new key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, or table.";
-            return;
+            return false;
         }
         pushCount++;
         lua_insert(mL, -2);
@@ -727,12 +727,14 @@ void LuaInterface::renameCVar(QList<TVar*> vars)
         } else {
             qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when deleting old key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
                                            << "\". Expected string, number, table, or function.";
-            return;
+            return false;
         }
         lua_pushnil(mL);
         lua_settable(mL, -3);
         var->clearNewName();
+        return true;
     }
+    return false;
 }
 
 bool LuaInterface::loadVar(TVar* var)
@@ -774,11 +776,62 @@ bool LuaInterface::loadVar(TVar* var)
     return true;
 }
 
+// Whether the name a rename is about to write to is free. A rename copies the
+// value onto the new key and only then nils the old one, so a name another
+// member of the same table already answers to loses that member's value without
+// a word - the write is refused instead.
+bool LuaInterface::newNameIsFree(TVar* var)
+{
+    if (var->isReference() || (var->getNewName() == var->getName() && var->getNewKeyType() == var->getKeyType())) {
+        // a member reached by a reference key is renamed onto the very key it
+        // already has, and so is one whose name has not in fact changed
+        return true;
+    }
+
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) == 0) {
+        if (!pushOwningTable(varOrder(var)) || !pushKey(var, var->getNewName(), var->getNewKeyType())) {
+            // nothing here to be destroyed: the rename will fail to reach this
+            // table or this key as well, and say so in its own words
+            lua_settop(mL, stackTop);
+            return true;
+        }
+        // Raw, like the walk that named the members of this table in the first
+        // place: a value an __index metamethod stands in with is not a member
+        // the rename would destroy.
+        lua_rawget(mL, -2);
+        const bool free = lua_isnoneornil(mL, -1);
+        lua_settop(mL, stackTop);
+        return free;
+    }
+    lua_settop(mL, stackTop);
+    return true;
+}
+
 void LuaInterface::renameVar(TVar* var)
 {
     //this assumes anything like reparenting has been done
 
     QList<TVar*> vars = varOrder(var);
+    if (vars.isEmpty()) {
+        // _G itself, which has no name to be renamed
+        return;
+    }
+
+    if (!newNameIsFree(var)) {
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - not renaming \"" << var->getName() << "\" to \"" << var->getNewName()
+                                       << "\": another variable of that name is already there, and renaming onto it would destroy it.";
+        return;
+    }
+
+    // what the bookkeeping this variable is in has to follow it to, worked out
+    // before the rename goes anywhere near the name it is keyed by
+    QStringList newNameParts = varUnit->shortVarName(var);
+    const QString oldFullName = newNameParts.join(qsl("."));
+    newNameParts.removeLast();
+    newNameParts.append(var->getNewName());
+    const QString newFullName = newNameParts.join(qsl("."));
+
     QString oldVariable = vars.at(0)->getName();
     QString newName;
     if (vars.size() > 1) {
@@ -794,7 +847,9 @@ void LuaInterface::renameVar(TVar* var)
                 newName.append(qsl("[%1]").arg(vars[i]->getName()));
             }
         } else if (kType == LUA_TTABLE) {
-            renameCVar(vars);
+            if (renameCVar(vars)) {
+                varUnit->renameVariableBookkeeping(oldFullName, newFullName);
+            }
             return;
         } else {
             // that leaves LUA_TSTRING
@@ -832,6 +887,12 @@ void LuaInterface::renameVar(TVar* var)
         var->clearNewName();
         return;
     }
+    // the variable is under its new name from here on, so what the profile
+    // remembers about it by name has to be under that name too - a saved or
+    // hidden mark left on the old name would go on to catch whichever unrelated
+    // variable is born there next
+    varUnit->renameVariableBookkeeping(oldFullName, newFullName);
+
     //delete it
     error = luaL_loadstring(mL, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
     if (error) {

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -464,119 +464,155 @@ void LuaInterface::createVar(TVar* var)
     setValue(var);
 }
 
-bool LuaInterface::setCValue(QList<TVar*> vars)
+// Pushes the key one element of a variable's path is reached by. A key the tree
+// named through a Lua registry reference - a table or a function used as a key -
+// comes back out of the registry, so the write lands on that key itself rather
+// than on the text of its reference number. Nothing is pushed when the key
+// cannot be built, which the caller has to treat as a failure: a write through a
+// key that is not the variable's own lands on some other member of the table.
+bool LuaInterface::pushKey(TVar* var, const QString& name, const int keyType)
 {
-    //make the new stack
-    TVar* var = vars.back();
-    if (setjmp(buf) == 0) {
-        const int stackSize = lua_gettop(mL);
-        lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
-        int i = 1;
-        for (; i < vars.size() - 1; i++) {
-            if (!loadValue(mL, vars[i], -2)) {
-                lua_settop(mL, stackSize);
-                return false;
-            }
+    if (var->isReference()) {
+        // registry references are integer refs so must stay toInt()
+        lua_rawgeti(mL, LUA_REGISTRYINDEX, name.toInt());
+        if (lua_isnoneornil(mL, -1)) {
+            // the reference has gone since the tree was built, so there is no
+            // key here to write through
+            lua_pop(mL, 1);
+            return false;
         }
-        //push our value onto the stack
+        return true;
+    }
+    if (keyType == LUA_TNUMBER) {
+        lua_pushnumber(mL, name.toDouble());
+        return true;
+    }
+    if (keyType == LUA_TBOOLEAN) {
+        lua_pushboolean(mL, name.toLower() == QLatin1String("true") ? 1 : 0);
+        return true;
+    }
+    // Everything else the tree names directly is a string key - a table or a
+    // function key is named through a reference, handled above. By length, so a
+    // key holding a quote or a newline is the key the walk read, and not
+    // something a generated string literal has to survive being written into.
+    const QByteArray key = name.toUtf8();
+    lua_pushlstring(mL, key.constData(), key.length());
+    return true;
+}
+
+// Pushes the table the last element of a variable's path lives in, ready for the
+// caller to write into. Walks down from _G one level at a time, dropping each
+// level as it enters the next, so a single value is left on the stack. On false
+// the caller owes the stack back - every write path here restores it anyway.
+bool LuaInterface::pushOwningTable(const QList<TVar*>& vars)
+{
+    if (vars.isEmpty()) {
+        return false;
+    }
+    // the level being looked at, the key pushed into it, the value to write, and
+    // a copy of the key to look the current value up with
+    if (!lua_checkstack(mL, 4)) {
+        qWarning().noquote().nospace() << "LuaInterface::pushOwningTable() WARNING - the Lua stack could not be grown, so \"" << vars.constLast()->getName() << "\" cannot be written to.";
+        return false;
+    }
+    lua_pushvalue(mL, LUA_GLOBALSINDEX);
+    for (int i = 0; i < vars.size() - 1; ++i) {
+        TVar* level = vars.at(i);
+        if (!lua_istable(mL, -1) || !pushKey(level, level->getName(), level->getKeyType())) {
+            return false;
+        }
+        lua_gettable(mL, -2);
+        lua_remove(mL, -2);
+    }
+    return lua_istable(mL, -1);
+}
+
+// Writes a variable's value into Lua. Through the C API, because generating Lua
+// source to do it put the value and the keys into that source as text, which a
+// value holding "]]" or a key holding a quote does not survive: the chunk failed
+// to parse, the write was quietly dropped and the parse error was left behind on
+// the Lua stack. A value starting with a newline lost that newline as well, to
+// the long-bracket literal it was written into.
+bool LuaInterface::setValue(TVar* var)
+{
+    //This function assumes the var has been modified and then called
+    const QList<TVar*> vars = varOrder(var);
+    if (vars.isEmpty()) {
+        // _G itself, which is in no table to be written into
+        return false;
+    }
+
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) == 0) {
+        if (!pushOwningTable(vars) || !pushKey(var, var->getName(), var->getKeyType())) {
+            qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - could not reach \"" << var->getName() << "\" to write to it.";
+            lua_settop(mL, stackTop);
+            return false;
+        }
         switch (var->getValueType()) {
-        case LUA_TSTRING:
-            lua_pushstring(mL, var->getValue().toUtf8().constData());
+        case LUA_TSTRING: {
+            const QByteArray value = var->getValue().toUtf8();
+            lua_pushlstring(mL, value.constData(), value.length());
             break;
+        }
         case LUA_TNUMBER:
             lua_pushnumber(mL, var->getValue().toDouble());
             break;
         case LUA_TBOOLEAN:
-            lua_pushboolean(mL, var->getValue().toLower() == "true" ? 1 : 0);
+            lua_pushboolean(mL, var->getValue().toLower() == QLatin1String("true") ? 1 : 0);
             break;
         case LUA_TTABLE:
+            // A table already there is left as it is: this is the call the
+            // editor makes for a table it has just created, and the "= {}" the
+            // generated source used would empty one that is already in use.
+            lua_pushvalue(mL, -1);
+            lua_gettable(mL, -3);
+            if (lua_istable(mL, -1)) {
+                lua_settop(mL, stackTop);
+                return true;
+            }
+            lua_pop(mL, 1);
             lua_newtable(mL);
             break;
         default:
-            lua_settop(mL, stackSize);
-            return false;
-        }
-        //set it up
-        if (lua_type(mL, -1) != var->getValueType()) {
-            lua_settop(mL, stackSize);
+            lua_settop(mL, stackTop);
             return false;
         }
         lua_settable(mL, -3);
+        lua_settop(mL, stackTop);
+        return true;
     }
+    lua_settop(mL, stackTop);
+    qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Lua panicked while writing to \"" << var->getName() << "\"; it has not been changed.";
     return false;
 }
 
-// sets the value of a Lua variable by running dynamically-generated Lua code
-bool LuaInterface::setValue(TVar* var)
-{
-    //This function assumes the var has been modified and then called
-
-
-    QList<TVar*> vars = varOrder(var);
-    QString variableChangeCode = vars[0]->getName();
-    for (int i = 1; i < vars.size(); i++) {
-        if (vars[i]->isReference()) {
-            return setCValue(vars);
-        }
-        const int keyType = vars[i]->getKeyType();
-        if (keyType == LUA_TNUMBER || keyType == LUA_TBOOLEAN) {
-            variableChangeCode.append(qsl("[%1]").arg(vars.at(i)->getName()));
-        } else {
-            variableChangeCode.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
-        }
-    }
-    switch (var->getValueType()) {
-    case LUA_TSTRING:
-        variableChangeCode.append(qsl(" = [[%1]]").arg(var->getValue()));
-        break;
-    case LUA_TNUMBER:
-        variableChangeCode.append(qsl(" = %1").arg(var->getValue()));
-        break;
-    case LUA_TBOOLEAN:
-        variableChangeCode.append(qsl(" = %1").arg(var->getValue()));
-        break;
-    case LUA_TTABLE:
-        variableChangeCode.append(QLatin1String(" = {}"));
-        break;
-    default:
-        return false;
-    }
-    int error = luaL_loadstring(mL, variableChangeCode.toUtf8().constData());
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << variableChangeCode << "\".";
-        return false;
-    }
-    error = lua_pcall(mL, 0, LUA_MULTRET, 0);
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << variableChangeCode << "\".";
-        return false;
-    }
-    return true;
-}
-
+// Through the C API for the same reasons setValue() is, and for one more: a
+// member reached by a table key was named in the generated source by the text of
+// its registry reference number, so the delete nil'ed a string key of that text
+// and left the member itself where it was, to reappear in the Variables view.
 void LuaInterface::deleteVar(TVar* var)
 {
-    QList<TVar*> vars = varOrder(var);
-    QString oldName = vars[0]->getName();
-    for (int i = 1; i < vars.size(); i++) {
-        const int keyType = vars[i]->getKeyType();
-        if (keyType == LUA_TNUMBER || keyType == LUA_TBOOLEAN) {
-            oldName.append(qsl("[%1]").arg(vars[i]->getName()));
-        } else {
-            oldName.append(qsl(R"(["%1"])").arg(vars[i]->getName()));
-        }
-    }
-    //delete it
-    oldName.append(qsl(" = nil"));
-    int error = luaL_loadstring(mL, oldName.toUtf8().constData());
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << oldName << "\".";
+    const QList<TVar*> vars = varOrder(var);
+    if (vars.isEmpty()) {
+        // _G itself, which the Variables view does not offer to delete
         return;
     }
-    error = lua_pcall(mL, 0, LUA_MULTRET, 0);
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << oldName << "\".";
+
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) == 0) {
+        if (!pushOwningTable(vars) || !pushKey(var, var->getName(), var->getKeyType())) {
+            qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - could not reach \"" << var->getName() << "\" to delete it.";
+            lua_settop(mL, stackTop);
+            return;
+        }
+        lua_pushnil(mL);
+        lua_settable(mL, -3);
+        lua_settop(mL, stackTop);
+        return;
     }
+    lua_settop(mL, stackTop);
+    qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Lua panicked while deleting \"" << var->getName() << "\"; it has not been deleted.";
 }
 
 void LuaInterface::renameCVar(QList<TVar*> vars)
@@ -796,7 +832,6 @@ void LuaInterface::renameVar(TVar* var)
         var->clearNewName();
         return;
     }
-
     //delete it
     error = luaL_loadstring(mL, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
     if (error) {

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -886,7 +886,7 @@ bool LuaInterface::renameVar(TVar* var)
             if (renameCVar(vars)) {
                 // where it goes, and why the bookkeeping moves here rather than
                 // once the rename is over: see the copying stage below
-                varUnit->renameVariableBookkeeping(oldFullName, newFullName);
+                varUnit->renameVariableBookkeeping(var, oldFullName, newFullName);
                 return true;
             }
             var->abandonNewName();
@@ -929,7 +929,7 @@ bool LuaInterface::renameVar(TVar* var)
     }
     // here rather than at the end: the variable is under its new name from this
     // point on, whatever the deleting stage below goes on to do
-    varUnit->renameVariableBookkeeping(oldFullName, newFullName);
+    varUnit->renameVariableBookkeeping(var, oldFullName, newFullName);
 
     //delete it
     error = luaL_loadstring(mL, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -79,7 +79,7 @@ public:
     bool loadValue(lua_State*, TVar*, int);
     bool setValue(TVar*);
     void deleteVar(TVar*);
-    void renameCVar(QList<TVar*>);
+    bool renameCVar(QList<TVar*>);
     void renameVar(TVar*);
     void createVar(TVar*);
     // whether a variable can be written back through the name the tree gave it,
@@ -103,6 +103,7 @@ private:
     void addSavedRootsMissingFromTheTree();
     bool pushKey(TVar*, const QString& name, const int keyType);
     bool pushOwningTable(const QList<TVar*>&);
+    bool newNameIsFree(TVar*);
 
     int depth = 0;
     lua_State* mL;

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -80,7 +80,9 @@ public:
     bool setValue(TVar*);
     void deleteVar(TVar*);
     bool renameCVar(QList<TVar*>);
-    void renameVar(TVar*);
+    // false when the rename did not happen - the variable keeps the name it had
+    // and the node keeps naming it, which the caller has to tell the user about
+    bool renameVar(TVar*);
     void createVar(TVar*);
     // whether a variable can be written back through the name the tree gave it,
     // which the editor asks before writing - the write paths themselves do not

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -77,7 +77,6 @@ public:
     QString getValue(TVar*);
     bool loadKey(lua_State*, TVar*);
     bool loadValue(lua_State*, TVar*, int);
-    bool setCValue(QList<TVar*>);
     bool setValue(TVar*);
     void deleteVar(TVar*);
     void renameCVar(QList<TVar*>);
@@ -102,6 +101,8 @@ private:
     TVar* resetVariableTree();
     bool readSavedVars();
     void addSavedRootsMissingFromTheTree();
+    bool pushKey(TVar*, const QString& name, const int keyType);
+    bool pushOwningTable(const QList<TVar*>&);
 
     int depth = 0;
     lua_State* mL;

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -51,6 +51,19 @@ TTreeWidget::TTreeWidget(QWidget* pW)
 void TTreeWidget::setTreeType(TreeType type)
 {
     mTreeType = type;
+
+    // A variables tree is a view of what Lua holds, and moving an item in it
+    // moves nothing in Lua - the item lands inside the table it was dropped on
+    // while the variable stays where it was, so the view ends up showing
+    // something that is not true (#9958). Until a move can be carried through to
+    // Lua, the tree does not offer one.
+    if (mTreeType == TreeType::Var) {
+        setDragDropMode(QAbstractItemView::NoDragDrop);
+        setDragEnabled(false);
+        setAcceptDrops(false);
+        setDropIndicatorShown(false);
+        viewport()->setAcceptDrops(false);
+    }
 }
 
 void TTreeWidget::setHost(Host* pH)

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -74,21 +74,38 @@ QString TVar::getName() const
     return name;
 }
 
+// std::sort() may walk off the ends of the range it is given unless this is a
+// strict weak ordering, so every pair of names has to be placed the same way
+// whichever other names are around. Only the out-parameter of toInt() says
+// whether a name is a number: its return value cannot, since "0" and a name
+// that is no number at all both convert to zero. Deciding it by the value put
+// the names into groups that contradicted each other - "2" < "10" < "11a" <
+// "2" was a cycle a table of mixed names really produced (#9956).
 bool TVarLessThan(TVar* varA, TVar* varB)
 {
     const QString a = varA->getName();
     const QString b = varB->getName();
-    bool isAOk = false;
-    bool isBOk = false;
+    bool isANumber = false;
+    bool isBNumber = false;
+    const int aNumber = a.toInt(&isANumber);
+    const int bNumber = b.toInt(&isBNumber);
 
-    // Previously we do not check the result of a toInt() call on the QStrings
-    // but they would happly return a zero value for a QString that can not be
-    // converted to a number and then the IF branch would be taken regardless
-    // of whether one or both of the QStrings was NOT actually a number
-    if (a.toInt(&isAOk) && b.toInt(&isBOk) && isAOk && isBOk) {
-        return a.toInt() < b.toInt();
+    if (isANumber != isBNumber) {
+        // numbers ahead of names, which is how a table of nothing but numbers
+        // already sorted
+        return isANumber;
     }
-    return a.toLower() < b.toLower();
+    if (isANumber) {
+        return aNumber < bNumber;
+    }
+    const QString aFolded = a.toLower();
+    const QString bFolded = b.toLower();
+    if (aFolded != bFolded) {
+        return aFolded < bFolded;
+    }
+    // "A" and "a" fold together, and leaving them equivalent would leave their
+    // order down to whatever the sort happened to do with them
+    return a < b;
 }
 
 QList<TVar*> TVar::getChildren(const bool isToSort)

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -91,8 +91,10 @@ bool TVarLessThan(TVar* varA, TVar* varB)
     const int bNumber = b.toInt(&isBNumber);
 
     if (isANumber != isBNumber) {
-        // numbers ahead of names, which is how a table of nothing but numbers
-        // already sorted
+        // Numbers ahead of names. Which way round is arbitrary - what matters
+        // is that it is the same way round for every such pair, so that the two
+        // kinds of name form two blocks rather than interleaving by whatever
+        // else is in the table.
         return isANumber;
     }
     if (isANumber) {

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -162,12 +162,26 @@ QString TVar::getNewName() const
     return nName;
 }
 
+// Commits a rename that has happened: the variable now answers to the name it
+// was renamed to, so this node has to as well. Only call it once Lua holds the
+// variable under that name - see abandonNewName() for the other outcome.
 void TVar::clearNewName()
 {
     name = nName;
     keyType = newKeyType;
     nName = QString();
     newKeyType = LUA_TNIL; // CHECK: Was 0 but perhaps it should have been -1 (LUA_TNONE ?)
+}
+
+// Drops a rename that is not going to happen, leaving the node naming the
+// variable Lua still has. clearNewName() was used for this too, which put the
+// refused name onto the node: every later read and write then went looking for
+// a variable of that name - and if the rename was refused because a sibling
+// already had it, that sibling is what they would have found.
+void TVar::abandonNewName()
+{
+    nName = QString();
+    newKeyType = LUA_TNIL;
 }
 
 bool TVar::setValue(const QString& val)

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -58,6 +58,7 @@ public:
     QString getName() const;
     QString getNewName() const;
     void clearNewName();
+    void abandonNewName();
     int getKeyType() const;
     int getNewKeyType() const;
     int getValueType() const;

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -29,6 +29,16 @@
 #include <QLocale>
 #include <QTreeWidgetItem>
 
+extern "C" {
+#if defined(INCLUDE_VERSIONED_LUA_HEADERS)
+#include <lua5.1/lauxlib.h>
+#include <lua5.1/lua.h>
+#else
+#include <lauxlib.h>
+#include <lua.h>
+#endif
+}
+
 
 VarUnit::VarUnit()
 : base(nullptr)
@@ -47,7 +57,14 @@ bool VarUnit::isHidden(TVar* var)
     // name-keyed lookup matches, and a profile save would then write out that
     // table's contents (#9769).
     if (var->pValue && hiddenTables.contains(var->pValue)) {
-        return true;
+        if (hiddenTableStillAlive(var->pValue)) {
+            return true;
+        }
+        // The table behind this address has been collected and Lua has handed
+        // the address to a new one - a fresh variable of the user's, not a
+        // hidden table. Forget the identity so it is not asked about again.
+        hiddenTables.remove(var->pValue);
+        mHiddenTableSlots.remove(var->pValue);
     }
     const QString fullName = shortVarName(var).join(qsl("."));
     if (hidden.contains(fullName)) {
@@ -63,6 +80,61 @@ void VarUnit::clearHiddenTables()
 {
     hiddenTables.clear();
     mHiddenTableByName.clear();
+    mHiddenTableSlots.clear();
+    if (mpAnchorState && mHiddenTableAnchors) {
+        luaL_unref(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
+        mHiddenTableAnchors = 0;
+    }
+}
+
+// Holds the table at valueIndex in a weak-valued registry table, so that
+// isHidden() can later ask whether its address still names it. Weak, so the
+// anchor never keeps the table alive: its slot reads nil from the moment the
+// table is collected, which is before Lua can hand the address to a new one.
+void VarUnit::anchorHiddenTable(lua_State* L, int valueIndex, const void* table)
+{
+    if (!table) {
+        return;
+    }
+    const int valueAt = valueIndex < 0 ? lua_gettop(L) + valueIndex + 1 : valueIndex;
+    mpAnchorState = L;
+    if (!mHiddenTableAnchors) {
+        lua_newtable(L);
+        lua_newtable(L);
+        lua_pushstring(L, "v");
+        lua_setfield(L, -2, "__mode");
+        lua_setmetatable(L, -2);
+        mHiddenTableAnchors = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+    lua_rawgeti(L, LUA_REGISTRYINDEX, mHiddenTableAnchors);
+    lua_pushvalue(L, valueAt);
+    mHiddenTableSlots.insert(table, luaL_ref(L, -2));
+    lua_pop(L, 1);
+}
+
+// What the save-time copy needs alongside the hiddenTables it assigns: the
+// anchors to answer liveness from. Borrowed, not owned - the copy never clears
+// or un-hides, so it never releases them.
+void VarUnit::shareHiddenTableAnchors(const VarUnit& source)
+{
+    mpAnchorState = source.mpAnchorState;
+    mHiddenTableAnchors = source.mHiddenTableAnchors;
+    mHiddenTableSlots = source.mHiddenTableSlots;
+}
+
+bool VarUnit::hiddenTableStillAlive(const void* table)
+{
+    const int slot = mHiddenTableSlots.value(table, 0);
+    if (!mpAnchorState || !mHiddenTableAnchors || !slot) {
+        // Remembered without an anchor (addHidden() outside a walk): there is
+        // nothing to disprove the identity with, so it stands as it did.
+        return true;
+    }
+    lua_rawgeti(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
+    lua_rawgeti(mpAnchorState, -1, slot);
+    const bool alive = lua_istable(mpAnchorState, -1) && lua_topointer(mpAnchorState, -1) == table;
+    lua_pop(mpAnchorState, 2);
+    return alive;
 }
 
 // Only tables are worth an identity: nothing else has contents for a saved
@@ -81,6 +153,12 @@ void VarUnit::forgetHiddenTable(const QString& fullName)
     const auto it = mHiddenTableByName.constFind(fullName);
     if (it == mHiddenTableByName.constEnd()) {
         return;
+    }
+    const int slot = mHiddenTableSlots.take(it.value());
+    if (slot && mpAnchorState && mHiddenTableAnchors) {
+        lua_rawgeti(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
+        luaL_unref(mpAnchorState, -1, slot);
+        lua_pop(mpAnchorState, 1);
     }
     hiddenTables.remove(it.value());
     mHiddenTableByName.erase(it);

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -463,6 +463,36 @@ void VarUnit::removeHidden(const QString& name)
     // does not remove the reference from TVar, similar to addHidden()
 }
 
+// Everything this unit remembers about a variable it remembers by the dotted
+// name the tree gave it, so a rename has to take those memberships with it. Left
+// behind, a saved or hidden mark keeps answering for the old name, and catches
+// whichever unrelated variable is born under it next; the renamed variable
+// meanwhile loses the mark the user put on it.
+void VarUnit::renameVariableBookkeeping(const QString& oldFullName, const QString& newFullName)
+{
+    if (oldFullName == newFullName || oldFullName.isEmpty() || newFullName.isEmpty()) {
+        return;
+    }
+    if (savedVars.remove(oldFullName)) {
+        savedVars.insert(newFullName);
+    }
+    if (hidden.remove(oldFullName)) {
+        hidden.insert(newFullName);
+    }
+    if (hiddenByUser.remove(oldFullName)) {
+        hiddenByUser.insert(newFullName);
+    }
+    // Only the name has changed: the table is the same table, so its address is
+    // still an identity and its anchor still answers for it. Forgetting the
+    // identity here instead would leave the table hidden by name alone.
+    const auto it = mHiddenTableByName.constFind(oldFullName);
+    if (it != mHiddenTableByName.constEnd()) {
+        const void* const table = it.value();
+        mHiddenTableByName.remove(oldFullName);
+        mHiddenTableByName.insert(newFullName, table);
+    }
+}
+
 void VarUnit::addSavedVar(TVar* var)
 {
     const QString fullName = shortVarName(var).join(qsl("."));

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -86,7 +86,6 @@ bool VarUnit::isHidden(TVar* var)
         // The table behind this address has been collected, so the address no
         // longer names a hidden table - typically it now names a fresh variable
         // of the user's. Forget the identity so it is not asked about again.
-        qDebug() << "VarUnit::isHidden() INFO - dropping the identity of a collected hidden table: address" << var->pValue << "no longer names it.";
         forgetHiddenTableAddress(var->pValue);
     }
     const QString fullName = shortVarName(var).join(qsl("."));
@@ -503,33 +502,25 @@ void VarUnit::removeHidden(const QString& name)
     // does not remove the reference from TVar, similar to addHidden()
 }
 
-// Whether a name-keyed entry is about the variable being renamed, or about
-// something inside it - a member of a renamed table is remembered by a name
-// beginning with the table's, so it moves too. The dot is what makes this a
-// path rather than a string prefix: "renHolderOther" begins with "renHolder"
-// and is a variable of its own that no rename of "renHolder" touches.
-static bool nameIsTheVariableOrInsideIt(const QString& name, const QString& fullName)
+// The exact names the rename moves: the variable's own and its real
+// descendants', read off the tree rather than matched as string prefixes. A
+// sibling whose own key holds a dot ("a.b" beside member "a") joins to the very
+// path a descendant of "a" would have, and a prefix rule would drag that
+// sibling's marks onto a name nothing has.
+static void collectRenamedPaths(TVar* var, const QString& oldPath, const QString& newPath, QHash<QString, QString>& renames)
 {
-    return name == fullName || name.startsWith(fullName + QLatin1Char('.'));
-}
-
-// ...and where such an entry ends up: the same tail, hung off the new name.
-static QString nameAfterTheRename(const QString& name, const QString& oldFullName, const QString& newFullName)
-{
-    return newFullName + name.mid(oldFullName.size());
-}
-
-static void renameNameKeyedEntries(QSet<QString>& names, const QString& oldFullName, const QString& newFullName)
-{
-    QStringList moving;
-    for (const QString& name : names) {
-        if (nameIsTheVariableOrInsideIt(name, oldFullName)) {
-            moving.append(name);
-        }
+    renames.insert(oldPath, newPath);
+    for (TVar* child : var->getChildren(false)) {
+        collectRenamedPaths(child, oldPath + QLatin1Char('.') + child->getName(), newPath + QLatin1Char('.') + child->getName(), renames);
     }
-    for (const QString& name : moving) {
-        names.remove(name);
-        names.insert(nameAfterTheRename(name, oldFullName, newFullName));
+}
+
+static void renameNameKeyedEntries(QSet<QString>& names, const QHash<QString, QString>& renames)
+{
+    for (auto it = renames.constBegin(); it != renames.constEnd(); ++it) {
+        if (names.remove(it.key())) {
+            names.insert(it.value());
+        }
     }
 }
 
@@ -538,28 +529,29 @@ static void renameNameKeyedEntries(QSet<QString>& names, const QString& oldFullN
 // it. Left behind, a saved or hidden mark keeps answering for the old name, and
 // catches whichever unrelated variable is born under it next; the renamed
 // variable meanwhile loses the mark the user put on it. Renaming a table moves
-// what is remembered about its members as well, whose names all begin with it.
-void VarUnit::renameVariableBookkeeping(const QString& oldFullName, const QString& newFullName)
+// what is remembered about its members as well - exactly its members, walked
+// from the tree, so an entry that merely reads like a member's path stays put.
+void VarUnit::renameVariableBookkeeping(TVar* var, const QString& oldFullName, const QString& newFullName)
 {
-    if (oldFullName == newFullName || oldFullName.isEmpty() || newFullName.isEmpty()) {
+    if (!var || oldFullName == newFullName || oldFullName.isEmpty() || newFullName.isEmpty()) {
         return;
     }
-    renameNameKeyedEntries(savedVars, oldFullName, newFullName);
-    renameNameKeyedEntries(hidden, oldFullName, newFullName);
-    renameNameKeyedEntries(hiddenByUser, oldFullName, newFullName);
+    QHash<QString, QString> renames;
+    collectRenamedPaths(var, oldFullName, newFullName, renames);
+    renameNameKeyedEntries(savedVars, renames);
+    renameNameKeyedEntries(hidden, renames);
+    renameNameKeyedEntries(hiddenByUser, renames);
     // Only the name has changed: the tables are the same tables, so their
     // addresses are still identities and their anchors still answer for them.
     // Forgetting the identities here instead would leave them hidden by name
     // alone.
-    QHash<QString, const void*> movingTables;
-    for (auto it = mHiddenTableByName.constBegin(); it != mHiddenTableByName.constEnd(); ++it) {
-        if (nameIsTheVariableOrInsideIt(it.key(), oldFullName)) {
-            movingTables.insert(it.key(), it.value());
+    for (auto it = renames.constBegin(); it != renames.constEnd(); ++it) {
+        const auto found = mHiddenTableByName.constFind(it.key());
+        if (found != mHiddenTableByName.constEnd()) {
+            const void* table = found.value();
+            mHiddenTableByName.erase(found);
+            mHiddenTableByName.insert(it.value(), table);
         }
-    }
-    for (auto it = movingTables.constBegin(); it != movingTables.constEnd(); ++it) {
-        mHiddenTableByName.remove(it.key());
-        mHiddenTableByName.insert(nameAfterTheRename(it.key(), oldFullName, newFullName), it.value());
     }
 }
 

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -235,11 +235,17 @@ void VarUnit::clearPointers()
     mPointers.clear();
 }
 
+// The same question as the TVar overload below, asked of the row in the
+// Variables view standing for that variable - so it has to give the same answer.
+// It used to leave out the size limit, and Qt's tristate cascade ticks a child
+// whose ItemIsUserCheckable flag buildVarTree() stripped, so a table over the
+// limit reached by ticking its parent stayed ticked, went into savedVars and was
+// written into the profile (#9957).
 bool VarUnit::shouldSave(QTreeWidgetItem* pWidgetItem)
 {
-    auto var = getWVar(pWidgetItem);
+    TVar* var = getWVar(pWidgetItem);
 
-    return !(!var || var->getValueType() == 6 || var->isReference());
+    return var && shouldSave(var);
 }
 
 bool VarUnit::shouldSave(TVar* var)

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -45,6 +45,9 @@ VarUnit::VarUnit()
 {
 }
 
+// Never releases mHiddenTableAnchors: the profile's lua_State is closed before
+// the LuaInterface owning this unit is replaced (see ~LuaInterface()), and an
+// unref into a freed state would crash. The registry entry dies with the state.
 VarUnit::~VarUnit() = default;
 
 bool VarUnit::isHidden(TVar* var)
@@ -60,11 +63,11 @@ bool VarUnit::isHidden(TVar* var)
         if (hiddenTableStillAlive(var->pValue)) {
             return true;
         }
-        // The table behind this address has been collected and Lua has handed
-        // the address to a new one - a fresh variable of the user's, not a
-        // hidden table. Forget the identity so it is not asked about again.
-        hiddenTables.remove(var->pValue);
-        mHiddenTableSlots.remove(var->pValue);
+        // The table behind this address has been collected, so the address no
+        // longer names a hidden table - typically it now names a fresh variable
+        // of the user's. Forget the identity so it is not asked about again.
+        qDebug() << "VarUnit::isHidden() INFO - dropping the identity of a collected hidden table: address" << var->pValue << "no longer names it.";
+        forgetHiddenTableAddress(var->pValue);
     }
     const QString fullName = shortVarName(var).join(qsl("."));
     if (hidden.contains(fullName)) {
@@ -73,18 +76,18 @@ bool VarUnit::isHidden(TVar* var)
     return hiddenByUser.contains(fullName);
 }
 
-// Thrown away at the start of every hiding walk, which is the only thing that
-// fills it: a Lua table's address is only an identity while that table is alive,
-// and Lua hands a freed one's address straight back out to the next table.
+// A hiding walk re-records every identity it finds, so the walk starts by
+// dropping the stale ones - and the anchor table backing them - wholesale here,
+// rather than pruning them one at a time as isHidden() queries them.
 void VarUnit::clearHiddenTables()
 {
     hiddenTables.clear();
     mHiddenTableByName.clear();
     mHiddenTableSlots.clear();
-    if (mpAnchorState && mHiddenTableAnchors) {
+    if (mpAnchorState && mHiddenTableAnchors && mOwnsAnchors) {
         luaL_unref(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
-        mHiddenTableAnchors = 0;
     }
+    mHiddenTableAnchors = 0;
 }
 
 // Holds the table at valueIndex in a weak-valued registry table, so that
@@ -96,8 +99,19 @@ void VarUnit::anchorHiddenTable(lua_State* L, int valueIndex, const void* table)
     if (!table) {
         return;
     }
-    const int valueAt = valueIndex < 0 ? lua_gettop(L) + valueIndex + 1 : valueIndex;
+    if (!lua_checkstack(L, 3)) {
+        // Unanchored, the address would still be trusted long after the table
+        // is gone, so the identity goes with the anchor - name-keyed hiding
+        // still applies.
+        qWarning() << "VarUnit::anchorHiddenTable() WARNING - the Lua stack could not be grown; this table is hidden by name only.";
+        forgetHiddenTableAddress(table);
+        return;
+    }
+    const int valueAt = (valueIndex > 0 || valueIndex <= LUA_REGISTRYINDEX) ? valueIndex : lua_gettop(L) + valueIndex + 1;
     mpAnchorState = L;
+    // a table two hidden names reach is anchored under each; free the first
+    // name's slot rather than stranding it until the next walk
+    releaseAnchorSlot(mHiddenTableSlots.take(table));
     if (!mHiddenTableAnchors) {
         lua_newtable(L);
         lua_newtable(L);
@@ -112,25 +126,41 @@ void VarUnit::anchorHiddenTable(lua_State* L, int valueIndex, const void* table)
     lua_pop(L, 1);
 }
 
-// What the save-time copy needs alongside the hiddenTables it assigns: the
-// anchors to answer liveness from. Borrowed, not owned - the copy never clears
-// or un-hides, so it never releases them.
+// The whole identity handoff for the save-time copy: which addresses are hidden
+// and the anchors to answer liveness from. The anchors are borrowed, not owned -
+// mOwnsAnchors keeps the copy from releasing the live unit's registry entries
+// out from under it.
 void VarUnit::shareHiddenTableAnchors(const VarUnit& source)
 {
+    hiddenTables = source.hiddenTables;
     mpAnchorState = source.mpAnchorState;
     mHiddenTableAnchors = source.mHiddenTableAnchors;
     mHiddenTableSlots = source.mHiddenTableSlots;
+    mOwnsAnchors = false;
 }
 
-bool VarUnit::hiddenTableStillAlive(const void* table)
+bool VarUnit::hiddenTableStillAlive(const void* table) const
 {
     const int slot = mHiddenTableSlots.value(table, 0);
     if (!mpAnchorState || !mHiddenTableAnchors || !slot) {
-        // Remembered without an anchor (addHidden() outside a walk): there is
-        // nothing to disprove the identity with, so it stands as it did.
-        return true;
+        // Anchoring failed or never ran, so nothing can tell this address apart
+        // from a recycled one. Not trusting it only costs hiding by identity -
+        // hiding by name still stands - while trusting it can swallow a fresh
+        // variable of the user's.
+        qWarning() << "VarUnit::hiddenTableStillAlive() WARNING - a hidden table was never anchored; it is hidden by name only.";
+        return false;
+    }
+    if (!lua_checkstack(mpAnchorState, 2)) {
+        return true; // cannot look, so the identity stands as it did
     }
     lua_rawgeti(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
+    if (!lua_istable(mpAnchorState, -1)) {
+        // a lifecycle bug (released or clobbered registry ref), not a collected
+        // table - do not start un-hiding over it
+        qWarning() << "VarUnit::hiddenTableStillAlive() WARNING - the anchor table is gone; the identity stands as it did.";
+        lua_pop(mpAnchorState, 1);
+        return true;
+    }
     lua_rawgeti(mpAnchorState, -1, slot);
     const bool alive = lua_istable(mpAnchorState, -1) && lua_topointer(mpAnchorState, -1) == table;
     lua_pop(mpAnchorState, 2);
@@ -154,14 +184,30 @@ void VarUnit::forgetHiddenTable(const QString& fullName)
     if (it == mHiddenTableByName.constEnd()) {
         return;
     }
-    const int slot = mHiddenTableSlots.take(it.value());
-    if (slot && mpAnchorState && mHiddenTableAnchors) {
-        lua_rawgeti(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
-        luaL_unref(mpAnchorState, -1, slot);
-        lua_pop(mpAnchorState, 1);
+    forgetHiddenTableAddress(it.value());
+}
+
+// Drops every trace of one remembered identity: the address, its anchor slot,
+// and the names that would hand it back.
+void VarUnit::forgetHiddenTableAddress(const void* table)
+{
+    hiddenTables.remove(table);
+    releaseAnchorSlot(mHiddenTableSlots.take(table));
+    mHiddenTableByName.removeIf([table](const auto& it) {
+        return it.value() == table;
+    });
+}
+
+void VarUnit::releaseAnchorSlot(int slot)
+{
+    if (!slot || !mOwnsAnchors || !mpAnchorState || !mHiddenTableAnchors) {
+        return;
     }
-    hiddenTables.remove(it.value());
-    mHiddenTableByName.erase(it);
+    lua_rawgeti(mpAnchorState, LUA_REGISTRYINDEX, mHiddenTableAnchors);
+    if (lua_istable(mpAnchorState, -1)) {
+        luaL_unref(mpAnchorState, -1, slot);
+    }
+    lua_pop(mpAnchorState, 1);
 }
 
 

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -50,6 +50,26 @@ VarUnit::VarUnit()
 // unref into a freed state would crash. The registry entry dies with the state.
 VarUnit::~VarUnit() = default;
 
+// A global may hold a dot in its own name - _G["mod.count"] - and the dotted name
+// everything here is keyed by then reads exactly like the path of member "count"
+// inside table "mod". Those are two different variables, so for such a root that
+// name is not an identity: what a hiding walk recorded, and what a save was told
+// to keep, was the member path, and answering the root from it hid the root out
+// of the Variables view and gave it the member's saved state (#9954).
+//
+// Only the sets Mudlet itself writes are fenced off. hiddenByUser stays keyed by
+// the colliding name because dlgTriggerEditor::slot_hideVariable() records the
+// user's own hide through addHidden(var, 1), which writes that very string for a
+// dotted root - refusing to answer it would make hiding such a root impossible,
+// where the ambiguity that remains is between two hides the user asked for.
+// A hidden table is also still recognised by identity in isHidden() below, which
+// no name collision reaches.
+bool VarUnit::rootNameReadsAsAMemberPath(TVar* var) const
+{
+    TVar* pParent = var ? var->getParent() : nullptr;
+    return pParent && pParent->getName() == qsl("_G") && var->getName().contains(QLatin1Char('.'));
+}
+
 bool VarUnit::isHidden(TVar* var)
 {
     if (var->getName() == qsl("_G")) { // we never hide global
@@ -70,7 +90,7 @@ bool VarUnit::isHidden(TVar* var)
         forgetHiddenTableAddress(var->pValue);
     }
     const QString fullName = shortVarName(var).join(qsl("."));
-    if (hidden.contains(fullName)) {
+    if (hidden.contains(fullName) && !rootNameReadsAsAMemberPath(var)) {
         return true;
     }
     return hiddenByUser.contains(fullName);
@@ -211,6 +231,10 @@ void VarUnit::releaseAnchorSlot(int slot)
 }
 
 
+// A name on its own cannot say whether it is a dotted root's or a member path's,
+// so this overload cannot make the distinction the TVar one does. It is only
+// asked about the names in savedVars (Host::hideMudletsVariables()), which a
+// dotted root can no longer get into - see addSavedVar().
 bool VarUnit::isHidden(const QString& fullname)
 {
     if (fullname == QLatin1String("_G")) { // we never hide global
@@ -254,6 +278,10 @@ bool VarUnit::shouldSave(TVar* var)
         return false;
     }
 
+    if (rootNameReadsAsAMemberPath(var)) {
+        return false;
+    }
+
     // Check if table is too large (max 10,000 items)
     if (var->getValueType() == LUA_TTABLE) {
         const int itemCount = countTableItems(var);
@@ -291,6 +319,12 @@ QString VarUnit::getUnsaveableReason(TVar* var)
     if (var->isReference()) {
         //: Tooltip explaining why a referenced variable cannot be saved
         return tr("Referenced variables cannot be saved.");
+    }
+
+    if (rootNameReadsAsAMemberPath(var)) {
+        //: Tooltip explaining why a global whose own name contains a dot cannot be saved
+        return tr("Saved variables are remembered by their dotted path, so a global with a dot in its own name "
+                  "cannot be told apart from a member of a table and cannot be saved.");
     }
 
     if (var->getValueType() == LUA_TTABLE) {
@@ -501,6 +535,12 @@ void VarUnit::renameVariableBookkeeping(const QString& oldFullName, const QStrin
 
 void VarUnit::addSavedVar(TVar* var)
 {
+    if (rootNameReadsAsAMemberPath(var)) {
+        // savedVars would key it by the member path's name, so the entry would
+        // mark that member saved instead. shouldSave() refuses such a root, so
+        // the Variables view never offers this in the first place.
+        return;
+    }
     const QString fullName = shortVarName(var).join(qsl("."));
     var->saved = true;
     savedVars.insert(fullName);
@@ -508,13 +548,22 @@ void VarUnit::addSavedVar(TVar* var)
 
 void VarUnit::removeSavedVar(TVar* var)
 {
-    const QString fullName = shortVarName(var).join(qsl("."));
-    savedVars.remove(fullName);
     var->saved = false;
+    if (rootNameReadsAsAMemberPath(var)) {
+        // ...and taking that entry out again would un-save the member, which
+        // clicking such a root's row in the Variables view used to do
+        return;
+    }
+    savedVars.remove(shortVarName(var).join(qsl(".")));
 }
 
 bool VarUnit::isSaved(TVar* var)
 {
+    if (rootNameReadsAsAMemberPath(var)) {
+        // nothing keyed by this name is about this root: the entry belongs to
+        // the member path, and addSavedVar() will not put such a root there
+        return false;
+    }
     const QString fullName = shortVarName(var).join(qsl("."));
     return (savedVars.contains(fullName) || var->saved);
 }

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -503,33 +503,63 @@ void VarUnit::removeHidden(const QString& name)
     // does not remove the reference from TVar, similar to addHidden()
 }
 
-// Everything this unit remembers about a variable it remembers by the dotted
-// name the tree gave it, so a rename has to take those memberships with it. Left
-// behind, a saved or hidden mark keeps answering for the old name, and catches
-// whichever unrelated variable is born under it next; the renamed variable
-// meanwhile loses the mark the user put on it.
+// Whether a name-keyed entry is about the variable being renamed, or about
+// something inside it - a member of a renamed table is remembered by a name
+// beginning with the table's, so it moves too. The dot is what makes this a
+// path rather than a string prefix: "renHolderOther" begins with "renHolder"
+// and is a variable of its own that no rename of "renHolder" touches.
+static bool nameIsTheVariableOrInsideIt(const QString& name, const QString& fullName)
+{
+    return name == fullName || name.startsWith(fullName + QLatin1Char('.'));
+}
+
+// ...and where such an entry ends up: the same tail, hung off the new name.
+static QString nameAfterTheRename(const QString& name, const QString& oldFullName, const QString& newFullName)
+{
+    return newFullName + name.mid(oldFullName.size());
+}
+
+static void renameNameKeyedEntries(QSet<QString>& names, const QString& oldFullName, const QString& newFullName)
+{
+    QStringList moving;
+    for (const QString& name : names) {
+        if (nameIsTheVariableOrInsideIt(name, oldFullName)) {
+            moving.append(name);
+        }
+    }
+    for (const QString& name : moving) {
+        names.remove(name);
+        names.insert(nameAfterTheRename(name, oldFullName, newFullName));
+    }
+}
+
+// Everything name-keyed this unit remembers about a variable it remembers by the
+// dotted name the tree gave it, so a rename has to take those memberships with
+// it. Left behind, a saved or hidden mark keeps answering for the old name, and
+// catches whichever unrelated variable is born under it next; the renamed
+// variable meanwhile loses the mark the user put on it. Renaming a table moves
+// what is remembered about its members as well, whose names all begin with it.
 void VarUnit::renameVariableBookkeeping(const QString& oldFullName, const QString& newFullName)
 {
     if (oldFullName == newFullName || oldFullName.isEmpty() || newFullName.isEmpty()) {
         return;
     }
-    if (savedVars.remove(oldFullName)) {
-        savedVars.insert(newFullName);
+    renameNameKeyedEntries(savedVars, oldFullName, newFullName);
+    renameNameKeyedEntries(hidden, oldFullName, newFullName);
+    renameNameKeyedEntries(hiddenByUser, oldFullName, newFullName);
+    // Only the name has changed: the tables are the same tables, so their
+    // addresses are still identities and their anchors still answer for them.
+    // Forgetting the identities here instead would leave them hidden by name
+    // alone.
+    QHash<QString, const void*> movingTables;
+    for (auto it = mHiddenTableByName.constBegin(); it != mHiddenTableByName.constEnd(); ++it) {
+        if (nameIsTheVariableOrInsideIt(it.key(), oldFullName)) {
+            movingTables.insert(it.key(), it.value());
+        }
     }
-    if (hidden.remove(oldFullName)) {
-        hidden.insert(newFullName);
-    }
-    if (hiddenByUser.remove(oldFullName)) {
-        hiddenByUser.insert(newFullName);
-    }
-    // Only the name has changed: the table is the same table, so its address is
-    // still an identity and its anchor still answers for it. Forgetting the
-    // identity here instead would leave the table hidden by name alone.
-    const auto it = mHiddenTableByName.constFind(oldFullName);
-    if (it != mHiddenTableByName.constEnd()) {
-        const void* const table = it.value();
-        mHiddenTableByName.remove(oldFullName);
-        mHiddenTableByName.insert(newFullName, table);
+    for (auto it = movingTables.constBegin(); it != movingTables.constEnd(); ++it) {
+        mHiddenTableByName.remove(it.key());
+        mHiddenTableByName.insert(nameAfterTheRename(it.key(), oldFullName, newFullName), it.value());
     }
 }
 

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -36,6 +36,8 @@ class TVar;
 
 class QTreeWidgetItem;
 
+struct lua_State;
+
 
 class VarUnit
 {
@@ -73,6 +75,8 @@ public:
     void addPointer(const void*);
     void clearPointers();
     void clearHiddenTables();
+    void anchorHiddenTable(lua_State*, int valueIndex, const void* table);
+    void shareHiddenTableAnchors(const VarUnit&);
     QString getUnsaveableReason(TVar*);
     QSet<QString> hidden;
     QSet<QString> hiddenByUser;
@@ -80,14 +84,14 @@ public:
     // one of them reached under a name of the user's own is still recognised.
     // An address is only an identity while that table is alive, and Lua hands a
     // collected one's address back out, so a hidden table dropped since the last
-    // hiding walk can name a live one - which is what clearHiddenTables() bounds
-    // to a single walk. What it costs if that does happen is one ride-along
-    // member of a saved table, since a name the profile saves is checked before
-    // hiding is. Pinning each table with a registry reference would make it
-    // exact, at the price of keeping an uninstalled package's tables alive for
-    // the session.
+    // hiding walk can name a live one - a fresh user variable landing on the
+    // address would vanish from the Variables view and from profile saves.
+    // isHidden() therefore checks the address against a weak anchor of the
+    // table (anchorHiddenTable()) before trusting it, which asks Lua whether
+    // that table is still alive without keeping it alive.
     // Travels with the private name map: assigning it alone (as the save-time
-    // copy does, which never un-hides anything) leaves un-hiding a no-op.
+    // copy does, which never un-hides anything) leaves un-hiding a no-op - the
+    // copy takes the anchors through shareHiddenTableAnchors() instead.
     QSet<const void*> hiddenTables;
     QSet<QString> savedVars;
 
@@ -95,6 +99,7 @@ private:
     int countTableItems(TVar*);
     void rememberHiddenTable(TVar*, const QString& fullName);
     void forgetHiddenTable(const QString& fullName);
+    bool hiddenTableStillAlive(const void* table);
     std::unique_ptr<TVar> base;
     QSet<QString> variableSet;
     // ?? variables
@@ -104,6 +109,13 @@ private:
     QSet<const void*> mPointers;
     // what un-hiding a name has to hand back to hiddenTables
     QHash<QString, const void*> mHiddenTableByName;
+    // The weak anchors behind hiddenTables: the interpreter they live in, the
+    // registry reference of a weak-valued table holding each hidden table, and
+    // which of its slots holds the table behind each address. 0 is not a value
+    // luaL_ref() hands out, so it stands for "no anchor" in both.
+    lua_State* mpAnchorState = nullptr;
+    int mHiddenTableAnchors = 0;
+    QHash<const void*, int> mHiddenTableSlots;
 };
 
 #endif // MUDLET_VARUNIT_H

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -72,6 +72,7 @@ public:
     void removeHidden(TVar* var);
     void removeHidden(const QString& name);
     bool isSaved(TVar*);
+    void renameVariableBookkeeping(const QString& oldFullName, const QString& newFullName);
     void addPointer(const void*);
     void clearPointers();
     void clearHiddenTables();

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -89,9 +89,9 @@ public:
     // isHidden() therefore checks the address against a weak anchor of the
     // table (anchorHiddenTable()) before trusting it, which asks Lua whether
     // that table is still alive without keeping it alive.
-    // Travels with the private name map: assigning it alone (as the save-time
-    // copy does, which never un-hides anything) leaves un-hiding a no-op - the
-    // copy takes the anchors through shareHiddenTableAnchors() instead.
+    // Never assign this on its own - an identity is only usable alongside its
+    // anchor, so the save-time copy takes both at once through
+    // shareHiddenTableAnchors().
     QSet<const void*> hiddenTables;
     QSet<QString> savedVars;
 
@@ -99,7 +99,9 @@ private:
     int countTableItems(TVar*);
     void rememberHiddenTable(TVar*, const QString& fullName);
     void forgetHiddenTable(const QString& fullName);
-    bool hiddenTableStillAlive(const void* table);
+    void forgetHiddenTableAddress(const void* table);
+    void releaseAnchorSlot(int slot);
+    bool hiddenTableStillAlive(const void* table) const;
     std::unique_ptr<TVar> base;
     QSet<QString> variableSet;
     // ?? variables
@@ -112,10 +114,15 @@ private:
     // The weak anchors behind hiddenTables: the interpreter they live in, the
     // registry reference of a weak-valued table holding each hidden table, and
     // which of its slots holds the table behind each address. 0 is not a value
-    // luaL_ref() hands out, so it stands for "no anchor" in both.
+    // luaL_ref() hands out, so it stands for "no anchor" in mHiddenTableAnchors
+    // and in the slot values alike.
     lua_State* mpAnchorState = nullptr;
     int mHiddenTableAnchors = 0;
     QHash<const void*, int> mHiddenTableSlots;
+    // false on a save-time copy, whose anchors are borrowed from the live unit
+    // (shareHiddenTableAnchors()): releasing them would pull the live unit's
+    // registry entries out from under it, so every luaL_unref is gated on this.
+    bool mOwnsAnchors = true;
 };
 
 #endif // MUDLET_VARUNIT_H

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -72,7 +72,7 @@ public:
     void removeHidden(TVar* var);
     void removeHidden(const QString& name);
     bool isSaved(TVar*);
-    void renameVariableBookkeeping(const QString& oldFullName, const QString& newFullName);
+    void renameVariableBookkeeping(TVar*, const QString& oldFullName, const QString& newFullName);
     void addPointer(const void*);
     void clearPointers();
     void clearHiddenTables();

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -97,6 +97,7 @@ public:
     QSet<QString> savedVars;
 
 private:
+    bool rootNameReadsAsAMemberPath(TVar*) const;
     int countTableItems(TVar*);
     void rememberHiddenTable(TVar*, const QString& fullName);
     void forgetHiddenTable(const QString& fullName);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -786,7 +786,6 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     saveTimeUnit->savedVars = vu->savedVars;
     saveTimeUnit->hidden = vu->hidden;
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
-    saveTimeUnit->hiddenTables = vu->hiddenTables;
     saveTimeUnit->shareHiddenTableAnchors(*vu);
     saveTimeInterface.getSavedVars();
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -787,6 +787,7 @@ void XMLexport::writeVariablePackage(Host* pHost, pugi::xml_node& mudletPackage)
     saveTimeUnit->hidden = vu->hidden;
     saveTimeUnit->hiddenByUser = vu->hiddenByUser;
     saveTimeUnit->hiddenTables = vu->hiddenTables;
+    saveTimeUnit->shareHiddenTableAnchors(*vu);
     saveTimeInterface.getSavedVars();
 
     // A saved global with a value anywhere inside it that no save can carry (see

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5197,6 +5197,9 @@ void dlgTriggerEditor::addVar(bool isFolder)
 {
     saveVar();
     mpVarsMainArea->comboBox_variable_key_type->setCurrentIndex(0);
+    // the variable left behind may have been one whose key type is not the
+    // user's to choose, which leaves the combobox disabled
+    mpVarsMainArea->comboBox_variable_key_type->setEnabled(true);
     if (isFolder) {
         // in lieu of readonly
         mpSourceEditorEdbee->setEnabled(false);
@@ -6919,7 +6922,8 @@ void dlgTriggerEditor::saveVar()
     if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
         bool nameNumberOk = false;
         newName.toDouble(&nameNumberOk);
-        // the key type combobox cannot express a boolean key, so keep an unchanged one boolean
+        // the key type combobox shows a boolean key but does not offer it as a
+        // choice, so a name that still reads as a boolean keeps its boolean key
         if (variable->getKeyType() == LUA_TBOOLEAN && (newName.toLower() == QLatin1String("true") || newName.toLower() == QLatin1String("false"))) {
             uiNameType = LUA_TBOOLEAN;
         } else if (nameNumberOk) {
@@ -8192,6 +8196,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
             mpVarsMainArea->comboBox_variable_value_type->setCurrentIndex(0);
         }
         mpVarsMainArea->comboBox_variable_key_type->setCurrentIndex(0);
+        mpVarsMainArea->comboBox_variable_key_type->setEnabled(true);
         mChangingVar = false;
         return;
     }
@@ -8203,7 +8208,16 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     switch (keyType) {
         //    case LUA_TNONE: // -1
         //    case LUA_TNIL: // 0
-        //    case LUA_TBOOLEAN: // 1
+    case LUA_TBOOLEAN: // 1
+        // index 5 = "key (boolean)". Without this the combobox would keep
+        // whatever the previously selected variable put there and name a key
+        // type this variable does not have (#9959).
+        mpVarsMainArea->comboBox_variable_key_type->setCurrentIndex(5);
+        // a boolean key can be renamed between true and false, but it cannot be
+        // recast: saveVar() puts a name that still reads as a boolean back to a
+        // boolean key whatever the combobox says
+        mpVarsMainArea->comboBox_variable_key_type->setEnabled(false);
+        break;
         //    case LUA_TLIGHTUSERDATA: // 2
     case LUA_TNUMBER: // 3
         // index 2 = "index (integer number)"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8165,13 +8165,17 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     TVar* var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
     QList<QTreeWidgetItem*> list;
     if (state == Qt::Checked || state == Qt::PartiallyChecked) {
-        if (var) {
+        // What may be saved is asked again rather than read off the check state,
+        // for the same reason slot_variableChanged() asks: a row can be left
+        // ticked from before whatever now makes it unsaveable - a table grown
+        // past the size limit, say - and clicking it would enrol it again.
+        if (var && vu->shouldSave(var)) {
             vu->addSavedVar(var);
         }
         recurseVariablesUp(pItem, list); // This does NOT modify pItem or what it points at
         for (auto& treeWidgetItem : list) {
             TVar* v = vu->getWVar(treeWidgetItem);
-            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked)) {
+            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked) && vu->shouldSave(v)) {
                 vu->addSavedVar(v);
             }
         }
@@ -8179,7 +8183,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
         recurseVariablesDown(pItem, list); // This does NOT modify pItem or what it points at
         for (auto& treeWidgetItem : list) {
             TVar* v = vu->getWVar(treeWidgetItem);
-            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked)) {
+            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked) && vu->shouldSave(v)) {
                 vu->addSavedVar(v);
             }
         }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6869,6 +6869,16 @@ int dlgTriggerEditor::canRecast(QTreeWidgetItem* pItem, int newNameType, int new
     return 1;
 }
 
+// A rename the Variables view asked for and did not get: nothing else on screen
+// would show that anything was refused, and the row has meanwhile been put back
+// to the name the variable still answers to.
+void dlgTriggerEditor::showVariableRenameRefused(TVar* variable)
+{
+    //: Warning shown in the editor's Variables view when a rename could not be carried out. %1 is the name the variable keeps.
+    showWarning(tr("\"%1\" was not renamed: another member of the same table already has that name, or this variable's key is a table or a function, which has no name to change.")
+                        .arg(variable->getName().toHtmlEscaped()));
+}
+
 void dlgTriggerEditor::saveVar()
 {
     // We can enter this function if:
@@ -6912,6 +6922,9 @@ void dlgTriggerEditor::saveVar()
         return;
     }
     mChangingVar = true;
+    // said at the very end: the tail of this function re-selects the row, which
+    // clears whatever notification is on screen
+    bool renameRefused = false;
     int uiNameType = mpVarsMainArea->comboBox_variable_key_type->itemData(mpVarsMainArea->comboBox_variable_key_type->currentIndex(), Qt::UserRole).toInt();
     int uiValueType = mpVarsMainArea->comboBox_variable_value_type->itemData(mpVarsMainArea->comboBox_variable_value_type->currentIndex(), Qt::UserRole).toInt();
     if ((uiNameType == LUA_TNUMBER || uiNameType == LUA_TSTRING) && newVar) {
@@ -7005,16 +7018,26 @@ void dlgTriggerEditor::saveVar()
                     change = change | 0x2;
                 }
                 if (change) {
+                    bool renamed = true;
                     if (change & 0x1 || newVar) {
-                        luaInterface->renameVar(variable);
+                        renamed = luaInterface->renameVar(variable);
                     }
                     if ((variable->getValueType() != LUA_TTABLE && change & 0x2) || newVar) {
                         luaInterface->setValue(variable);
                     }
-                    pItem->setText(0, newName);
-                    mpCurrentVarItem = nullptr;
+                    if (renamed) {
+                        pItem->setText(0, newName);
+                        mpCurrentVarItem = nullptr;
+                    } else {
+                        // the variable still answers to the name it had, so
+                        // that is what the row has to go back to showing
+                        pItem->setText(0, variable->getName());
+                        renameRefused = true;
+                    }
                 } else {
-                    variable->clearNewName();
+                    // nothing was renamed, so there is a pending new name to
+                    // drop rather than to write onto the variable
+                    variable->abandonNewName();
                 }
             }
         }
@@ -7067,14 +7090,20 @@ void dlgTriggerEditor::saveVar()
                 change = change | 0x2;
             }
             if (change) {
+                bool renamed = true;
                 if (change & 0x1 || newVar) {
-                    luaInterface->renameVar(var);
+                    renamed = luaInterface->renameVar(var);
                 }
                 if (change & 0x2 || newVar) {
                     luaInterface->setValue(var);
                 }
-                pItem->setText(0, newName);
-                mpCurrentVarItem = nullptr;
+                if (renamed) {
+                    pItem->setText(0, newName);
+                    mpCurrentVarItem = nullptr;
+                } else {
+                    pItem->setText(0, var->getName());
+                    renameRefused = true;
+                }
             }
         }
     }
@@ -7106,6 +7135,9 @@ void dlgTriggerEditor::saveVar()
     pItem->setIcon(0, icon);
     mChangingVar = false;
     slot_variableSelected(pItem);
+    if (renameRefused) {
+        showVariableRenameRefused(variable);
+    }
 }
 
 void dlgTriggerEditor::saveKey()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8057,12 +8057,19 @@ void dlgTriggerEditor::slot_variableChanged(QTreeWidgetItem* pItem)
         if (vu->isSaved(var)) {
             return;
         }
+        // A tick is not on its own a decision to save: Qt's tristate cascade
+        // ticks children the user cannot tick themselves, and marks a parent
+        // partially ticked from a tick on any child, so what may be saved is
+        // asked again here rather than read off the check state (#9957).
+        if (!vu->shouldSave(var)) {
+            return;
+        }
         vu->addSavedVar(var);
         QList<QTreeWidgetItem*> list;
         recurseVariablesUp(pItem, list);
         for (auto& treeWidgetItem : list) {
             TVar* v = vu->getWVar(treeWidgetItem);
-            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked)) {
+            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked) && vu->shouldSave(v)) {
                 vu->addSavedVar(v);
             }
         }
@@ -8070,7 +8077,7 @@ void dlgTriggerEditor::slot_variableChanged(QTreeWidgetItem* pItem)
         recurseVariablesDown(pItem, list);
         for (auto& treeWidgetItem : list) {
             TVar* v = vu->getWVar(treeWidgetItem);
-            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked)) {
+            if (v && (treeWidgetItem->checkState(column) == Qt::Checked || treeWidgetItem->checkState(column) == Qt::PartiallyChecked) && vu->shouldSave(v)) {
                 vu->addSavedVar(v);
             }
         }

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -96,6 +96,7 @@ class QFrame;
 class QToolButton;
 class TAction;
 class TKey;
+class TVar;
 class TConsole;
 class dlgVarsMainArea;
 class QShortcut;
@@ -205,6 +206,7 @@ public:
     void addVar(bool);
     int canRecast(QTreeWidgetItem*, int newNameType, int newValueType);
     void saveVar();
+    void showVariableRenameRefused(TVar*);
     void repopulateVars();
     void changeView(EditorViewType);
     void recurseVariablesUp(QTreeWidgetItem* const, QList<QTreeWidgetItem*>&);

--- a/src/dlgVarsMainArea.cpp
+++ b/src/dlgVarsMainArea.cpp
@@ -56,6 +56,8 @@ dlgVarsMainArea::dlgVarsMainArea(QWidget* pParentWidget)
     comboBox_variable_key_type->insertItem(2, tr("index (integer number)"), 3);              // LUA_TNUMBER
     comboBox_variable_key_type->insertItem(3, tr("table (use \"Add Group\" to create)"), 5); // LUA_TTABLE
     comboBox_variable_key_type->insertItem(4, tr("function (cannot create from GUI)"), 6);   // LUA_TFUNCTION
+    //: Shown in the Variables editor for a table member whose key is the boolean true or false, a key type that cannot be created from the GUI
+    comboBox_variable_key_type->insertItem(5, tr("key (boolean)"), LUA_TBOOLEAN);
 
     // Magic - part 2 use the features of the substitute data model to disable
     // the required entries - they can still be set programmatically for display
@@ -66,6 +68,10 @@ dlgVarsMainArea::dlgVarsMainArea(QWidget* pParentWidget)
 
     // Disable function type:
     item = contents->item(4);
+    item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+
+    // Disable boolean type:
+    item = contents->item(5);
     item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
 
 

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -259,11 +259,20 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         execLua("hiddenGroup = {} for i = 1, 512 do hiddenGroup[i] = {'payload'} end");
         interface->getVars(true); // the hiding walk Mudlet runs at profile load
         VarUnit* vu = interface->getVarUnit();
-        QVERIFY2(vu->hiddenTables.size() > 512, "the hiding walk is supposed to remember every table it finds");
+        // hiddenGroup itself plus its 512 members
+        QVERIFY2(vu->hiddenTables.size() >= 513, "the hiding walk is supposed to remember every table it finds");
         const QSet<const void*> oldAddresses = vu->hiddenTables;
 
         execLua("hiddenGroup = nil");
         lua_gc(L, LUA_GCCOLLECT, 0);
+
+        // Deterministic on every allocator: an address the collector has
+        // certainly reclaimed must be disproved as an identity when asked.
+        TVar probe;
+        probe.setName(qsl("probeVar"), LUA_TSTRING);
+        probe.pValue = *oldAddresses.constBegin();
+        QVERIFY2(!vu->isHidden(&probe), "a collected table's address must stop counting as a hidden identity");
+        QVERIFY(!vu->hiddenTables.contains(probe.pValue));
 
         for (int i = 0; i < 64; ++i) {
             execLua(qsl("fresh%1 = {'payload'}").arg(i));
@@ -277,7 +286,7 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
             recycled = recycled || oldAddresses.contains(fresh->pValue);
             QVERIFY2(!vu->isHidden(fresh), "a fresh variable must not inherit hiddenness from a collected table whose address it landed on");
         }
-        qDebug() << "a collected table's address was" << (recycled ? "recycled and checked" : "not handed out again, so identity decay went unexercised");
+        qDebug() << "a collected table's address was" << (recycled ? "recycled and checked" : "not handed out again, so end-to-end decay went unexercised");
     }
 
     // What the identity is for (#9769): a saved variable of the user's holding
@@ -293,7 +302,7 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         execLua("userAlias = apiT");
         interface->getVars(false);
 
-        TVar* alias = findGlobal("userAlias");
+        TVar* alias = findGlobal(qsl("userAlias"));
         QVERIFY(alias);
         QVERIFY2(vu->isHidden(alias), "a saved alias of a live hidden table has to be recognised by identity");
     }

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -929,6 +929,38 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QVERIFY(vu->savedVars.contains(qsl("dotHolder.a.b")));
     }
 
+    // A member's key can itself hold a dot, so "gt.a.b" names both a member
+    // "a.b" of gt and a member b of gt.a - the rename must move marks for what
+    // is really inside the renamed variable, not for whatever path reads as if
+    // it were.
+    void testRenameDoesNotMoveADottedKeySiblingsMark()
+    {
+        defineGlobalsTable();
+        execLua("gt = {a = 5} gt['a.b'] = 'sibling with a dotted key'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+        TVar* holder = findGlobal(qsl("gt"));
+        QVERIFY(holder);
+        TVar* dottedSibling = nullptr;
+        TVar* plainA = nullptr;
+        for (TVar* kid : holder->getChildren(false)) {
+            if (kid->getName() == qsl("a.b")) {
+                dottedSibling = kid;
+            } else if (kid->getName() == qsl("a")) {
+                plainA = kid;
+            }
+        }
+        QVERIFY(dottedSibling && plainA);
+        vu->addSavedVar(dottedSibling); // savedVars = {"gt.a.b"} - the sibling's mark
+        QVERIFY(vu->savedVars.contains(qsl("gt.a.b")));
+
+        plainA->setNewName(qsl("x"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(plainA));
+        qDebug() << "savedVars after renaming gt.a:" << vu->savedVars;
+        QVERIFY2(vu->savedVars.contains(qsl("gt.a.b")), "the dotted-key sibling's mark must not be dragged along by a rename of gt.a");
+        QVERIFY2(!vu->savedVars.contains(qsl("gt.x.b")), "no mark may be invented for a name nothing has");
+    }
+
 private:
     static std::unique_ptr<TVar> namedVar(const QString& name)
     {

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -469,7 +469,89 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         lua_pop(L, 1);
     }
 
+    // A rename copies the value onto the new key and only then nils the old one,
+    // so renaming onto a name a sibling already answers to used to overwrite that
+    // sibling's value without a word about it.
+    void testRenameOntoASiblingThatIsAlreadyThereIsRefused()
+    {
+        execLua("renHolder = {a = 'aval', b = 'bval'}");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("renHolder"));
+        QVERIFY(holder);
+        TVar* memberA = nullptr;
+        for (TVar* member : holder->getChildren(false)) {
+            if (member->getName() == qsl("a")) {
+                memberA = member;
+            }
+        }
+        QVERIFY(memberA);
+
+        memberA->setNewName(qsl("b"), LUA_TSTRING);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("would destroy it")));
+        interface->renameVar(memberA);
+
+        QCOMPARE(memberAsString(qsl("renHolder"), qsl("b")), qsl("bval"));
+        QCOMPARE(memberAsString(qsl("renHolder"), qsl("a")), qsl("aval"));
+        QCOMPARE(memberA->getName(), qsl("a"));
+    }
+
+    // A name a rename has moved off has to stop being the name the user's
+    // hiding decision is remembered by, both so the renamed variable keeps that
+    // decision and so an unrelated variable born under the old name does not
+    // inherit it and vanish from the Variables view.
+    void testRenameTakesTheUserHiddenMarkToTheNewName()
+    {
+        defineGlobalsTable(); // renaming a global is written as _G["new"] = old
+        execLua("hiddenRenamed = 1");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+        TVar* var = findGlobal(qsl("hiddenRenamed"));
+        QVERIFY(var);
+        vu->addHidden(var, 1); // the user's own hide, rather than a hiding walk's
+        QVERIFY(vu->isHidden(qsl("hiddenRenamed")));
+
+        var->setNewName(qsl("hiddenRenamedNew"), LUA_TSTRING);
+        interface->renameVar(var);
+
+        QVERIFY2(vu->isHidden(qsl("hiddenRenamedNew")), "the user's hiding decision has to follow the variable it was made about");
+        QVERIFY2(!vu->isHidden(qsl("hiddenRenamed")), "the name the variable no longer has must stop being hidden");
+
+        // ...which is what stops the next variable born there from inheriting it
+        execLua("hiddenRenamed = 2");
+        interface->getVars(false);
+        TVar* fresh = findGlobal(qsl("hiddenRenamed"));
+        QVERIFY(fresh);
+        QVERIFY2(!vu->isHidden(fresh), "a fresh variable must not be born hidden under a name a rename left behind");
+    }
+
+    // ...and the same for a saved variable: the profile saves it by name, so a
+    // mark left on the old name saves whatever turns up there instead.
+    void testRenameTakesTheSavedMarkToTheNewName()
+    {
+        defineGlobalsTable();
+        execLua("savedRenamed = 'value'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+        TVar* var = findGlobal(qsl("savedRenamed"));
+        QVERIFY(var);
+        vu->addSavedVar(var);
+
+        var->setNewName(qsl("savedRenamedNew"), LUA_TSTRING);
+        interface->renameVar(var);
+
+        QVERIFY(vu->savedVars.contains(qsl("savedRenamedNew")));
+        QVERIFY2(!vu->savedVars.contains(qsl("savedRenamed")), "the name the variable no longer has must stop being saved");
+    }
+
 private:
+    // The base library, which these tests do without, is what usually puts the
+    // globals table in _G - and a rename of a global is written as _G["new"].
+    void defineGlobalsTable()
+    {
+        lua_pushvalue(L, LUA_GLOBALSINDEX);
+        lua_setglobal(L, "_G");
+    }
+
     static int raiseOnWrite(lua_State* state) { return luaL_error(state, "this table cannot be written to"); }
 
     QString globalAsString(const QString& name)
@@ -477,6 +559,16 @@ private:
         lua_getglobal(L, name.toUtf8().constData());
         const QString value = QString::fromUtf8(lua_tostring(L, -1), static_cast<int>(lua_strlen(L, -1)));
         lua_pop(L, 1);
+        return value;
+    }
+
+    QString memberAsString(const QString& tableName, const QString& memberName)
+    {
+        lua_getglobal(L, tableName.toUtf8().constData());
+        lua_pushstring(L, memberName.toUtf8().constData());
+        lua_gettable(L, -2);
+        const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
+        lua_pop(L, 2);
         return value;
     }
 

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -549,6 +549,133 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QVERIFY2(!vu->savedVars.contains(qsl("savedRenamed")), "the name the variable no longer has must stop being saved");
     }
 
+    // A member whose key is a table of its own is named in the tree by the
+    // number of the registry reference holding that key, and that number is not
+    // a name a rename can write: renaming such a member deleted it outright.
+    void testRenamingATableKeyedMemberIsRefusedRatherThanDestroyingIt()
+    {
+        execLua("tableKeyHolder = {} do local key = {} tableKeyHolder[key] = 'keepme' end");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("tableKeyHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QVERIFY(members.first()->isReference());
+
+        members.first()->setNewName(qsl("renamedKey"), LUA_TSTRING);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("no name to change")));
+        QVERIFY(!interface->renameVar(members.first()));
+
+        QCOMPARE(luaMemberCount(qsl("tableKeyHolder")), 1);
+        QVERIFY2(memberAsString(qsl("tableKeyHolder"), qsl("renamedKey")).isEmpty(), "the rename must not have made a member of that name either");
+    }
+
+    // ...and the same for a function used as a key, which left the member alone
+    // but moved the saved mark onto a path naming nothing.
+    void testRenamingAFunctionKeyedMemberLeavesItsSavedMarkAlone()
+    {
+        execLua("fnKeyHolder = {} fnKeyHolder[function() end] = 'keepme'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+        TVar* holder = findGlobal(qsl("fnKeyHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QVERIFY(members.first()->isReference());
+        const QString keyName = members.first()->getName();
+        vu->savedVars.insert(qsl("fnKeyHolder.%1").arg(keyName));
+
+        members.first()->setNewName(qsl("renamedFn"), LUA_TSTRING);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("no name to change")));
+        QVERIFY(!interface->renameVar(members.first()));
+
+        QCOMPARE(luaMemberCount(qsl("fnKeyHolder")), 1);
+        QVERIFY2(!vu->savedVars.contains(qsl("fnKeyHolder.renamedFn")), "a refused rename must not move what is remembered onto a name that names nothing");
+        QVERIFY2(vu->savedVars.contains(qsl("fnKeyHolder.%1").arg(keyName)), "the mark stays on the member the user made it about");
+        QCOMPARE(members.first()->getName(), keyName);
+    }
+
+    // The name a rename would land on is looked up with the key type the rename
+    // is giving it, not the one the variable has: t[5] and t["5"] are two
+    // members, and asking about the wrong one waved the rename through.
+    void testRenameOntoANumberKeyedSiblingIsRefused()
+    {
+        execLua("numKeyHolder = {[5] = 'five', other = 'otherval'}");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("numKeyHolder"));
+        QVERIFY(holder);
+        TVar* other = nullptr;
+        for (TVar* member : holder->getChildren(false)) {
+            if (member->getName() == qsl("other")) {
+                other = member;
+            }
+        }
+        QVERIFY(other);
+
+        other->setNewName(qsl("5"), LUA_TNUMBER);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("would destroy it")));
+        QVERIFY(!interface->renameVar(other));
+
+        QCOMPARE(numberKeyedMemberAsString(qsl("numKeyHolder"), 5), qsl("five"));
+        QCOMPARE(memberAsString(qsl("numKeyHolder"), qsl("other")), qsl("otherval"));
+        QCOMPARE(other->getName(), qsl("other"));
+    }
+
+    // A write to a member sitting under a table used as a key has to put that
+    // key back on the stack out of the registry to get to the member at all -
+    // the text of the reference number reaches a member of its own instead.
+    void testSetValueReachesAMemberUnderATableKeyedIntermediate()
+    {
+        execLua("refHolder = {} do local key = {} refHolder[key] = {inner = 'placeholder'} end");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("refHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QVERIFY(members.first()->isReference());
+        TVar* inner = members.first()->getChildren(false).first();
+        QCOMPARE(inner->getName(), qsl("inner"));
+        inner->setValue(qsl("written"), LUA_TSTRING);
+
+        const int stackBefore = lua_gettop(L);
+        QVERIFY(interface->setValue(inner));
+        QCOMPARE(lua_gettop(L), stackBefore);
+
+        QCOMPARE(luaMemberCount(qsl("refHolder")), 1);
+        QCOMPARE(onlyMembersMemberAsString(qsl("refHolder"), qsl("inner")), qsl("written"));
+    }
+
+    // A rename that was refused leaves a new name pending on the node, and the
+    // editor goes on to its no-change path - which used to commit that pending
+    // name. The node then named the sibling the rename was refused over, and
+    // the next write through it went there.
+    void testARefusedRenameLeavesTheNodeNamingItsOwnVariable()
+    {
+        execLua("landmineHolder = {a = 'aval', b = 'bval'}");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("landmineHolder"));
+        QVERIFY(holder);
+        TVar* memberA = nullptr;
+        for (TVar* member : holder->getChildren(false)) {
+            if (member->getName() == qsl("a")) {
+                memberA = member;
+            }
+        }
+        QVERIFY(memberA);
+
+        memberA->setNewName(qsl("b"), LUA_TSTRING);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("would destroy it")));
+        QVERIFY(!interface->renameVar(memberA));
+
+        memberA->abandonNewName(); // what the editor does when nothing changed
+        QCOMPARE(memberA->getName(), qsl("a"));
+
+        memberA->setValue(qsl("written"), LUA_TSTRING);
+        QVERIFY(interface->setValue(memberA));
+        QCOMPARE(memberAsString(qsl("landmineHolder"), qsl("a")), qsl("written"));
+        QVERIFY2(memberAsString(qsl("landmineHolder"), qsl("b")) == qsl("bval"), "the write went to the sibling the rename was refused over");
+    }
+
     // The three names below are the cycle a real table of mixed names produced:
     // every one of the three comparisons answered true, so TVar::getChildren()
     // handed std::sort() an ordering that contradicted itself (#9956).
@@ -790,6 +917,52 @@ private:
         lua_gettable(L, -2);
         const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
         lua_pop(L, 2);
+        return value;
+    }
+
+    QString numberKeyedMemberAsString(const QString& tableName, const double key)
+    {
+        lua_getglobal(L, tableName.toUtf8().constData());
+        lua_pushnumber(L, key);
+        lua_gettable(L, -2);
+        const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
+        lua_pop(L, 2);
+        return value;
+    }
+
+    // walked with lua_next() rather than pairs(), which these tests do without
+    // the base library to provide
+    int luaMemberCount(const QString& tableName)
+    {
+        lua_getglobal(L, tableName.toUtf8().constData());
+        if (!lua_istable(L, -1)) {
+            lua_pop(L, 1);
+            return -1;
+        }
+        int count = 0;
+        lua_pushnil(L);
+        while (lua_next(L, -2)) {
+            ++count;
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+        return count;
+    }
+
+    // ...and the same for reading a member of the sole member of a table, whose
+    // key is a table of its own and so has no name to look it up by
+    QString onlyMembersMemberAsString(const QString& tableName, const QString& memberName)
+    {
+        lua_getglobal(L, tableName.toUtf8().constData());
+        lua_pushnil(L);
+        if (!lua_next(L, -2)) {
+            lua_pop(L, 1);
+            return QString();
+        }
+        lua_pushstring(L, memberName.toUtf8().constData());
+        lua_gettable(L, -2);
+        const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
+        lua_pop(L, 4);
         return value;
     }
 

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -307,7 +307,179 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QVERIFY2(vu->isHidden(alias), "a saved alias of a live hidden table has to be recognised by identity");
     }
 
+    // The write used to be a generated line of Lua source with the value spliced
+    // into a [[...]] literal, which a value holding "]]" closes early: the chunk
+    // did not parse, the write was quietly dropped and the parse error was left
+    // on the Lua stack of the profile's live interpreter.
+    void testSetValueWritesAStringHoldingClosingLongBrackets()
+    {
+        execLua("bracketVar = 'placeholder'");
+        interface->getVars(false);
+        TVar* var = findGlobal(qsl("bracketVar"));
+        QVERIFY(var);
+        var->setValue(qsl("a]]b"), LUA_TSTRING);
+
+        const int stackBefore = lua_gettop(L);
+        QVERIFY(interface->setValue(var));
+        QCOMPARE(lua_gettop(L), stackBefore);
+        QCOMPARE(globalAsString(qsl("bracketVar")), qsl("a]]b"));
+    }
+
+    // ...and a value ending in a single "]" closed the literal against the
+    // bracket the generated line ended with.
+    void testSetValueWritesAStringEndingInABracket()
+    {
+        execLua("trailVar = 'placeholder'");
+        interface->getVars(false);
+        TVar* var = findGlobal(qsl("trailVar"));
+        QVERIFY(var);
+        var->setValue(qsl("foo]"), LUA_TSTRING);
+
+        QVERIFY(interface->setValue(var));
+        QCOMPARE(globalAsString(qsl("trailVar")), qsl("foo]"));
+    }
+
+    // A long-bracket literal swallows a newline it starts with, so this write
+    // reported success and stored a different string than it was given.
+    void testSetValueKeepsALeadingNewlineInAString()
+    {
+        execLua("newlineVar = 'placeholder'");
+        interface->getVars(false);
+        TVar* var = findGlobal(qsl("newlineVar"));
+        QVERIFY(var);
+        var->setValue(qsl("\nfoo"), LUA_TSTRING);
+
+        QVERIFY(interface->setValue(var));
+        QCOMPARE(globalAsString(qsl("newlineVar")), qsl("\nfoo"));
+    }
+
+    // The keys went into that generated source as text too, inside a quoted
+    // literal - so a member whose key holds a quote was lost. XMLimport reaches
+    // this directly for every member it reads out of a profile save, which is
+    // where such a key comes from.
+    void testSetValueWritesAMemberWhoseKeyHoldsAQuote()
+    {
+        execLua("importHolder = {}");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("importHolder"));
+        QVERIFY(holder);
+        // what XMLimport::readVariable() builds before calling setValue()
+        TVar member;
+        member.setParent(holder);
+        member.setName(qsl("a\"b"), LUA_TSTRING);
+        member.setValue(qsl("42"), LUA_TNUMBER);
+
+        QVERIFY(interface->setValue(&member));
+        lua_getglobal(L, "importHolder");
+        lua_pushstring(L, "a\"b");
+        lua_gettable(L, -2);
+        QVERIFY2(lua_isnumber(L, -1), "the member has to be written under the key it is named by, quote and all");
+        QCOMPARE(lua_tonumber(L, -1), 42.0);
+        lua_pop(L, 2);
+    }
+
+    // A table already there is the table the editor has just made a node for, so
+    // writing it back must not empty it - the generated source assigned "= {}",
+    // which did.
+    void testSetValueOnATableAlreadyThereKeepsItsContents()
+    {
+        execLua("keepTable = {member = 'still here'}");
+        interface->getVars(false);
+        TVar* var = findGlobal(qsl("keepTable"));
+        QVERIFY(var);
+        QCOMPARE(var->getValueType(), LUA_TTABLE);
+
+        QVERIFY(interface->setValue(var));
+        lua_getglobal(L, "keepTable");
+        QVERIFY(lua_istable(L, -1));
+        lua_pushstring(L, "member");
+        lua_gettable(L, -2);
+        QCOMPARE(QString::fromUtf8(lua_tostring(L, -1)), qsl("still here"));
+        lua_pop(L, 2);
+    }
+
+    // A write that cannot get to the variable is a write that has to leave the
+    // interpreter as it found it: the generated source failed inside a pcall,
+    // which left the error message behind on the stack every trigger, alias and
+    // timer of the profile then runs on.
+    void testSetValueOnAMemberThatIsGoneLeavesTheStackAsItFoundIt()
+    {
+        execLua("goneHolder = {inner = {member = 'here for now'}}");
+        interface->getVars(false);
+        TVar* member = findGlobal(qsl("goneHolder"))->getChildren().first()->getChildren().first();
+        QCOMPARE(member->getName(), qsl("member"));
+        member->setValue(qsl("written"), LUA_TSTRING);
+        execLua("goneHolder.inner = nil");
+
+        const int stackBefore = lua_gettop(L);
+        for (int i = 0; i < 10; ++i) {
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("could not reach")));
+            QVERIFY(!interface->setValue(member));
+        }
+        QCOMPARE(lua_gettop(L), stackBefore);
+    }
+
+    // ...and the same when the write itself raises, which a table with a
+    // __newindex of its own can do at any time.
+    void testSetValueThatPanicsLeavesTheStackAsItFoundIt()
+    {
+        execLua("guardedHolder = {}");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("guardedHolder"));
+        QVERIFY(holder);
+        TVar member;
+        member.setParent(holder);
+        member.setName(qsl("blocked"), LUA_TSTRING);
+        member.setValue(qsl("value"), LUA_TSTRING);
+
+        lua_getglobal(L, "guardedHolder");
+        lua_newtable(L);
+        lua_pushcfunction(L, &raiseOnWrite);
+        lua_setfield(L, -2, "__newindex");
+        lua_setmetatable(L, -2);
+        lua_pop(L, 1);
+
+        const int stackBefore = lua_gettop(L);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("Lua panicked while writing")));
+        QVERIFY(!interface->setValue(&member));
+        QCOMPARE(lua_gettop(L), stackBefore);
+    }
+
+    // A member reached by a table key is named in the tree by the number of the
+    // registry reference holding that key. The delete used to put that number
+    // into generated source as a string key, so it nil'ed t["1"] while the
+    // member itself stayed where it was and came back with the next walk.
+    void testDeleteVarRemovesAMemberReachedByATableKey()
+    {
+        execLua("delHolder = {} do local key = {} delHolder[key] = 'keepme' end");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("delHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QVERIFY(members.first()->isReference());
+
+        const int stackBefore = lua_gettop(L);
+        interface->deleteVar(members.first());
+        QCOMPARE(lua_gettop(L), stackBefore);
+
+        lua_getglobal(L, "delHolder");
+        lua_pushnil(L);
+        QVERIFY2(lua_next(L, -2) == 0, "the member reached by a table key has to be the one that is deleted");
+        lua_pop(L, 1);
+    }
+
 private:
+    static int raiseOnWrite(lua_State* state) { return luaL_error(state, "this table cannot be written to"); }
+
+    QString globalAsString(const QString& name)
+    {
+        lua_getglobal(L, name.toUtf8().constData());
+        const QString value = QString::fromUtf8(lua_tostring(L, -1), static_cast<int>(lua_strlen(L, -1)));
+        lua_pop(L, 1);
+        return value;
+    }
+
     TVar* findGlobal(const QString& name)
     {
         TVar* base = interface->getVarUnit()->getBase();

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -27,6 +27,7 @@
 
 #include <cstdlib>
 #include <memory>
+#include <vector>
 
 extern "C" {
 #if defined(INCLUDE_VERSIONED_LUA_HEADERS)
@@ -61,6 +62,11 @@ static void* budgetedAllocator(void* userData, void* pointer, size_t /*oldSize*/
     }
     return realloc(pointer, newSize);
 }
+
+
+// The comparator TVar::getChildren() sorts the members of a table with. It is a
+// free function in TVar.cpp that TVar.h does not declare, so it is named here.
+bool TVarLessThan(TVar*, TVar*);
 
 
 class TVarTest : public QObject
@@ -543,7 +549,92 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QVERIFY2(!vu->savedVars.contains(qsl("savedRenamed")), "the name the variable no longer has must stop being saved");
     }
 
+    // The three names below are the cycle a real table of mixed names produced:
+    // every one of the three comparisons answered true, so TVar::getChildren()
+    // handed std::sort() an ordering that contradicted itself (#9956).
+    void testTVarLessThanPlacesNumbersAndNamesWithoutACycle()
+    {
+        const auto two = namedVar(qsl("2"));
+        const auto ten = namedVar(qsl("10"));
+        const auto elevenA = namedVar(qsl("11a"));
+
+        QVERIFY2(TVarLessThan(two.get(), ten.get()), "two numbers compare by value, so 2 comes before 10");
+        QVERIFY2(TVarLessThan(ten.get(), elevenA.get()), "a number comes before a name that is not one");
+        QVERIFY2(!TVarLessThan(elevenA.get(), two.get()), "so that name cannot also come before a number - that closes a cycle");
+    }
+
+    void testTVarLessThanIsAntisymmetric()
+    {
+        const QStringList names{qsl("0"), qsl("2"), qsl("10"), qsl("-1"), qsl("11a"), qsl("0abc"), qsl("a"), qsl("A"), qsl("zebra"), QString()};
+        for (const QString& first : names) {
+            const auto firstVar = namedVar(first);
+            QVERIFY2(!TVarLessThan(firstVar.get(), firstVar.get()), qPrintable(qsl("\"%1\" must not come before itself").arg(first)));
+            for (const QString& second : names) {
+                if (first == second) {
+                    continue;
+                }
+                const auto secondVar = namedVar(second);
+                const bool firstFirst = TVarLessThan(firstVar.get(), secondVar.get());
+                const bool secondFirst = TVarLessThan(secondVar.get(), firstVar.get());
+                QVERIFY2(!(firstFirst && secondFirst), qPrintable(qsl("\"%1\" and \"%2\" each came before the other").arg(first, second)));
+            }
+        }
+    }
+
+    // Folding the case leaves "A" and "a" equivalent, and equivalent names are
+    // left wherever the sort happens to put them - which is not the same place
+    // every time, so the view would reorder them for no reason the user made.
+    void testTVarLessThanSeparatesNamesThatOnlyDifferInCase()
+    {
+        const auto upper = namedVar(qsl("A"));
+        const auto lower = namedVar(qsl("a"));
+
+        QCOMPARE(TVarLessThan(upper.get(), lower.get()), true);
+        QCOMPARE(TVarLessThan(lower.get(), upper.get()), false);
+    }
+
+    // A strict weak ordering in full: both "comes before" and "neither comes
+    // before the other" have to carry across a third name, or std::sort() is
+    // free to read past the ends of the list it is sorting.
+    void testTVarLessThanIsTransitiveOverEveryTripleOfMixedNames()
+    {
+        const QStringList names{
+                qsl("0"), qsl("2"), qsl("10"), qsl("11"), qsl("-1"), qsl("-10"), qsl("2b"), qsl("11a"), qsl("a"), qsl("A"), qsl("_G"), qsl("zebra"), QString(), qsl("99999999999999999999")};
+        std::vector<std::unique_ptr<TVar>> vars;
+        vars.reserve(names.size());
+        for (const QString& name : names) {
+            vars.push_back(namedVar(name));
+        }
+
+        for (int i = 0; i < names.size(); ++i) {
+            for (int j = 0; j < names.size(); ++j) {
+                for (int k = 0; k < names.size(); ++k) {
+                    TVar* first = vars.at(i).get();
+                    TVar* second = vars.at(j).get();
+                    TVar* third = vars.at(k).get();
+                    const QString trio = qsl("\"%1\", \"%2\", \"%3\"").arg(names.at(i), names.at(j), names.at(k));
+                    if (TVarLessThan(first, second) && TVarLessThan(second, third)) {
+                        QVERIFY2(TVarLessThan(first, third), qPrintable(qsl("%1: the first must come before the third").arg(trio)));
+                    }
+                    const bool firstTwoTie = !TVarLessThan(first, second) && !TVarLessThan(second, first);
+                    const bool lastTwoTie = !TVarLessThan(second, third) && !TVarLessThan(third, second);
+                    if (firstTwoTie && lastTwoTie) {
+                        const bool endsTie = !TVarLessThan(first, third) && !TVarLessThan(third, first);
+                        QVERIFY2(endsTie, qPrintable(qsl("%1: names that tie with a third have to tie with each other").arg(trio)));
+                    }
+                }
+            }
+        }
+    }
+
 private:
+    static std::unique_ptr<TVar> namedVar(const QString& name)
+    {
+        auto var = std::make_unique<TVar>();
+        var->setName(name, LUA_TSTRING);
+        return var;
+    }
+
     // The base library, which these tests do without, is what usually puts the
     // globals table in _G - and a rename of a global is written as _G["new"].
     void defineGlobalsTable()

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -549,6 +549,51 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QVERIFY2(!vu->savedVars.contains(qsl("savedRenamed")), "the name the variable no longer has must stop being saved");
     }
 
+    // A hidden table is remembered by address as well as by name, and the name
+    // half is what un-hiding is asked by. Left on the old name, the address goes
+    // on answering for the table under a name nothing can give it back from - so
+    // the table can no longer be un-hidden at all.
+    void testRenameTakesAHiddenTablesIdentityToTheNewName()
+    {
+        defineGlobalsTable();
+        execLua("hiddenTableRenamed = {member = 'value'}");
+        interface->getVars(true); // the hiding walk Mudlet runs at profile load
+        VarUnit* vu = interface->getVarUnit();
+        TVar* var = findGlobal(qsl("hiddenTableRenamed"));
+        QVERIFY(var);
+        QVERIFY2(vu->isHidden(var), "the hiding walk is supposed to have hidden the table");
+
+        var->setNewName(qsl("hiddenTableRenamedNew"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(var));
+
+        QVERIFY2(vu->isHidden(var), "a rename does not change the table, so its identity still answers for it");
+        vu->removeHidden(qsl("hiddenTableRenamedNew"));
+        QVERIFY2(!vu->isHidden(var), "un-hiding the name the table now has has to give its identity up as well");
+    }
+
+    // ...and a member of a renamed table is remembered by a name beginning with
+    // the table's, so a rename of the table has to take those with it too - the
+    // saved mark was left pointing at a path with no variable at the end of it.
+    void testRenamingATableTakesItsMembersSavedMarksWithIt()
+    {
+        defineGlobalsTable();
+        execLua("renHolder = {a = 'aval'} renHolderOther = 'unrelated'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+        TVar* holder = findGlobal(qsl("renHolder"));
+        QVERIFY(holder);
+        vu->addSavedVar(holder->getChildren(false).first());
+        vu->addSavedVar(findGlobal(qsl("renHolderOther")));
+        QVERIFY(vu->savedVars.contains(qsl("renHolder.a")));
+
+        holder->setNewName(qsl("renHolderNew"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(holder));
+
+        QVERIFY2(vu->savedVars.contains(qsl("renHolderNew.a")), "what is saved inside a renamed table has to be saved under the name the table now has");
+        QVERIFY2(!vu->savedVars.contains(qsl("renHolder.a")), "and must stop being saved under a path that now names nothing");
+        QVERIFY2(vu->savedVars.contains(qsl("renHolderOther")), "a variable that merely starts with the same text is a variable of its own");
+    }
+
     // A member whose key is a table of its own is named in the tree by the
     // number of the registry reference holding that key, and that number is not
     // a name a rename can write: renaming such a member deleted it outright.

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -256,28 +256,28 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
     // plain allocator the very first one does.
     void testRecycledHiddenTableAddressDoesNotHideAFreshVariable()
     {
-        execLua("hiddenT = {'payload'}");
+        execLua("hiddenGroup = {} for i = 1, 512 do hiddenGroup[i] = {'payload'} end");
         interface->getVars(true); // the hiding walk Mudlet runs at profile load
         VarUnit* vu = interface->getVarUnit();
-        TVar* hiddenVar = findGlobal("hiddenT");
-        QVERIFY(hiddenVar);
-        QVERIFY2(vu->isHidden(hiddenVar), "the hiding walk is supposed to hide what it finds");
-        const void* oldAddress = hiddenVar->pValue;
-        QVERIFY(oldAddress);
+        QVERIFY2(vu->hiddenTables.size() > 512, "the hiding walk is supposed to remember every table it finds");
+        const QSet<const void*> oldAddresses = vu->hiddenTables;
 
-        execLua("hiddenT = nil");
+        execLua("hiddenGroup = nil");
         lua_gc(L, LUA_GCCOLLECT, 0);
 
-        bool recycled = false;
-        for (int i = 0; i < 64 && !recycled; ++i) {
+        for (int i = 0; i < 64; ++i) {
             execLua(qsl("fresh%1 = {'payload'}").arg(i));
-            interface->getVars(false);
+        }
+        interface->getVars(false);
+
+        bool recycled = false;
+        for (int i = 0; i < 64; ++i) {
             TVar* fresh = findGlobal(qsl("fresh%1").arg(i));
             QVERIFY(fresh);
-            recycled = fresh->pValue == oldAddress;
+            recycled = recycled || oldAddresses.contains(fresh->pValue);
             QVERIFY2(!vu->isHidden(fresh), "a fresh variable must not inherit hiddenness from a collected table whose address it landed on");
         }
-        qDebug() << "the collected table's address was" << (recycled ? "recycled and checked" : "not handed out again, so identity decay went unexercised");
+        qDebug() << "a collected table's address was" << (recycled ? "recycled and checked" : "not handed out again, so identity decay went unexercised");
     }
 
     // What the identity is for (#9769): a saved variable of the user's holding

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -246,7 +246,74 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         lua_close(failingState);
     }
 
+    // A hiding walk remembers every table by address, but an address is only an
+    // identity while its table is alive: once the table is collected, Lua hands
+    // the address to the next table it makes - often a fresh variable of the
+    // user's, which then inherited the hiddenness and vanished from the
+    // Variables view and from profile saves. Whether the address is in fact
+    // recycled is the allocator's business (under AddressSanitizer it rarely
+    // is), so the loop below takes whichever fresh table lands on it - and on a
+    // plain allocator the very first one does.
+    void testRecycledHiddenTableAddressDoesNotHideAFreshVariable()
+    {
+        execLua("hiddenT = {'payload'}");
+        interface->getVars(true); // the hiding walk Mudlet runs at profile load
+        VarUnit* vu = interface->getVarUnit();
+        TVar* hiddenVar = findGlobal("hiddenT");
+        QVERIFY(hiddenVar);
+        QVERIFY2(vu->isHidden(hiddenVar), "the hiding walk is supposed to hide what it finds");
+        const void* oldAddress = hiddenVar->pValue;
+        QVERIFY(oldAddress);
+
+        execLua("hiddenT = nil");
+        lua_gc(L, LUA_GCCOLLECT, 0);
+
+        bool recycled = false;
+        for (int i = 0; i < 64 && !recycled; ++i) {
+            execLua(qsl("fresh%1 = {'payload'}").arg(i));
+            interface->getVars(false);
+            TVar* fresh = findGlobal(qsl("fresh%1").arg(i));
+            QVERIFY(fresh);
+            recycled = fresh->pValue == oldAddress;
+            QVERIFY2(!vu->isHidden(fresh), "a fresh variable must not inherit hiddenness from a collected table whose address it landed on");
+        }
+        qDebug() << "the collected table's address was" << (recycled ? "recycled and checked" : "not handed out again, so identity decay went unexercised");
+    }
+
+    // What the identity is for (#9769): a saved variable of the user's holding
+    // one of the hidden tables reaches it under a name no name-keyed lookup
+    // matches. While that table is alive, the anchor must confirm it rather
+    // than get in its way.
+    void testASavedAliasOfALiveHiddenTableStaysHidden()
+    {
+        execLua("apiT = {'api table'}");
+        interface->getVars(true);
+        VarUnit* vu = interface->getVarUnit();
+        vu->savedVars.insert(qsl("userAlias")); // or the walk drops the second name to reach the table
+        execLua("userAlias = apiT");
+        interface->getVars(false);
+
+        TVar* alias = findGlobal("userAlias");
+        QVERIFY(alias);
+        QVERIFY2(vu->isHidden(alias), "a saved alias of a live hidden table has to be recognised by identity");
+    }
+
 private:
+    TVar* findGlobal(const QString& name)
+    {
+        TVar* base = interface->getVarUnit()->getBase();
+        if (!base) {
+            return nullptr;
+        }
+        const QList<TVar*> globals = base->getChildren(false);
+        for (TVar* global : globals) {
+            if (global->getName() == name) {
+                return global;
+            }
+        }
+        return nullptr;
+    }
+
     static void markSavedRoots(LuaInterface& luaInterface)
     {
         for (int i = 1; i <= 6; ++i) {

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -627,6 +627,136 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         }
     }
 
+    // A global is free to have a dot in its own name, and everything the
+    // Variables view remembers about a variable it remembers by the dotted path
+    // the tree gives it - so such a global reads exactly like a member of a
+    // table that happens to be named the same way. Both are real variables of
+    // their own, and both have to be in the tree with their own values (#9954).
+    void testADottedGlobalAndTheMatchingMemberAreBothInTheTree()
+    {
+        defineGlobalsTable();
+        execLua("colT = {b = 5} _G['colT.b'] = 'unrelated'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+
+        TVar* dottedRoot = findGlobal(qsl("colT.b"));
+        QVERIFY2(dottedRoot, "a global whose own name holds a dot has to be in the tree");
+        QCOMPARE(dottedRoot->getValue(), qsl("unrelated"));
+        QVERIFY2(!vu->isHidden(dottedRoot), "and nothing has hidden it");
+
+        TVar* table = findGlobal(qsl("colT"));
+        QVERIFY(table);
+        const QList<TVar*> members = table->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QCOMPARE(members.first()->getName(), qsl("b"));
+        QCOMPARE(members.first()->getValue(), qsl("5"));
+        QVERIFY2(members.first() != dottedRoot, "the member and the global of that name are two different nodes");
+    }
+
+    // The way a user meets this: the hiding walk at profile load records the
+    // member path "apiHolder.load", and a global of that name made afterwards
+    // then answered to the mark left for the member - so it was born hidden and
+    // never appeared in the Variables view.
+    void testAGlobalMadeAfterAHideWalkIsNotHiddenByAMatchingMemberPath()
+    {
+        defineGlobalsTable();
+        execLua("apiHolder = {load = 5}");
+        interface->getVars(true); // the hiding walk Mudlet runs at profile load
+        VarUnit* vu = interface->getVarUnit();
+        QVERIFY2(vu->hidden.contains(qsl("apiHolder.load")), "the walk is supposed to record the member path");
+
+        execLua("_G['apiHolder.load'] = 7");
+        interface->getVars(false);
+
+        TVar* dottedRoot = findGlobal(qsl("apiHolder.load"));
+        QVERIFY(dottedRoot);
+        QVERIFY2(!vu->isHidden(dottedRoot), "a global made after the hiding walk must not inherit a member path's hiding");
+        QCOMPARE(dottedRoot->getValue(), qsl("7"));
+
+        TVar* member = findGlobal(qsl("apiHolder"))->getChildren(false).first();
+        QCOMPARE(member->getName(), qsl("load"));
+        QVERIFY2(vu->isHidden(member), "the member the walk did hide has to stay hidden");
+    }
+
+    // ...and the same collision the other way round: the saved mark the user put
+    // on the member is keyed by that same dotted path, so the unrelated global
+    // read as saved too - and a profile save wrote it out in the member's place.
+    void testSavingAMemberDoesNotSaveTheGlobalOfThatDottedName()
+    {
+        defineGlobalsTable();
+        execLua("cfgT = {port = 23} _G['cfgT.port'] = 'not the member'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+
+        TVar* member = findGlobal(qsl("cfgT"))->getChildren(false).first();
+        QCOMPARE(member->getName(), qsl("port"));
+        vu->addSavedVar(member);
+
+        QVERIFY2(vu->isSaved(member), "the member the user ticked is saved");
+        TVar* dottedRoot = findGlobal(qsl("cfgT.port"));
+        QVERIFY(dottedRoot);
+        QVERIFY2(!vu->isSaved(dottedRoot), "an unrelated global must not be saved by the member's mark");
+    }
+
+    // Nor may going the other way take the member's mark away: clicking such a
+    // global's row in the Variables view removed the savedVars entry the user
+    // had made about the member.
+    void testTouchingTheDottedGlobalLeavesTheMembersSavedMarkAlone()
+    {
+        defineGlobalsTable();
+        execLua("keepT = {port = 23} _G['keepT.port'] = 'not the member'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+        TVar* member = findGlobal(qsl("keepT"))->getChildren(false).first();
+        vu->addSavedVar(member);
+        TVar* dottedRoot = findGlobal(qsl("keepT.port"));
+        QVERIFY(dottedRoot);
+
+        vu->addSavedVar(dottedRoot);
+        vu->removeSavedVar(dottedRoot);
+
+        QVERIFY2(vu->savedVars.contains(qsl("keepT.port")), "the member's saved mark is the user's and has to survive");
+        QVERIFY2(vu->isSaved(member), "so the member is still saved");
+    }
+
+    // Saving is fenced off for such a global rather than made to work: savedVars
+    // is keyed by the dotted path, and a name that reads as a member path cannot
+    // be told apart from one in it - so a save would restore the wrong variable.
+    void testADottedGlobalIsFencedOffFromBeingSaved()
+    {
+        defineGlobalsTable();
+        execLua("fenceT = {port = 23} _G['fenceT.port'] = 'not the member' plainGlobal = 'saveable'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+
+        TVar* dottedRoot = findGlobal(qsl("fenceT.port"));
+        QVERIFY(dottedRoot);
+        QVERIFY2(!vu->shouldSave(dottedRoot), "a global whose own name holds a dot cannot be saved");
+        QVERIFY2(!vu->getUnsaveableReason(dottedRoot).isEmpty(), "and the view has to say why");
+        QVERIFY(vu->getUnsaveableReason(dottedRoot).contains(qsl("dot")));
+
+        QVERIFY2(vu->shouldSave(findGlobal(qsl("plainGlobal"))), "a global with no dot in its name is saveable as before");
+        QVERIFY2(vu->shouldSave(findGlobal(qsl("fenceT"))->getChildren(false).first()), "and so is the member whose path reads the same");
+        QVERIFY2(vu->getUnsaveableReason(findGlobal(qsl("fenceT"))->getChildren(false).first()).isEmpty(), "the member has nothing to explain away");
+    }
+
+    // The fence is about the name a root is reached by, so it must not reach a
+    // member whose own key holds a dot - that member is found through its table.
+    void testAMemberWhoseOwnKeyHoldsADotIsStillSaveable()
+    {
+        defineGlobalsTable();
+        execLua("dotHolder = {} dotHolder['a.b'] = 'member value'");
+        interface->getVars(false);
+        VarUnit* vu = interface->getVarUnit();
+
+        TVar* member = findGlobal(qsl("dotHolder"))->getChildren(false).first();
+        QCOMPARE(member->getName(), qsl("a.b"));
+        QVERIFY2(vu->shouldSave(member), "a member of a table is reached through that table, dot in its key or not");
+        vu->addSavedVar(member);
+        QVERIFY(vu->isSaved(member));
+        QVERIFY(vu->savedVars.contains(qsl("dotHolder.a.b")));
+    }
+
 private:
     static std::unique_ptr<TVar> namedVar(const QString& name)
     {

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -1434,6 +1434,54 @@ private slots:
     }
 
     // ========================================================================
+    // A global whose own name holds a dot (#9954)
+    // ========================================================================
+
+    // The Variables view is where this is felt: the row for a global made after
+    // the hiding walk answered to the mark that walk left for a member of the
+    // same dotted path, so the row was never built and the global could not be
+    // seen, renamed or deleted.
+    void testGlobalWithADotInItsNameHasARowInTheVariablesView()
+    {
+        execLua(qsl("dotHolderTable = {member = 'the member'}"));
+        interface->getVars(true); // the hiding walk Mudlet runs at profile load
+        execLua(qsl("_G['dotHolderTable.member'] = 'the global'"));
+        interface->getVars(false);
+
+        TTreeWidget tree(nullptr);
+        auto* rootItem = new QTreeWidgetItem(&tree, QStringList() << qsl("Variables"));
+        VarUnit* vu = interface->getVarUnit();
+        vu->buildVarTree(rootItem, vu->getBase(), false);
+
+        QTreeWidgetItem* dottedItem = childItemNamed(rootItem, qsl("dotHolderTable.member"));
+        QVERIFY2(dottedItem, "the global has to have a row of its own in the Variables view");
+        QVERIFY2(!childItemNamed(rootItem, qsl("dotHolderTable")), "while the table the walk hid stays hidden");
+    }
+
+    // ...and that row is greyed out and untickable, with the reason on it: the
+    // save keys variables by the dotted path, so this one cannot be saved.
+    void testTheRowOfAGlobalWithADotInItsNameIsGreyedWithAReason()
+    {
+        execLua(qsl("_G['greyed.global'] = 'value' plainSaveable = 'value'"));
+        interface->getVars(false);
+
+        TTreeWidget tree(nullptr);
+        auto* rootItem = new QTreeWidgetItem(&tree, QStringList() << qsl("Variables"));
+        VarUnit* vu = interface->getVarUnit();
+        vu->buildVarTree(rootItem, vu->getBase(), false);
+
+        QTreeWidgetItem* dottedItem = childItemNamed(rootItem, qsl("greyed.global"));
+        QVERIFY(dottedItem);
+        QVERIFY2(!(dottedItem->flags() & Qt::ItemIsUserCheckable), "the row must not offer a tick that cannot be honoured");
+        QCOMPARE(dottedItem->foreground(0).color(), QColor("grey"));
+        QVERIFY2(!dottedItem->toolTip(0).isEmpty(), "the row has to say why it cannot be saved");
+
+        QTreeWidgetItem* plainItem = childItemNamed(rootItem, qsl("plainSaveable"));
+        QVERIFY(plainItem);
+        QVERIFY2(plainItem->flags() & Qt::ItemIsUserCheckable, "an ordinary global is still tickable");
+    }
+
+    // ========================================================================
     // Float keys and values
     // ========================================================================
 

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -18,10 +18,13 @@
  ***************************************************************************/
 
 #include <LuaInterface.h>
+#include <TTreeWidget.h>
 #include <TVar.h>
 #include <VarUnit.h>
 #include <utils.h>
 #include <QtTest/QtTest>
+
+#include <QTreeWidgetItem>
 
 #include <memory>
 
@@ -93,6 +96,30 @@ private:
             }
         }
         return nullptr;
+    }
+
+    static QTreeWidgetItem* childItemNamed(QTreeWidgetItem* parent, const QString& name)
+    {
+        for (int i = 0; i < parent->childCount(); ++i) {
+            if (parent->child(i)->text(0) == name) {
+                return parent->child(i);
+            }
+        }
+        return nullptr;
+    }
+
+    // The Variables view as repopulateVars() builds it: a root row carrying no
+    // check state of its own, holding a table whose member is over the 10,000
+    // item limit and, beside it, a table small enough to save.
+    QTreeWidgetItem* buildFenceTree(TTreeWidget& tree)
+    {
+        execLua(QStringLiteral("fenceHolder = {big = {}} "
+                               "for i = 1, 10001 do fenceHolder.big[i] = i end "
+                               "keptTable = {member = 'kept'}"));
+        interface->getVars(false);
+        auto* rootItem = new QTreeWidgetItem(&tree, QStringList() << QStringLiteral("Variables"));
+        interface->getVarUnit()->buildVarTree(rootItem, interface->getVarUnit()->getBase(), false);
+        return rootItem;
     }
 
     TVar* createVar(TVar* parent, const QString& name, int keyType, const QString& value, int valueType)
@@ -1328,6 +1355,82 @@ private slots:
         QVERIFY(vu->isSaved(&var));
         vu->removeSavedVar(&var);
         QVERIFY(!vu->isSaved(&var));
+    }
+
+    // ========================================================================
+    // The 10,000 item limit and the parent checkbox (#9957)
+    // ========================================================================
+
+    // Both overloads of shouldSave() answer for the same variable, so a row of
+    // the Variables view standing for an oversized table has to be refused the
+    // same way the table itself is.
+    void testWidgetRowOfAnOversizedTableIsRefusedTheSameWayTheTableIs()
+    {
+        TTreeWidget tree(nullptr);
+        QTreeWidgetItem* rootItem = buildFenceTree(tree);
+        QVERIFY(rootItem);
+        VarUnit* vu = interface->getVarUnit();
+        QTreeWidgetItem* holderItem = childItemNamed(rootItem, qsl("fenceHolder"));
+        QVERIFY(holderItem);
+        QTreeWidgetItem* bigItem = childItemNamed(holderItem, qsl("big"));
+        QTreeWidgetItem* keptItem = childItemNamed(rootItem, qsl("keptTable"));
+        QVERIFY(bigItem);
+        QVERIFY(keptItem);
+
+        QVERIFY2(!vu->shouldSave(vu->getWVar(bigItem)), "a table of 10001 members is over the limit");
+        QVERIFY2(!vu->shouldSave(bigItem), "and so is the row standing for it");
+        QVERIFY2(vu->shouldSave(keptItem), "while the row of a small table is still saveable");
+    }
+
+    // Ticking a row hands the tick to every row beneath it, an oversized table
+    // among them: Qt's tristate cascade writes the check state whether or not
+    // the child's ItemIsUserCheckable flag was taken away, which is what
+    // buildVarTree() does to a table over the limit. The sweep that runs after
+    // the tick is what has to take it back off again, or the table goes into
+    // savedVars and from there into the profile.
+    void testOversizedTableTickedThroughItsParentEndsUntickedAndUnsaved()
+    {
+        TTreeWidget tree(nullptr);
+        QTreeWidgetItem* rootItem = buildFenceTree(tree);
+        QVERIFY(rootItem);
+        VarUnit* vu = interface->getVarUnit();
+        QTreeWidgetItem* holderItem = childItemNamed(rootItem, qsl("fenceHolder"));
+        QVERIFY(holderItem);
+        QTreeWidgetItem* bigItem = childItemNamed(holderItem, qsl("big"));
+        QTreeWidgetItem* keptItem = childItemNamed(rootItem, qsl("keptTable"));
+        QVERIFY(bigItem);
+        QVERIFY(keptItem);
+        QVERIFY2(!(bigItem->flags() & Qt::ItemIsUserCheckable), "the view marks an oversized table untickable");
+
+        holderItem->setCheckState(0, Qt::Checked);
+        keptItem->setCheckState(0, Qt::Checked);
+        QVERIFY2(bigItem->checkState(0) == Qt::Checked, "Qt hands the tick to the untickable child all the same");
+
+        // the sweep TTreeWidget::mouseReleaseEvent() runs over each ticked row
+        // and everything under it
+        QList<QTreeWidgetItem*> sweep;
+        tree.getAllChildren(holderItem, sweep);
+        tree.getAllChildren(keptItem, sweep);
+        for (QTreeWidgetItem* item : sweep) {
+            if (!vu->shouldSave(item)) {
+                item->setCheckState(0, Qt::Unchecked);
+            }
+        }
+
+        QCOMPARE(bigItem->checkState(0), Qt::Unchecked);
+        QVERIFY2(keptItem->checkState(0) == Qt::Checked, "the fence must not reach past the tables it is for");
+
+        // and what dlgTriggerEditor::slot_variableChanged() does with what is
+        // left ticked - savedVars is what a profile save reads
+        for (QTreeWidgetItem* item : sweep) {
+            TVar* var = vu->getWVar(item);
+            if (var && item->checkState(0) != Qt::Unchecked) {
+                vu->addSavedVar(var);
+            }
+        }
+
+        QVERIFY2(!vu->savedVars.contains(qsl("fenceHolder.big")), "an oversized table ticked through its parent must not be saved");
+        QVERIFY2(vu->savedVars.contains(qsl("keptTable")), "a small table the user ticked still is");
     }
 
     // ========================================================================

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -479,7 +479,6 @@ private slots:
 
     void testCreateVarWithNumericKeyZeroAtRoot()
     {
-        QSKIP("PENDING: setValue generates invalid Lua for root numeric keys (needs _G[N] instead of bare N)");
         interface->getVars(false);
         createVar(interface->getVarUnit()->getBase(), QStringLiteral("0"), LUA_TNUMBER, QStringLiteral("zeroVal"), LUA_TSTRING);
         QCOMPARE(getLuaValue(QStringLiteral("_G[0]")), QStringLiteral("zeroVal"));
@@ -487,7 +486,6 @@ private slots:
 
     void testCreateVarWithNumericKeyAtRoot()
     {
-        QSKIP("PENDING: setValue generates invalid Lua for root numeric keys (needs _G[N] instead of bare N)");
         interface->getVars(false);
         createVar(interface->getVarUnit()->getBase(), QStringLiteral("5"), LUA_TNUMBER, QStringLiteral("fiveVal"), LUA_TSTRING);
         QCOMPARE(getLuaValue(QStringLiteral("_G[5]")), QStringLiteral("fiveVal"));
@@ -495,7 +493,6 @@ private slots:
 
     void testCreateVarWithNegativeNumericKeyAtRoot()
     {
-        QSKIP("PENDING: setValue generates invalid Lua for root numeric keys (needs _G[N] instead of bare N)");
         interface->getVars(false);
         createVar(interface->getVarUnit()->getBase(), QStringLiteral("-1"), LUA_TNUMBER, QStringLiteral("negVal"), LUA_TSTRING);
         QCOMPARE(getLuaValue(QStringLiteral("_G[-1]")), QStringLiteral("negVal"));
@@ -717,7 +714,6 @@ private slots:
 
     void testDeleteNumericKeyAtRoot()
     {
-        QSKIP("PENDING: deleteVar generates invalid Lua for root numeric keys (needs _G[N] instead of bare N)");
         execLua(QStringLiteral("_G[99] = 'rootNum'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), QStringLiteral("99"));
@@ -1158,7 +1154,6 @@ private slots:
 
     void testNumericKeyZeroRoundTrip()
     {
-        QSKIP("PENDING: setValue generates invalid Lua for root numeric keys (needs _G[N] instead of bare N)");
         interface->getVars(false);
         createVar(interface->getVarUnit()->getBase(), QStringLiteral("0"), LUA_TNUMBER, QStringLiteral("zeroRT"), LUA_TSTRING);
         QCOMPARE(getLuaValue(QStringLiteral("_G[0]")), QStringLiteral("zeroRT"));
@@ -1200,10 +1195,7 @@ private slots:
         var->setName(QStringLiteral("bracketVal"), LUA_TSTRING);
         var->setValue(QStringLiteral("a]]b"), LUA_TSTRING);
         interface->getVarUnit()->getBase()->addChild(var);
-        const bool result = interface->setValue(var);
-        if (!result) {
-            QSKIP("Known issue: setValue fails for strings containing ']]'");
-        }
+        QVERIFY(interface->setValue(var));
         QCOMPARE(getLuaValue(QStringLiteral("bracketVal")), QStringLiteral("a]]b"));
     }
 

--- a/test/functional_tests/VariableEditorWriteBackTest.cpp
+++ b/test/functional_tests/VariableEditorWriteBackTest.cpp
@@ -41,6 +41,8 @@
 #include "dlgVarsMainArea.h"
 #include "mudlet.h"
 
+#include <QDropEvent>
+#include <QMimeData>
 #include <QTreeWidget>
 
 extern "C" {
@@ -292,6 +294,60 @@ private slots:
         QVERIFY2(luaHolds(qsl("stringKeyGlobal"), qsl("edited global value")), "editing the global did not reach Lua");
 
         execLua(qsl("stringKeyGlobal = nil stringKeyDecoy = nil"));
+    }
+
+    // Dropping an item somewhere else in the Variables view rearranges the view
+    // and nothing else - the variable stays in the table Lua has it in - so the
+    // view does not offer the move at all (#9958).
+    void test_theVariablesTreeDoesNotOfferAMoveItCannotMake()
+    {
+        QCOMPARE(mpVariablesTree->dragDropMode(), QAbstractItemView::NoDragDrop);
+        QVERIFY2(!mpVariablesTree->dragEnabled(), "the Variables view still lets an item be picked up, and a move it makes is not made in Lua");
+        QVERIFY2(!mpVariablesTree->acceptDrops(), "the Variables view still takes drops");
+        QVERIFY2(!mpVariablesTree->viewport()->acceptDrops(), "the viewport is what the window system asks about a drop, and it still says yes");
+
+        // the other views do carry a move through to what they are showing, so
+        // this must not have taken the drag away from all of them
+        QTreeWidget* pTriggers = mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_triggers"));
+        QVERIFY2(pTriggers, "the editor has no triggers tree widget");
+        QCOMPARE(pTriggers->dragDropMode(), QAbstractItemView::InternalMove);
+        QVERIFY2(pTriggers->dragEnabled(), "the Triggers view lost the drag it can carry through");
+    }
+
+    // ...and a drop that arrives at the widget anyway moves nothing. Note this
+    // stands on its own only so far: QDropEvent takes its source() from the drag
+    // currently in flight, so a synthesised one is sourceless and QTreeWidget
+    // declines to move for it whatever the drop mode is. The widget state above
+    // is what stops a real drag.
+    void test_aDropOnTheVariablesTreeMovesNothing()
+    {
+        execLua(qsl("dropTargetTable = {} droppedGlobal = 'dropped value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pTarget = findVariableItem({qsl("dropTargetTable")});
+        QVERIFY2(pTarget, "the Variables view did not show the table to drop onto");
+        QTreeWidgetItem* pDragged = findVariableItem({qsl("droppedGlobal")});
+        QVERIFY2(pDragged, "the Variables view did not show the variable to drag");
+
+        mpVariablesTree->expandItem(mpVariablesTree->topLevelItem(0));
+        mpVariablesTree->scrollToItem(pTarget);
+        const QRect targetRect = mpVariablesTree->visualItemRect(pTarget);
+        QVERIFY2(!targetRect.isEmpty(), "the tree has not laid the target out, so the drop would land nowhere");
+
+        selectVariable(pDragged);
+        const QModelIndex draggedIndex = mpVariablesTree->currentIndex();
+        QVERIFY2(draggedIndex.isValid(), "the tree has no model index for the variable being dragged");
+        QScopedPointer<QMimeData> mimeData(mpVariablesTree->model()->mimeData({draggedIndex}));
+        QVERIFY2(mimeData, "the tree gave nothing to carry in the drop");
+        QDropEvent dropEvent(targetRect.center(), Qt::MoveAction, mimeData.data(), Qt::LeftButton, Qt::NoModifier);
+        QApplication::sendEvent(mpVariablesTree->viewport(), &dropEvent);
+
+        QVERIFY2(!dropEvent.isAccepted(), "the Variables view took a drop it cannot carry through to Lua");
+        QCOMPARE(pTarget->childCount(), 0);
+        QCOMPARE(luaMemberCount(qsl("dropTargetTable")), 0);
+        QVERIFY2(luaHolds(qsl("droppedGlobal"), qsl("dropped value")), "the variable did not stay where Lua has it");
+
+        execLua(qsl("dropTargetTable = nil droppedGlobal = nil"));
     }
 
 private:

--- a/test/functional_tests/VariableEditorWriteBackTest.cpp
+++ b/test/functional_tests/VariableEditorWriteBackTest.cpp
@@ -350,7 +350,61 @@ private slots:
         execLua(qsl("dropTargetTable = nil droppedGlobal = nil"));
     }
 
+    // The key type shown belongs to the variable selected, and a boolean key is
+    // a key type of its own: showing the one the variable looked at before it
+    // had says something untrue about this one (#9959).
+    void test_aBooleanKeyedMemberNamesItsOwnKeyType()
+    {
+        execLua(qsl("booleanKeyTable = {[true] = 'boolean member value', [2] = 'integer member value'} booleanKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pBooleanMember = findVariableItem({qsl("booleanKeyTable"), qsl("true")});
+        QVERIFY2(pBooleanMember, "the Variables view did not show the member under its boolean key");
+        QTreeWidgetItem* pIntegerMember = findVariableItem({qsl("booleanKeyTable"), qsl("2")});
+        QVERIFY2(pIntegerMember, "the Variables view did not show the member under its integer key");
+        QTreeWidgetItem* pStringKeyed = findVariableItem({qsl("booleanKeyDecoy")});
+        QVERIFY2(pStringKeyed, "the Variables view did not show the string-keyed variable");
+
+        selectVariable(pIntegerMember);
+        selectVariable(pBooleanMember);
+        const QString afterAnIntegerKey = keyTypeShown();
+
+        selectVariable(pStringKeyed);
+        selectVariable(pBooleanMember);
+        const QString afterAStringKey = keyTypeShown();
+
+        QCOMPARE(afterAStringKey, afterAnIntegerKey);
+        QVERIFY2(afterAnIntegerKey.contains(qsl("boolean"), Qt::CaseInsensitive),
+                 qPrintable(qsl("the key type shown for a boolean key was \"%1\", which does not name a boolean").arg(afterAnIntegerKey)));
+
+        selectVariable(pStringKeyed);
+        execLua(qsl("booleanKeyTable = nil booleanKeyDecoy = nil"));
+    }
+
+    // ...and what is shown for it is a description, not an instruction: leaving
+    // the member alone leaves the key it is under boolean.
+    void test_leavingABooleanKeyedMemberKeepsItsKey()
+    {
+        execLua(qsl("booleanRoundTripTable = {[true] = 'boolean member value'} booleanRoundTripDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("booleanRoundTripTable"), qsl("true")});
+        QVERIFY2(pMember, "the Variables view did not show the member under its boolean key");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("booleanRoundTripDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        selectVariable(pDecoy);
+
+        QCOMPARE(luaMemberCount(qsl("booleanRoundTripTable")), 1);
+        QVERIFY2(luaHolds(qsl("booleanRoundTripTable[true]"), qsl("boolean member value")), "the member did not stay under the boolean key it was read from");
+
+        execLua(qsl("booleanRoundTripTable = nil booleanRoundTripDecoy = nil"));
+    }
+
 private:
+    QString keyTypeShown() const { return mpEditor->mpVarsMainArea->comboBox_variable_key_type->currentText(); }
+
     void execLua(const QString& code)
     {
         lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();

--- a/test/functional_tests/VariableEditorWriteBackTest.cpp
+++ b/test/functional_tests/VariableEditorWriteBackTest.cpp
@@ -32,8 +32,10 @@
 #include <QtTest/QtTest>
 
 #include "Host.h"
+#include "LuaInterface.h"
 #include "MudletInstanceCoordinator.h"
 #include "TLuaInterpreter.h"
+#include "VarUnit.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
@@ -400,6 +402,45 @@ private slots:
         QVERIFY2(luaHolds(qsl("booleanRoundTripTable[true]"), qsl("boolean member value")), "the member did not stay under the boolean key it was read from");
 
         execLua(qsl("booleanRoundTripTable = nil booleanRoundTripDecoy = nil"));
+    }
+
+    // Qt's tristate cascade ticks rows the user cannot tick themselves, so a tick
+    // on a table's parent reaches a table the size limit rules out - and what may
+    // be saved has to be asked again rather than read off the check state
+    // (#9957). The parent of an oversized table is over the limit itself, so
+    // neither of them may be enrolled here.
+    void test_tickingTheParentOfAnOversizedTableSavesNeitherOfThem()
+    {
+        execLua(qsl("bypassHolder = {small = 1, big = {}} for i = 1, 10001 do bypassHolder.big[i] = i end"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pParent = findVariableItem({qsl("bypassHolder")});
+        QVERIFY2(pParent, "the Variables view did not show the holder table");
+        QTreeWidgetItem* pBig = findVariableItem({qsl("bypassHolder"), qsl("big")});
+        QVERIFY2(pBig, "the Variables view did not show the oversized table");
+
+        VarUnit* pVarUnit = mpHost->getLuaInterface()->getVarUnit();
+        pVarUnit->savedVars.clear();
+        mpEditor->mpCurrentVarItem = nullptr; // nothing left over from an earlier test to be saved
+
+        // the real signal path: setCheckState() cascades down and each change
+        // reaches slot_variableChanged() through itemChanged
+        pParent->setCheckState(0, Qt::Checked);
+
+        QVERIFY2(!pVarUnit->savedVars.contains(qsl("bypassHolder")), "a table over the size limit was enrolled for saving by a tick on it");
+        QVERIFY2(!pVarUnit->savedVars.contains(qsl("bypassHolder.big")), "the oversized table was enrolled for saving through its parent");
+        QVERIFY2(pVarUnit->savedVars.contains(qsl("bypassHolder.small")), "a member that is saveable is still enrolled by the same tick");
+
+        // ...and neither does clicking the row afterwards, which finds it ticked
+        QCOMPARE(pBig->checkState(0), Qt::Checked);
+        mpEditor->slot_variableSelected(pBig);
+        QVERIFY2(!pVarUnit->savedVars.contains(qsl("bypassHolder.big")), "clicking a row left ticked from before enrolled the oversized table it stands for");
+        QVERIFY2(!pVarUnit->savedVars.contains(qsl("bypassHolder")), "...and its parent with it");
+
+        mpEditor->mpCurrentVarItem = nullptr;
+        pVarUnit->savedVars.clear();
+        execLua(qsl("bypassHolder = nil"));
+        mpEditor->repopulateVars();
     }
 
 private:

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -268,6 +268,34 @@ private slots:
         QCOMPARE(luaL_dostring(L, "untickedMemberTable = nil"), 0);
     }
 
+    // A global is free to hold a dot in its own name, and savedVars is keyed by
+    // the dotted path - so such a global reads exactly like a member of a table
+    // of that path. The save used to write that global out under the member's
+    // entry, which handed the next session the wrong variable's value (#9954).
+    void test_globalWithADotInItsNameIsNotExportedUnderAMembersSavedName()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L,
+                               "dottedNameTable = {member = 'the member value'} "
+                               "_G['dottedNameTable.member'] = 'the unrelated global value'"),
+                 0);
+        // what ticking the table and its member in the Variables view records
+        vu->savedVars.insert(qsl("dottedNameTable"));
+        vu->savedVars.insert(qsl("dottedNameTable.member"));
+        lI->getVars(false);
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        QVERIFY2(xml.contains(qsl("the member value")), "the member the user ticked has to be exported");
+        QVERIFY2(!xml.contains(qsl("the unrelated global value")), "the unrelated global of that dotted name must not be exported in its place");
+
+        vu->savedVars.remove(qsl("dottedNameTable"));
+        vu->savedVars.remove(qsl("dottedNameTable.member"));
+        QCOMPARE(luaL_dostring(L, "dottedNameTable = nil _G['dottedNameTable.member'] = nil"), 0);
+    }
+
     // A member table beyond the 10,000-item save limit must not ride along -
     // it would bloat every profile save.
     void test_oversizedMemberTableIsNotExported()

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -812,6 +812,59 @@ private slots:
         QCOMPARE(luaL_dostring(L, "unhiddenHolderTable, unhiddenInnerTable = nil"), 0);
     }
 
+    // The save-time copy answers hiding from identities borrowed off the live
+    // unit, and those decay the same way. A top-level saved global is safe
+    // regardless - its savedVars name is honoured before hiding is - so the
+    // exposed shape is a member riding along inside a saved table: one landing
+    // on a collected hidden table's address must still be written out with its
+    // table, not silently dropped from the save. This is the save half of the
+    // recycled-address bug; the TLuaInterfaceTest unit tests cover the view
+    // half. Whether an address is really handed out again is the allocator's
+    // business, so the freed batch is opportunistic - the identity injected
+    // behind the 'injected' member stands in for the allocator
+    // deterministically, putting a fresh table's address in the state a
+    // collected identity decays to: remembered, with nothing left to vouch
+    // for it.
+    void test_rideAlongMemberOnACollectedHiddenTableAddressIsStillExported()
+    {
+        QVERIFY2(!mpEditor, "this test rebuilds the shared variable tree, so it must run before the Variables-view tests");
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        QCOMPARE(luaL_dostring(L, "recycledGroup = {} for i = 1, 512 do recycledGroup[i] = {'batch filler'} end"), 0);
+
+        const QSet<QString> hiddenBefore = vu->hidden;
+        const QSet<const void*> hiddenTablesBefore = vu->hiddenTables;
+        mpHost->hideMudletsVariables();
+
+        // one chunk, so nothing else allocates between the collect and the
+        // fresh member tables that could take the freed blocks first
+        QCOMPARE(luaL_dostring(L,
+                               "recycledGroup = nil collectgarbage('collect') "
+                               "freshHolderTable = {} "
+                               "for i = 0, 63 do freshHolderTable['m' .. i] = {'fresh member value ' .. i} end "
+                               "freshHolderTable.injected = {'injected member value'}"),
+                 0);
+        vu->savedVars.insert(qsl("freshHolderTable"));
+
+        lua_getglobal(L, "freshHolderTable");
+        lua_getfield(L, -1, "injected");
+        vu->hiddenTables.insert(lua_topointer(L, -1));
+        lua_pop(L, 2);
+
+        const QString xml = exportProfileXml();
+        QVERIFY(!xml.isEmpty());
+        for (int i = 0; i < 64; ++i) {
+            QVERIFY2(xml.contains(qsl("fresh member value %1").arg(i)), "a fresh member of a saved table must ride along even when it lands on a collected hidden table's address");
+        }
+        QVERIFY2(xml.contains(qsl("injected member value")), "an identity nothing vouches for must not swallow the member now on that address");
+
+        vu->savedVars.remove(qsl("freshHolderTable"));
+        vu->hidden = hiddenBefore;
+        vu->hiddenTables = hiddenTablesBefore;
+        QCOMPARE(luaL_dostring(L, "freshHolderTable = nil"), 0);
+    }
+
     // A script adds to a saved table while the editor sits on the Variables
     // view. A session's last save is taken with whatever view was left on
     // screen, so quitting from there is enough to reach this.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `LuaInterface::setValue()`/`deleteVar()` now write through the Lua C API instead of generating Lua source, so string values containing `]]` or starting with a newline, member keys containing quotes, and table-keyed members all survive editing, deletion, and profile load intact (`setCValue()` became dead code and is removed).
- Renames are made safe: a rename onto an existing sibling or of a reference-keyed member is refused with a visible message instead of silently destroying data; a renamed table takes its members' saved/hidden marks along; a refused rename can no longer commit the refused name into the tree's bookkeeping.
- The Variables view stops misleading: members sort with a valid ordering (no more shuffling), the 10,000-item save limit holds when ticked through a parent or a stale row, drag-and-drop that silently moved nothing is disabled, boolean keys display their real type, and a global with a dot in its name is a variable of its own rather than inheriting a member path's hidden/saved state.
- 40+ new tests across the unit and functional suites, each verified to fail without its fix; five stale `QSKIP`s removed for behavior the rewrite fixed.

#### Motivation for adding to Mudlet
Each of these was found in a systematic audit of the Variables view, empirically reproduced before filing, and fixed with the reproduction promoted to a regression test — closing every currently-open Variables-view defect from that audit in one reviewed batch.

#### Other info (issues closed, discussion etc)
Closes #9949, closes #9950, closes #9951, closes #9952, closes #9953, closes #9954, closes #9955, closes #9956, closes #9957, closes #9958, closes #9959.

Builds on the hidden-table identity work in #9944 (branched from it; that PR should merge first). The branch was itself put through a multi-agent review; all confirmed findings are fixed in the final three commits, and claims that failed empirical verification were dropped rather than patched. Suite totals: TLuaInterfaceTest 38/38, TVariableEditorTest 123/123 (7 pre-existing skips, down from 12), functional trio 3/3.

**Test case:** `lua t = {a = "aval", b = "bval"}` — rename `a` to `b` in the Variables view (refused with a message, `bval` survives); set a variable's value to text containing `]]` and reload the profile (value intact); `lua o = {} do local k = {} o[k] = 1 end` — delete the member under `o` (actually gone after a view refresh).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc5q1odV4iwvw6tVTxiJm8)_