### PR TITLE
Infra: cover the updater's version comparison and CredentialManager's async API

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -116,6 +116,20 @@ set_tests_properties(CMakeListsConsistencyTest PROPERTIES
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
 )
 
+# The version comparison every update offer is decided by. Built from the one
+# updater source it covers rather than linked against the Mudlet library, because
+# the library only contains it when configured with USE_UPDATER - which CI's
+# -testing builds are not. utils.h reaches QApplication, hence Qt6::Widgets.
+add_executable(SemVerTest
+    SemVerTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/SemVer.cpp
+)
+target_link_libraries(SemVerTest PRIVATE Qt6::Test Qt6::Widgets)
+add_test(NAME SemVerTest COMMAND $<TARGET_FILE:SemVerTest>)
+set_tests_properties(SemVerTest PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
+)
+
 # Pairing of a release's assets with its SHA256SUMS.txt. Built from the updater
 # sources rather than linked against the Mudlet library, because the library only
 # contains them when configured with USE_UPDATER.

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -20,11 +20,18 @@
 #include <CredentialManager.h>
 #include <QtTest/QtTest>
 
+#include <QTemporaryDir>
+
 // Hermetic unit tests: MUDLET_TEST_MODE forces encrypted file storage so these run
 // deterministically on every platform without touching a system keychain. The real
 // keychain paths - including the qtkeychain 0.17 Windows naming migrations - are covered
 // by CredentialManagerKeychainTest, kept as a separate executable so its Windows-only,
 // environment-dependent tests cannot affect this suite.
+//
+// Two APIs are covered here. The static one is file storage by construction. The
+// async one is what dlgConnectionProfiles and dlgProfilePreferences actually call,
+// and MUDLET_TEST_MODE routes it down the same file storage, so its callbacks are
+// delivered synchronously and need no event loop.
 
 class CredentialManagerTest : public QObject
 {
@@ -39,9 +46,18 @@ private slots:
     void testEmptyPassword();
     void testRemovePassword();
     void testInputSanitization();
+    void testOverlongKeyNamesAreRejected();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
+    void testAsyncStoreAndRetrieve();
+    void testAsyncApiSharesTheStoreWithTheStaticOne();
+    void testAsyncRemovePassword();
+    void testCredentialExistsWithoutHandingOverTheSecret();
+    void testAsyncEmptyArgumentsAreReportedThroughTheCallback();
     void cleanupTestCase();
+
+private:
+    QTemporaryDir mConfigDir;
 };
 
 void CredentialManagerTest::initTestCase()
@@ -49,6 +65,13 @@ void CredentialManagerTest::initTestCase()
     // Set environment variable to indicate we're in test mode
     // This prevents keychain access that would require user password input
     qputenv("MUDLET_TEST_MODE", "1");
+
+    // Credentials are filed under QStandardPaths::AppConfigLocation, so without
+    // this the suite writes into the home directory of whoever runs it. Only
+    // takes effect where QStandardPaths honours XDG, which is where ctest runs
+    // several of these binaries at once.
+    QVERIFY(mConfigDir.isValid());
+    qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
 }
 
 void CredentialManagerTest::testStoreAndRetrieve()
@@ -201,6 +224,24 @@ void CredentialManagerTest::testInputSanitization()
     CredentialManager::removeCredential(profile, normalKey);
 }
 
+// Key names are a path component, so the length cap is what stops one long
+// enough to trip the filesystem ever reaching it
+void CredentialManagerTest::testOverlongKeyNamesAreRejected()
+{
+    const QString profile = "OverlongKeyProfile";
+    const QString password = "test_password";
+    const QString longestAccepted(100, QChar('k'));
+    const QString tooLong(101, QChar('k'));
+
+    QVERIFY(CredentialManager::storeCredential(profile, longestAccepted, password));
+
+    QVERIFY(!CredentialManager::storeCredential(profile, tooLong, password));
+    QVERIFY(CredentialManager::retrieveCredential(profile, tooLong).isEmpty());
+    QVERIFY(!CredentialManager::removeCredential(profile, tooLong));
+
+    CredentialManager::removeCredential(profile, longestAccepted);
+}
+
 void CredentialManagerTest::testPathTraversalPrevention()
 {
     QString profile = "PathTraversalTestProfile";
@@ -266,6 +307,175 @@ void CredentialManagerTest::testConcurrentAccess()
     CredentialManager::removeCredential(profile, key);
 }
 
+// The async API is what the connection dialog and the preferences dialog call,
+// so a credential stored through it has to come back through it
+void CredentialManagerTest::testAsyncStoreAndRetrieve()
+{
+    CredentialManager manager;
+    const QString profile = "AsyncProfile";
+    const QString key = "password";
+
+    bool stored = false;
+    QString storeError = "callback never ran";
+    manager.storePassword(profile, key, "async_secret", [&](bool success, const QString& error) {
+        stored = success;
+        storeError = error;
+    });
+    QVERIFY2(stored, qPrintable(storeError));
+    QVERIFY(storeError.isEmpty());
+
+    bool retrieved = false;
+    QString password;
+    QString retrieveError = "callback never ran";
+    manager.retrievePassword(profile, key, [&](bool success, QString value, const QString& error) {
+        retrieved = success;
+        password = value;
+        retrieveError = error;
+    });
+    QVERIFY2(retrieved, qPrintable(retrieveError));
+    QCOMPARE(password, QString("async_secret"));
+    QVERIFY(retrieveError.isEmpty());
+}
+
+// The static API is the migration and cleanup path for credentials the async API
+// wrote, so the two have to be looking at the same store rather than two of them
+void CredentialManagerTest::testAsyncApiSharesTheStoreWithTheStaticOne()
+{
+    CredentialManager manager;
+    const QString profile = "AsyncSharedProfile";
+    const QString key = "password";
+
+    bool stored = false;
+    manager.storePassword(profile, key, "shared_secret", [&](bool success, const QString&) {
+        stored = success;
+    });
+    QVERIFY(stored);
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("shared_secret"));
+
+    // and the other way round
+    QVERIFY(CredentialManager::storeCredential(profile, key, "written_statically"));
+    QString password;
+    manager.retrievePassword(profile, key, [&](bool, QString value, const QString&) {
+        password = value;
+    });
+    QCOMPARE(password, QString("written_statically"));
+}
+
+void CredentialManagerTest::testAsyncRemovePassword()
+{
+    CredentialManager manager;
+    const QString profile = "AsyncRemovalProfile";
+    const QString key = "password";
+
+    bool stored = false;
+    manager.storePassword(profile, key, "doomed_secret", [&](bool success, const QString&) {
+        stored = success;
+    });
+    QVERIFY(stored);
+
+    bool removed = false;
+    QString removeError = "callback never ran";
+    manager.removePassword(profile, key, [&](bool success, const QString& error) {
+        removed = success;
+        removeError = error;
+    });
+    QVERIFY2(removed, qPrintable(removeError));
+
+    bool retrieved = true;
+    QString password = "not overwritten";
+    manager.retrievePassword(profile, key, [&](bool success, QString value, const QString&) {
+        retrieved = success;
+        password = value;
+    });
+    QVERIFY(!retrieved);
+    QVERIFY(password.isEmpty());
+    QVERIFY(CredentialManager::retrieveCredential(profile, key).isEmpty());
+}
+
+// The preferences dialog asks only whether a password is set, so this must answer
+// without the caller ever holding the secret - and a profile with no password
+// stored is not a profile with an empty password
+void CredentialManagerTest::testCredentialExistsWithoutHandingOverTheSecret()
+{
+    CredentialManager manager;
+    const QString profile = "AsyncExistsProfile";
+    const QString key = "password";
+
+    auto exists = [&manager, &profile, &key]() {
+        bool answered = false;
+        bool present = false;
+        manager.credentialExists(profile, key, [&](bool value) {
+            answered = true;
+            present = value;
+        });
+        return answered && present;
+    };
+
+    QVERIFY(!exists());
+
+    bool stored = false;
+    manager.storePassword(profile, key, "existing_secret", [&](bool success, const QString&) {
+        stored = success;
+    });
+    QVERIFY(stored);
+    QVERIFY(exists());
+
+    // An empty password is how "no password saved" is spelled, so it does not
+    // count as a stored credential
+    manager.storePassword(profile, key, QString(""), [&](bool success, const QString&) {
+        stored = success;
+    });
+    QVERIFY(stored);
+    QVERIFY(!exists());
+
+    manager.removePassword(profile, key, [](bool, const QString&) {});
+    QVERIFY(!exists());
+}
+
+// Every entry point answers its caller rather than returning silently, which is
+// what a dialog waiting on the callback to re-enable itself depends on
+void CredentialManagerTest::testAsyncEmptyArgumentsAreReportedThroughTheCallback()
+{
+    CredentialManager manager;
+    const QString empty;
+
+    bool stored = true;
+    QString storeError;
+    manager.storePassword(empty, "password", "secret", [&](bool success, const QString& error) {
+        stored = success;
+        storeError = error;
+    });
+    QVERIFY(!stored);
+    QVERIFY(!storeError.isEmpty());
+
+    bool retrieved = true;
+    QString retrieveError;
+    manager.retrievePassword("AsyncProfile", empty, [&](bool success, QString, const QString& error) {
+        retrieved = success;
+        retrieveError = error;
+    });
+    QVERIFY(!retrieved);
+    QVERIFY(!retrieveError.isEmpty());
+
+    bool removed = true;
+    QString removeError;
+    manager.removePassword(empty, empty, [&](bool success, const QString& error) {
+        removed = success;
+        removeError = error;
+    });
+    QVERIFY(!removed);
+    QVERIFY(!removeError.isEmpty());
+
+    bool answered = false;
+    bool present = true;
+    manager.credentialExists(empty, "password", [&](bool value) {
+        answered = true;
+        present = value;
+    });
+    QVERIFY(answered);
+    QVERIFY(!present);
+}
+
 void CredentialManagerTest::cleanupTestCase()
 {
     // Clean up test passwords
@@ -287,6 +497,12 @@ void CredentialManagerTest::cleanupTestCase()
     CredentialManager::removeCredential("Game&Server", "password");
     CredentialManager::removeCredential("Game Server", "password");
     CredentialManager::removeCredential("Game-Server", "password");
+
+    CredentialManager::removeCredential("AsyncProfile", "password");
+    CredentialManager::removeCredential("AsyncSharedProfile", "password");
+    CredentialManager::removeCredential("AsyncRemovalProfile", "password");
+    CredentialManager::removeCredential("AsyncExistsProfile", "password");
+    CredentialManager::removeCredential("OverlongKeyProfile", QString(100, QChar('k')));
 }
 
 #include "CredentialManagerTest.moc"

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -224,8 +224,11 @@ void CredentialManagerTest::testInputSanitization()
     CredentialManager::removeCredential(profile, normalKey);
 }
 
-// Key names are a path component, so the length cap is what stops one long
-// enough to trip the filesystem ever reaching it
+// A key name becomes a path component, and utils::sanitizeForPath truncates one
+// to 50 characters - so any two keys sharing their first 50 resolve to the same
+// file. Storing under the accepted key first is therefore what gives the
+// rejection of the overlong one something to fail at: were the cap dropped, the
+// overlong key would read that same credential straight back rather than nothing.
 void CredentialManagerTest::testOverlongKeyNamesAreRejected()
 {
     const QString profile = "OverlongKeyProfile";
@@ -234,10 +237,14 @@ void CredentialManagerTest::testOverlongKeyNamesAreRejected()
     const QString tooLong(101, QChar('k'));
 
     QVERIFY(CredentialManager::storeCredential(profile, longestAccepted, password));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, longestAccepted), password);
 
     QVERIFY(!CredentialManager::storeCredential(profile, tooLong, password));
     QVERIFY(CredentialManager::retrieveCredential(profile, tooLong).isEmpty());
     QVERIFY(!CredentialManager::removeCredential(profile, tooLong));
+
+    // and the rejection left the accepted key's credential alone
+    QCOMPARE(CredentialManager::retrieveCredential(profile, longestAccepted), password);
 
     CredentialManager::removeCredential(profile, longestAccepted);
 }
@@ -401,35 +408,49 @@ void CredentialManagerTest::testCredentialExistsWithoutHandingOverTheSecret()
     const QString profile = "AsyncExistsProfile";
     const QString key = "password";
 
-    auto exists = [&manager, &profile, &key]() {
-        bool answered = false;
-        bool present = false;
-        manager.credentialExists(profile, key, [&](bool value) {
+    // Whether the question was answered is tracked apart from the answer, so a
+    // callback that never runs cannot read as "no credential stored" - a caller
+    // that re-enables itself from this reply would hang on exactly that
+    bool answered = false;
+    bool present = false;
+    auto lookUp = [&manager, &profile, &key, &answered, &present]() {
+        answered = false;
+        present = false;
+        manager.credentialExists(profile, key, [&answered, &present](bool value) {
             answered = true;
             present = value;
         });
-        return answered && present;
     };
 
-    QVERIFY(!exists());
+    lookUp();
+    QVERIFY(answered);
+    QVERIFY(!present);
 
     bool stored = false;
     manager.storePassword(profile, key, "existing_secret", [&](bool success, const QString&) {
         stored = success;
     });
     QVERIFY(stored);
-    QVERIFY(exists());
+    lookUp();
+    QVERIFY(answered);
+    QVERIFY(present);
 
     // An empty password is how "no password saved" is spelled, so it does not
-    // count as a stored credential
+    // count as a stored credential. It has to be an empty QString rather than a
+    // null one: storeCredentialToFile rejects a null credential as a programming
+    // error, so a null here would assert nothing about existence.
     manager.storePassword(profile, key, QString(""), [&](bool success, const QString&) {
         stored = success;
     });
     QVERIFY(stored);
-    QVERIFY(!exists());
+    lookUp();
+    QVERIFY(answered);
+    QVERIFY(!present);
 
     manager.removePassword(profile, key, [](bool, const QString&) {});
-    QVERIFY(!exists());
+    lookUp();
+    QVERIFY(answered);
+    QVERIFY(!present);
 }
 
 // Every entry point answers its caller rather than returning silently, which is
@@ -439,41 +460,52 @@ void CredentialManagerTest::testAsyncEmptyArgumentsAreReportedThroughTheCallback
     CredentialManager manager;
     const QString empty;
 
-    bool stored = true;
-    QString storeError;
-    manager.storePassword(empty, "password", "secret", [&](bool success, const QString& error) {
-        stored = success;
-        storeError = error;
-    });
-    QVERIFY(!stored);
-    QVERIFY(!storeError.isEmpty());
+    // Which complaint comes back matters as much as the failure itself. Without
+    // the guard these calls still fail - they get as far as generateFilePath,
+    // which refuses an empty component - so only the message distinguishes a
+    // rejected argument from storage that went wrong.
+    const QString rejected = "cannot be empty";
 
-    bool retrieved = true;
-    QString retrieveError;
-    manager.retrievePassword("AsyncProfile", empty, [&](bool success, QString, const QString& error) {
-        retrieved = success;
-        retrieveError = error;
-    });
-    QVERIFY(!retrieved);
-    QVERIFY(!retrieveError.isEmpty());
+    // Either half missing is enough, so a guard narrowed to one of them is caught
+    const QList<QPair<QString, QString>> incomplete = {{empty, "password"}, {"AsyncGuardProfile", empty}, {empty, empty}};
 
-    bool removed = true;
-    QString removeError;
-    manager.removePassword(empty, empty, [&](bool success, const QString& error) {
-        removed = success;
-        removeError = error;
-    });
-    QVERIFY(!removed);
-    QVERIFY(!removeError.isEmpty());
+    for (const auto& [profile, key] : incomplete) {
+        bool stored = true;
+        QString storeError;
+        manager.storePassword(profile, key, "secret", [&](bool success, const QString& error) {
+            stored = success;
+            storeError = error;
+        });
+        QVERIFY(!stored);
+        QVERIFY2(storeError.contains(rejected), qPrintable(storeError));
 
-    bool answered = false;
-    bool present = true;
-    manager.credentialExists(empty, "password", [&](bool value) {
-        answered = true;
-        present = value;
-    });
-    QVERIFY(answered);
-    QVERIFY(!present);
+        bool retrieved = true;
+        QString retrieveError;
+        manager.retrievePassword(profile, key, [&](bool success, QString, const QString& error) {
+            retrieved = success;
+            retrieveError = error;
+        });
+        QVERIFY(!retrieved);
+        QVERIFY2(retrieveError.contains(rejected), qPrintable(retrieveError));
+
+        bool removed = true;
+        QString removeError;
+        manager.removePassword(profile, key, [&](bool success, const QString& error) {
+            removed = success;
+            removeError = error;
+        });
+        QVERIFY(!removed);
+        QVERIFY2(removeError.contains(rejected), qPrintable(removeError));
+
+        bool answered = false;
+        bool present = true;
+        manager.credentialExists(profile, key, [&](bool value) {
+            answered = true;
+            present = value;
+        });
+        QVERIFY(answered);
+        QVERIFY(!present);
+    }
 }
 
 void CredentialManagerTest::cleanupTestCase()

--- a/test/SemVerTest.cpp
+++ b/test/SemVerTest.cpp
@@ -38,8 +38,9 @@
  * Built from src/updater/SemVer.cpp rather than linked against the Mudlet
  * library, because the library only contains it when configured with
  * USE_UPDATER - and CI's -testing builds are configured without it. Like
- * ReleaseChangelogSpanTest that means no utils.h, hence QStringLiteral rather
- * than qsl().
+ * ReleaseChangelogSpanTest this file includes no utils.h of its own, so qsl()
+ * is out of scope here and the literals below are QStringLiteral. SemVer.cpp
+ * does include it, which is what the target's Qt6::Widgets link is for.
  *
  * Run with: ctest -R SemVerTest -V
  */

--- a/test/SemVerTest.cpp
+++ b/test/SemVerTest.cpp
@@ -1,0 +1,179 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "../src/updater/SemVer.h"
+
+#include <QtTest/QtTest>
+
+/*
+ * Covers the version comparison every update offer is decided by. Release's
+ * operators delegate to SemVer, so which release the updater treats as newer -
+ * and therefore whether a user is offered an update at all - comes down to what
+ * is asserted here.
+ *
+ * Two of these properties have already cost a release. A version SemVer cannot
+ * read makes Release fall back to comparing build dates, so tagging a release
+ * "Mudlet-5.0" rather than "Mudlet-5.0.0" silently stops it being offered by
+ * version at all (CI/check-release-tag.sh now rejects such a tag). And the
+ * components are numbers rather than text, so 4.22.0 has to outrank 4.9.0 -
+ * comparing the version as a string gets that backwards, and would strand every
+ * user on the older release.
+ *
+ * Built from src/updater/SemVer.cpp rather than linked against the Mudlet
+ * library, because the library only contains it when configured with
+ * USE_UPDATER - and CI's -testing builds are configured without it. Like
+ * ReleaseChangelogSpanTest that means no utils.h, hence QStringLiteral rather
+ * than qsl().
+ *
+ * Run with: ctest -R SemVerTest -V
+ */
+
+namespace {
+dblsqd::SemVer version(const QString& text)
+{
+    return dblsqd::SemVer(text);
+}
+
+// Both directions of a comparison, since an ordering that says "a is older than
+// b" and "b is older than a" at once is as broken as one that says neither
+void assertOlder(const QString& older, const QString& newer)
+{
+    QVERIFY2(version(older) < version(newer), qPrintable(QStringLiteral("%1 should sort below %2").arg(older, newer)));
+    QVERIFY2(!(version(newer) < version(older)), qPrintable(QStringLiteral("%1 should not sort below %2").arg(newer, older)));
+    QVERIFY2(!(version(older) == version(newer)), qPrintable(QStringLiteral("%1 and %2 should not be equal").arg(older, newer)));
+}
+} // namespace
+
+class SemVerTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void aThreeComponentVersionIsReadable();
+    void aTwoComponentVersionIsNotSemVerAtAll();
+    void malformedVersionsAreRejected();
+    void componentsAreComparedAsNumbersAndNotAsText();
+    void majorOutranksMinorOutranksPatch();
+    void aPrereleaseSortsBelowTheReleaseItLeadsTo();
+    void ptbBuildsOfOneVersionAreOrderedByTheirDate();
+    void buildMetadataDoesNotChangeAVersion();
+    void anUnreadableVersionNeverCompares();
+};
+
+void SemVerTest::aThreeComponentVersionIsReadable()
+{
+    QVERIFY(version(QStringLiteral("1.2.3")).isValid());
+    QVERIFY(version(QStringLiteral("0.0.0")).isValid());
+    QVERIFY(version(QStringLiteral("4.22.0")).isValid());
+    QVERIFY(version(QStringLiteral("4.22.0-ptb-2026-08-08-7c6b5a49")).isValid());
+}
+
+// The shape of tag that stopped 4.22.0 reaching anyone by version: two
+// components read as no version at all, so Release falls back to build dates
+void SemVerTest::aTwoComponentVersionIsNotSemVerAtAll()
+{
+    QVERIFY(!version(QStringLiteral("4.22")).isValid());
+    QVERIFY(!version(QStringLiteral("5.0")).isValid());
+    QVERIFY(!version(QStringLiteral("5.0-ptb-2026-08-08-7c6b5a49")).isValid());
+}
+
+void SemVerTest::malformedVersionsAreRejected()
+{
+    QVERIFY(!version(QString()).isValid());
+    QVERIFY(!version(QStringLiteral("v1.2.3")).isValid());
+    QVERIFY(!version(QStringLiteral("Mudlet-1.2.3")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3.4")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3-")).isValid());
+    // Leading zeroes are a different version to SemVer, so they are not one at all
+    QVERIFY(!version(QStringLiteral("01.2.3")).isValid());
+    QVERIFY(!version(QStringLiteral("1.02.3")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.03")).isValid());
+}
+
+// Text ordering puts "4.22.0" below "4.9.0", which would offer every 4.22.0 user
+// a downgrade and leave every 4.9.0 user believing they are current
+void SemVerTest::componentsAreComparedAsNumbersAndNotAsText()
+{
+    assertOlder(QStringLiteral("4.9.0"), QStringLiteral("4.22.0"));
+    assertOlder(QStringLiteral("1.2.9"), QStringLiteral("1.2.10"));
+    assertOlder(QStringLiteral("9.0.0"), QStringLiteral("10.0.0"));
+}
+
+void SemVerTest::majorOutranksMinorOutranksPatch()
+{
+    assertOlder(QStringLiteral("1.9.9"), QStringLiteral("2.0.0"));
+    assertOlder(QStringLiteral("1.2.9"), QStringLiteral("1.3.0"));
+    assertOlder(QStringLiteral("1.2.3"), QStringLiteral("1.2.4"));
+
+    QVERIFY(version(QStringLiteral("1.2.3")) == version(QStringLiteral("1.2.3")));
+    QVERIFY(!(version(QStringLiteral("1.2.3")) < version(QStringLiteral("1.2.3"))));
+}
+
+// A public test build is a prerelease of the version it carries, so somebody
+// running 5.0.0-ptb-... is behind 5.0.0 and has to be offered it
+void SemVerTest::aPrereleaseSortsBelowTheReleaseItLeadsTo()
+{
+    assertOlder(QStringLiteral("5.0.0-ptb-2026-08-08-7c6b5a49"), QStringLiteral("5.0.0"));
+    assertOlder(QStringLiteral("1.0.0-alpha"), QStringLiteral("1.0.0"));
+    assertOlder(QStringLiteral("4.22.0"), QStringLiteral("5.0.0-ptb-2026-08-08-7c6b5a49"));
+}
+
+// The date in a PTB tag is zero-padded and most-significant first, so ordering
+// the prerelease identifier as text orders the builds chronologically
+void SemVerTest::ptbBuildsOfOneVersionAreOrderedByTheirDate()
+{
+    assertOlder(QStringLiteral("4.22.0-ptb-2026-08-07-eaa991b9"), QStringLiteral("4.22.0-ptb-2026-08-08-7c6b5a49"));
+    assertOlder(QStringLiteral("4.22.0-ptb-2026-07-31-1a2b3c4d"), QStringLiteral("4.22.0-ptb-2026-08-01-dfdcb137"));
+    assertOlder(QStringLiteral("4.22.0-ptb-2025-12-31-1a2b3c4d"), QStringLiteral("4.22.0-ptb-2026-01-01-dfdcb137"));
+}
+
+// Build metadata identifies the build, not the version, so two builds of one
+// version are the same version and neither is an update to the other
+void SemVerTest::buildMetadataDoesNotChangeAVersion()
+{
+    QVERIFY(version(QStringLiteral("1.2.3+build.1")).isValid());
+    QVERIFY(version(QStringLiteral("1.2.3+build.1")) == version(QStringLiteral("1.2.3+build.2")));
+    QVERIFY(version(QStringLiteral("1.2.3+build.1")) == version(QStringLiteral("1.2.3")));
+    QVERIFY(!(version(QStringLiteral("1.2.3+build.1")) < version(QStringLiteral("1.2.3+build.2"))));
+    QVERIFY(!(version(QStringLiteral("1.2.3+build.2")) < version(QStringLiteral("1.2.3+build.1"))));
+
+    // The prerelease still counts when metadata is attached to it
+    assertOlder(QStringLiteral("1.2.3-alpha+build.1"), QStringLiteral("1.2.3+build.1"));
+}
+
+// std::sort needs a strict weak ordering, and an unreadable version has no place
+// in one - so it compares below nothing, above nothing and equal to nothing, its
+// own spelling included. Release::operator< and operator== exist to give such a
+// version a total order anyway, by date and by text respectively.
+void SemVerTest::anUnreadableVersionNeverCompares()
+{
+    const auto unreadable = QStringLiteral("4.22");
+    const auto readable = QStringLiteral("4.22.0");
+
+    QVERIFY(!(version(unreadable) < version(readable)));
+    QVERIFY(!(version(readable) < version(unreadable)));
+    QVERIFY(!(version(unreadable) == version(readable)));
+
+    QVERIFY(!(version(unreadable) < version(unreadable)));
+    QVERIFY(!(version(unreadable) == version(unreadable)));
+}
+
+QTEST_GUILESS_MAIN(SemVerTest)
+
+#include "SemVerTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Two test-only additions, both to subjects the coverage baseline showed as thin.

**`test/SemVerTest.cpp` (new, 9 cases)** covers `src/updater/SemVer.cpp`, which had no test of its own. It is built from that one source rather than linked against the Mudlet library, mirroring the `ReleaseChangelogSpanTest` / `ReleaseChecksumPairingTest` / `ReleasePlatformAssetTest` blocks beside it - the library only carries the updater under `USE_UPDATER`, and CI's `-testing` builds are configured without it, so a test that linked the library would silently not exist there. No `mudlet_core` link, so it costs a compile rather than a 250MB binary, and `QTEST_GUILESS_MAIN` means it needs no display.

**`test/CredentialManagerTest.cpp` (6 cases added to an existing binary)** covers the async API - `storePassword`, `retrievePassword`, `removePassword`, `credentialExists` - which is what the connection and preferences dialogs actually call and which had no test at all; the suite only exercised the static file-storage API. `MUDLET_TEST_MODE` already routes these down file storage, so the callbacks arrive synchronously and no keychain is involved. The suite also stops writing credentials into the home directory of whoever runs it.

#### Motivation for adding to Mudlet

`SemVer` decides which release the updater treats as newer, so it decides whether a user is offered an update at all, and two of the properties now pinned have each already cost a release: a version SemVer cannot read falls back to comparing build dates, which is how a `Mudlet-5.0`-shaped tag stops a release reaching anyone by version; and the components are numbers rather than text, so 4.22.0 has to outrank 4.9.0, which a string comparison gets backwards.

The `CredentialManager` gap was the more surprising one - the tested API is the legacy one, and the API every dialog calls was untested.

#### Other info (issues closed, discussion etc)

The QtKeychain-backed paths were deliberately left alone. On Linux CI qtkeychain resolves to the libsecret backend, whose `isAvailable()` only checks that `libsecret-1.so` loads, and CI installs no Secret Service; the plain-file fallback in qtkeychain is reachable only from the KWallet paths and only with `setInsecureFallback(true)`, which Mudlet sets to `false`. A real backend can be stood up with `dbus-run-session` plus `gnome-keyring-daemon` and a non-empty unlock password (an empty one makes it try to spawn `gcr-prompter`, which needs a display), but that is new CI infrastructure rather than something to slip into a test PR. Separately, `attemptCompatNamingMigration` is unreachable on anything but Windows - its only call site is inside `#if defined(Q_OS_WIN)`.

Two pre-existing defects turned up while writing these and are **not** fixed here, so nothing below is pinned by a test: `utils::sanitizeForPath` truncates to 50 characters while `isValidKeyName` accepts up to 100, so two keys sharing their first 50 share one credential file - storing under two such keys and reading the first back returns the second's secret. The same truncation applies to profile names, where it costs the first profile its password instead, since the encryption keys on the full name. And the async API never calls `isValidKeyName` at all, so it accepts keys the static API rejects and then writes them where the static API can never read them.

**Test case:**

```
ctest -R 'SemVerTest|CredentialManagerTest' -V
```

Every case was mutation-verified: each reddens under at least one break of the code it covers. Two assertions that first passed for the wrong reason - an existence helper that folded "callback never ran" into "no credential stored", and empty-argument cases that asserted only that *some* error came back - were found in review and are fixed in the third commit.

Assisted-by: Claude:claude-opus-5
