### PR TITLE
Infra: Add tests for untested Lua library internals

### DIFF
--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -1134,6 +1134,107 @@ describe("Tests DB.lua functions", function()
     end)
   end)
 
+  -- what a fetched Timestamp answers is covered above; the accessors themselves
+  -- are pure Lua and need no database, so they are driven directly here
+  describe("Tests the functionality of db.__Timestamp", function()
+    local epoch = 1748288082 -- 2025-05-26T19:34:42+00:00
+    local parts = {year = 2015, month = 6, day = 14, hour = 9, min = 30, sec = 15}
+
+    describe("Tests the functionality of db.__Timestamp:as_number", function()
+      it("should return the epoch it was made from", function()
+        assert.are.equal(epoch, db:Timestamp(epoch):as_number())
+      end)
+
+      it("should return the epoch a table of parts was converted to", function()
+        assert.are.equal(os.time(parts), db:Timestamp(parts):as_number())
+      end)
+
+      it("should return nil and a message for a timestamp holding no number", function()
+        local value, err = db:Timestamp(nil):as_number()
+        assert.is_nil(value)
+        assert.are.equal("db.Timestamp:as_number: timestamp seems to be invalid and isn't a number", err)
+      end)
+
+      it("should return nil and a message for CURRENT_TIMESTAMP before the database fills it in", function()
+        local value, err = db:Timestamp("CURRENT_TIMESTAMP"):as_number()
+        assert.is_nil(value)
+        assert.are.equal("db.Timestamp:as_number: timestamp seems to be invalid and isn't a number", err)
+      end)
+    end)
+
+    describe("Tests the functionality of db.__Timestamp:as_string", function()
+      it("should default to a month-first date and a 24 hour clock", function()
+        local formatted = db:Timestamp(epoch):as_string()
+        assert.are.equal(os.date("%m-%d-%Y %H:%M:%S", epoch), formatted)
+        -- os.date on its own would agree with any default format, so pin the shape too
+        assert.is_truthy(formatted:match("^%d%d%-%d%d%-%d%d%d%d %d%d:%d%d:%d%d$"))
+      end)
+
+      it("should use the format it is given", function()
+        assert.are.equal("2015-06-14", db:Timestamp(parts):as_string("%Y-%m-%d"))
+      end)
+
+      it("should return the string nil and a message for a timestamp holding no number", function()
+        -- it promises a string, so an invalid timestamp is reported as one rather
+        -- than making every caller wrap the result in tostring()
+        local value, err = db:Timestamp(nil):as_string()
+        assert.are.equal("nil", value)
+        assert.are.equal("db.Timestamp:as_string: timestamp seems to be invalid and isn't a number", err)
+      end)
+    end)
+
+    describe("Tests the functionality of db.__Timestamp:as_table", function()
+      it("should return the date parts of the epoch it holds", function()
+        assert.are.same(os.date("*t", epoch), db:Timestamp(epoch):as_table())
+      end)
+
+      it("should give back the parts it was built from", function()
+        local actual = db:Timestamp(parts):as_table()
+        assert.are.equal(2015, actual.year)
+        assert.are.equal(6, actual.month)
+        assert.are.equal(14, actual.day)
+        assert.are.equal(9, actual.hour)
+        assert.are.equal(30, actual.min)
+        assert.are.equal(15, actual.sec)
+      end)
+
+      it("should return nil and a message for a timestamp holding no number", function()
+        local value, err = db:Timestamp(nil):as_table()
+        assert.is_nil(value)
+        assert.are.equal("db.Timestamp:as_table: timestamp seems to be invalid and isn't a number", err)
+      end)
+    end)
+
+    describe("Tests the functionality of db.__Timestamp:set", function()
+      it("should give a timestamp holding no number a real value", function()
+        local timestamp = db:Timestamp(nil)
+        assert.is_nil((timestamp:as_number()))
+        timestamp:set(epoch)
+        assert.are.equal(epoch, timestamp:as_number())
+        assert.are.equal(os.date("%m-%d-%Y %H:%M:%S", epoch), timestamp:as_string())
+      end)
+
+      it("should replace a value that was already there", function()
+        local timestamp = db:Timestamp(epoch)
+        timestamp:set(epoch + 86400)
+        assert.are.equal(epoch + 86400, timestamp:as_number())
+      end)
+
+      it("should turn a CURRENT_TIMESTAMP placeholder into a real time", function()
+        local timestamp = db:Timestamp("CURRENT_TIMESTAMP")
+        timestamp:set(epoch)
+        assert.are.equal(epoch, timestamp:as_number())
+      end)
+
+      it("should refuse anything that is not a number", function()
+        local timestamp = db:Timestamp(epoch)
+        assert.has_error(function() timestamp:set("nope") end, "db.Timestamp:set: timestamp needs to be a number")
+        assert.has_error(function() timestamp:set(nil) end, "db.Timestamp:set: timestamp needs to be a number")
+        assert.are.equal(epoch, timestamp:as_number(), "a refused value must not have been stored")
+      end)
+    end)
+  end)
+
   describe("Tests, if hanging indexes are removed", function()
     local test_db_name = db:safe_name("remove_indexes_test")
     local test_db_file = getMudletHomeDir() .. "/Database_" .. test_db_name .. ".db"
@@ -1916,6 +2017,76 @@ describe("Tests DB.lua functions", function()
         }
       })
       assert.are.equal(2, #db:fetch(mydb.sheet))
+    end)
+  end)
+
+  -- the rollback specs above drive these four through a whole transaction; this
+  -- covers what each one does on its own, since db:merge_unique is the only
+  -- caller in the library and a package can use them in any order it likes
+  describe("Tests the functionality of db.Database:_begin, db.Database:_commit, db.Database:_rollback and db.Database:_end", function()
+    local dbName = "txntestingonly"
+    local otherName = "txnothertestingonly"
+
+    before_each(function()
+      mydb = db:create(dbName, {sheet = {name = ""}})
+      db:add(mydb.sheet, {name = "committed"})
+    end)
+
+    after_each(function()
+      db:close()
+      os.remove(getMudletHomeDir() .. "/Database_" .. dbName .. ".db")
+      os.remove(getMudletHomeDir() .. "/Database_" .. otherName .. ".db")
+      mydb = nil
+    end)
+
+    local function names()
+      local result = {}
+      for _, row in ipairs(db:fetch(mydb.sheet)) do
+        result[#result + 1] = row.name
+      end
+      table.sort(result)
+      return result
+    end
+
+    it("_begin stops every write committing on its own and _end starts it again", function()
+      assert.is_true(db.__autocommit[mydb._db_name])
+      mydb:_begin()
+      assert.is_false(db.__autocommit[mydb._db_name])
+      mydb:_end()
+      assert.is_true(db.__autocommit[mydb._db_name])
+    end)
+
+    it("_begin only reaches the database it was called on", function()
+      local other = db:create(otherName, {sheet = {name = ""}})
+      mydb:_begin()
+      assert.is_false(db.__autocommit[mydb._db_name])
+      assert.is_true(db.__autocommit[other._db_name])
+      mydb:_end()
+    end)
+
+    it("_commit keeps the work so far while leaving later work rollback-able", function()
+      mydb:_begin()
+      db:add(mydb.sheet, {name = "kept"})
+      mydb:_commit()
+      db:add(mydb.sheet, {name = "dropped"})
+      mydb:_rollback()
+      mydb:_end()
+      assert.are.same({"committed", "kept"}, names())
+    end)
+
+    it("_end is only a flag, so it does not commit what is still pending", function()
+      mydb:_begin()
+      db:add(mydb.sheet, {name = "pending"})
+      mydb:_end()
+      -- nothing committed the row, so a rollback afterwards still takes it away
+      mydb:_rollback()
+      assert.are.same({"committed"}, names())
+    end)
+
+    it("_rollback outside a transaction leaves the committed rows alone", function()
+      db:add(mydb.sheet, {name = "autocommitted"})
+      mydb:_rollback()
+      assert.are.same({"autocommitted", "committed"}, names())
     end)
   end)
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -1134,8 +1134,8 @@ describe("Tests DB.lua functions", function()
     end)
   end)
 
-  -- what a fetched Timestamp answers is covered above; the accessors themselves
-  -- are pure Lua and need no database, so they are driven directly here
+  -- the accessors are pure Lua and need no database, so they are driven
+  -- directly rather than through a fetched row
   describe("Tests the functionality of db.__Timestamp", function()
     local epoch = 1748288082 -- 2025-05-26T19:34:42+00:00
     local parts = {year = 2015, month = 6, day = 14, hour = 9, min = 30, sec = 15}
@@ -1147,6 +1147,10 @@ describe("Tests DB.lua functions", function()
 
       it("should return the epoch a table of parts was converted to", function()
         assert.are.equal(os.time(parts), db:Timestamp(parts):as_number())
+      end)
+
+      it("should return the epoch a string was parsed into", function()
+        assert.are.equal(os.time(parts), db:Timestamp("2015-06-14 09:30:15"):as_number())
       end)
 
       it("should return nil and a message for a timestamp holding no number", function()
@@ -1164,10 +1168,9 @@ describe("Tests DB.lua functions", function()
 
     describe("Tests the functionality of db.__Timestamp:as_string", function()
       it("should default to a month-first date and a 24 hour clock", function()
-        local formatted = db:Timestamp(epoch):as_string()
-        assert.are.equal(os.date("%m-%d-%Y %H:%M:%S", epoch), formatted)
-        -- os.date on its own would agree with any default format, so pin the shape too
-        assert.is_truthy(formatted:match("^%d%d%-%d%d%-%d%d%d%d %d%d:%d%d:%d%d$"))
+        -- built from parts rather than an epoch so the expected string is a
+        -- literal, not os.date restating the format the function already used
+        assert.are.equal("06-14-2015 09:30:15", db:Timestamp(parts):as_string())
       end)
 
       it("should use the format it is given", function()
@@ -1209,9 +1212,9 @@ describe("Tests DB.lua functions", function()
       it("should give a timestamp holding no number a real value", function()
         local timestamp = db:Timestamp(nil)
         assert.is_nil((timestamp:as_number()))
-        timestamp:set(epoch)
-        assert.are.equal(epoch, timestamp:as_number())
-        assert.are.equal(os.date("%m-%d-%Y %H:%M:%S", epoch), timestamp:as_string())
+        timestamp:set(os.time(parts))
+        assert.are.equal(os.time(parts), timestamp:as_number())
+        assert.are.equal("06-14-2015 09:30:15", timestamp:as_string())
       end)
 
       it("should replace a value that was already there", function()
@@ -2020,14 +2023,17 @@ describe("Tests DB.lua functions", function()
     end)
   end)
 
-  -- the rollback specs above drive these four through a whole transaction; this
-  -- covers what each one does on its own, since db:merge_unique is the only
-  -- caller in the library and a package can use them in any order it likes
+  -- the rollback specs above drive these four through one whole transaction;
+  -- this covers what each does on its own. db:merge_unique is their only
+  -- in-library caller and it never calls _rollback at all.
   describe("Tests the functionality of db.Database:_begin, db.Database:_commit, db.Database:_rollback and db.Database:_end", function()
     local dbName = "txntestingonly"
     local otherName = "txnothertestingonly"
 
     before_each(function()
+      -- a run that died mid-transaction would otherwise leave rows behind
+      os.remove(getMudletHomeDir() .. "/Database_" .. dbName .. ".db")
+      os.remove(getMudletHomeDir() .. "/Database_" .. otherName .. ".db")
       mydb = db:create(dbName, {sheet = {name = ""}})
       db:add(mydb.sheet, {name = "committed"})
     end)

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -1756,6 +1756,109 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
   end)
 
+  -- the twenty-one c/d/h echo, insert, link and popup functions are one-line
+  -- calls into xEcho, so the argument shapes and the branches none of them can
+  -- reach are covered here rather than twenty-one times over
+  describe("Tests the functionality of xEcho", function()
+    local windowName = "guiUtilsXEchoConsole"
+    local labelName = "guiUtilsXEchoLabel"
+
+    setup(function()
+      createMiniConsole(windowName, 0, 0, 400, 200)
+      setWindowWrap(windowName, 60)
+      createLabel(labelName, 0, 0, 100, 30, 1)
+    end)
+
+    teardown(function()
+      deleteMiniConsole(windowName)
+      deleteLabel(labelName)
+    end)
+
+    before_each(function()
+      clearWindow(windowName)
+      moveCursor(windowName, 0, 0)
+    end)
+
+    local function currentLine()
+      selectCurrentLine(windowName)
+      return getSelection(windowName)
+    end
+
+    it("Should name the wrapper that called it when the text is not a string", function()
+      -- the message is built from the style and the function name, so a caller
+      -- of cecho is told about cecho rather than about xEcho
+      local ok, err = pcall(xEcho, "Color", "echo", 5)
+      assert.is_false(ok)
+      assert.is_truthy(err:find("cecho: bad argument #1, string expected, got number", 1, true))
+
+      local hexOk, hexErr = pcall(xEcho, "Hex", "insertText", {})
+      assert.is_false(hexOk)
+      assert.is_truthy(hexErr:find("hinsertText: bad argument #1, string expected, got table", 1, true))
+    end)
+
+    it("Should write to the window named in its first argument", function()
+      xEcho("Color", "echo", windowName, "<red>xEchoWindow")
+      assert.are.equal("xEchoWindow", currentLine())
+    end)
+
+    it("Should treat main as the main console rather than as a window name", function()
+      clearWindow()
+      moveCursor(0, 0)
+      xEcho("Color", "echo", "main", "<red>xEchoMainNamed")
+      selectCurrentLine()
+      assert.are.equal("xEchoMainNamed", getSelection())
+    end)
+
+    it("Should fall back to the main console when given only the text", function()
+      clearWindow()
+      moveCursor(0, 0)
+      xEcho("Color", "echo", "<red>xEchoMainOnly")
+      selectCurrentLine()
+      assert.are.equal("xEchoMainOnly", getSelection())
+    end)
+
+    it("Should apply every colour change in the string, not just the first", function()
+      xEcho("Decimal", "echo", windowName, "<255,0,0>AA<0,0,255>BB")
+      assert.are.equal("AABB", currentLine())
+      selectSection(windowName, 0, 2)
+      assert.are.same({255, 0, 0}, getTextFormat(windowName).foreground)
+      selectSection(windowName, 2, 2)
+      assert.are.same({0, 0, 255}, getTextFormat(windowName).foreground)
+    end)
+
+    it("Should refuse anything but a plain echo on a label", function()
+      local ok, err = xEcho("Color", "echoLink", labelName, "<red>x", "send('x')", "a hint")
+      assert.is_nil(ok)
+      assert.are.equal("you cannot use echoLink, echoPopup, or insertText with Labels", err)
+    end)
+
+    it("Should echo to a label, where a newline becomes a line break", function()
+      -- a label holds HTML and has no text getter, so the readback here is only
+      -- that the label branch runs through instead of raising
+      assert.has_no.errors(function() xEcho("Color", "echo", labelName, "<red>first\nsecond") end)
+    end)
+
+    it("Should insist on a command and a hint for the link variants", function()
+      local ok, err = pcall(xEcho, "Color", "echoLink", "text", "send('x')")
+      assert.is_false(ok)
+      assert.is_truthy(err:find("Insufficient arguments, usage: ([window, ] string, command, hint)", 1, true))
+
+      local improperOk, improperErr = pcall(xEcho, "Color", "echoLink", "text", "send('x')", "a hint", 5)
+      assert.is_false(improperOk)
+      assert.is_truthy(improperErr:find("Improper arguments, usage: ([window, ] string, command, hint)", 1, true))
+    end)
+
+    it("Should insist on commands and hints for the popup variants", function()
+      local ok, err = pcall(xEcho, "Color", "echoPopup", "text", {"send('x')"})
+      assert.is_false(ok)
+      assert.is_truthy(err:find("Insufficient arguments, usage: ([window, ] string, {commands}, {hints})", 1, true))
+
+      local improperOk, improperErr = pcall(xEcho, "Color", "echoPopup", "text", {"send('x')"}, {"a hint"}, 5)
+      assert.is_false(improperOk)
+      assert.is_truthy(improperErr:find("Improper arguments, usage: ([window, ] string, {commands}, {hints})", 1, true))
+    end)
+  end)
+
   describe("Tests the functionality of hinsertText and dinsertText", function()
     local windowName = "guiUtilsInsertConsole"
 
@@ -2128,6 +2231,57 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
   end)
 
+  describe("Tests the functionality of xReplace", function()
+    local windowName = "guiUtilsXReplaceBuffer"
+
+    teardown(function()
+      deleteMiniConsole(windowName)
+    end)
+
+    before_each(function()
+      createBuffer(windowName)
+      clearWindow(windowName)
+      moveCursor(windowName, 0, 0)
+      echo(windowName, "hello world")
+      moveCursor(windowName, 0, 0)
+    end)
+
+    local function currentLine()
+      selectCurrentLine(windowName)
+      return getSelection(windowName)
+    end
+
+    it("Should insert the replacement plainly when it is given no type", function()
+      -- creplace, dreplace and hreplace always name a type, so the plain
+      -- insertText fallback is only reachable by calling xReplace itself
+      selectString(windowName, "world", 1)
+      xReplace(windowName, "<red>earth")
+      assert.are.equal("hello <red>earth", currentLine())
+    end)
+
+    it("Should insert plainly for a type it does not know either", function()
+      selectString(windowName, "world", 1)
+      xReplace(windowName, "<red>earth", "z")
+      assert.are.equal("hello <red>earth", currentLine())
+    end)
+
+    it("Should put the replacement where the selection was", function()
+      selectString(windowName, "hello", 1)
+      xReplace(windowName, "goodbye", "c")
+      assert.are.equal("goodbye world", currentLine())
+    end)
+
+    it("Should fall back to the main console when the window is left out", function()
+      clearWindow()
+      moveCursor(0, 0)
+      echo("xReplaceMain marker")
+      selectString("marker", 1)
+      xReplace("<red>replaced", nil, "c")
+      selectCurrentLine()
+      assert.are.equal("xReplaceMain replaced", getSelection())
+    end)
+  end)
+
   describe("Tests the functionality of creplace, dreplace and hreplace", function()
     local windowName = "guiUtilsColourReplaceBuffer"
 
@@ -2318,6 +2472,99 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
 
     it("Should error when resetLabelCursor is not given a string", function()
       assert.has_error(function() resetLabelCursor(5) end)
+    end)
+  end)
+
+  -- GUIUtils.lua replaces the eight C++ callback setters with one shared Lua
+  -- wrapper, so what it does with the callback it is handed is common to all of
+  -- them. Firing a callback needs a real mouse or key event and so is out of
+  -- reach here; this is the registration half.
+  describe("Tests the functionality of the shared callback setter wrapper", function()
+    local labelName = "guiUtilsCallbackLabel"
+    local cmdLineName = "guiUtilsActionCmdLine"
+    local labelSetters = {
+      "setLabelClickCallback",
+      "setLabelDoubleClickCallback",
+      "setLabelReleaseCallback",
+      "setLabelMoveCallback",
+      "setLabelWheelCallback",
+      "setLabelOnEnter",
+      "setLabelOnLeave",
+    }
+
+    setup(function()
+      createLabel(labelName, 10, 10, 60, 30, 1)
+      createCommandLine(cmdLineName, 10, 10, 140, 30)
+    end)
+
+    teardown(function()
+      deleteLabel(labelName)
+      deleteCommandLine(cmdLineName)
+    end)
+
+    describe("Tests the functionality of setLabelClickCallback, setLabelDoubleClickCallback, setLabelReleaseCallback, setLabelMoveCallback, setLabelWheelCallback, setLabelOnEnter and setLabelOnLeave", function()
+      for _, setter in ipairs(labelSetters) do
+        it(setter .. " accepts a function, a function name and nil", function()
+          assert.is_true(_G[setter](labelName, function() end))
+          -- a string is compiled into a function calling that name, which does
+          -- not have to exist until the callback runs
+          assert.is_true(_G[setter](labelName, "guiUtilsNoSuchGlobalFunction"))
+          -- and nil is how a label callback is cleared again
+          assert.is_true(_G[setter](labelName, nil))
+        end)
+
+        it(setter .. " refuses a value that is none of those", function()
+          local ok, err = pcall(_G[setter], labelName, 42)
+          assert.is_false(ok)
+          assert.is_truthy(err:find(setter .. ": bad argument #2 type (function expected, got number!)", 1, true))
+        end)
+      end
+    end)
+
+    describe("Tests the functionality of setCmdLineAction", function()
+      it("Should accept a function", function()
+        assert.is_true(setCmdLineAction(cmdLineName, function() end))
+      end)
+
+      it("Should accept a function name as a string", function()
+        assert.is_true(setCmdLineAction(cmdLineName, "guiUtilsNoSuchGlobalFunction"))
+      end)
+
+      it("Should accept extra arguments to pass the action", function()
+        assert.is_true(setCmdLineAction(cmdLineName, function() end, "one", 2))
+      end)
+
+      it("Should refuse nil where the label callbacks take it as a request to clear", function()
+        -- the one function the wrapper singles out: resetCmdLineAction is how a
+        -- command line action is cleared, so nil here is a mistake
+        local ok, err = pcall(setCmdLineAction, cmdLineName, nil)
+        assert.is_false(ok)
+        assert.is_truthy(err:find("setCmdLineAction: bad argument #2 type (function expected, got nil!)", 1, true))
+        assert.is_true(setLabelClickCallback(labelName, nil))
+      end)
+
+      it("Should refuse a value that is neither function, string nor nil", function()
+        local ok, err = pcall(setCmdLineAction, cmdLineName, 42)
+        assert.is_false(ok)
+        assert.is_truthy(err:find("setCmdLineAction: bad argument #2 type (function expected, got number!)", 1, true))
+      end)
+
+      it("Should report a command line it cannot find", function()
+        local ok, err = setCmdLineAction("guiUtilsNoSuchCommandLine", function() end)
+        assert.is_nil(ok)
+        assert.are.equal("command line name 'guiUtilsNoSuchCommandLine' not found", err)
+      end)
+
+      it("Should reject an empty command line name", function()
+        local ok, err = setCmdLineAction("", function() end)
+        assert.is_nil(ok)
+        assert.are.equal("command line name cannot be an empty string", err)
+      end)
+
+      it("Should let resetCmdLineAction clear what it set", function()
+        setCmdLineAction(cmdLineName, function() end)
+        assert.is_true(resetCmdLineAction(cmdLineName))
+      end)
     end)
   end)
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -1756,9 +1756,9 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
   end)
 
-  -- the twenty-one c/d/h echo, insert, link and popup functions are one-line
-  -- calls into xEcho, so the argument shapes and the branches none of them can
-  -- reach are covered here rather than twenty-one times over
+  -- the c/d/h echo, insert, link and popup functions are all one-line calls
+  -- into xEcho and share its argument handling, so that is specced once here
+  -- rather than once per wrapper
   describe("Tests the functionality of xEcho", function()
     local windowName = "guiUtilsXEchoConsole"
     local labelName = "guiUtilsXEchoLabel"
@@ -1801,7 +1801,7 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.are.equal("xEchoWindow", currentLine())
     end)
 
-    it("Should treat main as the main console rather than as a window name", function()
+    it("Should echo to the main console when main is the window it is given", function()
       clearWindow()
       moveCursor(0, 0)
       xEcho("Color", "echo", "main", "<red>xEchoMainNamed")
@@ -1832,10 +1832,37 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.are.equal("you cannot use echoLink, echoPopup, or insertText with Labels", err)
     end)
 
-    it("Should echo to a label, where a newline becomes a line break", function()
-      -- a label holds HTML and has no text getter, so the readback here is only
-      -- that the label branch runs through instead of raising
-      assert.has_no.errors(function() xEcho("Color", "echo", labelName, "<red>first\nsecond") end)
+    it("Should echo to a label, turning a newline into a line break", function()
+      -- a label holds HTML, so the newline must arrive as <br> or the second
+      -- line is run together with the first
+      xEcho("Color", "echo", labelName, "<red>first\nsecond")
+      local html = getLabelText(labelName)
+      assert.is_truthy(html:find("first<br>second", 1, true))
+      assert.is_nil(html:find("\n", 1, true))
+    end)
+
+    it("Should take a link or a popup with no window at all", function()
+      -- the documented cechoLink(text, command, hint) form: three arguments and
+      -- the first one is the text, not a window name
+      clearWindow()
+      moveCursor(0, 0)
+      xEcho("Color", "echoLink", "<red>xEchoBareLink", "send('x')", "a hint")
+      selectCurrentLine()
+      assert.are.equal("xEchoBareLink", getSelection())
+
+      clearWindow()
+      moveCursor(0, 0)
+      xEcho("Color", "echoPopup", "<red>xEchoBarePopup", {"send('x')"}, {"a hint"})
+      selectCurrentLine()
+      assert.are.equal("xEchoBarePopup", getSelection())
+    end)
+
+    it("Should take the fourth argument as a format flag when it is a boolean", function()
+      clearWindow()
+      moveCursor(0, 0)
+      xEcho("Color", "echoLink", "<red>xEchoFormattedLink", "send('x')", "a hint", true)
+      selectCurrentLine()
+      assert.are.equal("xEchoFormattedLink", getSelection())
     end)
 
     it("Should insist on a command and a hint for the link variants", function()
@@ -2509,7 +2536,8 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
           -- a string is compiled into a function calling that name, which does
           -- not have to exist until the callback runs
           assert.is_true(_G[setter](labelName, "guiUtilsNoSuchGlobalFunction"))
-          -- and nil is how a label callback is cleared again
+          -- nil is accepted rather than refused, which is how these seven clear
+          -- a callback and where they part company with setCmdLineAction below
           assert.is_true(_G[setter](labelName, nil))
         end)
 
@@ -2517,6 +2545,16 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
           local ok, err = pcall(_G[setter], labelName, 42)
           assert.is_false(ok)
           assert.is_truthy(err:find(setter .. ": bad argument #2 type (function expected, got number!)", 1, true))
+        end)
+
+        it(setter .. " reports a label it cannot find and rejects an empty name", function()
+          local ok, err = _G[setter]("guiUtilsNoSuchLabel", function() end)
+          assert.is_nil(ok)
+          assert.are.equal("label name 'guiUtilsNoSuchLabel' not found", err)
+
+          local emptyOk, emptyErr = _G[setter]("", function() end)
+          assert.is_nil(emptyOk)
+          assert.are.equal("label name cannot be an empty string", emptyErr)
         end)
       end
     end)
@@ -2530,13 +2568,17 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
         assert.is_true(setCmdLineAction(cmdLineName, "guiUtilsNoSuchGlobalFunction"))
       end)
 
-      it("Should accept extra arguments to pass the action", function()
+      it("Should accept extra arguments alongside the action", function()
+        -- what the wrapper then does with them is only observable once the
+        -- action fires, which needs a real keypress
         assert.is_true(setCmdLineAction(cmdLineName, function() end, "one", 2))
       end)
 
       it("Should refuse nil where the label callbacks take it as a request to clear", function()
-        -- the one function the wrapper singles out: resetCmdLineAction is how a
-        -- command line action is cleared, so nil here is a mistake
+        -- the one function the wrapper singles out, because resetCmdLineAction
+        -- is how a command line action is cleared. The label setter is asserted
+        -- here too: the refusal on its own does not show the wrapper made the
+        -- distinction, since the C++ setter rejects a nil action as well.
         local ok, err = pcall(setCmdLineAction, cmdLineName, nil)
         assert.is_false(ok)
         assert.is_truthy(err:find("setCmdLineAction: bad argument #2 type (function expected, got nil!)", 1, true))
@@ -2561,9 +2603,14 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
         assert.are.equal("command line name cannot be an empty string", err)
       end)
 
-      it("Should let resetCmdLineAction clear what it set", function()
+      it("Should have resetCmdLineAction as the way to take the action back", function()
+        -- resetCmdLineAction is not wrapped, so it answers for the command line
+        -- rather than for whether an action was ever set on it
         setCmdLineAction(cmdLineName, function() end)
         assert.is_true(resetCmdLineAction(cmdLineName))
+        local ok, err = resetCmdLineAction("guiUtilsNoSuchCommandLine")
+        assert.is_nil(ok)
+        assert.are.equal("command line name 'guiUtilsNoSuchCommandLine' not found", err)
       end)
     end)
   end)

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -574,6 +574,58 @@ describe("Tests the functionality of IDMgr", function()
       assert.are.same({}, other:getTimers())
     end)
 
+    -- IDMgr is a local in IDManager.lua, so the class itself is only reachable
+    -- as the metatable of an instance it has already handed out
+    describe("Tests the functionality of IDMgr:new", function()
+      local IDMgr = getmetatable(getNewIDManager())
+      local made
+
+      before_each(function()
+        made = {}
+      end)
+
+      after_each(function()
+        for _, manager in ipairs(made) do
+          manager:deleteAllTimers()
+          manager:deleteAllTriggers()
+          manager:deleteAllEvents()
+        end
+      end)
+
+      local function newManager()
+        local manager = IDMgr:new()
+        made[#made + 1] = manager
+        return manager
+      end
+
+      it("Should give a manager its own four empty stores", function()
+        local fresh = newManager()
+        assert.are.same({}, fresh.events)
+        assert.are.same({}, fresh.timers)
+        assert.are.same({}, fresh.triggers)
+        assert.are.same({}, fresh.regexTriggers)
+      end)
+
+      it("Should not let two managers share a store", function()
+        local first, second = newManager(), newManager()
+        first:registerTimer("mine", 100, function() end)
+        assert.are.same({"mine"}, first:getTimers())
+        assert.are.same({}, second:getTimers())
+      end)
+
+      it("Should reach the IDMgr methods through the metatable it sets", function()
+        local fresh = newManager()
+        assert.are.equal(IDMgr, getmetatable(fresh))
+        assert.are.equal(IDMgr, IDMgr.__index)
+        assert.is_function(fresh.registerTimer)
+        assert.is_function(fresh.emergencyStop)
+      end)
+
+      it("Should be what getNewIDManager hands out", function()
+        assert.are.equal(IDMgr, getmetatable(getNewIDManager()))
+      end)
+    end)
+
     describe("Tests the functionality of IDMgr:registerTrigger and IDMgr:registerRegexTrigger", function()
       it("Should register a substring trigger that fires", function()
         _G.PrivateMgrFire = 0
@@ -675,6 +727,143 @@ describe("Tests the functionality of IDMgr", function()
       end)
     end)
 
+    describe("Tests the functionality of IDMgr:registerTimer", function()
+      -- the suite itself runs inside a tempTimer, so nothing fires until the
+      -- event loop is handed back control for a moment
+      local function pumpEventLoop(milliseconds)
+        tempTimer(milliseconds / 1000, function() raiseEvent("idManagerTimerPump") end)
+        waitForEvent("idManagerTimerPump", milliseconds + 1000)
+      end
+
+      local function pumpUntil(condition)
+        for _ = 1, 20 do
+          if condition() then
+            return
+          end
+          pumpEventLoop(50)
+        end
+      end
+
+      it("Should give the timer a live tempTimer and list it under its name", function()
+        assert.is_true(mgr:registerTimer("timer", 100, function() end))
+        assert.is_number(remainingTime(mgr.timers["timer"].handlerID))
+        assert.are.same({"timer"}, mgr:getTimers())
+      end)
+
+      it("Should run the function it was given exactly once", function()
+        local fired = 0
+        mgr:registerTimer("timer", 0.05, function() fired = fired + 1 end)
+        local handlerID = mgr.timers["timer"].handlerID
+
+        pumpUntil(function() return fired > 0 end)
+        pumpEventLoop(200)
+
+        assert.are.equal(1, fired)
+        -- a timer that is not repeating is gone once it has fired
+        assert.is_nil(remainingTime(handlerID))
+      end)
+
+      it("Should hand the fourth argument to tempTimer as its repeating flag", function()
+        local fired = 0
+        mgr:registerTimer("timer", 0.05, function() fired = fired + 1 end, true)
+        local handlerID = mgr.timers["timer"].handlerID
+
+        pumpUntil(function() return fired > 1 end)
+
+        assert.is_true(fired > 1, "a repeating timer should fire more than once")
+        assert.is_number(remainingTime(handlerID), "a repeating timer stays alive after firing")
+      end)
+
+      it("Should replace an earlier timer of the same name instead of adding one", function()
+        mgr:registerTimer("timer", 5000, function() end)
+        local firstID = mgr.timers["timer"].handlerID
+
+        assert.is_true(mgr:registerTimer("timer", 5000, function() end))
+
+        assert.are_not.equal(firstID, mgr.timers["timer"].handlerID)
+        assert.is_nil(remainingTime(firstID), "the timer it replaces has to be killed")
+        assert.are.same({"timer"}, mgr:getTimers())
+      end)
+
+      it("Should report the upstream failure instead of raising", function()
+        local ok, err = mgr:registerTimer("bad", "not a number", function() end)
+        assert.is_nil(ok)
+        assert.is_string(err)
+        assert.is_nil(mgr.timers["bad"])
+        assert.are.same({}, mgr:getTimers())
+      end)
+    end)
+
+    describe("Tests the functionality of IDMgr:stopTimer", function()
+      it("Should kill the tempTimer while leaving the name registered", function()
+        mgr:registerTimer("timer", 100, function() end)
+        local handlerID = mgr.timers["timer"].handlerID
+
+        assert.is_true(mgr:stopTimer("timer"))
+
+        assert.is_nil(remainingTime(handlerID), "stopping has to kill the tempTimer, not just the bookkeeping")
+        assert.are.equal(-1, mgr.timers["timer"].handlerID)
+        assert.are.same({"timer"}, mgr:getTimers())
+      end)
+
+      it("Should report the stopped timer as inactive", function()
+        mgr:registerTimer("timer", 100, function() end)
+        mgr:stopTimer("timer")
+        local remaining, err = mgr:remainingTime("timer")
+        assert.is_nil(remaining)
+        assert.are.equal("timer is inactive", err)
+      end)
+
+      it("Should leave the other timers running", function()
+        mgr:registerTimer("stopped", 100, function() end)
+        mgr:registerTimer("running", 100, function() end)
+        mgr:stopTimer("stopped")
+        assert.is_number(mgr:remainingTime("running"))
+      end)
+
+      it("Should stay stopped when asked a second time", function()
+        mgr:registerTimer("timer", 100, function() end)
+        assert.is_true(mgr:stopTimer("timer"))
+        assert.is_true(mgr:stopTimer("timer"))
+        assert.are.equal(-1, mgr.timers["timer"].handlerID)
+      end)
+
+      it("Should return false for a name it does not know", function()
+        assert.is_false(mgr:stopTimer("no such timer"))
+      end)
+    end)
+
+    describe("Tests the functionality of IDMgr:getTimers", function()
+      it("Should return an empty list for a fresh manager", function()
+        assert.are.same({}, mgr:getTimers())
+      end)
+
+      it("Should list every registered timer name, sorted", function()
+        mgr:registerTimer("charlie", 100, function() end)
+        mgr:registerTimer("alpha", 100, function() end)
+        mgr:registerTimer("bravo", 100, function() end)
+        assert.are.same({"alpha", "bravo", "charlie"}, mgr:getTimers())
+      end)
+
+      it("Should keep listing a timer that was stopped but not deleted", function()
+        mgr:registerTimer("stopped", 100, function() end)
+        mgr:stopTimer("stopped")
+        assert.are.same({"stopped"}, mgr:getTimers())
+      end)
+
+      it("Should forget a deleted timer", function()
+        mgr:registerTimer("gone", 100, function() end)
+        mgr:deleteTimer("gone")
+        assert.are.same({}, mgr:getTimers())
+      end)
+
+      it("Should not report events or triggers as timers", function()
+        mgr:registerEvent("event", "privateMgrTimerListEvent", function() end)
+        mgr:registerTrigger("trigger", "private_mgr_timers_not_triggers", function() end)
+        assert.are.same({}, mgr:getTimers())
+      end)
+    end)
+
     describe("Tests the functionality of IDMgr:stopAllTimers and IDMgr:deleteAllTimers", function()
       it("Should stop every timer while leaving them registered", function()
         mgr:registerTimer("one", 100, function() end)
@@ -736,6 +925,58 @@ describe("Tests the functionality of IDMgr", function()
         assert.is_equal(-1, mgr.regexTriggers["re"].handlerID)
         -- stopped, not deleted, so it can still be resumed
         assert.are.same({"re"}, mgr:getTriggers())
+      end)
+    end)
+
+    describe("Tests the functionality of IDMgr:registerEvent", function()
+      local eventName = "privateMgrRegisterEvent"
+
+      it("Should register a handler that fires on the event", function()
+        local fired = 0
+        assert.is_true(mgr:registerEvent("handler", eventName, function() fired = fired + 1 end))
+        raiseEvent(eventName)
+        assert.are.equal(1, fired)
+        assert.are.same({"handler"}, mgr:getEvents())
+      end)
+
+      it("Should pass the arguments the event was raised with", function()
+        local seen
+        mgr:registerEvent("handler", eventName, function(_, first, second) seen = {first, second} end)
+        raiseEvent(eventName, "alpha", 2)
+        assert.are.same({"alpha", 2}, seen)
+      end)
+
+      it("Should stop after one event when the fourth argument asks for a one shot", function()
+        local fired = 0
+        mgr:registerEvent("handler", eventName, function() fired = fired + 1 end, true)
+        raiseEvent(eventName)
+        raiseEvent(eventName)
+        assert.are.equal(1, fired)
+      end)
+
+      it("Should keep firing without that fourth argument", function()
+        local fired = 0
+        mgr:registerEvent("handler", eventName, function() fired = fired + 1 end)
+        raiseEvent(eventName)
+        raiseEvent(eventName)
+        assert.are.equal(2, fired)
+      end)
+
+      it("Should replace a handler registered under the same name", function()
+        local first, second = 0, 0
+        mgr:registerEvent("handler", eventName, function() first = first + 1 end)
+        mgr:registerEvent("handler", eventName, function() second = second + 1 end)
+        raiseEvent(eventName)
+        assert.are.equal(0, first, "the first registration has to be killed, not left behind")
+        assert.are.equal(1, second)
+        assert.are.same({"handler"}, mgr:getEvents())
+      end)
+
+      it("Should report the upstream failure instead of raising", function()
+        local ok, err = mgr:registerEvent("bad", eventName, 5)
+        assert.is_nil(ok)
+        assert.is_string(err)
+        assert.is_nil(mgr.events["bad"])
       end)
     end)
 
@@ -879,6 +1120,44 @@ describe("Tests the functionality of IDMgr", function()
         mgr:registerTimer("timer", 100, function() end)
         mgr:stopAllEvents()
         assert.is_number(mgr:remainingTime("timer"))
+      end)
+    end)
+
+    describe("Tests the functionality of IDMgr:deleteAllEvents", function()
+      local eventName = "privateMgrDeleteAllEvent"
+
+      it("Should stop every handler firing and empty the store", function()
+        local fired = 0
+        mgr:registerEvent("one", eventName, function() fired = fired + 1 end)
+        mgr:registerEvent("two", eventName, function() fired = fired + 1 end)
+
+        assert.is_true(mgr:deleteAllEvents())
+
+        raiseEvent(eventName)
+        assert.are.equal(0, fired)
+        assert.are.same({}, mgr:getEvents())
+      end)
+
+      it("Should leave the deleted handlers beyond resuming", function()
+        mgr:registerEvent("one", eventName, function() end)
+        mgr:deleteAllEvents()
+        assert.is_false(mgr:resumeEvent("one"))
+      end)
+
+      it("Should leave timers and triggers alone", function()
+        mgr:registerEvent("event", eventName, function() end)
+        mgr:registerTimer("timer", 100, function() end)
+        mgr:registerTrigger("trigger", "private_mgr_delete_all_events", function() end)
+
+        mgr:deleteAllEvents()
+
+        assert.is_number(mgr:remainingTime("timer"))
+        assert.are.same({"timer"}, mgr:getTimers())
+        assert.are.same({"trigger"}, mgr:getTriggers())
+      end)
+
+      it("Should return true for a manager with no handlers", function()
+        assert.is_true(mgr:deleteAllEvents())
       end)
     end)
 

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -616,13 +616,13 @@ describe("Tests the functionality of IDMgr", function()
       it("Should reach the IDMgr methods through the metatable it sets", function()
         local fresh = newManager()
         assert.are.equal(IDMgr, getmetatable(fresh))
-        assert.are.equal(IDMgr, IDMgr.__index)
         assert.is_function(fresh.registerTimer)
         assert.is_function(fresh.emergencyStop)
       end)
 
-      it("Should be what getNewIDManager hands out", function()
+      it("Should give every manager the same metatable", function()
         assert.are.equal(IDMgr, getmetatable(getNewIDManager()))
+        assert.are.equal(IDMgr, getmetatable(newManager()))
       end)
     end)
 
@@ -728,8 +728,8 @@ describe("Tests the functionality of IDMgr", function()
     end)
 
     describe("Tests the functionality of IDMgr:registerTimer", function()
-      -- the suite itself runs inside a tempTimer, so nothing fires until the
-      -- event loop is handed back control for a moment
+      -- Mudlet is single threaded, so a spec body holds the event loop until it
+      -- returns and no timer can fire inside one: hand control back for a moment
       local function pumpEventLoop(milliseconds)
         tempTimer(milliseconds / 1000, function() raiseEvent("idManagerTimerPump") end)
         waitForEvent("idManagerTimerPump", milliseconds + 1000)
@@ -750,29 +750,42 @@ describe("Tests the functionality of IDMgr", function()
         assert.are.same({"timer"}, mgr:getTimers())
       end)
 
-      it("Should run the function it was given exactly once", function()
-        local fired = 0
-        mgr:registerTimer("timer", 0.05, function() fired = fired + 1 end)
-        local handlerID = mgr.timers["timer"].handlerID
+      -- waitForEvent is test mode only, so the two specs that wait for a timer
+      -- to fire cannot run when the suite is started by hand with runTests
+      local canPump = os.getenv("MUDLET_TEST_MODE") ~= nil
 
-        pumpUntil(function() return fired > 0 end)
-        pumpEventLoop(200)
+      if not canPump then
+        pending("Should run the function it was given exactly once - needs MUDLET_TEST_MODE for waitForEvent")
+        pending("Should hand the fourth argument to tempTimer as its repeating flag - needs MUDLET_TEST_MODE for waitForEvent")
+      else
+        it("Should run the function it was given exactly once", function()
+          local fired = 0
+          mgr:registerTimer("timer", 0.05, function() fired = fired + 1 end)
+          local handlerID = mgr.timers["timer"].handlerID
 
-        assert.are.equal(1, fired)
-        -- a timer that is not repeating is gone once it has fired
-        assert.is_nil(remainingTime(handlerID))
-      end)
+          pumpUntil(function() return fired > 0 end)
+          pumpEventLoop(200)
 
-      it("Should hand the fourth argument to tempTimer as its repeating flag", function()
-        local fired = 0
-        mgr:registerTimer("timer", 0.05, function() fired = fired + 1 end, true)
-        local handlerID = mgr.timers["timer"].handlerID
+          assert.are.equal(1, fired)
+          -- a timer that is not repeating is gone once it has fired
+          assert.is_nil(remainingTime(handlerID))
+        end)
 
-        pumpUntil(function() return fired > 1 end)
+        -- IDMgr keeps this flag in a field called oneShot for every store, but
+        -- for timers it reaches tempTimer as its repeating argument, which is
+        -- the opposite meaning to the event case below - and it matches what
+        -- registerNamedTimer(..., [repeating]) is documented to take
+        it("Should hand the fourth argument to tempTimer as its repeating flag", function()
+          local fired = 0
+          mgr:registerTimer("timer", 0.05, function() fired = fired + 1 end, true)
+          local handlerID = mgr.timers["timer"].handlerID
 
-        assert.is_true(fired > 1, "a repeating timer should fire more than once")
-        assert.is_number(remainingTime(handlerID), "a repeating timer stays alive after firing")
-      end)
+          pumpUntil(function() return fired > 1 end)
+
+          assert.is_true(fired > 1, "a repeating timer should fire more than once")
+          assert.is_number(remainingTime(handlerID), "a repeating timer stays alive after firing")
+        end)
+      end
 
       it("Should replace an earlier timer of the same name instead of adding one", function()
         mgr:registerTimer("timer", 5000, function() end)
@@ -792,6 +805,12 @@ describe("Tests the functionality of IDMgr", function()
         assert.is_nil(mgr.timers["bad"])
         assert.are.same({}, mgr:getTimers())
       end)
+
+      -- BUG: IDMgr:register stops whatever is registered under the name before
+      -- it tries the new registration, and puts nothing back when that fails,
+      -- so a re-registration with a bad argument kills a working timer while
+      -- leaving the name in getTimers() looking registered.
+      pending("Should leave the running timer alone when a re-registration fails")
     end)
 
     describe("Tests the functionality of IDMgr:stopTimer", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

93 new busted specs for the last non-Geyser gaps in the Lua library's coverage - internals that only ever ran through a wrapper, so no spec named them directly:

- **IDManager.lua** - `IDMgr:new`, `:registerTimer`, `:registerEvent`, `:stopTimer`, `:getTimers`, `:deleteAllEvents`. The class is a file-local, so the specs reach it as the metatable of a manager `getNewIDManager()` handed out. The fourth argument of `registerTimer` and `registerEvent` had never been exercised: one is `tempTimer`'s repeating flag, the other asks `registerAnonymousEventHandler` for a one-shot.
- **DB.lua** - `db.__Timestamp:as_number/:as_string/:as_table/:set` (previously only compared to each other in a round-trip; `:set` was untouched) and `db.Database:_begin/_commit/_rollback/_end` one at a time rather than as one whole transaction.
- **GUIUtils.lua** - `xEcho` (the engine behind the c/d/h echo, insert, link and popup functions) and `xReplace` (behind `creplace`/`dreplace`/`hreplace`), covering the argument shapes and the plain-`insertText` fallback no wrapper reaches. Plus the one Lua wrapper shared by `setCmdLineAction` and the seven `setLabel*Callback` functions.

#### Motivation for adding to Mudlet

Closes the last non-Geyser lua-lib holes in spec coverage. Busted specs are shared with Mudlet Web, so this grows that platform's coverage too.

#### Other info (issues closed, discussion etc)

One spec is `pending()` rather than green, describing a defect it found: `IDMgr:register` stops whatever is registered under a name before trying the new registration and puts nothing back when that fails, so `registerNamedTimer` with a bad argument silently kills a working timer and leaves the name listed as if it were still registered. Filed as #10047.

Deliberately not covered:
- `openMudletHomeDir()` hands a real path to `openUrl()`, which opens the platform file manager - not something CI should do.
- `utf8_filenames.lua`'s 18 os/io/lfs wrappers are only loaded under `#if defined(Q_OS_WINDOWS)`, and only installed when the Windows ANSI codepage has a mapping table.
- Firing a label callback or a command line action needs a real `QMouseEvent`/`QWheelEvent` or an Enter keypress; `sendCmdLine()` only fills the command line in, it does not submit it. The registration half is covered.

**Test case:** suite goes 3339 -> 3432 successes, 0 failures, green twice (fresh profile, then a re-run on the same profile). Also A/B'd without `MUDLET_TEST_MODE`, the `runTests` workflow the README documents: same 6 pre-existing errors before and after, no new failures. Sabotage-checked: 41 specs confirmed to go red against 19 deliberate breakages of the product code (wrong store read, dropped `killTimer`, dropped type check, flipped autocommit flag, dropped label guard, dropped string compilation, ...), then the code was restored.

Assisted-by: Claude:claude-opus-5
