### PR TITLE
Fix: Databases are still created when an index names a column that isn't there

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -367,7 +367,9 @@ end
 ---   so they work there too: enemies = {"name", "city", _index = "city"}
 ---   An _index entry naming a column the sheet does not have cannot be created, so
 ---   that entry is skipped and a warning is printed, while everything else the
----   sheet asks for is made as usual.
+---   sheet asks for is made as usual. The indexes the sheet already has are left
+---   alone in that case, since what is left of _index is no longer the whole set
+---   it asked for.
 function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
@@ -386,6 +388,7 @@ function db:create(db_name, sheets, force)
   for sheet_name, sheet in pairs(sheets) do
     local columns = {}
     local options = {}
+    local has_skipped_index = false
 
     -- the sheet was provided in {"column1", "column2"} format
     if sheet[1] ~= nil then
@@ -467,8 +470,10 @@ function db:create(db_name, sheets, force)
       -- db:_drop_orphaned_indexes take the typo for part of the wanted set. It
       -- is a warning rather than an error because the rest of the sheet is
       -- sound and its data is reachable without the index, so a script that has
-      -- lived with the stray name goes on working. The shapes _validate_index
-      -- refused above are left to it to report.
+      -- lived with the stray name goes on working. What is left of _index is no
+      -- longer everything the sheet asked for, though, so the sheet is marked
+      -- for db:_drop_orphaned_indexes to leave the indexes it has alone. The
+      -- shapes _validate_index refused above are left to it to report.
       if type(options._index) == "table" then
         local wanted = {}
 
@@ -486,17 +491,21 @@ function db:create(db_name, sheets, force)
           -- rest of its columns is not the one that was asked for
           if not unknown_column then
             wanted[#wanted + 1] = index_entry
-          elseif unknown_column == "_row_id" then
-            table.insert(warnings, "db:create - "..sheet_name.." - _index names \"_row_id\", which is the "..
-              "key every sheet is given rather than one of its own columns: that index is skipped.")
-          elseif unknown_column:lower() == "asc" or unknown_column:lower() == "desc" then
-            -- db:_sql_columns would build the ordering term, but
-            -- db:_index_valid refuses it, so the index was never made
-            table.insert(warnings, "db:create - "..sheet_name.." - _index names \""..unknown_column..
-              "\", and an index takes column names only, not a sort direction: that index is skipped.")
           else
-            table.insert(warnings, "db:create - "..sheet_name.." - _index names \""..unknown_column..
-              "\", which is not one of the sheet's columns: that index is skipped.")
+            has_skipped_index = true
+
+            if unknown_column == "_row_id" then
+              table.insert(warnings, "db:create - "..sheet_name.." - _index names \"_row_id\", which is the "..
+                "key every sheet is given rather than one of its own columns: that index is skipped.")
+            elseif unknown_column:lower() == "asc" or unknown_column:lower() == "desc" then
+              -- db:_sql_columns would build the ordering term, but
+              -- db:_index_valid refuses it, so the index was never made
+              table.insert(warnings, "db:create - "..sheet_name.." - _index names \""..unknown_column..
+                "\", and an index takes column names only, not a sort direction: that index is skipped.")
+            else
+              table.insert(warnings, "db:create - "..sheet_name.." - _index names \""..unknown_column..
+                "\", which is not one of the sheet's columns: that index is skipped.")
+            end
           end
         end
 
@@ -504,7 +513,7 @@ function db:create(db_name, sheets, force)
       end
     end
 
-    schema[sheet_name] = { columns = columns, options = options }
+    schema[sheet_name] = { columns = columns, options = options, has_skipped_index = has_skipped_index }
   end
 
   assert(is_valid, table.concat(msgs, "\n"))
@@ -1027,6 +1036,15 @@ end
 -- Conditionally drops orphaned indexes.
 function db:_drop_orphaned_indexes(conn, s_name, schema)
   local cur, err;
+
+  -- db:create dropped an _index entry naming a column the sheet does not have,
+  -- so what is left of _index is not the whole set the sheet asked for and
+  -- pruning against it would take the indexes the typo never mentioned with it.
+  -- Nothing is dropped this time round; the create that spells the column right
+  -- prunes as usual.
+  if schema.has_skipped_index then
+    return true, nil
+  end
 
   local sql = ([[
     SELECT

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -318,13 +318,18 @@ end
 --- any columns or indexes which didn't exist before to that database. If the database already has all the
 --- specified columns and indexes, it will do nothing. <br/><br/>
 ---
---- Because it is meant to run unguarded, a fault in the schema is only fatal when it has to be.
---- A schema whose shape no sheet can be built from is a hard error: a malformed _index, _unique
---- or _violations value is refused and cancels the script. A schema that is sound but asks for
---- something which cannot be honoured, such as an _index on a column the sheet does not declare,
---- has that part skipped and reported through printError instead, so the sheet and the data in it
---- stay reachable. Keep new validation on that side of the line: a database the user can no longer
---- open costs more than the mistake being reported. <br/><br/>
+--- Because it is meant to run unguarded, a fault in the schema is only fatal when it has to be,
+--- and where that line falls depends on what the faulty part holds. Something derived can be left
+--- out and reported: an _index naming a column the sheet does not declare is skipped rather than
+--- refused, because every row stays reachable without the index. A column is not derived. A sheet
+--- built without one takes writes to it silently, since db:add reports the rejected INSERT the
+--- same way and returns nil, which callers do not check, so a script can record nothing for weeks
+--- with no sign of it. A fault that would cost the sheet a column therefore stays fatal, and its
+--- message names the key so the fix is obvious. <br/><br/>
+---
+--- Note when weighing that up that printError is a quiet channel: it reaches the editor's Errors
+--- tab, which is hidden until the user opens it, and the main console only when they have turned
+--- on echoing Lua errors. <br/><br/>
 ---
 --- The database will be called Database_<sanitized database name>.db and will be stored in the
 --- Mudlet configuration directory. <br/><br/>

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -325,7 +325,9 @@ end
 --- built without one takes writes to it silently, since db:add reports the rejected INSERT the
 --- same way and returns nil, which callers do not check, so a script can record nothing for weeks
 --- with no sign of it. A fault that would cost the sheet a column therefore stays fatal, and its
---- message names the key so the fix is obvious. <br/><br/>
+--- message names the key so the fix is obvious. A value whose shape no sheet can be built from is
+--- refused as well, whatever it holds: a malformed _index, _unique or _violations leaves nothing to
+--- skip and nothing to build from. <br/><br/>
 ---
 --- Note when weighing that up that printError is a quiet channel: it reaches the editor's Errors
 --- tab, which is hidden until the user opens it, and the main console only when they have turned

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -365,12 +365,15 @@ end
 ---   A sheet may also be given as a plain list of its column names, which then all
 ---   hold text and default to "". The sheet options are keys rather than list members,
 ---   so they work there too: enemies = {"name", "city", _index = "city"}
+---   An _index entry naming a column the sheet does not have cannot be created, so
+---   that entry is skipped and a warning is printed, while everything else the
+---   sheet asks for is made as usual.
 function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
   end
 
-  local is_valid, msgs = true, {}
+  local is_valid, msgs, warnings = true, {}, {}
   local schema = {}
   db_name = db:safe_name(db_name)
 
@@ -458,33 +461,46 @@ function db:create(db_name, sheets, force)
         options._index = { options._index }
       end
 
-      -- An index on a column this sheet does not declare is refused rather than
-      -- carried: db:_migrate_indexes cannot make the index a typo asks for, and
-      -- a typo that replaced the only entry leaves db:_drop_orphaned_indexes
-      -- treating it as the whole wanted set, dropping the index the sheet did
-      -- have. The shapes _validate_index refused above are left to it to report.
+      -- An index on a column this sheet does not declare is dropped from the
+      -- wanted set and reported rather than carried: db:_migrate_indexes cannot
+      -- make the index a typo asks for, and leaving the entry in place has
+      -- db:_drop_orphaned_indexes take the typo for part of the wanted set. It
+      -- is a warning rather than an error because the rest of the sheet is
+      -- sound and its data is reachable without the index, so a script that has
+      -- lived with the stray name goes on working. The shapes _validate_index
+      -- refused above are left to it to report.
       if type(options._index) == "table" then
+        local wanted = {}
+
         for _, index_entry in ipairs(options._index) do
           local index_columns = type(index_entry) == "table" and index_entry or {index_entry}
+          local unknown_column
+
           for _, column_name in ipairs(index_columns) do
-            if type(column_name) == "string" and columns[column_name] == nil then
-              local lowered = column_name:lower()
-              is_valid = false
-              if column_name == "_row_id" then
-                table.insert(msgs, "db:create - "..sheet_name.." - _index names \"_row_id\", which is the "..
-                  "key every sheet is given rather than one of its own columns.")
-              elseif lowered == "asc" or lowered == "desc" then
-                -- db:_sql_columns would build the ordering term, but
-                -- db:_index_valid refuses it, so the index was never made
-                table.insert(msgs, "db:create - "..sheet_name.." - _index names \""..column_name..
-                  "\", and an index takes column names only, not a sort direction.")
-              else
-                table.insert(msgs, "db:create - "..sheet_name.." - _index names \""..column_name..
-                  "\", which is not one of the sheet's columns.")
-              end
+            if not unknown_column and type(column_name) == "string" and columns[column_name] == nil then
+              unknown_column = column_name
             end
           end
+
+          -- one unknown column costs the whole entry: a compound index on the
+          -- rest of its columns is not the one that was asked for
+          if not unknown_column then
+            wanted[#wanted + 1] = index_entry
+          elseif unknown_column == "_row_id" then
+            table.insert(warnings, "db:create - "..sheet_name.." - _index names \"_row_id\", which is the "..
+              "key every sheet is given rather than one of its own columns: that index is skipped.")
+          elseif unknown_column:lower() == "asc" or unknown_column:lower() == "desc" then
+            -- db:_sql_columns would build the ordering term, but
+            -- db:_index_valid refuses it, so the index was never made
+            table.insert(warnings, "db:create - "..sheet_name.." - _index names \""..unknown_column..
+              "\", and an index takes column names only, not a sort direction: that index is skipped.")
+          else
+            table.insert(warnings, "db:create - "..sheet_name.." - _index names \""..unknown_column..
+              "\", which is not one of the sheet's columns: that index is skipped.")
+          end
         end
+
+        options._index = wanted
       end
     end
 
@@ -492,6 +508,12 @@ function db:create(db_name, sheets, force)
   end
 
   assert(is_valid, table.concat(msgs, "\n"))
+
+  -- after the assert: what is wrong with the schema comes before what was left
+  -- out of it, and a sheet that never got made has nothing to warn about
+  for _, warning in ipairs(warnings) do
+    printError(warning, true, false)
+  end
 
   if not db:_isActiveDBName(db_name) then
     db.__conn[db_name] = db.__env:connect(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -318,6 +318,14 @@ end
 --- any columns or indexes which didn't exist before to that database. If the database already has all the
 --- specified columns and indexes, it will do nothing. <br/><br/>
 ---
+--- Because it is meant to run unguarded, a fault in the schema is only fatal when it has to be.
+--- A schema whose shape no sheet can be built from is a hard error: a malformed _index, _unique
+--- or _violations value is refused and cancels the script. A schema that is sound but asks for
+--- something which cannot be honoured, such as an _index on a column the sheet does not declare,
+--- has that part skipped and reported through printError instead, so the sheet and the data in it
+--- stay reachable. Keep new validation on that side of the line: a database the user can no longer
+--- open costs more than the mistake being reported. <br/><br/>
+---
 --- The database will be called Database_<sanitized database name>.db and will be stored in the
 --- Mudlet configuration directory. <br/><br/>
 ---

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3200,9 +3200,14 @@ describe("Tests db:create with a single column name as _index", function()
     local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _index = "citty"}})
     assert.is_truthy(string.find(warnings, '_index names "citty", which is not one of the sheet\'s columns', 1, true))
     assert.is_true(db:add(mydb.people, {name = "Bob", city = "Ankh-Morpork"}))
-    -- the typo left the sheet asking for no index it can have, so the one it
-    -- used to have is orphaned like any other index no longer asked for
-    assert.are.same({}, indexNames("people"))
+    -- and the index the sheet had is still there: what is left of _index is no
+    -- longer the whole set it asked for, so nothing is pruned against it
+    assert.are.same({db:_index_name("people", "city")}, indexNames("people"))
+
+    -- only for as long as the typo is there, though: a sheet that asks for an
+    -- index it can have prunes the ones it no longer asks for, as ever
+    db:create(dbName, {people = {name = "", city = "", _index = "name"}})
+    assert.are.same({db:_index_name("people", "name")}, indexNames("people"))
   end)
 
   it("warns about a typo in a list or a compound index too", function()
@@ -3216,8 +3221,9 @@ describe("Tests db:create with a single column name as _index", function()
     assert.is_table(mydb)
     assert.is_truthy(string.find(warnings, '_index names "citty"', 1, true))
     -- a compound index is wanted whole: an index on the half of it that names a
-    -- real column is not the one that was asked for
-    assert.are.same({}, indexNames("people"))
+    -- real column is not the one that was asked for, and the single-column index
+    -- the sheet already had is not dropped over it either
+    assert.are.same({db:_index_name("people", "city")}, indexNames("people"))
   end)
 
   it("warns about a sort direction where a column name belongs", function()

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3176,59 +3176,75 @@ describe("Tests db:create with a single column name as _index", function()
     assert.are.equal("Bob", rows[1].name)
   end)
 
-  it("refuses a column the sheet does not have, keeping the indexes it had", function()
-    -- an index on a column that is not there can never be created, and taking
-    -- the typo for the wanted set would drop the indexes the sheet did have
+  -- db:create reports an index it cannot make through printError and carries
+  -- on, so what it says is collected rather than caught
+  local function createCollectingWarnings(sheets)
+    local collected = {}
+    -- through _G: a spec file's globals are its own, so plain assignment would
+    -- leave db:create with the printError it already has
+    local originalPrintError = _G.printError
+    _G.printError = function(msg) collected[#collected + 1] = msg end
+    finally(function() _G.printError = originalPrintError end)
+
+    local result = db:create(dbName, sheets)
+    _G.printError = originalPrintError
+    return result, table.concat(collected, "\n")
+  end
+
+  it("warns about a column the sheet does not have instead of refusing the sheet", function()
+    -- an index on a column that is not there can never be created, but the rest
+    -- of the sheet is sound and its data is reachable without the index
     db:create(dbName, {people = {name = "", city = "", _index = "city"}})
     assert.are.equal(1, #indexNames("people"))
 
-    local ok, err = pcall(function()
-      db:create(dbName, {people = {name = "", city = "", _index = "citty"}})
-    end)
-    assert.is_false(ok)
-    assert.is_truthy(string.find(err, '_index names "citty", which is not one of the sheet\'s columns', 1, true))
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _index = "citty"}})
+    assert.is_truthy(string.find(warnings, '_index names "citty", which is not one of the sheet\'s columns', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob", city = "Ankh-Morpork"}))
+    -- the typo left the sheet asking for no index it can have, so the one it
+    -- used to have is orphaned like any other index no longer asked for
+    assert.are.same({}, indexNames("people"))
+  end)
+
+  it("warns about a typo in a list or a compound index too", function()
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _index = {"city", "citty"}}})
+    assert.is_table(mydb)
+    assert.is_truthy(string.find(warnings, '_index names "citty"', 1, true))
+    -- only the entry that names the column which is not there is dropped
     assert.are.same({db:_index_name("people", "city")}, indexNames("people"))
+
+    mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _index = {{"city", "citty"}}}})
+    assert.is_table(mydb)
+    assert.is_truthy(string.find(warnings, '_index names "citty"', 1, true))
+    -- a compound index is wanted whole: an index on the half of it that names a
+    -- real column is not the one that was asked for
+    assert.are.same({}, indexNames("people"))
   end)
 
-  it("refuses a typo in a list or a compound index too", function()
-    local ok, err = pcall(function()
-      db:create(dbName, {people = {name = "", city = "", _index = {"city", "citty"}}})
-    end)
-    assert.is_false(ok)
-    assert.is_truthy(string.find(err, '_index names "citty"', 1, true))
-
-    ok, err = pcall(function()
-      db:create(dbName, {people = {name = "", city = "", _index = {{"city", "citty"}}}})
-    end)
-    assert.is_false(ok)
-    assert.is_truthy(string.find(err, '_index names "citty"', 1, true))
-  end)
-
-  it("refuses a sort direction where a column name belongs", function()
+  it("warns about a sort direction where a column name belongs", function()
     -- db:_sql_columns would render "name" desc, but db:_index_valid refuses the
     -- entry, so an index with a sort direction has never been created: saying so
     -- beats leaving the sheet with no index and no complaint
-    local ok, err = pcall(function()
-      db:create(dbName, {people = {name = "", city = "", _index = {{"name", "desc"}}}})
-    end)
-    assert.is_false(ok)
-    assert.is_truthy(string.find(err, "an index takes column names only, not a sort direction", 1, true))
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _index = {{"name", "desc"}}}})
+    assert.is_table(mydb)
+    assert.is_truthy(string.find(warnings, "an index takes column names only, not a sort direction", 1, true))
+    assert.are.same({}, indexNames("people"))
 
-    -- a sheet that really has a column of that name is not refused; what
+    -- a sheet that really has a column of that name is not warned about; what
     -- db:_sql_columns then makes of it is that function's business
-    assert.is_table(db:create(dbName, {people = {name = "", desc = "", _index = {{"name", "desc"}}}}))
+    local other, otherWarnings = createCollectingWarnings({people = {name = "", desc = "", _index = {{"name", "desc"}}}})
+    assert.is_table(other)
+    assert.are.equal("", otherWarnings)
   end)
 
-  it("refuses the _row_id no sheet definition names either", function()
+  it("warns about the _row_id no sheet definition names either", function()
     -- the sheet is given one, but no definition declares it: it is not there to
     -- index on the db:create that makes the sheet, and db:_drop_orphaned_indexes
     -- cannot match the leading underscore, so an index on it was dropped and
     -- made again on every db:create after that
-    local ok, err = pcall(function()
-      db:create(dbName, {people = {name = "", city = "", _index = "_row_id"}})
-    end)
-    assert.is_false(ok)
-    assert.is_truthy(string.find(err, '_index names "_row_id"', 1, true))
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _index = "_row_id"}})
+    assert.is_table(mydb)
+    assert.is_truthy(string.find(warnings, '_index names "_row_id"', 1, true))
+    assert.are.same({}, indexNames("people"))
   end)
 end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `db:create` no longer refuses the whole schema when an `_index` entry names a column the sheet does not declare: that entry is dropped from the wanted set and reported through `printError`, and everything else the sheet asks for is created as usual.
- One unknown column costs the whole entry, since a compound index on its remaining columns is not the index that was asked for.
- Malformed `_index`/`_unique`/`_violations` *shapes* are still hard errors; only the unknown-column case is downgraded.

#### Motivation for adding to Mudlet

Scripts that had carried a stray index name for years kept working until 4.22 turned it into an error, which stops the database being made at all - an index that can never be created should not cost the user access to their data.

#### Other info (issues closed, discussion etc)

Closes #10038.

This restores the pre-4.22 outcome (`db:_index_valid` silently skipped such an index) and adds the message that was missing.

It also keeps the other half of what #9801 asked for ("either warn and keep the existing indexes, or refuse the create outright" - #9815 took the second option, this takes the first): once an entry is dropped, what is left of `_index` is no longer the whole set the sheet asked for, so `db:_drop_orphaned_indexes` leaves that sheet's indexes alone for that create rather than pruning against a partial set. The create that spells the column right prunes as usual. Without this the silent index loss of #9801 would come back, merely announced.

The four `DB_spec` cases covering this changed from "refuses" to "warns", and now also pin which indexes survive.

**Test case:** `db:create("test", {people = {name = "", city = "", _index = "citty"}})` - the error console shows `_index names "citty", which is not one of the sheet's columns: that index is skipped.`, and the returned db is usable (`db:add` / `db:fetch` work).

Assisted-by: Claude:claude-opus-5[1m]
Signed-off-by: Piotr Wilczynski <delwing@gmail.com>

