### PR TITLE
Infra: Build the map functional tests into one executable

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -12,7 +12,6 @@ set(FUNCTIONAL_TEST_SOURCES
     dlgTriggerEditorUndoRedoTest.cpp
     EditorBannerViewSwitchTest.cpp
     TDiscordModeTest.cpp
-    MapAreaReassignmentTest.cpp
     UnitDeferredDeleteTest.cpp
     CorruptTriggerPatternsTest.cpp
     TutorialInvitationLayoutTest.cpp
@@ -25,9 +24,6 @@ set(FUNCTIONAL_TEST_SOURCES
     PackageRemovalSaveTeardownTest.cpp
     TutorialInvitationGateTest.cpp
     ModuleSaveTeardownTest.cpp
-    MapRoundTripTest.cpp
-    MapProgressDialogSeamTest.cpp
-    MapCloseDuringImportTest.cpp
     StarterUiSectionsTest.cpp
     TtsInterruptingSpeakTest.cpp
     HostWidgetDecouplingTest.cpp
@@ -40,7 +36,6 @@ set(FUNCTIONAL_TEST_SOURCES
     StarterUiTriggerCostTest.cpp
     StarterUiGaugePanelTest.cpp
     ExperiencedPlayerGateTest.cpp
-    EmbeddedMapperCreationTest.cpp
 )
 
 # The updater sources are only built with USE_UPDATER, and on macOS the
@@ -113,6 +108,15 @@ set(TELNET_GROUP_TEST_SOURCES
     TelnetStringSequenceRecoveryTest.cpp
     TelnetTlsPromptTest.cpp
     TOscTest.cpp
+)
+
+# The map: its rooms and areas, its file format, and the mapper widget
+set(MAP_GROUP_TEST_SOURCES
+    EmbeddedMapperCreationTest.cpp
+    MapAreaReassignmentTest.cpp
+    MapCloseDuringImportTest.cpp
+    MapProgressDialogSeamTest.cpp
+    MapRoundTripTest.cpp
 )
 
 set(FUNCTIONAL_TEST_UTILS
@@ -190,6 +194,7 @@ endmacro()
 add_grouped_test_binary(functional_window_tests ${WINDOW_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_profile_tests ${PROFILE_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_telnet_tests ${TELNET_GROUP_TEST_SOURCES})
+add_grouped_test_binary(functional_map_tests ${MAP_GROUP_TEST_SOURCES})
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})

--- a/test/functional_tests/EmbeddedMapperCreationTest.cpp
+++ b/test/functional_tests/EmbeddedMapperCreationTest.cpp
@@ -47,12 +47,7 @@
 
 using namespace std::chrono_literals;
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForEmbeddedMapperTest();
+#include "GroupedTest.h"
 
 class EmbeddedMapperCreationTest : public QObject
 {
@@ -78,8 +73,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForEmbeddedMapperTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -194,20 +187,5 @@ private:
     }
 };
 
-void initializeQRCResourcesForEmbeddedMapperTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "EmbeddedMapperCreationTest.moc"
-QTEST_MAIN(EmbeddedMapperCreationTest)
+MUDLET_GROUPED_TEST_MAIN(EmbeddedMapperCreationTest)

--- a/test/functional_tests/EmbeddedMapperCreationTest.cpp
+++ b/test/functional_tests/EmbeddedMapperCreationTest.cpp
@@ -45,9 +45,9 @@
 #include "dlgMapper.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
-
 #include "GroupedTest.h"
+
+using namespace std::chrono_literals;
 
 class EmbeddedMapperCreationTest : public QObject
 {

--- a/test/functional_tests/MapAreaReassignmentTest.cpp
+++ b/test/functional_tests/MapAreaReassignmentTest.cpp
@@ -50,12 +50,7 @@
 #include "TRoomDB.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForMapAreaReassignmentTest();
+#include "GroupedTest.h"
 
 namespace {
 // Sizes for the reported cost curve: a per-room cost that climbs with them is
@@ -346,8 +341,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForMapAreaReassignmentTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -716,20 +709,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForMapAreaReassignmentTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MapAreaReassignmentTest.moc"
-QTEST_MAIN(MapAreaReassignmentTest)
+MUDLET_GROUPED_TEST_MAIN(MapAreaReassignmentTest)

--- a/test/functional_tests/MapCloseDuringImportTest.cpp
+++ b/test/functional_tests/MapCloseDuringImportTest.cpp
@@ -59,12 +59,7 @@
 
 using namespace std::chrono_literals;
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForMapCloseDuringImportTest();
+#include "GroupedTest.h"
 
 class MapCloseDuringImportTest : public QObject
 {
@@ -128,8 +123,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForMapCloseDuringImportTest();
-
         QVERIFY(mConfigDir.isValid());
         QVERIFY(mSaveDir.isValid());
         mSavedXdg = qgetenv("XDG_CONFIG_HOME");
@@ -229,20 +222,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForMapCloseDuringImportTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MapCloseDuringImportTest.moc"
-QTEST_MAIN(MapCloseDuringImportTest)
+MUDLET_GROUPED_TEST_MAIN(MapCloseDuringImportTest)

--- a/test/functional_tests/MapCloseDuringImportTest.cpp
+++ b/test/functional_tests/MapCloseDuringImportTest.cpp
@@ -57,9 +57,9 @@
 #include "TRoomDB.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
-
 #include "GroupedTest.h"
+
+using namespace std::chrono_literals;
 
 class MapCloseDuringImportTest : public QObject
 {

--- a/test/functional_tests/MapProgressDialogSeamTest.cpp
+++ b/test/functional_tests/MapProgressDialogSeamTest.cpp
@@ -49,12 +49,7 @@
 #include "TRoomDB.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForMapProgressDialogSeamTest();
+#include "GroupedTest.h"
 
 class MapProgressDialogSeamTest : public QObject
 {
@@ -105,8 +100,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForMapProgressDialogSeamTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -308,20 +301,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForMapProgressDialogSeamTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MapProgressDialogSeamTest.moc"
-QTEST_MAIN(MapProgressDialogSeamTest)
+MUDLET_GROUPED_TEST_MAIN(MapProgressDialogSeamTest)

--- a/test/functional_tests/MapRoundTripTest.cpp
+++ b/test/functional_tests/MapRoundTripTest.cpp
@@ -52,12 +52,7 @@
 #include "TRoomDB.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForMapRoundTripTest();
+#include "GroupedTest.h"
 
 namespace {
 const int scmRoom1 = 101;
@@ -469,8 +464,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForMapRoundTripTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -592,20 +585,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForMapRoundTripTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "MapRoundTripTest.moc"
-QTEST_MAIN(MapRoundTripTest)
+MUDLET_GROUPED_TEST_MAIN(MapRoundTripTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Continues the grouping from #9993, #9996, #10000, #10008, #10014 and #10015: the five map tests - rooms and areas, the binary map format, the progress seam and the embedded mapper - build into one `functional_map_tests` binary rather than getting an executable each. Every one keeps its own `add_test` entry, so a ctest case is still its own process with its own `QApplication`, its own untouched statics and its own properties. Only the link is shared.
- Each file drops its `qInitResources_*` externs and its own `initializeQRCResources()` copy, since the group's `main()` registers the resource collections once, where `src/main.cpp` does. All five registered theirs ahead of their `portable.txt` `QSKIP` guard, so nothing moves relative to it.
- All 115 ctest case names and every one of their properties - timeouts, sanitizer environment, labels, leak-check membership - are unchanged.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

Based on #10015 rather than `development`, so that the wave's remaining `CMakeLists.txt` merges resolve once rather than repeatedly; the base goes back to `development` when #10015 lands.

**Test case:** `ctest --preset linux-debug-nosan` - 115/115 pass; `ctest -N` lists the same 115 names as the base branch and `ctest --show-only=json-v1` reports zero differences across all 382 property entries of those 115 cases, checked under both `linux-debug-nosan` and `linux-debug` so the leak-check branch is covered too. Measured rather than averaged: the five executables were 1.229GiB and five link steps, the one binary is 0.252GiB and one link, so the directory drops 0.98GiB and goes from 32 executables to 28.

Mutation-checked both ways, each rebuilding only the group binary and running all five cases: dropping the `mapOperationInProgress()` guard from `mudlet::closeHost()` reddens `MapCloseDuringImportTest` alone, on the use-after-free it exists to catch; dropping `mMapProgressCancelRequested = true` from `TMap::slot_mapProgressDialogCancelled()` reddens `MapProgressDialogSeamTest` alone, on its own `test_jsonImportCancellationAbortsViaSeam()` assertion. The other four stayed green in both runs.

Assisted-by: Claude:claude-opus-5
