### PR TITLE
add: Load profiles without connecting, with --offline

### DIFF
--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Runs the busted Lua specs the way CI's "(Linux) Run Lua tests" step does:
 # starts the HTTP, Discord IPC and MMCP peer fixtures, then drives the built
-# Mudlet through the "Mudlet self-test" profile under xvfb.
+# Mudlet through the "Mudlet self-test" profile under xvfb. --offline stops the
+# profile connecting to its game server, which is also what leaves the telnet
+# socket in the state feedTelnet() needs.
 #
 # Usage: .claude/scripts/run-lua-tests.sh [path-to-mudlet-binary]
 # Defaults to the linux-debug-nosan build. Needs the rocks and apt packages
@@ -91,7 +93,17 @@ export DBUS_SESSION_BUS_ADDRESS='disabled:'
 export TESTS_DIRECTORY="$WS/src/mudlet-lua/tests"
 export QUIT_MUDLET_AFTER_TESTS=true
 
+# Mudlet exits 0 whatever the specs did, so a failing run is only visible
+# through the marker file busted writes - the same signal CI's separate
+# "Passed Lua tests" step checks. Keep it in this run's temp directory so
+# concurrent runs cannot read each other's.
+export MUDLET_TEST_FAILURE_MARKER="$TMP/busted-tests-failed"
+
 cd "$WS"
 rc=0
-timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --mirror || rc=$?
+timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --mirror --offline || rc=$?
+if [ -e "$MUDLET_TEST_FAILURE_MARKER" ]; then
+  echo "Lua tests failed - see the busted output above."
+  rc=1
+fi
 exit $rc

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -604,7 +604,7 @@ jobs:
       # wall-clock time, so the suite needs a budget of its own: the run itself
       # takes ~75s, and the rest is headroom for a slow runner stretching those.
       timeout-minutes: 6
-      run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror
+      run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror --offline
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
@@ -651,7 +651,7 @@ jobs:
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       # The suite alone can run past a minute on the slower Intel runners
       timeout-minutes: 3
-      run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror
+      run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror --offline
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -200,7 +200,7 @@ jobs:
         fi
         echo "fixture HTTP server ready on 127.0.0.1:${MUDLET_TEST_HTTP_PORT}"
 
-        $GITHUB_WORKSPACE/build-$MSYSTEM/release/mudlet.exe --profile "Mudlet self-test"
+        $GITHUB_WORKSPACE/build-$MSYSTEM/release/mudlet.exe --profile "Mudlet self-test" --offline
 
     - name: Passed Lua tests
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -173,7 +173,7 @@ jobs:
         fi
         echo "fixture HTTP server ready on 127.0.0.1:${MUDLET_TEST_HTTP_PORT}"
 
-        $GITHUB_WORKSPACE/build-$MSYSTEM/release/mudlet.exe --profile "Mudlet self-test"
+        $GITHUB_WORKSPACE/build-$MSYSTEM/release/mudlet.exe --profile "Mudlet self-test" --offline
 
     - name: Passed Lua tests
       shell: msys2 {0}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -650,7 +650,7 @@ jobs:
       # wall-clock time, so the suite needs a budget of its own: the run itself
       # takes ~75s, and the rest is headroom for a slow runner stretching those.
       timeout-minutes: 6
-      run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror
+      run: xvfb-run --auto-servernum ${{github.workspace}}/src/mudlet --profile "Mudlet self-test" --mirror --offline
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1
@@ -697,7 +697,7 @@ jobs:
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
       # The suite alone can run past a minute on the slower Intel runners
       timeout-minutes: 3
-      run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror
+      run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror --offline
       env:
         AUTORUN_BUSTED_TESTS: 'true'
         MUDLET_TEST_MODE: 1

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8014,6 +8014,12 @@ int TLuaInterpreter::setConfig(lua_State* L)
     }
     if (key == qsl("specialForceGAOff")) {
         host.mFORCE_GA_OFF = getVerifiedBool(L, __func__, 2, "value");
+        if (host.mTelnet.getConnectionState() == QAbstractSocket::UnconnectedState) {
+            // a live session has to keep parsing with the value it connected
+            // with, so only a profile that is not connected - one opened
+            // offline, say - takes the change before the next connect does
+            host.mTelnet.cacheHostSettings();
+        }
         return success();
     }
     if (key == qsl("specialForceCharsetNegotiationOff")) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -552,6 +552,20 @@ void cTelnet::abandonHostLookup()
     }
 }
 
+// cTelnet keeps its own copies of these two Host flags. connectIt() refreshes
+// them per connection, so a profile opened offline - which never gets there -
+// has to take them when it loads, or it parses telnet on the defaults rather
+// than on what the profile saved.
+void cTelnet::cacheHostSettings()
+{
+    if (!mpHost) {
+        return;
+    }
+
+    mUSE_IRE_DRIVER_BUGFIX = mpHost->mUSE_IRE_DRIVER_BUGFIX;
+    mFORCE_GA_OFF = mpHost->mFORCE_GA_OFF;
+}
+
 void cTelnet::connectIt(const QString& address, int port)
 {
     // Set early - before the recursion-on-busy-socket block below - so the
@@ -568,8 +582,7 @@ void cTelnet::connectIt(const QString& address, int port)
     abandonHostLookup();
 
     if (mpHost) {
-        mUSE_IRE_DRIVER_BUGFIX = mpHost->mUSE_IRE_DRIVER_BUGFIX;
-        mFORCE_GA_OFF = mpHost->mFORCE_GA_OFF;
+        cacheHostSettings();
         mCycleCountMTTS = 0;
         newEnvironVariablesSent.clear();
 #if !defined(QT_NO_SSL)
@@ -5605,7 +5618,7 @@ Some data loss is likely - please mention this problem to the game admins.)",
         }
     MAIN_LOOP_END:;
         if (recvdGA) {
-            if (!mFORCE_GA_OFF) { //FIXME: isn't initialized correctly
+            if (!mFORCE_GA_OFF) {
                 mGA_Driver = true;
 
                 if (mCommands > 0) {

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -202,6 +202,7 @@ public:
     void setAutoReconnect(bool status);
     void encodingChanged(const QByteArray&);
     void set_USE_IRE_DRIVER_BUGFIX(bool b) { mUSE_IRE_DRIVER_BUGFIX = b; }
+    void cacheHostSettings();
     void setDontReconnect(bool b) { mDontReconnect = b; }
     void recordReplay();
     bool loadReplay(const QString&, QString* pErrMsg = nullptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -405,6 +405,10 @@ int main(int argc, char* argv[])
             QStringList() << qsl("o") << qsl("only"), qsl("Set Mudlet to only show this predefined MUD profile and hide all other predefined ones."), qsl("predefined_game"));
     parser.addOption(onlyPredefinedProfileToShow);
 
+    // long-only, as -o is taken by --only just above
+    const QCommandLineOption openOffline(qsl("offline"), qsl("Open the profiles loaded at startup without connecting to their game server"));
+    parser.addOption(openOffline);
+
     const QCommandLineOption steamMode(QStringList() << qsl("steammode"), qsl("Adjusts Mudlet settings to match Steam's requirements."));
     parser.addOption(steamMode);
 
@@ -446,6 +450,10 @@ int main(int argc, char* argv[])
                                                           "       -o, --only=<predefined>      make Mudlet only show the specific\n"
                                                           "                                    predefined game, may be repeated."));
         texts << appendLF.arg(QCoreApplication::translate("main", "       -f, --fullscreen             start Mudlet in fullscreen mode."));
+        texts << appendLF.arg(QCoreApplication::translate("main",
+                                                          "       --offline                    open the profiles loaded at startup\n"
+                                                          "                                    without connecting to their game\n"
+                                                          "                                    server."));
         texts << appendLF.arg(QCoreApplication::translate("main",
                                                           "       --steammode                  adjusts Mudlet settings to match\n"
                                                           "                                    Steam's requirements."));
@@ -623,6 +631,7 @@ int main(int argc, char* argv[])
     }
 
     const QStringList onlyProfiles = parser.values(onlyPredefinedProfileToShow);
+    const bool offlineProfiles = parser.isSet(openOffline);
     const bool showSplash = parser.isSet(showSplashscreen);
     QImage splashImage = mudlet::getSplashScreen(releaseVersion, publicTestVersion);
 
@@ -1084,7 +1093,7 @@ int main(int argc, char* argv[])
         });
     }
 
-    QTimer::singleShot(0ms, qApp, [cliProfiles, telnetUri]() {
+    QTimer::singleShot(0ms, qApp, [cliProfiles, telnetUri, offlineProfiles]() {
         // Migrate portable password files to secure storage before any
         // profile dialog or auto-login code runs.  The migration is
         // synchronous (uses static CredentialManager helpers) so it is
@@ -1100,7 +1109,7 @@ int main(int argc, char* argv[])
         }
 
         // Always load auto-login profiles first
-        mudlet::self()->startAutoLogin(cliProfiles);
+        mudlet::self()->startAutoLogin(cliProfiles, offlineProfiles);
 
         // Then handle telnet URI if provided
         if (!telnetUri.isEmpty()) {

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -1,9 +1,9 @@
 describe("Tests MXP handling", function()
 
   setup(function()
-    -- feedTelnet cannot negotiate MXP here as the test profile's socket is
-    -- not in the unconnected state, so force the MXP processor on instead -
-    -- that also locks secure mode, letting feedTriggers carry MXP tags
+    -- these specs carry MXP tags in through feedTriggers, so the processor is
+    -- forced on: that is what locks secure mode, which negotiating MXP with a
+    -- server would not do
     setConfig("specialForceMXPProcessorOn", true)
   end)
 

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -1182,10 +1182,10 @@ describe("Tests C++ functions in the Miscallaneous category", function()
       end)
 
       it("merges the keys it was given into an incoming GMCP table", function()
-        -- The merge only happens as GMCP or MSDP arrives from a server, and
-        -- the self-test profile's socket is never in the unconnected state that
-        -- feedTelnet() needs, so there is no way to deliver one from Lua.
-        pending("delivering GMCP to the profile needs a server connection")
+        -- The merge only happens as GMCP or MSDP arrives from a server. Now
+        -- that specs run offline, feedTelnet() can deliver a GMCP
+        -- subnegotiation itself, so this is writable - just not written yet.
+        pending("feeding the profile a GMCP subnegotiation is not written yet")
       end)
     end)
 

--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -63,11 +63,17 @@ AUTORUN_BUSTED_TESTS=true \
 MUDLET_TEST_MODE=1 \
 QUIT_MUDLET_AFTER_TESTS=true \
 TESTS_DIRECTORY=<full path>/src/mudlet-lua/tests \
-xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror
+xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror --offline
 ```
 
 A failure writes a marker file (`/tmp/busted-tests-failed` on Linux/macOS) so the
 caller can detect it.
+
+`--offline` opens the profile without connecting to its game server, which is
+what lets a spec use `feedTelnet()` - that function only injects while the telnet
+socket is unconnected. Specs that rely on it fail without the flag, so keep it on
+every invocation; when opening the profile through the GUI instead, use the
+connection dialog's **Offline** button.
 
 By default Mudlet reads and writes `~/.config/mudlet`, so two runs started at the
 same time (for example from different checkouts) share one `Mudlet self-test`
@@ -93,7 +99,7 @@ QUIT_MUDLET_AFTER_TESTS=true \
 TESTS_DIRECTORY=<full path>/src/mudlet-lua/tests \
 XDG_CONFIG_HOME="$CONFIG_DIR" \
 MUDLET_TEST_FAILURE_MARKER="$CONFIG_DIR/busted-tests-failed" \
-xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror
+xvfb-run -a ./build/src/mudlet --profile "Mudlet self-test" --mirror --offline
 ```
 
 ## Creating tests

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -411,14 +411,51 @@ describe("Trigger processing", function()
     end)
 
     -- feedTelnet only performs injection while the telnet socket is unconnected;
-    -- otherwise it refuses with nil + a message. Its successful-injection and
-    -- prompt paths cannot be exercised in busted. The type-check happens before
-    -- the connection check, so the argument-type contract is still verifiable.
+    -- otherwise it refuses with nil + a message. That is the state --offline
+    -- leaves the profile in, so the injection path runs here against the real
+    -- telnet parser.
     describe("feedTelnet contract", function()
+
+        local function feedOrExplain(data)
+            local ok, msg = feedTelnet(data)
+            assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
+        end
+
+        -- every injection below leaves the buffer somewhere the specs after it
+        -- read from, and an assert that throws would otherwise skip the restore
+        after_each(function()
+            deselect()
+            feedTelnet("\r\n")
+            setConfig("specialForceGAOff", false)
+        end)
 
         it("raises an error when the data argument is not a string", function()
             -- a table is never string-coercible, unlike a number
             assert.has_error(function() feedTelnet({}) end)
+        end)
+
+        it("runs against a profile that reports no connection", function()
+            local _, _, connected = getConnectionInfo()
+            assert.is_false(connected, "getConnectionInfo() must not report an established connection")
+        end)
+
+        it("injects server data for the telnet parser to decode", function()
+            -- reading the colour back proves the bytes travelled through the
+            -- telnet parser rather than being appended as plain text
+            feedOrExplain("\27[31mSpecFedRedLine\27[0m\r\n")
+            assert.is_true(selectString("SpecFedRedLine", 1) >= 0, "the injected line did not reach the buffer")
+            assert.are.same(color_table.ansi_red, {getFgColor()})
+        end)
+
+        it("treats a line ended by IAC GA as a prompt", function()
+            feedOrExplain("SpecFedPrompt> <T_IAC><T_GA>")
+            assert.is_true(isPrompt(), "IAC GA should have marked the fed line a prompt")
+        end)
+
+        it("stops honouring IAC GA once the profile forces GA off", function()
+            setConfig("specialForceGAOff", true)
+            feedOrExplain("SpecGaForcedOff> <T_IAC><T_GA>")
+            assert.is_false(isPrompt(), "a forced-off GA must not mark the fed line a prompt")
         end)
 
         it("refuses to inject while the socket is not unconnected", function()
@@ -1021,10 +1058,9 @@ describe("Trigger processing", function()
 
     end)
 
-    -- Prompt pipeline. Prompt-line *firing* would need feedTelnet to inject an
-    -- IAC GA, but feedTelnet is refused here because the self-test socket is not
-    -- in the unconnected state (see the feedTelnet note above), so only the
-    -- creation contracts and isPrompt's shape are exercised offline.
+    -- Prompt pipeline. Only the creation contracts are exercised here; a prompt
+    -- trigger *firing* is still untested, and the feedTelnet block above shows
+    -- how to inject the IAC GA that would need.
     describe("prompt triggers and isPrompt", function()
 
         after_each(function()
@@ -1032,9 +1068,7 @@ describe("Trigger processing", function()
             _G.TrigSpec = nil
         end)
 
-        it("isPrompt reports false when no prompt has been marked", function()
-            -- no IAC GA is ever injected in this profile, so the current line is
-            -- never a prompt
+        it("isPrompt reports false when the cursor is not on a prompt line", function()
             assert.is_false(isPrompt())
         end)
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4875,7 +4875,7 @@ void mudlet::doAutoLogin(const QString& profile_name, const bool offline)
         return;
     }
 
-    loadProfile(profile_name, true);
+    loadProfile(profile_name, !offline);
 
     slot_connectionDialogueFinished(profile_name, !offline);
     enableToolbarButtons();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4718,7 +4718,7 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
     }
 }
 
-void mudlet::startAutoLogin(const QStringList& cliProfiles)
+void mudlet::startAutoLogin(const QStringList& cliProfiles, const bool offline)
 {
     QElapsedTimer timer;
     timer.start();
@@ -4744,7 +4744,7 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
         if (!hostName.isEmpty()) {
             QElapsedTimer timer;
             timer.start();
-            doAutoLogin(hostName);
+            doAutoLogin(hostName, offline);
             hostList.removeOne(hostName);
             loadedProfiles++;
             qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed() / 1000.0 << "seconds";
@@ -4756,7 +4756,7 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
         if (val.toInt() == Qt::Checked) {
             QElapsedTimer timer;
             timer.start();
-            doAutoLogin(hostName);
+            doAutoLogin(hostName, offline);
             loadedProfiles++;
             qDebug() << "Profile" << hostName << "loaded in" << timer.elapsed() / 1000.0 << "seconds";
         }
@@ -4864,7 +4864,7 @@ void mudlet::attachDebugArea(const QString& hostname)
     smpDebugArea->hide();
 }
 
-void mudlet::doAutoLogin(const QString& profile_name)
+void mudlet::doAutoLogin(const QString& profile_name, const bool offline)
 {
     if (profile_name.isEmpty()) {
         return;
@@ -4877,7 +4877,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
 
     loadProfile(profile_name, true);
 
-    slot_connectionDialogueFinished(profile_name, true);
+    slot_connectionDialogueFinished(profile_name, !offline);
     enableToolbarButtons();
 }
 
@@ -5035,7 +5035,8 @@ void mudlet::handleTelnetUri(const QString& uri)
     }
 
     qDebug() << "mudlet::handleTelnetUri() - Auto-loading profile:" << profileName;
-    doAutoLogin(profileName);
+    // a telnet:// URI is an explicit request to connect, so --offline does not apply to it
+    doAutoLogin(profileName, false);
 
     // Reset flag after telnet:// or telnets:// URI processing is complete
     mProcessingTelnetUri = false;
@@ -5137,6 +5138,10 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
         raise();
         activateWindow();
     } else {
+        // no connectIt() on this path, so the telnet parser would otherwise run
+        // on the defaults rather than on the profile's own settings
+        pHost->mTelnet.cacheHostSettings();
+
         const QString infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
         pHost->postMessage(infoMsg);
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5038,6 +5038,14 @@ void mudlet::handleTelnetUri(const QString& uri)
     // a telnet:// URI is an explicit request to connect, so --offline does not apply to it
     doAutoLogin(profileName, false);
 
+    // doAutoLogin() skips a profile that is already open, which with --offline
+    // leaves it loaded but never dialled, so the URI is honoured here instead.
+    // A profile it just connected is past UnconnectedState by now.
+    Host* pHost = mHostManager.getHost(profileName);
+    if (pHost && pHost->mTelnet.getConnectionState() == QAbstractSocket::UnconnectedState) {
+        pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
+    }
+
     // Reset flag after telnet:// or telnets:// URI processing is complete
     mProcessingTelnetUri = false;
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -217,7 +217,7 @@ public:
     void restoreFloatingDockGeometries();
     void deleteProfileData(const QString& profile, const QString& item);
     void disableToolbarButtons();
-    void doAutoLogin(const QString&);
+    void doAutoLogin(const QString&, bool offline);
     void enableToolbarButtons();
     void updateMainWindowToolbarState();
     void updateMainWindowTitle();
@@ -311,7 +311,7 @@ public:
     // Brings up the preferences dialog and selects the tab whos objectName is
     // supplied, for the given Host - or the active one if none is given:
     void showOptionsDialog(const QString&, Host* = nullptr);
-    void startAutoLogin(const QStringList&);
+    void startAutoLogin(const QStringList&, bool offline = false);
     bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
     void setStorePasswordsSecurely(const bool storeSecurely) { mStorePasswordsSecurely = storeSecurely; }
     enums::controlsVisibility toolBarVisibility() const { return mToolbarVisibility; }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- New `--offline` command line flag: the profiles Mudlet opens at startup (`--profile`, and any flagged for autologin) load without connecting to their game server. A `telnet://` URI still connects, since that is an explicit request to.
- Every busted spec harness now passes it: `.claude/scripts/run-lua-tests.sh` and the six CI spec-run legs across Linux, macOS and Windows. Those runs no longer dial mudlet.org:23.
- An offline profile now takes the Host settings `connectIt()` copies into cTelnet, and `setConfig("specialForceGAOff")` reaches cTelnet while the profile is unconnected. Both were silently left at cTelnet's defaults, so an offline profile parsed telnet on the wrong config.

#### Motivation for adding to Mudlet

`feedTelnet()` only injects while the telnet socket is unconnected, so no spec could ever feed raw telnet bytes - three spec files carried comments saying so. This unblocks converting C++ functional tests into busted specs, which are ~30KB each instead of ~290MB of build tree, and makes the spec runs hermetic.

#### Other info (issues closed, discussion etc)

- Spec coverage for the new contract lives in `Trigger_spec.lua`'s feedTelnet block: not connected, injection accepted, an SGR-coloured line read back with its colour, `IAC GA` marking a prompt, and that marking stopping when the profile forces GA off. All of them fail without the flag.
- `run-lua-tests.sh` now returns non-zero when the specs fail; Mudlet exits 0 regardless, so a red run used to look green locally.
- `performance-analysis.yml` is deliberately untouched: it runs the display benchmark, not the specs, and its numbers are tracked over time.

**Test case:** run `.claude/scripts/run-lua-tests.sh`; it should report 3232 successes / 0 failures, and dropping `--offline` from the script should fail three of them.

Assisted-by: Claude:claude-opus-5