### PR TITLE
Improve: db:create says how to fix a list-form sheet it refuses

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -312,6 +312,18 @@ function db:_validate_index(index)
 end
 
 
+-- NOT LUADOC
+-- Lua's reserved words, so db:create can tell a column name that may be written
+-- as a bare key in the {name = ""} sheet form from one that has to be bracketed
+local lua_reserved_words = {
+  ["and"] = true, ["break"] = true, ["do"] = true, ["else"] = true, ["elseif"] = true,
+  ["end"] = true, ["false"] = true, ["for"] = true, ["function"] = true, ["if"] = true,
+  ["in"] = true, ["local"] = true, ["nil"] = true, ["not"] = true, ["or"] = true,
+  ["repeat"] = true, ["return"] = true, ["then"] = true, ["true"] = true,
+  ["until"] = true, ["while"] = true,
+}
+
+
 --- Creates and/or modifies an existing database. This function is safe to define at a top-level of a Mudlet
 --- script: in fact it is recommended you run this function at a top-level without any kind of guards.
 --- If the named database does not exist it will create it. If the database does exist then it will add
@@ -412,22 +424,71 @@ function db:create(db_name, sheets, force)
       -- otherwise: sweeping keys in with the column names would make a column
       -- out of an index definition. Numeric keys are checked against #sheet so
       -- that a stray [7] in a two-item list is not taken for a column name.
+      -- These stay hard errors rather than being skipped the way an unusable
+      -- _index entry is: a sheet built without one of its columns takes every
+      -- write to that column silently, since db:add reports the rejected INSERT
+      -- to the same place and returns nil, which callers do not check.
       local column_count = #sheet
+
+      -- both working forms, spelled with the names this sheet did give plus the
+      -- one being complained about, so the fix can be read straight off the
+      -- message. Leaving that name out would advise a sheet without the column
+      -- the user was declaring, which is the state this refusal exists to stop.
+      local function keyed_entry(name)
+        if name:match("^[%a_][%w_]*$") and not lua_reserved_words[name] then
+          return name..' = ""'
+        end
+        -- anything else is not a bare key, so the form the message tells the
+        -- user to write would not parse
+        return "["..string.format("%q", name)..'] = ""'
+      end
+
+      local function both_forms(extra_name)
+        local listed, keyed = {}, {}
+        for i = 1, column_count do
+          if type(sheet[i]) == "string" then
+            listed[#listed + 1] = string.format("%q", sheet[i])
+            keyed[#keyed + 1] = keyed_entry(sheet[i])
+          end
+        end
+        if extra_name then
+          listed[#listed + 1] = string.format("%q", extra_name)
+          keyed[#keyed + 1] = keyed_entry(extra_name)
+        end
+        if listed[1] == nil then
+          return '{"name", "city"}', '{name = "", city = ""}'
+        end
+        return "{"..table.concat(listed, ", ").."}", "{"..table.concat(keyed, ", ").."}"
+      end
+
       for key, value in pairs(sheet) do
         if type(key) == "number" and key % 1 == 0 and key >= 1 and key <= column_count then
           if type(value) == "string" then
             columns[value] = ""
           else
+            -- no example here: the two forms would have to be spelled without
+            -- the name this entry was meant to give, which reads as advice to
+            -- drop the column rather than to name it
             is_valid = false
             table.insert(msgs, "db:create - "..sheet_name.." - column name #"..key..
               " is a "..type(value)..", but a sheet's column names have to be strings.")
           end
         elseif type(key) == "string" and string.starts(key, "_") then
           options[key] = value
-        else
+        elseif type(key) == "number" then
+          -- past the end, at or below zero, or fractional: none of them is a
+          -- position in the list, so none of them names a column
           is_valid = false
-          table.insert(msgs, "db:create - "..sheet_name.." - "..tostring(key)..
-            " is neither one of the sheet's column names nor a sheet option: a sheet is either a list of column names or a table of column names and their default values.")
+          table.insert(msgs, "db:create - "..sheet_name.." - ["..tostring(key)..
+            "] is not a position in this "..column_count.." item list, so it names no column. "..
+            "A sheet given as a list runs from 1 with no gaps.")
+        else
+          -- only a string key names a column the example can offer to declare
+          local list_form, keyed_form = both_forms(type(key) == "string" and key or nil)
+          is_valid = false
+          table.insert(msgs, "db:create - "..sheet_name.." - "..string.format("%q", tostring(key))..
+            " is a key, but a sheet given as a list takes its column names as list members. Write "..
+            list_form..", or use the "..keyed_form.." form to give a column a default.")
         end
       end
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3556,13 +3556,89 @@ describe("Tests db:create with a sheet given as a list of column names", functio
     assert.are.equal(1, #db:fetch(mydb.people))
   end)
 
-  it("refuses a key that is neither a column name nor a sheet option", function()
-    -- neither form on its own: "city" is keyed, and it is not a sheet option
+  it("names the key it refuses, and both forms that would take it as a column", function()
+    -- neither form on its own: "city" is keyed, and it is not a sheet option.
+    -- Refused rather than skipped, because a sheet built without one of its
+    -- columns takes every write to that column silently
     local ok, err = pcall(function()
       db:create(dbName, {people = {"name", city = ""}})
     end)
     assert.is_false(ok)
-    assert.is_truthy(string.find(err, "city is neither one of the sheet's column names nor a sheet option", 1, true))
+    assert.is_truthy(string.find(err, '"city" is a key', 1, true))
+    -- the examples carry the refused name as well as the ones the sheet gave:
+    -- offering a sheet without it would advise the very state this refusal stops
+    assert.is_truthy(string.find(err, 'Write {"name", "city"}', 1, true))
+    assert.is_truthy(string.find(err, 'use the {name = "", city = ""} form', 1, true))
+  end)
+
+  it("brackets a column name the keyed form cannot take bare", function()
+    -- the listed form quotes every name, but the keyed form writes them as keys,
+    -- and a name that is not a bare identifier does not parse as one: the
+    -- message would be telling the user to write something Lua refuses
+    local ok, err = pcall(function()
+      db:create(dbName, {people = {"first name", bogus = ""}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, '{"first name", "bogus"}', 1, true))
+    assert.is_truthy(string.find(err, '{["first name"] = "", bogus = ""}', 1, true))
+
+    -- a name that is one of Lua's own words is no more a bare key than that one
+    ok, err = pcall(function()
+      db:create(dbName, {people = {"end", bogus = ""}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, '{["end"] = "", bogus = ""}', 1, true))
+  end)
+
+  it("tells a numeric key that is not a position in the list from a stray one", function()
+    -- "7 is neither one of the sheet's column names nor a sheet option" was
+    -- nonsense: 7 plainly is a numeric list key, and what is wrong with it is
+    -- that the list has no seventh place
+    local ok, err = pcall(function()
+      db:create(dbName, {people = {"name", "city", [7] = "extra"}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, "[7] is not a position in this 2 item list", 1, true))
+
+    -- a place at or below zero is no more a position than one past the end
+    ok, err = pcall(function()
+      db:create(dbName, {people = {"name", "city", [0] = "extra"}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, "[0] is not a position in this 2 item list", 1, true))
+
+    -- nor is one that is not whole. This is the guard whose loss is silent: drop
+    -- the key % 1 == 0 test and db:create quietly makes a column called extra
+    ok, err = pcall(function()
+      db:create(dbName, {people = {"name", "city", [1.5] = "extra"}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, "[1.5] is not a position in this 2 item list", 1, true))
+  end)
+
+  it("takes a numeric key that continues the list, and refuses the first one that skips", function()
+    -- # decides what counts as a position, so the boundary is where the list
+    -- stops being contiguous rather than anywhere the sheet was written
+    local mydb = db:create(dbName, {people = {"name", "city", [3] = "extra"}})
+    assert.are.same({city = "", extra = "", name = ""}, db.__schema[dbName].people.columns)
+    assert.is_true(db:add(mydb.people, {name = "Bob", extra = "x"}))
+
+    local ok, err = pcall(function()
+      db:create(dbName, {people = {"name", "city", [4] = "extra"}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, "[4] is not a position in this 2 item list", 1, true))
+  end)
+
+  it("falls back to a made-up example when the sheet named nothing to build one from", function()
+    -- a key that is not a string names no column, so there is nothing of the
+    -- sheet's own to spell the two forms with
+    local ok, err = pcall(function()
+      db:create(dbName, {people = {[1] = 42, [true] = ""}})
+    end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, 'Write {"name", "city"}', 1, true))
+    assert.is_truthy(string.find(err, 'use the {name = "", city = ""} form', 1, true))
   end)
 
   it("refuses a listed column name that is not a string", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The errors `db:create` raises for a sheet given as a list of column names now say what to write instead: both working forms, spelled with the names that sheet gave plus the one being refused.
- A numeric key gets its own message. `7 is neither one of the sheet's column names nor a sheet option` was nonsense, since 7 plainly is a numeric list key; what is wrong with it is that the list has no seventh place.
- The keyed example brackets a name that is not a bare identifier, so the form the message tells the user to write always parses.

```
- db:create - books - nickname is neither one of the sheet's column names nor a sheet
  option: a sheet is either a list of column names or a table of column names and their
  default values.
+ db:create - books - "nickname" is a key, but a sheet given as a list takes its column
  names as list members. Write {"title", "author", "nickname"}, or use the
  {title = "", author = "", nickname = ""} form to give a column a default.

- db:create - books - 7 is neither one of the sheet's column names nor a sheet option: ...
+ db:create - books - [7] is not a position in this 2 item list, so it names no column.
  A sheet given as a list runs from 1 with no gaps.
```

#### Motivation for adding to Mudlet

#9815 made these fatal, and `db:create` is documented as safe to run unguarded at the top of a script, so the message is all the user gets before their script stops.

They stay fatal, which is the other half of #10049. Skipping the entry was tried first, to match what #10033 does for `_index`, and it is worse: a sheet built without one of its columns takes every write to that column silently, since `db:add` reports the rejected INSERT through `printError` and returns `nil`, which callers do not check. `db:create` succeeds, the script writes, and zero rows are stored. An index is derived and can be skipped; a column holds data and cannot.

#### Other info (issues closed, discussion etc)

Closes #10049. Stacked on #10033, so the base is `fix-db-index-unknown-column-warning` and this retargets to `development` when that merges.

**Test case:** `db:create("test", {people = {"name", city = ""}})` - the error names `"city"` and shows `{"name", "city"}` and `{name = "", city = ""}`.

+4 specs (276 to 280), each verified failing against the base. The fractional-key guard is mutation-checked: dropping `key % 1 == 0` makes `[1.5]` a silent column, and the spec catches it.

Assisted-by: Claude:claude-opus-5
