### PR TITLE
Infra: Build the trigger functional tests into one executable

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -7,21 +7,15 @@ cmake_language(DEFER CALL restore_windows_test_output)
 
 set(FUNCTIONAL_TEST_SOURCES
     TriggerEditorTest.cpp
-    TFeedTriggersRecursionTest.cpp
-    MultilineTriggerReentrancyTest.cpp
     dlgTriggerEditorUndoRedoTest.cpp
     EditorBannerViewSwitchTest.cpp
     TDiscordModeTest.cpp
     MapAreaReassignmentTest.cpp
-    UnitDeferredDeleteTest.cpp
-    CorruptTriggerPatternsTest.cpp
     TutorialInvitationLayoutTest.cpp
     FeatureCalloutTest.cpp
     VariableEditorWriteBackTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
-    SetScriptCallbackTest.cpp
     PackageSelfRemovalTest.cpp
-    UnitProcessingDepthTest.cpp
     PackageRemovalSaveTeardownTest.cpp
     TutorialInvitationGateTest.cpp
     ModuleSaveTeardownTest.cpp
@@ -115,6 +109,16 @@ set(TELNET_GROUP_TEST_SOURCES
     TOscTest.cpp
 )
 
+# Triggers and the other scriptable units, and what a running script does to them
+set(TRIGGER_GROUP_TEST_SOURCES
+    CorruptTriggerPatternsTest.cpp
+    MultilineTriggerReentrancyTest.cpp
+    SetScriptCallbackTest.cpp
+    TFeedTriggersRecursionTest.cpp
+    UnitDeferredDeleteTest.cpp
+    UnitProcessingDepthTest.cpp
+)
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
@@ -190,6 +194,7 @@ endmacro()
 add_grouped_test_binary(functional_window_tests ${WINDOW_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_profile_tests ${PROFILE_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_telnet_tests ${TELNET_GROUP_TEST_SOURCES})
+add_grouped_test_binary(functional_trigger_tests ${TRIGGER_GROUP_TEST_SOURCES})
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})

--- a/test/functional_tests/CorruptTriggerPatternsTest.cpp
+++ b/test/functional_tests/CorruptTriggerPatternsTest.cpp
@@ -56,12 +56,7 @@
 #include "TriggerUnit.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForCorruptTriggerPatternsTest();
+#include "GroupedTest.h"
 
 namespace {
 const QString scmCorruptFolderName = qsl("corrupt folder");
@@ -234,8 +229,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForCorruptTriggerPatternsTest();
-
         QVERIFY(mConfigDir.isValid());
         mSavedXdg = qgetenv("XDG_CONFIG_HOME");
         QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
@@ -325,20 +318,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForCorruptTriggerPatternsTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "CorruptTriggerPatternsTest.moc"
-QTEST_MAIN(CorruptTriggerPatternsTest)
+MUDLET_GROUPED_TEST_MAIN(CorruptTriggerPatternsTest)

--- a/test/functional_tests/MultilineTriggerReentrancyTest.cpp
+++ b/test/functional_tests/MultilineTriggerReentrancyTest.cpp
@@ -32,12 +32,7 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResources();
+#include "GroupedTest.h"
 
 // A multiline trigger's completed TMatchState used to stay in mConditionMap
 // while its script ran. Feeding text from that script re-enters trigger
@@ -77,8 +72,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -216,20 +209,5 @@ private:
     }
 };
 
-void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MultilineTriggerReentrancyTest.moc"
-QTEST_MAIN(MultilineTriggerReentrancyTest)
+MUDLET_GROUPED_TEST_MAIN(MultilineTriggerReentrancyTest)

--- a/test/functional_tests/SetScriptCallbackTest.cpp
+++ b/test/functional_tests/SetScriptCallbackTest.cpp
@@ -63,12 +63,7 @@ extern "C" {
 #endif
 }
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForSetScriptCallbackTest();
+#include "GroupedTest.h"
 
 class SetScriptCallbackTest : public QObject
 {
@@ -123,8 +118,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForSetScriptCallbackTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -347,20 +340,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForSetScriptCallbackTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "SetScriptCallbackTest.moc"
-QTEST_MAIN(SetScriptCallbackTest)
+MUDLET_GROUPED_TEST_MAIN(SetScriptCallbackTest)

--- a/test/functional_tests/TFeedTriggersRecursionTest.cpp
+++ b/test/functional_tests/TFeedTriggersRecursionTest.cpp
@@ -33,14 +33,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResources();
+using namespace std::chrono_literals;
 
 // Validates the guards that stop a self-feeding trigger (one whose action calls
 // feedTriggers() or feedTelnet() with text that re-matches it) from recursing the
@@ -68,8 +63,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -263,20 +256,5 @@ private slots:
     }
 };
 
-void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "TFeedTriggersRecursionTest.moc"
-QTEST_MAIN(TFeedTriggersRecursionTest)
+MUDLET_GROUPED_TEST_MAIN(TFeedTriggersRecursionTest)

--- a/test/functional_tests/UnitDeferredDeleteTest.cpp
+++ b/test/functional_tests/UnitDeferredDeleteTest.cpp
@@ -72,14 +72,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForUnitDeferredDeleteTest();
+using namespace std::chrono_literals;
 
 class UnitDeferredDeleteTest : public QObject
 {
@@ -108,8 +103,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForUnitDeferredDeleteTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -947,20 +940,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForUnitDeferredDeleteTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "UnitDeferredDeleteTest.moc"
-QTEST_MAIN(UnitDeferredDeleteTest)
+MUDLET_GROUPED_TEST_MAIN(UnitDeferredDeleteTest)

--- a/test/functional_tests/UnitProcessingDepthTest.cpp
+++ b/test/functional_tests/UnitProcessingDepthTest.cpp
@@ -46,12 +46,7 @@
 #include "TLuaInterpreter.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForUnitProcessingDepthTest();
+#include "GroupedTest.h"
 
 class UnitProcessingDepthTest : public QObject
 {
@@ -71,8 +66,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForUnitProcessingDepthTest();
-
         // Keep the test hermetic: resolve the config dir to a temporary
         // directory rather than the user's real profiles.
         QVERIFY(mConfigDir.isValid());
@@ -234,20 +227,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForUnitProcessingDepthTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "UnitProcessingDepthTest.moc"
-QTEST_MAIN(UnitProcessingDepthTest)
+MUDLET_GROUPED_TEST_MAIN(UnitProcessingDepthTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The six trigger and scriptable-unit tests build as one `functional_trigger_tests` executable rather than one each, with `MUDLET_GROUPED_TEST_MAIN()` in place of `QTEST_MAIN()`. Every test keeps its own `add_test` entry, so each ctest case still runs as its own process with its own `QApplication` and untouched statics - only the link is shared.
- Each file's `initializeQRCResources*()` copy goes away, since the group's `main()` registers the resource collections where `src/main.cpp` does. Two of the six defined that function at global scope under the same name, which is the duplicate symbol this removal avoids.
- No test bodies change: per-test config-dir isolation, timeouts and leak-check membership are all per-case ctest properties and stay verbatim.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` passes 115/115 - `ctest -N` lists the same 115 names as development and `ctest --show-only=json-v1` reports zero differences across all 115 cases' 382 properties, while the six executables' 1.47 GiB becomes 256.9 MiB and six link steps become one.

Mutation-checked twice: inverting the drain assertion in `UnitProcessingDepthTest` and the surviving-pattern expectation in `CorruptTriggerPatternsTest` reddened exactly that case each time, with the other five green.

Assisted-by: Claude:claude-opus-5
