### PR TITLE
Fix: Web links carrying a config or preset parameter are no longer misread

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3755,31 +3755,65 @@ bool TBuffer::parseUriQueryParameters(const QString& uri, Mudlet::HyperlinkStyli
     qDebug() << "[OSC] Query string:" << queryString;
 #endif
 
-    // Decode the query string first, since the server percent-encodes the entire URL
-    QString decodedQueryString = QUrl::fromPercentEncoding(queryString.toUtf8());
-#if defined(DEBUG_OSC_PROCESSING)
-    qDebug() << "[OSC] Decoded query string:" << decodedQueryString;
-#endif
-
-    // Extract config= and preset= from the query string.
-    // The config value is JSON which may contain '&' characters inside strings,
-    // so we use brace-depth counting to find where the JSON object ends rather
-    // than naively splitting on '&'.
+    // Extract config= and preset= from the query string, splitting it into parameters first
+    // and decoding only the values (RFC 3986 2.4). Decoding the whole query first would turn
+    // an escaped name - %63%6F%6E%66%69%67, the escape servers are told to use for a literal
+    // "config" in a web URL - back into "config" and consume it as styling. So a key counts
+    // as reserved only when it is raw and literal, which is the same key decodeOSC() compares
+    // when deciding what to strip out of the URL it opens: both leave an escaped name as URL
+    // data. The two still divide the query into parameters differently, as decodeOSC() splits
+    // on '&' alone and the brace matching below does not.
     QString configJson;
     QString presetName;
-    QString remaining = decodedQueryString;
+    QString remaining = queryString;
 
     while (!remaining.isEmpty()) {
-        // Find config={...} using brace matching
-        if (remaining.startsWith(qsl("config={"))) {
-            int braceStart = 7; // length of "config="
+        const int ampPos = remaining.indexOf('&');
+        const int paramEnd = (ampPos == -1) ? remaining.size() : ampPos;
+        const QString laterParams = (ampPos == -1) ? QString() : remaining.mid(ampPos + 1);
+
+        // Accept '%3D' as the key/value separator as well, matching decodeOSC()
+        const int literalEq = remaining.indexOf('=');
+        const int encodedEq = remaining.indexOf(qsl("%3D"), 0, Qt::CaseInsensitive);
+        int eqPos = -1;
+        int eqLength = 0;
+        if (literalEq >= 0 && literalEq < paramEnd && (encodedEq < 0 || literalEq < encodedEq)) {
+            eqPos = literalEq;
+            eqLength = 1;
+        } else if (encodedEq >= 0 && encodedEq < paramEnd) {
+            eqPos = encodedEq;
+            eqLength = 3;
+        }
+
+        if (eqPos < 0) {
+            remaining = laterParams;
+            continue;
+        }
+
+        const QString key = remaining.left(eqPos);
+        const int valueStart = eqPos + eqLength;
+
+        if (key != qsl("config")) {
+            if (key == qsl("preset")) {
+                presetName = QUrl::fromPercentEncoding(remaining.mid(valueStart, paramEnd - valueStart).toUtf8());
+            }
+            remaining = laterParams;
+            continue;
+        }
+
+        // A config value sent as unencoded JSON can carry '&' inside its strings, so find
+        // where the object ends by brace depth rather than at the next '&'
+        int valueEnd = paramEnd;
+        if (valueStart < remaining.size() && remaining.at(valueStart) == '{') {
             int depth = 0;
             bool inString = false;
             bool escaped = false;
-            int end = -1;
+            // Stands if the scan finds no closing brace: the JSON is malformed, so take the
+            // rest as config and let the parser handle it
+            valueEnd = remaining.size();
 
-            for (int i = braceStart; i < remaining.size(); ++i) {
-                QChar ch = remaining.at(i);
+            for (int i = valueStart; i < remaining.size(); ++i) {
+                const QChar ch = remaining.at(i);
                 if (escaped) {
                     escaped = false;
                     continue;
@@ -3798,41 +3832,17 @@ bool TBuffer::parseUriQueryParameters(const QString& uri, Mudlet::HyperlinkStyli
                     } else if (ch == '}') {
                         --depth;
                         if (depth == 0) {
-                            end = i + 1;
+                            valueEnd = i + 1;
                             break;
                         }
                     }
                 }
             }
-
-            if (end > braceStart) {
-                configJson = remaining.mid(braceStart, end - braceStart);
-                // Skip past the JSON and any trailing '&'
-                remaining = (end < remaining.size() && remaining.at(end) == '&') ? remaining.mid(end + 1) : remaining.mid(end);
-            } else {
-                // Malformed JSON - take the rest as config and let the parser handle it
-                configJson = remaining.mid(braceStart);
-                remaining.clear();
-            }
-            continue;
         }
 
-        // Find the next '&' for non-config parameters
-        int ampPos = remaining.indexOf('&');
-        QString param = (ampPos == -1) ? remaining : remaining.left(ampPos);
-        remaining = (ampPos == -1) ? QString() : remaining.mid(ampPos + 1);
-
-        int eqPos = param.indexOf('=');
-        if (eqPos == -1) {
-            continue;
-        }
-
-        QString key = param.left(eqPos);
-        QString value = param.mid(eqPos + 1);
-
-        if (key == qsl("preset")) {
-            presetName = value;
-        }
+        configJson = QUrl::fromPercentEncoding(remaining.mid(valueStart, valueEnd - valueStart).toUtf8());
+        // Skip past the value and any trailing '&'
+        remaining = (valueEnd < remaining.size() && remaining.at(valueEnd) == '&') ? remaining.mid(valueEnd + 1) : remaining.mid(valueEnd);
     }
 
 #if defined(DEBUG_OSC_PROCESSING)

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -486,6 +486,122 @@ private slots:
     }
   }
 
+  // A percent-encoded reserved parameter name is ordinary URL data, not OSC 8
+  // styling - that is the escape servers are told to use to put a literal
+  // "config" or "preset" parameter in a web URL. The styling parser has to agree
+  // with the URL-stripping path above, which already keeps the encoded name.
+  void test_Osc8UrlParams_EncodedReservedNameIsNotStyling() {
+    const QString encodedConfigName = qsl("%63%6F%6E%66%69%67");
+    injectData(qsl("\x1b]8;;https://example.com/?") + encodedConfigName +
+               qsl("=%7B%22tooltip%22%3A%22URL-DATA%22%2C%22style%22%3A%7B%"
+                   "22color%22%3A%22red%22%7D%7D\x1b\\Encoded\x1b]8;;\x1b\\"));
+
+    TMainConsole *console = mpHost->mpConsole;
+    int linkId = 0;
+    for (int line = console->buffer.getLastLineNumber();
+         line >= 0 && linkId == 0; --line) {
+      linkId = console->buffer.getLinkIndexAt(line, 0);
+    }
+    QVERIFY2(linkId > 0, "Expected to find a link in the buffer");
+
+    // Had the encoded name been consumed as styling, the hint would be the
+    // config's tooltip ("URL-DATA") instead of the URL Mudlet is about to open
+    const QString tooltip = console->buffer.getLinkTooltip(linkId);
+    QCOMPARE(tooltip, qsl("Open browser to: https://example.com/?") +
+                          encodedConfigName +
+                          qsl("=%7B%22tooltip%22%3A%22URL-DATA%22%2C%22style%"
+                              "22%3A%7B%22color%22%3A%22red%22%7D%7D"));
+    QVERIFY2(!console->getLinkStore().getStyling(linkId).hasCustomStyling,
+             "Encoded 'config' must not apply custom link styling");
+
+    const QStringList commands = console->getLinkStore().getLinksConst(linkId);
+    QVERIFY2(!commands.isEmpty(), "Expected a command for the link");
+    QVERIFY2(commands.first().contains(encodedConfigName),
+             qPrintable(qsl("Expected the encoded parameter to survive into the "
+                            "opened URL: %1")
+                            .arg(commands.first())));
+  }
+
+  // The rewritten split reaches a reserved parameter through generic key
+  // matching rather than only at the head of the query, so these shapes each
+  // take a different route through it than they used to: a percent-encoded
+  // value bounded by the next '&', a reserved key that is not the first
+  // parameter, and the '%3D' separator.
+  void test_Osc8ReservedParamShapes_data() {
+    QTest::addColumn<QString>("query");
+    QTest::addColumn<QString>("expectedTooltip");
+    QTest::addColumn<QString>("mustRemainInUrl");
+
+    QTest::newRow("encoded config bounded by a later param")
+        << qsl("?config=%7B%22tooltip%22%3A%22Encoded%20config%22%7D&page=1")
+        << qsl("Encoded config") << qsl("page=1");
+    QTest::newRow("encoded config after another param")
+        << qsl("?page=1&config=%7B%22tooltip%22%3A%22Later%20config%22%7D")
+        << qsl("Later config") << qsl("page=1");
+    QTest::newRow("raw JSON config after another param")
+        << qsl("?page=1&config={\"tooltip\":\"Raw later\"}")
+        << qsl("Raw later") << qsl("page=1");
+    QTest::newRow("raw JSON config with an unencoded ampersand inside a string")
+        << qsl("?config={\"tooltip\":\"Tea & Cake\"}") << qsl("Tea & Cake")
+        << QString();
+    QTest::newRow("encoded separator")
+        << qsl("?config%3D%7B%22tooltip%22%3A%22Encoded%20separator%22%7D")
+        << qsl("Encoded separator") << QString();
+  }
+
+  void test_Osc8ReservedParamShapes() {
+    QFETCH(QString, query);
+    QFETCH(QString, expectedTooltip);
+    QFETCH(QString, mustRemainInUrl);
+
+    injectData(qsl("\x1b]8;;https://example.com/") + query +
+               qsl("\x1b\\Link\x1b]8;;\x1b\\"));
+
+    TMainConsole *console = mpHost->mpConsole;
+    int linkId = 0;
+    for (int line = console->buffer.getLastLineNumber();
+         line >= 0 && linkId == 0; --line) {
+      linkId = console->buffer.getLinkIndexAt(line, 0);
+    }
+    QVERIFY2(linkId > 0, "Expected to find a link in the buffer");
+
+    QCOMPARE(console->buffer.getLinkTooltip(linkId), expectedTooltip);
+
+    if (!mustRemainInUrl.isEmpty()) {
+      const QStringList commands = console->getLinkStore().getLinksConst(linkId);
+      QVERIFY2(!commands.isEmpty(), "Expected a command for the link");
+      QVERIFY2(commands.first().contains(mustRemainInUrl),
+               qPrintable(qsl("Expected '%1' to survive into the opened URL: %2")
+                              .arg(mustRemainInUrl, commands.first())));
+    }
+  }
+
+  // preset= is matched on its raw key by the same loop as config=, so a
+  // registered preset must still resolve while a percent-encoded name must not.
+  void test_Osc8PresetNameMatchedOnRawKeyOnly() {
+    injectData(qsl("\x1b]8;;preset:danger?config=%7B%22style%22%3A%7B%22color%"
+                   "22%3A%22red%22%7D%7D\x1b\\\x1b]8;;\x1b\\"));
+
+    TMainConsole *console = mpHost->mpConsole;
+    auto stylingFor = [&](const QString &query) {
+      injectData(qsl("\x1b]8;;https://example.com/") + query +
+                 qsl("\x1b\\Link\x1b]8;;\x1b\\"));
+      int linkId = 0;
+      for (int line = console->buffer.getLastLineNumber();
+           line >= 0 && linkId == 0; --line) {
+        linkId = console->buffer.getLinkIndexAt(line, 0);
+      }
+      return console->getLinkStore().getStyling(linkId);
+    };
+
+    QVERIFY2(stylingFor(qsl("?preset=danger")).hasCustomStyling,
+             "A registered preset named by its raw key should style the link");
+    QVERIFY2(stylingFor(qsl("?page=1&preset=danger")).hasCustomStyling,
+             "A preset should resolve when it is not the first parameter");
+    QVERIFY2(!stylingFor(qsl("?%70%72%65%73%65%74=danger")).hasCustomStyling,
+             "A percent-encoded 'preset' name is URL data, not a preset");
+  }
+
   // =====================================================================
   // OSC 8 Hyperlink Context Menu Title Tests
   // =====================================================================

--- a/test/functional_tests/TOscTest.cpp
+++ b/test/functional_tests/TOscTest.cpp
@@ -583,7 +583,16 @@ private slots:
                    "22%3A%22red%22%7D%7D\x1b\\\x1b]8;;\x1b\\"));
 
     TMainConsole *console = mpHost->mpConsole;
-    auto stylingFor = [&](const QString &query) {
+    // Returns 0 when the query produced no link at all. Each caller has to
+    // reject that before asking for styling, because getStyling() answers an
+    // unknown id with a default-constructed styling whose hasCustomStyling is
+    // false - which would let the negative assertion below pass without a link
+    // ever having been created. The buffer is cleared first for the same
+    // reason: the scan runs backwards, so a query that makes no link would
+    // otherwise find the one left by the previous query and be checked against
+    // that instead.
+    auto linkIdFor = [&](const QString &query) {
+      console->buffer.clear();
       injectData(qsl("\x1b]8;;https://example.com/") + query +
                  qsl("\x1b\\Link\x1b]8;;\x1b\\"));
       int linkId = 0;
@@ -591,14 +600,23 @@ private slots:
            line >= 0 && linkId == 0; --line) {
         linkId = console->buffer.getLinkIndexAt(line, 0);
       }
-      return console->getLinkStore().getStyling(linkId);
+      return linkId;
     };
 
-    QVERIFY2(stylingFor(qsl("?preset=danger")).hasCustomStyling,
+    const int rawKeyLink = linkIdFor(qsl("?preset=danger"));
+    QVERIFY2(rawKeyLink > 0, "No link found for ?preset=danger");
+    QVERIFY2(console->getLinkStore().getStyling(rawKeyLink).hasCustomStyling,
              "A registered preset named by its raw key should style the link");
-    QVERIFY2(stylingFor(qsl("?page=1&preset=danger")).hasCustomStyling,
+
+    const int laterParamLink = linkIdFor(qsl("?page=1&preset=danger"));
+    QVERIFY2(laterParamLink > 0, "No link found for ?page=1&preset=danger");
+    QVERIFY2(console->getLinkStore().getStyling(laterParamLink).hasCustomStyling,
              "A preset should resolve when it is not the first parameter");
-    QVERIFY2(!stylingFor(qsl("?%70%72%65%73%65%74=danger")).hasCustomStyling,
+
+    const int encodedNameLink = linkIdFor(qsl("?%70%72%65%73%65%74=danger"));
+    QVERIFY2(encodedNameLink > 0,
+             "No link found for the percent-encoded preset name");
+    QVERIFY2(!console->getLinkStore().getStyling(encodedNameLink).hasCustomStyling,
              "A percent-encoded 'preset' name is URL data, not a preset");
   }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- OSC 8 hyperlinks: a web URL's query is now split into parameters before it is percent-decoded, so a percent-encoded `config`/`preset` parameter name stays ordinary URL data instead of being consumed as link styling.
- A parameter counts as reserved only when its raw key is literally `config` or `preset` - the same key the URL-stripping path already compares.
- Reserved values are still decoded as before, and the tolerance for unencoded JSON braces (including an unencoded `&` inside a JSON string) is kept by running the brace matching over the raw query.

#### Motivation for adding to Mudlet

The wiki tells servers to percent-encode the parameter name when a web URL needs a literal `config` or `preset` parameter, but that documented escape did not work - the link got both behaviors at once, styled from the parameter and still carrying it in the opened URL.

#### Other info (issues closed, discussion etc)

Fixes #9964. Follows RFC 3986 section 2.4, which requires a URI's components to be separated before percent-encoded octets are decoded.

Found while reviewing this change and filed separately as #9965: `decodeOSC()`'s reserved-parameter stripping splits on `&` alone, so an unencoded `&` inside config JSON leaks a JSON fragment into the opened URL. Independent of this fix and untouched here.

**Test case:** send an OSC 8 link whose web URL carries a percent-encoded `config` name:

```
ESC ] 8 ; ; https://www.example.com?%63%6F%6E%66%69%67=%7B%22tooltip%22%3A%22THIS-SHOULD-BE-URL-DATA%22%7D ESC \ Example link ESC ] 8 ; ; ESC \
```

Hovering must show the full URL with the encoded name intact, not `THIS-SHOULD-BE-URL-DATA`. Covered by `test_Osc8UrlParams_EncodedReservedNameIsNotStyling`, `test_Osc8ReservedParamShapes` and `test_Osc8PresetNameMatchedOnRawKeyOnly` in `test/functional_tests/TOscTest.cpp` (`ctest -R TOscTest`).