### PR TITLE
infrastructure: build Linux and macOS against Qt 6.11.1

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -60,7 +60,7 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests + leak detection'
             compiler: gcc_64
             gcc_compiler_version: 10
-            qt: '6.9.0'
+            qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
             # Enable AddressSanitizer for PTB and testing builds, but not release
@@ -69,13 +69,13 @@ jobs:
           - os: macos-15-intel
             buildname: 'macos (x86_64) / c++, lua tests'
             compiler: clang_64
-            qt: '6.9.0'
+            qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
             buildname: 'macos (arm64) / c++, lua tests'
             compiler: clang_64
-            qt: '6.9.0'
+            qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -41,7 +41,7 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests + leak detection'
             compiler: gcc_64
             gcc_compiler_version: 10
-            qt: '6.9.0'
+            qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
             # Enable AddressSanitizer for PTB and testing builds, but not release
@@ -52,22 +52,22 @@ jobs:
             buildname: 'ubuntu (x86_64)'
             compiler: gcc_64
             gcc_compiler_version: 12
-            qt: '6.9.0'
+            qt: '6.11.1'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             compiler: clang_64
             gcc_compiler_version: 10
-            qt: '6.9.0'
+            qt: '6.11.1'
           - os: macos-15-intel
             buildname: 'macos (x86_64) / c++, lua tests'
             compiler: clang_64
-            qt: '6.9.0'
+            qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
           - os: macos-14
             buildname: 'macos (arm64) / c++, lua tests'
             compiler: clang_64
-            qt: '6.9.0'
+            qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - language: cpp
             buildname: 'CodeQL'
-            qt: '6.9.0'
+            qt: '6.11.1'
             triplet: x64-linux
             compiler: gcc_64
             gcc_compiler_version: 10

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         include:
           - buildname: 'pi'
-            qt: '6.9.0'
             triplet: arm64-linux
             compiler: gcc_64
             os: [ self-hosted, pi4 ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ cmake_minimum_required(VERSION 3.25.1)
 
 if(APPLE)
   # minimum supported version by Qt6
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "")
 endif()
 
 project(mudlet)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Pins Qt to **6.11.1** for Linux and macOS — 9 pins across `build-mudlet.yml`, `build-mudlet-pr.yml` and `codeql-analysis.yml`.
- Raises `CMAKE_OSX_DEPLOYMENT_TARGET` from 12.0 to **13.0**, which Qt 6.11.1 requires.
- Removes an inert `qt` key from `performance-analysis.yml`.

#### Motivation for adding to Mudlet

Linux and macOS were pinned to 6.9.0 while Windows floats on rolling MSYS2 packages currently shipping 6.11.1, so platforms built from one tree were two minor releases apart. Qt changes text layout, font handling and painting between minor releases, so a defect could exist on one platform and be invisible on the others — and CI was testing the pinned platforms against a Qt no Windows user runs.

#### Other info (issues closed, discussion etc)

Fixes #9991.

**Why 6.11.1 and not something newer.** 6.11.2 exists but cannot be installed — an archive after `qtbase` is corrupt and fails to extract under both py7zr and an external `7z`, so `install-qt-action` would fail. 6.12.0 has no published supported-platforms page yet (`doc.qt.io/qt-6.12/supported-platforms.html` is a 404), and since Qt is bundled in the AppImage, `.app` and Windows package, its platform floor becomes our users' floor — not something to adopt sight-unseen. 6.11.1 is also exactly what MSYS2 ships, so this puts all three platforms on the same version for now.

**What this drops, and why it is acceptable.** Relative to 6.9.0 this raises the macOS floor from 12 to 13 and the oldest Red Hat from 8.6 to 8.10. Both are already unsupported:

- macOS 12 stopped receiving security updates in **November 2024** (last update 12.7.6). The newest Mac that cannot move past it is a **2017 MacBook Air**; every newer Mac can run macOS 13 or later.
- Red Hat only updates a series' **final** minor. That is 8.10, supported to 31 May 2029, and EUS for RHEL 8 ended with 8.8 — so 8.6 has no update path at all.

**The macOS deployment target has to move with the pin.** Qt 6.11.1's frameworks are built for macOS 13, so leaving the target at 12.0 produced 21 linker warnings of the form `building for macOS-12.0, but linking with dylib '@rpath/QtCore.framework/...' which was built for newer version 13.0`. Worse than the noise, it would have shipped a bundle advertising `LSMinimumSystemVersion` 12.0 that cannot actually run on macOS 12 — an install-then-fail rather than a clean refusal.

**Linux needs no equivalent change.** There is no deployment-target setting on Linux; the floor is implied by the build machine's glibc, and the deployed AppImage is built on `ubuntu-22.04` (glibc 2.35), already stricter than the 2.34 that Qt 6.11 requires. So the Linux floor does not move.

**Why `performance-analysis.yml`'s pin was removed rather than updated.** That workflow has no `install-qt-action` step and never references `matrix.qt` — the self-hosted Pi builds against its distro Qt from apt — so the value was inert. Updating it to 6.11.1 would have asserted a pin that does not exist. Its `triplet` and `compiler` keys are equally unused but are not Qt pins, so they are left for a separate tidy-up.

**Test case:**

Built against 6.11.1 on both pinned platforms before opening this:

| platform | configure | build | tests |
| --- | --- | --- | --- |
| Linux aarch64 / gcc, Debug | ✅ | ✅ all of `mudlet_core` | `GlyphOverflowTest` 10/10 |
| macOS arm64 / clang, Debug | ✅ | ✅ full app | — |

The macOS build is clean after the deployment-target bump: 0 errors and **0** Qt framework version warnings, down from 21. For completeness, 6.9.3, 6.10.3 and 6.12.0 were also built and tested on Linux and all passed, so this is not a case of 6.11.1 being the only version that works.

Not covered locally, and left to CI: the `macos-15-intel` leg (this machine is arm64, and the Homebrew dependencies are arm64-only so an x86_64 cross-build is not practical), the deployment and bundling steps, and the `ubuntu-22.04` glibc margin.