### PR TITLE
infrastructure: Functional tests bind an ephemeral port instead of fixed ones

### DIFF
--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -53,7 +53,7 @@ class ActionSelfRemovalTest : public QObject
 private:
     TelnetServerStub* mpServer = nullptr;
     const QString mpHostname = "Test-ActionSelfRemoval";
-    const QString mpPort = "4009";
+    QString mpPort; // assigned the stub's actual ephemeral port in init()
     const QString mpLocalhost = "localhost";
 
     // Builds a package the way an installed package with a toolbar button is laid
@@ -109,7 +109,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mpPort.toUShort());
+        mpServer->start(mpLocalhost, 0);
+        mpPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/ProfileRoundTripTest.cpp
+++ b/test/functional_tests/ProfileRoundTripTest.cpp
@@ -103,7 +103,7 @@ private:
     Host* mpTarget = nullptr;
     const QString mSourceName = qsl("ProfileRoundTrip-Test");
     const QString mTargetName = qsl("ProfileRoundTripTarget-Test");
-    const QString mPort = qsl("4013");
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
     const QString mLocalhost = qsl("localhost");
     QTemporaryDir mSaveDir;
 
@@ -456,7 +456,8 @@ private slots:
         initializeQRCResourcesForProfileRoundTripTest();
 
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mLocalhost, mPort.toUShort());
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/TMediaLoopTest.cpp
+++ b/test/functional_tests/TMediaLoopTest.cpp
@@ -96,7 +96,7 @@ private:
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
     const QString mHostname = "Test-Media-Loop";
-    const QString mPort = "4012";
+    QString mPort; // assigned the stub's actual ephemeral port in init()
     const QString mLocalhost = "localhost";
 
     // Length of the generated clip. Long enough that "still playing" cannot be an
@@ -135,7 +135,8 @@ private slots:
     void init()
     {
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mLocalhost, mPort.toUShort());
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));

--- a/test/functional_tests/UndoServerWrapReplay.cpp
+++ b/test/functional_tests/UndoServerWrapReplay.cpp
@@ -27,7 +27,7 @@
 //   REPLAY_OUT     - path to write buffer dump to (required)
 //   REPLAY_UNWRAP  - "1" to enable mUndoServerWrap (default off)
 //   REPLAY_WIDTH   - wrap column to undo (default 80)
-//   REPLAY_PORT    - local stub port (default 4010)
+//   REPLAY_PORT    - local stub port (default: an ephemeral OS-assigned one)
 
 #include <QtTest/QtTest>
 
@@ -64,10 +64,12 @@ private slots:
 
     void init()
     {
-        mPort = qEnvironmentVariable("REPLAY_PORT", qsl("4010"));
-        mProfileName = qsl("Replay-%1").arg(mPort);
+        // An unset or unparseable REPLAY_PORT gives 0, which the stub takes as
+        // "any free port", so concurrent replays share neither socket nor profile.
         mpServer = new TelnetServerStub(qApp);
-        mpServer->start(mpLocalhost, mPort.toUShort());
+        mpServer->start(mpLocalhost, qEnvironmentVariable("REPLAY_PORT").toUShort());
+        mPort = QString::number(mpServer->serverPort());
+        mProfileName = qsl("Replay-%1").arg(mPort);
         mudlet::start();
         mudlet::self()->setupConfig();
         mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `ActionSelfRemovalTest`, `TMediaLoopTest` and `ProfileRoundTripTest` bound the fixed ports 4009, 4012 and 4013. They now bind port 0 and feed the profile whatever `serverPort()` reports, the idiom the rest of `test/functional_tests/` already uses.
- The manual `UndoServerWrapReplay` tool defaults to an ephemeral port too, its per-run profile name following it. `REPLAY_PORT` still pins a port when set, so the existing replay harness is unaffected.
- No `TelnetServerStub::start()` call site in the suite binds a fixed port after this.

#### Motivation for adding to Mudlet

Two test runs on one machine (two worktrees, or two CI legs on a shared runner) fought over the same socket, and the loser silently connected to the winner's stub instead of failing.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` is 115/115 green; each affected test passes five runs in a row, and two concurrent instances of each pass together, where the pre-change ActionSelfRemovalTest logs "The bound address is already in use" on the second instance. Feeding a deliberately wrong port makes both ActionSelfRemovalTest and ProfileRoundTripTest fail, so the port really is load-bearing.

Assisted-by: Claude:claude-opus-5
