### PR TITLE
Fix: Windows CI builds again after an msys2 update broke Lua module installs

### DIFF
--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -204,6 +204,22 @@ echo "- Adjust LUA_PATH and LUA_CPATH to find per-user modules"
 echo "- See 'luarocks path --help' for details"
 
 
+# mingw-w64-libarchive 3.8.9-2 hardlinks bsdunzip to "unzip" in ${MINGW_BASE_DIR}/bin,
+# which shadows Info-ZIP's /usr/bin/unzip on PATH. bsdunzip opens extracted files
+# without O_BINARY, so on Windows every "\n" it writes becomes "\r\n": CRLF sources
+# gain a blank line between every line (breaking "\" macro continuations) and archives
+# nested inside a .src.rock are corrupted outright. Pin luarocks to Info-ZIP instead.
+if [ -x /usr/bin/unzip ]; then
+  echo "  Pinning luarocks to Info-ZIP unzip (bsdunzip mangles line endings)..."
+  echo "    unzip on PATH: $(command -v unzip)"
+  cat >> "${MINGW_BASE_DIR}/etc/luarocks/config-5.1.lua" <<'EOF'
+
+variables = variables or {}
+variables.UNZIP = "/usr/bin/unzip"
+EOF
+  echo ""
+fi
+
 ROCKCOMMAND="${MINGW_BASE_DIR}/bin/luarocks --lua-version 5.1"
 echo ""
 echo "  Checking, and installing if needed, the luarocks used by Mudlet..."

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -19,7 +19,10 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-# Version: 2.4.0    Add Python, needed by the fixture HTTP server the Lua
+# Version: 2.5.0    Pin luarocks to Info-ZIP unzip, since libarchive now
+#                   hardlinks bsdunzip over "unzip" and it mangles line
+#                   endings when it unpacks a rock
+#          2.4.0    Add Python, needed by the fixture HTTP server the Lua
 #                   tests run against
 #          2.3.0    Switch from MINGW64 to CLANG64
 #          2.2.0    Add CMake package for CMake-based builds

--- a/CI/setup-windows-sdk.sh
+++ b/CI/setup-windows-sdk.sh
@@ -209,14 +209,16 @@ echo "- See 'luarocks path --help' for details"
 # without O_BINARY, so on Windows every "\n" it writes becomes "\r\n": CRLF sources
 # gain a blank line between every line (breaking "\" macro continuations) and archives
 # nested inside a .src.rock are corrupted outright. Pin luarocks to Info-ZIP instead.
-if [ -x /usr/bin/unzip ]; then
+# luarocks is a native Windows binary, so it needs a Windows path here rather than
+# the MSYS one - cygpath -m keeps forward slashes so the value needs no Lua escaping.
+INFOZIP_UNZIP="$(/usr/bin/cygpath -m /usr/bin/unzip.exe 2>/dev/null)"
+if [ -x /usr/bin/unzip.exe ] && [ -n "${INFOZIP_UNZIP}" ] \
+   && [ "$(grep -c "variables.UNZIP" "${MINGW_BASE_DIR}/etc/luarocks/config-5.1.lua")" -eq 0 ]; then
   echo "  Pinning luarocks to Info-ZIP unzip (bsdunzip mangles line endings)..."
   echo "    unzip on PATH: $(command -v unzip)"
-  cat >> "${MINGW_BASE_DIR}/etc/luarocks/config-5.1.lua" <<'EOF'
-
-variables = variables or {}
-variables.UNZIP = "/usr/bin/unzip"
-EOF
+  echo "    pinning to:    ${INFOZIP_UNZIP}"
+  printf '\nvariables = variables or {}\nvariables.UNZIP = "%s"\n' "${INFOZIP_UNZIP}" \
+    >> "${MINGW_BASE_DIR}/etc/luarocks/config-5.1.lua"
   echo ""
 fi
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Pins luarocks to Info-ZIP's `unzip` in `CI/setup-windows-sdk.sh`, instead of letting it pick up whatever `unzip` is first on `PATH`.
- Logs which `unzip` the job resolved, so the next time this shifts it is visible in the build log rather than only in the wreckage downstream.
- Bumps the script's own version to 2.5.0.

#### Motivation for adding to Mudlet
`windows64` was failing on every PR in the "(Windows) Build Environment Setup" step, before Mudlet was compiled at all — four rocks failed to install (`luautf8`, `lrexlib-pcre2`, `argparse`, and `busted` via `dkjson`) and the script exited 6.

`mingw-w64-libarchive` 3.8.9-2 (msys2/MINGW-packages#30696, built 2026-08-15) hardlinks `bsdunzip` to `unzip` in the mingw bin directory, where it shadows Info-ZIP's `/usr/bin/unzip`. luarocks invokes bare `unzip` with no flags, so it now gets bsdunzip. bsdunzip opens extracted files with `open(O_RDWR|O_CREAT|O_TRUNC)` and never sets `O_BINARY`, so on Windows the CRT rewrites every `\n` it writes as `\r\n`. Its own `-a` text conversion is not involved — that is gated behind `a_opt`, which luarocks never passes.

So a CRLF source file gains a line break after every line, which strips the body off any `\`-continued macro, and any archive nested inside a `.src.rock` is corrupted outright.

#### Other info (issues closed, discussion etc)
Closes #9961.

Confirmed on the runner rather than only reasoned about — the diagnostic added here printed:

```
unzip on PATH: /clang64/bin/unzip
```

which is libarchive's bsdunzip hardlink shadowing Info-ZIP. With the pin in place, "(Windows) Build Environment Setup" completes and every rock installs.

Supporting evidence, from applying the same transform to the shipped archives locally:

- `lpcre2.c` ships at 502 lines and becomes 1004, reproducing clang's reported error lines 97, 103, 113 and 1004 exactly. At line 95 the `#define ALG_PUSHSUB(...) \` continues into a blank line 96, dropping its body to file scope at 97 — which is the `function definition is not allowed here` and unbalanced `SET_INFO_FIELD` braces seen in CI.
- Gunzipping the rewritten tarball reproduces `invalid compressed data--format violated` verbatim.
- The rocks themselves are intact as served — all four archives pass `gzip -t` / `unzip -t` when downloaded directly.
- Real `bsdunzip` on Linux produces byte-identical output to Info-ZIP (same md5), confirming this is Windows text mode rather than a bsdunzip logic bug.

Last green `windows64` on `development` was run 31922932375 at 02:53 UTC on 2026-08-16; red from 09:15 onward. The only archive-tooling package that moved in that window was `libarchive` 3.8.9-1 → 3.8.9-2 (`msys2-runtime` and msys `unzip` are identical in both runs).

Note that luarocks needs a Windows path here — the MSYS `/usr/bin/unzip` is not resolvable by the native binary, so the value goes through `cygpath -m`.

**Test case:** this PR's own `windows64` job — it gets past "(Windows) Build Environment Setup" with all rocks installed, and the new log line shows which `unzip` was selected.

No upstream MSYS2 report is being filed; this change stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bwWHdZEQ3R12Nz7UxrDoW