### PR TITLE
infrastructure: build macOS and Linux releases with optimisation, as Windows does

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -370,6 +370,7 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -370,7 +370,7 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=${{ startsWith(github.ref, 'refs/tags/Mudlet-') && 'Release' || '' }}
           -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -362,6 +362,7 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -362,7 +362,7 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
           -G Ninja
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=${{ startsWith(github.ref, 'refs/tags/Mudlet-') && 'Release' || '' }}
           -DCMAKE_PREFIX_PATH=${{ env.CMAKE_PREFIX_PATH != '' && env.CMAKE_PREFIX_PATH || (env.QT_PREFIX != '' && env.QT_PREFIX || env.MINGW_BASE_DIR) }}
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}

--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -166,7 +166,7 @@ add_dependencies(copy_sentry sentry_without_transport)
 add_dependencies(${EXE_MUDLET_TARGET} copy_sentry)
 
 if(APPLE)
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT USE_SANITIZER)
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
         add_custom_command(TARGET ${EXE_MUDLET_TARGET} POST_BUILD
             COMMAND dsymutil $<TARGET_FILE:${EXE_MUDLET_TARGET}> -o $<TARGET_FILE:${EXE_MUDLET_TARGET}>.dSYM
             COMMAND strip -x $<TARGET_FILE:${EXE_MUDLET_TARGET}>
@@ -179,7 +179,7 @@ if(APPLE)
         )
     endif()
 elseif(UNIX)
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT USE_SANITIZER)
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
         add_custom_command(TARGET ${EXE_MUDLET_TARGET} POST_BUILD
             COMMAND objcopy --only-keep-debug $<TARGET_FILE:${EXE_MUDLET_TARGET}> $<TARGET_FILE:${EXE_MUDLET_TARGET}>.debug
             COMMAND strip --strip-debug $<TARGET_FILE:${EXE_MUDLET_TARGET}>

--- a/src/cmake/WithSentry.cmake
+++ b/src/cmake/WithSentry.cmake
@@ -166,7 +166,7 @@ add_dependencies(copy_sentry sentry_without_transport)
 add_dependencies(${EXE_MUDLET_TARGET} copy_sentry)
 
 if(APPLE)
-    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT USE_SANITIZER)
         add_custom_command(TARGET ${EXE_MUDLET_TARGET} POST_BUILD
             COMMAND dsymutil $<TARGET_FILE:${EXE_MUDLET_TARGET}> -o $<TARGET_FILE:${EXE_MUDLET_TARGET}>.dSYM
             COMMAND strip -x $<TARGET_FILE:${EXE_MUDLET_TARGET}>
@@ -179,7 +179,7 @@ if(APPLE)
         )
     endif()
 elseif(UNIX)
-    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    if(CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT USE_SANITIZER)
         add_custom_command(TARGET ${EXE_MUDLET_TARGET} POST_BUILD
             COMMAND objcopy --only-keep-debug $<TARGET_FILE:${EXE_MUDLET_TARGET}> $<TARGET_FILE:${EXE_MUDLET_TARGET}>.debug
             COMMAND strip --strip-debug $<TARGET_FILE:${EXE_MUDLET_TARGET}>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Pass `-DCMAKE_BUILD_TYPE=Release` for **tagged releases** on macOS and Linux, which have never had a build type and so compiled at `-O0`. PTB, development and PR builds are unchanged, keeping their sanitisers and debuggability.

#### Motivation for adding to Mudlet

macOS and Linux releases have been shipping unoptimised. `CMAKE_BUILD_TYPE` is never set for them, so CMake appends no `CMAKE_CXX_FLAGS_<CONFIG>`, nothing else supplies an `-O` flag, and `lukka/run-cmake@v3` pushes a build type only in its `CMakeListsTxtBasic` branch while Mudlet uses `CMakeListsTxtAdvanced`.

Every other build path in the project already sets one - Windows `Release` in `CI/build-mudlet-for-windows.sh`, the Flatpak `RelWithDebInfo` in `CI/org.mudlet.mudlet.yml`, `performance-analysis.yml` `Release`, and even the vendored sentry-native sub-build - so this brings the two that were left behind into line rather than introducing anything new.

Measured on a trigger-heavy workload: **2.9x more throughput** once optimised (27,000 feeds / 5.4M trigger firings unoptimised versus 78,100 / 15.6M at `-O2`, over an identical 25 seconds).

This also silently affects the four libraries built in-tree - `edbee-lib`, `communi`, `qtkeychain`, `qt-tags-widget` - of which edbee-lib, the script editor widget, is the one likely to be noticeable. Qt, PCRE2, hunspell, libzip, pugixml, assimp and Lua all arrive prebuilt and are unaffected.

#### Other info (issues closed, discussion etc)

Fixes #10009.

**Scoped to tagged releases, per review.** Optimisation reaches `refs/tags/Mudlet-*` only; PTB, development and PR builds stay unoptimised with their sanitisers intact, because a Public Test Build exists to be tested and at `-O3` the inlining alone costs AddressSanitizer much of the precision in its stack traces.

Both workflows build PTBs and releases from the same configure step - `build-mudlet.yml` triggers on pushes to `master`, `development` and `release-*` as well as on `Mudlet-*` tags - so scoping this to releases needs a tag conditional rather than simply leaving the PR workflow alone. The condition is deliberately the same predicate the release deploy step already uses two dozen lines below (`startsWith(github.ref, 'refs/tags/Mudlet-')`), so "optimised" and "published" cannot drift apart without someone editing both. It also sits directly above the existing `USE_SANITIZER` argument, which uses the same test in the opposite sense, so the pair reads as one intent: tags get optimisation and no sanitiser, everything else the reverse.

One thing worth stating explicitly, since it looks contradictory otherwise: PTB tags share the release prefix (`Mudlet-4.22.0-ptb-2026-08-18-2aaca329`), yet PTBs are not optimised. That holds because PTB tags are pushed by CI using `GITHUB_TOKEN`, and GitHub does not trigger workflow runs from events created with that token - so `github.ref` is never a PTB tag at build time. Verified against the run history: `ref=Mudlet-4.22.0` triggered a build on 2026-07-06, while the seven PTB tags pushed between 12 and 18 August triggered none. The existing `USE_SANITIZER` argument has depended on the same behaviour for years.

**Verified on the shipped artifacts, not just inferred.** All three builds the website serves for 4.22.0 disassemble to `-O0` code, spilling `this` and their arguments to the stack and reloading them immediately. Across the macOS binary, of the 968 functions that `-O2` shrinks by 20% or more, 68.2% match the `-O0` size to within 10% and only 2.5% match `-O2` (median ratios 1.002 and 1.559). Details and disassembly are in the issue.

**Why `Release` rather than `RelWithDebInfo`.** It matches Windows, and it is what enables the post-build strip in `WithSentry.cmake`, which has been guarded on `CMAKE_BUILD_TYPE STREQUAL "Release"` - a condition that has never been true on these platforms. `-O3` is not faster than `-O2` here: three alternating runs put the medians 0.6% apart against a 6.7% spread within `-O2` alone, and binary size was equivalent. The choice is consistency, not speed.

**What the strip is worth on a tag build**, applying the exact sequences already in the file:

| | Linux x86_64 | macOS arm64 |
| --- | --- | --- |
| executable before | 205.2 MB | 33.0 MB |
| after strip | **65.6 MB** (-68%) | **29.8 MB** (-10%) |
| download | AppImage 170.2 -> **110.9 MB** (-35%) | not measured |

macOS gains less because its DWARF already lives in the `.dSYM` rather than the executable. On Linux `objcopy --add-gnu-debuglink` is *already running* today; only the `strip --strip-debug` that should follow it was missing.

**Windows keeps its exclusion**, which the file already explains: stripping `mudlet.exe` would remove its RSDS debug-directory entry and lose the debug-id that matches minidumps to the uploaded PDB. That is PE/PDB-specific and does not apply to Mach-O or ELF - `LC_UUID` and `.note.gnu.build-id` both survive a strip, which is why the existing sequences were written the way they are.

**Please sanity-check symbolication before merging.** @vadi2 has offered to, and I agree it is the one risk that matters. The mechanism looks sound - the identity records survive stripping and `CI/send_debug_files_to_sentry.sh` already uploads the companions - but confirming that a crash in a stripped release resolves to source lines in Sentry needs access to the project's Sentry, which I do not have.

**Test case:**

No behaviour changes to test by hand. The optimised configuration was validated before it was scoped down to tags:

| | Build | ctest |
| --- | --- | --- |
| CI, all four platforms, commit `98e77289` | 12/12 checks green | included |
| macOS arm64 local, AppleClang, `-O3 -DNDEBUG` | exit 0 | **115/115** |
| Linux arm64 local, gcc, Qt 6.9.0, in podman | exit 0, 945 targets | **115/115** |

Worth being explicit that from here on **CI builds the unoptimised configuration**, so the first place `-O3` runs is a tag build. The evidence above is therefore the standing proof that the optimised build is sound, and #10023 proposes the CI check that would keep it that way.

`NDEBUG`'s blast radius was audited too: it reaches exactly four `assert()` calls in Mudlet's own code (`TRoomDB.cpp:1164`, `TTrigger.cpp:242`, `TLuaInterpreter.cpp:7020`, `TBuffer.cpp:1260`), all pure predicates with no side effects, and zero in the four in-tree vendored libraries. Qt's 67 `Q_ASSERT`s are unaffected because `QT_NO_DEBUG` is already defined today.

All three configurations were checked locally after the rescope: a tag-shaped configure gives `-O3` and one strip command, a non-tag gives no `-O` and no strip, and a non-tag with `USE_SANITIZER=Address` stays unoptimised, unstripped and instrumented.

The dead LTO block found alongside this is filed separately as #10010, and #10023 covers the CI fail-safe so this cannot silently regress.

