### PR TITLE
Infra: Build the media functional tests into one executable

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -6,16 +6,13 @@ endif()
 cmake_language(DEFER CALL restore_windows_test_output)
 
 set(FUNCTIONAL_TEST_SOURCES
-    TDiscordModeTest.cpp
     TutorialInvitationLayoutTest.cpp
     FeatureCalloutTest.cpp
     TutorialInvitationGateTest.cpp
     StarterUiSectionsTest.cpp
-    TtsInterruptingSpeakTest.cpp
     HostWidgetDecouplingTest.cpp
     DialogTeardownTest.cpp
     HostChildTeardownTest.cpp
-    TMediaLoopTest.cpp
     StarterUiTriggerCostTest.cpp
     StarterUiGaugePanelTest.cpp
     ExperiencedPlayerGateTest.cpp
@@ -131,6 +128,13 @@ set(PACKAGE_GROUP_TEST_SOURCES
     PackageSelfRemovalTest.cpp
 )
 
+# Sound and music, text-to-speech, and the rich presence published to Discord
+set(MEDIA_GROUP_TEST_SOURCES
+    TDiscordModeTest.cpp
+    TMediaLoopTest.cpp
+    TtsInterruptingSpeakTest.cpp
+)
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
@@ -210,6 +214,7 @@ add_grouped_test_binary(functional_trigger_tests ${TRIGGER_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_editor_tests ${EDITOR_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_map_tests ${MAP_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_package_tests ${PACKAGE_GROUP_TEST_SOURCES})
+add_grouped_test_binary(functional_media_tests ${MEDIA_GROUP_TEST_SOURCES})
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})
@@ -287,7 +292,7 @@ set_tests_properties(ProfileLifecycleTest PROPERTIES TIMEOUT 300)
 
 # TMediaLoopTest probes the audio backend and creates a fresh profile per test method,
 # and each clip has to be waited out in real time, so it needs a longer timeout.
-# QTEST_MAIN does not run src/main.cpp, so pin QT_MEDIA_BACKEND to what main.cpp picks for
+# No test binary runs src/main.cpp, so pin QT_MEDIA_BACKEND to what main.cpp picks for
 # the shipped application - otherwise the tests silently exercise Qt's default backend for
 # the platform rather than the one users actually get.
 if(APPLE)

--- a/test/functional_tests/TDiscordModeTest.cpp
+++ b/test/functional_tests/TDiscordModeTest.cpp
@@ -57,20 +57,9 @@ extern "C" {
 #endif
 }
 
-using namespace std::chrono_literals;
+#include "GroupedTest.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-extern void qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-extern void qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-extern void qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-void initializeQRCResourcesForDiscordModeTest();
+using namespace std::chrono_literals;
 
 class TDiscordModeTest : public QObject
 {
@@ -182,8 +171,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForDiscordModeTest();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -593,20 +580,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForDiscordModeTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "TDiscordModeTest.moc"
-QTEST_MAIN(TDiscordModeTest)
+MUDLET_GROUPED_TEST_MAIN(TDiscordModeTest)

--- a/test/functional_tests/TMediaLoopTest.cpp
+++ b/test/functional_tests/TMediaLoopTest.cpp
@@ -36,12 +36,7 @@
 #include "mudlet.h"
 #include "utils.h"
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForMediaLoop();
+#include "GroupedTest.h"
 
 using namespace std::chrono_literals;
 
@@ -137,8 +132,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForMediaLoop();
-
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -1086,20 +1079,5 @@ private:
     }
 };
 
-void initializeQRCResourcesForMediaLoop()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "TMediaLoopTest.moc"
-QTEST_MAIN(TMediaLoopTest)
+MUDLET_GROUPED_TEST_MAIN(TMediaLoopTest)

--- a/test/functional_tests/TtsInterruptingSpeakTest.cpp
+++ b/test/functional_tests/TtsInterruptingSpeakTest.cpp
@@ -55,12 +55,7 @@
 #include <QTextToSpeech>
 #endif
 
-extern void qInitResources_mudlet();
-extern void qInitResources_qm();
-extern void qInitResources_additional_splash_screens();
-extern void qInitResources_mudlet_fonts_common();
-extern void qInitResources_mudlet_fonts_posix();
-void initializeQRCResourcesForTtsInterruptingSpeakTest();
+#include "GroupedTest.h"
 
 class TtsInterruptingSpeakTest : public QObject
 {
@@ -98,8 +93,6 @@ private:
 private slots:
     void initTestCase()
     {
-        initializeQRCResourcesForTtsInterruptingSpeakTest();
-
         QVERIFY(mConfigDir.isValid());
         mSavedXdg = qgetenv("XDG_CONFIG_HOME");
         QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
@@ -224,20 +217,5 @@ private slots:
     }
 };
 
-void initializeQRCResourcesForTtsInterruptingSpeakTest()
-{
-#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
-    qInitResources_additional_splash_screens();
-#endif
-#ifdef INCLUDE_FONTS
-    qInitResources_mudlet_fonts_common();
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    qInitResources_mudlet_fonts_posix();
-#endif
-#endif
-    qInitResources_mudlet();
-    qInitResources_qm();
-}
-
 #include "TtsInterruptingSpeakTest.moc"
-QTEST_MAIN(TtsInterruptingSpeakTest)
+MUDLET_GROUPED_TEST_MAIN(TtsInterruptingSpeakTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `TDiscordModeTest`, `TMediaLoopTest` and `TtsInterruptingSpeakTest` build as one `functional_media_tests` executable rather than one each, with `MUDLET_GROUPED_TEST_MAIN()` from #9993 in place of `QTEST_MAIN()`. Every test keeps its own `add_test` entry, so each ctest case still runs as its own process with its own `QApplication`, its own application name and untouched statics - only the link is shared.
- Each file's `initializeQRCResources*()` copy goes away, since the group's `main()` registers the resource collections where `src/main.cpp` does.
- Nothing else changes: the XDG isolation blocks from #10012, `TMediaLoopTest`'s ephemeral-port stub, the include order and the pre-existing formatting of these files are all untouched.

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` passes 115/115, `ctest -N` lists the same 115 names as development, and `ctest --show-only=json-v1` reports zero property differences across all 115 (382 property entries, none of them an empty row), while the three executables' 753.9 MiB becomes 253.9 MiB and three link steps become one.

Mutation-checked once per member, each reddening exactly its own case out of the 115 and on its own assertion message: making a `loops=-1` playlist `Sequential` rather than `Loop` reddens `TMediaLoopTest`, dropping the #9659 interrupting-`Ready` guard from `TLuaInterpreter::ttsStateChanged()` reddens `TtsInterruptingSpeakTest`, and dropping the mode gate from `Host::processGMCPDiscordInfo()` reddens `TDiscordModeTest`. A probe in the grouped binary reports `~/.config/<test class>` for each of the three, and all three also pass under `linux-debug`, where they still carry `detect_leaks=1:intercept_tls_get_addr=0`.

Assisted-by: Claude:claude-opus-5
