### PR TITLE
Fix: Geyser menu parents and user window dock position

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -773,7 +773,12 @@ end
 local function createMenus(self, parent, name, func)
     local label = self.adjLabel
     local menuTxt = self.Locale[name] and self.Locale[name].message or name
-    label:addMenuLabel(name, parent)
+    -- addMenuLabel reports a parent it cannot use rather than raising, and the
+    -- two lines below would then index a nil menu element instead of saying why
+    local added, err = label:addMenuLabel(name, parent)
+    if not added then
+        error(err)
+    end
     label:findMenuElement(parent.."."..name):echo(menuTxt, "nocolor")
     label:setMenuAction(parent.."."..name, func, self, name)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -1344,7 +1344,7 @@ function Geyser.Label:findMenuElement(name, parent, findParent)
     end
     if type(item) == "table" then
       local itemParent = menu[i-1]
-      local element, menuTable = self:findMenuElement(name, parent.MenuLabels[itemParent])
+      local element, menuTable = self:findMenuElement(name, parent.MenuLabels[itemParent], findParent)
       if element then
         return element, menuTable
       end
@@ -1406,11 +1406,16 @@ end
 -- @param name Name of the new menu item.
 -- @param parent name of the parent where the new item will be created in (optional)
 -- @param index of the new menu item (optional)
+-- @return true, or false plus an error message when the parent could not be found
 function Geyser.Label:addMenuLabel(name, parent, index)
   local menuElement, menuParent = self:findMenuElement(parent, self.rightClickMenu, true)
 
-  if parent and not menuParent then
-    error ("showMenuLabel: Couldn't find menu parent "..parent)
+  -- findMenuElement answers nil plus a message rather than nil plus nil, so the
+  -- element it did not find is what tells a missing parent apart from a found
+  -- one. A parent declared without a submenu table for its children is a miss
+  -- here too, because there is no table to hang the new item off.
+  if parent and not menuElement then
+    return false, "addMenuLabel: Couldn't find menu parent "..parent
   end
 
   menuElement = menuElement or self.rightClickMenu
@@ -1433,6 +1438,8 @@ function Geyser.Label:addMenuLabel(name, parent, index)
   if index then
     self:changeMenuIndex(parent..name, index)
   end
+
+  return true
 end
 
 --- changes a right click menu items index

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -1405,15 +1405,22 @@ end
 --- adds a new item to the right click menu
 -- @param name Name of the new menu item.
 -- @param parent name of the parent where the new item will be created in (optional)
--- @param index of the new menu item (optional)
--- @return true, or false plus an error message when the parent could not be found
+-- @param index of the new menu item (optional). Not usable together with a nested
+--        parent: an item is named for the parent it sits in, so the index lookup
+--        misses and raises.
+-- @return true, or false plus a message when the item cannot be added
 function Geyser.Label:addMenuLabel(name, parent, index)
+  if type(name) ~= "string" then
+    return false, "addMenuLabel: needs the name of the item to add as a string, got "..type(name)
+  end
+
   local menuElement, menuParent = self:findMenuElement(parent, self.rightClickMenu, true)
 
-  -- findMenuElement answers nil plus a message rather than nil plus nil, so the
-  -- element it did not find is what tells a missing parent apart from a found
-  -- one. A parent declared without a submenu table for its children is a miss
-  -- here too, because there is no table to hang the new item off.
+  -- findMenuElement reports failure as nil plus a message, so the second return
+  -- is a string rather than nil when it fails and cannot be tested for absence -
+  -- the element is what has to be checked. With findParent set it only answers
+  -- for a parent that is followed by a submenu table, so a parent declared
+  -- without one lands here as well: appending to it has nowhere to go.
   if parent and not menuElement then
     return false, "addMenuLabel: Couldn't find menu parent "..parent
   end

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -60,7 +60,15 @@ end
 --@param pos possible positions are "top", "bottom","left", "right" and "floating"
 function Geyser.UserWindow:setDockPosition(pos)
   self.dockPosition = pos
-  return openUserWindow(self.name, false, self.autoDock, pos)
+  local docked = openUserWindow(self.name, false, self.autoDock, pos)
+  -- reopening the dock puts the window back on screen whether it was hidden or
+  -- not, so a window that still believes itself hidden is shown properly rather
+  -- than left desynced: Geyser.Container:hide() skips anything already hidden,
+  -- which would otherwise make the next hide() do nothing
+  if self.hidden or self.auto_hidden then
+    self:show()
+  end
+  return docked
 end
 
 --- Enables the automatic docking at the borders if it was previously disabled

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -61,11 +61,11 @@ end
 function Geyser.UserWindow:setDockPosition(pos)
   self.dockPosition = pos
   local docked = openUserWindow(self.name, false, self.autoDock, pos)
-  -- reopening the dock puts the window back on screen whether it was hidden or
-  -- not, so a window that still believes itself hidden is shown properly rather
-  -- than left desynced: Geyser.Container:hide() skips anything already hidden,
-  -- which would otherwise make the next hide() do nothing
-  if self.hidden or self.auto_hidden then
+  -- opening the dock brings the window back on screen, so leaving self.hidden
+  -- set would make the next hide() a no-op: Geyser.Container:hide() skips the
+  -- widget for anything that already believes itself hidden. auto_hidden is
+  -- deliberately left alone: clearing that one is the container cascade's job.
+  if self.hidden then
     self:show()
   end
   return docked

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -1869,6 +1869,23 @@ describe("Tests Adjustable.Container borders, persistence and menu items", funct
       assert.are.equal(itemCount, #container.customItems)
     end)
 
+    it("newCustomItem says which menu parent is missing", function()
+      -- addMenuLabel answers rather than raising, so without that answer being
+      -- checked this comes out as a nil index on the line after it
+      local container = make("gapCustomItemNoParent")
+      -- take the submenu table away from "customItemsLabel", so it is still in
+      -- the menu but has nowhere to put a child. Removing the label itself
+      -- instead would orphan that table, and findMenuElement recurses forever
+      -- on a submenu whose parent entry is gone.
+      local menuItems = container.adjLabel.rightClickMenu.MenuItems
+      table.remove(menuItems, table.index_of(menuItems, "customItemsLabel") + 1)
+
+      local ok, message = pcall(function() container:newCustomItem("gapOrphan", function() end) end)
+
+      assert.is_false(ok)
+      assert.is_truthy(tostring(message):find("Couldn't find menu parent customItemsLabel", 1, true))
+    end)
+
     it("customMenu does nothing while the container is minimized", function()
       local container = make("gapCustomMinimized")
       local runs = 0

--- a/src/mudlet-lua/tests/GeyserLabel_spec.lua
+++ b/src/mudlet-lua/tests/GeyserLabel_spec.lua
@@ -1449,9 +1449,19 @@ describe("Tests Geyser.Label right click menus", function()
 
       local element, submenu = other:findMenuElement("A.B", other.rightClickMenu, true)
 
-      assert.are.equal(other:findMenuElement("A.B"), element)
-      -- B's own children, not the table B itself is an entry in
+      -- the submenu hanging off B, not the submenu B is itself listed in
       assert.are.same({"C"}, submenu)
+      assert.are.equal(other:findMenuElement("A.B"), element)
+    end)
+
+    it("names an item for the parent it sits in, not for its whole path", function()
+      -- this is what makes an item added under "A.B" answer to "B.D", and it is
+      -- why a name with more than one dot in it never resolves
+      local other = Geyser.Label:new({name = "glmDeepName", x = 0, y = 0, width = 100, height = 30})
+      other:createRightClickMenu({MenuItems = {"A", {"B", {"C"}}}})
+
+      assert.is_not_nil(other:findMenuElement("B.C"))
+      assert.is_nil(other:findMenuElement("A.B.C"))
     end)
   end)
 
@@ -1514,7 +1524,7 @@ describe("Tests Geyser.Label right click menus", function()
     end)
 
     it("adds an item at the index it is given", function()
-      label:addMenuLabel("Fourth", nil, 2)
+      assert.is_true(label:addMenuLabel("Fourth", nil, 2))
       assert.are.same({"First", "Fourth", "Second", "Third"}, menuOrder())
     end)
 
@@ -1554,21 +1564,32 @@ describe("Tests Geyser.Label right click menus", function()
       assert.is_true(added)
     end)
 
+    it("reports a name it cannot make an item out of", function()
+      -- without this the menu takes the value as an entry and answers true, so
+      -- the caller is told an item was added that createMenuItems then skips
+      local added, message = label:addMenuLabel(5)
+
+      assert.is_false(added)
+      assert.is_truthy(message:find("addMenuLabel: needs the name of the item to add", 1, true))
+      assert.are.same({"First", "Second", "Third"}, menuOrder())
+    end)
+
     it("reports a parent it cannot find rather than raising", function()
       local added, message = label:addMenuLabel("Child", "Nowhere")
 
       assert.is_false(added)
-      assert.are.equal("addMenuLabel: Couldn't find menu parent Nowhere", message)
+      assert.is_truthy(message:find("addMenuLabel: Couldn't find menu parent Nowhere", 1, true))
       assert.are.same({"First", "Second", "Third"}, menuOrder())
     end)
 
     it("reports a parent that was declared without a submenu", function()
-      -- "Second" is a plain entry rather than one followed by a table of its
-      -- children, so there is nothing to add an item to
+      -- addMenuLabel appends to a submenu, it does not make one, so "Second" -
+      -- a plain entry rather than one followed by a table of its children - is
+      -- refused
       local added, message = label:addMenuLabel("Child", "Second")
 
       assert.is_false(added)
-      assert.are.equal("addMenuLabel: Couldn't find menu parent Second", message)
+      assert.is_truthy(message:find("addMenuLabel: Couldn't find menu parent Second", 1, true))
       assert.are.same({"First", "Second", "Third"}, menuOrder())
       assert.is_nil(label:findMenuElement("Second.Child"))
     end)
@@ -1580,7 +1601,7 @@ describe("Tests Geyser.Label right click menus", function()
       local added, message = other:addMenuLabel("D", "A.B")
 
       assert.is_false(added)
-      assert.are.equal("addMenuLabel: Couldn't find menu parent A.B", message)
+      assert.is_truthy(message:find("addMenuLabel: Couldn't find menu parent A.B", 1, true))
       assert.is_nil(other:findMenuElement("B.D"))
       assert.is_nil(other:findMenuElement("A.D"))
     end)

--- a/src/mudlet-lua/tests/GeyserLabel_spec.lua
+++ b/src/mudlet-lua/tests/GeyserLabel_spec.lua
@@ -1442,6 +1442,17 @@ describe("Tests Geyser.Label right click menus", function()
     it("hands back nothing at all when it is given no name", function()
       assert.is_nil(label:findMenuElement())
     end)
+
+    it("hands back a nested item's own submenu when it is asked for a parent", function()
+      local other = Geyser.Label:new({name = "glmFindParent", x = 0, y = 0, width = 100, height = 30})
+      other:createRightClickMenu({MenuItems = {"A", {"B", {"C"}}}})
+
+      local element, submenu = other:findMenuElement("A.B", other.rightClickMenu, true)
+
+      assert.are.equal(other:findMenuElement("A.B"), element)
+      -- B's own children, not the table B itself is an entry in
+      assert.are.same({"C"}, submenu)
+    end)
   end)
 
   describe("Geyser.Label:setMenuAction", function()
@@ -1497,7 +1508,7 @@ describe("Tests Geyser.Label right click menus", function()
 
   describe("Geyser.Label:addMenuLabel", function()
     it("adds an item at the end of the menu", function()
-      label:addMenuLabel("Fourth")
+      assert.is_true(label:addMenuLabel("Fourth"))
       assert.are.same({"First", "Second", "Third", "Fourth"}, menuOrder())
       assert.is_not_nil(label:findMenuElement("Fourth"))
     end)
@@ -1528,16 +1539,51 @@ describe("Tests Geyser.Label right click menus", function()
       assert.is_false(menuItem("Second").ignore)
     end)
 
-    -- addMenuLabel means to report a parent it cannot find, but the guard it
-    -- does that with is dead: findMenuElement answers nil plus an error message
-    -- rather than nil plus nil, so `not menuParent` is never true and the
-    -- message is then used as the table to append the new item to. Both a
-    -- parent that is not in the menu and one that was declared without a
-    -- submenu therefore come out as "attempt to index local 'menuParent' (a
-    -- string value)" from inside GeyserLabel.lua.
-    pending("Geyser.Label:addMenuLabel reporting a parent it cannot find - the guard is dead, so it raises a Lua indexing error from inside Geyser instead of its own message")
+    it("adds an item under a nested parent named by its full path", function()
+      local other = Geyser.Label:new({name = "glmDeep", x = 0, y = 0, width = 100, height = 30})
+      other:createRightClickMenu({MenuItems = {"A", {"B", {"C"}}}})
 
-    pending("Geyser.Label:addMenuLabel putting an item under a parent that has no submenu yet - same dead guard, so it raises rather than making the submenu")
+      local added = other:addMenuLabel("D", "A.B")
+
+      -- an item is named for the parent it sits in, so D under B is "B.D"
+      local child = other:findMenuElement("B.D")
+      assert.is_not_nil(child, "D was not put inside B")
+      assert.are.equal(other:findMenuElement("A.B"), child.nestParent)
+      -- and it is not a second entry beside B, in A's own submenu
+      assert.is_nil(other:findMenuElement("A.D"), "D was put beside B instead of inside it")
+      assert.is_true(added)
+    end)
+
+    it("reports a parent it cannot find rather than raising", function()
+      local added, message = label:addMenuLabel("Child", "Nowhere")
+
+      assert.is_false(added)
+      assert.are.equal("addMenuLabel: Couldn't find menu parent Nowhere", message)
+      assert.are.same({"First", "Second", "Third"}, menuOrder())
+    end)
+
+    it("reports a parent that was declared without a submenu", function()
+      -- "Second" is a plain entry rather than one followed by a table of its
+      -- children, so there is nothing to add an item to
+      local added, message = label:addMenuLabel("Child", "Second")
+
+      assert.is_false(added)
+      assert.are.equal("addMenuLabel: Couldn't find menu parent Second", message)
+      assert.are.same({"First", "Second", "Third"}, menuOrder())
+      assert.is_nil(label:findMenuElement("Second.Child"))
+    end)
+
+    it("reports a nested parent that was declared without a submenu", function()
+      local other = Geyser.Label:new({name = "glmDeepLeaf", x = 0, y = 0, width = 100, height = 30})
+      other:createRightClickMenu({MenuItems = {"A", {"B"}}})
+
+      local added, message = other:addMenuLabel("D", "A.B")
+
+      assert.is_false(added)
+      assert.are.equal("addMenuLabel: Couldn't find menu parent A.B", message)
+      assert.is_nil(other:findMenuElement("B.D"))
+      assert.is_nil(other:findMenuElement("A.D"))
+    end)
   end)
 
   describe("Geyser.Label:changeMenuIndex", function()

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -487,9 +487,9 @@ describe("Tests functionality of Geyser.UserWindow", function()
     end)
 
     -- Opening the dock is what puts a window at a position, and it brings the
-    -- window back on screen with it. That is the visible behaviour packages
-    -- dock against, so the flags are what follow the window rather than the
-    -- other way around.
+    -- window back on screen with it. The other way to settle that would have
+    -- been to hide the window again afterwards; showing it is what these specs
+    -- pin, because a dock reopening visible is long standing behaviour.
     it("brings a hidden window back with it rather than leaving it half hidden", function()
       local userWindow = track(Geyser.UserWindow:new({name = "guwDockHidden", x = 10, y = 20, width = 200, height = 150}))
       floatAgain(userWindow)
@@ -533,16 +533,50 @@ describe("Tests functionality of Geyser.UserWindow", function()
     it("leaves a window that was never hidden alone", function()
       local userWindow = track(Geyser.UserWindow:new({name = "guwDockVisible", x = 10, y = 20, width = 200, height = 150}))
       floatAgain(userWindow)
-      local label = track(Geyser.Label:new({name = "guwDockVisibleLabel", x = 0, y = 0, width = "50%", height = "50%"}, userWindow))
-      label:hide()
+      local shown = spy.on(userWindow, "show")
+      undo[#undo + 1] = function() shown:revert() end
 
       userWindow:setDockPosition("right")
 
-      -- a child put away by hand stays away: only the window's own stale flag
-      -- is what setDockPosition is allowed to clear
-      assert.is_true(label.hidden)
-      assert.is_false(windowVisible("guwDockVisibleLabel"))
+      -- there is no stale flag to repair here, so the window and everything in
+      -- it is left untouched rather than walked over on every dock change
+      assert.spy(shown).was_not.called()
       assert.is_false(userWindow.hidden)
+      assert.is_true(windowVisible("guwDockVisible"))
+    end)
+
+    it("leaves a child that was put away by hand where it is", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDockVisibleChild", x = 10, y = 20, width = 200, height = 150}))
+      floatAgain(userWindow)
+      local label = track(Geyser.Label:new({name = "guwDockHandHidden", x = 0, y = 0, width = "50%", height = "50%"}, userWindow))
+      label:hide()
+      userWindow:hide()
+
+      userWindow:setDockPosition("right")
+
+      -- bringing the window back shows its children automatically, and an
+      -- automatic show clears only auto_hidden, so a child hidden by hand keeps
+      -- its own flag and stays away
+      assert.is_true(label.hidden)
+      assert.is_false(windowVisible("guwDockHandHidden"))
+      assert.is_true(windowVisible("guwDockVisibleChild"))
+    end)
+
+    it("clears the flag the window put on itself, not the one its container put there", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDockAutoHidden", x = 10, y = 20, width = 200, height = 150}))
+      floatAgain(userWindow)
+      userWindow:hide()
+      userWindow.container:hide()
+
+      userWindow:setDockPosition("right")
+
+      assert.is_false(userWindow.hidden)
+      -- auto_hidden is the container's to clear, so the window is still the
+      -- container's to bring back
+      assert.is_true(userWindow.auto_hidden)
+      userWindow.container:show()
+      assert.is_false(userWindow.auto_hidden)
+      assert.is_true(windowVisible("guwDockAutoHidden"))
     end)
   end)
 

--- a/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
+++ b/src/mudlet-lua/tests/GeyserUserWindow_spec.lua
@@ -486,22 +486,64 @@ describe("Tests functionality of Geyser.UserWindow", function()
       assert.are.same({x = 30, y = 40, width = 220, height = 160}, geometry("guwFloatBack"))
     end)
 
-    it("records the position of a window that is hidden", function()
+    -- Opening the dock is what puts a window at a position, and it brings the
+    -- window back on screen with it. That is the visible behaviour packages
+    -- dock against, so the flags are what follow the window rather than the
+    -- other way around.
+    it("brings a hidden window back with it rather than leaving it half hidden", function()
       local userWindow = track(Geyser.UserWindow:new({name = "guwDockHidden", x = 10, y = 20, width = 200, height = 150}))
       floatAgain(userWindow)
       userWindow:hide()
+      assert.is_false(windowVisible("guwDockHidden"))
+
       userWindow:setDockPosition("right")
+
       assert.are.equal("right", userWindow.dockPosition)
-      assert.is_true(userWindow.hidden)
+      assert.is_true(windowVisible("guwDockHidden"))
+      assert.is_false(userWindow.hidden)
     end)
 
-    -- setDockPosition reopens the dock, so a hidden user window comes back on
-    -- screen while self.hidden stays true. Geyser.Container:hide() skips the
-    -- widget for anything that already believes itself hidden, so hide() is
-    -- then a no-op and the window cannot be put away again without show()ing
-    -- it first. Recorded rather than asserted, so that fixing it does not have
-    -- to fight a spec.
-    pending("Geyser.UserWindow:setDockPosition leaving a hidden window hidden - it reopens the dock and leaves self.hidden true, which makes the window unhideable until it is shown once")
+    it("leaves a window it brought back hideable again", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDockRehide", x = 10, y = 20, width = 200, height = 150}))
+      floatAgain(userWindow)
+      userWindow:hide()
+      userWindow:setDockPosition("right")
+
+      -- Geyser.Container:hide() skips the widget for anything that already
+      -- believes itself hidden, so a stale flag here makes this a no-op
+      userWindow:hide()
+
+      assert.is_true(userWindow.hidden)
+      assert.is_false(windowVisible("guwDockRehide"))
+    end)
+
+    it("brings the children of a hidden window back with it", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDockChild", x = 10, y = 20, width = 200, height = 150}))
+      floatAgain(userWindow)
+      local label = track(Geyser.Label:new({name = "guwDockChildLabel", x = 0, y = 0, width = "100%", height = "100%"}, userWindow))
+      userWindow:hide()
+      assert.is_false(windowVisible("guwDockChildLabel"))
+
+      userWindow:setDockPosition("right")
+
+      assert.is_true(windowVisible("guwDockChildLabel"))
+      assert.is_false(label.auto_hidden)
+    end)
+
+    it("leaves a window that was never hidden alone", function()
+      local userWindow = track(Geyser.UserWindow:new({name = "guwDockVisible", x = 10, y = 20, width = 200, height = 150}))
+      floatAgain(userWindow)
+      local label = track(Geyser.Label:new({name = "guwDockVisibleLabel", x = 0, y = 0, width = "50%", height = "50%"}, userWindow))
+      label:hide()
+
+      userWindow:setDockPosition("right")
+
+      -- a child put away by hand stays away: only the window's own stale flag
+      -- is what setDockPosition is allowed to clear
+      assert.is_true(label.hidden)
+      assert.is_false(windowVisible("guwDockVisibleLabel"))
+      assert.is_false(userWindow.hidden)
+    end)
   end)
 
   pending("Geyser.UserWindow:setDockPosition docking the window against the edge it names - which edge a user window ended up docked to, and whether it docks by itself when dragged, are not readable from Lua")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Geyser.Label:addMenuLabel` reports a parent it cannot use instead of raising a Lua indexing error from inside Geyser. Its guard read `if parent and not menuParent`, but `findMenuElement` answers nil plus a *message*, so `menuParent` was a truthy string that was then indexed as a table. It now answers `false` plus that message, under its own name rather than the wrong `showMenuLabel:` prefix, and `true` when the item was added.
- `Geyser.Label:findMenuElement` passes `findParent` through its recursion, so a dotted parent resolves to that item's own submenu rather than the table it sits in. `addMenuLabel("D", "A.B")` put D beside B; it now puts it inside B.
- `Geyser.UserWindow:setDockPosition` shows a window whose hidden flag was left stale. Opening the dock brings the window back on screen, and leaving `hidden` set made the next `hide()` a no-op in `Geyser.Container:hide()`, which skips anything that already believes itself hidden.
- Follow-on from the first item, both found in review: `addMenuLabel` refuses a name it cannot make an item out of rather than answering `true` for a no-op, and `Adjustable.Container`'s `createMenus` passes the new answer on, so a missing menu parent still names itself instead of surfacing as a nil index on the line after it.

#### Motivation for adding to Mudlet

All three are silent or misleading failures in the Geyser API that package authors build UIs on. A missing menu parent produced `attempt to index local 'menuParent' (a string value)` pointing at Geyser's own source rather than at the caller's mistake; a nested `addMenuLabel` quietly built the wrong menu with no error at all; and a docked user window came back on screen while still claiming to be hidden, leaving it impossible to hide again without showing it first.

#### Other info (issues closed, discussion etc)

Closes #10046, closes #10050, closes #10052

Compatibility: a scan of 224 official packages plus the in-tree and external repos found none affected by the raise-to-return change or the menu nesting fix, and #10050's fix repairs WoTMUD's mapper/comms windows and aardkit, whose user windows are currently stuck visible.

Deliberately left alone: `setDockPosition` still cannot repair a window hidden by its container rather than by hand, because `Geyser.Container:show()` never clears `auto_hidden` and `Geyser.UserWindow:show()` discards its answer. That is pre-existing and unchanged here (A/B verified), and the new "clears the flag the window put on itself" spec pins the boundary. `addMenuLabel` also still raises when an `index` is combined with a nested parent, which is pre-existing and now documented on the parameter; the obvious one-line repair mangles item names that contain a dot, so it needs its own change.

**Test case:** full busted suite green twice, fresh profile 3497 successes / 0 failures / 0 errors / 67 pending and same-profile re-run 3495 / 0 / 0 / 69 (the two extra pendings are Xvfb resize-dependent UI specs, unrelated). Two `pending()` placeholders from #10042 were flipped to real specs and ten more added. Every flipped and new spec was proven to fail against the unfixed code before passing with it: 7 red in `GeyserLabel_spec` (4 failures, 3 errors, including the two `attempt to index` shapes from #10046), 4 red in `GeyserUserWindow_spec`, and 1 red each for the two review follow-ons. Three specs pass either way by design: the menu naming convention documents pre-existing behaviour, and two guard the fix against over-reaching.

Assisted-by: Claude:claude-opus-5
