### PR TITLE
Infra: Test ctelnet's out-of-band protocol handling

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -301,8 +301,8 @@ set_tests_properties(GlyphOverflowTest PROPERTIES TIMEOUT 600)
 set_tests_properties(TelnetCharsetNegotiationTest PROPERTIES TIMEOUT 300)
 
 # TelnetNewEnvironTest, TelnetOptionsReportTest and TelnetAtcpMspTest each boot a
-# full profile against a loopback server, and the MSP half of the last waits out
-# real HTTP requests, so the 60s default is too tight under a sanitizer
+# full profile, which is nearly all of their runtime and the part a sanitizer and
+# a loaded runner stretch, so they get the same headroom as their neighbours
 set_tests_properties(TelnetNewEnvironTest TelnetOptionsReportTest TelnetAtcpMspTest PROPERTIES TIMEOUT 300)
 
 # ProfileLifecycleTest opens and closes several profiles, and every open is a

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -70,10 +70,13 @@ set(TELNET_GROUP_TEST_SOURCES
     CsiCursorForwardTest.cpp
     cTelnetBufferTest.cpp
     GMCPCharLoginTest.cpp
+    TelnetAtcpMspTest.cpp
     TelnetBenchmark.cpp
     TelnetCharsetNegotiationTest.cpp
     TelnetConnectFailureTest.cpp
     TelnetConnectLookupRaceTest.cpp
+    TelnetNewEnvironTest.cpp
+    TelnetOptionsReportTest.cpp
     TelnetReconnectStateTest.cpp
     TelnetStringSequenceRecoveryTest.cpp
     TelnetTlsPromptTest.cpp
@@ -296,6 +299,11 @@ set_tests_properties(GlyphOverflowTest PROPERTIES TIMEOUT 600)
 # TelnetCharsetNegotiationTest creates a fresh profile per test case, each of which
 # also reconnects, so it needs a longer timeout
 set_tests_properties(TelnetCharsetNegotiationTest PROPERTIES TIMEOUT 300)
+
+# TelnetNewEnvironTest, TelnetOptionsReportTest and TelnetAtcpMspTest each boot a
+# full profile against a loopback server, and the MSP half of the last waits out
+# real HTTP requests, so the 60s default is too tight under a sanitizer
+set_tests_properties(TelnetNewEnvironTest TelnetOptionsReportTest TelnetAtcpMspTest PROPERTIES TIMEOUT 300)
 
 # ProfileLifecycleTest opens and closes several profiles, and every open is a
 # full profile load and every close a full save, so it needs a longer timeout

--- a/test/functional_tests/RecordingTelnetServer.h
+++ b/test/functional_tests/RecordingTelnetServer.h
@@ -34,9 +34,11 @@
 // several out-of-band protocols (NEW_ENVIRON above all) are only observable in
 // what Mudlet replies with.
 //
-// Deliberately no Q_OBJECT: it declares no signals or slots of its own, so
-// connecting to lambdas is enough and the header stays usable from more than one
-// test in the same binary without a moc step.
+// Deliberately no Q_OBJECT: there is no matching .cpp for AUTOMOC to attach a moc
+// step to (TelnetServerStub.h gets away with it only because TelnetServerStub.cpp
+// is in FUNCTIONAL_TEST_UTILS), and the class declares no signals or slots of its
+// own, so connecting to lambdas with itself as context is enough. Adding a signal
+// later would fail at link rather than at compile.
 class RecordingTelnetServer : public QObject
 {
 public:
@@ -55,16 +57,20 @@ public:
         });
     }
 
-    // Port 0: an ephemeral port, so concurrent test runs cannot collide.
-    bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    // Port 0: an ephemeral port, so concurrent test runs cannot collide. An
+    // unchecked failure here reads much later as a connection that never
+    // arrives, since serverPort() then answers 0.
+    [[nodiscard]] bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
     quint16 serverPort() const { return mServer.serverPort(); }
 
     QByteArray received() const { return mReceived; }
     void forgetReceived() { mReceived.clear(); }
 
 private:
-    QTcpServer mServer;
+    // The buffer is declared first so it outlives the server, and with it the
+    // accepted sockets whose read handlers write into it.
     QByteArray mReceived;
+    QTcpServer mServer;
 };
 
 // One IAC SB ... IAC SE block, with the escaped IAC pairs collapsed.
@@ -74,13 +80,31 @@ struct Subnegotiation
     QByteArray payload;
 };
 
-// Every subnegotiation in a captured stream, in the order it was sent.
+// Every subnegotiation in a captured stream, in the order it was sent. Ordinary
+// data around them is skipped, including the doubled IAC Mudlet writes for a
+// literal 0xFF - which would otherwise read as the start of a block whenever the
+// byte after it happened to be SB.
 inline QList<Subnegotiation> subnegotiationsIn(const QByteArray& stream)
 {
+    const auto byteAt = [&stream](const int index) {
+        return static_cast<unsigned char>(stream.at(index));
+    };
+    constexpr auto iac = static_cast<unsigned char>(TN_IAC);
+    constexpr auto sb = static_cast<unsigned char>(TN_SB);
+    constexpr auto se = static_cast<unsigned char>(TN_SE);
+
     QList<Subnegotiation> found;
     int i = 0;
     while (i + 1 < stream.size()) {
-        if (static_cast<unsigned char>(stream.at(i)) != static_cast<unsigned char>(TN_IAC) || static_cast<unsigned char>(stream.at(i + 1)) != static_cast<unsigned char>(TN_SB)) {
+        if (byteAt(i) != iac) {
+            ++i;
+            continue;
+        }
+        if (byteAt(i + 1) == iac) {
+            i += 2;
+            continue;
+        }
+        if (byteAt(i + 1) != sb) {
             ++i;
             continue;
         }
@@ -88,25 +112,39 @@ inline QList<Subnegotiation> subnegotiationsIn(const QByteArray& stream)
             break;
         }
         Subnegotiation subnegotiation;
-        subnegotiation.option = static_cast<unsigned char>(stream.at(i + 2));
+        subnegotiation.option = byteAt(i + 2);
         int j = i + 3;
         bool terminated = false;
+        bool truncated = false;
         while (j < stream.size()) {
-            if (static_cast<unsigned char>(stream.at(j)) == static_cast<unsigned char>(TN_IAC) && j + 1 < stream.size()) {
-                const unsigned char next = static_cast<unsigned char>(stream.at(j + 1));
-                if (next == static_cast<unsigned char>(TN_SE)) {
+            if (byteAt(j) == iac) {
+                if (j + 1 >= stream.size()) {
+                    break;
+                }
+                const unsigned char next = byteAt(j + 1);
+                if (next == se) {
                     terminated = true;
                     j += 2;
                     break;
                 }
-                if (next == static_cast<unsigned char>(TN_IAC)) {
+                if (next == iac) {
                     subnegotiation.payload.append(static_cast<char>(TN_IAC));
                     j += 2;
                     continue;
                 }
+                if (next == sb) {
+                    // The next block has begun, so this one lost its terminator:
+                    // drop it rather than swallowing its successor's bytes.
+                    truncated = true;
+                    break;
+                }
             }
             subnegotiation.payload.append(stream.at(j));
             ++j;
+        }
+        if (truncated) {
+            i = j;
+            continue;
         }
         if (!terminated) {
             // A subnegotiation still arriving: leave it for the next capture
@@ -119,7 +157,6 @@ inline QList<Subnegotiation> subnegotiationsIn(const QByteArray& stream)
     return found;
 }
 
-// The subnegotiations for one option only.
 inline QList<Subnegotiation> subnegotiationsFor(const QByteArray& stream, const unsigned char option)
 {
     QList<Subnegotiation> found;

--- a/test/functional_tests/RecordingTelnetServer.h
+++ b/test/functional_tests/RecordingTelnetServer.h
@@ -1,0 +1,134 @@
+#ifndef MUDLET_RECORDINGTELNETSERVER_H
+#define MUDLET_RECORDINGTELNETSERVER_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QByteArray>
+#include <QHostAddress>
+#include <QList>
+#include <QObject>
+#include <QtNetwork/QTcpServer>
+#include <QtNetwork/QTcpSocket>
+
+#include "ctelnet.h"
+
+// TelnetServerStub speaks; this one only listens, so a test can assert on the
+// bytes a game would have received. Everything a client sends is kept, since
+// several out-of-band protocols (NEW_ENVIRON above all) are only observable in
+// what Mudlet replies with.
+//
+// Deliberately no Q_OBJECT: it declares no signals or slots of its own, so
+// connecting to lambdas is enough and the header stays usable from more than one
+// test in the same binary without a moc step.
+class RecordingTelnetServer : public QObject
+{
+public:
+    explicit RecordingTelnetServer(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        connect(&mServer, &QTcpServer::newConnection, this, [this]() {
+            QTcpSocket* socket = mServer.nextPendingConnection();
+            if (!socket) {
+                return;
+            }
+            connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
+                mReceived.append(socket->readAll());
+            });
+            connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+        });
+    }
+
+    // Port 0: an ephemeral port, so concurrent test runs cannot collide.
+    bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    quint16 serverPort() const { return mServer.serverPort(); }
+
+    QByteArray received() const { return mReceived; }
+    void forgetReceived() { mReceived.clear(); }
+
+private:
+    QTcpServer mServer;
+    QByteArray mReceived;
+};
+
+// One IAC SB ... IAC SE block, with the escaped IAC pairs collapsed.
+struct Subnegotiation
+{
+    unsigned char option = 0;
+    QByteArray payload;
+};
+
+// Every subnegotiation in a captured stream, in the order it was sent.
+inline QList<Subnegotiation> subnegotiationsIn(const QByteArray& stream)
+{
+    QList<Subnegotiation> found;
+    int i = 0;
+    while (i + 1 < stream.size()) {
+        if (static_cast<unsigned char>(stream.at(i)) != static_cast<unsigned char>(TN_IAC) || static_cast<unsigned char>(stream.at(i + 1)) != static_cast<unsigned char>(TN_SB)) {
+            ++i;
+            continue;
+        }
+        if (i + 2 >= stream.size()) {
+            break;
+        }
+        Subnegotiation subnegotiation;
+        subnegotiation.option = static_cast<unsigned char>(stream.at(i + 2));
+        int j = i + 3;
+        bool terminated = false;
+        while (j < stream.size()) {
+            if (static_cast<unsigned char>(stream.at(j)) == static_cast<unsigned char>(TN_IAC) && j + 1 < stream.size()) {
+                const unsigned char next = static_cast<unsigned char>(stream.at(j + 1));
+                if (next == static_cast<unsigned char>(TN_SE)) {
+                    terminated = true;
+                    j += 2;
+                    break;
+                }
+                if (next == static_cast<unsigned char>(TN_IAC)) {
+                    subnegotiation.payload.append(static_cast<char>(TN_IAC));
+                    j += 2;
+                    continue;
+                }
+            }
+            subnegotiation.payload.append(stream.at(j));
+            ++j;
+        }
+        if (!terminated) {
+            // A subnegotiation still arriving: leave it for the next capture
+            // rather than reporting a payload that has not finished.
+            break;
+        }
+        found.append(subnegotiation);
+        i = j;
+    }
+    return found;
+}
+
+// The subnegotiations for one option only.
+inline QList<Subnegotiation> subnegotiationsFor(const QByteArray& stream, const unsigned char option)
+{
+    QList<Subnegotiation> found;
+    for (const Subnegotiation& subnegotiation : subnegotiationsIn(stream)) {
+        if (subnegotiation.option == option) {
+            found.append(subnegotiation);
+        }
+    }
+    return found;
+}
+
+#endif // MUDLET_RECORDINGTELNETSERVER_H

--- a/test/functional_tests/TelnetAtcpMspTest.cpp
+++ b/test/functional_tests/TelnetAtcpMspTest.cpp
@@ -33,8 +33,8 @@
 // all, which is checked by following it with a well-formed one and finding only
 // that one's request. Playback itself is out of reach without an audio backend,
 // so the parameters that only ever reach the player (volume, loops, priority,
-// continue and tag) are exercised for their effect on the request rather than
-// asserted one by one.
+// continue and tag) are exercised only far enough to show they do not stop the
+// file being fetched.
 
 #include <QFileInfo>
 #include <QStringList>
@@ -76,13 +76,19 @@ public:
                 return;
             }
             connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
-                const QByteArray request = socket->readAll();
+                // Accumulated rather than read once: a request line split across
+                // two reads would otherwise be dropped without a trace, and the
+                // test would blame Mudlet for a request the stub lost.
+                QByteArray request = socket->property("request").toByteArray();
+                request.append(socket->readAll());
                 const int requestLineEnd = request.indexOf("\r\n");
-                if (requestLineEnd > 0) {
-                    const QList<QByteArray> parts = request.left(requestLineEnd).split(' ');
-                    if (parts.size() >= 2) {
-                        mRequestedPaths.append(QString::fromLatin1(parts.at(1)));
-                    }
+                if (requestLineEnd < 0) {
+                    socket->setProperty("request", request);
+                    return;
+                }
+                const QList<QByteArray> parts = request.left(requestLineEnd).split(' ');
+                if (parts.size() >= 2) {
+                    mRequestedPaths.append(QString::fromLatin1(parts.at(1)));
                 }
                 socket->write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
                 socket->disconnectFromHost();
@@ -92,15 +98,17 @@ public:
     }
 
     // Port 0: an ephemeral port, so concurrent test runs cannot collide.
-    bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    [[nodiscard]] bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
     quint16 serverPort() const { return mServer.serverPort(); }
 
     QStringList requestedPaths() const { return mRequestedPaths; }
     void forgetRequests() { mRequestedPaths.clear(); }
 
 private:
-    QTcpServer mServer;
+    // The path list is declared first so it outlives the server, and with it the
+    // accepted sockets whose read handlers write into it.
     QStringList mRequestedPaths;
+    QTcpServer mServer;
 };
 
 class TelnetAtcpMspTest : public QObject
@@ -173,8 +181,8 @@ private:
         return value;
     }
 
-    // The composer is a top-level window of its own rather than a child of the
-    // Host, so this is the only way to see whether one is up.
+    // Scanned off the top-level widgets rather than read from cTelnet::mpComposer,
+    // so a window the pointer has already let go of still shows up.
     static QList<dlgComposer*> openComposers()
     {
         QList<dlgComposer*> found;
@@ -267,6 +275,7 @@ private slots:
     {
         QVERIFY(mpHost);
         mpHost->mEnableMSP = true;
+        mpHost->mEnableGMCP = true;
         // Every media message is answered by the local stub rather than by a
         // lookup of "www.localhost", which is where an MSP message with no URL
         // of its own would otherwise send Mudlet.
@@ -276,8 +285,8 @@ private slots:
     }
 
     // The single-line form: everything up to the first space is the variable,
-    // the rest its value, and the dots come out of the name because Lua cannot
-    // index "Room.Brief" as one key.
+    // the rest its value, and the dots come out of the name so a script can write
+    // atcp.RoomBrief.
     void test_singleLineAtcpReachesTheLuaTable()
     {
         feedAtcp("Room.Brief Cave entrance");
@@ -301,8 +310,8 @@ private slots:
         QCOMPARE(atcpValue(qsl("CharStatus")), qsl("ready hp:100"));
     }
 
-    // Room.Num is the one ATCP variable cTelnet acts on itself: it is what tells
-    // the mapper which room the player is in.
+    // Room.Num is the one ATCP variable that both reaches the Lua table and moves
+    // state inside cTelnet: it is what tells the mapper where the player is.
     void test_roomNumMovesTheMapper()
     {
         QVERIFY2(mpHost->mpMap, "the profile has no map, so there is nothing for Room.Num to move");
@@ -311,8 +320,9 @@ private slots:
         QCOMPARE(mpHost->mpMap->mRoomIdHash.value(mHostname), 4242);
     }
 
-    // The one thing ATCP sends back. A game that asks for it and gets nothing
-    // has no way to know what it is talking to.
+    // The only thing Mudlet sends unprompted in reply to an incoming ATCP
+    // message. A game that asks for it and gets nothing has no way to know what
+    // it is talking to.
     void test_authRequestIsAnsweredWithTheClientHandshake()
     {
         feedAtcp("Auth.Request");
@@ -372,9 +382,9 @@ private slots:
     // a backslash or a line break cannot end the message early.
     void test_savingTheComposerQuotesTheBufferItSendsBack()
     {
-        // The buffer goes back over whichever of the two protocols is live, and
-        // GMCP is the one a profile prefers - but only once a game has offered
-        // it, which the recording server never does on its own.
+        // The preference picks the protocol and the negotiated flag then has to
+        // agree, so GMCP has to be both preferred (it is, by default) and offered
+        // - which the recording server never does on its own.
         announce(TN_WILL, static_cast<char>(OPT_GMCP));
         QVERIFY2(mpHost->mTelnet.isGMCPEnabled(), "GMCP did not turn on, so the composer had nothing to send its buffer over");
         // Turning GMCP on makes Mudlet introduce itself over it, so wait that
@@ -398,8 +408,44 @@ private slots:
                  "saving the composer sent no GMCP message");
         const QList<Subnegotiation> sent = subnegotiationsFor(mpServer->received(), OPT_GMCP);
         QCOMPARE(sent.size(), 1);
-        // moc does not understand raw string literals, so this stays escaped:
+        // moc mis-lexes this particular raw string - the quotes inside it leave it
+        // thinking the class is still inside a string, and it then emits no meta
+        // object at all - so it stays escaped. Raw strings are fine elsewhere.
         QCOMPARE(sent.first().payload, QByteArray("IRE.Composer.SetBuffer \"a \\\"quoted\\\" back\\\\slash\\nand a second line\""));
+
+        QVERIFY2(QTest::qWaitFor(
+                         []() {
+                             return openComposers().isEmpty();
+                         },
+                         5000),
+                 "saving the composer left its window behind");
+    }
+
+    // The other arm of the same save: a profile with GMCP turned off sends the
+    // buffer as ATCP instead, in a completely different shape - and with no
+    // quoting at all, which is what an ATCP-only game receives.
+    void test_savingTheComposerFallsBackToAtcpWithGmcpOff()
+    {
+        mpHost->mEnableGMCP = false;
+        announce(TN_WILL, static_cast<char>(OPT_ATCP));
+        QVERIFY2(mpHost->mTelnet.isATCPEnabled(), "ATCP did not turn on, so the composer had nothing to send its buffer over");
+        waitForEverythingSentSoFar();
+        mpServer->forgetReceived();
+
+        feedAtcp("Client.Compose Note");
+        QCOMPARE(openComposers().size(), 1);
+        mpHost->mTelnet.atcpComposerSave(qsl("a \"quoted\" line"));
+
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return !subnegotiationsFor(mpServer->received(), OPT_ATCP).isEmpty();
+                         },
+                         10000),
+                 "saving the composer sent no ATCP message");
+        const QList<Subnegotiation> sent = subnegotiationsFor(mpServer->received(), OPT_ATCP);
+        QCOMPARE(sent.size(), 1);
+        QCOMPARE(sent.first().payload, QByteArray("olesetbuf \n a \"quoted\" line\n"));
+        QVERIFY2(mpServer->received().contains("*s\n"), "the ATCP save did not tell the game the buffer was submitted");
 
         QVERIFY2(QTest::qWaitFor(
                          []() {
@@ -477,14 +523,24 @@ private slots:
         QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/bark.wav")}));
     }
 
-    // A server-supplied file name that climbs out of the profile's media
-    // directory must not be fetched, since fetching it is what would write it
-    // there.
-    void test_aFileNameThatEscapesTheMediaDirectoryIsRefused()
+    // A server-supplied file name that names somewhere other than inside the
+    // profile's media directory must not be fetched, since fetching it is what
+    // would write it there.
+    void test_aFileNameOutsideTheMediaDirectoryIsRefused_data()
     {
-        feedMsp("!!SOUND(../escape.wav)");
+        QTest::addColumn<QByteArray>("message");
+
+        QTest::newRow("parent directory traversal") << QByteArray("!!SOUND(../escape.wav)");
+        QTest::newRow("absolute path") << QByteArray("!!SOUND(/tmp/escape.wav)");
+    }
+
+    void test_aFileNameOutsideTheMediaDirectoryIsRefused()
+    {
+        QFETCH(QByteArray, message);
+
+        feedMsp(message);
         feedMsp("!!SOUND(sentinel.wav)");
-        QVERIFY2(waitForMediaRequests(1), "the sentinel after the traversal attempt fetched nothing");
+        QVERIFY2(waitForMediaRequests(1), "the sentinel after the refused file name fetched nothing");
         settleMediaRequests();
         QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
     }

--- a/test/functional_tests/TelnetAtcpMspTest.cpp
+++ b/test/functional_tests/TelnetAtcpMspTest.cpp
@@ -1,0 +1,410 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// Two of the older out-of-band protocols, and what a payload from them does
+// once cTelnet has taken it off the wire.
+//
+// ATCP (setATCPVariables) hands its variables to Lua, so the tests read the
+// atcp table back out of the interpreter - the same place a script would look.
+// Its one reply, to Auth.Request, goes out on the socket and is read off a
+// recording server.
+//
+// MSP (setMSPVariables) hands a parsed TMediaData to TMedia, which keeps no
+// public record of it, so the visible consequence is the media file Mudlet then
+// goes and fetches: the request URL carries the file name and, through the
+// extension TMedia picks when there is none, whether MSP was parsed as a sound
+// or a piece of music. What a malformed message must do is produce no request at
+// all, which is checked by following it with a well-formed one and finding only
+// that one's request. Playback itself is out of reach without an audio backend,
+// so the parameters that only ever reach the player (volume, loops, priority,
+// continue and tag) are exercised for their effect on the request rather than
+// asserted one by one.
+
+#include <QFileInfo>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QtNetwork/QTcpServer>
+#include <QtNetwork/QTcpSocket>
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "RecordingTelnetServer.h"
+#include "TLuaInterpreter.h"
+#include "TMap.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// Answers everything with 404 and remembers what was asked for. A 404 keeps the
+// profile's media directory empty, which matters because a media file that
+// exists is one Mudlet stops fetching.
+class RecordingHttpServer : public QObject
+{
+public:
+    explicit RecordingHttpServer(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        connect(&mServer, &QTcpServer::newConnection, this, [this]() {
+            QTcpSocket* socket = mServer.nextPendingConnection();
+            if (!socket) {
+                return;
+            }
+            connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
+                const QByteArray request = socket->readAll();
+                const int requestLineEnd = request.indexOf("\r\n");
+                if (requestLineEnd > 0) {
+                    const QList<QByteArray> parts = request.left(requestLineEnd).split(' ');
+                    if (parts.size() >= 2) {
+                        mRequestedPaths.append(QString::fromLatin1(parts.at(1)));
+                    }
+                }
+                socket->write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+                socket->disconnectFromHost();
+            });
+            connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+        });
+    }
+
+    // Port 0: an ephemeral port, so concurrent test runs cannot collide.
+    bool start() { return mServer.listen(QHostAddress::LocalHost, 0); }
+    quint16 serverPort() const { return mServer.serverPort(); }
+
+    QStringList requestedPaths() const { return mRequestedPaths; }
+    void forgetRequests() { mRequestedPaths.clear(); }
+
+private:
+    QTcpServer mServer;
+    QStringList mRequestedPaths;
+};
+
+class TelnetAtcpMspTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    RecordingTelnetServer* mpServer = nullptr;
+    RecordingHttpServer* mpMediaServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-Telnet-Atcp-Msp");
+    const QString mLocalhost = qsl("localhost");
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    void feedSubnegotiation(const char option, const QByteArray& payload)
+    {
+        QByteArray data;
+        data.append(TN_IAC).append(TN_SB).append(option).append(payload).append(TN_IAC).append(TN_SE);
+        mpHost->mTelnet.loopbackTest(data);
+    }
+
+    void feedAtcp(const QByteArray& message) { feedSubnegotiation(static_cast<char>(OPT_ATCP), message); }
+    void feedMsp(const QByteArray& message) { feedSubnegotiation(OPT_MSP, message); }
+
+    // What a script would see. The table is created by LuaGlobal.lua, so a
+    // missing one means the profile's Lua support never loaded rather than that
+    // ATCP failed.
+    QString atcpValue(const QString& key) const
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, "atcp");
+        if (!lua_istable(L, -1)) {
+            lua_pop(L, 1);
+            return QString();
+        }
+        lua_getfield(L, -1, key.toUtf8().constData());
+        const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
+        lua_pop(L, 2);
+        return value;
+    }
+
+    QString mediaLocation() const { return qsl("http://127.0.0.1:%1/msp/").arg(mpMediaServer->serverPort()); }
+
+    // Waits for the media requests a test expects, so a test that sends a
+    // message expected to produce nothing can follow it with one that does and
+    // then check what the whole run asked for.
+    bool waitForMediaRequests(const int expected)
+    {
+        return QTest::qWaitFor(
+                [this, expected]() {
+                    return mpMediaServer->requestedPaths().size() >= expected;
+                },
+                15000);
+    }
+
+    // The well-formed message that follows a malformed one is issued second, so
+    // its request all but always arrives second - but two requests are two TCP
+    // connections and nothing orders their arrival, so a short settle after it
+    // is what stops a regression passing by losing that race.
+    void settleMediaRequests() { QTest::qWait(200ms); }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new RecordingTelnetServer(qApp);
+        QVERIFY2(mpServer->start(), "RecordingTelnetServer failed to bind a loopback port");
+        mpMediaServer = new RecordingHttpServer(qApp);
+        QVERIFY2(mpMediaServer->start(), "RecordingHttpServer failed to bind a loopback port");
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15s), "The test profile never connected to the recording server.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpMediaServer;
+        mpMediaServer = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void init()
+    {
+        QVERIFY(mpHost);
+        mpHost->mEnableMSP = true;
+        // Every media message is answered by the local stub rather than by a
+        // lookup of "www.localhost", which is where an MSP message with no URL
+        // of its own would otherwise send Mudlet.
+        mpHost->setMediaLocationMSP(mediaLocation());
+        mpMediaServer->forgetRequests();
+        mpServer->forgetReceived();
+    }
+
+    // The single-line form: everything up to the first space is the variable,
+    // the rest its value, and the dots come out of the name because Lua cannot
+    // index "Room.Brief" as one key.
+    void test_singleLineAtcpReachesTheLuaTable()
+    {
+        feedAtcp("Room.Brief Cave entrance");
+        QCOMPARE(atcpValue(qsl("RoomBrief")), qsl("Cave entrance"));
+    }
+
+    // The multi-line form: the first line names the variable and everything
+    // after it is the value, with the line breaks taken out.
+    void test_multiLineAtcpKeepsEveryLineOfTheValue()
+    {
+        feedAtcp("Char.Vitals\nhp:100\nmana:50");
+        QCOMPARE(atcpValue(qsl("CharVitals")), qsl("hp:100mana:50"));
+    }
+
+    // A first line that carries a word after the variable name: the word belongs
+    // to the value, not to the name, or the name Lua is given is one no script
+    // could have been written against.
+    void test_wordsAfterTheVariableNameBelongToTheValue()
+    {
+        feedAtcp("Char.Status ready\nhp:100");
+        QCOMPARE(atcpValue(qsl("CharStatus")), qsl("ready hp:100"));
+    }
+
+    // Room.Num is the one ATCP variable cTelnet acts on itself: it is what tells
+    // the mapper which room the player is in.
+    void test_roomNumMovesTheMapper()
+    {
+        QVERIFY2(mpHost->mpMap, "the profile has no map, so there is nothing for Room.Num to move");
+        feedAtcp("Room.Num 4242");
+        QCOMPARE(atcpValue(qsl("RoomNum")), qsl("4242"));
+        QCOMPARE(mpHost->mpMap->mRoomIdHash.value(mHostname), 4242);
+    }
+
+    // The one thing ATCP sends back. A game that asks for it and gets nothing
+    // has no way to know what it is talking to.
+    void test_authRequestIsAnsweredWithTheClientHandshake()
+    {
+        feedAtcp("Auth.Request");
+
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return !subnegotiationsFor(mpServer->received(), OPT_ATCP).isEmpty();
+                         },
+                         10000),
+                 "Mudlet never answered Auth.Request");
+
+        const QList<Subnegotiation> replies = subnegotiationsFor(mpServer->received(), OPT_ATCP);
+        QCOMPARE(replies.size(), 1);
+        const QByteArray hello = replies.first().payload;
+        QVERIFY2(hello.startsWith("hello Mudlet "), qPrintable(qsl("the ATCP handshake did not name the client: %1").arg(QString::fromLatin1(hello))));
+        for (const char* capability : {"composer 1", "char_vitals 1", "room_brief 1", "room_exits 1", "map_display 1"}) {
+            QVERIFY2(hello.contains(capability), qPrintable(qsl("the ATCP handshake did not offer %1: %2").arg(QString::fromLatin1(capability), QString::fromLatin1(hello))));
+        }
+    }
+
+    // MSP names a file without an extension and leaves the client to pick one
+    // per media type, so the file requested is where a sound and a piece of
+    // music part company.
+    void test_soundAndMusicPickTheirOwnDefaultExtension()
+    {
+        feedMsp(QByteArray("!!SOUND(bark U=") + mediaLocation().toUtf8() + ")");
+        QVERIFY2(waitForMediaRequests(1), "no media was fetched for a well-formed !!SOUND");
+        feedMsp("!!MUSIC(theme)");
+        QVERIFY2(waitForMediaRequests(2), "no media was fetched for a well-formed !!MUSIC");
+
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/bark.wav"), qsl("/msp/theme.mid")}));
+    }
+
+    // An extension the game supplied is left alone, and a sub-directory in the
+    // name is part of the file rather than something to flatten away.
+    void test_anExplicitExtensionAndSubdirectoryAreKept()
+    {
+        feedMsp("!!SOUND(fx/step.ogg)");
+        QVERIFY2(waitForMediaRequests(1), "no media was fetched for a file name with a sub-directory");
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/fx/step.ogg")}));
+    }
+
+    // The URL a game supplies is remembered on the profile, which is what lets
+    // its later messages leave it out.
+    void test_theMediaUrlIsRememberedOnTheProfile()
+    {
+        const QString supplied = qsl("http://127.0.0.1:%1/other/").arg(mpMediaServer->serverPort());
+        feedMsp(QByteArray("!!SOUND(bark.wav U=") + supplied.toUtf8() + ")");
+        QVERIFY2(waitForMediaRequests(1), "no media was fetched for a message carrying its own URL");
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/other/bark.wav")}));
+        QCOMPARE(mpHost->mediaLocationMSP(), supplied);
+    }
+
+    // Anything that does not meet the MSP standard has to be dropped rather than
+    // half-parsed. The well-formed message at the end is what proves the ones
+    // before it were dropped and not merely slow.
+    void test_messagesThatDoNotMeetTheStandardAreDropped_data()
+    {
+        QTest::addColumn<QByteArray>("message");
+
+        QTest::newRow("no closing parenthesis") << QByteArray("!!SOUND(bark.wav");
+        QTest::newRow("not a sound or music command") << QByteArray("!!VIDEO(bark.wav)");
+        QTest::newRow("no command at all") << QByteArray("bark.wav)");
+        QTest::newRow("a parameter with no value") << QByteArray("!!SOUND(bark.wav V)");
+        QTest::newRow("a parameter with two values") << QByteArray("!!SOUND(bark.wav V=1=2)");
+    }
+
+    void test_messagesThatDoNotMeetTheStandardAreDropped()
+    {
+        QFETCH(QByteArray, message);
+
+        feedMsp(message);
+        feedMsp("!!SOUND(sentinel.wav)");
+        QVERIFY2(waitForMediaRequests(1), "the well-formed message that follows the malformed one fetched nothing either");
+        settleMediaRequests();
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
+    }
+
+    // The robustness principle: a parameter Mudlet does not understand is
+    // skipped, and the ones it does understand are still applied - so the file
+    // is still fetched rather than the whole message being thrown away.
+    void test_parametersMudletDoesNotUnderstandAreSkipped()
+    {
+        feedMsp("!!SOUND(bark.wav V=50 L=3 P=70 C=0 T=combat Z=9)");
+        QVERIFY2(waitForMediaRequests(1), "a message with an unrecognised parameter was thrown away instead of being fetched");
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/bark.wav")}));
+    }
+
+    // "Off" is a stop, not a file: nothing may be fetched for it.
+    void test_offStopsRatherThanFetchingAFile()
+    {
+        feedMsp("!!SOUND(Off)");
+        feedMsp("!!SOUND(sentinel.wav)");
+        QVERIFY2(waitForMediaRequests(1), "the sentinel after !!SOUND(Off) fetched nothing");
+        settleMediaRequests();
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
+    }
+
+    // A server-supplied file name that climbs out of the profile's media
+    // directory must not be fetched, since fetching it is what would write it
+    // there.
+    void test_aFileNameThatEscapesTheMediaDirectoryIsRefused()
+    {
+        feedMsp("!!SOUND(../escape.wav)");
+        feedMsp("!!SOUND(sentinel.wav)");
+        QVERIFY2(waitForMediaRequests(1), "the sentinel after the traversal attempt fetched nothing");
+        settleMediaRequests();
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
+    }
+
+    // The standard puts a line ending on an MSP message, and games have been
+    // known to send ANSI in one; neither may reach the file name.
+    void test_lineEndingsAndAnsiAreScrubbedFromTheMessage()
+    {
+        feedMsp("!!SOUND(bark.wav)\r\n");
+        QVERIFY2(waitForMediaRequests(1), "a message with the line ending the standard puts on it fetched nothing");
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/bark.wav")}));
+    }
+
+    // MSP turned off is MSP not acted on, however well-formed the message.
+    void test_nothingIsFetchedWhileMspIsTurnedOff()
+    {
+        mpHost->mEnableMSP = false;
+        feedMsp("!!SOUND(refused.wav)");
+        mpHost->mEnableMSP = true;
+        feedMsp("!!SOUND(sentinel.wav)");
+        QVERIFY2(waitForMediaRequests(1), "the sentinel sent once MSP was back on fetched nothing");
+        settleMediaRequests();
+        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
+    }
+};
+
+#include "TelnetAtcpMspTest.moc"
+MUDLET_GROUPED_TEST_MAIN(TelnetAtcpMspTest)

--- a/test/functional_tests/TelnetAtcpMspTest.cpp
+++ b/test/functional_tests/TelnetAtcpMspTest.cpp
@@ -52,6 +52,7 @@
 #include "TLuaInterpreter.h"
 #include "TMap.h"
 #include "ctelnet.h"
+#include "dlgComposer.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
 #include "utils.h"
@@ -129,6 +130,30 @@ private:
     }
 
     void feedAtcp(const QByteArray& message) { feedSubnegotiation(static_cast<char>(OPT_ATCP), message); }
+
+    void announce(const char command, const char option)
+    {
+        QByteArray data;
+        data.append(TN_IAC).append(command).append(option);
+        mpHost->mTelnet.loopbackTest(data);
+    }
+
+    // Mudlet answers a DO TIMING_MARK with WONT TIMING_MARK whatever else is
+    // going on (RFC 860), so that answer arriving means everything written
+    // before it has reached the server - which is what lets a forgetReceived()
+    // after it drop all of the earlier traffic rather than some of it.
+    void waitForEverythingSentSoFar()
+    {
+        announce(TN_DO, OPT_TIMING_MARK);
+        QByteArray marker;
+        marker.append(TN_IAC).append(TN_WONT).append(OPT_TIMING_MARK);
+        QVERIFY2(QTest::qWaitFor(
+                         [this, &marker]() {
+                             return mpServer->received().contains(marker);
+                         },
+                         10000),
+                 "the telnet marker never came back");
+    }
     void feedMsp(const QByteArray& message) { feedSubnegotiation(OPT_MSP, message); }
 
     // What a script would see. The table is created by LuaGlobal.lua, so a
@@ -146,6 +171,20 @@ private:
         const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
         lua_pop(L, 2);
         return value;
+    }
+
+    // The composer is a top-level window of its own rather than a child of the
+    // Host, so this is the only way to see whether one is up.
+    static QList<dlgComposer*> openComposers()
+    {
+        QList<dlgComposer*> found;
+        const QWidgetList widgets = QApplication::topLevelWidgets();
+        for (QWidget* widget : widgets) {
+            if (auto* composer = qobject_cast<dlgComposer*>(widget)) {
+                found.append(composer);
+            }
+        }
+        return found;
     }
 
     QString mediaLocation() const { return qsl("http://127.0.0.1:%1/msp/").arg(mpMediaServer->serverPort()); }
@@ -294,6 +333,82 @@ private slots:
         }
     }
 
+    // Client.Compose puts an editor up. A game that repeats the request - or
+    // spams it - must not stack a second one on top, since only the newest
+    // would be the one cTelnet then answers for.
+    void test_composeOpensOneEditorHoweverOftenItIsAskedFor()
+    {
+        QCOMPARE(openComposers().size(), 0);
+
+        feedAtcp("Client.Compose Note\nfirst draft");
+        QCOMPARE(openComposers().size(), 1);
+        dlgComposer* composer = openComposers().first();
+        QCOMPARE(composer->title->text(), qsl("Note"));
+        QCOMPARE(composer->edit->toPlainText(), qsl("first draft"));
+
+        feedAtcp("Client.Compose Second\nanother draft");
+        QCOMPARE(openComposers().size(), 1);
+        QCOMPARE(openComposers().first()->title->text(), qsl("Note"));
+
+        // Cancelling tells the game the buffer was abandoned, and takes the
+        // window with it - the editor is deleted on close.
+        mpHost->mTelnet.atcpComposerCancel();
+        QVERIFY2(QTest::qWaitFor(
+                         []() {
+                             return openComposers().isEmpty();
+                         },
+                         5000),
+                 "cancelling the composer left its window behind");
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return mpServer->received().contains("*q\nno\n");
+                         },
+                         10000),
+                 "cancelling the composer did not tell the game the buffer was abandoned");
+    }
+
+    // Saving sends the buffer back. With GMCP on - the default - that is an
+    // IRE.Composer.SetBuffer with the text quoted, so a draft carrying a quote,
+    // a backslash or a line break cannot end the message early.
+    void test_savingTheComposerQuotesTheBufferItSendsBack()
+    {
+        // The buffer goes back over whichever of the two protocols is live, and
+        // GMCP is the one a profile prefers - but only once a game has offered
+        // it, which the recording server never does on its own.
+        announce(TN_WILL, static_cast<char>(OPT_GMCP));
+        QVERIFY2(mpHost->mTelnet.isGMCPEnabled(), "GMCP did not turn on, so the composer had nothing to send its buffer over");
+        // Turning GMCP on makes Mudlet introduce itself over it, so wait that
+        // out before forgetting - otherwise the handshake lands in the capture
+        // this test then reads.
+        waitForEverythingSentSoFar();
+        mpServer->forgetReceived();
+
+        feedAtcp("Client.Compose Note");
+        QCOMPARE(openComposers().size(), 1);
+        QCOMPARE(openComposers().first()->title->text(), qsl("Note"));
+        QCOMPARE(openComposers().first()->edit->toPlainText(), QString());
+
+        mpHost->mTelnet.atcpComposerSave(qsl("a \"quoted\" back\\slash\nand a second line"));
+
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return !subnegotiationsFor(mpServer->received(), OPT_GMCP).isEmpty();
+                         },
+                         10000),
+                 "saving the composer sent no GMCP message");
+        const QList<Subnegotiation> sent = subnegotiationsFor(mpServer->received(), OPT_GMCP);
+        QCOMPARE(sent.size(), 1);
+        // moc does not understand raw string literals, so this stays escaped:
+        QCOMPARE(sent.first().payload, QByteArray("IRE.Composer.SetBuffer \"a \\\"quoted\\\" back\\\\slash\\nand a second line\""));
+
+        QVERIFY2(QTest::qWaitFor(
+                         []() {
+                             return openComposers().isEmpty();
+                         },
+                         5000),
+                 "saving the composer left its window behind");
+    }
+
     // MSP names a file without an extension and leaves the client to pick one
     // per media type, so the file requested is where a sound and a piece of
     // music part company.
@@ -362,16 +477,6 @@ private slots:
         QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/bark.wav")}));
     }
 
-    // "Off" is a stop, not a file: nothing may be fetched for it.
-    void test_offStopsRatherThanFetchingAFile()
-    {
-        feedMsp("!!SOUND(Off)");
-        feedMsp("!!SOUND(sentinel.wav)");
-        QVERIFY2(waitForMediaRequests(1), "the sentinel after !!SOUND(Off) fetched nothing");
-        settleMediaRequests();
-        QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
-    }
-
     // A server-supplied file name that climbs out of the profile's media
     // directory must not be fetched, since fetching it is what would write it
     // there.
@@ -384,9 +489,10 @@ private slots:
         QCOMPARE(mpMediaServer->requestedPaths(), QStringList({qsl("/msp/sentinel.wav")}));
     }
 
-    // The standard puts a line ending on an MSP message, and games have been
-    // known to send ANSI in one; neither may reach the file name.
-    void test_lineEndingsAndAnsiAreScrubbedFromTheMessage()
+    // The standard puts a line ending on an MSP message. It has to come off
+    // before the closing parenthesis is looked for, or every well-formed message
+    // a game sends reads as malformed.
+    void test_theLineEndingTheStandardPutsOnAMessageIsStripped()
     {
         feedMsp("!!SOUND(bark.wav)\r\n");
         QVERIFY2(waitForMediaRequests(1), "a message with the line ending the standard puts on it fetched nothing");

--- a/test/functional_tests/TelnetNewEnvironTest.cpp
+++ b/test/functional_tests/TelnetNewEnvironTest.cpp
@@ -1,0 +1,585 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// NEW_ENVIRON (RFC 1572) and its MNES profile
+// (https://tintin.mudhalla.net/protocols/mnes/) are the one out-of-band
+// protocol whose whole point is what Mudlet *sends*: a game asks for variables
+// and every answer, every "I do not maintain that one", and every later INFO
+// update goes out on the wire, where nothing inside the client can see it. So
+// these tests read the bytes off a recording server rather than off Mudlet, and
+// assert on the reply a game would actually parse.
+//
+// Requests arrive by loopback so they are processed before the call returns; the
+// replies are real socket writes, waited out by asking for a DO TIMING_MARK
+// afterwards. Mudlet always answers that with WONT TIMING_MARK, so a test that
+// expects no reply at all has a deterministic marker to wait for rather than a
+// fixed sleep that would pass on a slow runner by accident.
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "RecordingTelnetServer.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// One NEW_ENVIRON variable as it appears in an IS or INFO reply. RFC 1572 makes
+// "defined but empty" and "not defined at all" different things - a VAL byte
+// with nothing after it against no VAL byte - so hasValue is not the same
+// question as value.isEmpty().
+struct EnvironVariable
+{
+    char type = NEW_ENVIRON_VAR;
+    QByteArray name;
+    bool hasValue = false;
+    QByteArray value;
+};
+
+// The variables in an IS or INFO payload, the leading command byte already
+// dropped by the caller. NEW_ENVIRON_ESC quotes the byte that follows it, which
+// is how a name or value gets to carry one of the protocol's own delimiters.
+static QList<EnvironVariable> variablesIn(const QByteArray& payload)
+{
+    QList<EnvironVariable> found;
+    int i = 0;
+    while (i < payload.size()) {
+        const char type = payload.at(i);
+        if (type != NEW_ENVIRON_VAR && type != NEW_ENVIRON_USERVAR) {
+            ++i;
+            continue;
+        }
+        EnvironVariable variable;
+        variable.type = type;
+        ++i;
+        bool readingValue = false;
+        while (i < payload.size()) {
+            const char byte = payload.at(i);
+            if (byte == NEW_ENVIRON_ESC && i + 1 < payload.size()) {
+                (readingValue ? variable.value : variable.name).append(payload.at(i + 1));
+                i += 2;
+                continue;
+            }
+            if (byte == NEW_ENVIRON_VAR || byte == NEW_ENVIRON_USERVAR) {
+                break;
+            }
+            if (byte == NEW_ENVIRON_VAL && !readingValue) {
+                readingValue = true;
+                variable.hasValue = true;
+                ++i;
+                continue;
+            }
+            (readingValue ? variable.value : variable.name).append(byte);
+            ++i;
+        }
+        found.append(variable);
+    }
+    return found;
+}
+
+class TelnetNewEnvironTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    RecordingTelnetServer* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-Telnet-New-Environ");
+    const QString mLocalhost = qsl("localhost");
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    static QByteArray subnegotiation(const char option, const QByteArray& payload)
+    {
+        QByteArray data;
+        data.append(TN_IAC).append(TN_SB).append(option).append(payload).append(TN_IAC).append(TN_SE);
+        return data;
+    }
+
+    void feed(const QByteArray& data)
+    {
+        QByteArray copy = data;
+        mpHost->mTelnet.loopbackTest(copy);
+    }
+
+    void announce(const char command, const char option)
+    {
+        QByteArray data;
+        data.append(TN_IAC).append(command).append(option);
+        feed(data);
+    }
+
+    // Waits out whatever the request under test produced. Mudlet answers a DO
+    // TIMING_MARK with WONT TIMING_MARK whatever else is going on (RFC 860), so
+    // that answer arriving means every earlier reply is already recorded -
+    // including a reply of nothing at all, which is why no test here sleeps.
+    QByteArray sentBytes()
+    {
+        announce(TN_DO, OPT_TIMING_MARK);
+        QByteArray marker;
+        marker.append(TN_IAC).append(TN_WONT).append(OPT_TIMING_MARK);
+        const bool arrived = QTest::qWaitFor(
+                [this, &marker]() {
+                    return mpServer->received().contains(marker);
+                },
+                10000);
+        if (!arrived) {
+            qWarning() << "the TIMING_MARK marker never came back, so what follows may be an incomplete capture";
+        }
+        QByteArray stream = mpServer->received();
+        // The marker belongs to the wait, not to the request under test.
+        const int markerAt = stream.indexOf(marker);
+        return markerAt >= 0 ? stream.left(markerAt) : stream;
+    }
+
+    // The NEW_ENVIRON replies in what Mudlet has sent since the last clear.
+    QList<Subnegotiation> newEnvironReplies() { return subnegotiationsFor(sentBytes(), static_cast<unsigned char>(OPT_NEW_ENVIRON)); }
+
+
+    // Turns the protocol on the way a game does, and leaves the recorder empty
+    // so the test only sees what its own request produced.
+    void enableNewEnviron()
+    {
+        announce(TN_WILL, OPT_NEW_ENVIRON);
+        QVERIFY2(mpHost->mTelnet.isNewEnvironEnabled(), "NEW_ENVIRON did not turn on, so nothing below would be answered");
+        mpServer->forgetReceived();
+    }
+
+    void requestSend(const QByteArray& body) { feed(subnegotiation(OPT_NEW_ENVIRON, QByteArray(1, NEW_ENVIRON_SEND) + body)); }
+
+    static QByteArray named(const char type, const QByteArray& name) { return QByteArray(1, type) + name; }
+
+    // The variables of the one reply a test expects, or an empty list and a
+    // description of what was captured instead - QCOMPARE cannot be used in a
+    // helper that returns a value, so the caller checks 'problem' first and gets
+    // a failure message that says what went wrong rather than "size 0 != 1".
+    QList<EnvironVariable> soleReplyVariables(const char expectedCommand, QString& problem)
+    {
+        problem.clear();
+        const QList<Subnegotiation> replies = newEnvironReplies();
+        if (replies.size() != 1) {
+            problem = qsl("expected exactly one NEW_ENVIRON reply, captured %1").arg(replies.size());
+            return {};
+        }
+        const QByteArray payload = replies.first().payload;
+        if (payload.isEmpty()) {
+            problem = qsl("the reply carried no command byte at all");
+            return {};
+        }
+        if (payload.at(0) != expectedCommand) {
+            problem = qsl("the reply's command byte was %1, expected %2").arg(QString::number(payload.at(0)), QString::number(expectedCommand));
+            return {};
+        }
+        return variablesIn(payload.mid(1));
+    }
+
+    static EnvironVariable variableNamed(const QList<EnvironVariable>& variables, const QByteArray& name)
+    {
+        for (const EnvironVariable& variable : variables) {
+            if (variable.name == name) {
+                return variable;
+            }
+        }
+        return EnvironVariable{};
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new RecordingTelnetServer(qApp);
+        QVERIFY2(mpServer->start(), "RecordingTelnetServer failed to bind a loopback port");
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15s), "The test profile never connected to the recording server.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // Every test starts from the preferences a fresh profile has, so one that
+    // turns MNES (or the protocol itself) off cannot decide what the next sees.
+    void init()
+    {
+        QVERIFY(mpHost);
+        mpHost->mEnableNEWENVIRON = true;
+        mpHost->mEnableMNES = false;
+        mpHost->mAdvertiseScreenReader = false;
+        mpHost->mEnableOSC8Hyperlinks = true;
+        mpServer->forgetReceived();
+    }
+
+    // The negotiation itself: an offer is taken up, and taken up only if the
+    // player left the protocol on.
+    void test_serverOfferIsAnsweredAccordingToThePreference()
+    {
+        announce(TN_WILL, OPT_NEW_ENVIRON);
+        QVERIFY2(mpHost->mTelnet.isNewEnvironEnabled(), "an offered NEW_ENVIRON was not turned on");
+        QByteArray expected;
+        expected.append(TN_IAC).append(TN_DO).append(OPT_NEW_ENVIRON);
+        QVERIFY2(sentBytes().contains(expected), "Mudlet did not answer WILL NEW-ENVIRON with DO");
+
+        mpServer->forgetReceived();
+        mpHost->mEnableNEWENVIRON = false;
+        announce(TN_WILL, OPT_NEW_ENVIRON);
+        QVERIFY2(!mpHost->mTelnet.isNewEnvironEnabled(), "NEW_ENVIRON stayed on after the player turned it off");
+        expected.clear();
+        expected.append(TN_IAC).append(TN_DONT).append(OPT_NEW_ENVIRON);
+        QVERIFY2(sentBytes().contains(expected), "Mudlet did not refuse NEW-ENVIRON with DONT when the preference was off");
+    }
+
+    // A bare SEND asks for everything Mudlet is prepared to say. All of it is
+    // sent as USERVAR, because the two RFC 1572 well-known names (USER and
+    // SYSTEMTYPE) are deliberately not advertised without an opt-in.
+    void test_bareSendReturnsEveryVariable()
+    {
+        enableNewEnviron();
+        requestSend({});
+
+        const QList<Subnegotiation> replies = newEnvironReplies();
+        QCOMPARE(replies.size(), 1);
+        QCOMPARE(replies.first().payload.at(0), NEW_ENVIRON_IS);
+
+        const QList<EnvironVariable> variables = variablesIn(replies.first().payload.mid(1));
+        QVERIFY2(variables.size() > 20, qPrintable(qsl("a bare SEND returned only %1 variables").arg(variables.size())));
+
+        for (const EnvironVariable& variable : variables) {
+            QVERIFY2(variable.type == NEW_ENVIRON_USERVAR, qPrintable(qsl("%1 was sent as a well-known VAR, which needs an opt-in").arg(QString::fromLatin1(variable.name))));
+        }
+
+        QCOMPARE(variableNamed(variables, "CLIENT_NAME").value, QByteArray("MUDLET"));
+        QCOMPARE(variableNamed(variables, "CHARSET").value, QByteArray("UTF-8"));
+        QCOMPARE(variableNamed(variables, "TERMINAL_TYPE").value, QByteArray("ANSI-TRUECOLOR"));
+        QCOMPARE(variableNamed(variables, "ANSI").value, QByteArray("1"));
+        QCOMPARE(variableNamed(variables, "VT100").value, QByteArray("0"));
+        QCOMPARE(variableNamed(variables, "WORD_WRAP").value, QByteArray::number(mpHost->mWrapAt));
+        QVERIFY2(!variableNamed(variables, "CLIENT_VERSION").value.isEmpty(), "CLIENT_VERSION came back without a version");
+    }
+
+    // Naming one variable gets that one and nothing else, which is what a game
+    // polling a single value relies on.
+    void test_namedUservarIsAnsweredOnItsOwn()
+    {
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_USERVAR, "CHARSET"));
+
+        QString problem;
+        const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(variables.size(), 1);
+        const EnvironVariable variable = variables.first();
+        QCOMPARE(variable.type, NEW_ENVIRON_USERVAR);
+        QCOMPARE(variable.name, QByteArray("CHARSET"));
+        QVERIFY(variable.hasValue);
+        QCOMPARE(variable.value, QByteArray("UTF-8"));
+    }
+
+    // RFC 1572 keeps the two namespaces apart: asked for a value Mudlet keeps as
+    // a USERVAR under the well-known VAR type, the answer has to be "not defined
+    // there" - a name with no VALUE after it - rather than the value.
+    void test_uservarAskedForAsAWellKnownVariableComesBackUndefined()
+    {
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_VAR, "CHARSET"));
+
+        QString problem;
+        const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(variables.size(), 1);
+        const EnvironVariable variable = variables.first();
+        QCOMPARE(variable.type, NEW_ENVIRON_VAR);
+        QCOMPARE(variable.name, QByteArray("CHARSET"));
+        QVERIFY2(!variable.hasValue, "a USERVAR was answered under the VAR type instead of being reported undefined there");
+    }
+
+    // A name Mudlet has never heard of is answered, not ignored: RFC 1572 wants
+    // the variable echoed with no VALUE so the game stops waiting on it.
+    void test_unknownVariableComesBackUndefined()
+    {
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_USERVAR, "NOT_A_MUDLET_VARIABLE"));
+
+        QString problem;
+        const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(variables.size(), 1);
+        const EnvironVariable variable = variables.first();
+        QCOMPARE(variable.type, NEW_ENVIRON_USERVAR);
+        QCOMPARE(variable.name, QByteArray("NOT_A_MUDLET_VARIABLE"));
+        QVERIFY2(!variable.hasValue, "a variable Mudlet does not maintain was answered with a value");
+    }
+
+    // A type byte with no name after it means "everything of this type", so the
+    // two types select different halves of the advertised set - and Mudlet's
+    // well-known half is deliberately empty.
+    void test_bareTypeByteSelectsThatTypeOnly()
+    {
+        enableNewEnviron();
+        requestSend(QByteArray(1, NEW_ENVIRON_USERVAR));
+        const QList<Subnegotiation> uservarReplies = newEnvironReplies();
+        QCOMPARE(uservarReplies.size(), 1);
+        const QList<EnvironVariable> uservars = variablesIn(uservarReplies.first().payload.mid(1));
+        QVERIFY2(uservars.size() > 20, qPrintable(qsl("a bare USERVAR returned only %1 variables").arg(uservars.size())));
+
+        mpServer->forgetReceived();
+        requestSend(QByteArray(1, NEW_ENVIRON_VAR));
+        const QList<Subnegotiation> varReplies = newEnvironReplies();
+        QCOMPARE(varReplies.size(), 1);
+        QCOMPARE(varReplies.first().payload.at(0), NEW_ENVIRON_IS);
+        QVERIFY2(variablesIn(varReplies.first().payload.mid(1)).isEmpty(), "well-known variables were advertised even though none are opted in to");
+    }
+
+    // A game may put any byte in a variable name, the protocol's own delimiters
+    // included, as long as it quotes them - and the echo has to quote them right
+    // back or the reply reads as several variables at the far end.
+    void test_specialBytesInARequestedNameAreQuotedInTheReply()
+    {
+        enableNewEnviron();
+
+        // IAC arrives doubled and is un-doubled by the telnet reader, so what
+        // reaches NEW_ENVIRON is one 0xFF; VAL and ESC are not telnet-special
+        // and arrive as themselves.
+        QByteArray rawName;
+        rawName.append('A').append(static_cast<char>(TN_IAC)).append(static_cast<char>(TN_IAC)).append('B').append(NEW_ENVIRON_ESC).append('C').append(NEW_ENVIRON_VAL).append('D');
+        requestSend(named(NEW_ENVIRON_USERVAR, rawName));
+
+        QByteArray expectedName;
+        expectedName.append('A').append(static_cast<char>(TN_IAC)).append('B').append(NEW_ENVIRON_ESC).append('C').append(NEW_ENVIRON_VAL).append('D');
+
+        QString problem;
+        const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(variables.size(), 1);
+        const EnvironVariable variable = variables.first();
+        QCOMPARE(variable.name, expectedName);
+        QVERIFY2(!variable.hasValue, "a name full of delimiters was matched against a variable Mudlet maintains");
+    }
+
+    // Two malformed requests that must produce nothing rather than a reply built
+    // from whatever the bytes happened to say: one too short to hold a command,
+    // and one whose command is not SEND.
+    void test_malformedRequestsAreIgnored()
+    {
+        enableNewEnviron();
+
+        feed(subnegotiation(OPT_NEW_ENVIRON, {}));
+        QVERIFY2(newEnvironReplies().isEmpty(), "a NEW_ENVIRON subnegotiation with no command byte was answered");
+
+        mpServer->forgetReceived();
+        feed(subnegotiation(OPT_NEW_ENVIRON, QByteArray(1, NEW_ENVIRON_IS) + named(NEW_ENVIRON_VAR, "CHARSET")));
+        QVERIFY2(newEnvironReplies().isEmpty(), "a NEW_ENVIRON request that was not a SEND was answered");
+    }
+
+    // Nothing at all goes out once the game has withdrawn the option, neither an
+    // answer to a request nor an unsolicited update.
+    void test_nothingIsSentOnceTheGameWithdrawsTheOption()
+    {
+        enableNewEnviron();
+        requestSend({});
+        QCOMPARE(newEnvironReplies().size(), 1);
+
+        announce(TN_WONT, OPT_NEW_ENVIRON);
+        QVERIFY2(!mpHost->mTelnet.isNewEnvironEnabled(), "a withdrawn NEW_ENVIRON was still marked enabled");
+
+        mpServer->forgetReceived();
+        requestSend({});
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("CHARSET"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "Mudlet kept answering NEW_ENVIRON after the game withdrew it");
+    }
+
+    // An INFO update is only owed to a game that asked for the variable in the
+    // first place - sending one for a variable it never requested tells it about
+    // a name it has no idea what to do with.
+    void test_infoIsSentOnlyForVariablesTheGameAskedFor()
+    {
+        enableNewEnviron();
+        requestSend({});
+        QCOMPARE(newEnvironReplies().size(), 1);
+
+        mpServer->forgetReceived();
+        mpHost->mAdvertiseScreenReader = true;
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
+
+        QString problem;
+        const QList<EnvironVariable> updates = soleReplyVariables(NEW_ENVIRON_INFO, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(updates.size(), 1);
+        const EnvironVariable updated = updates.first();
+        QCOMPARE(updated.type, NEW_ENVIRON_USERVAR);
+        QCOMPARE(updated.name, QByteArray("SCREEN_READER"));
+        QCOMPARE(updated.value, QByteArray("1"));
+
+        mpServer->forgetReceived();
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("NOT_A_MUDLET_VARIABLE"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "an INFO went out for a variable the game never requested");
+    }
+
+    // The hyperlink capabilities change together, so they are announced together
+    // - one subnegotiation the game sees as a single consistent state, not a run
+    // of partial ones.
+    void test_hyperlinkCapabilitiesAreAnnouncedInOneUpdate()
+    {
+        enableNewEnviron();
+        requestSend({});
+        QCOMPARE(newEnvironReplies().size(), 1);
+
+        mpServer->forgetReceived();
+        mpHost->mEnableOSC8Hyperlinks = false;
+        mpHost->mTelnet.sendInfoNewEnvironOSCHyperlinks();
+
+        const QList<Subnegotiation> replies = newEnvironReplies();
+        QCOMPARE(replies.size(), 1);
+        QCOMPARE(replies.first().payload.at(0), NEW_ENVIRON_INFO);
+
+        const QList<EnvironVariable> variables = variablesIn(replies.first().payload.mid(1));
+        QVERIFY2(variables.size() > 5, qPrintable(qsl("only %1 hyperlink variables were announced").arg(variables.size())));
+        for (const EnvironVariable& variable : variables) {
+            QVERIFY2(variable.name.startsWith("OSC_HYPERLINKS"), qPrintable(qsl("%1 rode along with the hyperlink update").arg(QString::fromLatin1(variable.name))));
+            QCOMPARE(variable.value, QByteArray("0"));
+        }
+    }
+
+    // MNES narrows the advertised set to five names and moves them into the
+    // well-known namespace, which is the whole difference between the two
+    // protocols on the wire.
+    void test_mnesAnswersItsFiveVariablesAsWellKnownOnes()
+    {
+        mpHost->mEnableMNES = true;
+        enableNewEnviron();
+        requestSend({});
+
+        const QList<Subnegotiation> replies = newEnvironReplies();
+        QCOMPARE(replies.size(), 1);
+        QCOMPARE(replies.first().payload.at(0), NEW_ENVIRON_IS);
+
+        const QList<EnvironVariable> variables = variablesIn(replies.first().payload.mid(1));
+        QCOMPARE(variables.size(), 5);
+        QStringList names;
+        for (const EnvironVariable& variable : variables) {
+            QCOMPARE(variable.type, NEW_ENVIRON_VAR);
+            names << QString::fromLatin1(variable.name);
+        }
+        names.sort();
+        QCOMPARE(names, QStringList({qsl("CHARSET"), qsl("CLIENT_NAME"), qsl("CLIENT_VERSION"), qsl("MTTS"), qsl("TERMINAL_TYPE")}));
+    }
+
+    // Under MNES a name outside that set is not Mudlet's to answer at all, while
+    // one inside it that Mudlet chooses not to supply is answered as maintained
+    // but empty. IPADDRESS is the deliberate example of the second.
+    void test_mnesAnswersOnlyMnesNames()
+    {
+        mpHost->mEnableMNES = true;
+        enableNewEnviron();
+
+        requestSend(named(NEW_ENVIRON_VAR, "ANSI"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "MNES answered a variable that is not part of MNES");
+
+        mpServer->forgetReceived();
+        requestSend(named(NEW_ENVIRON_VAR, "IPADDRESS"));
+        QString addressProblem;
+        const QList<EnvironVariable> addressReply = soleReplyVariables(NEW_ENVIRON_IS, addressProblem);
+        QVERIFY2(addressProblem.isEmpty(), qPrintable(addressProblem));
+        QCOMPARE(addressReply.size(), 1);
+        const EnvironVariable address = addressReply.first();
+        QCOMPARE(address.name, QByteArray("IPADDRESS"));
+        QVERIFY2(address.hasValue, "IPADDRESS was reported as a name MNES does not know rather than one Mudlet does not fill in");
+        QVERIFY2(address.value.isEmpty(), "Mudlet supplied an IP address, which it deliberately does not do");
+
+        mpServer->forgetReceived();
+        requestSend(named(NEW_ENVIRON_VAR, "CLIENT_NAME"));
+        QString clientNameProblem;
+        const QList<EnvironVariable> clientNameReply = soleReplyVariables(NEW_ENVIRON_IS, clientNameProblem);
+        QVERIFY2(clientNameProblem.isEmpty(), qPrintable(clientNameProblem));
+        QCOMPARE(clientNameReply.size(), 1);
+        const EnvironVariable clientName = clientNameReply.first();
+        QCOMPARE(clientName.name, QByteArray("CLIENT_NAME"));
+        QCOMPARE(clientName.value, QByteArray("MUDLET"));
+    }
+
+    // The MTTS bitvector is how a game learns MNES is on offer before it asks
+    // for anything, so the bit has to follow the preference.
+    void test_mnesIsAdvertisedInTheMttsBitvector()
+    {
+        QVERIFY2(!(mpHost->mTelnet.getNewEnvironDataMap().value(qsl("MTTS")).second.toInt() & MTTS_STD_MNES), "MNES was advertised in MTTS while it was turned off");
+
+        mpHost->mEnableMNES = true;
+        QVERIFY2(mpHost->mTelnet.getNewEnvironDataMap().value(qsl("MTTS")).second.toInt() & MTTS_STD_MNES, "MNES was not advertised in MTTS while it was turned on");
+
+        // MNES rides on NEW_ENVIRON, so it cannot be advertised without it.
+        mpHost->mEnableNEWENVIRON = false;
+        QVERIFY2(!(mpHost->mTelnet.getNewEnvironDataMap().value(qsl("MTTS")).second.toInt() & MTTS_STD_MNES), "MNES was advertised in MTTS with NEW_ENVIRON turned off");
+    }
+};
+
+#include "TelnetNewEnvironTest.moc"
+MUDLET_GROUPED_TEST_MAIN(TelnetNewEnvironTest)

--- a/test/functional_tests/TelnetNewEnvironTest.cpp
+++ b/test/functional_tests/TelnetNewEnvironTest.cpp
@@ -18,8 +18,8 @@
  ***************************************************************************/
 
 // NEW_ENVIRON (RFC 1572) and its MNES profile
-// (https://tintin.mudhalla.net/protocols/mnes/) are the one out-of-band
-// protocol whose whole point is what Mudlet *sends*: a game asks for variables
+// (https://tintin.mudhalla.net/protocols/mnes/) are the out-of-band protocol
+// where nearly all the behaviour is in what Mudlet *sends*: a game asks for variables
 // and every answer, every "I do not maintain that one", and every later INFO
 // update goes out on the wire, where nothing inside the client can see it. So
 // these tests read the bytes off a recording server rather than off Mudlet, and
@@ -156,9 +156,17 @@ private:
                 },
                 10000);
         if (!arrived) {
-            qWarning() << "the TIMING_MARK marker never came back, so what follows may be an incomplete capture";
+            // Mudlet answers a DO TIMING_MARK whatever else is going on, so this
+            // is never a slow reply - the connection is gone and every "nothing
+            // was sent" below would pass for the wrong reason.
+            QTest::qFail("the telnet marker never came back, so the capture is worthless", __FILE__, __LINE__);
+            return {};
         }
-        QByteArray stream = mpServer->received();
+        const QByteArray stream = mpServer->received();
+        // Cleared here rather than by the caller: a second call would otherwise
+        // match the first call's marker, skip its wait and hand back the earlier
+        // request's bytes.
+        mpServer->forgetReceived();
         // The marker belongs to the wait, not to the request under test.
         const int markerAt = stream.indexOf(marker);
         return markerAt >= 0 ? stream.left(markerAt) : stream;
@@ -168,8 +176,10 @@ private:
     QList<Subnegotiation> newEnvironReplies() { return subnegotiationsFor(sentBytes(), static_cast<unsigned char>(OPT_NEW_ENVIRON)); }
 
 
-    // Turns the protocol on the way a game does, and leaves the recorder empty
-    // so the test only sees what its own request produced.
+    // Turns the protocol on the way a game does, and clears the recorder. The DO
+    // that answers it can still land afterwards, which is why the assertions
+    // below filter to NEW_ENVIRON subnegotiations rather than reading the raw
+    // stream.
     void enableNewEnviron()
     {
         announce(TN_WILL, OPT_NEW_ENVIRON);
@@ -214,6 +224,20 @@ private:
             return {};
         }
         return variablesIn(payload.mid(1));
+    }
+
+    // How many hyperlink capabilities are on offer, counted off the advertised
+    // set rather than hard-coded, so one added later does not need this updating.
+    int advertisedHyperlinkVariables() const
+    {
+        const QMap<QString, QPair<bool, QString>> newEnvironDataMap = mpHost->mTelnet.getNewEnvironDataMap();
+        int advertised = 0;
+        for (auto it = newEnvironDataMap.cbegin(); it != newEnvironDataMap.cend(); ++it) {
+            if (it.key().startsWith(qsl("OSC_HYPERLINKS"))) {
+                ++advertised;
+            }
+        }
+        return advertised;
     }
 
     static EnvironVariable variableNamed(const QList<EnvironVariable>& variables, const QByteArray& name)
@@ -322,7 +346,10 @@ private slots:
         QCOMPARE(replies.first().payload.at(0), NEW_ENVIRON_IS);
 
         const QList<EnvironVariable> variables = variablesIn(replies.first().payload.mid(1));
-        QVERIFY2(variables.size() > 20, qPrintable(qsl("a bare SEND returned only %1 variables").arg(variables.size())));
+        // Exactly the advertised set, so a variable dropped from the reply is a
+        // failure rather than a number that still clears a loose floor.
+        QCOMPARE(variables.size(), mpHost->mTelnet.getNewEnvironDataMap().size());
+        QVERIFY2(variables.size() > 20, qPrintable(qsl("only %1 variables are advertised at all, so the comparison above proves little").arg(variables.size())));
 
         for (const EnvironVariable& variable : variables) {
             QVERIFY2(variable.type == NEW_ENVIRON_USERVAR, qPrintable(qsl("%1 was sent as a well-known VAR, which needs an opt-in").arg(QString::fromLatin1(variable.name))));
@@ -400,7 +427,7 @@ private slots:
         const QList<Subnegotiation> uservarReplies = newEnvironReplies();
         QCOMPARE(uservarReplies.size(), 1);
         const QList<EnvironVariable> uservars = variablesIn(uservarReplies.first().payload.mid(1));
-        QVERIFY2(uservars.size() > 20, qPrintable(qsl("a bare USERVAR returned only %1 variables").arg(uservars.size())));
+        QCOMPARE(uservars.size(), mpHost->mTelnet.getNewEnvironDataMap().size());
 
         mpServer->forgetReceived();
         requestSend(QByteArray(1, NEW_ENVIRON_VAR));
@@ -413,6 +440,14 @@ private slots:
     // A game may put any byte in a variable name, the protocol's own delimiters
     // included, as long as it quotes them - and the echo has to quote them right
     // back or the reply reads as several variables at the far end.
+    //
+    // The quoting is asserted on the raw capture rather than on the decoded name:
+    // an IAC that lost its doubling decodes to the same name, so only the bytes
+    // themselves can say whether it was quoted. NEW_ENVIRON_ESC quoting is not
+    // undone on the receive side, so the name that comes back carries the ESC
+    // bytes the game sent - that is Mudlet's behaviour today rather than what
+    // RFC 1572 asks for, and this pins it so a conformance fix is a deliberate
+    // change to this test and not a surprise.
     void test_specialBytesInARequestedNameAreQuotedInTheReply()
     {
         enableNewEnviron();
@@ -424,16 +459,90 @@ private slots:
         rawName.append('A').append(static_cast<char>(TN_IAC)).append(static_cast<char>(TN_IAC)).append('B').append(NEW_ENVIRON_ESC).append('C').append(NEW_ENVIRON_VAL).append('D');
         requestSend(named(NEW_ENVIRON_USERVAR, rawName));
 
+        const QByteArray wire = sentBytes();
+
+        // What a game reads off the socket: IAC doubled again for telnet, ESC
+        // and VAL each quoted with an ESC for NEW_ENVIRON.
+        QByteArray expectedOnTheWire;
+        expectedOnTheWire.append('A')
+                .append(static_cast<char>(TN_IAC))
+                .append(static_cast<char>(TN_IAC))
+                .append('B')
+                .append(NEW_ENVIRON_ESC)
+                .append(NEW_ENVIRON_ESC)
+                .append('C')
+                .append(NEW_ENVIRON_ESC)
+                .append(NEW_ENVIRON_VAL)
+                .append('D');
+        QVERIFY2(wire.contains(expectedOnTheWire), qPrintable(qsl("the reply did not quote the name it echoed; it reads %1").arg(QString::fromLatin1(wire.toHex(' ')))));
+
+        const QList<Subnegotiation> replies = subnegotiationsFor(wire, static_cast<unsigned char>(OPT_NEW_ENVIRON));
+        QCOMPARE(replies.size(), 1);
+        const QList<EnvironVariable> variables = variablesIn(replies.first().payload.mid(1));
+        QCOMPARE(variables.size(), 1);
+
         QByteArray expectedName;
         expectedName.append('A').append(static_cast<char>(TN_IAC)).append('B').append(NEW_ENVIRON_ESC).append('C').append(NEW_ENVIRON_VAL).append('D');
+        QCOMPARE(variables.first().name, expectedName);
+        QVERIFY2(!variables.first().hasValue, "a name full of delimiters was matched against a variable Mudlet maintains");
+    }
+
+    // A game asks for several variables in one SEND far more often than for one,
+    // and the parser carries state between them - the name it has collected is
+    // only flushed when the next type byte arrives. Asking for one name at a time
+    // never runs that flush.
+    void test_severalNamesInOneRequestAreAllAnswered()
+    {
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_USERVAR, "CHARSET") + named(NEW_ENVIRON_USERVAR, "ANSI") + named(NEW_ENVIRON_USERVAR, "TRUECOLOR"));
 
         QString problem;
         const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
         QVERIFY2(problem.isEmpty(), qPrintable(problem));
-        QCOMPARE(variables.size(), 1);
-        const EnvironVariable variable = variables.first();
-        QCOMPARE(variable.name, expectedName);
-        QVERIFY2(!variable.hasValue, "a name full of delimiters was matched against a variable Mudlet maintains");
+        QCOMPARE(variables.size(), 3);
+        QCOMPARE(variableNamed(variables, "CHARSET").value, QByteArray("UTF-8"));
+        QCOMPARE(variableNamed(variables, "ANSI").value, QByteArray("1"));
+        QCOMPARE(variableNamed(variables, "TRUECOLOR").value, QByteArray("1"));
+    }
+
+    // The two namespaces in one request, which is where the parser has to keep
+    // track of which type the name it is collecting belongs to.
+    void test_aRequestMixingBothNamespacesKeepsThemApart()
+    {
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_VAR, "CHARSET") + named(NEW_ENVIRON_USERVAR, "ANSI"));
+
+        QString problem;
+        const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(variables.size(), 2);
+
+        const EnvironVariable wellKnown = variableNamed(variables, "CHARSET");
+        QCOMPARE(wellKnown.type, NEW_ENVIRON_VAR);
+        QVERIFY2(!wellKnown.hasValue, "a name asked for under the well-known type came back with the USERVAR value");
+
+        const EnvironVariable userVar = variableNamed(variables, "ANSI");
+        QCOMPARE(userVar.type, NEW_ENVIRON_USERVAR);
+        QCOMPARE(userVar.value, QByteArray("1"));
+    }
+
+    // The other half of negotiation: a game that asks Mudlet to turn NEW_ENVIRON
+    // on, rather than offering to, and then withdraws its request.
+    void test_aRequestToEnableIsAnsweredAndCanBeWithdrawn()
+    {
+        announce(TN_DO, OPT_NEW_ENVIRON);
+        QVERIFY2(mpHost->mTelnet.isNewEnvironEnabled(), "a DO NEW-ENVIRON did not turn the protocol on");
+        QByteArray expected;
+        expected.append(TN_IAC).append(TN_WILL).append(OPT_NEW_ENVIRON);
+        QVERIFY2(sentBytes().contains(expected), "Mudlet did not answer DO NEW-ENVIRON with WILL");
+
+        mpServer->forgetReceived();
+        announce(TN_DONT, OPT_NEW_ENVIRON);
+        QVERIFY2(!mpHost->mTelnet.isNewEnvironEnabled(), "a DONT NEW-ENVIRON left the protocol on");
+
+        mpServer->forgetReceived();
+        requestSend({});
+        QVERIFY2(newEnvironReplies().isEmpty(), "Mudlet kept answering NEW_ENVIRON after the game withdrew its request");
     }
 
     // Two malformed requests that must produce nothing rather than a reply built
@@ -449,6 +558,12 @@ private slots:
         mpServer->forgetReceived();
         feed(subnegotiation(OPT_NEW_ENVIRON, QByteArray(1, NEW_ENVIRON_IS) + named(NEW_ENVIRON_VAR, "CHARSET")));
         QVERIFY2(newEnvironReplies().isEmpty(), "a NEW_ENVIRON request that was not a SEND was answered");
+
+        // The control: a well-formed request over the same connection is still
+        // answered, so neither silence above can be the capture having died.
+        mpServer->forgetReceived();
+        requestSend(named(NEW_ENVIRON_USERVAR, "CHARSET"));
+        QCOMPARE(newEnvironReplies().size(), 1);
     }
 
     // Nothing at all goes out once the game has withdrawn the option, neither an
@@ -537,7 +652,8 @@ private slots:
         QCOMPARE(replies.first().payload.at(0), NEW_ENVIRON_INFO);
 
         const QList<EnvironVariable> variables = variablesIn(replies.first().payload.mid(1));
-        QVERIFY2(variables.size() > 5, qPrintable(qsl("only %1 hyperlink variables were announced").arg(variables.size())));
+        QCOMPARE(variables.size(), advertisedHyperlinkVariables());
+        QVERIFY2(advertisedHyperlinkVariables() > 10, "too few hyperlink capabilities are advertised for the comparison above to prove anything");
         for (const EnvironVariable& variable : variables) {
             QVERIFY2(variable.name.startsWith("OSC_HYPERLINKS"), qPrintable(qsl("%1 rode along with the hyperlink update").arg(QString::fromLatin1(variable.name))));
             QCOMPARE(variable.value, QByteArray("0"));
@@ -545,8 +661,7 @@ private slots:
     }
 
     // MNES narrows the advertised set to five names and moves them into the
-    // well-known namespace, which is the whole difference between the two
-    // protocols on the wire.
+    // well-known namespace.
     void test_mnesAnswersItsFiveVariablesAsWellKnownOnes()
     {
         mpHost->mEnableMNES = true;
@@ -570,7 +685,8 @@ private slots:
 
     // Under MNES a name outside that set is not Mudlet's to answer at all, while
     // one inside it that Mudlet chooses not to supply is answered as maintained
-    // but empty. IPADDRESS is the deliberate example of the second.
+    // but empty. IPADDRESS reaches the second path by being in the MNES name list
+    // and absent from the data map.
     void test_mnesAnswersOnlyMnesNames()
     {
         mpHost->mEnableMNES = true;

--- a/test/functional_tests/TelnetNewEnvironTest.cpp
+++ b/test/functional_tests/TelnetNewEnvironTest.cpp
@@ -179,6 +179,17 @@ private:
 
     void requestSend(const QByteArray& body) { feed(subnegotiation(OPT_NEW_ENVIRON, QByteArray(1, NEW_ENVIRON_SEND) + body)); }
 
+    // A fresh connection, which is the one thing that clears the record of what
+    // this game has asked for so far - it outlives a test method otherwise.
+    void reconnect()
+    {
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        mpHost->mTelnet.disconnectIt();
+        mpHost->mTelnet.reconnect();
+        QVERIFY2(connected.wait(15s), "the profile did not come back after a reconnect");
+        mpServer->forgetReceived();
+    }
+
     static QByteArray named(const char type, const QByteArray& name) { return QByteArray(1, type) + name; }
 
     // The variables of the one reply a test expects, or an empty list and a
@@ -457,10 +468,10 @@ private slots:
         QVERIFY2(newEnvironReplies().isEmpty(), "Mudlet kept answering NEW_ENVIRON after the game withdrew it");
     }
 
-    // An INFO update is only owed to a game that asked for the variable in the
-    // first place - sending one for a variable it never requested tells it about
-    // a name it has no idea what to do with.
-    void test_infoIsSentOnlyForVariablesTheGameAskedFor()
+    // A preference the game has already been told about is worth an INFO when it
+    // changes, carrying the new value under the same type the original answer
+    // used - anything else and the game files the update under a second name.
+    void test_infoUpdateCarriesTheNewValue()
     {
         enableNewEnviron();
         requestSend({});
@@ -478,10 +489,34 @@ private slots:
         QCOMPARE(updated.type, NEW_ENVIRON_USERVAR);
         QCOMPARE(updated.name, QByteArray("SCREEN_READER"));
         QCOMPARE(updated.value, QByteArray("1"));
+    }
 
+    // An INFO is only owed to a game that asked for the variable in the first
+    // place: one it never requested arrives as a name it has no idea what to do
+    // with. The reconnect is what makes that testable, since the record of what
+    // has been asked for is only cleared by a fresh connection.
+    void test_noInfoIsSentForAVariableTheGameNeverAskedFor()
+    {
+        reconnect();
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_USERVAR, "CHARSET"));
+        QCOMPARE(newEnvironReplies().size(), 1);
+
+        // In the advertised set, and its value has changed, but this game has
+        // only ever asked about CHARSET.
         mpServer->forgetReceived();
-        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("NOT_A_MUDLET_VARIABLE"));
-        QVERIFY2(newEnvironReplies().isEmpty(), "an INFO went out for a variable the game never requested");
+        mpHost->mAdvertiseScreenReader = true;
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "an INFO went out for a variable the game never asked for");
+
+        // The control: the one variable it did ask about is still updated.
+        mpServer->forgetReceived();
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("CHARSET"));
+        QString problem;
+        const QList<EnvironVariable> updates = soleReplyVariables(NEW_ENVIRON_INFO, problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(updates.size(), 1);
+        QCOMPARE(updates.first().name, QByteArray("CHARSET"));
     }
 
     // The hyperlink capabilities change together, so they are announced together

--- a/test/functional_tests/TelnetNewEnvironTest.cpp
+++ b/test/functional_tests/TelnetNewEnvironTest.cpp
@@ -506,11 +506,13 @@ private slots:
     }
 
     // The two namespaces in one request, which is where the parser has to keep
-    // track of which type the name it is collecting belongs to.
+    // track of which type the name it is collecting belongs to. The USERVAR comes
+    // first so the name before the switch is flushed by the well-known arm - the
+    // mirror of the arm the all-USERVAR request above runs.
     void test_aRequestMixingBothNamespacesKeepsThemApart()
     {
         enableNewEnviron();
-        requestSend(named(NEW_ENVIRON_VAR, "CHARSET") + named(NEW_ENVIRON_USERVAR, "ANSI"));
+        requestSend(named(NEW_ENVIRON_USERVAR, "ANSI") + named(NEW_ENVIRON_VAR, "CHARSET"));
 
         QString problem;
         const QList<EnvironVariable> variables = soleReplyVariables(NEW_ENVIRON_IS, problem);
@@ -715,6 +717,29 @@ private slots:
         const EnvironVariable clientName = clientNameReply.first();
         QCOMPARE(clientName.name, QByteArray("CLIENT_NAME"));
         QCOMPARE(clientName.value, QByteArray("MUDLET"));
+    }
+
+    // MNES has its own request parser, with the same flush-on-the-next-name shape
+    // and the same hole if only one name is ever asked for.
+    void test_severalMnesNamesInOneRequestAreAllAnswered()
+    {
+        mpHost->mEnableMNES = true;
+        enableNewEnviron();
+        requestSend(named(NEW_ENVIRON_VAR, "CLIENT_NAME") + named(NEW_ENVIRON_VAR, "CHARSET") + named(NEW_ENVIRON_VAR, "TERMINAL_TYPE"));
+
+        // MNES answers a name at a time rather than gathering them into one IS.
+        const QList<Subnegotiation> replies = newEnvironReplies();
+        QCOMPARE(replies.size(), 3);
+
+        QList<EnvironVariable> answered;
+        for (const Subnegotiation& reply : replies) {
+            QCOMPARE(reply.payload.at(0), NEW_ENVIRON_IS);
+            answered.append(variablesIn(reply.payload.mid(1)));
+        }
+        QCOMPARE(answered.size(), 3);
+        QCOMPARE(variableNamed(answered, "CLIENT_NAME").value, QByteArray("MUDLET"));
+        QCOMPARE(variableNamed(answered, "CHARSET").value, QByteArray("UTF-8"));
+        QCOMPARE(variableNamed(answered, "TERMINAL_TYPE").value, QByteArray("ANSI-TRUECOLOR"));
     }
 
     // The MTTS bitvector is how a game learns MNES is on offer before it asks

--- a/test/functional_tests/TelnetOptionsReportTest.cpp
+++ b/test/functional_tests/TelnetOptionsReportTest.cpp
@@ -20,15 +20,14 @@
 // cTelnet::decodeOption() names every telnet option Mudlet can meet, and the
 // "Telnet Options:" block of the statistics report is its only caller outside
 // the DEBUG_TELNET builds - so what a player is shown when they ask what was
-// negotiated is exactly this table. Nothing exercised it, which left the whole
-// switch (and the report that reads it) at zero coverage: an option constant
-// renumbered on one side only would have been reported under the wrong name
-// with nothing to say so.
+// negotiated is exactly this table, and an option constant renumbered on one
+// side only is reported under the wrong name with nothing to say so.
 //
-// The report is driven from heAnnouncedState, which processTelnetCommand() sets
-// for every option a server announces - including ones Mudlet goes on to refuse
-// - so announcing the whole 0-255 range in one pass reaches every arm of the
-// switch, the unofficial numbers and the UNKNOWN fallback included.
+// The report lists an option that either side announced. The sweep below leans
+// on the server half, heAnnouncedState, which processTelnetCommand() sets for
+// every option a server announces - including ones Mudlet goes on to refuse - so
+// announcing the whole 0-255 range in one pass reaches every arm of the switch,
+// the unofficial numbers and the UNKNOWN fallback included.
 
 #include <QFileInfo>
 #include <QTemporaryDir>
@@ -59,7 +58,7 @@ private:
     Host* mpHost = nullptr;
     const QString mHostname = qsl("Test-Telnet-Options-Report");
     const QString mLocalhost = qsl("localhost");
-    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    QString mPort;
 
     // setupConfig() consults portable.txt before the XDG logic
     static bool portableMarkerPresent()
@@ -169,7 +168,6 @@ private slots:
         qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
 
         mpServer = new TelnetServerStub(qApp);
-        // An ephemeral OS-assigned port, so concurrent test runs cannot collide.
         mpServer->start(mLocalhost, 0);
         QVERIFY2(mpServer->isListening(), "TelnetServerStub failed to bind a loopback port");
         mPort = QString::number(mpServer->serverPort());
@@ -260,6 +258,11 @@ private slots:
 
         const QString report = mpHost->mTelnet.assembleTelnetOptionsReport();
         QCOMPARE(report.count(QLatin1Char('\n')), 256);
+
+        // TTYPE was announced by Mudlet in the test above and by the server here,
+        // so its line is the one that carries both halves - the join nothing else
+        // in this file reaches.
+        QCOMPARE(lineFor(report, qsl("TTYPE (24)")), qsl("  TTYPE (24): server enabled, client enabled"));
 
         const QHash<int, QString> named = expectedOptionNames();
         for (int option = 0; option <= 255; ++option) {

--- a/test/functional_tests/TelnetOptionsReportTest.cpp
+++ b/test/functional_tests/TelnetOptionsReportTest.cpp
@@ -1,0 +1,289 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// cTelnet::decodeOption() names every telnet option Mudlet can meet, and the
+// "Telnet Options:" block of the statistics report is its only caller outside
+// the DEBUG_TELNET builds - so what a player is shown when they ask what was
+// negotiated is exactly this table. Nothing exercised it, which left the whole
+// switch (and the report that reads it) at zero coverage: an option constant
+// renumbered on one side only would have been reported under the wrong name
+// with nothing to say so.
+//
+// The report is driven from heAnnouncedState, which processTelnetCommand() sets
+// for every option a server announces - including ones Mudlet goes on to refuse
+// - so announcing the whole 0-255 range in one pass reaches every arm of the
+// switch, the unofficial numbers and the UNKNOWN fallback included.
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class TelnetOptionsReportTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-Telnet-Options-Report");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    // The names decodeOption() is contracted to produce. Held here rather than
+    // read back off the function under test, so a renumbered constant or a
+    // mistyped name is a failure instead of a report that agrees with itself.
+    static QHash<int, QString> expectedOptionNames()
+    {
+        return {{0, qsl("BINARY (0)")},
+                {1, qsl("ECHO (1)")},
+                {2, qsl("RECONNECTION (2)")},
+                {3, qsl("SUPPRESS_GO_AHEAD (3)")},
+                {4, qsl("APPROX_MSG_SIZE (4)")},
+                {5, qsl("STATUS (5)")},
+                {6, qsl("TIMING_MARK (6)")},
+                {7, qsl("REMOTE_CTRL_TRANS_AND_ECHO (7)")},
+                {8, qsl("OUTPUT_L_WIDTH (8)")},
+                {9, qsl("OUTPUT_P_SIZE (9)")},
+                {10, qsl("OUTPUT_CR_DISPOSITION (10)")},
+                {11, qsl("OUTPUT_HTAB_STOPS (11)")},
+                {12, qsl("OUTPUT_HTAB_DISPOSITION (12)")},
+                {13, qsl("OUTPUT_FF_DISPOSITION (13)")},
+                {14, qsl("OUTPUT_VTAB_STOPS (14)")},
+                {15, qsl("OUTPUT_VTAB_DISPOSITION (15)")},
+                {16, qsl("OUTPUT_LF_DISPOSITION (16)")},
+                {17, qsl("EXTENDED_ASCII (17)")},
+                {18, qsl("LOGOUT (18)")},
+                {19, qsl("BYTE_MACRO (19)")},
+                {20, qsl("DATA_ENTRY_TERMINAL (20)")},
+                {21, qsl("SUPDUP (21)")},
+                {22, qsl("SUPDUP_OUTPUT (22)")},
+                {23, qsl("SEND_LOCATION (23)")},
+                {24, qsl("TTYPE (24)")},
+                {25, qsl("EOR (25)")},
+                {26, qsl("TACACS_USER_ID (26)")},
+                {27, qsl("OUTPUT_MARKING (27)")},
+                {28, qsl("TERMINAL_LOCATION_NUMBER (28)")},
+                {29, qsl("TELNET_3270_REGIME (29)")},
+                {30, qsl("X3_PAD (30)")},
+                {31, qsl("NAWS (31)")},
+                {32, qsl("TERMINAL_SPEED (32)")},
+                {33, qsl("REMOTE_FLOW_CONTROL (33)")},
+                {34, qsl("LINEMODE (34)")},
+                {35, qsl("X_DISPLAY_LOCATION (35)")},
+                {36, qsl("ENVIRONMENT_OPTION (36)")},
+                {37, qsl("AUTHENTICATION_OPTION (37)")},
+                {38, qsl("ENCRYPTION_OPTION (38)")},
+                {39, qsl("NEW-ENVIRON (39)")},
+                {40, qsl("TN3270E (40)")},
+                {41, qsl("XAUTH (41)")},
+                {42, qsl("CHARSET (42)")},
+                {43, qsl("TELNET_REMOTE_SERIAL_PORT (43)")},
+                {44, qsl("COM_PORT_CONTROL_OPTION (44)")},
+                {45, qsl("TELNET_SUPPRESS_LOCAL_ECHO (45)")},
+                {46, qsl("TELNET_START_TLS (46)")},
+                {47, qsl("KERMIT (47)")},
+                {48, qsl("SEND_URL (48)")},
+                {49, qsl("FORWARD_X (49)")},
+                {69, qsl("MSDP (69)")},
+                {70, qsl("MSSP (70)")},
+                {85, qsl("MCCP (85)")},
+                {86, qsl("MCCP2 (86)")},
+                {87, qsl("MCCP3 (87)")},
+                {88, qsl("MCCP4 (88)")},
+                {90, qsl("MSP (90)")},
+                {91, qsl("MXP (91)")},
+                {93, qsl("ZENITH (93)")},
+                {102, qsl("AARDWOLF (102)")},
+                {138, qsl("TELOPT_PRAGMA_LOGON (138)")},
+                {139, qsl("TELOPT_SSPI_LOGON (139)")},
+                {140, qsl("TELOPT_PRAGMA_HEARTBEAT (140)")},
+                {200, qsl("ATCP (200)")},
+                {201, qsl("GMCP (201)")},
+                {255, qsl("EXTENDED_OPTIONS_LIST (255)")}};
+    }
+
+    // Feeds one IAC <command> <option> as if the server had sent it. Loopback
+    // rather than the socket, so the whole sequence is processed before the call
+    // returns and no wait is needed for the state it leaves behind.
+    void announce(const char command, const int option)
+    {
+        QByteArray data;
+        data.append(TN_IAC).append(command).append(static_cast<char>(static_cast<unsigned char>(option)));
+        mpHost->mTelnet.loopbackTest(data);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        // An ephemeral OS-assigned port, so concurrent test runs cannot collide.
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), "TelnetServerStub failed to bind a loopback port");
+        mPort = QString::number(mpServer->serverPort());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        // The report's "server"/"client" and "enabled"/"disabled" words go
+        // through tr(), so without pinning a language the assertions below would
+        // hold or not depending on the runner's locale. The option names
+        // themselves are deliberately not translated.
+        mudlet::self()->setInterfaceLanguage(qsl("en_US"));
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, mPort);
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15s), "The test profile never connected to the stub server.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // Both sides of the report, and the four state words it can pick, on a
+    // connection where only these four options have been negotiated. This runs
+    // before the sweep below, which sets every bit there is and so leaves no
+    // option whose absence could still be shown.
+    void test_reportDistinguishesTheTwoSidesAndTheirStates()
+    {
+        QVERIFY(mpHost);
+
+        const QString untouched = mpHost->mTelnet.assembleTelnetOptionsReport();
+        QCOMPARE(untouched.count(QLatin1Char('\n')), 1);
+        QVERIFY2(!untouched.contains(QLatin1String("(24)")), qPrintable(qsl("options were already negotiated before the test announced any: %1").arg(untouched)));
+
+        // Server side, accepted: Mudlet answers a WILL NAWS with DO.
+        announce(TN_WILL, OPT_NAWS);
+        // Server side, refused: Mudlet operates in line mode, so LINEMODE is
+        // announced by the server and turned down.
+        announce(TN_WILL, OPT_LINEMODE);
+        // Client side, accepted: a DO TERMINAL_TYPE is answered with WILL.
+        announce(TN_DO, OPT_TERMINAL_TYPE);
+        // Client side, refused: nothing answers a DO SEND_LOCATION but WONT.
+        announce(TN_DO, 23);
+
+        const QString report = mpHost->mTelnet.assembleTelnetOptionsReport();
+        QCOMPARE(report.count(QLatin1Char('\n')), 4);
+
+        // An option only the server announced has no client half, and one only
+        // Mudlet answered has no server half - so the side each line names is
+        // as much a part of the report as the option name is.
+        QCOMPARE(lineFor(report, qsl("NAWS (31)")), qsl("  NAWS (31): server enabled"));
+        QCOMPARE(lineFor(report, qsl("LINEMODE (34)")), qsl("  LINEMODE (34): server disabled"));
+        QCOMPARE(lineFor(report, qsl("TTYPE (24)")), qsl("  TTYPE (24): client enabled"));
+        QCOMPARE(lineFor(report, qsl("SEND_LOCATION (23)")), qsl("  SEND_LOCATION (23): client disabled"));
+    }
+
+    // Every arm of decodeOption(), by announcing the whole option number space:
+    // the official names, the unofficial ones, and the UNKNOWN fallback for the
+    // numbers with no name. heAnnouncedState is set before any option-specific
+    // handling, so an option Mudlet refuses is reported just the same.
+    void test_everyAnnouncedOptionIsNamedInTheReport()
+    {
+        QVERIFY(mpHost);
+
+        QByteArray sweep;
+        for (int option = 0; option <= 255; ++option) {
+            sweep.append(TN_IAC).append(TN_WILL).append(static_cast<char>(static_cast<unsigned char>(option)));
+        }
+        mpHost->mTelnet.loopbackTest(sweep);
+
+        const QString report = mpHost->mTelnet.assembleTelnetOptionsReport();
+        QCOMPARE(report.count(QLatin1Char('\n')), 256);
+
+        const QHash<int, QString> named = expectedOptionNames();
+        for (int option = 0; option <= 255; ++option) {
+            // Every name carries its own number, so a plain search cannot match
+            // the wrong line - and the fallback has to spell the number out too.
+            const QString expected = named.value(option, qsl("UNKNOWN (%1)").arg(option));
+            QVERIFY2(report.contains(expected),
+                     qPrintable(qsl("option %1 was not reported as \"%2\"; its line reads \"%3\"").arg(QString::number(option), expected, lineFor(report, qsl("(%1)").arg(option)))));
+        }
+    }
+
+private:
+    // The single report line containing 'needle', for failure messages.
+    static QString lineFor(const QString& report, const QString& needle)
+    {
+        const QStringList lines = report.split(QLatin1Char('\n'));
+        for (const QString& line : lines) {
+            if (line.contains(needle)) {
+                return line;
+            }
+        }
+        return QString();
+    }
+};
+
+#include "TelnetOptionsReportTest.moc"
+MUDLET_GROUPED_TEST_MAIN(TelnetOptionsReportTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Three functional tests join the telnet group binary, plus the listen-only server stub the last two read their bytes off. No production code is touched.

- `TelnetOptionsReportTest` - the "Telnet Options:" block of `stats`, and through it every arm of `cTelnet::decodeOption()`, by announcing all 256 option numbers in one pass.
- `TelnetNewEnvironTest` - NEW_ENVIRON (RFC 1572) and MNES, asserted on the bytes Mudlet sends rather than on state inside the client.
- `TelnetAtcpMspTest` - ATCP variables, the composer and its two reply shapes, and MSP message parsing.

#### Motivation for adding to Mudlet

`ctelnet.cpp` was the weakest large file in the coverage baseline, and its out-of-band protocol handling was the bulk of what was missing: `decodeOption()` and the report that reads it had never been executed at all, so an option constant renumbered on one side only would have been shown to players under the wrong name with nothing to say so.

What Mudlet *replies* with over NEW_ENVIRON is only visible server-side, which is why this is C++ rather than a busted spec.

Measured on `src/ctelnet.cpp`: **44.0% -> 67.5%** line coverage, 736 previously-unexecuted lines.

#### Other info (issues closed, discussion etc)

**Test case:** 47 cases across the three classes. Each one was mutation-verified - the product path it covers was broken and exactly that case confirmed red, then restored - across 8 batches of 41 mutations. Two examples: dropping the IAC doubling in `prepareNewEnvironData()` reddens only the quoting test, and renumbering one `decodeOption()` arm reddens only the option sweep.

Green under `linux-debug` with `detect_leaks=1` and no leak reports; the whole 14-test telnet group passes; stable over five sequential and two concurrent runs (every port is bound as 0 and read back).

`cTelnet::decodeOption()` lines 1882-1981, which the baseline measured at zero, are reachable: `assembleTelnetOptionsReport()` calls it for every option either side announced, and `TMainConsole::showStatistics()` calls that. Not dead code.

Assisted-by: Claude:claude-opus-5