### PR TITLE
Infra: Build the package functional tests into one executable

### DIFF
--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -36,12 +36,7 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResources();
+#include "GroupedTest.h"
 
 // Regression tests for the self-uninstall use-after-free: a package toolbar
 // button whose Lua script calls uninstallPackage() on its own package used to
@@ -116,8 +111,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -255,20 +248,5 @@ private slots:
     }
 };
 
-void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "ActionSelfRemovalTest.moc"
-QTEST_MAIN(ActionSelfRemovalTest)
+MUDLET_GROUPED_TEST_MAIN(ActionSelfRemovalTest)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -20,23 +20,18 @@ set(FUNCTIONAL_TEST_SOURCES
     VariableEditorWriteBackTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
     SetScriptCallbackTest.cpp
-    PackageSelfRemovalTest.cpp
     UnitProcessingDepthTest.cpp
-    PackageRemovalSaveTeardownTest.cpp
     TutorialInvitationGateTest.cpp
-    ModuleSaveTeardownTest.cpp
     MapRoundTripTest.cpp
     MapProgressDialogSeamTest.cpp
     MapCloseDuringImportTest.cpp
     StarterUiSectionsTest.cpp
     TtsInterruptingSpeakTest.cpp
     HostWidgetDecouplingTest.cpp
-    ActionSelfRemovalTest.cpp
     DialogTeardownTest.cpp
     HostChildTeardownTest.cpp
     EdbeeReinitTest.cpp
     TMediaLoopTest.cpp
-    DefaultPackagesTest.cpp
     StarterUiTriggerCostTest.cpp
     StarterUiGaugePanelTest.cpp
     ExperiencedPlayerGateTest.cpp
@@ -115,6 +110,15 @@ set(TELNET_GROUP_TEST_SOURCES
     TOscTest.cpp
 )
 
+# Packages and modules: installing them, saving them and removing them
+set(PACKAGE_GROUP_TEST_SOURCES
+    ActionSelfRemovalTest.cpp
+    DefaultPackagesTest.cpp
+    ModuleSaveTeardownTest.cpp
+    PackageRemovalSaveTeardownTest.cpp
+    PackageSelfRemovalTest.cpp
+)
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
@@ -190,6 +194,7 @@ endmacro()
 add_grouped_test_binary(functional_window_tests ${WINDOW_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_profile_tests ${PROFILE_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_telnet_tests ${TELNET_GROUP_TEST_SOURCES})
+add_grouped_test_binary(functional_package_tests ${PACKAGE_GROUP_TEST_SOURCES})
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})

--- a/test/functional_tests/DefaultPackagesTest.cpp
+++ b/test/functional_tests/DefaultPackagesTest.cpp
@@ -51,12 +51,7 @@ extern "C" {
 #endif
 }
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForDefaultPackagesTest();
+#include "GroupedTest.h"
 
 class DefaultPackagesTest : public QObject
 {
@@ -84,8 +79,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForDefaultPackagesTest();
-
         // Keep the test hermetic: point the config dir resolution at a
         // temporary directory instead of the user's real profiles.
         QVERIFY(mConfigDir.isValid());
@@ -291,20 +284,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForDefaultPackagesTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "DefaultPackagesTest.moc"
-QTEST_MAIN(DefaultPackagesTest)
+MUDLET_GROUPED_TEST_MAIN(DefaultPackagesTest)

--- a/test/functional_tests/ModuleSaveTeardownTest.cpp
+++ b/test/functional_tests/ModuleSaveTeardownTest.cpp
@@ -65,14 +65,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForModuleSaveTeardownTest();
+using namespace std::chrono_literals;
 
 class ModuleSaveTeardownTest : public QObject
 {
@@ -345,8 +340,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForModuleSaveTeardownTest();
-
         // Keep the test hermetic: point the config dir resolution at a temporary
         // directory instead of the user's real profiles.
         QVERIFY(mConfigDir.isValid());
@@ -482,20 +475,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForModuleSaveTeardownTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "ModuleSaveTeardownTest.moc"
-QTEST_MAIN(ModuleSaveTeardownTest)
+MUDLET_GROUPED_TEST_MAIN(ModuleSaveTeardownTest)

--- a/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
+++ b/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
@@ -58,14 +58,9 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForPackageRemovalSaveTeardownTest();
+using namespace std::chrono_literals;
 
 class PackageRemovalSaveTeardownTest : public QObject
 {
@@ -155,8 +150,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForPackageRemovalSaveTeardownTest();
-
         // Keep the test hermetic: point the config dir resolution at a temporary
         // directory instead of the user's real profiles - one of the tests below
         // drives an archive that tries to have the profiles folder deleted.
@@ -362,20 +355,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForPackageRemovalSaveTeardownTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "PackageRemovalSaveTeardownTest.moc"
-QTEST_MAIN(PackageRemovalSaveTeardownTest)
+MUDLET_GROUPED_TEST_MAIN(PackageRemovalSaveTeardownTest)

--- a/test/functional_tests/PackageSelfRemovalTest.cpp
+++ b/test/functional_tests/PackageSelfRemovalTest.cpp
@@ -80,12 +80,7 @@ extern "C" {
 #endif
 }
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForPackageSelfRemovalTest();
+#include "GroupedTest.h"
 
 // TriggerUnit only holds its depth inside processDataStream(), so a save at
 // depth has to come from a trigger's own script. Stands in for the Lua
@@ -132,8 +127,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForPackageSelfRemovalTest();
-
         // Keep the test hermetic: point the config dir resolution at a
         // temporary directory instead of the user's real profiles.
         QVERIFY(mConfigDir.isValid());
@@ -655,20 +648,5 @@ private:
     }
 };
 
-void initializeQRCResourcesForPackageSelfRemovalTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "PackageSelfRemovalTest.moc"
-QTEST_MAIN(PackageSelfRemovalTest)
+MUDLET_GROUPED_TEST_MAIN(PackageSelfRemovalTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The five package and module tests build as one `functional_package_tests` executable rather than one each, with `MUDLET_GROUPED_TEST_MAIN()` from #9993 in place of `QTEST_MAIN()`. Every test keeps its own `add_test` entry, so each ctest case still runs as its own process with its own `QApplication`, its own application name and untouched statics - only the link is shared.
- Each file's `initializeQRCResources*()` copy goes away, since the group's `main()` registers the resource collections where `src/main.cpp` does.
- Nothing else changes: the XDG isolation blocks from #10012, the include order and the pre-project formatting of these files are all untouched.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` passes 115/115 - `ctest -N` lists the same 115 names as development and `ctest --show-only=json-v1` reports zero property differences across all 115 (382 property entries, none of them an empty row), while the five executables' 1.23 GiB becomes 256.3 MiB and five link steps become one. The five also pass under `linux-debug`, where they still carry `detect_leaks=1:intercept_tls_get_addr=0`.

Mutation-checked twice: dropping the `generic_mapper` preinstall from `setupPreInstallPackages()` reddens `DefaultPackagesTest` alone, and dropping the `uninstallList` skip from `XMLexport`'s profile trigger export reddens `PackageSelfRemovalTest` alone, each on its own assertion message, with the other four cases green both times. A probe in the grouped binary reports `~/.config/<test class>` for each of the five, so these per-profile package installs are not quietly sharing one config store.

Based on #10016 rather than `development`, so that the four wave-2 groups cannot re-conflict on the same `CMakeLists.txt` as they merge; the 115/115 run above is against that chain, i.e. the trigger, editor, map and package groups all built together.

Assisted-by: Claude:claude-opus-5
