### PR TITLE
infra: measure the display in PipelineBenchmark, and make its corpus realistic

### DIFF
--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -63,9 +63,12 @@ unrepresentative line length biases every number:
 
 Retuning it is legitimate, but it **moves every absolute number the benchmark
 reports**, so `kCorpusVersion` in `PipelineBenchmark.cpp` must be bumped with any
-change to `generateCorpus()`. The compare script treats `corpus_version` as an
-invariant and refuses a comparison across a change to it, rather than reporting
-the corpus difference as a code regression.
+change to `generateCorpus()`. The benchmark checks the corpus against the byte
+count that version is known to produce and fails at startup if they disagree, so
+an unbumped edit - or a line shape accidentally left without a `switch` case,
+which these builds are too permissive to warn about - cannot silently reshape the
+corpus. The compare script then treats `corpus_version` as an invariant and
+refuses a comparison across a change to it.
 
 ## How to run
 
@@ -112,6 +115,7 @@ METRIC defaults_peak_rss_kb ...
 METRIC display_paints_per_sec ...
 METRIC display_paint_ms ...
 METRIC display_rows_per_paint ...
+METRIC display_cols_per_paint ...
 METRIC display_lines_per_sec ...
 ```
 
@@ -205,10 +209,14 @@ Because it is the arbiter of the gate, the script refuses (exit code 2) rather
 than silently passing whenever it cannot trust the comparison:
 
 - an invariant (`text_corpus_lines`, `text_corpus_bytes`, `trigger_count`,
-  `build_asan`, `corpus_version`) is missing from either run, or differs between
-  them - the two runs used different corpora, trigger sets or build flavours.
-  `build_asan` specifically stops an ASan build being compared against a release
-  build, and `corpus_version` stops a comparison across a retuned corpus.
+  `build_asan`, `corpus_version`, `display_rows_per_paint`,
+  `display_cols_per_paint`) is missing from either run, or differs between them -
+  the two runs used different corpora, trigger sets, screen geometry or build
+  flavours. `build_asan` specifically stops an ASan build being compared against
+  a release build, `corpus_version` stops a comparison across a retuned corpus,
+  and the two `display_*` invariants stop one across a differently-sized screen.
+  Because the invariants come from several slots, compare **full runs**: a
+  single-slot run on both sides is refused for the missing ones.
 - a **gated** metric is missing from either run, or its "before" value is not
   positive (a valid throughput/time baseline must be greater than zero).
 - a `--gate` name matches no metric in either run (usually a typo).
@@ -246,9 +254,14 @@ the pane is unclipped rather than trusting that.
 `display_lines_per_sec` is `display_paints_per_sec` multiplied by the rows on
 screen, which makes it directly comparable to `text_lines_per_sec` - and worth
 comparing, because the display is by a wide margin the narrowest part of the
-pipeline. `display_rows_per_paint` records the rows the paint path actually
-drew; it depends on the font, so it is reported rather than treated as an
-invariant.
+pipeline.
+
+`display_rows_per_paint` and `display_cols_per_paint` record the size of the
+drawn screen, and are **invariants**: they move with the font metrics and the
+surrounding layout, so two builds reporting different ones did not draw the same
+workload, and comparing their throughput would report a geometry difference as a
+code change. That is the same role `text_corpus_lines` and `text_corpus_bytes`
+play for the text bench.
 
 The slot runs last so that its render target and the paint path's cached screen
 pixmap fall outside both `peak_rss_kb` and `defaults_peak_rss_kb`, whose

--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -33,7 +33,7 @@ so the Lua `feedTriggers()` entry point is covered too) - and measures:
 It is **report-only**: it makes no timing assertions (absolute speed varies
 wildly between machines and CI runners) and always passes as long as the
 pipeline actually processed data - which is genuinely asserted: each phase
-verifies the console buffer filled to its scrollback cap, the trigger phase
+verifies the console buffer filled with thousands of lines, the trigger phase
 verifies every trigger compiled and registered, and an untimed sentinel trigger
 proves the trigger engine consumes what the loopback path feeds. A
 silently-disconnected pipeline fails the run instead of reporting

--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -12,19 +12,21 @@ explains how to do that.
 The harness is the `PipelineBenchmark` functional test
 (`test/functional_tests/PipelineBenchmark.cpp`). It drives a real Mudlet profile
 with a fixed, deterministically-generated corpus (mixed plain text, ANSI SGR
-colour, UTF-8 and long wrapping-heavy prose) through the production
-`cTelnet::processSocketData -> TBuffer::translateToPlainText -> TConsole ->
-TriggerUnit` path via `cTelnet::loopbackTest()` - the same code an online
-session runs (that path internally calls `TMainConsole::printOnDisplay()`, so the
-Lua `feedTriggers()` entry point is covered too) - and measures:
+colour, UTF-8, block-glyph map art and long wrapping-heavy prose) through the
+production `cTelnet::processSocketData -> TBuffer::translateToPlainText ->
+TConsole -> TriggerUnit` path via `cTelnet::loopbackTest()` - the same code an
+online session runs (that path internally calls `TMainConsole::printOnDisplay()`,
+so the Lua `feedTriggers()` entry point is covered too) - and measures:
 
 - **text pipeline throughput** - no triggers active (`text_*` metrics)
-- **trigger engine throughput** - the same corpus with a realistic ~34-trigger
+- **trigger engine throughput** - the same corpus with a realistic 46-trigger
   set active covering the plain substring, Perl regex with capture groups,
   begin-of-line substring, ANSI colour and multiline matcher kinds
   (`trigger_*` metrics). Lua-code matchers are deliberately excluded to keep
   Lua execution out of the timed path, and prompt triggers need a GA signal a
   loopback feed cannot produce.
+- **display throughput** - how fast a filled buffer is drawn back out again
+  (`display_*` metrics), covered below
 - **peak resident set size** for the whole process, from `/proc/self/status`
   `VmHWM` on Linux (`peak_rss_kb`)
 
@@ -40,6 +42,30 @@ reports the **fastest single pass** - the least-disturbed pass isolates the
 code's intrinsic speed from transient CPU contention, which is exactly what a
 before/after comparison needs. That makes the numbers stable (~2% run-to-run)
 even on a shared/CI box running other builds alongside it.
+
+### The corpus
+
+The corpus is generated, not recorded: a fixed seed makes its bytes identical on
+every machine and every run, which is what a regression gate needs and what a
+captured log could not give. Its **line-length distribution** is tuned to 25 000
+lines of real Achaea logs, because per-line cost dominates the pipeline and an
+unrepresentative line length biases every number:
+
+| property | corpus | real logs |
+| --- | --- | --- |
+| mean line length | 52 chars | 55 |
+| median | 54 | 50 |
+| p90 | 81 | 82 |
+| p99 | 114 | 115 |
+| longest line | 362 | 362 |
+| lines <= 20 chars | 3.7% | 3.2% |
+| lines >= 100 chars | 1.7% | 2.2% |
+
+Retuning it is legitimate, but it **moves every absolute number the benchmark
+reports**, so `kCorpusVersion` in `PipelineBenchmark.cpp` must be bumped with any
+change to `generateCorpus()`. The compare script treats `corpus_version` as an
+invariant and refuses a comparison across a change to it, rather than reporting
+the corpus difference as a code regression.
 
 ## How to run
 
@@ -73,6 +99,7 @@ diffed mechanically (the values below are illustrative, not a target):
 
 ```
 METRIC build_asan 1
+METRIC corpus_version 2
 METRIC text_lines_per_sec 4281.46
 METRIC text_mb_per_sec 0.41
 METRIC trigger_lines_per_sec 3323.25
@@ -82,7 +109,10 @@ METRIC defaults_root_triggers ...
 METRIC defaults_text_lines_per_sec ...
 METRIC defaults_text_best_pass_ms ...
 METRIC defaults_peak_rss_kb ...
-...
+METRIC display_paints_per_sec ...
+METRIC display_paint_ms ...
+METRIC display_rows_per_paint ...
+METRIC display_lines_per_sec ...
 ```
 
 ### Two profile configurations, and why the split matters
@@ -120,13 +150,13 @@ HOME=$scratch XDG_CONFIG_HOME=$scratch/.config QT_QPA_PLATFORM=offscreen \
   ./test/functional_tests/PipelineBenchmark
 ```
 
-Comparing a build from before this split against one from after it will abort
-with "gated metric defaults_text_lines_per_sec is missing from the before run".
-That is the script working as intended - the two harnesses are not comparable.
-Pass `--gate text_lines_per_sec,trigger_lines_per_sec` to compare across the
-change, bearing in mind the older run's `text_lines_per_sec` includes whichever
-default packages that machine's `experiencedMudletPlayer()` allowed it - the
-older harness had no guard - while the newer one includes none.
+Comparing a run captured before this split against one from after it aborts, as
+does comparing across a corpus retune. That is the script working as intended -
+the two runs did not measure the same thing. To compare a Mudlet old enough to
+predate a harness change, copy the *current* `PipelineBenchmark.cpp` into the
+older tree and build it against that tree's `mudlet_core`, so both sides run
+identical measurement code and only the engine differs. That is how the 4.22.0
+side of the 5.0 sweep was measured.
 
 ## The before/after workflow (the 10% gate)
 
@@ -175,9 +205,10 @@ Because it is the arbiter of the gate, the script refuses (exit code 2) rather
 than silently passing whenever it cannot trust the comparison:
 
 - an invariant (`text_corpus_lines`, `text_corpus_bytes`, `trigger_count`,
-  `build_asan`) is missing from either run, or differs between them - the two
-  runs used different corpora, trigger sets or build flavours. `build_asan`
-  specifically stops an ASan build being compared against a release build.
+  `build_asan`, `corpus_version`) is missing from either run, or differs between
+  them - the two runs used different corpora, trigger sets or build flavours.
+  `build_asan` specifically stops an ASan build being compared against a release
+  build, and `corpus_version` stops a comparison across a retuned corpus.
 - a **gated** metric is missing from either run, or its "before" value is not
   positive (a valid throughput/time baseline must be greater than zero).
 - a `--gate` name matches no metric in either run (usually a typo).
@@ -196,11 +227,43 @@ change specifically targets trigger matching, gate on it explicitly and confirm
 the movement is real - `--gate text_lines_per_sec,trigger_lines_per_sec,trigger_overhead_ms`,
 ideally over a couple of runs or with a slightly relaxed threshold.
 
+## The display benchmark (`display_*`)
+
+Everything else here measures how fast text gets *into* the buffer.
+`benchDisplay` measures how fast it gets back *out* onto the screen, which a user
+experiences as scrollback smoothness. It fills the buffer with the corpus, sizes
+the main window to 1200x800 and calls `TTextEdit::render()` on the upper pane 200
+times per pass, scrolling more than a full screen between paints so
+`drawForeground()`'s scroll-blit shortcut cannot serve any part of a frame from
+the previous one. `render()` runs `paintEvent` synchronously, so the number is
+the drawing code rather than a race with Qt's paint coalescing.
+
+Sizing has to go through the **main window**: `TTextEdit` takes its row count
+from its *visible* region, so resizing the pane alone leaves it clipped by its
+unchanged parents and it silently redraws a fraction of itself. The slot asserts
+the pane is unclipped rather than trusting that.
+
+`display_lines_per_sec` is `display_paints_per_sec` multiplied by the rows on
+screen, which makes it directly comparable to `text_lines_per_sec` - and worth
+comparing, because the display is by a wide margin the narrowest part of the
+pipeline. `display_rows_per_paint` records the rows the paint path actually
+drew; it depends on the font, so it is reported rather than treated as an
+invariant.
+
+The slot runs last so that its render target and the paint path's cached screen
+pixmap fall outside both `peak_rss_kb` and `defaults_peak_rss_kb`, whose
+difference is documented above as what the default packages cost.
+
+The `display_*` metrics are reported, not gated by default. They measure at
+least as tightly as the text metrics do on an unloaded machine, so gate on them
+explicitly when a change touches drawing:
+`--gate text_lines_per_sec,trigger_lines_per_sec,display_lines_per_sec`.
+
 ## Companion: Stressinator (live GUI display path)
 
-`PipelineBenchmark` deliberately stops at the core pipeline: it runs offscreen
-and never paints a widget, so it does not measure the on-screen rendering and
-echo path. That path needs a live window and is covered by the **Stressinator
+`benchDisplay` drives `TTextEdit` directly and offscreen, so it covers drawing
+but not the surrounding live-window path - compositing, the echo round trip and
+Lua-driven output. That needs a real window and is covered by the **Stressinator
 display benchmark** (`src/packages/StressinatorDisplayBench/`),
 pre-installed into the `mudlet.org` self-test profile.
 
@@ -225,9 +288,10 @@ or a committed baseline - capture your own "before" on the machine you are
 testing on and compare against that.
 
 It predates the two-profile split above, so its `text_lines_per_sec` includes
-the default packages and there are no `defaults_*` rows. Read the ratios between
-the `text_*` and `trigger_*` rows; do not compare any figure here against a
-current run.
+the default packages and there are no `defaults_*` rows; it also predates both
+the corpus retune and the trigger set growing to 46, so not even `trigger_count`
+describes a current run. Read the ratios between the `text_*` and `trigger_*`
+rows; do not compare any figure here against a current run.
 
 | Metric | Example value |
 | --- | --- |

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -30,8 +30,10 @@ import sys
 # Fixed properties of the corpus/trigger set plus the build flavour; if any
 # differ, the two runs used different harnesses or build configurations and the
 # comparison is invalid - so we abort. build_asan guards against comparing an
-# ASan build to a release build, whose absolute numbers are incomparable.
-INVARIANTS = ("text_corpus_lines", "text_corpus_bytes", "trigger_count", "build_asan")
+# ASan build to a release build, whose absolute numbers are incomparable;
+# corpus_version guards against comparing across a retune of the generated
+# corpus, which moves every absolute number the benchmark reports.
+INVARIANTS = ("text_corpus_lines", "text_corpus_bytes", "trigger_count", "build_asan", "corpus_version")
 
 # Gated by default: throughput (lines/sec) for the text and trigger pipelines,
 # plus the shipped default packages on the same corpus - the pipeline metrics run

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -33,7 +33,20 @@ import sys
 # ASan build to a release build, whose absolute numbers are incomparable;
 # corpus_version guards against comparing across a retune of the generated
 # corpus, which moves every absolute number the benchmark reports.
-INVARIANTS = ("text_corpus_lines", "text_corpus_bytes", "trigger_count", "build_asan", "corpus_version")
+# display_rows/cols_per_paint describe the display bench's workload the way
+# text_corpus_* describe the text bench's. They move with the font metrics and
+# the surrounding layout, and a build that draws a differently-sized screen did
+# not do the same work - which is a reason to refuse the comparison, not to
+# report the difference as a throughput change.
+INVARIANTS = (
+    "text_corpus_lines",
+    "text_corpus_bytes",
+    "trigger_count",
+    "build_asan",
+    "corpus_version",
+    "display_rows_per_paint",
+    "display_cols_per_paint",
+)
 
 # Gated by default: throughput (lines/sec) for the text and trigger pipelines,
 # plus the shipped default packages on the same corpus - the pipeline metrics run

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -104,8 +104,9 @@ private:
     // Report the FASTEST pass, not the average: the least-disturbed pass isolates
     // intrinsic speed from transient CPU contention (this often runs on a shared/CI
     // box), which is what a before/after gate wants. More passes raise the chance
-    // one lands in a clean window; TConsole's 10 000-line scrollback cap bounds
-    // memory regardless of corpus size.
+    // one lands in a clean window, at the cost of buffer memory: the console's
+    // line limit sits far above what this corpus produces, so no pass is trimmed
+    // away and every pass adds to the buffer.
     static constexpr int kCorpusLines = 25000;
     static constexpr int kFeedPasses = 6;
     // Bump with any change to generateCorpus(). compare-perf-baseline.py reads
@@ -288,7 +289,7 @@ private:
                 break;
             case LineShape::MapArt: {
                 // Rows of U+2588 FULL BLOCK, as a game's drawn map produces. The
-                // only shape that puts a box-drawing glyph in front of the
+                // only shape that puts a Block Elements glyph in front of the
                 // renderer benchDisplay() times.
                 const int indent = pick(6);
                 for (int space = 0; space < indent; ++space) {
@@ -567,7 +568,8 @@ private slots:
         const double seconds = feedCorpusBestPass(host, kFeedPasses);
         mTextBestPassSeconds = seconds;
         // A silently-disconnected pipeline would report absurdly good numbers, so
-        // prove data flowed: the console must sit near its 10 000-line scrollback cap.
+        // prove data flowed: the console must hold thousands of lines rather than
+        // just a login banner.
         const int bufferedLines = host->mpConsole->buffer.getLastLineNumber();
         QVERIFY2(bufferedLines > 1000, qPrintable(qsl("console buffer only holds %1 lines - the pipeline did not process the corpus").arg(bufferedLines)));
 

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -28,8 +28,8 @@
  * corpus through the production cTelnet::loopbackTest() path and prints one
  * `METRIC <name> <value>` line per measurement.
  *
- * `text_*`, `trigger_*` and `peak_rss_kb` come from a profile with the default
- * packages suppressed; `defaults_*` from one carrying them.
+ * `text_*`, `trigger_*`, `display_*` and `peak_rss_kb` come from a profile with
+ * the default packages suppressed; `defaults_*` from one carrying them.
  *
  * Built with the functional tests but deliberately NOT registered with ctest by
  * default (report-only and slow); run it directly, or configure with
@@ -70,6 +70,7 @@
 #include "MudletInstanceCoordinator.h"
 #include "TLuaInterpreter.h"
 #include "TMainConsole.h"
+#include "TTextEdit.h"
 #include "TTrigger.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
@@ -107,6 +108,81 @@ private:
     // memory regardless of corpus size.
     static constexpr int kCorpusLines = 25000;
     static constexpr int kFeedPasses = 6;
+    // Bump with any change to generateCorpus(). compare-perf-baseline.py reads
+    // this as an invariant, so it refuses a cross-corpus comparison instead of
+    // reporting the corpus difference as a code regression.
+    static constexpr int kCorpusVersion = 2;
+
+    // A typical main-window size, and enough paints per pass to sit well clear
+    // of timer noise.
+    static constexpr int kDisplayWindowWidth = 1200;
+    static constexpr int kDisplayWindowHeight = 800;
+    static constexpr int kDisplayPaints = 200;
+    static constexpr int kDisplayPasses = 5;
+
+    enum class LineShape {
+        Prompt,
+        Damage,
+        RoomTitle,
+        Tell,
+        Experience,
+        Inventory,
+        Utf8,
+        Ember,
+        Forest,
+        MapArt,
+        Ack,
+        Afflictions,
+        Narrative,
+        RoomEvent,
+        RoomDescription,
+        LongParagraph,
+    };
+
+    struct ShapeWeight
+    {
+        LineShape shape;
+        int weight;
+    };
+
+    // Mixed to the line-length distribution measured over 25 000 lines of real
+    // Achaea logs: mean 55 characters, median 50, p90 82, ~3% of lines at 20
+    // characters or fewer and ~2% at 100 or more. Weights are relative to their
+    // own sum, so one can be retuned without rebalancing the others - but any
+    // change to the mix or to a shape's text moves every absolute metric the
+    // benchmark reports, so bump kCorpusVersion with it.
+    static constexpr ShapeWeight kLineMix[] = {
+            {LineShape::Prompt, 185},
+            {LineShape::Damage, 120},
+            {LineShape::RoomTitle, 10},
+            {LineShape::Tell, 50},
+            {LineShape::Experience, 65},
+            {LineShape::Inventory, 40},
+            {LineShape::Utf8, 25},
+            {LineShape::Ember, 35},
+            {LineShape::Forest, 35},
+            {LineShape::MapArt, 32},
+            {LineShape::Ack, 185},
+            {LineShape::Afflictions, 75},
+            {LineShape::Narrative, 95},
+            {LineShape::RoomEvent, 105},
+            {LineShape::RoomDescription, 22},
+            {LineShape::LongParagraph, 5},
+    };
+
+    static LineShape shapeForRoll(int roll)
+    {
+        LineShape shape = kLineMix[0].shape;
+        int cursor = 0;
+        for (const ShapeWeight& entry : kLineMix) {
+            shape = entry.shape;
+            cursor += entry.weight;
+            if (roll < cursor) {
+                break;
+            }
+        }
+        return shape;
+    }
 
     // Seeded with a constant so the corpus bytes are identical on every run and
     // every machine; one line per '\n' keeps the processed-line count exact.
@@ -123,49 +199,73 @@ private:
         static const char* const actors[] = {"Gandalf", "Aragorn", "Legolas", "Gimli", "Frodo"};
         static const char* const foes[] = {"orc", "goblin", "troll", "wraith", "spider"};
         static const char* const items[] = {"a rusty sword", "a wooden shield", "a healing potion", "a silver ring", "a torn map"};
+        static const char* const ailments[] = {"asthma", "clumsiness", "paresis", "slickness", "anorexia", "haemophilia", "lethargy", "dementia"};
+        static const char* const bearings[] = {"north", "southeast", "west", "northwest", "east"};
+        static const char* const acks[] = {"You have recovered equilibrium.",
+                                           "You may drink another elixir.",
+                                           "Your muscles are too numb to do that.",
+                                           "You must regain your balance first.",
+                                           "Your bleeding slows to a trickle.",
+                                           "There is nothing here to pick up.",
+                                           "Balance Used: 0.89 seconds"};
+        static const char* const tells[] = {"meet me at the tower", "are you coming to the raid tonight", "bring rope and a lantern", "the warren is clear, head north when you can"};
+        static const char* const asides[] = {
+                "a nervous fear on his face.", "watching the treeline for any movement.", "and vanishes into the crowd without a word.", "shouting something you cannot quite make out."};
+        static const char* const events[] = {"sets the corpse of a fallen goblin alight upon a righteous pyre.",
+                                             "steps through the gate and is gone before you can call out.",
+                                             "drops a torn map underfoot and does not stop to pick it up.",
+                                             "hauls a crate of salted fish up from the water steps."};
+        static const char* const descriptions[] = {"A wide flagstone plaza opens out here, ringed by market stalls whose awnings snap and billow in the wind.",
+                                                   "Shelves of dark timber lean inward overhead, so heavy with ledgers that the passage seems about to close over you.",
+                                                   "The road widens into a muddy yard where cart tracks cross and re-cross beneath a swinging lantern."};
 
         QByteArray out;
-        out.reserve(static_cast<qsizetype>(lines) * 96);
+        out.reserve(static_cast<qsizetype>(lines) * 72);
+        int weightTotal = 0;
+        for (const ShapeWeight& entry : kLineMix) {
+            weightTotal += entry.weight;
+        }
         int count = 0;
         for (int i = 0; i < lines; ++i) {
-            switch (pick(11)) {
-            case 0:
-                out += "You are standing in a dark forest. The trees tower above you.";
+            switch (shapeForRoll(pick(weightTotal))) {
+            case LineShape::Prompt:
+                out += "\x1b[33mHP: ";
+                out += QByteArray::number(pick(100) + 1);
+                out += "/100 MP: ";
+                out += QByteArray::number(pick(50) + 1);
+                out += "/50 EX: ";
+                out += QByteArray::number(pick(900000) + 100000);
+                out += " [eb] [s] [Bld:";
+                out += QByteArray::number(pick(80));
+                out += "] [";
+                out += actors[pick(5)];
+                out += "]\x1b[0m";
                 break;
-            case 1:
+            case LineShape::Damage:
                 out += "\x1b[1;31mThe ";
                 out += foes[pick(5)];
                 out += " hits you for ";
                 out += QByteArray::number(pick(40) + 1);
                 out += " damage!\x1b[0m";
                 break;
-            case 2:
+            case LineShape::RoomTitle:
                 out += "\x1b[32mThe ";
                 out += rooms[pick(5)];
                 out += "\x1b[0m";
                 break;
-            case 3:
+            case LineShape::Tell:
                 out += "\x1b[36m";
                 out += actors[pick(5)];
-                out += " tells you 'meet me at the tower'\x1b[0m";
+                out += " tells you '";
+                out += tells[pick(4)];
+                out += "'\x1b[0m";
                 break;
-            case 4:
+            case LineShape::Experience:
                 out += "You gain ";
                 out += QByteArray::number(pick(500) + 1);
                 out += " experience points.";
                 break;
-            case 5:
-                out += "The caf\xc3\xa9 serves cr\xc3\xa8me br\xc3\xbbl\xc3\xa9"
-                       "e. \xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e \xe2\x98\xba";
-                break;
-            case 6:
-                out += "\x1b[33mHP: ";
-                out += QByteArray::number(pick(100) + 1);
-                out += "/100 MP: ";
-                out += QByteArray::number(pick(50) + 1);
-                out += "/50\x1b[0m";
-                break;
-            case 7:
+            case LineShape::Inventory:
                 out += "You are carrying: ";
                 out += items[pick(5)];
                 out += ", ";
@@ -174,23 +274,79 @@ private:
                 out += QByteArray::number(pick(100));
                 out += " gold coins.";
                 break;
-            case 8:
+            case LineShape::Utf8:
+                out += "The caf\xc3\xa9 serves cr\xc3\xa8me br\xc3\xbbl\xc3\xa9"
+                       "e. \xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e \xe2\x98\xba";
+                break;
+            case LineShape::Ember:
                 out += "\x1b[38;5;208mA glowing ember drifts past the ";
                 out += rooms[pick(5)];
                 out += ".\x1b[0m";
                 break;
-            case 9:
+            case LineShape::Forest:
+                out += "You are standing in a dark forest. The trees tower above you.";
+                break;
+            case LineShape::MapArt: {
+                // Rows of U+2588 FULL BLOCK, as a game's drawn map produces. The
+                // only shape that puts a box-drawing glyph in front of the
+                // renderer benchDisplay() times.
+                const int indent = pick(6);
+                for (int space = 0; space < indent; ++space) {
+                    out += ' ';
+                }
+                const int runs = 1 + pick(2);
+                for (int run = 0; run < runs; ++run) {
+                    if (run) {
+                        out += "  ";
+                    }
+                    const int width = 1 + pick(8);
+                    for (int block = 0; block < width; ++block) {
+                        out += "\xe2\x96\x88";
+                    }
+                }
+                break;
+            }
+            case LineShape::Ack:
+                out += acks[pick(7)];
+                break;
+            case LineShape::Afflictions: {
+                out += "You are afflicted with: ";
+                const int listed = 2 + pick(5);
+                for (int entry = 0; entry < listed; ++entry) {
+                    if (entry) {
+                        out += ", ";
+                    }
+                    out += ailments[pick(8)];
+                }
+                out += ".";
+                break;
+            }
+            case LineShape::Narrative:
+                out += actors[pick(5)];
+                out += " turns to the ";
+                out += bearings[pick(5)];
+                out += ", ";
+                out += asides[pick(4)];
+                break;
+            case LineShape::RoomEvent:
+                out += "(";
+                out += rooms[pick(5)];
+                out += ") ";
+                out += actors[pick(5)];
+                out += " ";
+                out += events[pick(4)];
+                break;
+            case LineShape::RoomDescription:
+                out += descriptions[pick(3)];
+                break;
+            case LineShape::LongParagraph:
                 // One long single-line paragraph, to force word-wrap passes the
-                // short templates never exercise.
+                // short shapes never exercise. Rare, matching the real logs'
+                // handful of lines past 300 characters.
                 out += "The ancient library stretches away in every direction, its towering shelves crammed with "
                        "mouldering tomes, cracked scrolls and curiosities gathered across a hundred forgotten ages; "
                        "dust drifts through the amber shafts of light that spill from the high stained-glass windows, "
-                       "and somewhere far above, unseen, the slow tick of a great clock marks out the patient centuries "
-                       "as you catch your breath and let your gaze wander over the winding aisles ahead.";
-                break;
-            default:
-                out += "A gentle breeze carries the scent of pine and distant woodsmoke across the clearing "
-                       "as you catch your breath and survey the winding path ahead.";
+                       "and somewhere far above the slow tick of a great clock marks out the patient centuries.";
                 break;
             }
             out += "\r\n";
@@ -316,6 +472,25 @@ private:
         std::fflush(stdout);
     }
 
+    // A pane that drew nothing still yields a pixmap, just a uniform one - so
+    // more than one colour is the proof that benchDisplay timed real drawing
+    // rather than an empty widget.
+    static bool frameHasContent(const QImage& frame)
+    {
+        if (frame.isNull()) {
+            return false;
+        }
+        const QRgb first = frame.pixel(0, 0);
+        for (int y = 0; y < frame.height(); ++y) {
+            for (int x = 0; x < frame.width(); ++x) {
+                if (frame.pixel(x, y) != first) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     // Process-wide peak RSS in kB (VmHWM never decreases). /proc pseudo-files
     // report a size of 0, so QFile::atEnd() is immediately true and readLine()
     // loops never start - read it all in one go.
@@ -352,9 +527,11 @@ private slots:
         initializeQRCResources();
         mCorpus = generateCorpus(kCorpusLines, mCorpusLines);
         mCorpusBytes = mCorpus.size();
-        // An invariant, emitted here so it is present regardless of which bench
-        // slots run: the compare script rejects an ASan-vs-release comparison.
+        // Invariants, emitted here so they are present regardless of which bench
+        // slots run: the compare script rejects an ASan-vs-release comparison,
+        // and a comparison across two different corpora.
         emitMetric("build_asan", static_cast<qint64>(BENCH_BUILD_ASAN));
+        emitMetric("corpus_version", static_cast<qint64>(kCorpusVersion));
         qInfo().nospace() << "Corpus: " << mCorpusLines << " lines, " << mCorpusBytes << " bytes";
     }
 
@@ -409,6 +586,7 @@ private slots:
     {
         Host* host = startProfile();
         QVERIFY(host);
+        QVERIFY(noTriggersAreRunningYet(host));
 
         const auto result = host->mTelnet.setEncoding("ISO 8859-1", false);
         QVERIFY2(result.first, qPrintable(result.second));
@@ -515,6 +693,74 @@ private slots:
         if (peakRssKb >= 0) {
             emitMetric("defaults_peak_rss_kb", peakRssKb);
         }
+    }
+
+    // Everything above measures how fast text gets INTO the buffer; this measures
+    // how fast it gets back OUT onto the screen. render() runs paintEvent
+    // synchronously, so the timing is the drawing code rather than a race with
+    // Qt's paint coalescing.
+    //
+    // Declared last on purpose: its render target and the paint path's cached
+    // screen pixmap would otherwise land between peak_rss_kb and
+    // defaults_peak_rss_kb, whose difference is what the default packages cost.
+    void benchDisplay()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(noTriggersAreRunningYet(host));
+
+        // Real coloured, wide-glyph text to draw rather than blank rows.
+        host->mTelnet.loopbackTest(mCorpus);
+        const int bufferedLines = host->mpConsole->buffer.getLastLineNumber();
+        QVERIFY2(bufferedLines > 1000, qPrintable(qsl("console buffer only holds %1 lines - the pipeline did not process the corpus").arg(bufferedLines)));
+
+        // Sized through the main window rather than the pane: TTextEdit takes its
+        // row count from its VISIBLE region, so a pane resized on its own stays
+        // clipped by its unchanged parents and quietly redraws a fraction of
+        // itself at a flattering speed.
+        mudlet::self()->resize(kDisplayWindowWidth, kDisplayWindowHeight);
+
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY(pane);
+        QVERIFY2(pane->visibleRegion().boundingRect().height() >= pane->height(),
+                 qPrintable(qsl("the display pane is %1px tall but only %2px of it are unclipped, so this would time a partial redraw")
+                                    .arg(pane->height())
+                                    .arg(pane->visibleRegion().boundingRect().height())));
+        const int rows = pane->getScreenHeight();
+        QVERIFY2(rows > 1, qPrintable(qsl("the display pane draws %1 rows, which is too few to describe a console").arg(rows)));
+
+        QPixmap target(pane->size());
+        target.fill(Qt::magenta);
+        pane->scrollTo(bufferedLines / 2);
+        pane->render(&target);
+        // Proves text really reaches the pixmap, and keeps first-paint costs -
+        // glyph caches, the pane's own screen pixmap - out of the timed passes.
+        QVERIFY2(frameHasContent(target.toImage()), "the rendered frame is a single flat colour - nothing was drawn, so the timings below would describe an empty widget");
+
+        // scrollTo(line) draws the rows ending just ABOVE line, so `rows` is the
+        // first argument that fills the pane. Advancing by more than one screenful
+        // per paint keeps drawForeground()'s scroll-blit shortcut from serving any
+        // part of a frame from the previous one, so every paint is a full redraw.
+        const int stride = rows + 1;
+        const int span = std::max(1, bufferedLines - rows);
+
+        double best = std::numeric_limits<double>::max();
+        for (int pass = 0; pass < kDisplayPasses; ++pass) {
+            QElapsedTimer timer;
+            timer.start();
+            for (int i = 0; i < kDisplayPaints; ++i) {
+                pane->scrollTo(rows + (i * stride) % span);
+                pane->render(&target);
+            }
+            best = std::min(best, timer.nsecsElapsed() / 1.0e9);
+        }
+
+        const double paintsPerSec = kDisplayPaints / best;
+        emitMetric("display_paints_per_sec", paintsPerSec);
+        emitMetric("display_paint_ms", (best / kDisplayPaints) * 1000.0);
+        emitMetric("display_rows_per_paint", static_cast<qint64>(rows));
+        // Lines/s the display can sustain, directly comparable to text_lines_per_sec.
+        emitMetric("display_lines_per_sec", paintsPerSec * rows);
     }
 
 private:

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -113,6 +113,12 @@ private:
     // this as an invariant, so it refuses a cross-corpus comparison instead of
     // reporting the corpus difference as a code regression.
     static constexpr int kCorpusVersion = 2;
+    // What kCorpusVersion 2 generates. Checked at startup, so editing the corpus
+    // without bumping the version fails here instead of silently invalidating
+    // every comparison against an earlier run - and so a shape accidentally left
+    // without a switch case, which the functional tests build too permissively to
+    // warn about, cannot quietly skew the mix either.
+    static constexpr qint64 kCorpusBytesForVersion = 1467189;
 
     // A typical main-window size, and enough paints per pass to sit well clear
     // of timer noise.
@@ -528,6 +534,8 @@ private slots:
         initializeQRCResources();
         mCorpus = generateCorpus(kCorpusLines, mCorpusLines);
         mCorpusBytes = mCorpus.size();
+        QCOMPARE(mCorpusLines, kCorpusLines);
+        QCOMPARE(mCorpusBytes, kCorpusBytesForVersion);
         // Invariants, emitted here so they are present regardless of which bench
         // slots run: the compare script rejects an ASan-vs-release comparison,
         // and a comparison across two different corpora.
@@ -731,20 +739,34 @@ private slots:
         const int rows = pane->getScreenHeight();
         QVERIFY2(rows > 1, qPrintable(qsl("the display pane draws %1 rows, which is too few to describe a console").arg(rows)));
 
-        QPixmap target(pane->size());
-        target.fill(Qt::magenta);
-        pane->scrollTo(bufferedLines / 2);
-        pane->render(&target);
-        // Proves text really reaches the pixmap, and keeps first-paint costs -
-        // glyph caches, the pane's own screen pixmap - out of the timed passes.
-        QVERIFY2(frameHasContent(target.toImage()), "the rendered frame is a single flat colour - nothing was drawn, so the timings below would describe an empty widget");
-
         // scrollTo(line) draws the rows ending just ABOVE line, so `rows` is the
         // first argument that fills the pane. Advancing by more than one screenful
         // per paint keeps drawForeground()'s scroll-blit shortcut from serving any
         // part of a frame from the previous one, so every paint is a full redraw.
         const int stride = rows + 1;
         const int span = std::max(1, bufferedLines - rows);
+
+        QPixmap target(pane->size());
+        target.fill(Qt::magenta);
+        // Rendered at the position the timed loop starts from, so what is proven
+        // here is a frame the loop actually draws.
+        pane->scrollTo(rows);
+        pane->render(&target);
+        // Proves text really reaches the pixmap, and keeps first-paint costs -
+        // glyph caches, the pane's own screen pixmap - out of the timed passes.
+        QVERIFY2(frameHasContent(target.toImage()), "the rendered frame is a single flat colour - nothing was drawn, so the timings below would describe an empty widget");
+
+        // drawForeground() only skips its scroll-blit shortcut while the scroll
+        // between two paints exceeds the rows on screen, and imageTopLine() is the
+        // very offset it differences to decide that. Prove the stride clears it:
+        // otherwise most of each frame is served from the previous one and the
+        // timings describe a partial redraw, several times too fast, with every
+        // other assertion here still passing.
+        const int firstTop = pane->imageTopLine();
+        pane->scrollTo(rows + stride);
+        const int steppedTop = pane->imageTopLine();
+        QVERIFY2(qAbs(steppedTop - firstTop) > rows,
+                 qPrintable(qsl("a %1-line stride moves the top line by %2 on a %3-row screen, so consecutive paints would share cached rows").arg(stride).arg(qAbs(steppedTop - firstTop)).arg(rows)));
 
         double best = std::numeric_limits<double>::max();
         for (int pass = 0; pass < kDisplayPasses; ++pass) {
@@ -760,7 +782,11 @@ private slots:
         const double paintsPerSec = kDisplayPaints / best;
         emitMetric("display_paints_per_sec", paintsPerSec);
         emitMetric("display_paint_ms", (best / kDisplayPaints) * 1000.0);
+        // The size of the drawn area, and so of the workload: both are invariants
+        // the compare script refuses to look past, because a font or layout
+        // difference between two builds means they did not draw the same thing.
         emitMetric("display_rows_per_paint", static_cast<qint64>(rows));
+        emitMetric("display_cols_per_paint", static_cast<qint64>(pane->getColumnCount()));
         // Lines/s the display can sustain, directly comparable to text_lines_per_sec.
         emitMetric("display_lines_per_sec", paintsPerSec * rows);
     }


### PR DESCRIPTION
Three gaps the 4.22.0-vs-development A/B sweep found in `PipelineBenchmark` itself. All three are measured, not theoretical.

- **The display was unmeasured, and it is the narrowest part of the pipeline.** New `benchDisplay()` times `TTextEdit::render()` over a filled buffer, scrolling more than a screenful between paints so `drawForeground()`'s scroll-blit shortcut cannot serve part of a frame. On one machine the pipeline takes in 209 775 lines/s while the display sustains 15 516 - **13.5x narrower**. The sweep measured paint time dropping 39% between 4.22.0 and development, the single biggest 5.0 win, with nothing watching it.
- **`benchLatin1Decode()` was missing the `noTriggersAreRunningYet()` guard** the other three slots have. During the sweep it was the one benchmark that happily produced a number from a profile still carrying default-package triggers, reporting a bogus "+133%" that was really measuring the default packages.
- **The corpus was unrepresentative.** It stays synthetic and seeded with `0xC0FFEE`, so its bytes are still identical on every machine and run; only the distribution changed. It was *bimodal* rather than merely long - 18% of lines under 20 characters, 19% over 100, little in between. It now also emits `█` map art, the only shape putting a Block Elements glyph in front of the renderer `benchDisplay()` times.

Test case: `QT_QPA_PLATFORM=offscreen ./test/functional_tests/PipelineBenchmark` under a fresh `HOME` - 8 passed, 0 failed, with `display_*` metrics present.

| line length, rendered chars | before | after | real logs |
|---|---|---|---|
| mean | 87.6 | 52.3 | 55.0 |
| median | 40 | 54 | 50 |
| p90 | 143 | 81 | 82 |
| p99 | 451 | 114 | 115 |
| longest | 451 | 362 | 362 |
| <= 20 chars | 18.2% | 3.7% | 3.2% |
| >= 100 chars | 18.8% | 1.7% | 2.2% |
| total bytes | 2 388 911 | 1 467 189 | 1 429 145 |

Measured against 25 000 lines of real Achaea logs from public pastes, used as a reference only and not committed.

**Absolute numbers are not comparable across this commit.** Changing the corpus moves every figure the benchmark reports. A new `corpus_version` invariant makes `compare-perf-baseline.py` refuse such a comparison outright (exit 2) rather than report the corpus difference as a code regression.

### Guards, because a benchmark's worst failure is a plausible number

Each of these was confirmed to fail before it was relied on:

- A shortened scroll stride makes `drawForeground()` serve most of each frame from cache - 3 of 34 rows drawn - and reports **4x** the real throughput with every other assertion passing. `benchDisplay()` now asserts that a stride-sized scroll moves `imageTopLine()` by more than a screenful, the exact condition `drawForeground()` tests. Forcing a one-line stride fails the run and emits no metric.
- The corpus is checked at startup against the byte count its version is known to produce. Editing a weight without bumping `kCorpusVersion` fails; so does dropping a line shape's `switch` case, which compiles **without a warning** since these builds set no `-Wall`.
- `display_rows_per_paint` and `display_cols_per_paint` are invariants, not reported values: they move with the font metrics and the layout, so a build that drew a differently-sized screen did not do the same work.

### One correction to the sweep's published display figures

The implementation this started from resized the *pane*, which does not work: `TTextEdit` derives its row count from its **visible** region, so a pane resized alone stays clipped by its unchanged parents. It drew 22 rows while reporting 36. **The A/B ratio the sweep published is unaffected** - both binaries carried the identical error, so the measured "-39% paint time / +64% display throughput" improvement stands. Only the **absolute** `display_lines_per_sec` figures were inflated, by about 64%. This version sizes the main window, asserts the pane is unclipped, and reports the row count the paint path actually used.

`REGISTER_PERF_BENCHMARK` still defaults OFF, so none of this runs in normal CI.

Assisted-by: Claude:claude-opus-5
