### PR TITLE
Infra: cover untested media and mapper behaviour with tests

### DIFF
--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -1765,19 +1765,19 @@ describe("Tests mapper functions against a shared fixture", function()
 
     it("setMapBackgroundColor is read back by getMapBackgroundColor", function()
       assert.is_true(setMapBackgroundColor(12, 34, 56, 78))
-      assert.same({12, 34, 56, 78}, {getMapBackgroundColor()})
+      assert.are.same({12, 34, 56, 78}, {getMapBackgroundColor()})
     end)
 
     it("a background set without an alpha is opaque", function()
       assert.is_true(setMapBackgroundColor(12, 34, 56, 78))
       assert.is_true(setMapBackgroundColor(9, 8, 7))
-      assert.same({9, 8, 7, 255}, {getMapBackgroundColor()})
+      assert.are.same({9, 8, 7, 255}, {getMapBackgroundColor()})
     end)
 
     it("setMapRoomExitsColor is read back by getMapRoomExitsColor", function()
       -- three components, not four: the exit colour carries no alpha either way
       assert.is_true(setMapRoomExitsColor(21, 43, 65))
-      assert.same({21, 43, 65}, {getMapRoomExitsColor()})
+      assert.are.same({21, 43, 65}, {getMapRoomExitsColor()})
     end)
 
     it("a component outside 0-255 is refused and changes nothing", function()
@@ -1789,13 +1789,13 @@ describe("Tests mapper functions against a shared fixture", function()
         assert.is_string(err)
         assert.is_truthy(err:find("needs to be between 0-255", 1, true), err)
       end
-      assert.same({10, 20, 30, 40}, {getMapBackgroundColor()})
+      assert.are.same({10, 20, 30, 40}, {getMapBackgroundColor()})
 
       assert.is_true(setMapRoomExitsColor(11, 22, 33))
       local exitsOk, exitsErr = setMapRoomExitsColor(11, 22, 999)
       assert.is_nil(exitsOk)
       assert.is_string(exitsErr)
-      assert.same({11, 22, 33}, {getMapRoomExitsColor()})
+      assert.are.same({11, 22, 33}, {getMapRoomExitsColor()})
     end)
 
     it("a component that is not a number hard-errors", function()
@@ -1817,16 +1817,17 @@ describe("Tests mapper functions against a shared fixture", function()
   describe("Tests setDefaultAreaVisible", function()
     -- The flag itself has no Lua readback: TMap::mShowDefaultArea is read by
     -- the mapper's area list, the map view's painting and the preferences
-    -- checkbox, and by no Lua function at all. What a spec can hold onto is
-    -- therefore the call's own contract.
+    -- checkbox, and by no Lua function other than this setter's own fixup.
+    -- What a spec can hold onto is therefore the call's own contract.
     teardown(function()
       setDefaultAreaVisible(true)
     end)
 
     it("reports success while the mapper widget is up", function()
       assert.is_true(setDefaultAreaVisible(false))
-      -- and again the other way, which is the corner case the fixup inside
-      -- guards: re-enabling while the widget sits on the default area
+      -- and again the other way, which must also report success. This does not
+      -- reach the combo box fixup inside: that needs the 2D map parked on the
+      -- default area, and the fixture's rooms are all in named ones.
       assert.is_true(setDefaultAreaVisible(true))
     end)
 

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -1815,6 +1815,12 @@ describe("Tests mapper functions against a shared fixture", function()
   end)
 
   describe("Tests setDefaultAreaVisible", function()
+    -- Opened here as well as in the outer setup: the success branch needs the
+    -- mapper widget, and busted can be asked to shuffle these blocks.
+    setup(function()
+      assert.is_true(openMapWidget())
+    end)
+
     -- The flag itself has no Lua readback: TMap::mShowDefaultArea is read by
     -- the mapper's area list, the map view's painting and the preferences
     -- checkbox, and by no Lua function other than this setter's own fixup.

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -946,6 +946,31 @@ describe("Tests mapper functions against a shared fixture", function()
       assert.has_error(function() setExit(rA1, rA2, "sideways") end)
     end)
 
+    it("setExit takes the short alias of every direction, whatever its case", function()
+      -- dirToNumber() accepts a one or two letter alias as well as the full
+      -- name, and nothing reached that half of it: every spec here writes a
+      -- full name, and the lockExit/hasExitLock wrappers in Other.lua translate
+      -- their direction to a number before the C++ call ever sees it.
+      local aliases = {
+        {"n", "north"}, {"e", "east"}, {"s", "south"}, {"w", "west"},
+        {"u", "up"}, {"d", "down"}, {"ne", "northeast"}, {"nw", "northwest"},
+        {"se", "southeast"}, {"sw", "southwest"}, {"i", "in"}, {"o", "out"},
+      }
+      local a = createRoomID(); addRoom(a); setRoomArea(a, areaAlpha)
+      local b = createRoomID(); addRoom(b); setRoomArea(b, areaAlpha)
+      for _, pair in ipairs(aliases) do
+        local short, long = pair[1], pair[2]
+        assert.is_true(setExit(a, b, short), short)
+        assert.are.equal(b, getRoomExits(a)[long], short)
+      end
+      -- the direction is lowercased before it is matched, so the aliases are
+      -- as case-insensitive as the full names are
+      local c = createRoomID(); addRoom(c); setRoomArea(c, areaAlpha)
+      assert.is_true(setExit(a, c, "SW"))
+      assert.are.equal(c, getRoomExits(a)["southwest"])
+      deleteRoom(a); deleteRoom(b); deleteRoom(c)
+    end)
+
     it("getAllRoomEntrances lists the rooms that exit into a room", function()
       local entrances = getAllRoomEntrances(rA2)
       assert.is_table(entrances)
@@ -1722,6 +1747,91 @@ describe("Tests mapper functions against a shared fixture", function()
       local zoom, err = getMapZoom(missingAreaId)
       assert.is_nil(zoom)
       assert.is_string(err)
+    end)
+  end)
+
+  describe("Tests the map background and room exit colours", function()
+    local originalBackground, originalRoomExits
+
+    setup(function()
+      originalBackground = {getMapBackgroundColor()}
+      originalRoomExits = {getMapRoomExitsColor()}
+    end)
+
+    teardown(function()
+      setMapBackgroundColor(unpack(originalBackground))
+      setMapRoomExitsColor(unpack(originalRoomExits))
+    end)
+
+    it("setMapBackgroundColor is read back by getMapBackgroundColor", function()
+      assert.is_true(setMapBackgroundColor(12, 34, 56, 78))
+      assert.same({12, 34, 56, 78}, {getMapBackgroundColor()})
+    end)
+
+    it("a background set without an alpha is opaque", function()
+      assert.is_true(setMapBackgroundColor(12, 34, 56, 78))
+      assert.is_true(setMapBackgroundColor(9, 8, 7))
+      assert.same({9, 8, 7, 255}, {getMapBackgroundColor()})
+    end)
+
+    it("setMapRoomExitsColor is read back by getMapRoomExitsColor", function()
+      -- three components, not four: the exit colour carries no alpha either way
+      assert.is_true(setMapRoomExitsColor(21, 43, 65))
+      assert.same({21, 43, 65}, {getMapRoomExitsColor()})
+    end)
+
+    it("a component outside 0-255 is refused and changes nothing", function()
+      assert.is_true(setMapBackgroundColor(10, 20, 30, 40))
+      local rejected = {{-1, 20, 30}, {10, 256, 30}, {10, 20, -5}, {10, 20, 30, 300}}
+      for _, components in ipairs(rejected) do
+        local ok, err = setMapBackgroundColor(unpack(components))
+        assert.is_nil(ok)
+        assert.is_string(err)
+        assert.is_truthy(err:find("needs to be between 0-255", 1, true), err)
+      end
+      assert.same({10, 20, 30, 40}, {getMapBackgroundColor()})
+
+      assert.is_true(setMapRoomExitsColor(11, 22, 33))
+      local exitsOk, exitsErr = setMapRoomExitsColor(11, 22, 999)
+      assert.is_nil(exitsOk)
+      assert.is_string(exitsErr)
+      assert.same({11, 22, 33}, {getMapRoomExitsColor()})
+    end)
+
+    it("a component that is not a number hard-errors", function()
+      assert.has_error(function() setMapBackgroundColor("red", 0, 0) end)
+      assert.has_error(function() setMapRoomExitsColor(0, "green", 0) end)
+    end)
+
+    it("a component too large for an int hard-errors rather than wrapping", function()
+      -- getVerifiedInt() reads a Lua number as a 64 bit integer and refuses one
+      -- that will not fit an int, which is a separate refusal from the type
+      -- check above and from the 0-255 range check: without it the value would
+      -- be truncated into range and silently accepted.
+      local ok, err = pcall(function() setMapBackgroundColor(2 ^ 40, 0, 0) end)
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find("integer over/under-flow", 1, true), tostring(err))
+    end)
+  end)
+
+  describe("Tests setDefaultAreaVisible", function()
+    -- The flag itself has no Lua readback - nothing outside the mapper's own
+    -- combo box and painting reads TMap::mShowDefaultArea - so what a spec can
+    -- hold onto is the call's own contract.
+    teardown(function()
+      setDefaultAreaVisible(true)
+    end)
+
+    it("reports success while the mapper widget is up", function()
+      assert.is_true(setDefaultAreaVisible(false))
+      -- and again the other way, which is the corner case the fixup inside
+      -- guards: re-enabling while the widget sits on the default area
+      assert.is_true(setDefaultAreaVisible(true))
+    end)
+
+    it("hard-errors when its argument is not a boolean", function()
+      assert.has_error(function() setDefaultAreaVisible("yes") end)
+      assert.has_error(function() setDefaultAreaVisible() end)
     end)
   end)
 

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -1815,9 +1815,10 @@ describe("Tests mapper functions against a shared fixture", function()
   end)
 
   describe("Tests setDefaultAreaVisible", function()
-    -- The flag itself has no Lua readback - nothing outside the mapper's own
-    -- combo box and painting reads TMap::mShowDefaultArea - so what a spec can
-    -- hold onto is the call's own contract.
+    -- The flag itself has no Lua readback: TMap::mShowDefaultArea is read by
+    -- the mapper's area list, the map view's painting and the preferences
+    -- checkbox, and by no Lua function at all. What a spec can hold onto is
+    -- therefore the call's own contract.
     teardown(function()
       setDefaultAreaVisible(true)
     end)

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -1343,10 +1343,12 @@ describe("Media playback effects with a generated sound file", function()
     end
     -- TMedia::releaseMediaSourceAfterEvents() ends a playback one event-loop
     -- turn late, so that a looping track's EndOfMedia can still restart it
-    -- (#9566). sysMediaFinished is raised from inside the stop, so no event can
-    -- see that deferral; the closing caption is the other half of the same
-    -- ending and is printed by the deferred turn itself. Closed captions are
-    -- off by default, so turning them on is what makes it reachable at all.
+    -- (#9566). No event can see that deferral - on a backend that reports the
+    -- stop synchronously sysMediaFinished is raised from inside the call, and
+    -- on one that does not it merely arrives later - but the closing caption is
+    -- the other half of the same ending, and the deferred turn is what prints
+    -- it. Closed captions are off by default, so turning them on is what makes
+    -- it reachable at all.
     local captionKey = "busted-caption-deferred"
     local wasCaptioned = getConfig("enableClosedCaption")
     assert.is_true(setConfig("enableClosedCaption", true))
@@ -1429,6 +1431,11 @@ describe("Media playback effects with a generated sound file", function()
     onCleanup(function() feedGmcp("Client.Media.Stop {}") end)
   end
 
+  -- The profile's "accept media from the game" preference gates parseGMCP() and
+  -- has no getConfig key to read it back with, so a profile that has it turned
+  -- off would fail the specs below with nothing but a bare timeout to go on.
+  local gmcpRefused = "no sysMediaStarted for a Client.Media message - is the profile set to accept media from the game?"
+
   it("a Client.Media.Play message plays the file it names and reports it", function()
     if mediaPlaybackUnavailable() then
       return
@@ -1439,7 +1446,7 @@ describe("Media playback effects with a generated sound file", function()
     feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "key": "busted-gmcp-play", "tag": "busted-gmcp-tag"}')
 
     local event, file, _, mediaType, key, tag = waitForEvent("sysMediaStarted", 5000)
-    assert.equals("sysMediaStarted", event)
+    assert.equals("sysMediaStarted", event, gmcpRefused)
     assert.equals(longSoundFile, file)
     -- a message that names no type is played as a sound
     assert.equals("sound", mediaType)
@@ -1461,7 +1468,7 @@ describe("Media playback effects with a generated sound file", function()
     feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "type": "music", "key": "busted-gmcp-music"}')
 
     local event, _, _, mediaType, key = waitForEvent("sysMediaStarted", 5000)
-    assert.equals("sysMediaStarted", event)
+    assert.equals("sysMediaStarted", event, gmcpRefused)
     assert.equals("music", mediaType)
     assert.equals("busted-gmcp-music", key)
   end)
@@ -1477,7 +1484,7 @@ describe("Media playback effects with a generated sound file", function()
     stopGmcpMediaAfterwards()
 
     feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "key": "busted-gmcp-stopped"}')
-    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)), gmcpRefused)
     assert.equals(0, #finished)
 
     feedGmcp("Client.Media.Stop {}")
@@ -1499,7 +1506,7 @@ describe("Media playback effects with a generated sound file", function()
     stopGmcpMediaAfterwards()
 
     feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "key": "busted-gmcp-paused"}')
-    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)), gmcpRefused)
 
     -- a key that matches nothing leaves it playing
     feedGmcp('Client.Media.Pause {"key": "busted-gmcp-pause-absent"}')

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -1351,13 +1351,16 @@ describe("Media playback effects with a generated sound file", function()
     -- it reachable at all.
     local captionKey = "busted-caption-deferred"
     local wasCaptioned = getConfig("enableClosedCaption")
-    assert.is_true(setConfig("enableClosedCaption", true))
     onCleanup(function() setConfig("enableClosedCaption", wasCaptioned) end)
+    assert.is_true(setConfig("enableClosedCaption", true))
 
-    -- Every caption this spec's playback prints carries its key, and nothing
-    -- else in the buffer does. Counted from the buffer's last line rather than
-    -- from the one after it: that line is still open, so the first caption
-    -- completes it instead of starting a line of its own.
+    -- Counted by key, not by line delta: the window between mark and the last
+    -- line does receive captions from other specs, because a playback stopped
+    -- in an earlier one prints its own caption a turn later, by which time
+    -- captions are on. The key filter is what keeps those out, so do not
+    -- simplify this into a line count. Counted from the buffer's last line
+    -- rather than from the one after it, too: that line is still open, so the
+    -- first caption completes it instead of starting a line of its own.
     local mark = getLastLineNumber("main")
     local function captionCount()
       local last = getLastLineNumber("main")
@@ -1427,8 +1430,12 @@ describe("Media playback effects with a generated sound file", function()
     assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(err))
   end
 
+  -- Deliberately not feedGmcp(): after_each drains the cleanup list without a
+  -- pcall, so an undo that raised would skip every cleanup registered before it
+  -- and the stops that follow the drain. A refused injection is the spec body's
+  -- problem, not the undo's.
   local function stopGmcpMediaAfterwards()
-    onCleanup(function() feedGmcp("Client.Media.Stop {}") end)
+    onCleanup(function() feedTelnet("<T_IAC><T_SB><O_GMCP>Client.Media.Stop {}<T_IAC><T_SE>") end)
   end
 
   -- The profile's "accept media from the game" preference gates parseGMCP() and
@@ -1453,7 +1460,9 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals("busted-gmcp-play", key)
     assert.equals("busted-gmcp-tag", tag)
 
-    -- and the API's own queries do not see the server's playback
+    -- Pinning today's behaviour, not asserting it is right: the API queries
+    -- filter on the API protocol, so a script cannot see server-driven media at
+    -- all. Unifying the lists one day would fail this deliberately.
     assert.equals(0, #getPlayingSounds())
     assert.equals(0, #getPlayingMusic())
   end)
@@ -1467,10 +1476,25 @@ describe("Media playback effects with a generated sound file", function()
 
     feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "type": "music", "key": "busted-gmcp-music"}')
 
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
     local event, _, _, mediaType, key = waitForEvent("sysMediaStarted", 5000)
     assert.equals("sysMediaStarted", event, gmcpRefused)
     assert.equals("music", mediaType)
     assert.equals("busted-gmcp-music", key)
+
+    -- The event's type is stamped on the request before the list to track it in
+    -- is chosen, so it alone cannot tell a mislabelled track from a misfiled
+    -- one. A typed stop can: it only reaches the list of the type it names.
+    feedGmcp('Client.Media.Stop {"type": "sound"}')
+    pumpEvents(250)
+    assert.equals(0, #finished, "a sound-typed stop reached the music list")
+
+    feedGmcp('Client.Media.Stop {"type": "music"}')
+    waitForCount("sysMediaFinished", finished, 1)
+    assert.equals(1, #finished)
+    assert.equals("busted-gmcp-music", finished[1].key)
   end)
 
   it("a Client.Media.Stop message ends what a Client.Media.Play started", function()

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -1513,13 +1513,13 @@ describe("Media playback effects with a generated sound file", function()
   end)
 
   it("a Client.Media.Pause message with no fields pauses everything the server started", function()
-    -- Every field parseJSONForMediaPause() reads is optional, and a request
-    -- with none of them set pauses all of the server's media - which is what
-    -- Client.Media.Stop with no fields does for stopping. It never gets there:
-    -- parseGMCP() answers "client.media.stop" above its empty-object guard and
-    -- everything else below it, so an empty Client.Media.Pause is dropped
-    -- without being read at all.
-    pending("Client.Media.Pause {} is discarded by the empty-object guard in TMedia::parseGMCP()")
+    -- #10043. Every field parseJSONForMediaPause() reads is optional, and a
+    -- request with none of them set pauses all of the server's media - which is
+    -- what Client.Media.Stop with no fields does for stopping. It never gets
+    -- there: parseGMCP() answers "client.media.stop" above its empty-object
+    -- guard and everything else below it, so an empty Client.Media.Pause is
+    -- dropped without being read at all.
+    pending("#10043: Client.Media.Pause {} is discarded by the empty-object guard in TMedia::parseGMCP()")
   end)
 
   it("a Client.Media.Load message fetches the file without playing it", function()

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -1189,6 +1189,34 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(otherLongSoundFile, music[1].name)
   end)
 
+  it("stopMusic stops only the track its table form names", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- stopMusic's table parser had only ever been reached with an argument it
+    -- refuses, so the filter it builds - and the stop it then performs - had
+    -- nothing holding them.
+    local started = {}
+    collect("sysMediaStarted", started)
+
+    writeSoundFiles()
+    assert.is_true(playMusicFile({name = longSoundFile, key = "busted-music-table-stopped"}))
+    waitForCount("sysMediaStarted", started, 1)
+    assert.is_true(playMusicFile({name = otherLongSoundFile, key = "busted-music-table-spared"}))
+    waitForCount("sysMediaStarted", started, 2)
+    assert.equals(2, #getPlayingMusic())
+
+    -- a key that matches nothing stops nothing
+    assert.is_true(stopMusic({key = "busted-music-table-absent"}))
+    assert.equals(2, #getPlayingMusic())
+
+    assert.is_true(stopMusic({key = "busted-music-table-stopped"}))
+    local music = getPlayingMusic()
+    assert.equals(1, #music)
+    assert.equals(otherLongSoundFile, music[1].name)
+    assert.equals("busted-music-table-spared", music[1].key)
+  end)
+
   it("pauseMusic and getPausedMusic take the same key filter", function()
     if mediaPlaybackUnavailable() then
       return
@@ -1274,6 +1302,98 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(0, #getPlayingVideos())
   end)
 
+  it("the video pause and stop table forms act only on the key they name", function()
+    if videoWidgetUnavailable() or mediaPlaybackUnavailable() then
+      return
+    end
+    -- pauseVideos and stopVideos take a table and nothing else, and every spec
+    -- so far reached their parsers either with an argument they refuse or with
+    -- no argument at all - which is a different branch of the public call that
+    -- never enters the parser. Neither filter had a covering assertion.
+    withVideoLabel()
+    writeSoundFiles()
+    assert.is_true(playVideoFile({name = longSoundFile, key = videoLabel}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+    assert.equals(1, #getPlayingVideos())
+
+    -- a filter naming another key leaves the video playing
+    assert.is_true(pauseVideos({key = "busted-video-table-absent"}))
+    assert.equals(1, #getPlayingVideos())
+    assert.equals(0, #getPausedVideos())
+
+    assert.is_true(pauseVideos({key = videoLabel}))
+    assert.equals(0, #getPlayingVideos())
+    assert.equals(1, #getPausedVideos())
+
+    -- resumed by playing the same file again, so the stop below has something
+    -- left to stop
+    assert.is_true(playVideoFile({name = longSoundFile, key = videoLabel}))
+    assert.equals(1, #getPlayingVideos())
+
+    assert.is_true(stopVideos({key = "busted-video-table-absent"}))
+    assert.equals(1, #getPlayingVideos())
+
+    assert.is_true(stopVideos({key = videoLabel}))
+    assert.equals(0, #getPlayingVideos())
+  end)
+
+  it("the closing caption of a stop is printed a turn after the call, not inside it", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- TMedia::releaseMediaSourceAfterEvents() ends a playback one event-loop
+    -- turn late, so that a looping track's EndOfMedia can still restart it
+    -- (#9566). sysMediaFinished is raised from inside the stop, so no event can
+    -- see that deferral; the closing caption is the other half of the same
+    -- ending and is printed by the deferred turn itself. Closed captions are
+    -- off by default, so turning them on is what makes it reachable at all.
+    local captionKey = "busted-caption-deferred"
+    local wasCaptioned = getConfig("enableClosedCaption")
+    assert.is_true(setConfig("enableClosedCaption", true))
+    onCleanup(function() setConfig("enableClosedCaption", wasCaptioned) end)
+
+    -- Every caption this spec's playback prints carries its key, and nothing
+    -- else in the buffer does. Counted from the buffer's last line rather than
+    -- from the one after it: that line is still open, so the first caption
+    -- completes it instead of starting a line of its own.
+    local mark = getLastLineNumber("main")
+    local function captionCount()
+      local last = getLastLineNumber("main")
+      if last < mark then
+        return 0
+      end
+      local seen = 0
+      for _, line in ipairs(getLines("main", mark, last + 1)) do
+        if line:find(captionKey, 1, true) then
+          seen = seen + 1
+        end
+      end
+      return seen
+    end
+
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = longSoundFile, key = captionKey}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+    -- the opening caption is printed by the same handler that raised the event
+    -- waited for above, so let that turn run out before counting
+    pumpEvents(250)
+    local opened = captionCount()
+    assert.equals(1, opened, "the opening caption did not reach the console")
+
+    assert.is_true(stopSounds())
+    -- checked before anything is waited on: nothing may have printed yet
+    assert.equals(opened, captionCount(), "the closing caption was printed inside the stop instead of a turn later")
+
+    if #finished == 0 then
+      waitForEvent("sysMediaFinished", 5000)
+    end
+    pumpEvents(250)
+    assert.equals(opened + 1, captionCount(), "the deferred turn printed no closing caption")
+  end)
+
   it("playVideoFile starts nothing when its key names no widget to draw into", function()
     if mediaPlaybackUnavailable() then
       return
@@ -1285,6 +1405,152 @@ describe("Media playback effects with a generated sound file", function()
     assert.is_true(playVideoFile({name = longSoundFile, key = "busted-media-no-such-widget"}))
     assert.equals(0, #getPlayingVideos())
     assert.equals(0, #getPausedVideos())
+  end)
+
+  -- The server's half of the media API. A Client.Media.* GMCP message reaches
+  -- TMedia through a different door from the play*File() calls above: the
+  -- telnet parser hands the subnegotiation to TMedia::parseGMCP(), which picks
+  -- one of the parseJSONForMedia*() readers. Those readers had nothing holding
+  -- them, and they are what decides the media type, the file and the key a
+  -- server-driven playback runs under.
+  --
+  -- Two things shape every spec below. The subnegotiation handler dispatches on
+  -- the option byte alone, so no GMCP negotiation is needed to reach it - which
+  -- is just as well, because these run offline. And GMCP media is tracked in
+  -- player lists of its own, apart from the API's: getPlayingSounds() cannot
+  -- see it and stopSounds() cannot stop it, so each spec has to send its own
+  -- Client.Media.Stop to clean up after itself.
+  local function feedGmcp(message)
+    local ok, err = feedTelnet("<T_IAC><T_SB><O_GMCP>" .. message .. "<T_IAC><T_SE>")
+    assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(err))
+  end
+
+  local function stopGmcpMediaAfterwards()
+    onCleanup(function() feedGmcp("Client.Media.Stop {}") end)
+  end
+
+  it("a Client.Media.Play message plays the file it names and reports it", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+    stopGmcpMediaAfterwards()
+
+    feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "key": "busted-gmcp-play", "tag": "busted-gmcp-tag"}')
+
+    local event, file, _, mediaType, key, tag = waitForEvent("sysMediaStarted", 5000)
+    assert.equals("sysMediaStarted", event)
+    assert.equals(longSoundFile, file)
+    -- a message that names no type is played as a sound
+    assert.equals("sound", mediaType)
+    assert.equals("busted-gmcp-play", key)
+    assert.equals("busted-gmcp-tag", tag)
+
+    -- and the API's own queries do not see the server's playback
+    assert.equals(0, #getPlayingSounds())
+    assert.equals(0, #getPlayingMusic())
+  end)
+
+  it("a Client.Media.Play message that names a type is played as that type", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    writeSoundFiles()
+    stopGmcpMediaAfterwards()
+
+    feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "type": "music", "key": "busted-gmcp-music"}')
+
+    local event, _, _, mediaType, key = waitForEvent("sysMediaStarted", 5000)
+    assert.equals("sysMediaStarted", event)
+    assert.equals("music", mediaType)
+    assert.equals("busted-gmcp-music", key)
+  end)
+
+  it("a Client.Media.Stop message ends what a Client.Media.Play started", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
+    writeSoundFiles()
+    stopGmcpMediaAfterwards()
+
+    feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "key": "busted-gmcp-stopped"}')
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+    assert.equals(0, #finished)
+
+    feedGmcp("Client.Media.Stop {}")
+    waitForCount("sysMediaFinished", finished, 1)
+    -- the file runs for ten seconds, so a finish this soon is the stop taking
+    -- effect rather than the file running out
+    assert.equals(1, #finished)
+    assert.equals("busted-gmcp-stopped", finished[1].key)
+  end)
+
+  it("a Client.Media.Pause message parks the playback the server started", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local paused = {}
+    collect("sysMediaPaused", paused)
+
+    writeSoundFiles()
+    stopGmcpMediaAfterwards()
+
+    feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "key": "busted-gmcp-paused"}')
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    -- a key that matches nothing leaves it playing
+    feedGmcp('Client.Media.Pause {"key": "busted-gmcp-pause-absent"}')
+    pumpEvents(250)
+    assert.equals(0, #paused)
+
+    feedGmcp('Client.Media.Pause {"key": "busted-gmcp-paused"}')
+    waitForCount("sysMediaPaused", paused, 1)
+    assert.equals(1, #paused)
+    assert.equals("busted-gmcp-paused", paused[1].key)
+  end)
+
+  it("a Client.Media.Pause message with no fields pauses everything the server started", function()
+    -- Every field parseJSONForMediaPause() reads is optional, and a request
+    -- with none of them set pauses all of the server's media - which is what
+    -- Client.Media.Stop with no fields does for stopping. It never gets there:
+    -- parseGMCP() answers "client.media.stop" above its empty-object guard and
+    -- everything else below it, so an empty Client.Media.Pause is dropped
+    -- without being read at all.
+    pending("Client.Media.Pause {} is discarded by the empty-object guard in TMedia::parseGMCP()")
+  end)
+
+  it("a Client.Media.Load message fetches the file without playing it", function()
+    if noFixtureServer() then
+      return
+    end
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    -- the load reader stamps the preload volume, which is what keeps the
+    -- download from being played the moment it lands
+    local downloadName = "busted-gmcp-download.wav"
+    local downloaded = mediaDirectory .. "/" .. downloadName
+    lfs.mkdir(mediaDirectory)
+    os.remove(downloaded)
+    onCleanup(function() os.remove(downloaded) end)
+    stopGmcpMediaAfterwards()
+
+    local done, started = {}, {}
+    collect("sysDownloadDone", done)
+    collect("sysMediaStarted", started)
+
+    feedGmcp('Client.Media.Load {"name": "' .. downloadName .. '", "url": "' .. fixtureUrl() .. '/media"}')
+    waitForCount("sysDownloadDone", done, 1)
+    assert.equals(1, #done)
+    assert.is_not_nil(lfs.attributes(downloaded, "mode"), "the load did not keep the file it downloaded")
+
+    -- a playback would begin after the download event, and a preload raises no
+    -- sysMediaStarted to wait for, so give the player the turns it would need
+    pumpEvents(1000)
+    assert.equals(0, #started, "a Client.Media.Load played the file it had just fetched")
   end)
 end)
 

--- a/src/mudlet-lua/tests/Telnet_spec.lua
+++ b/src/mudlet-lua/tests/Telnet_spec.lua
@@ -144,3 +144,23 @@ describe("Tests telnet subnegotiation handling", function()
     assert.is_nil(displayed:find("SUBNEG_LEAK_MARKER", 1, true), "subnegotiation payload past the size cap leaked into the display instead of being dropped until IAC SE")
   end)
 end)
+
+describe("Tests addSupportedTelnetOption", function()
+  -- Only the argument contract is reachable. What the call changes is the
+  -- reply cTelnet writes back when the server offers that option - IAC DO
+  -- rather than IAC DONT - and the option bit that goes with it, which nothing
+  -- outside further negotiation and the editor's statistics report ever reads.
+  -- Bytes sent to the server are not observable from Lua, and the report is
+  -- reachable only from a button in the editor, so the acceptance itself
+  -- cannot be asserted here.
+
+  it("returns nothing for an option number it accepts", function()
+    -- 200 is unassigned, so registering it changes nothing any other spec sees
+    assert.is_nil(addSupportedTelnetOption(200))
+  end)
+
+  it("raises a Lua error when the option is missing or not a number", function()
+    assert.has_error(function() addSupportedTelnetOption() end)
+    assert.has_error(function() addSupportedTelnetOption("mssp") end)
+  end)
+end)

--- a/src/mudlet-lua/tests/Telnet_spec.lua
+++ b/src/mudlet-lua/tests/Telnet_spec.lua
@@ -155,8 +155,10 @@ describe("Tests addSupportedTelnetOption", function()
   -- cannot be asserted here.
 
   it("returns nothing for an option number it accepts", function()
-    -- 200 is unassigned, so registering it changes nothing any other spec sees
-    assert.is_nil(addSupportedTelnetOption(200))
+    -- 137 is an option Mudlet has no handler for, so registering it only adds
+    -- a map entry that no negotiation in this offline run will consult. Do not
+    -- reach for a round number here: 200 is ATCP and 201 is GMCP.
+    assert.is_nil(addSupportedTelnetOption(137))
   end)
 
   it("raises a Lua error when the option is missing or not a number", function()

--- a/src/mudlet-lua/tests/Telnet_spec.lua
+++ b/src/mudlet-lua/tests/Telnet_spec.lua
@@ -165,4 +165,12 @@ describe("Tests addSupportedTelnetOption", function()
     assert.has_error(function() addSupportedTelnetOption() end)
     assert.has_error(function() addSupportedTelnetOption("mssp") end)
   end)
+
+  it("raises a Lua error for a number too large to be an option", function()
+    -- there is no range check on the option itself, so the refusal that does
+    -- exist is getVerifiedInt's, and it is the only one worth holding
+    local ok, err = pcall(function() addSupportedTelnetOption(2 ^ 40) end)
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("integer over/under-flow", 1, true), tostring(err))
+  end)
 end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -1059,9 +1059,10 @@ describe("Trigger processing", function()
     end)
 
     -- Prompt pipeline, driven through the real telnet parser: a prompt trigger
-    -- matches on the line having been marked a prompt and on nothing else, so
-    -- feedTriggers() can never fire one and the IAC GA the feedTelnet block
-    -- above injects is the only way in.
+    -- matches on the line carrying the prompt mark and on nothing else, and
+    -- that mark is set by the line terminator the telnet parser hands the
+    -- buffer - which is why the spec below fires one with the IAC GA the
+    -- feedTelnet block above injects rather than with feedTriggers().
     describe("prompt triggers and isPrompt", function()
 
         -- Killed here rather than at the end of the spec that made it: a

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -1116,11 +1116,18 @@ describe("Trigger processing", function()
 
         it("tempPromptTrigger fires on a line the server ended with IAC GA", function()
             _G.TrigSpec = {fired = 0}
-            liveTriggerId = tempPromptTrigger(function() _G.TrigSpec.fired = _G.TrigSpec.fired + 1 end)
+            liveTriggerId = tempPromptTrigger(function()
+                _G.TrigSpec.fired = _G.TrigSpec.fired + 1
+                -- read from inside the trigger, which is the only place the
+                -- cursor is on the line that matched
+                _G.TrigSpec.wasPrompt = isPrompt()
+            end)
             assert.is_number(liveTriggerId)
+            assert.is_true(liveTriggerId > 0)
 
             local ok, msg = feedTelnet("SpecPromptFires> <T_IAC><T_GA>")
             local afterPrompt = _G.TrigSpec.fired
+            local wasPrompt = _G.TrigSpec.wasPrompt
             -- the GA leaves the prompt line open, and the specs after this one
             -- read the buffer
             feedTelnet("\r\n")
@@ -1133,6 +1140,28 @@ describe("Trigger processing", function()
             assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
             assert.are.equal(1, afterPrompt, "the prompt trigger did not fire on the line ended by IAC GA")
             assert.are.equal(1, afterOrdinary, "the prompt trigger fired on a line that was not a prompt")
+            assert.is_true(wasPrompt, "isPrompt() was false on the line a prompt trigger matched")
+        end)
+
+        it("tempPromptTrigger stops firing once its expiration count is used up", function()
+            -- the second argument is the whole point of the expiring form, and
+            -- until a prompt could be fed there was no way to see it run out
+            _G.TrigSpec = {fired = 0}
+            liveTriggerId = tempPromptTrigger(function() _G.TrigSpec.fired = _G.TrigSpec.fired + 1 end, 1)
+            assert.is_number(liveTriggerId)
+            assert.is_true(liveTriggerId > 0)
+
+            local ok, msg = feedTelnet("SpecPromptExpiresOne> <T_IAC><T_GA>")
+            local afterFirst = _G.TrigSpec.fired
+            feedTelnet("\r\n")
+            feedTelnet("SpecPromptExpiresTwo> <T_IAC><T_GA>")
+            local afterSecond = _G.TrigSpec.fired
+            feedTelnet("\r\n")
+            deselect()
+
+            assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
+            assert.are.equal(1, afterFirst, "the expiring prompt trigger did not fire on the first prompt")
+            assert.are.equal(1, afterSecond, "the prompt trigger fired again after its one firing was used up")
         end)
 
     end)

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -1058,12 +1058,23 @@ describe("Trigger processing", function()
 
     end)
 
-    -- Prompt pipeline. Only the creation contracts are exercised here; a prompt
-    -- trigger *firing* is still untested, and the feedTelnet block above shows
-    -- how to inject the IAC GA that would need.
+    -- Prompt pipeline, driven through the real telnet parser: a prompt trigger
+    -- matches on the line having been marked a prompt and on nothing else, so
+    -- feedTriggers() can never fire one and the IAC GA the feedTelnet block
+    -- above injects is the only way in.
     describe("prompt triggers and isPrompt", function()
 
+        -- Killed here rather than at the end of the spec that made it: a
+        -- prompt trigger has no pattern to be choosy about, so one left behind
+        -- by a failed assertion would fire on every prompt the rest of the
+        -- suite feeds.
+        local liveTriggerId
+
         after_each(function()
+            if liveTriggerId then
+                killTrigger(liveTriggerId)
+                liveTriggerId = nil
+            end
             disableTrigger("SpecPermPrompt")
             _G.TrigSpec = nil
         end)
@@ -1100,6 +1111,27 @@ describe("Trigger processing", function()
             assert.is_nil(id)
             assert.is_string(err)
             assert.is_truthy(err:find("greater than zero", 1, true), "got: " .. tostring(err))
+        end)
+
+        it("tempPromptTrigger fires on a line the server ended with IAC GA", function()
+            _G.TrigSpec = {fired = 0}
+            liveTriggerId = tempPromptTrigger(function() _G.TrigSpec.fired = _G.TrigSpec.fired + 1 end)
+            assert.is_number(liveTriggerId)
+
+            local ok, msg = feedTelnet("SpecPromptFires> <T_IAC><T_GA>")
+            local afterPrompt = _G.TrigSpec.fired
+            -- the GA leaves the prompt line open, and the specs after this one
+            -- read the buffer
+            feedTelnet("\r\n")
+            -- an ordinary line carries no prompt mark, so it must leave the
+            -- count where the prompt put it
+            feedTelnet("SpecPromptOrdinaryLine\r\n")
+            local afterOrdinary = _G.TrigSpec.fired
+            deselect()
+
+            assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
+            assert.are.equal(1, afterPrompt, "the prompt trigger did not fire on the line ended by IAC GA")
+            assert.are.equal(1, afterOrdinary, "the prompt trigger fired on a line that was not a prompt")
         end)
 
     end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds 20 busted specs and one `pending()` for core and media API paths a coverage sweep found unheld. No production code changes.

Media (`Media_spec.lua`):
- The `stopMusic`, `stopVideos` and `pauseVideos` table parsers. Every existing spec reached them with an argument they refuse, so the filter each builds, and the stop or pause it then performs, had nothing holding it.
- The closing caption of a stop, which `TMedia::releaseMediaSourceAfterEvents()` prints one event-loop turn late. `sysMediaFinished` is raised from inside the stop, so no event can observe that deferral.
- The `Client.Media` GMCP readers (`Play`, `Stop`, `Pause`, `Load`), reachable offline because the subnegotiation handler dispatches on the option byte alone.

Core:
- `Mapper_spec`: `setExit`'s short direction aliases (`n`, `ne`, `sw`, ...), which is the half of `dirToNumber()` nothing reached; the map background and room-exit colour round trips, including `getVerifiedInt()`'s integer overflow refusal; `setDefaultAreaVisible`'s contract.
- `Trigger_spec`: a prompt trigger firing on a line ended by IAC GA. The file previously carried a comment saying this was untested.
- `Telnet_spec`: `addSupportedTelnetOption`'s argument contract.

#### Motivation for adding to Mudlet

These are the leftovers of the core and media coverage sweep: code paths where a mutation changed no test's outcome. The media table parsers are the clearest case, since each is a second, independently written copy of an argument parser whose ordered twin was already covered. The `Client.Media` readers are the server's half of the media API and had no coverage at all.

#### Other info (issues closed, discussion etc)

Left pending, not frozen: `Client.Media.Pause` with no fields, filed as #10043. `TMedia::parseGMCP()` answers `client.media.stop` above its empty-object guard and everything else below it, so a blanket pause is dropped before `parseJSONForMediaPause()`, whose fields are all optional, can read it. The equivalent `Client.Media.Stop {}` works. This PR pins the behaviour with a `pending()` rather than fixing it.

Also recorded, as spec comments, are the paths that stay unreachable from Lua: `addSupportedTelnetOption`'s effect is the reply bytes plus an option bit read only by further negotiation and an editor-only report, and `setDefaultAreaVisible`'s flag has no Lua readback.

**Test case:**

Run the Lua specs the way CI does, or locally:

```
.claude/scripts/run-lua-tests.sh
```

Every new spec was checked against a deliberately broken build: 12 mutations across 13 of the new specs, each reddening the spec that covers it, and no spec reddening for a mutation it does not cover. The mutations disabled, one at a time, the `stopMusic`/`stopVideos`/`pauseVideos` table-form stop and pause, the deferred closing caption (both deleted and made synchronous), `dirToNumber`'s short aliases, `checkIntArg`'s overflow refusal, `setDefaultAreaVisible`'s success return, `TTrigger::match_prompt`, and the `Client.Media` play/pause/load dispatch.

That check earned its keep: it exposed that the caption spec had been passing for the wrong reason, because the console's last line is still open and the first caption completes it rather than starting a new line.

Full suite green twice, on a fresh profile and on a re-run against the same profile: 3359 successes / 0 failures / 0 errors / 65 pending, and 3357 / 0 / 0 / 67 on the reused profile, where the two extra pendings are pre-existing profile-state-dependent `UI_spec` cases.

Assisted-by: Claude:claude-opus-5
