### PR TITLE
infrastructure: Build several functional tests into one executable

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -20,8 +20,6 @@ set(FUNCTIONAL_TEST_SOURCES
     dlgTriggerEditorUndoRedoTest.cpp
     EditorBannerViewSwitchTest.cpp
     TDiscordModeTest.cpp
-    WindowStateGettersTest.cpp
-    MainConsoleSelectionTest.cpp
     WindowLayoutSaveTest.cpp
     TelnetCharsetNegotiationTest.cpp
     MapAreaReassignmentTest.cpp
@@ -44,7 +42,6 @@ set(FUNCTIONAL_TEST_SOURCES
     VariableEditorWriteBackTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
     SetScriptCallbackTest.cpp
-    MainWindowSizeReportTest.cpp
     ProfileSaveShutdownRaceTest.cpp
     XMLexportVariablesTest.cpp
     ProfileRoundTripTest.cpp
@@ -62,7 +59,6 @@ set(FUNCTIONAL_TEST_SOURCES
     StarterUiSectionsTest.cpp
     TtsInterruptingSpeakTest.cpp
     TelnetConnectLookupRaceTest.cpp
-    NarrowWindowWrapTest.cpp
     HostWidgetDecouplingTest.cpp
     ActionSelfRemovalTest.cpp
     ProfileFolderNameTest.cpp
@@ -77,7 +73,6 @@ set(FUNCTIONAL_TEST_SOURCES
     StarterUiGaugePanelTest.cpp
     ProfileSwitchShortcutTest.cpp
     ExperiencedPlayerGateTest.cpp
-    WindowBackgroundTest.cpp
     EmbeddedMapperCreationTest.cpp
 )
 
@@ -92,17 +87,39 @@ if(USE_UPDATER)
     list(APPEND FUNCTIONAL_TEST_SOURCES FeedChecksumRaceTest.cpp)
 endif()
 
+# Tests that share one executable rather than getting one each. A functional
+# test binary statically links mudlet_core and costs a build tree ~250MB plus a
+# link step, and none of that is per-test - so tests of one subsystem are built
+# together and told on the command line which class to run. See GroupedTest.h.
+#
+# A new window or console test belongs here rather than in
+# FUNCTIONAL_TEST_SOURCES, and writes MUDLET_GROUPED_TEST_MAIN() rather than
+# QTEST_MAIN(). Its class name has to match its filename, since that is the name
+# ctest passes on the command line and the group binary looks up.
+set(WINDOW_GROUP_TEST_SOURCES
+    MainConsoleSelectionTest.cpp
+    MainWindowSizeReportTest.cpp
+    NarrowWindowWrapTest.cpp
+    WindowBackgroundTest.cpp
+    WindowStateGettersTest.cpp
+)
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
 )
 
+# mudlet_lsan_hooks has to be linked explicitly, see src/CMakeLists.txt
+macro(add_functional_test_binary target)
+    add_executable(${target} ${ARGN} ${FUNCTIONAL_TEST_UTILS})
+    add_dependencies(${target} ${LIB_MUDLET_TARGET})
+    target_link_libraries(${target} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
+    set_target_properties(${target} PROPERTIES ENABLE_EXPORTS ON)
+endmacro()
+
 # Manual replay tool for verifying mUndoServerWrap against captured game
 # output - built but deliberately not registered with ctest:
-add_executable(UndoServerWrapReplay UndoServerWrapReplay.cpp ${FUNCTIONAL_TEST_UTILS})
-add_dependencies(UndoServerWrapReplay ${LIB_MUDLET_TARGET})
-target_link_libraries(UndoServerWrapReplay PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
-set_target_properties(UndoServerWrapReplay PROPERTIES ENABLE_EXPORTS ON)
+add_functional_test_binary(UndoServerWrapReplay UndoServerWrapReplay.cpp)
 
 # Report-only perf harness for manual before/after comparisons
 # (test/compare-perf-baseline.py runs the built binary directly). Built with the
@@ -111,10 +128,7 @@ set_target_properties(UndoServerWrapReplay PROPERTIES ENABLE_EXPORTS ON)
 # so running it every CI pipeline only burns minutes. -DREGISTER_PERF_BENCHMARK=ON
 # also registers it with ctest.
 option(REGISTER_PERF_BENCHMARK "Register the report-only PipelineBenchmark with ctest (it is built either way)" OFF)
-add_executable(PipelineBenchmark PipelineBenchmark.cpp ${FUNCTIONAL_TEST_UTILS})
-add_dependencies(PipelineBenchmark ${LIB_MUDLET_TARGET})
-target_link_libraries(PipelineBenchmark PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
-set_target_properties(PipelineBenchmark PROPERTIES ENABLE_EXPORTS ON)
+add_functional_test_binary(PipelineBenchmark PipelineBenchmark.cpp)
 if(REGISTER_PERF_BENCHMARK)
     add_test(NAME PipelineBenchmark COMMAND $<TARGET_FILE:PipelineBenchmark>)
     # large corpus fed repeatedly, so allow a generous timeout
@@ -142,13 +156,24 @@ else()
     set(leakCheckAvailable FALSE)
 endif()
 
-# mudlet_lsan_hooks has to be linked explicitly, see src/CMakeLists.txt
+set(allFunctionalTestNames "")
+
 foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
     get_filename_component(test_name ${test_file} NAME_WE)
-    add_executable(${test_name} ${test_file} ${FUNCTIONAL_TEST_UTILS})
-    add_dependencies(${test_name} ${LIB_MUDLET_TARGET})
-    target_link_libraries(${test_name} PRIVATE Qt6::Test ${LIB_MUDLET_TARGET} mudlet_lsan_hooks)
-    set_target_properties(${test_name} PROPERTIES ENABLE_EXPORTS ON)
+    add_functional_test_binary(${test_name} ${test_file})
+    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+    list(APPEND allFunctionalTestNames ${test_name})
+endforeach()
+
+add_functional_test_binary(functional_window_tests GroupedTestMain.cpp ${WINDOW_GROUP_TEST_SOURCES})
+foreach(test_file ${WINDOW_GROUP_TEST_SOURCES})
+    get_filename_component(test_name ${test_file} NAME_WE)
+    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:functional_window_tests> ${test_name})
+    list(APPEND allFunctionalTestNames ${test_name})
+endforeach()
+
+# Both lists' cases, so a grouped test's properties are the solo ones verbatim
+foreach(test_name ${allFunctionalTestNames})
     if(leakCheckAvailable AND NOT test_name IN_LIST leakCheckExcludedTests)
         # intercept_tls_get_addr=0 is what stops the tracer crash of #9809, at
         # the cost of not scanning dynamic TLS blocks for roots. Up to GCC 13 and
@@ -177,7 +202,6 @@ foreach(test_file ${FUNCTIONAL_TEST_SOURCES})
         set(leakCheck "detect_leaks=0")
         set(leakLog "")
     endif()
-    add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
     set_tests_properties(${test_name} PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen;${leakLog}ASAN_OPTIONS=${leakCheck}"
         LABELS "functional"

--- a/test/functional_tests/GroupedTest.h
+++ b/test/functional_tests/GroupedTest.h
@@ -1,0 +1,75 @@
+#ifndef MUDLET_GROUPEDTEST_H
+#define MUDLET_GROUPEDTEST_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+
+#include "utils.h"
+
+// Every functional test executable statically links mudlet_core, which costs a
+// build tree ~250MB and a link step each. Tests that can share one binary use
+// MUDLET_GROUPED_TEST_MAIN() in place of QTEST_MAIN(): instead of defining
+// main() it hands GroupedTestMain.cpp's main() a function that runs this one
+// class, and that main() runs exactly the class named on the command line.
+//
+// So a grouped ctest case is still its own process, with its own QApplication
+// and untouched static state - only the link is shared. Qt has the same idea
+// behind QTEST_BATCH_TESTS, but the official Qt binaries are built with
+// QT_FEATURE_batch_test_support off, so the registry has to be ours.
+namespace GroupedTest {
+
+using EntryFunction = int (*)(int, char**);
+
+void registerCase(const char* name, EntryFunction entry);
+
+// Registration has to have happened by the time main() runs, so it rides on the
+// constructor of the file-scope object the macro below declares.
+struct Registrar
+{
+    Registrar(const char* name, EntryFunction entry) { registerCase(name, entry); }
+};
+
+} // namespace GroupedTest
+
+// The body is QTEST_MAIN's, less its Qt-selftest coverage hook, so a grouped run
+// sets up what QTEST_MAIN sets up in the same order. QTEST_MAIN_SETUP() and
+// QTEST_SET_MAIN_SOURCE_PATH come from qtest.h; the first picks QApplication
+// over QCoreApplication from the Qt libraries this translation unit sees and the
+// second reads __FILE__, so both have to expand in the test's own file rather
+// than in main().
+//
+// The application name is the one thing sharing a binary would otherwise change:
+// QStandardPaths::AppConfigLocation is built from it, and Mudlet keeps profile
+// encryption keys and passwords under there, so leaving it at the executable's
+// name would give a whole group one store instead of a test each.
+#define MUDLET_GROUPED_TEST_MAIN(TestObject)                                                                                                                                                           \
+    static int run##TestObject(int argc, char* argv[])                                                                                                                                                 \
+    {                                                                                                                                                                                                  \
+        QT_PREPEND_NAMESPACE(QTest::Internal::callInitMain)<TestObject>();                                                                                                                             \
+        QTEST_MAIN_SETUP()                                                                                                                                                                             \
+        app.setApplicationName(qsl(#TestObject));                                                                                                                                                      \
+        TestObject tc;                                                                                                                                                                                 \
+        QTEST_SET_MAIN_SOURCE_PATH                                                                                                                                                                     \
+        return QTest::qExec(&tc, argc, argv);                                                                                                                                                          \
+    }                                                                                                                                                                                                  \
+    static const GroupedTest::Registrar registrar##TestObject(#TestObject, &run##TestObject);
+
+#endif // MUDLET_GROUPEDTEST_H

--- a/test/functional_tests/GroupedTestMain.cpp
+++ b/test/functional_tests/GroupedTestMain.cpp
@@ -1,0 +1,98 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// main() for every grouped functional test binary - see GroupedTest.h for the
+// shape and why it exists.
+
+#include "GroupedTest.h"
+
+#include <QLatin1Char>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+
+#include <cstdio>
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+
+namespace {
+
+// Function-local, so it is built on first use: the registrars are file-scope
+// objects in other translation units, and nothing orders their construction
+// against a file-scope container here.
+QMap<QString, GroupedTest::EntryFunction>& registry()
+{
+    static QMap<QString, GroupedTest::EntryFunction> cases;
+    return cases;
+}
+
+// A Qt Resource Collection in a static library only reaches the executable if
+// something on the executable's side names it, and a binary that does not runs
+// quietly on without its resources, bundled fonts included. Doing it here means
+// a grouped test cannot forget to. src/main.cpp registers them in this same
+// spot, before the QApplication exists.
+void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+} // namespace
+
+void GroupedTest::registerCase(const char* name, EntryFunction entry)
+{
+    registry().insert(QString::fromUtf8(name), entry);
+}
+
+int main(int argc, char* argv[])
+{
+    initializeQRCResources();
+
+    // Reporting the names and then exiting non-zero rather than succeeding: an
+    // add_test() that forgot to pass one would otherwise be a green ctest case
+    // that ran no test at all.
+    if (argc < 2 || !registry().contains(QString::fromUtf8(argv[1]))) {
+        fprintf(stderr,
+                "%s runs one test class per invocation, named as its first argument.\n"
+                "usage: %s <test class> [Qt Test arguments]\n"
+                "this binary holds: %s\n",
+                argv[0],
+                argv[0],
+                qUtf8Printable(QStringList(registry().keys()).join(QLatin1Char(' '))));
+        return 2;
+    }
+
+    // qExec skips argv[0] and reads every later argument that is not an option
+    // as a test function to run, so the class name has to take argv[0]'s place
+    // rather than stay in front of the arguments meant for it.
+    return registry().value(QString::fromUtf8(argv[1]))(argc - 1, argv + 1);
+}

--- a/test/functional_tests/MainConsoleSelectionTest.cpp
+++ b/test/functional_tests/MainConsoleSelectionTest.cpp
@@ -30,14 +30,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResources();
+using namespace std::chrono_literals;
 
 // Regression test for #3922: left-clicking into the main console to give it
 // focus must not leave a one-character selection behind. Such a stray
@@ -83,8 +78,6 @@ private:
     }
 
 private slots:
-    void initTestCase() { initializeQRCResources(); }
-
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
@@ -247,20 +240,5 @@ private:
     }
 };
 
-void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MainConsoleSelectionTest.moc"
-QTEST_MAIN(MainConsoleSelectionTest)
+MUDLET_GROUPED_TEST_MAIN(MainConsoleSelectionTest)

--- a/test/functional_tests/MainWindowSizeReportTest.cpp
+++ b/test/functional_tests/MainWindowSizeReportTest.cpp
@@ -31,14 +31,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForMainWindowSizeReportTest();
+using namespace std::chrono_literals;
 
 // getMainWindowSize() is what Geyser, the Lua function of the same name and MXP
 // frame placement all measure against, so a report that stops following the
@@ -102,8 +97,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForMainWindowSizeReportTest();
-
         mpServer = new TelnetServerStub(qApp);
         mpServer->start(mLocalhost, 0);
         mPort = QString::number(mpServer->serverPort());
@@ -288,20 +281,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForMainWindowSizeReportTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MainWindowSizeReportTest.moc"
-QTEST_MAIN(MainWindowSizeReportTest)
+MUDLET_GROUPED_TEST_MAIN(MainWindowSizeReportTest)

--- a/test/functional_tests/NarrowWindowWrapTest.cpp
+++ b/test/functional_tests/NarrowWindowWrapTest.cpp
@@ -33,12 +33,7 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResources();
+#include "GroupedTest.h"
 
 // A wrap width that cannot hold a single glyph - because it is zero, because
 // the glyph is wider than the width, or because the indentation uses the width
@@ -61,8 +56,6 @@ private:
     const QString mWideText = QString(QChar(0x6F22)) + QChar(0x5B57);
 
 private slots:
-    void initTestCase() { initializeQRCResources(); }
-
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
@@ -379,20 +372,5 @@ private:
     }
 };
 
-void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "NarrowWindowWrapTest.moc"
-QTEST_MAIN(NarrowWindowWrapTest)
+MUDLET_GROUPED_TEST_MAIN(NarrowWindowWrapTest)

--- a/test/functional_tests/WindowBackgroundTest.cpp
+++ b/test/functional_tests/WindowBackgroundTest.cpp
@@ -32,6 +32,8 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
+#include "GroupedTest.h"
+
 extern "C" {
 #if defined(INCLUDE_VERSIONED_LUA_HEADERS)
 #include <lua5.1/lua.h>
@@ -41,13 +43,6 @@ extern "C" {
 }
 
 using namespace std::chrono_literals;
-
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForWindowBackgroundTest();
 
 // Covers the full-window background feature added in #9394.
 class WindowBackgroundTest : public QObject
@@ -124,8 +119,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForWindowBackgroundTest();
-
         QVERIFY(mImageDir.isValid());
 
         mpServer = new TelnetServerStub(qApp);
@@ -395,20 +388,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForWindowBackgroundTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "WindowBackgroundTest.moc"
-QTEST_MAIN(WindowBackgroundTest)
+MUDLET_GROUPED_TEST_MAIN(WindowBackgroundTest)

--- a/test/functional_tests/WindowStateGettersTest.cpp
+++ b/test/functional_tests/WindowStateGettersTest.cpp
@@ -38,14 +38,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForWindowStateGettersTest();
+using namespace std::chrono_literals;
 
 class WindowStateGettersTest : public QObject
 {
@@ -70,8 +65,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForWindowStateGettersTest();
-
         mpServer = new TelnetServerStub(qApp);
         mpServer->start(mLocalhost, 0);
         mPort = QString::number(mpServer->serverPort());
@@ -216,20 +209,5 @@ private:
     }
 };
 
-void initializeQRCResourcesForWindowStateGettersTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "WindowStateGettersTest.moc"
-QTEST_MAIN(WindowStateGettersTest)
+MUDLET_GROUPED_TEST_MAIN(WindowStateGettersTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `MUDLET_GROUPED_TEST_MAIN()` replaces `QTEST_MAIN()` in a test file: rather than defining `main()` it registers the class with the one `main()` in `GroupedTestMain.cpp`, so several tests can share an executable. That `main()` runs exactly the class named as its first argument, and each test keeps its own `add_test` entry - so every ctest case still runs in its own process, with its own `QApplication` and untouched statics. Only the link is shared.
- Applies it to five window/console tests, as `functional_window_tests`. All 115 ctest case names and every one of their properties - timeouts, sanitizer environment, labels, leak-check membership - are unchanged.
- The group's `main()` registers the Qt resource collections once, where `src/main.cpp` does, so each test's own copy of `initializeQRCResources()` goes away. Two of the five were non-static and would have collided at link time, and a grouped test can no longer forget to register the bundled fonts.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree, and there are 77 of them taking up 20GB.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` - `ctest -N` lists the same 115 names as before and `ctest --show-only=json-v1` reports zero property differences, while the tree drops from 77 executables and 24GB to 73 and 23GB.

Mutation-checked both ways: dropping `name.isEmpty() ||` from `Host::windowGeometry()` reddens `WindowStateGettersTest` alone, and removing the #3922 guard in `TTextEdit::mouseMoveEvent()` reddens `MainConsoleSelectionTest` alone. Under `linux-debug` the grouped binary carries the LSan hooks as a solo one does, and a deliberate 1MB leak in one grouped class still fails that case with the other four green.

One doc follow-up for a maintainer: `CLAUDE.md`'s Tests section still says "Each functional test is its own executable ... ~290MB", which is no longer true of the five in this group. `test/functional_tests/CMakeLists.txt` carries the instructions for adding a window/console test in the meantime.

Assisted-by: Claude:claude-opus-5