### PR TITLE
Infra: Build the starter UI functional tests into one executable

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -7,18 +7,11 @@ cmake_language(DEFER CALL restore_windows_test_output)
 
 set(FUNCTIONAL_TEST_SOURCES
     TDiscordModeTest.cpp
-    TutorialInvitationLayoutTest.cpp
-    FeatureCalloutTest.cpp
-    TutorialInvitationGateTest.cpp
-    StarterUiSectionsTest.cpp
     TtsInterruptingSpeakTest.cpp
     HostWidgetDecouplingTest.cpp
     DialogTeardownTest.cpp
     HostChildTeardownTest.cpp
     TMediaLoopTest.cpp
-    StarterUiTriggerCostTest.cpp
-    StarterUiGaugePanelTest.cpp
-    ExperiencedPlayerGateTest.cpp
 )
 
 # The updater sources are only built with USE_UPDATER, and on macOS the
@@ -131,6 +124,18 @@ set(PACKAGE_GROUP_TEST_SOURCES
     PackageSelfRemovalTest.cpp
 )
 
+# Onboarding and in-app guidance: the starter UI, the tutorial invitation,
+# the feature callouts and the experienced-player gate
+set(STARTERUI_GROUP_TEST_SOURCES
+    ExperiencedPlayerGateTest.cpp
+    FeatureCalloutTest.cpp
+    StarterUiGaugePanelTest.cpp
+    StarterUiSectionsTest.cpp
+    StarterUiTriggerCostTest.cpp
+    TutorialInvitationGateTest.cpp
+    TutorialInvitationLayoutTest.cpp
+)
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
@@ -210,6 +215,7 @@ add_grouped_test_binary(functional_trigger_tests ${TRIGGER_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_editor_tests ${EDITOR_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_map_tests ${MAP_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_package_tests ${PACKAGE_GROUP_TEST_SOURCES})
+add_grouped_test_binary(functional_starterui_tests ${STARTERUI_GROUP_TEST_SOURCES})
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})

--- a/test/functional_tests/ExperiencedPlayerGateTest.cpp
+++ b/test/functional_tests/ExperiencedPlayerGateTest.cpp
@@ -37,14 +37,7 @@
 #include "MudletInstanceCoordinator.h"
 #include "mudlet.h"
 
-// init() reads compiled-in resources, which are not registered automatically in
-// a test binary that links mudlet_core statically
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForExperiencedPlayerGateTest();
+#include "GroupedTest.h"
 
 class ExperiencedPlayerGateTest : public QObject
 {
@@ -302,7 +295,6 @@ private slots:
         QVERIFY(QDir().mkpath(qsl("%1/profiles").arg(configDir)));
         qputenv("XDG_CONFIG_HOME", mLiveConfig.path().toUtf8());
 
-        initializeQRCResourcesForExperiencedPlayerGateTest();
         mudlet::start();
         mudlet::self()->setupConfig();
         QCOMPARE(mudlet::getMudletPath(enums::mainPath), configDir);
@@ -334,20 +326,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForExperiencedPlayerGateTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "ExperiencedPlayerGateTest.moc"
-QTEST_MAIN(ExperiencedPlayerGateTest)
+MUDLET_GROUPED_TEST_MAIN(ExperiencedPlayerGateTest)

--- a/test/functional_tests/FeatureCalloutTest.cpp
+++ b/test/functional_tests/FeatureCalloutTest.cpp
@@ -25,6 +25,8 @@
 #include "enums.h"
 #include "mudlet.h"
 
+#include "GroupedTest.h"
+
 /*
  * A feature callout is a Qt::ToolTip window, which the platforms Mudlet ships
  * on keep above ordinary windows - including the windows of whatever
@@ -224,4 +226,4 @@ private slots:
 };
 
 #include "FeatureCalloutTest.moc"
-QTEST_MAIN(FeatureCalloutTest)
+MUDLET_GROUPED_TEST_MAIN(FeatureCalloutTest)

--- a/test/functional_tests/StarterUiGaugePanelTest.cpp
+++ b/test/functional_tests/StarterUiGaugePanelTest.cpp
@@ -41,12 +41,7 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-static void initializeQRCResources();
+#include "GroupedTest.h"
 
 class StarterUiGaugePanelTest : public QObject
 {
@@ -69,8 +64,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -397,20 +390,5 @@ private:
     }
 };
 
-static void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "StarterUiGaugePanelTest.moc"
-QTEST_MAIN(StarterUiGaugePanelTest)
+MUDLET_GROUPED_TEST_MAIN(StarterUiGaugePanelTest)

--- a/test/functional_tests/StarterUiSectionsTest.cpp
+++ b/test/functional_tests/StarterUiSectionsTest.cpp
@@ -46,12 +46,7 @@
 #include "dlgMapper.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-static void initializeQRCResources();
+#include "GroupedTest.h"
 
 class StarterUiSectionsTest : public QObject
 {
@@ -74,8 +69,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -772,20 +765,5 @@ private:
     }
 };
 
-static void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "StarterUiSectionsTest.moc"
-QTEST_MAIN(StarterUiSectionsTest)
+MUDLET_GROUPED_TEST_MAIN(StarterUiSectionsTest)

--- a/test/functional_tests/StarterUiTriggerCostTest.cpp
+++ b/test/functional_tests/StarterUiTriggerCostTest.cpp
@@ -38,12 +38,7 @@
 #include <QTreeWidget>
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-static void initializeQRCResources();
+#include "GroupedTest.h"
 
 class StarterUiTriggerCostTest : public QObject
 {
@@ -77,8 +72,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResources();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -876,20 +869,5 @@ __starterUi.shapeCount = BaseUI.vitalsShapeCount()
     }
 };
 
-static void initializeQRCResources()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "StarterUiTriggerCostTest.moc"
-QTEST_MAIN(StarterUiTriggerCostTest)
+MUDLET_GROUPED_TEST_MAIN(StarterUiTriggerCostTest)

--- a/test/functional_tests/TutorialInvitationGateTest.cpp
+++ b/test/functional_tests/TutorialInvitationGateTest.cpp
@@ -37,12 +37,7 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForTutorialInvitationGateTest();
+#include "GroupedTest.h"
 
 class TutorialInvitationGateTest : public QObject
 {
@@ -55,8 +50,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForTutorialInvitationGateTest();
-
         QVERIFY(mConfigDir.isValid());
         QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
 
@@ -114,20 +107,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForTutorialInvitationGateTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "TutorialInvitationGateTest.moc"
-QTEST_MAIN(TutorialInvitationGateTest)
+MUDLET_GROUPED_TEST_MAIN(TutorialInvitationGateTest)

--- a/test/functional_tests/TutorialInvitationLayoutTest.cpp
+++ b/test/functional_tests/TutorialInvitationLayoutTest.cpp
@@ -24,8 +24,8 @@
  * last line and leave it scrolling.
  *
  * A fresh install is the only state that shows the invitation, so this runs in
- * its own binary - mudlet::experiencedMudletPlayer() memoises for the life of
- * the process, and TutorialInvitationGateTest owns the opposite case.
+ * a process of its own - mudlet::experiencedMudletPlayer() memoises for the
+ * life of the process, and TutorialInvitationGateTest owns the opposite case.
  *
  * Run with: ctest -R TutorialInvitationLayoutTest -V
  */
@@ -39,12 +39,7 @@
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForTutorialInvitationLayoutTest();
+#include "GroupedTest.h"
 
 class TutorialInvitationLayoutTest : public QObject
 {
@@ -57,8 +52,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForTutorialInvitationLayoutTest();
-
         QVERIFY(mConfigDir.isValid());
         // $XDG_CONFIG_HOME/mudlet/profiles is the opt-in marker, without which
         // setupConfig() would keep using a legacy ~/.config/mudlet
@@ -123,20 +116,5 @@ private:
     }
 };
 
-void initializeQRCResourcesForTutorialInvitationLayoutTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "TutorialInvitationLayoutTest.moc"
-QTEST_MAIN(TutorialInvitationLayoutTest)
+MUDLET_GROUPED_TEST_MAIN(TutorialInvitationLayoutTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The seven starter UI tests - the dock's sections and gauges, its per-line trigger cost, the tutorial invitation, the feature callouts and the experienced-player gate - build as one `functional_starterui_tests` executable rather than one each, with `MUDLET_GROUPED_TEST_MAIN()` from #9993 in place of `QTEST_MAIN()`. Every test keeps its own `add_test` entry, so each ctest case still runs as its own process with its own `QApplication`, its own application name and untouched statics - only the link is shared.
- Each file's `initializeQRCResources*()` copy goes away, since the group's `main()` registers the resource collections where `src/main.cpp` does. That moves registration for two of them: `FeatureCalloutTest` registered none at all before, and `ExperiencedPlayerGateTest` registered its own from inside a test slot, behind that slot's `portable.txt` `QSKIP`. Neither asserts on anything a resource collection changes.
- Nothing else changes bar one comment: `TutorialInvitationLayoutTest` said it "runs in its own binary" because `experiencedMudletPlayer()` memoises for the life of the process. A process of its own is what that needs and what it still gets, so the comment now says that. The XDG isolation blocks from #10012, the include order and the pre-project formatting are untouched.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` passes 115/115 - `ctest -N` lists the same 115 names as development and `ctest --show-only=json-v1` reports zero property differences across all 115 (382 property entries, none of them an empty row), while the seven executables' 1.69 GiB becomes 257.1 MiB and seven link steps become one.

Mutation-checked twice: emptying `TFeatureCallout::markDismissed()` reddens `FeatureCalloutTest` alone, and dropping the `setMinimumHeight()` from `dlgConnectionProfiles::fitWelcomeMessageToContents()` reddens `TutorialInvitationLayoutTest` alone, each on its own assertion message, with the other six green both times. A `%{appname}` probe of the grouped binary reports the test class for each of the seven, so `TutorialInvitationGateTest` and `TutorialInvitationLayoutTest` - which must not share a process, since the gate memoises - keep separate config stores as well as separate processes.

The teardown and media groups are being converted in parallel and land in the same `CMakeLists.txt`, so the three are meant to be stacked rather than each merging `development`.

Assisted-by: Claude:claude-opus-5
