### PR TITLE
Fix: Update downloads no longer pile up in the temp directory

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -114,8 +114,58 @@ Updater::Updater(QObject* parent, QSettings* settings, bool testVersion)
 
 Updater::~Updater() = default;
 
+// A download is kept deliberately - UpdateDialog records it in settings and
+// reuses it next launch rather than fetching another 135MB - and the installer
+// copied from it on Windows has to outlive Mudlet, since the batch file only
+// runs it once Mudlet has exited. What was missing is anything to collect the
+// ones that never get reused: the installer copy, which nothing has ever
+// deleted, and downloads orphaned when Mudlet went away without recording them
+// (#9985). Those accumulated at ~135MB apiece.
+//
+// keepFilePath is the download UpdateDialog still intends to use. Everything
+// else is fair game once it has had time to be claimed - a second Mudlet may
+// have just started a download of its own, and an installer waiting for the
+// batch file to pick it up is only seconds old.
+void Updater::cleanupStaleUpdateFiles(const QString& directory, const QString& keepFilePath)
+{
+    if (directory.isEmpty()) {
+        qWarning() << "No temporary directory to clean leftover update files from";
+        return;
+    }
+
+    const QDir tempDir(directory);
+    const QStringList leftovers{qsl("mudlet-update-*"), qsl("mudlet-setup-*.exe")};
+    const QDateTime unclaimedBy = QDateTime::currentDateTime().addSecs(-3600);
+    const QString keepFile = keepFilePath.isEmpty() ? QString() : QFileInfo(keepFilePath).absoluteFilePath();
+    qint64 freedBytes = 0;
+    int removedCount = 0;
+    int failedCount = 0;
+
+    for (const QFileInfo& fileInfo : tempDir.entryInfoList(leftovers, QDir::Files)) {
+        if (fileInfo.absoluteFilePath() == keepFile || fileInfo.lastModified() > unclaimedBy) {
+            continue;
+        }
+        const qint64 fileSize = fileInfo.size();
+        if (QFile::remove(fileInfo.absoluteFilePath())) {
+            freedBytes += fileSize;
+            ++removedCount;
+        } else {
+            ++failedCount;
+        }
+    }
+
+    if (removedCount) {
+        qWarning() << "Removed" << removedCount << "leftover update file(s), freeing" << (freedBytes / 1024) << "KB";
+    }
+    if (failedCount) {
+        qWarning() << "Could not remove" << failedCount << "leftover update file(s) in" << directory << "- retrying on the next start";
+    }
+}
+
 void Updater::checkUpdatesOnStart()
 {
+    cleanupStaleUpdateFiles(QStandardPaths::writableLocation(QStandardPaths::TempLocation), dblsqd::UpdateDialog::pendingDownloadPath(mSettings));
+
 #if defined(Q_OS_MACOS)
     setupOnMacOS();
 #elif defined(Q_OS_LINUX)

--- a/src/updater.h
+++ b/src/updater.h
@@ -59,6 +59,9 @@ public:
     bool updateAutomatically() const;
     bool shouldShowChangelog();
     bool ready() const;
+    // Removes update downloads and installers left behind by previous runs
+    // (#9985). Takes the directory so it can be pointed at a test one.
+    static void cleanupStaleUpdateFiles(const QString& directory, const QString& keepFilePath);
 
 private:
     std::unique_ptr<dblsqd::Feed> feed;

--- a/src/updater/Feed.cpp
+++ b/src/updater/Feed.cpp
@@ -422,7 +422,10 @@ void Feed::handleDownloadReadyRead()
         if (extensionPos > -1) {
             fileName.insert(extensionPos, qsl("-XXXXXX"));
         }
-        mDownloadFile = new QTemporaryFile(QDir::tempPath() + qsl("/") + fileName);
+        // The prefix is what lets Updater::cleanupStaleUpdateFiles() recognise
+        // these later: the download outlives this object (setAutoRemove(false)
+        // below) and the name comes from the redirect, which is a bare GUID.
+        mDownloadFile = new QTemporaryFile(QDir::tempPath() + qsl("/mudlet-update-") + fileName);
         if (!mDownloadFile->open()) {
             qWarning() << "Failed to create temporary file for download:" << mDownloadFile->errorString();
             //: Error shown when a temporary file cannot be created for the update download. %1 is the system error message.

--- a/src/updater/UpdateDialog.cpp
+++ b/src/updater/UpdateDialog.cpp
@@ -329,6 +329,11 @@ void UpdateDialog::disableAutoShow()
     connect(qApp, &QGuiApplication::lastWindowClosed, qApp, &QCoreApplication::quit);
 }
 
+QString UpdateDialog::pendingDownloadPath(QSettings* settings)
+{
+    return settingsValue(qsl("updateFilePath"), QString(), settings).toString();
+}
+
 // "DBLSQD/" prefix retained for backward compatibility with user settings from the previous update system
 QVariant UpdateDialog::settingsValue(const QString& key, const QVariant& defaultValue, QSettings* settings)
 {

--- a/src/updater/UpdateDialog.h
+++ b/src/updater/UpdateDialog.h
@@ -57,6 +57,9 @@ public:
     void setMaxVersion(const QString& version);
     void setPreviousVersion(const QString& version);
 
+    // The download this dialog will reuse on the next launch instead of
+    // fetching it again - Updater's cleanup has to leave it alone (#9985)
+    static QString pendingDownloadPath(QSettings* settings);
     static bool autoDownloadEnabled(QVariant defaultValue, QSettings* settings);
     static bool autoDownloadEnabled(QSettings* settings);
     static void enableAutoDownload(bool enabled, QSettings* settings);

--- a/test/functional_tests/NewReleaseDialogTeardownTest.cpp
+++ b/test/functional_tests/NewReleaseDialogTeardownTest.cpp
@@ -24,7 +24,9 @@
 #include <QtTest/QtTest>
 
 #include <QApplication>
+#include <QDateTime>
 #include <QPointer>
+#include <QScopeGuard>
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTemporaryDir>
@@ -34,6 +36,9 @@
 #include <memory>
 
 /*
+ * What the Updater has to clean up after itself: the dialog it owns, and the
+ * files it leaves in the temp directory.
+ *
  * Regression test for https://github.com/Mudlet/Mudlet/issues/9122:
  * STATUS_HEAP_CORRUPTION at application close on Windows.
  *
@@ -65,7 +70,51 @@ class NewReleaseDialogTeardownTest : public QObject
 
 private slots:
     void updateDialogDestroyedBeforeApplicationTeardown();
+    void staleUpdateFilesAreSweptAtStartup();
 };
+
+/*
+ * Regression test for https://github.com/Mudlet/Mudlet/issues/9985: nothing ever
+ * deleted the installer copied for the batch file to run, nor a download Mudlet
+ * went away without recording, so each update left ~135MB in the temp directory.
+ *
+ * What must survive matters as much as what goes: UpdateDialog records a
+ * download and reuses it on the next launch, and an installer waiting for the
+ * batch file is seconds old - sweeping either turns a disk fix into a 135MB
+ * re-download or a lost update.
+ */
+void NewReleaseDialogTeardownTest::staleUpdateFilesAreSweptAtStartup()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    const QStringList leftovers{qsl("mudlet-update-Mudlet-5.0.0-linux-x64.AppImage-abc123.tar"), qsl("mudlet-update-81fcfb86-2e9a-40f5-8f40-42fd5f689e5c.SDYFjK"), qsl("mudlet-setup-1786938971.exe")};
+    const QStringList bystanders{qsl("mudlet-update.bat"), qsl("mudlet_updated_at"), qsl("setup.exe"), qsl("Mudlet-5.0.0-windows-64-installer.exe")};
+    const QString pendingDownload = qsl("mudlet-update-still-wanted.exe");
+    const QString justCopiedInstaller = qsl("mudlet-setup-1786999999.exe");
+
+    const QDateTime longEnoughAgo = QDateTime::currentDateTime().addSecs(-7200);
+    for (const QString& name : leftovers + bystanders + QStringList{pendingDownload}) {
+        QFile file(tempDir.filePath(name));
+        QVERIFY2(file.open(QIODevice::WriteOnly), qPrintable(name));
+        QVERIFY(file.setFileTime(longEnoughAgo, QFileDevice::FileModificationTime));
+        file.close();
+    }
+    QFile freshFile(tempDir.filePath(justCopiedInstaller));
+    QVERIFY(freshFile.open(QIODevice::WriteOnly));
+    freshFile.close();
+
+    Updater::cleanupStaleUpdateFiles(tempDir.path(), tempDir.filePath(pendingDownload));
+
+    for (const QString& name : leftovers) {
+        QVERIFY2(!QFile::exists(tempDir.filePath(name)), qPrintable(qsl("%1 should have been swept - see #9985").arg(name)));
+    }
+    for (const QString& name : bystanders) {
+        QVERIFY2(QFile::exists(tempDir.filePath(name)), qPrintable(qsl("%1 is not ours to delete").arg(name)));
+    }
+    QVERIFY2(QFile::exists(tempDir.filePath(pendingDownload)), "the download UpdateDialog means to reuse must survive, or every launch re-downloads it");
+    QVERIFY2(QFile::exists(tempDir.filePath(justCopiedInstaller)), "an installer this recent may still be waiting for the batch file that runs it");
+}
 
 void NewReleaseDialogTeardownTest::updateDialogDestroyedBeforeApplicationTeardown()
 {
@@ -75,6 +124,24 @@ void NewReleaseDialogTeardownTest::updateDialogDestroyedBeforeApplicationTeardow
 
     QTemporaryDir settingsDir;
     QVERIFY(settingsDir.isValid());
+
+    // Test mode does not redirect TempLocation, and checkUpdatesOnStart() sweeps
+    // leftover update files out of it - point it somewhere disposable so a real
+    // pending update on this machine is not collected by the test run (#9985)
+    QTemporaryDir sweepableTempDir;
+    QVERIFY(sweepableTempDir.isValid());
+    // TMPDIR is what Qt reads on Unix, TMP and TEMP on Windows
+    const QList<QByteArray> tempVariables{"TMPDIR", "TMP", "TEMP"};
+    QList<QByteArray> realTempDirs;
+    for (const QByteArray& variable : tempVariables) {
+        realTempDirs.append(qgetenv(variable.constData()));
+        qputenv(variable.constData(), sweepableTempDir.path().toLocal8Bit());
+    }
+    const auto restoreTempDirs = qScopeGuard([&tempVariables, &realTempDirs]() {
+        for (int i = 0; i < tempVariables.size(); ++i) {
+            qputenv(tempVariables.at(i).constData(), realTempDirs.at(i));
+        }
+    });
     QSettings settings(settingsDir.filePath(qsl("updater-test.ini")), QSettings::IniFormat);
 
     int argc = 1;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- sweeps leftover update files out of the temp directory at startup: the installer copy nothing has ever deleted, and downloads Mudlet went away without recording
- gives the download a `mudlet-update-` name so it can be told apart from everyone else's temp files - the redirect names it after a bare GUID
- leaves alone the download the update dialog means to reuse next launch, and anything less than an hour old, since an installer waiting for its batch file is seconds old

#### Motivation for adding to Mudlet

Measured on a Windows 11 VM with the temp directory emptied first: applying an update leaves `mudlet-setup-<epoch>.exe` at 135,100,240 bytes, and closing without applying leaves the download at the same size. Neither is ever removed. A day of update testing accumulated 1,553 MB.

#### Other info (issues closed, discussion etc)

Fixes #9985

**Test case:** update Mudlet, quit, and start it again an hour later - `%TEMP%` should no longer be holding `mudlet-setup-*.exe`, while an update you downloaded but declined still gets reused instead of downloaded again.

Assisted-by: Claude:claude-opus-5
