### PR TITLE
Fix: Crash when resetting a profile that shows custom map info

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -34,6 +34,7 @@
 #include "GifTracker.h"
 #include "GMCPAuthenticator.h"
 #include "LuaInterface.h"
+#include "mapInfoContributorManager.h"
 #include "MMCP.h"
 #include "MMCPServer.h"
 #include "mudlet.h"
@@ -969,6 +970,13 @@ void Host::resetProfile_phase2()
     // freshly-issued registry indices in the new state, which surfaces as
     // "attempt to call a number value" when label callbacks fire.
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    // Lua map info contributors cannot cross that swap either: each holds a
+    // reference in the state initLuaGlobals() closes below, and a callback that
+    // captures it. Left registered, the registering script's own re-run in
+    // compileAll() further down unrefs against the closed state, and one that
+    // nothing re-registers is called on it by every later map redraw. The
+    // scripts that registered them put them back against the new state.
+    mpMap->mMapInfoContributorManager->removeLuaContributors();
     mEventHandlerMap.clear();
     mAnonymousEventHandlerFunctions.clear();
     mEventMap.clear();

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -41,6 +41,8 @@ MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH)
 
 MapInfoContributorManager::~MapInfoContributorManager()
 {
+    // Only safe because Host declares mLuaInterpreter before mpMap, so this
+    // manager - a child of TMap - is destroyed while that state is still open.
     for (auto it = mLuaCallbackRefs.begin(); it != mLuaCallbackRefs.end(); ++it) {
         luaL_unref(it->L, LUA_REGISTRYINDEX, it->ref);
     }
@@ -76,6 +78,28 @@ bool MapInfoContributorManager::removeContributor(const QString& name)
     ordering.removeOne(name);
     emit signal_contributorsUpdated();
     return contributors.remove(name) > 0;
+}
+
+void MapInfoContributorManager::removeLuaContributors()
+{
+    if (mLuaCallbackRefs.isEmpty()) {
+        return;
+    }
+    // Unlike removeContributor() this leaves mpHost->mMapInfoContributors
+    // alone: that is the saved set of enabled contributor names, and every
+    // consumer of it intersects it with getContributorKeys(), so a name with no
+    // contributor is inert - which is what lets one that is registered again
+    // come back enabled.
+    for (const auto& [name, callbackRef] : std::as_const(mLuaCallbackRefs).asKeyValueRange()) {
+        // there is no way to notice a caller that got the order wrong: unrefing
+        // a closed state is a use-after-free that only some platforms fault on
+        Q_ASSERT(callbackRef.L == mpHost->mLuaInterpreter.getLuaGlobalState());
+        luaL_unref(callbackRef.L, LUA_REGISTRYINDEX, callbackRef.ref);
+        contributors.remove(name);
+        ordering.removeOne(name);
+    }
+    mLuaCallbackRefs.clear();
+    emit signal_contributorsUpdated();
 }
 
 void MapInfoContributorManager::releaseLuaCallbackRef(const QString& name)

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -31,6 +31,11 @@ MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH)
 : QObject(parent)
 , mpHost(pH)
 {
+    registerBuiltInContributors();
+}
+
+void MapInfoContributorManager::registerBuiltInContributors()
+{
     registerContributor(qsl("Short"), [=, this](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
         return shortInfo(roomID, selectionSize, areaId, displayAreaId, infoColor);
     });
@@ -99,6 +104,13 @@ void MapInfoContributorManager::removeLuaContributors()
         ordering.removeOne(name);
     }
     mLuaCallbackRefs.clear();
+    // Registering under a built-in's name replaces it, so put the built-ins
+    // back rather than leave a reset profile with fewer contributors than a
+    // freshly loaded one. Only once the refs above are cleared, or this would
+    // unref them a second time.
+    if (!contributors.contains(qsl("Short")) || !contributors.contains(qsl("Full"))) {
+        registerBuiltInContributors();
+    }
     emit signal_contributorsUpdated();
 }
 

--- a/src/mapInfoContributorManager.h
+++ b/src/mapInfoContributorManager.h
@@ -73,6 +73,7 @@ signals:
     void signal_contributorsUpdated();
 
 private:
+    void registerBuiltInContributors();
     void releaseLuaCallbackRef(const QString& name);
 
     QList<QString> ordering;

--- a/src/mapInfoContributorManager.h
+++ b/src/mapInfoContributorManager.h
@@ -58,6 +58,10 @@ public:
     void registerContributor(const QString& name, MapInfoCallback callback);
     void registerContributor(const QString& name, MapInfoCallback callback, lua_State* L, int callbackRef);
     bool removeContributor(const QString& name);
+    // A Lua contributor cannot outlive the lua_State it was registered on: it
+    // holds a registry reference in that state and a callback that captures it,
+    // so call this before the state is closed.
+    void removeLuaContributors();
     bool enableContributor(const QString& name);
     bool disableContributor(const QString& name);
     MapInfoCallback getContributor(const QString& name);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -209,8 +209,8 @@ foreach(test_name ${allFunctionalTestNames})
     )
 endforeach()
 
-# ResetProfileTest creates a full profile per test method (30 tests),
-# so it needs a longer timeout than the default 60s
+# ResetProfileTest creates a full profile per test method, so it needs a longer
+# timeout than the default 60s
 set_tests_properties(ResetProfileTest PROPERTIES TIMEOUT 300)
 
 # Undo/redo tests need a longer timeout due to large batch operations

--- a/test/functional_tests/ResetProfileTest.cpp
+++ b/test/functional_tests/ResetProfileTest.cpp
@@ -938,6 +938,28 @@ private slots:
     QCOMPARE(luaL_dostring(newL, "killMapInfo('reset.stale')"), 0);
   }
 
+  // registerMapInfo() can be given a built-in's name, which replaces the
+  // built-in callback. Dropping that on reset must not leave the profile with
+  // fewer contributors than a freshly loaded one has.
+  void test_builtinMapInfoRestoredAfterShadowingContributorDropped() {
+    auto *pManager = mpHost->mpMap->mMapInfoContributorManager;
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QCOMPARE(luaL_dostring(L, "registerMapInfo('Short', function() return "
+                              "'shadowed' end)"),
+             0);
+
+    performReset();
+
+    QVERIFY2(pManager->getContributorKeys().contains(qsl("Short")),
+             "the built-in contributor should be back once the Lua one that "
+             "replaced it is dropped");
+    QColor color;
+    auto info = pManager->getContributor(qsl("Short"))(0, 0, -1, -1, color);
+    QVERIFY2(info.text.isEmpty(),
+             "'Short' should be Mudlet's own contributor again, which reports "
+             "nothing for a room that does not exist");
+  }
+
   // Dropping the contributors is only acceptable because the script that
   // registered them runs again in the same reset, in compileAll(); the enabled
   // state is the user's saved choice and is deliberately not dropped with them,

--- a/test/functional_tests/ResetProfileTest.cpp
+++ b/test/functional_tests/ResetProfileTest.cpp
@@ -55,6 +55,7 @@
 #include "XMLexport.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
+#include "mapInfoContributorManager.h"
 #include "mudlet.h"
 
 extern "C" {
@@ -851,6 +852,123 @@ private slots:
     QVERIFY2(newVu->hidden.contains(qsl("Geyser")),
              "Mudlet's internal variables should be re-hidden after reset, "
              "as on profile load");
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 18: MapInfoContributorManager stale lua_State (#10001)
+  // -----------------------------------------------------------------------
+
+  // registerMapInfo() stores the lua_State it was called on plus a registry
+  // reference, and the callback captures that state too, while phase2's
+  // initLuaGlobals() closes it. A contributor left registered across a reset
+  // therefore holds a dangling state: the next killMapInfo()/registerMapInfo()
+  // on that name unrefs into freed memory - which a package that does both in
+  // its init hits from compileAll() later in the same phase2 - and one that
+  // nothing re-registers is called on that state by every later map redraw.
+  void test_luaMapInfoContributorsRemovedByReset() {
+    auto *pManager = mpHost->mpMap->mMapInfoContributorManager;
+    QVERIFY(pManager);
+    QSignalSpy spy(pManager,
+                   &MapInfoContributorManager::signal_contributorsUpdated);
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QCOMPARE(luaL_dostring(L, "registerMapInfo('reset.contrib', function() "
+                              "return 'info' end)\n"
+                              "registerMapInfo('reset.contrib2', function() "
+                              "return 'info' end)"),
+             0);
+    QVERIFY(pManager->getContributorKeys().contains(qsl("reset.contrib")));
+    QVERIFY(pManager->getContributorKeys().contains(qsl("reset.contrib2")));
+    spy.clear();
+
+    performReset();
+
+    QCOMPARE(mpHost->mpMap->mMapInfoContributorManager, pManager);
+    QVERIFY2(!pManager->getContributorKeys().contains(qsl("reset.contrib")),
+             "Lua map info contributor should not outlive the lua_State it was "
+             "registered on");
+    QVERIFY2(!pManager->getContributorKeys().contains(qsl("reset.contrib2")),
+             "every Lua map info contributor should go, not just one");
+    QVERIFY2(pManager->getContributorKeys().contains(qsl("Short")),
+             "built-in contributors have no Lua reference and must stay");
+    QVERIFY2(pManager->getContributorKeys().contains(qsl("Full")),
+             "built-in contributors have no Lua reference and must stay");
+    QVERIFY2(
+        !spy.isEmpty(),
+        "the mapper rebuilds its info menu from signal_contributorsUpdated");
+  }
+
+  // The reporter's package kills a contributor before re-registering it, and
+  // after a reset that kill is the call that unrefs into the closed state. The
+  // dangling unref is not what fails here without the fix: liblua is linked as
+  // a prebuilt system library and so is not ASan-instrumented, and ASan leaves
+  // freed memory intact by default, so on Linux the read of the closed state
+  // goes unnoticed (on Windows it crashes with an access violation). What goes
+  // red is the kill still finding a contributor - which is also what a fix that
+  // dropped the name from the ordering but left it in the contributor map would
+  // do.
+  void test_mapInfoKillAfterResetFindsNothingToRemove() {
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QCOMPARE(luaL_dostring(L, "registerMapInfo('reset.stale', function() "
+                              "return 'info' end)"),
+             0);
+
+    performReset();
+
+    lua_State *newL = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QCOMPARE(luaL_dostring(newL,
+                           "resetStaleKilled, resetStaleMessage = "
+                           "killMapInfo('reset.stale')\n"
+                           "registerMapInfo('reset.stale', function() return "
+                           "'info' end)"),
+             0);
+    lua_getglobal(newL, "resetStaleKilled");
+    QVERIFY2(lua_isnil(newL, -1),
+             "the reset should have left killMapInfo() nothing to remove");
+    lua_pop(newL, 1);
+    lua_getglobal(newL, "resetStaleMessage");
+    QVERIFY2(
+        lua_isstring(newL, -1),
+        "killMapInfo() should report the label as missing, as it does on a "
+        "profile that has just been loaded");
+    lua_pop(newL, 1);
+    QVERIFY2(mpHost->mpMap->mMapInfoContributorManager->getContributorKeys()
+                 .contains(qsl("reset.stale")),
+             "re-registering after a reset should work");
+
+    QCOMPARE(luaL_dostring(newL, "killMapInfo('reset.stale')"), 0);
+  }
+
+  // Dropping the contributors is only acceptable because the script that
+  // registered them runs again in the same reset, in compileAll(); the enabled
+  // state is the user's saved choice and is deliberately not dropped with them,
+  // so the contributor comes back exactly as it was.
+  void test_scriptRegisteredMapInfoReturnsAfterReset() {
+    auto *pScript = new TScript(qsl("mapInfoRegisteringScript"), mpHost);
+    pScript->setScript(qsl("registerMapInfo('reset.pkg', function() return "
+                           "'info' end)"));
+    mpHost->getScriptUnit()->registerScript(pScript);
+    pScript->setIsActive(true);
+    pScript->compile();
+    lua_State *L = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QCOMPARE(luaL_dostring(L, "enableMapInfo('reset.pkg')"), 0);
+    QVERIFY(mpHost->mMapInfoContributors.contains(qsl("reset.pkg")));
+
+    performReset();
+
+    lua_State *newL = mpHost->mLuaInterpreter.getLuaGlobalState();
+    QCOMPARE(luaL_dostring(newL, "resetPkgEnabled = getMapInfo()['reset.pkg']"),
+             0);
+    lua_getglobal(newL, "resetPkgEnabled");
+    QVERIFY2(lua_isboolean(newL, -1),
+             "the registering script should have put its contributor back");
+    QVERIFY2(lua_toboolean(newL, -1),
+             "the user's enabled choice should survive the reset");
+    lua_pop(newL, 1);
+
+    // stop the script re-registering into every later test's reset
+    pScript->setScript(qsl(""));
+    pScript->setIsActive(false);
+    QCOMPARE(luaL_dostring(newL, "killMapInfo('reset.pkg')"), 0);
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `resetProfile()` closes the profile's Lua state, but map info contributors registered from Lua kept a pointer to it plus a reference inside it, so the next `killMapInfo()`/`registerMapInfo()` on such a name reached into freed memory - typically from the registering package's own init, which the same reset re-runs moments later.
- Those contributors are now dropped while the old state is still alive, so their references are released cleanly. The scripts that registered them put them back during the same reset, and the built-in "Short"/"Full" contributors are untouched.
- Which contributors the user has ticked is deliberately left alone, so one that is registered again comes back enabled as before.

#### Motivation for adding to Mudlet

Resetting a profile that uses `registerMapInfo()` crashes Mudlet with no Lua error - reported on Windows 11, and reproduced here as a use-after-free inside `luaL_unref()` under AddressSanitizer.

#### Other info (issues closed, discussion etc)

Fixes #10001

**Test case:** `ctest -R ResetProfileTest` - three new cases in `test/functional_tests/ResetProfileTest.cpp` (Group 18) register map info contributors, reset the profile, then kill and re-register them; two of them fail on development and pass with this change.

Assisted-by: Claude:claude-opus-5