### PR TITLE
Infra: Build the updater functional tests into one executable

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -221,9 +221,9 @@ endfunction()
 
 # Both passes are needed. Targets carry the name that actually reaches disk,
 # OUTPUT_NAME included, but only for the tests this configuration builds:
-# NewReleaseDialogTeardownTest, for one, is registered only under USE_UPDATER.
-# Source names are what the registration loops derive executable names from,
-# and are present whatever the configuration.
+# functional_release_tests, for one, is created only under USE_UPDATER. Source
+# names are what the registration loops derive executable names from, are
+# present whatever the configuration, and are all a grouped test ever has.
 function(mudlet_check_test_executable_names directory)
     mudlet_reject_uac_installer_target_names("${directory}")
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -8,27 +8,18 @@ cmake_language(DEFER CALL restore_windows_test_output)
 set(FUNCTIONAL_TEST_SOURCES
 )
 
-# The updater sources are only built with USE_UPDATER, and on macOS the
-# Updater wraps Sparkle instead of creating an UpdateDialog
-if(USE_UPDATER AND NOT APPLE)
-    list(APPEND FUNCTIONAL_TEST_SOURCES NewReleaseDialogTeardownTest.cpp)
-endif()
-
-# dblsqd::Feed itself is built on every platform that has the updater
-if(USE_UPDATER)
-    list(APPEND FUNCTIONAL_TEST_SOURCES FeedChecksumRaceTest.cpp)
-endif()
-
 # Tests that share one executable rather than getting one each. A functional
 # test binary statically links mudlet_core and costs a build tree ~250MB plus a
 # link step, and none of that is per-test - so tests of one subsystem are built
 # together and told on the command line which class to run. See GroupedTest.h.
 #
 # A new test belongs in its subsystem's list below if there is one, and then
-# writes MUDLET_GROUPED_TEST_MAIN() rather than QTEST_MAIN(); a subsystem with
-# no list yet still belongs in FUNCTIONAL_TEST_SOURCES. A grouped test's class
-# name has to match its filename, since that is the name ctest passes on the
-# command line and the group binary looks up.
+# writes MUDLET_GROUPED_TEST_MAIN() rather than QTEST_MAIN() - or
+# MUDLET_GROUPED_TEST_APPLESS_MAIN() rather than QTEST_APPLESS_MAIN(), if it
+# builds its own application object. A subsystem with no list yet still belongs
+# in FUNCTIONAL_TEST_SOURCES. A grouped test's class name has to match its
+# filename, since that is the name ctest passes on the command line and the
+# group binary looks up.
 
 # Windows, consoles and the text they draw
 set(WINDOW_GROUP_TEST_SOURCES
@@ -144,6 +135,25 @@ set(MEDIA_GROUP_TEST_SOURCES
     TtsInterruptingSpeakTest.cpp
 )
 
+# The updater: the release feed it reads and the dialog it offers. Named for
+# releases rather than the updater because Windows refuses to launch an unsigned
+# executable whose name contains "update" without elevation (#9748), which the
+# name gate in ../CMakeLists.txt enforces. Both members are conditional and not
+# on the same condition, so this list is appended to rather than declared, and
+# its target is only created if anything landed in it.
+set(RELEASE_GROUP_TEST_SOURCES)
+
+# The updater sources are only built with USE_UPDATER, and on macOS the
+# Updater wraps Sparkle instead of creating an UpdateDialog
+if(USE_UPDATER AND NOT APPLE)
+    list(APPEND RELEASE_GROUP_TEST_SOURCES NewReleaseDialogTeardownTest.cpp)
+endif()
+
+# dblsqd::Feed itself is built on every platform that has the updater
+if(USE_UPDATER)
+    list(APPEND RELEASE_GROUP_TEST_SOURCES FeedChecksumRaceTest.cpp)
+endif()
+
 set(FUNCTIONAL_TEST_UTILS
     TelnetServerStub.cpp
     DiscordIpcServerStub.cpp
@@ -226,6 +236,9 @@ add_grouped_test_binary(functional_package_tests ${PACKAGE_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_starterui_tests ${STARTERUI_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_teardown_tests ${TEARDOWN_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_media_tests ${MEDIA_GROUP_TEST_SOURCES})
+if(RELEASE_GROUP_TEST_SOURCES)
+    add_grouped_test_binary(functional_release_tests ${RELEASE_GROUP_TEST_SOURCES})
+endif()
 
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})

--- a/test/functional_tests/FeedChecksumRaceTest.cpp
+++ b/test/functional_tests/FeedChecksumRaceTest.cpp
@@ -31,6 +31,8 @@
 #include <QTcpSocket>
 #include <QTimer>
 
+#include "GroupedTest.h"
+
 /*
  * Regression test for https://github.com/Mudlet/Mudlet/issues/9938 (Sentry
  * MUDLET-4M): EXCEPTION_ACCESS_VIOLATION_READ at address 0x8 inside
@@ -202,5 +204,5 @@ void FeedChecksumRaceTest::secondDownloadRequestDuringChecksumFetchDoesNotCrash(
     QVERIFY2(feed.isDownloading(), "the download started by the first request must still be running");
 }
 
-QTEST_MAIN(FeedChecksumRaceTest)
+MUDLET_GROUPED_TEST_MAIN(FeedChecksumRaceTest)
 #include "FeedChecksumRaceTest.moc"

--- a/test/functional_tests/GroupedTest.h
+++ b/test/functional_tests/GroupedTest.h
@@ -26,9 +26,11 @@
 
 // Every functional test executable statically links mudlet_core, which costs a
 // build tree ~250MB and a link step each. Tests that can share one binary use
-// MUDLET_GROUPED_TEST_MAIN() in place of QTEST_MAIN(): instead of defining
-// main() it hands GroupedTestMain.cpp's main() a function that runs this one
-// class, and that main() runs exactly the class named on the command line.
+// MUDLET_GROUPED_TEST_MAIN() in place of QTEST_MAIN() - or
+// MUDLET_GROUPED_TEST_APPLESS_MAIN() in place of QTEST_APPLESS_MAIN(): instead
+// of defining main() it hands GroupedTestMain.cpp's main() a function that runs
+// this one class, and that main() runs exactly the class named on the command
+// line.
 //
 // So a grouped ctest case is still its own process, with its own QApplication
 // and untouched static state - only the link is shared. Qt has the same idea
@@ -49,27 +51,36 @@ struct Registrar
 
 } // namespace GroupedTest
 
-// The body is QTEST_MAIN's, less its Qt-selftest coverage hook, so a grouped run
-// sets up what QTEST_MAIN sets up in the same order. QTEST_MAIN_SETUP() and
-// QTEST_SET_MAIN_SOURCE_PATH come from qtest.h; the first picks QApplication
-// over QCoreApplication from the Qt libraries this translation unit sees and the
-// second reads __FILE__, so both have to expand in the test's own file rather
-// than in main().
+// Internal - write one of the two macros below instead.
 //
-// The application name is the one thing sharing a binary would otherwise change:
-// QStandardPaths::AppConfigLocation is built from it, and Mudlet keeps profile
-// encryption keys and passwords under there, so leaving it at the executable's
-// name would give a whole group one store instead of a test each.
-#define MUDLET_GROUPED_TEST_MAIN(TestObject)                                                                                                                                                           \
+// The body is QTEST_MAIN_WRAPPER's, less its Qt-selftest coverage hook, so a
+// grouped run sets up what QTEST_MAIN sets up in the same order - and the two
+// macros below differ by the setup they hand it, exactly as QTEST_MAIN and
+// QTEST_APPLESS_MAIN do. QTEST_MAIN_SETUP() and QTEST_SET_MAIN_SOURCE_PATH come
+// from qtest.h; the first picks QApplication over QCoreApplication from the Qt
+// libraries this translation unit sees and the second reads __FILE__, so both
+// have to expand in the test's own file rather than in main().
+#define MUDLET_GROUPED_TEST_WRAPPER(TestObject, ...)                                                                                                                                                   \
     static int run##TestObject(int argc, char* argv[])                                                                                                                                                 \
     {                                                                                                                                                                                                  \
         QT_PREPEND_NAMESPACE(QTest::Internal::callInitMain)<TestObject>();                                                                                                                             \
-        QTEST_MAIN_SETUP()                                                                                                                                                                             \
-        app.setApplicationName(qsl(#TestObject));                                                                                                                                                      \
+        __VA_ARGS__                                                                                                                                                                                    \
         TestObject tc;                                                                                                                                                                                 \
         QTEST_SET_MAIN_SOURCE_PATH                                                                                                                                                                     \
         return QTest::qExec(&tc, argc, argv);                                                                                                                                                          \
     }                                                                                                                                                                                                  \
     static const GroupedTest::Registrar registrar##TestObject(#TestObject, &run##TestObject);
+
+// The application name is the one thing sharing a binary would otherwise change:
+// QStandardPaths::AppConfigLocation is built from it, and Mudlet keeps profile
+// encryption keys and passwords under there, so leaving it at the executable's
+// name would give a whole group one store instead of a test each.
+#define MUDLET_GROUPED_TEST_MAIN(TestObject) MUDLET_GROUPED_TEST_WRAPPER(TestObject, QTEST_MAIN_SETUP() app.setApplicationName(qsl(#TestObject));)
+
+// For a test that builds and exec()s its own QApplication: no QTEST_MAIN_SETUP(),
+// so nothing here creates a second one. Setting the name before any application
+// object exists is what QCoreApplication expects - it keeps what was set and only
+// falls back to the executable's own name when nothing was.
+#define MUDLET_GROUPED_TEST_APPLESS_MAIN(TestObject) MUDLET_GROUPED_TEST_WRAPPER(TestObject, QCoreApplication::setApplicationName(qsl(#TestObject));)
 
 #endif // MUDLET_GROUPEDTEST_H

--- a/test/functional_tests/NewReleaseDialogTeardownTest.cpp
+++ b/test/functional_tests/NewReleaseDialogTeardownTest.cpp
@@ -35,6 +35,8 @@
 
 #include <memory>
 
+#include "GroupedTest.h"
+
 /*
  * What the Updater has to clean up after itself: the dialog it owns, and the
  * files it leaves in the temp directory.
@@ -61,7 +63,7 @@
  * it. Applying an update does exactly that: it calls close() and then done()
  * on the dialog, which crashed on Windows.
  *
- * QTEST_APPLESS_MAIN is used because the test itself must own the
+ * The appless entry point is used because the test itself must own the
  * QApplication lifetime to walk it through quit and destruction.
  */
 class NewReleaseDialogTeardownTest : public QObject
@@ -210,5 +212,5 @@ void NewReleaseDialogTeardownTest::updateDialogDestroyedBeforeApplicationTeardow
     QVERIFY2(dialog.isNull(), "UpdateDialog must be destroyed when the application quits: deleting it any later (from ~Updater, inside the application's destructor) corrupts the heap - see #9122");
 }
 
-QTEST_APPLESS_MAIN(NewReleaseDialogTeardownTest)
+MUDLET_GROUPED_TEST_APPLESS_MAIN(NewReleaseDialogTeardownTest)
 #include "NewReleaseDialogTeardownTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `FeedChecksumRaceTest` and `NewReleaseDialogTeardownTest` build as one `functional_release_tests` executable rather than one each, with `MUDLET_GROUPED_TEST_MAIN()` from #9993 in place of `QTEST_MAIN()`. Every test keeps its own `add_test` entry, so each ctest case still runs as its own process with its own `QApplication`, its own application name and untouched statics - only the link is shared.
- `NewReleaseDialogTeardownTest` builds and `exec()`s its own `QApplication` on purpose, so it gets a new `MUDLET_GROUPED_TEST_APPLESS_MAIN()`: the same entry point without `QTEST_MAIN_SETUP()`, exactly as `QTEST_APPLESS_MAIN` differs from `QTEST_MAIN`. Both grouped macros now share one wrapper, the way Qt's own two do.
- The two members sit on different CMake conditions (`USE_UPDATER AND NOT APPLE` and `USE_UPDATER`), so the group's source list is assembled rather than declared and the target is only created when it is non-empty. The binary is named for releases rather than the updater because the name gate in `test/CMakeLists.txt` rejects `update` as a substring (#9748).

#### Motivation for adding to Mudlet

A functional test executable statically links `mudlet_core` and costs ~250MB and a link step in every build tree.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest --preset linux-debug-nosan` passes 115/115, `ctest -N` lists the same 115 names as development, and `ctest --show-only=json-v1` reports zero property differences across all 115 (382 property entries, none empty, captured post-build so every case carries its command). The generated `CTestTestfile.cmake` differs only in the two `add_test` command lines. The two executables' 444.1 MiB becomes 252.4 MiB and two link steps become one.

Mutation-checked once per member, each reddening exactly its own case out of the 115 and on its own assertion: dropping the `mChecksumsReply` half of the #9938 guard in `Feed::isDownloading()` reddens `FeedChecksumRaceTest`, and deleting the `UpdateDialog` outright in the updater's `aboutToQuit` handler instead of with `deleteLater()` reddens `NewReleaseDialogTeardownTest`. A probe in the grouped binary reports `NewReleaseDialogTeardownTest` and `~/.config/NewReleaseDialogTeardownTest` for the appless case, so the application name - and the profile key store `QStandardPaths::AppConfigLocation` builds from it - is still per-test. Both cases also pass under `linux-debug`, where `FeedChecksumRaceTest` still carries `detect_leaks=1:intercept_tls_get_addr=0` beside its leak-exempt group-mate.

The conditional assembly was checked across all four `USE_UPDATER`/`APPLE` combinations: on macOS only `FeedChecksumRaceTest` joins the group, and with the updater off no target is created and ctest lists the same 113 names as development does in that configuration.

Assisted-by: Claude:claude-opus-5
