### PR TITLE
improve: game text draws faster by not laying out blank spaces

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -956,7 +956,9 @@ void TTextEdit::paintGraphemeForeground(QPainter& painter, const GraphemeRun& ru
     if (painter.pen().color() != effectiveFgColor) {
         painter.setPen(effectiveFgColor);
     }
-    painter.drawText(textRect, Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
+    if (grapheme.size() != 1 || grapheme.at(0) != QChar::Space || useQtUnderline || useQtOverline || useQtStrikeOut) {
+        painter.drawText(textRect, Qt::AlignCenter | Qt::TextDontClip | Qt::TextSingleLine, grapheme);
+    }
 
     // Draw custom decorations (colored underlines, overlines, strikethrough)
     drawCustomDecorations(painter, effectiveFgColor, textRect, charStyle);

--- a/test/functional_tests/GlyphOverflowTest.cpp
+++ b/test/functional_tests/GlyphOverflowTest.cpp
@@ -88,6 +88,10 @@ private:
     static const inline QStringList kTestFamilies = {qsl("Bitstream Vera Sans Mono"), qsl("Ubuntu Mono")};
     static constexpr int kFirstSize = 9;
     static constexpr int kLastSize = 30;
+    static constexpr int kSpaceRunCount = 20;
+    // Any size where the bundled families are legible; these two cases are about
+    // whether a decoration is drawn at all, not about how tall its cell is.
+    static constexpr int kDecorationSize = 14;
 
     static bool pixelIsInk(QRgb pixel, QRgb background)
     {
@@ -435,6 +439,47 @@ private slots:
         }
     }
 
+    // A blank cell has no glyph to draw, so its underline is the only thing that
+    // reaches the screen from it. Qt draws that underline as part of the text
+    // for an unlinked cell, which is what stops such a cell being skipped.
+    void test_underlinedSpacesKeepTheirUnderline()
+    {
+        Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
+        QVERIFY2(host->mpConsole->mUpperPane, "No upper pane available");
+        applyFont(host, kTestFamilies.first(), kDecorationSize);
+        const QString spaces(kSpaceRunCount, QLatin1Char(' '));
+
+        // Undecorated the same run is genuinely blank, so this pins the check
+        // below to the underline rather than to anything else on the row
+        runLua(host, qsl("clearWindow() echo('%1') echo('\\n')").arg(spaces));
+        const int blankInk = inkOnLine(host, spaces);
+        QVERIFY2(blankInk >= 0, "could not find the run of spaces in the buffer");
+        QCOMPARE(blankInk, 0);
+
+        runLua(host, qsl("clearWindow() setUnderline(true) echo('%1') setUnderline(false) echo('\\n')").arg(spaces));
+        const int underlinedInk = inkOnLine(host, spaces);
+        QVERIFY2(underlinedInk >= 0, "could not find the underlined run of spaces in the buffer");
+        QVERIFY2(underlinedInk > 0, "an underlined run of spaces rendered no ink, so its underline was lost");
+    }
+
+    // A link suppresses Qt's own underline so a custom-coloured one can be drawn
+    // separately, which means a linked blank cell is skipped and its underline
+    // can only come from the decoration pass that follows the glyph.
+    void test_linkedSpacesKeepTheirUnderline()
+    {
+        Host* host = startOfflineProfile();
+        QVERIFY2(host, "Could not start an offline profile");
+        QVERIFY2(host->mpConsole->mUpperPane, "No upper pane available");
+        applyFont(host, kTestFamilies.first(), kDecorationSize);
+        const QString spaces(kSpaceRunCount, QLatin1Char(' '));
+
+        runLua(host, qsl("clearWindow() setUnderline(true) echoLink('%1', '', 'hint', true) setUnderline(false) echo('\\n')").arg(spaces));
+        const int ink = inkOnLine(host, spaces);
+        QVERIFY2(ink >= 0, "could not find the linked run of spaces in the buffer");
+        QVERIFY2(ink > 0, "a linked, underlined run of spaces rendered no ink, so its underline was lost");
+    }
+
     void cleanup()
     {
         const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
@@ -539,6 +584,39 @@ private:
         const QImage rendered = renderPane(host);
         const int cellHeight = cellHeightOf(pane);
         return collectInk(rendered, (underscoreLine - pane->imageTopLine()) * cellHeight, cellHeight, cellWidthOf(pane));
+    }
+
+    // How many pixels of the row holding the given line differ from the console
+    // background, sampled across the columns that line occupies. -1 if the line
+    // is not in the buffer or has scrolled out of view.
+    int inkOnLine(Host* host, const QString& lineText)
+    {
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        const int line = findLine(host, lineText);
+        if (line < 0) {
+            return -1;
+        }
+        pane->forceUpdate();
+        QApplication::processEvents();
+
+        const QImage rendered = renderPane(host);
+        const int cellHeight = cellHeightOf(pane);
+        const int top = (line - pane->imageTopLine()) * cellHeight;
+        if (top < 0) {
+            return -1;
+        }
+        const QRgb background = host->mpConsole->getConsoleBgColor().rgb();
+        const int lastY = qMin(top + cellHeight, rendered.height()) - 1;
+        const int lastX = qMin(lineText.size() * cellWidthOf(pane), rendered.width()) - 1;
+        int ink = 0;
+        for (int y = top; y <= lastY; ++y) {
+            for (int x = 0; x <= lastX; ++x) {
+                if (pixelIsInk(rendered.pixel(x, y), background)) {
+                    ++ink;
+                }
+            }
+        }
+        return ink;
     }
 
     static int findLine(Host* host, const QString& text)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `TTextEdit::paintGraphemeForeground()` skips the per-cell `drawText()` call for a space that has no rule drawn through it. Measured **−6.6% of total paint time**.
- Two cases added to the existing `GlyphOverflowTest` (no new test executable): an unlinked run of underlined spaces keeps its underline, and so does a linked one.

#### Motivation for adding to Mudlet

Per-glyph `drawText()` is the single largest cost in a console repaint, and roughly a sixth of ordinary game output is spaces that put no ink on the screen yet cost nearly as much to lay out as a letter.

#### Other info (issues closed, discussion etc)

Fixes #9975, which carries the full measurements.

Where a ~3,000 µs main-console repaint goes (RelWithDebInfo, sanitizers off, driven with ANSI-coloured ASCII game output): per-glyph `drawText` 38-40%, two full-screen pixmap blits ~51%, pixmap alloc ~5%, background fills 1.7%, line layout 1.0%. A space costs ~3,206 ns to draw against ~4,119 ns for a letter — the text-layout machinery dominates and rasterising nothing is the small part.

The variant was round-robined *per paint* inside one process so both arms saw identical thermal and scheduling conditions. That mattered: sequential per-variant runs moved the baseline by 34% and at one point inverted the sign of a result.

**Why the condition tests `useQt*` and not the raw attributes.** `useQtUnderline`/`useQtOverline`/`useQtStrikeOut` are precisely "what `drawText()` will draw". A linked cell has all three false because links suppress Qt's own decorations so a custom-coloured one can be drawn instead, and wavy/dotted/dashed underlines are likewise drawn later. Those cells are therefore safe to skip, and their decorations still arrive from `drawCustomDecorations()`, which is why that call is deliberately left outside the guard rather than being skipped along with the glyph.

**Is the guard worth it, given every character pays it?** The guard costs 0.65 ns per character and saves ~3,206 ns per space, so break-even is **0.02% of characters** — one space per ~4,900, or a single space somewhere in 117 lines of 42 characters. A line with no spaces at all loses 27 ns of ~173,000 (0.016%); typical game output at ~16% spaces sits about 800x above break-even.

**Test case:**

Both new cases were confirmed to fail without the fix, and independently of each other:

| change | result |
| --- | --- |
| drop `useQtUnderline` from the condition | `test_underlinedSpacesKeepTheirUnderline` fails, the linked case still passes |
| use an early `return` instead, skipping the decoration pass | `test_linkedSpacesKeepTheirUnderline` fails, the unlinked case still passes |

`test_underlinedSpacesKeepTheirUnderline` also asserts that an *undecorated* run of spaces renders zero ink, so the underline assertion cannot pass vacuously. Full `GlyphOverflowTest`: 10 passed, 0 failed, 8.5 s (was 8 cases, ~10 s in CI, against a 600 s timeout).

Manually verified as well: underline, strikeout, overline, bold-italic, ANSI-fed and linked runs all keep an unbroken rule through their spaces; a rule over nothing but spaces still renders; and coloured backgrounds, reverse video and drag-selection still fill blank cells with no holes.