### PR TITLE
Fix: Applying an update no longer crashes Mudlet

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -97,11 +97,17 @@ Updater::Updater(QObject* parent, QSettings* settings, bool testVersion)
     // last window closes, #9388), which means ~Updater only runs inside the
     // application's own destructor - after ~QApplication has torn down all
     // widget infrastructure. Deleting a QWidget that late corrupts the heap on
-    // Windows (#9122). aboutToQuit fires as the event loop exits, after the
-    // dialog's last-window-closed flow has finished but while the application
-    // is still fully alive, so destroy it there instead.
+    // Windows (#9122). aboutToQuit fires while the application is still fully
+    // alive, so destroy it there instead.
+    //
+    // deleteLater(), not delete: quit() emits aboutToQuit synchronously and the
+    // dialog quits when dismissed, so this can run with dialog code still on
+    // the stack (#9967). Qt flushes pending DeferredDelete events as exec()
+    // unwinds, so the dialog is still destroyed before ~QApplication.
     connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, [this]() {
-        delete updateDialog.data();
+        if (updateDialog) {
+            updateDialog->deleteLater();
+        }
     });
 #endif
 }

--- a/src/updater.h
+++ b/src/updater.h
@@ -62,10 +62,11 @@ public:
 
 private:
     std::unique_ptr<dblsqd::Feed> feed;
-    // Owned, but deleted on QCoreApplication::aboutToQuit rather than in
+    // Owned, but destroyed from QCoreApplication::aboutToQuit rather than in
     // ~Updater: the Updater is parented to the application object, so its
     // destructor runs during application teardown - too late to destroy a
-    // QWidget (#9122). QPointer nulls itself once the dialog is destroyed.
+    // QWidget (#9122). The deletion is deferred, so this stays non-null for
+    // the rest of the quit cascade (#9967).
     QPointer<dblsqd::UpdateDialog> updateDialog;
 #if !defined(Q_OS_MACOS)
     QPushButton* mpInstallOrRestart;

--- a/test/functional_tests/NewReleaseDialogTeardownTest.cpp
+++ b/test/functional_tests/NewReleaseDialogTeardownTest.cpp
@@ -44,12 +44,17 @@
  * heap. The dialog must instead be destroyed on aboutToQuit, while the
  * application is still fully alive.
  *
- * The timing is pinned from both sides: the dialog must still be alive when
+ * The timing is pinned from three sides: the dialog must still be alive when
  * the last window closes (its purpose is to offer an update at exactly that
- * point, #9388), and must be gone once the event loop has exited. Note that
- * with no update to offer the dialog's own last-window-closed handler calls
- * quit(), which in Qt 6 emits aboutToQuit synchronously - so the dialog is
- * destroyed inside that cascade, before close() even returns.
+ * point, #9388), must survive the quit it triggers itself, and must be gone
+ * once the event loop has exited.
+ *
+ * The middle one is https://github.com/Mudlet/Mudlet/issues/9967: quit() emits
+ * aboutToQuit synchronously and the dialog quits the application when it is
+ * dismissed, so an aboutToQuit handler that deletes the dialog outright frees
+ * it underneath its own dismissal - and underneath the caller that dismissed
+ * it. Applying an update does exactly that: it calls close() and then done()
+ * on the dialog, which crashed on Windows.
  *
  * QTEST_APPLESS_MAIN is used because the test itself must own the
  * QApplication lifetime to walk it through quit and destruction.
@@ -81,9 +86,8 @@ void NewReleaseDialogTeardownTest::updateDialogDestroyedBeforeApplicationTeardow
 
     // Connected before checkUpdatesOnStart() creates the dialog, so with
     // direct connections firing in connection order this probe runs before
-    // the dialog's own last-window-closed handler - the last moment the
-    // dialog is guaranteed to exist, as that handler quits when there is no
-    // update to offer and the quit destroys the dialog
+    // the dialog's own last-window-closed handler, which quits the
+    // application when there is no update to offer
     QPointer<dblsqd::UpdateDialog> dialog;
     bool dialogAliveAtLastWindowClosed = false;
     connect(app.get(), &QGuiApplication::lastWindowClosed, this, [&dialog, &dialogAliveAtLastWindowClosed]() {
@@ -102,19 +106,40 @@ void NewReleaseDialogTeardownTest::updateDialogDestroyedBeforeApplicationTeardow
     }
     QVERIFY2(dialog, "expected the Updater to have created its UpdateDialog");
 
+    // The Updater connected its own aboutToQuit handler in its constructor, so
+    // this direct connection runs straight after it and sees what it did
+    bool aboutToQuitFired = false;
+    bool dialogAliveInAboutToQuit = false;
+    connect(app.get(), &QCoreApplication::aboutToQuit, this, [&dialog, &aboutToQuitFired, &dialogAliveInAboutToQuit]() {
+        aboutToQuitFired = true;
+        dialogAliveInAboutToQuit = !dialog.isNull();
+    });
+
     auto* window = new QWidget;
     window->show();
-    QTimer::singleShot(0, app.get(), [&window]() {
+    bool dialogAliveAfterQuit = false;
+    QTimer::singleShot(0, app.get(), [&window, &dialog, &dialogAliveAfterQuit]() {
         window->close();
         delete window;
         // The dialog's own last-window-closed handler quits when no update is
         // available; quit explicitly so the test cannot hang if an update is
         // available (the dialog then shows itself and waits for the user)
         QCoreApplication::quit();
+        // Read before anything can return to the event loop: this is the
+        // window in which applying an update goes on using the dialog
+        dialogAliveAfterQuit = !dialog.isNull();
+        if (!dialog.isNull()) {
+            // the pair that crashed on Windows, in the order the updater runs it
+            dialog->close();
+            dialog->done(0);
+        }
     });
     app->exec();
 
     QVERIFY2(dialogAliveAtLastWindowClosed, "the UpdateDialog must still be alive when the last window closes so it can offer an update at that point - see #9388");
+    QVERIFY2(aboutToQuitFired, "aboutToQuit never fired, so the checks either side of it prove nothing");
+    QVERIFY2(dialogAliveInAboutToQuit, "the Updater's aboutToQuit handler must not destroy the UpdateDialog outright - see #9967");
+    QVERIFY2(dialogAliveAfterQuit, "the UpdateDialog must outlive the quit it triggers: applying an update keeps using it afterwards - see #9967");
     QVERIFY2(dialog.isNull(), "UpdateDialog must be destroyed when the application quits: deleting it any later (from ~Updater, inside the application's destructor) corrupts the heap - see #9122");
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- the update dialog is now destroyed with `deleteLater()` from the `aboutToQuit` handler instead of `delete`, so it outlives the quit it triggers itself
- Qt flushes pending `DeferredDelete` events as `exec()` unwinds, so it is still gone before `~QApplication` and #9122 stays fixed
- the teardown test now pins all three points in the dialog's lifetime, and fails without this change

#### Motivation for adding to Mudlet

Clicking **Update** crashed Mudlet on Windows every time, so everyone who updated got a crash reporter. `close()` on the dialog quits the application, `quit()` emits `aboutToQuit` synchronously, and the handler added in #9604 freed the dialog right there - underneath the code that was still dismissing it. Reproduced 3/3 in a Windows 11 VM under lldb: access violation with `rax = 0xFEEEFEEEFEEEFEEE`, the freed-heap fill pattern.

#### Other info (issues closed, discussion etc)

Fixes #9967

**Test case:** install a PTB, let it download the newer one, close Mudlet, then click Update on the dialog that appears - it should install and relaunch with no crash reporter.

Assisted-by: Claude:claude-opus-5
