### PR TITLE
Infra: Build the editor functional tests into one executable

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -6,19 +6,14 @@ endif()
 cmake_language(DEFER CALL restore_windows_test_output)
 
 set(FUNCTIONAL_TEST_SOURCES
-    TriggerEditorTest.cpp
     TFeedTriggersRecursionTest.cpp
     MultilineTriggerReentrancyTest.cpp
-    dlgTriggerEditorUndoRedoTest.cpp
-    EditorBannerViewSwitchTest.cpp
     TDiscordModeTest.cpp
     MapAreaReassignmentTest.cpp
     UnitDeferredDeleteTest.cpp
     CorruptTriggerPatternsTest.cpp
     TutorialInvitationLayoutTest.cpp
     FeatureCalloutTest.cpp
-    VariableEditorWriteBackTest.cpp
-    ScriptEventHandlerLifetimeTest.cpp
     SetScriptCallbackTest.cpp
     PackageSelfRemovalTest.cpp
     UnitProcessingDepthTest.cpp
@@ -34,7 +29,6 @@ set(FUNCTIONAL_TEST_SOURCES
     ActionSelfRemovalTest.cpp
     DialogTeardownTest.cpp
     HostChildTeardownTest.cpp
-    EdbeeReinitTest.cpp
     TMediaLoopTest.cpp
     DefaultPackagesTest.cpp
     StarterUiTriggerCostTest.cpp
@@ -115,6 +109,16 @@ set(TELNET_GROUP_TEST_SOURCES
     TOscTest.cpp
 )
 
+# The script editor, and the trigger, variable and script forms it hosts
+set(EDITOR_GROUP_TEST_SOURCES
+    dlgTriggerEditorUndoRedoTest.cpp
+    EdbeeReinitTest.cpp
+    EditorBannerViewSwitchTest.cpp
+    ScriptEventHandlerLifetimeTest.cpp
+    TriggerEditorTest.cpp
+    VariableEditorWriteBackTest.cpp
+)
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
@@ -190,6 +194,7 @@ endmacro()
 add_grouped_test_binary(functional_window_tests ${WINDOW_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_profile_tests ${PROFILE_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_telnet_tests ${TELNET_GROUP_TEST_SOURCES})
+add_grouped_test_binary(functional_editor_tests ${EDITOR_GROUP_TEST_SOURCES})
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})

--- a/test/functional_tests/EdbeeReinitTest.cpp
+++ b/test/functional_tests/EdbeeReinitTest.cpp
@@ -44,28 +44,9 @@
 #include "edbee/models/textgrammar.h"
 #include "edbee/views/texttheme.h"
 
+#include "GroupedTest.h"
+
 using namespace std::chrono_literals;
-
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-
-static void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
 
 class EdbeeReinitTest : public QObject
 {
@@ -120,8 +101,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -187,4 +166,4 @@ private slots:
 };
 
 #include "EdbeeReinitTest.moc"
-QTEST_MAIN(EdbeeReinitTest)
+MUDLET_GROUPED_TEST_MAIN(EdbeeReinitTest)

--- a/test/functional_tests/EditorBannerViewSwitchTest.cpp
+++ b/test/functional_tests/EditorBannerViewSwitchTest.cpp
@@ -43,28 +43,9 @@
 #include "dlgTriggerEditor.h"
 #include "mudlet.h"
 
+#include "GroupedTest.h"
+
 using namespace std::chrono_literals;
-
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-
-static void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
 
 class EditorBannerViewSwitchTest : public QObject
 {
@@ -129,8 +110,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -347,4 +326,4 @@ private slots:
 };
 
 #include "EditorBannerViewSwitchTest.moc"
-QTEST_MAIN(EditorBannerViewSwitchTest)
+MUDLET_GROUPED_TEST_MAIN(EditorBannerViewSwitchTest)

--- a/test/functional_tests/ScriptEventHandlerLifetimeTest.cpp
+++ b/test/functional_tests/ScriptEventHandlerLifetimeTest.cpp
@@ -36,28 +36,9 @@
 #include "dlgTriggerEditor.h"
 #include "mudlet.h"
 
+#include "GroupedTest.h"
+
 using namespace std::chrono_literals;
-
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-
-static void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
 
 // Run with: ctest -R ScriptEventHandlerLifetimeTest -V
 //
@@ -176,8 +157,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -453,4 +432,4 @@ private slots:
 };
 
 #include "ScriptEventHandlerLifetimeTest.moc"
-QTEST_MAIN(ScriptEventHandlerLifetimeTest)
+MUDLET_GROUPED_TEST_MAIN(ScriptEventHandlerLifetimeTest)

--- a/test/functional_tests/TriggerEditorTest.cpp
+++ b/test/functional_tests/TriggerEditorTest.cpp
@@ -37,14 +37,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForTriggerEditorTest();
+using namespace std::chrono_literals;
 
 class TriggerEditorTest : public QObject {
   Q_OBJECT
@@ -91,8 +86,6 @@ private:
 
 private slots:
   void initTestCase() {
-    initializeQRCResourcesForTriggerEditorTest();
-
     if (portableMarkerPresent()) {
       QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, "
             "so the config dir cannot be redirected");
@@ -166,19 +159,5 @@ private slots:
   }
 };
 
-void initializeQRCResourcesForTriggerEditorTest() {
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-  qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-  qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-  qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-  qInitResources_mudlet();
-  qInitResources_qm();
-}
-
 #include "TriggerEditorTest.moc"
-QTEST_MAIN(TriggerEditorTest)
+MUDLET_GROUPED_TEST_MAIN(TriggerEditorTest)

--- a/test/functional_tests/VariableEditorWriteBackTest.cpp
+++ b/test/functional_tests/VariableEditorWriteBackTest.cpp
@@ -62,12 +62,7 @@ extern "C" {
 #endif
 }
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForVariableEditorWriteBackTest();
+#include "GroupedTest.h"
 
 class VariableEditorWriteBackTest : public QObject
 {
@@ -92,8 +87,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForVariableEditorWriteBackTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -590,20 +583,5 @@ private:
     }
 };
 
-void initializeQRCResourcesForVariableEditorWriteBackTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "VariableEditorWriteBackTest.moc"
-QTEST_MAIN(VariableEditorWriteBackTest)
+MUDLET_GROUPED_TEST_MAIN(VariableEditorWriteBackTest)

--- a/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
+++ b/test/functional_tests/dlgTriggerEditorUndoRedoTest.cpp
@@ -43,27 +43,9 @@
 #include "dlgTriggersMainArea.h"
 #include "mudlet.h"
 
+#include "GroupedTest.h"
+
 using namespace std::chrono_literals;
-
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-
-static void initializeQRCResources() {
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-  qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-  qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-  qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-  qInitResources_mudlet();
-  qInitResources_qm();
-}
 
 class dlgTriggerEditorUndoRedoTest : public QObject {
   Q_OBJECT
@@ -140,8 +122,6 @@ private:
 
 private slots:
   void initTestCase() {
-    initializeQRCResources();
-
     if (portableMarkerPresent()) {
       QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, "
             "so the config dir cannot be redirected");
@@ -2401,4 +2381,4 @@ private slots:
 };
 
 #include "dlgTriggerEditorUndoRedoTest.moc"
-QTEST_MAIN(dlgTriggerEditorUndoRedoTest)
+MUDLET_GROUPED_TEST_MAIN(dlgTriggerEditorUndoRedoTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The six script-editor tests build as one `functional_editor_tests` executable rather than one each, with `MUDLET_GROUPED_TEST_MAIN()` from #9993 in place of `QTEST_MAIN()`. Every test keeps its own `add_test` entry, so each ctest case still runs as its own process with its own `QApplication` and untouched statics - only the link is shared.
- Each file's `initializeQRCResources*()` copy goes away, since the group's `main()` registers the resource collections where `src/main.cpp` does.
- Nothing else in the six files moves: the per-test config isolation from #10012, the slot order and the pre-project brace style two of them are written in are all untouched.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` passes 115/115 - `ctest -N` lists the same 115 names as development and `ctest --show-only=json-v1` reports zero differences across all 382 property rows, under the sanitizer-free and the AddressSanitizer preset alike, while the six executables' 1.47 GiB becomes 257.3 MiB and six link steps become one.

Mutation-checked twice: dropping `unmarkQString()` from `SingleLineTextEdit::createMimeDataFromSelection()` reddens `TriggerEditorTest` alone, and deleting the #9835 `slot_scriptMainAreaClearHandlerSelection()` call from `dlgTriggerEditor::slot_scriptsSelected()` reddens `ScriptEventHandlerLifetimeTest` alone, with the other five cases green both times. `dlgTriggerEditorUndoRedoTest` keeps its leak-check exemption and its `TIMEOUT 300` while its five group-mates keep `detect_leaks=1`.

Assisted-by: Claude:claude-opus-5
