### PR TITLE
Fix: Crash reports are now sent on Linux and macOS

### DIFF
--- a/src/crash_reporter/CMakeLists.txt
+++ b/src/crash_reporter/CMakeLists.txt
@@ -31,6 +31,18 @@ if(TARGET ${EXE_MUDLET_TARGET})
     )
 endif()
 
+# Packaging copies this executable out of the build tree instead of installing
+# it, so BUILD_RPATH rather than INSTALL_RPATH is what ships. $ORIGIN/lib is the
+# AppImage layout and @executable_path/../Frameworks the .app bundle; with
+# neither, the shipped binary knows only the build machine's Qt path and the
+# loader kills it before it can report anything. Both are appended to the
+# automatically determined entries, so build-tree runs are unaffected.
+if(APPLE)
+    set_target_properties(MudletCrashReporter PROPERTIES BUILD_RPATH "@executable_path/../Frameworks")
+elseif(UNIX)
+    set_target_properties(MudletCrashReporter PROPERTIES BUILD_RPATH "$ORIGIN/lib")
+endif()
+
 add_dependencies(MudletCrashReporter sentry_with_transport)
 
 target_include_directories(MudletCrashReporter PRIVATE


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Give `MudletCrashReporter` a `BUILD_RPATH` of `$ORIGIN/lib` on Linux and `@executable_path/../Frameworks` on macOS.

#### Motivation for adding to Mudlet

The shipped reporter knew only the CI runner's absolute Qt path, so on a user's machine it fell back to the system Qt and the loader killed it before it could send anything. Sentry has 704 Windows events, 3 macOS ones, and 0 Linux ever.

#### Other info (issues closed, discussion etc)

Closes #10037.

Packaging copies this executable out of the build tree rather than installing it, so `BUILD_RPATH` is what ships. Both entries are appended to the automatically determined ones, so build-tree runs are unaffected. Both bundles already contain the Qt the reporter needs - it just could not find it.

Everything else in the chain already worked: crashpad captures the crash, the DSN is compiled in, CI uploads the debug files, and Sentry symbolicates. Crashing the released 4.22.0 AppImage with the bundled Qt reachable produced a real, fully symbolicated `mudlet@4.22.0` / `mechanism: minidump` issue.

macOS is inferred from inspecting the shipped binary rather than reproduced on a Mac.

**Test case:** crash a packaged build (`MUDLET_CRASH_TEST=1`, then connect to any game) and confirm the crash dialog appears and the report reaches Sentry. `readelf -d MudletCrashReporter` should list `$ORIGIN/lib` first; on macOS `otool -l` should show `@executable_path/../Frameworks`.

Assisted-by: Claude:claude-opus-5