### PR TITLE
Fix: Switching map areas no longer leaves rooms selected off-screen

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -680,6 +680,7 @@ void T2DMap::switchArea(const QString& newAreaName)
                 areaViewedChangedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
                 areaViewedChangedEvent.mArgumentList.append(QString::number(mAreaID));
                 areaViewedChangedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+                pruneRoomSelectionToArea(areaID);
                 mAreaID = areaID;
                 mLastViewedAreaID = mAreaID;
             }
@@ -921,6 +922,9 @@ std::pair<bool, QString> T2DMap::centerview(int roomId)
         }
     }
 
+    if (mAreaID != areaId) {
+        pruneRoomSelectionToArea(areaId);
+    }
     mAreaID = areaId;
     mLastViewedAreaID = areaId;
     mRoomID = roomId;
@@ -2499,7 +2503,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
         mpMap->mNewMove = false;
 
         mRoomID = playerRoomId;
-        mAreaID = pPlayerRoom->getArea();
+        const int playerAreaID = pPlayerRoom->getArea();
+        if (mAreaID != playerAreaID) {
+            pruneRoomSelectionToArea(playerAreaID);
+        }
+        mAreaID = playerAreaID;
         if (mLastViewedAreaID != mAreaID) {
             areaViewedChangedEvent.mArgumentList.append(qsl("sysMapAreaChanged"));
             areaViewedChangedEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -5240,6 +5248,15 @@ void T2DMap::slot_setArea()
             const auto& targetAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(newAreaId);
             mpMap->mpMapper->comboBox_showArea->setCurrentText(targetAreaName);
             switchArea(targetAreaName);
+            // The rooms are still selected, so land on them rather than on
+            // whichever room switchArea() would otherwise have picked:
+            TRoom* pCenterRoom = getCenterSelection() ? mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId) : nullptr;
+            if (pCenterRoom) {
+                mMapCenterX = pCenterRoom->x();
+                mMapCenterY = -pCenterRoom->y();
+                mMapCenterZ = pCenterRoom->z();
+                mpMap->set3DViewCenter(newAreaId, mMapCenterX, -mMapCenterY, mMapCenterZ);
+            }
         }
         update();
     });
@@ -6218,10 +6235,62 @@ void T2DMap::clearSelection()
     if (!mMultiSelection && !mMultiSelectionSet.isEmpty()) {
         mMultiSelectionSet.clear();
         mMultiSelectionHighlightRoomId = 0;
-        mMultiSelectionListWidget.hide();
-        mMultiSelectionListWidget.clear();
+        hideSelectionWidget();
         update();
     }
+}
+
+void T2DMap::hideSelectionWidget()
+{
+    mMultiSelectionListWidget.hide();
+    // clear() makes the widget emit itemSelectionChanged() which would in turn
+    // call update() - not something we want when this is reached from within
+    // paintEvent():
+    mMultiSelectionListWidget.blockSignals(true);
+    mMultiSelectionListWidget.clear();
+    mMultiSelectionListWidget.blockSignals(false);
+}
+
+// Drops the selected rooms that are not in the area that is about to be shown.
+// Without this a selection would survive an area change but be off-screen, so
+// anything done to it - deleting those rooms, say - would happen unseen.
+void T2DMap::pruneRoomSelectionToArea(const int areaId)
+{
+    if (mMultiSelectionSet.isEmpty() || !mpMap || !mpMap->mpRoomDB) {
+        return;
+    }
+
+    QSet<int> roomsInNewArea;
+    for (const int roomId : std::as_const(mMultiSelectionSet)) {
+        TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
+        if (pRoom && pRoom->getArea() == areaId) {
+            roomsInNewArea.insert(roomId);
+        }
+    }
+
+    if (roomsInNewArea.size() == mMultiSelectionSet.size()) {
+        // Everything selected has come along to the new area - as happens when
+        // the rooms themselves were just moved into it:
+        return;
+    }
+
+    mMultiSelectionSet = roomsInNewArea;
+    if (!mMultiSelectionSet.contains(mMultiSelectionHighlightRoomId)) {
+        switch (mMultiSelectionSet.size()) {
+        case 0:
+            mMultiSelectionHighlightRoomId = 0;
+            break;
+        case 1:
+            mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.constBegin());
+            break;
+        default:
+            getCenterSelection();
+        }
+    }
+
+    // The listing is now stale; it gets rebuilt by updateSelectionWidget() on
+    // the next mouse interaction with what, if anything, is still selected:
+    hideSelectionWidget();
 }
 
 std::pair<bool, QString> T2DMap::exportAreaToImage(int areaId, const QString& filePath, std::optional<int> zLevel, qreal zoom, bool exportAllZLevels)

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -413,6 +413,8 @@ private:
 
     void updateSelectionWidget();
     void resizeMultiSelectionWidget();
+    void hideSelectionWidget();
+    void pruneRoomSelectionToArea(int areaId);
     std::pair<int, int> getMousePosition();
     std::pair<bool, QString> performImageSave(const QPixmap& pixmap, const QString& filePath, const QString& format);
     bool isSnapCustomLinePointsToGridEnabled() const;

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -104,6 +104,7 @@ set(EDITOR_GROUP_TEST_SOURCES
 set(MAP_GROUP_TEST_SOURCES
     EmbeddedMapperCreationTest.cpp
     MapAreaReassignmentTest.cpp
+    MapAreaSelectionTest.cpp
     MapCloseDuringImportTest.cpp
     MapProgressDialogSeamTest.cpp
     MapRoundTripTest.cpp

--- a/test/functional_tests/MapAreaSelectionTest.cpp
+++ b/test/functional_tests/MapAreaSelectionTest.cpp
@@ -1,0 +1,240 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Piotr Wilczynski - delwing@gmail.com            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * A room selection belongs to the area it was made in: showing another area
+ * has to drop it, or it stays live but off-screen and the context menu's
+ * Delete then removes rooms the user cannot see (issue #9933).
+ *
+ * The selection is private to the mapper widget and there is no Lua way to
+ * make one, so this cannot be a busted spec.
+ *
+ * Run with: ctest -R MapAreaSelectionTest -V
+ */
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "T2DMap.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapAreaSelectionTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+    T2DMap* mp2dMap = nullptr;
+    const QString mProfileName = qsl("MapAreaSelection-Test");
+    const QString mAreaAName = qsl("area A");
+    const QString mAreaBName = qsl("area B");
+    int mAreaA = 0;
+    int mAreaB = 0;
+    static constexpr int scmRoomInA = 100;
+    static constexpr int scmSecondRoomInA = 101;
+    static constexpr int scmRoomInB = 200;
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+    TRoomDB* roomDB() const { return mpHost->mpMap->mpRoomDB.get(); }
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    // One room in each of two areas, with the widget showing area A. A second
+    // room in area A gives the multi-room case something to select.
+    void buildTwoAreaMap()
+    {
+        map()->mapClear();
+        QVERIFY(roomDB()->getRoomIDList().isEmpty());
+
+        mAreaA = roomDB()->addArea(mAreaAName);
+        mAreaB = roomDB()->addArea(mAreaBName);
+        QVERIFY(mAreaA > 0);
+        QVERIFY(mAreaB > 0);
+
+        for (const int roomId : {scmRoomInA, scmSecondRoomInA, scmRoomInB}) {
+            QVERIFY(map()->addRoom(roomId));
+            QVERIFY(map()->setRoomArea(roomId, roomId == scmRoomInB ? mAreaB : mAreaA));
+            QVERIFY(map()->setRoomCoordinates(roomId, roomId % 10, 0, 0));
+        }
+
+        mp2dMap->switchArea(mAreaAName);
+        QCOMPARE(mp2dMap->mAreaID, mAreaA);
+    }
+
+    void selectRooms(const QSet<int>& roomIds)
+    {
+        mp2dMap->mMultiSelectionSet = roomIds;
+        QVERIFY(mp2dMap->getCenterSelection());
+        QCOMPARE(mp2dMap->mMultiSelectionSet, roomIds);
+        QVERIFY(roomIds.contains(mp2dMap->getCenterSelectedRoomId()));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+        QVERIFY(map());
+
+        // What dlgMapper's constructor does to the widget it owns; the dialog
+        // itself is not needed for any of the paths under test
+        mp2dMap = new T2DMap();
+        mp2dMap->mpMap = map();
+        mp2dMap->mpHost = mpHost;
+    }
+
+    void cleanupTestCase()
+    {
+        delete mp2dMap;
+        mp2dMap = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // The area dropdown, which is what dlgMapper and TMapView both drive
+    void switchingAreaDropsTheSelection()
+    {
+        buildTwoAreaMap();
+        selectRooms({scmRoomInA});
+
+        mp2dMap->switchArea(mAreaBName);
+
+        QCOMPARE(mp2dMap->mAreaID, mAreaB);
+        QVERIFY2(mp2dMap->mMultiSelectionSet.isEmpty(), "the room selected in area A survived the switch to area B");
+        QCOMPARE(mp2dMap->getCenterSelectedRoomId(), 0);
+    }
+
+    void switchingAreaDropsAMultiRoomSelection()
+    {
+        buildTwoAreaMap();
+        selectRooms({scmRoomInA, scmSecondRoomInA});
+
+        mp2dMap->switchArea(mAreaB);
+
+        QCOMPARE(mp2dMap->mAreaID, mAreaB);
+        QVERIFY2(mp2dMap->mMultiSelectionSet.isEmpty(), "the rooms selected in area A survived the switch to area B");
+        QCOMPARE(mp2dMap->getCenterSelectedRoomId(), 0);
+    }
+
+    // Lua centerview() on a room in another area
+    void centerviewOnAnotherAreaDropsTheSelection()
+    {
+        buildTwoAreaMap();
+        selectRooms({scmRoomInA});
+
+        const auto [centered, message] = mp2dMap->centerview(scmRoomInB);
+        QVERIFY2(centered, qPrintable(message));
+
+        QCOMPARE(mp2dMap->mAreaID, mAreaB);
+        QVERIFY2(mp2dMap->mMultiSelectionSet.isEmpty(), "the room selected in area A survived a centerview() into area B");
+        QCOMPARE(mp2dMap->getCenterSelectedRoomId(), 0);
+    }
+
+    // Staying put is not an area change, so nothing is dropped
+    void centerviewWithinTheSameAreaKeepsTheSelection()
+    {
+        buildTwoAreaMap();
+        selectRooms({scmRoomInA});
+
+        const auto [centered, message] = mp2dMap->centerview(scmSecondRoomInA);
+        QVERIFY2(centered, qPrintable(message));
+
+        QCOMPARE(mp2dMap->mAreaID, mAreaA);
+        QCOMPARE(mp2dMap->mMultiSelectionSet, QSet<int>{scmRoomInA});
+    }
+
+    // "Move to area" moves the selected rooms and then follows them, so they
+    // are on-screen in the new area and stay selected
+    void selectionThatMovedToTheNewAreaIsKept()
+    {
+        buildTwoAreaMap();
+        const QSet<int> selection{scmRoomInA, scmSecondRoomInA};
+        selectRooms(selection);
+
+        for (const int roomId : selection) {
+            QVERIFY(map()->setRoomArea(roomId, mAreaB));
+        }
+        mp2dMap->switchArea(mAreaBName);
+
+        QCOMPARE(mp2dMap->mAreaID, mAreaB);
+        QCOMPARE(mp2dMap->mMultiSelectionSet, selection);
+    }
+
+    // Only the rooms left behind go
+    void onlyTheRoomsOutsideTheNewAreaAreDropped()
+    {
+        buildTwoAreaMap();
+        selectRooms({scmRoomInA, scmSecondRoomInA});
+        QVERIFY(map()->setRoomArea(scmSecondRoomInA, mAreaB));
+
+        mp2dMap->switchArea(mAreaBName);
+
+        QCOMPARE(mp2dMap->mAreaID, mAreaB);
+        QCOMPARE(mp2dMap->mMultiSelectionSet, QSet<int>{scmSecondRoomInA});
+        QCOMPARE(mp2dMap->getCenterSelectedRoomId(), scmSecondRoomInA);
+    }
+};
+
+#include "MapAreaSelectionTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MapAreaSelectionTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The mapper now drops a room selection when the area on show changes — via the area dropdown, a Lua `centerview()` into another area, or the view following the player across an area boundary.
- Rooms that moved into the new area themselves stay selected, so "Move to area" keeps working; that flow now also centres the view on those rooms rather than on whichever room the area switch happened to land on.
- Adds `MapAreaSelectionTest` to the grouped map functional tests. The selection is private to the mapper widget and there is no Lua way to make one, so this could not be a busted spec.

#### Motivation for adding to Mudlet

A selection made in one area stayed live but invisible after switching areas, so right-clicking empty space in the new area offered Delete for rooms the user could not see — with no confirmation and no undo.

#### Other info (issues closed, discussion etc)

Fixes #9933. Long-standing, predates 4.20. Related: #8356, #9932.

**Test case:** Create two areas with one room each. Select the room in area A, switch to area B with the dropdown, and right-click empty space — no room menu should appear (before this, Delete there removed the room in area A). Then select rooms in one area, right-click → "Move to area…" and pick another: they stay selected and the view centres on them.

Assisted-by: Claude:claude-opus-5[1m]
Signed-off-by: Piotr Wilczynski <delwing@gmail.com>