### PR TITLE
Infra: cover the map download chain with functional tests

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -105,7 +105,10 @@ set(MAP_GROUP_TEST_SOURCES
     EmbeddedMapperCreationTest.cpp
     MapAreaReassignmentTest.cpp
     MapCloseDuringImportTest.cpp
+    MapDownloadTest.cpp
+    MapFileStatsTest.cpp
     MapProgressDialogSeamTest.cpp
+    MapRoomGeometryTest.cpp
     MapRoundTripTest.cpp
 )
 

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -1,0 +1,685 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Covers TMap::downloadMap() and the three slots that finish the job it starts -
+ * slot_setDownloadProgress(), slot_downloadError() and slot_replyFinished() -
+ * against a stub HTTP server standing in for a game's MMP map.
+ *
+ * In production nothing but a widget starts one: the mapper's "Download from
+ * game" menu item, the same button in the preferences' Mapper tab, and the map
+ * context menu. There is no Lua entry point, so the busted suite cannot reach
+ * any of this and the tests below call TMap directly, exactly as those three
+ * widgets do.
+ *
+ * A real profile rather than a bare Host, because the interesting part of the
+ * chain is what happens after the bytes land: the reply handler writes the file,
+ * parses it, and reports every outcome to the console through Host::postMessage()
+ * - and hands a non-XML file to TMainConsole::loadMap(). A Host with no console
+ * would stack those messages up unread and crash on that last call.
+ *
+ * Run with: ctest -R MapDownloadTest -V
+ */
+
+#include <QFileInfo>
+#include <QHash>
+#include <QHostAddress>
+#include <QSignalSpy>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "TMainConsole.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgMapper.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+// The shape I.R.E. games serve: a <map> document of areas and rooms, which is
+// what XMLimport::readMap() consumes. Deliberately hand-written - Mudlet has no
+// XML map exporter to generate one with.
+const QByteArray scmMapXml = QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                               "<map>\n"
+                                               " <areas>\n"
+                                               "  <area id=\"1\" name=\"Downloaded Area\"/>\n"
+                                               " </areas>\n"
+                                               " <rooms>\n"
+                                               "  <room id=\"1\" area=\"1\" title=\"Entrance\" environment=\"2\">\n"
+                                               "   <coord x=\"0\" y=\"0\" z=\"0\"/>\n"
+                                               "   <exit direction=\"east\" target=\"2\"/>\n"
+                                               "  </room>\n"
+                                               "  <room id=\"2\" area=\"1\" title=\"Hallway\" environment=\"2\">\n"
+                                               "   <coord x=\"1\" y=\"0\" z=\"0\"/>\n"
+                                               "   <exit direction=\"west\" target=\"1\"/>\n"
+                                               "  </room>\n"
+                                               " </rooms>\n"
+                                               "</map>\n");
+
+// downloadMap() has no idea how big the file will be, so it seeds the progress
+// range with this until the reply reports a real total:
+constexpr int scmAssumedFileSize = 4000000;
+
+} // namespace
+
+// A minimum-viable HTTP server serving one canned answer per path. Every route
+// is opt-in so an unregistered path is a 404, which is what a game that has no
+// map to offer produces.
+class StubMapServer : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum class Answer {
+        // 200 with a Content-Length, sent in one go
+        Whole,
+        // 200 with a Content-Length, sent in two halves a beat apart, so the
+        // reply reports progress more than once
+        Chunked,
+        // 200 with no Content-Length, so the reply's total stays at -1
+        Unsized,
+        // 200 with a Content-Length far larger than what is ever sent, so the
+        // download stays in flight until the client gives up on it
+        Stalled,
+    };
+
+    explicit StubMapServer(QObject* parent = nullptr)
+    : QObject(parent)
+    {
+        connect(&mServer, &QTcpServer::newConnection, this, &StubMapServer::acceptConnections);
+    }
+
+    // Port 0: the OS picks a free one, so concurrent runs of this test cannot
+    // collide on it. Read it back with url().
+    bool listen() { return mServer.listen(QHostAddress::LocalHost, 0); }
+
+    QString url(const QString& path) const { return qsl("http://127.0.0.1:%1%2").arg(QString::number(mServer.serverPort()), path); }
+
+    void serve(const QString& path, const QByteArray& body, const Answer answer = Answer::Whole) { mRoutes.insert(path, {answer, body}); }
+
+    QStringList requestedPaths() const { return mRequestedPaths; }
+    void forgetRequests() { mRequestedPaths.clear(); }
+
+private:
+    struct Route
+    {
+        Answer answer{Answer::Whole};
+        QByteArray body;
+    };
+
+    void acceptConnections()
+    {
+        while (auto* socket = mServer.nextPendingConnection()) {
+            connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
+                readRequest(socket);
+            });
+            connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+        }
+    }
+
+    void readRequest(QTcpSocket* socket)
+    {
+        QByteArray& buffer = mBuffers[socket];
+        buffer.append(socket->readAll());
+        if (!buffer.contains("\r\n\r\n")) {
+            return;
+        }
+        const QList<QByteArray> requestLine = buffer.left(buffer.indexOf("\r\n")).split(' ');
+        mBuffers.remove(socket);
+        const QString path = requestLine.size() > 1 ? QString::fromUtf8(requestLine.at(1)) : QString();
+        mRequestedPaths << path;
+
+        if (!mRoutes.contains(path)) {
+            socket->write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            socket->disconnectFromHost();
+            return;
+        }
+
+        const Route route = mRoutes.value(path);
+        switch (route.answer) {
+        case Answer::Whole:
+            sendHeader(socket, route.body.size());
+            socket->write(route.body);
+            socket->flush();
+            socket->disconnectFromHost();
+            return;
+        case Answer::Chunked: {
+            sendHeader(socket, route.body.size());
+            const qsizetype half = route.body.size() / 2;
+            socket->write(route.body.left(half));
+            socket->flush();
+            const QByteArray rest = route.body.mid(half);
+            QTimer::singleShot(150ms, socket, [socket, rest]() {
+                socket->write(rest);
+                socket->flush();
+                socket->disconnectFromHost();
+            });
+            return;
+        }
+        case Answer::Unsized:
+            socket->write("HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nConnection: close\r\n\r\n");
+            socket->write(route.body);
+            socket->flush();
+            socket->disconnectFromHost();
+            return;
+        case Answer::Stalled:
+            sendHeader(socket, scmAssumedFileSize);
+            socket->write(route.body);
+            socket->flush();
+            return;
+        }
+    }
+
+    static void sendHeader(QTcpSocket* socket, const qsizetype length)
+    {
+        socket->write("HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nContent-Length: " + QByteArray::number(length) + "\r\nConnection: close\r\n\r\n");
+    }
+
+    QTcpServer mServer;
+    QHash<QTcpSocket*, QByteArray> mBuffers;
+    QHash<QString, Route> mRoutes;
+    QStringList mRequestedPaths;
+};
+
+class MapDownloadTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpTelnetServer = nullptr;
+    StubMapServer* mpMapServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("MapDownload-Test");
+    const QString mLocalhost = qsl("localhost");
+    int mConsoleMark = 0;
+    QByteArray mPaddedMapXml;
+    QByteArray mBinaryMap;
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    // Everything the download chain reports, it reports to the console. Reading
+    // from a mark set at the start of each test keeps one test's messages from
+    // answering another's assertion.
+    QString consoleTextSinceMark() const
+    {
+        QString text;
+        auto& buffer = mpHost->mpConsole->buffer;
+        for (int i = mConsoleMark, last = buffer.getLastLineNumber(); i <= last; ++i) {
+            text.append(buffer.line(i)).append(QChar::Space);
+        }
+        return text;
+    }
+
+    bool consoleShows(const QString& needle) const { return consoleTextSinceMark().contains(needle); }
+
+    // The progress display closing is the last thing slot_replyFinished()'s
+    // cleanup does, on every one of its exits, so it is what "the download is
+    // over" means from outside.
+    bool runDownload(const QString& remoteUrl, const QString& localFileName = QString())
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QSignalSpy closeSpy(pMap, &TMap::signal_mapProgressClose);
+        pMap->downloadMap(remoteUrl, localFileName);
+        return closeSpy.count() == 1 || closeSpy.wait(15000);
+    }
+
+    void watchMapDownloadEvent() const
+    {
+        mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("mapDownloadsSeen = 0\n"
+                                                                 "registerAnonymousEventHandler('sysMapDownloadEvent', function() mapDownloadsSeen = mapDownloadsSeen + 1 end)"));
+    }
+
+    void forgetMapDownloadEvents() const { mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("mapDownloadsSeen = 0")); }
+
+    bool mapDownloadEventCountIs(const int expected) const { return mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("assert(mapDownloadsSeen == %1)").arg(expected)); }
+
+    // The parse that follows a download reports its own progress on the same
+    // display, so the download's reports are the ones before the cancel button
+    // is taken away. Counting the emissions at that moment separates the two.
+    struct ProgressPhases
+    {
+        int ranges{0};
+        int values{0};
+    };
+
+    QMetaObject::Connection markParseStart(const QSignalSpy& rangeSpy, const QSignalSpy& valueSpy, ProgressPhases& phases) const
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        return connect(pMap, &TMap::signal_mapProgressDisableCancel, pMap, [&rangeSpy, &valueSpy, &phases]() {
+            phases.ranges = rangeSpy.count();
+            phases.values = valueSpy.count();
+        });
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpTelnetServer = new TelnetServerStub(qApp);
+        mpTelnetServer->start(mLocalhost, 0);
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpTelnetServer->serverPort()));
+        QVERIFY2(mpHost, "the test profile could not be created");
+        QSignalSpy connectionSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectionSpy.count() == 1 || connectionSpy.wait(5000), "the test profile never connected to the stub game");
+        QVERIFY(mpHost->mpConsole);
+        // No mapper widget yet, so every download below takes the standalone
+        // progress path the signals under test belong to. The last test in this
+        // file creates one, which is why it is last.
+        QVERIFY2(mpHost->mpMap->mpMapper.isNull(), "a mapper widget already exists, so the standalone progress path will not be taken");
+
+        watchMapDownloadEvent();
+
+        // Big enough that the reply reports progress in more than one step:
+        mPaddedMapXml = scmMapXml;
+        mPaddedMapXml.insert(mPaddedMapXml.indexOf("</map>"), "<!-- " + QByteArray(256 * 1024, 'x') + " -->\n");
+
+        mpMapServer = new StubMapServer(qApp);
+        QVERIFY2(mpMapServer->listen(), "the stub map server could not listen on localhost");
+        mpMapServer->serve(qsl("/map.xml"), scmMapXml);
+        mpMapServer->serve(qsl("/mmp.xml"), scmMapXml);
+        mpMapServer->serve(qsl("/chunked.xml"), mPaddedMapXml, StubMapServer::Answer::Chunked);
+        mpMapServer->serve(qsl("/unsized.xml"), mPaddedMapXml, StubMapServer::Answer::Unsized);
+        mpMapServer->serve(qsl("/stalled.xml"), QByteArray(64, 'x'), StubMapServer::Answer::Stalled);
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpMapServer;
+        mpMapServer = nullptr;
+        delete mpTelnetServer;
+        mpTelnetServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void init()
+    {
+        mConsoleMark = mpHost->mpConsole->buffer.getLastLineNumber();
+        mpMapServer->forgetRequests();
+        forgetMapDownloadEvents();
+    }
+
+    // A test that fails part way through can leave a download in flight, and
+    // the import flag it holds would refuse every download after it - so the
+    // one failure would be reported as several.
+    void cleanup()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        if (!pMap->hasActiveTransferProgress()) {
+            return;
+        }
+        QSignalSpy closeSpy(pMap, &TMap::signal_mapProgressClose);
+        pMap->slot_downloadCancel();
+        closeSpy.wait(15000);
+    }
+
+    // The whole chain on a good day: request, save, parse, announce.
+    void test_downloadedXmlMapIsSavedAndParsed()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        pMap->mapClear();
+        QVERIFY(pMap->mpRoomDB->isEmpty());
+
+        QSignalSpy startSpy(pMap, &TMap::signal_mapTransferProgressStart);
+        QSignalSpy disableCancelSpy(pMap, &TMap::signal_mapProgressDisableCancel);
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the map download never finished");
+
+        QCOMPARE(mpMapServer->requestedPaths(), QStringList{qsl("/map.xml")});
+        QCOMPARE(startSpy.count(), 1);
+        QCOMPARE(startSpy.at(0).at(0).toString(), qsl("Map download"));
+        QVERIFY2(startSpy.at(0).at(1).toString().contains(mProfileName), "the progress label does not name the profile the map is for");
+        // The download can be aborted; the parse that follows it cannot, so the
+        // cancel button has to go away between the two.
+        QCOMPARE(disableCancelSpy.count(), 1);
+
+        // A download with no local name of its own lands on the profile's
+        // map.xml, inside this test's own config root:
+        const QString stored = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
+        QFile file(stored);
+        QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(qsl("the downloaded map was not saved to %1").arg(stored)));
+        QCOMPARE(file.readAll(), scmMapXml);
+
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+        QCOMPARE(pMap->mpRoomDB->getAreaNamesMap().value(1), qsl("Downloaded Area"));
+        TRoom* pRoom = pMap->mpRoomDB->getRoom(1);
+        QVERIFY(pRoom);
+        QCOMPARE(pRoom->name, qsl("Entrance"));
+        QCOMPARE(pRoom->getEast(), 2);
+
+        QVERIFY2(consoleShows(qsl("Map download initiated")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(consoleShows(qsl("map downloaded and stored")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(mapDownloadEventCountIs(1), "sysMapDownloadEvent was not raised exactly once for a successful download");
+        QVERIFY(!pMap->hasActiveTransferProgress());
+    }
+
+    // The reply's own total only turns up after the first progress report, so
+    // the range starts as a guess and is corrected once.
+    void test_progressRangeStartsAsAGuessAndIsCorrectedFromTheReply()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QSignalSpy rangeSpy(pMap, &TMap::signal_mapProgressSetRange);
+        QSignalSpy valueSpy(pMap, &TMap::signal_mapProgressSetValue);
+        ProgressPhases phases;
+        const QMetaObject::Connection mark = markParseStart(rangeSpy, valueSpy, phases);
+
+        const bool finished = runDownload(mpMapServer->url(qsl("/chunked.xml")));
+        disconnect(mark);
+        QVERIFY2(finished, "the map download never finished");
+
+        QCOMPARE(phases.ranges, 2);
+        QCOMPARE(rangeSpy.at(0).at(0).toInt(), 0);
+        QCOMPARE(rangeSpy.at(0).at(1).toInt(), scmAssumedFileSize);
+        QCOMPARE(rangeSpy.at(1).at(1).toInt(), static_cast<int>(mPaddedMapXml.size()));
+        QVERIFY(phases.values > 0);
+        QCOMPARE(valueSpy.at(phases.values - 1).at(0).toInt(), static_cast<int>(mPaddedMapXml.size()));
+    }
+
+    // A reply with no Content-Length reports its total as -1 for the whole
+    // download - the I.R.E. games' behaviour the guard was written for. The
+    // range has to keep the guess rather than be set to a negative maximum.
+    void test_progressRangeIsLeftAloneWhenTheReplyHasNoTotal()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QSignalSpy rangeSpy(pMap, &TMap::signal_mapProgressSetRange);
+        QSignalSpy valueSpy(pMap, &TMap::signal_mapProgressSetValue);
+        ProgressPhases phases;
+        const QMetaObject::Connection mark = markParseStart(rangeSpy, valueSpy, phases);
+
+        const bool finished = runDownload(mpMapServer->url(qsl("/unsized.xml")));
+        disconnect(mark);
+        QVERIFY2(finished, "the map download never finished");
+
+        QCOMPARE(phases.ranges, 1);
+        QCOMPARE(rangeSpy.at(0).at(1).toInt(), scmAssumedFileSize);
+    }
+
+    // Progress arriving with no progress display to put it on - which the abort
+    // path can produce, since it takes the display down before the reply ends.
+    void test_progressWithNoDisplayIsIgnored()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QVERIFY(!pMap->hasActiveTransferProgress());
+        QSignalSpy rangeSpy(pMap, &TMap::signal_mapProgressSetRange);
+        QSignalSpy valueSpy(pMap, &TMap::signal_mapProgressSetValue);
+
+        pMap->slot_setDownloadProgress(512, 1024);
+
+        QCOMPARE(rangeSpy.count(), 0);
+        QCOMPARE(valueSpy.count(), 0);
+    }
+
+    // A game with no map to serve answers 404. Nothing must be left behind: the
+    // next download has to be accepted, which is what proves the import flag was
+    // cleared on the way out.
+    void test_httpErrorIsReportedAndLeavesNothingBehind()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        const QString stored = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
+        QFile::remove(stored);
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/nosuchmap.xml"))), "the failed map download never finished");
+
+        QVERIFY2(consoleShows(qsl("Map download encountered an error")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(!QFileInfo::exists(stored), "a failed download still wrote a map file");
+        QVERIFY(!pMap->hasActiveTransferProgress());
+        QVERIFY2(mapDownloadEventCountIs(0), "a failed download raised sysMapDownloadEvent");
+
+        // ...and the chain is free to run again:
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after a failed one never finished");
+        QVERIFY2(QFileInfo::exists(stored), "the download after a failed one was refused, so the import flag was left set");
+        QVERIFY2(mapDownloadEventCountIs(1), "the download after a failed one did not raise sysMapDownloadEvent");
+    }
+
+    void test_secondDownloadIsRefusedWhileOneIsStillRunning()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QSignalSpy startSpy(pMap, &TMap::signal_mapTransferProgressStart);
+
+        pMap->downloadMap(mpMapServer->url(qsl("/stalled.xml")));
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return !mpMapServer->requestedPaths().isEmpty();
+                         },
+                         10000),
+                 "the first download never reached the server");
+
+        pMap->downloadMap(mpMapServer->url(qsl("/map.xml")));
+
+        QVERIFY2(consoleShows(qsl("when one has already been")), qPrintable(consoleTextSinceMark()));
+        QCOMPARE(mpMapServer->requestedPaths(), QStringList{qsl("/stalled.xml")});
+        // Refused before it could put a second progress display over the first:
+        QCOMPARE(startSpy.count(), 1);
+    }
+
+    // A JSON import or export owns the same standalone progress display. Letting
+    // a download start on top of it would leave the JSON operation's dialog to be
+    // closed by the download's cleanup, and the download's own parse would
+    // mapClear() the JSON import out from under itself.
+    void test_downloadIsRefusedWhileAJsonOperationOwnsTheProgressDisplay()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QTemporaryDir jsonDir;
+        QVERIFY(jsonDir.isValid());
+        QSignalSpy exportStartSpy(pMap, &TMap::signal_mapJsonProgressStart);
+        QSignalSpy exportCloseSpy(pMap, &TMap::signal_mapProgressClose);
+
+        bool downloadAttempted = false;
+        const QMetaObject::Connection reenter = connect(pMap, &TMap::signal_mapJsonProgressStart, pMap, [this, pMap, &downloadAttempted]() {
+            downloadAttempted = true;
+            pMap->downloadMap(mpMapServer->url(qsl("/map.xml")));
+        });
+        const auto [wrote, writeMessage] = pMap->writeJsonMapFile(qsl("%1/reentrancy.json").arg(jsonDir.path()));
+        disconnect(reenter);
+
+        QVERIFY(downloadAttempted);
+        QVERIFY2(wrote, qPrintable(writeMessage));
+        QVERIFY2(consoleShows(qsl("already in progress")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(mpMapServer->requestedPaths().isEmpty(), "a download started on top of a JSON export");
+        // The export it interrupted still took its own display down, exactly once:
+        QCOMPARE(exportStartSpy.count(), 1);
+        QCOMPARE(exportCloseSpy.count(), 1);
+        QVERIFY(!pMap->hasActiveTransferProgress());
+    }
+
+    void test_invalidUrlIsRefusedBeforeAnyRequest()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        QSignalSpy startSpy(pMap, &TMap::signal_mapTransferProgressStart);
+
+        // QUrl::fromUserInput() falls back to prepending a scheme and takes
+        // almost anything, so reaching this guard needs an input that cannot be
+        // read as a host either - a stray percent escape is one.
+        pMap->downloadMap(qsl("%zz"));
+
+        QVERIFY2(consoleShows(qsl("invalid URL")), qPrintable(consoleTextSinceMark()));
+        QCOMPARE(startSpy.count(), 0);
+        QVERIFY(mpMapServer->requestedPaths().isEmpty());
+        QVERIFY(!pMap->hasActiveTransferProgress());
+
+        // The import flag has to have been cleared on that early exit, or the
+        // profile could never download a map again:
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after an invalid URL was refused, so the import flag was left set");
+    }
+
+    // Abort is not an error, so it must not add an error line to the console on
+    // top of the alert the cancel itself posts.
+    //
+    // QNetworkReply::abort() delivers finished() synchronously, so the whole
+    // chain has unwound by the time slot_downloadCancel() returns - no waiting
+    // needed. Note that it unwinds through the save-and-parse path rather than
+    // the error one, since slot_replyFinished() deliberately does not treat a
+    // cancel as an error, so the partial file is written and handed to the XML
+    // reader, which opens a progress display of its own for it.
+    void test_cancelStopsTheDownloadWithoutReportingAnError()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+
+        pMap->downloadMap(mpMapServer->url(qsl("/stalled.xml")));
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return !mpMapServer->requestedPaths().isEmpty();
+                         },
+                         10000),
+                 "the download never reached the server");
+
+        pMap->slot_downloadCancel();
+
+        QVERIFY2(consoleShows(qsl("canceled, on user's request")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(!consoleShows(qsl("Map download encountered an error")), qPrintable(consoleTextSinceMark()));
+        QVERIFY(!pMap->hasActiveTransferProgress());
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after a canceled one was refused, so the import flag was left set");
+    }
+
+    void test_undownloadableDestinationIsReported()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        // Inside the profile's own directory but below a path component that is
+        // not there, so QSaveFile cannot open it:
+        const QString unwritable = qsl("%1/no-such-directory/map.xml").arg(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml")), unwritable), "the map download never finished");
+
+        QVERIFY2(consoleShows(qsl("unable to open destination file")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(!QFileInfo::exists(unwritable), "the destination file was written after all");
+        QVERIFY(!pMap->hasActiveTransferProgress());
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after an unwritable destination was refused, so the import flag was left set");
+    }
+
+    // What the mapper's "Download from game" does: no URL, so the location the
+    // game advertised over MMP is used.
+    void test_mmpMapLocationIsUsedWhenNoUrlIsGiven()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        pMap->setMmpMapLocation(mpMapServer->url(qsl("/mmp.xml")));
+
+        TMap* map = pMap;
+        QSignalSpy closeSpy(map, &TMap::signal_mapProgressClose);
+        map->downloadMap();
+        QVERIFY2(closeSpy.count() == 1 || closeSpy.wait(15000), "the map download never finished");
+
+        QCOMPARE(mpMapServer->requestedPaths(), QStringList{qsl("/mmp.xml")});
+        pMap->setMmpMapLocation(QString());
+    }
+
+    // A URL that does not end in "xml" is a binary map file, which goes to
+    // TMainConsole::loadMap() rather than the XML reader.
+    //
+    // Last on purpose: loadMap() creates the mapper widget, and from then on
+    // TMap puts its progress on that widget instead of emitting the standalone
+    // signals every test above watches. A profile's mapper cannot be destroyed
+    // again, so this cannot be undone within the process.
+    void test_downloadedBinaryMapIsLoadedThroughTheConsole()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        pMap->mapClear();
+        QVERIFY(pMap->mpRoomDB->addArea(qsl("Serialized Area")) > 0);
+        QVERIFY(pMap->addRoom(7));
+        QVERIFY(pMap->setRoomArea(7, 1));
+        QVERIFY(pMap->setRoomCoordinates(7, 3, 4, 5));
+
+        QByteArray serialized;
+        QDataStream out(&serialized, QIODevice::WriteOnly);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            out.setVersion(mudlet::scmQDataStreamFormat_5_12);
+        }
+        QVERIFY(pMap->serialize(out));
+        mBinaryMap = serialized;
+        mpMapServer->serve(qsl("/map.dat"), mBinaryMap);
+
+        pMap->mapClear();
+        QVERIFY(pMap->mpRoomDB->isEmpty());
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.dat"))), "the binary map download never finished");
+
+        // A non-XML download is stored under the profile's map directory, not as
+        // its map.xml:
+        const QString stored = mudlet::getMudletPath(enums::profileMapPathFileName, mProfileName, qsl("map.dat"));
+        QVERIFY2(QFileInfo::exists(stored), qPrintable(qsl("the downloaded map was not saved to %1").arg(stored)));
+
+        TRoom* pRoom = pMap->mpRoomDB->getRoom(7);
+        QVERIFY2(pRoom, "the binary map was not loaded back through the console");
+        QCOMPARE(pRoom->x(), 3);
+        QCOMPARE(pRoom->y(), 4);
+        QCOMPARE(pRoom->z(), 5);
+        QVERIFY2(consoleShows(qsl("map downloaded and stored")), qPrintable(consoleTextSinceMark()));
+    }
+};
+
+#include "MapDownloadTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MapDownloadTest)

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -174,24 +174,16 @@ private:
             socket->flush();
             socket->disconnectFromHost();
             return;
-        case Answer::Chunked: {
+        case Answer::Chunked:
             sendHeader(socket, route.body.size());
-            const qsizetype half = route.body.size() / 2;
-            socket->write(route.body.left(half));
-            socket->flush();
-            const QByteArray rest = route.body.mid(half);
-            QTimer::singleShot(150ms, socket, [socket, rest]() {
-                socket->write(rest);
-                socket->flush();
-                socket->disconnectFromHost();
-            });
+            sendInParts(socket, route.body, 2);
             return;
-        }
         case Answer::Unsized:
             socket->write("HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nConnection: close\r\n\r\n");
-            socket->write(route.body);
-            socket->flush();
-            socket->disconnectFromHost();
+            // Three, so that a progress report carrying no total lands after the
+            // range has already been set from the guess - which is the only
+            // moment the "is the total known" guard decides anything.
+            sendInParts(socket, route.body, 3);
             return;
         case Answer::Stalled:
             sendHeader(socket, scmAssumedFileSize);
@@ -204,6 +196,26 @@ private:
     static void sendHeader(QTcpSocket* socket, const qsizetype length)
     {
         socket->write("HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nContent-Length: " + QByteArray::number(length) + "\r\nConnection: close\r\n\r\n");
+    }
+
+    // A beat between the parts, so the reply reports progress a known number of
+    // times rather than however many times loopback happens to split one write.
+    static void sendInParts(QTcpSocket* socket, const QByteArray& body, const int parts)
+    {
+        const qsizetype partSize = body.size() / parts;
+        socket->write(body.left(partSize));
+        socket->flush();
+        for (int part = 1; part < parts; ++part) {
+            const bool last = part == parts - 1;
+            const QByteArray chunk = last ? body.mid(part * partSize) : body.mid(part * partSize, partSize);
+            QTimer::singleShot(std::chrono::milliseconds(150 * part), socket, [socket, chunk, last]() {
+                socket->write(chunk);
+                socket->flush();
+                if (last) {
+                    socket->disconnectFromHost();
+                }
+            });
+        }
     }
 
     QTcpServer mServer;
@@ -375,16 +387,13 @@ private slots:
 
     // A test that fails part way through can leave a download in flight, and
     // the import flag it holds would refuse every download after it - so the
-    // one failure would be reported as several.
+    // one failure would be reported as several. Unconditional because the flag
+    // is not observable from here and a cancel with nothing to cancel costs
+    // only a console line, which the next test's mark leaves behind anyway.
     void cleanup()
     {
-        TMap* pMap = mpHost->mpMap.data();
-        if (!pMap->hasActiveTransferProgress()) {
-            return;
-        }
-        QSignalSpy closeSpy(pMap, &TMap::signal_mapProgressClose);
-        pMap->slot_downloadCancel();
-        closeSpy.wait(15000);
+        mpHost->mpMap->slot_downloadCancel();
+        qApp->processEvents();
     }
 
     // The whole chain on a good day: request, save, parse, announce.
@@ -449,10 +458,12 @@ private slots:
         QCOMPARE(valueSpy.at(phases.values - 1).at(0).toInt(), static_cast<int>(mPaddedMapXml.size()));
     }
 
-    // A reply with no Content-Length reports its total as -1 for the whole
-    // download - the I.R.E. games' behaviour the guard was written for. The
-    // range has to keep the guess rather than be set to a negative maximum.
-    void test_progressRangeIsLeftAloneWhenTheReplyHasNoTotal()
+    // A reply with no Content-Length reports its total as -1 while it is being
+    // received - the I.R.E. games' behaviour the guard was written for - and
+    // only learns its own size once the connection closes. Every range the
+    // download sets has to be a maximum a progress bar can use, so none of the
+    // -1s may reach one.
+    void test_progressRangeIsNeverSetFromAReplyWithNoTotal()
     {
         TMap* pMap = mpHost->mpMap.data();
         QSignalSpy rangeSpy(pMap, &TMap::signal_mapProgressSetRange);
@@ -464,23 +475,12 @@ private slots:
         disconnect(mark);
         QVERIFY2(finished, "the map download never finished");
 
-        QCOMPARE(phases.ranges, 1);
+        QVERIFY(phases.ranges >= 1);
         QCOMPARE(rangeSpy.at(0).at(1).toInt(), scmAssumedFileSize);
-    }
-
-    // Progress arriving with no progress display to put it on - which the abort
-    // path can produce, since it takes the display down before the reply ends.
-    void test_progressWithNoDisplayIsIgnored()
-    {
-        TMap* pMap = mpHost->mpMap.data();
-        QVERIFY(!pMap->hasActiveTransferProgress());
-        QSignalSpy rangeSpy(pMap, &TMap::signal_mapProgressSetRange);
-        QSignalSpy valueSpy(pMap, &TMap::signal_mapProgressSetValue);
-
-        pMap->slot_setDownloadProgress(512, 1024);
-
-        QCOMPARE(rangeSpy.count(), 0);
-        QCOMPARE(valueSpy.count(), 0);
+        for (int i = 0; i < phases.ranges; ++i) {
+            const int maximum = rangeSpy.at(i).at(1).toInt();
+            QVERIFY2(maximum > 0, qPrintable(qsl("progress range %1 of %2 was given a maximum of %3").arg(i).arg(phases.ranges).arg(maximum)));
+        }
     }
 
     // A game with no map to serve answers 404. Nothing must be left behind: the

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -18,15 +18,22 @@
  ***************************************************************************/
 
 /*
- * Covers TMap::downloadMap() and the three slots that finish the job it starts -
- * slot_setDownloadProgress(), slot_downloadError() and slot_replyFinished() -
- * against a stub HTTP server standing in for a game's MMP map.
+ * Covers TMap::downloadMap() and the four slots that finish the job it starts -
+ * slot_setDownloadProgress(), slot_downloadError(), slot_downloadCancel() and
+ * slot_replyFinished() - against a stub HTTP server standing in for a game's
+ * MMP map.
  *
- * In production nothing but a widget starts one: the mapper's "Download from
- * game" menu item, the same button in the preferences' Mapper tab, and the map
- * context menu. There is no Lua entry point, so the busted suite cannot reach
- * any of this and the tests below call TMap directly, exactly as those three
- * widgets do.
+ * In production nothing but a widget starts one: the mapper's empty-state
+ * "Download from game" button, the map context menu, and the preferences'
+ * Mapper tab, which creates the mapper first if there is none. There is no Lua
+ * entry point, so the busted suite cannot reach any of this.
+ *
+ * All three of those callers therefore have a visible mapper, and
+ * createTransferProgress() puts progress on that widget when there is one. The
+ * tests below deliberately run with no mapper at all, which is the other branch:
+ * the standalone progress signals a frontend renders as its own dialog, and the
+ * one a hidden-mapper profile takes. The last test in the file creates a mapper
+ * and cannot be undone, which is why it is last.
  *
  * A real profile rather than a bare Host, because the interesting part of the
  * chain is what happens after the bytes land: the reply handler writes the file,
@@ -63,8 +70,6 @@
 
 #include <chrono>
 
-using namespace std::chrono_literals;
-
 namespace {
 
 // The shape I.R.E. games serve: a <map> document of areas and rooms, which is
@@ -87,8 +92,8 @@ const QByteArray scmMapXml = QByteArrayLiteral("<?xml version=\"1.0\" encoding=\
                                                " </rooms>\n"
                                                "</map>\n");
 
-// downloadMap() has no idea how big the file will be, so it seeds the progress
-// range with this until the reply reports a real total:
+// TMap::downloadMap() has no idea how big the file will be, so it seeds
+// mExpectedFileSize with this until the reply reports a real total:
 constexpr int scmAssumedFileSize = 4000000;
 
 } // namespace
@@ -104,10 +109,11 @@ public:
     enum class Answer {
         // 200 with a Content-Length, sent in one go
         Whole,
-        // 200 with a Content-Length, sent in two halves a beat apart, so the
-        // reply reports progress more than once
+        // 200 with a Content-Length, sent in halves a beat apart, so the reply
+        // reports progress more than once
         Chunked,
-        // 200 with no Content-Length, so the reply's total stays at -1
+        // 200 with no Content-Length, so the reply reports no total until the
+        // connection closes
         Unsized,
         // 200 with a Content-Length far larger than what is ever sent, so the
         // download stays in flight until the client gives up on it
@@ -144,7 +150,10 @@ private:
             connect(socket, &QTcpSocket::readyRead, this, [this, socket]() {
                 readRequest(socket);
             });
-            connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+            connect(socket, &QTcpSocket::disconnected, this, [this, socket]() {
+                mBuffers.remove(socket);
+                socket->deleteLater();
+            });
         }
     }
 
@@ -198,8 +207,9 @@ private:
         socket->write("HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nContent-Length: " + QByteArray::number(length) + "\r\nConnection: close\r\n\r\n");
     }
 
-    // A beat between the parts, so the reply reports progress a known number of
-    // times rather than however many times loopback happens to split one write.
+    // A beat between the parts, so the reply reports progress at least once per
+    // part rather than however few times loopback happens to coalesce one write
+    // into. It is a floor, not an exact count.
     static void sendInParts(QTcpSocket* socket, const QByteArray& body, const int parts)
     {
         const qsizetype partSize = body.size() / parts;
@@ -260,6 +270,9 @@ private:
     {
         QString text;
         auto& buffer = mpHost->mpConsole->buffer;
+        // From the mark itself, not past it: every console message ends in a
+        // newline, so the line the mark names is the empty one the next message
+        // starts writing into rather than the previous test's last line.
         for (int i = mConsoleMark, last = buffer.getLastLineNumber(); i <= last; ++i) {
             text.append(buffer.line(i)).append(QChar::Space);
         }
@@ -268,9 +281,11 @@ private:
 
     bool consoleShows(const QString& needle) const { return consoleTextSinceMark().contains(needle); }
 
-    // The progress display closing is the last thing slot_replyFinished()'s
-    // cleanup does, on every one of its exits, so it is what "the download is
-    // over" means from outside.
+    // Every exit from slot_replyFinished() runs the same cleanup, and closing
+    // the progress display is the only part of it anything outside can see. The
+    // import flag is cleared just after, so waiting on the signal through the
+    // event loop - rather than reading the spy the instant it fires - is what
+    // makes "the download is over" true by the time this returns.
     bool runDownload(const QString& remoteUrl, const QString& localFileName = QString())
     {
         TMap* pMap = mpHost->mpMap.data();
@@ -393,6 +408,9 @@ private slots:
     {
         mpHost->mpMap->slot_downloadCancel();
         qApp->processEvents();
+        // Here rather than at the end of the case that sets it, so a failure
+        // part way through that case cannot leak it into the next one:
+        mpHost->mpMap->setMmpMapLocation(QString());
     }
 
     // The whole chain on a good day: request, save, parse, announce.
@@ -415,8 +433,8 @@ private slots:
         // cancel button has to go away between the two.
         QCOMPARE(disableCancelSpy.count(), 1);
 
-        // A download with no local name of its own lands on the profile's
-        // map.xml, inside this test's own config root:
+        // A download with no local name of its own and an URL ending in "xml"
+        // lands on the profile's map.xml, inside this test's own config root:
         const QString stored = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
         QFile file(stored);
         QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(qsl("the downloaded map was not saved to %1").arg(stored)));
@@ -435,8 +453,10 @@ private slots:
         QVERIFY(!pMap->hasActiveTransferProgress());
     }
 
-    // The reply's own total only turns up after the first progress report, so
-    // the range starts as a guess and is corrected once.
+    // The first progress report always seeds the range from the guess without
+    // consulting the total it was handed, even when the reply knew its size all
+    // along - so a real total can only take effect on a later report, which is
+    // why this download is served in parts.
     void test_progressRangeStartsAsAGuessAndIsCorrectedFromTheReply()
     {
         TMap* pMap = mpHost->mpMap.data();
@@ -474,6 +494,10 @@ private slots:
         disconnect(mark);
         QVERIFY2(finished, "the map download never finished");
 
+        // Without a report that arrives while the total is still unknown AND
+        // the range already set, the guard below is never consulted and the
+        // rest of this would pass without testing anything:
+        QVERIFY2(phases.values >= 3, qPrintable(qsl("the reply reported progress %1 times, too few to reach the guard").arg(phases.values)));
         QVERIFY(phases.ranges >= 1);
         QCOMPARE(rangeSpy.at(0).at(1).toInt(), scmAssumedFileSize);
         for (int i = 0; i < phases.ranges; ++i) {
@@ -532,6 +556,13 @@ private slots:
     void test_downloadIsRefusedWhileAJsonOperationOwnsTheProgressDisplay()
     {
         TMap* pMap = mpHost->mpMap.data();
+        // A map with rooms in it, so the export the download interrupts is
+        // doing real work rather than writing an empty one - the case before
+        // this can leave the map cleared:
+        pMap->mapClear();
+        QVERIFY(pMap->mpRoomDB->addArea(qsl("Exported Area")) > 0);
+        QVERIFY(pMap->addRoom(1));
+        QVERIFY(pMap->setRoomArea(1, 1));
         QTemporaryDir jsonDir;
         QVERIFY(jsonDir.isValid());
         QSignalSpy exportStartSpy(pMap, &TMap::signal_mapJsonProgressStart);
@@ -575,15 +606,18 @@ private slots:
         QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after an invalid URL was refused, so the import flag was left set");
     }
 
-    // Abort is not an error, so it must not add an error line to the console on
-    // top of the alert the cancel itself posts.
+    // An abort is not a download error, so slot_downloadError() has to stay
+    // quiet about it and leave the console with only the alert the cancel posts.
     //
     // QNetworkReply::abort() delivers finished() synchronously, so the whole
     // chain has unwound by the time slot_downloadCancel() returns - no waiting
-    // needed. Note that it unwinds through the save-and-parse path rather than
-    // the error one, since slot_replyFinished() deliberately does not treat a
-    // cancel as an error, so the partial file is written and handed to the XML
-    // reader, which opens a progress display of its own for it.
+    // needed. It unwinds through the save-and-parse path rather than the error
+    // one, since slot_replyFinished() deliberately excludes a cancel from its
+    // error exit: what reaches the destination file is whatever the aborted
+    // reply still has to give, which is nothing, and the empty result is then
+    // handed to the map reader. So a second, different error line - about the
+    // parse - does follow, which is why the assertion below names the download
+    // error rather than looking for the absence of errors.
     void test_cancelStopsTheDownloadWithoutReportingAnError()
     {
         TMap* pMap = mpHost->mpMap.data();
@@ -601,6 +635,7 @@ private slots:
         QVERIFY2(consoleShows(qsl("canceled, on user's request")), qPrintable(consoleTextSinceMark()));
         QVERIFY2(!consoleShows(qsl("Map download encountered an error")), qPrintable(consoleTextSinceMark()));
         QVERIFY(!pMap->hasActiveTransferProgress());
+        QVERIFY2(mapDownloadEventCountIs(0), "a canceled download raised sysMapDownloadEvent");
 
         QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after a canceled one was refused, so the import flag was left set");
     }
@@ -627,17 +662,32 @@ private slots:
         TMap* pMap = mpHost->mpMap.data();
         pMap->setMmpMapLocation(mpMapServer->url(qsl("/mmp.xml")));
 
-        TMap* map = pMap;
-        QSignalSpy closeSpy(map, &TMap::signal_mapProgressClose);
-        map->downloadMap();
-        QVERIFY2(closeSpy.count() == 1 || closeSpy.wait(15000), "the map download never finished");
+        QVERIFY2(runDownload(QString()), "the map download never finished");
 
         QCOMPARE(mpMapServer->requestedPaths(), QStringList{qsl("/mmp.xml")});
-        pMap->setMmpMapLocation(QString());
     }
 
-    // A URL that does not end in "xml" is a binary map file, which goes to
-    // TMainConsole::loadMap() rather than the XML reader.
+    // The game answers, but with a document that stops part way through - the
+    // shape a server cutting the response short produces. The reader has already
+    // cleared the map by the time the parse fails, so the least that has to be
+    // true is that the failure is reported, no download event goes out, and the
+    // next attempt is accepted.
+    void test_aTruncatedMapIsReportedAsAParseFailure()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        mpMapServer->serve(qsl("/truncated.xml"), QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<map>\n <areas>\n  <area id=\"1\" name=\"Half an"));
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/truncated.xml"))), "the map download never finished");
+
+        QVERIFY2(consoleShows(qsl("failure in parsing destination file")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(mapDownloadEventCountIs(0), "a map that failed to parse still raised sysMapDownloadEvent");
+        QVERIFY(!pMap->hasActiveTransferProgress());
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after an unparseable one was refused, so the import flag was left set");
+    }
+
+    // A destination file name that does not end in "xml" - which an URL not
+    // ending in "xml" is what gives it by default - is a binary map file, and
+    // goes to TMainConsole::loadMap() rather than the XML reader.
     //
     // Last on purpose: loadMap() creates the mapper widget, and from then on
     // TMap puts its progress on that widget instead of emitting the standalone
@@ -676,6 +726,7 @@ private slots:
         QCOMPARE(pRoom->y(), 4);
         QCOMPARE(pRoom->z(), 5);
         QVERIFY2(consoleShows(qsl("map downloaded and stored")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(mapDownloadEventCountIs(1), "the binary path did not raise sysMapDownloadEvent");
     }
 };
 

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -238,7 +238,6 @@ private:
     const QString mLocalhost = qsl("localhost");
     int mConsoleMark = 0;
     QByteArray mPaddedMapXml;
-    QByteArray mBinaryMap;
 
     // setupConfig() consults portable.txt before the XDG logic
     static bool portableMarkerPresent()
@@ -659,8 +658,7 @@ private slots:
             out.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         QVERIFY(pMap->serialize(out));
-        mBinaryMap = serialized;
-        mpMapServer->serve(qsl("/map.dat"), mBinaryMap);
+        mpMapServer->serve(qsl("/map.dat"), serialized);
 
         pMap->mapClear();
         QVERIFY(pMap->mpRoomDB->isEmpty());

--- a/test/functional_tests/MapFileStatsTest.cpp
+++ b/test/functional_tests/MapFileStatsTest.cpp
@@ -19,14 +19,17 @@
 
 /*
  * Covers TMap::retrieveMapFileStats(), which reads another profile's saved map
- * far enough to say what it holds without loading it. The preferences' Mapper
- * tab is its only caller - it fills in the "copy a map from another profile"
- * list - so there is no Lua route to it, and the tests below call it directly.
+ * far enough to say what it holds without loading it. Its one caller is
+ * dlgProfilePreferences::slot_copyMap(), behind the preferences' "copy to N
+ * destination(s)" button: before this profile's map is written into each
+ * destination, that destination's own last saved map is read for the room its
+ * player was standing in, so the copy does not move them. There is no Lua route
+ * to any of it, so the tests below call it directly.
  *
- * Reading somebody else's file with somebody else's serializer is the whole
- * point of it: the map it reports on must not become the map it is called on.
- * The player's room is looked up by profile name, so it also has to be the
- * requested profile's room rather than the reading profile's.
+ * Reading somebody else's file without becoming it is the whole point: the map
+ * reported on must not replace the map the call was made on, and the player
+ * room is keyed by profile name, so it has to be the requested profile's entry
+ * rather than the reading profile's.
  *
  * Run with: ctest -R MapFileStatsTest -V
  */
@@ -77,8 +80,8 @@ private:
 
     QString otherProfileMapDir() const { return mudlet::getMudletPath(enums::profileMapsPath, mOtherProfileName); }
 
-    // Two areas, four rooms, and a player room recorded against the profile the
-    // file claims to belong to.
+    // The player room has to be recorded against the profile the file will
+    // claim to belong to, since that is the entry the read looks up.
     void buildMapToSave() const
     {
         map()->mapClear();
@@ -101,8 +104,9 @@ private:
         map()->mRoomIdHash[mProfileName] = 1;
     }
 
-    // The same QDataStream setup TMainConsole::saveMap uses
-    bool writeMapFile(const QString& pathFileName) const
+    // The same QDataStream setup TMainConsole::saveMap uses. saveVersion 0 means
+    // the map's own; anything else has to be within mMinVersion..mMaxVersion.
+    bool writeMapFile(const QString& pathFileName, const int saveVersion = 0) const
     {
         QSaveFile file(pathFileName);
         if (!file.open(QIODevice::WriteOnly)) {
@@ -112,7 +116,7 @@ private:
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
             out.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
-        return map()->serialize(out) && file.commit();
+        return map()->serialize(out, saveVersion) && file.commit();
     }
 
 private slots:
@@ -189,11 +193,19 @@ private slots:
         }
         QVERIFY(QDir().mkpath(otherProfileMapDir()));
         const QString pathFileName = qsl("%1/20260819-01-01-01map").arg(otherProfileMapDir());
-        QVERIFY(writeMapFile(pathFileName));
+        // An older format than this build's own, so what comes back is read
+        // from the file rather than being this map's version by coincidence:
+        QVERIFY(writeMapFile(pathFileName, 19));
 
-        // What this map holds before the read, to compare against afterwards:
+        // Every one of the five answers has a counterpart in this map, so the
+        // live map is moved away from all of them before the read - otherwise a
+        // reader that returned its own state instead of the file's would pass:
+        QVERIFY(map()->addRoom(99));
+        QVERIFY(map()->setRoomArea(99, 1));
+        map()->mRoomIdHash[mOtherProfileName] = 99;
+        map()->mRoomIdHash[mProfileName] = 99;
         const int ownRoomCount = map()->mpRoomDB->getRoomMap().size();
-        const int ownPlayerRoom = map()->mRoomIdHash.value(mProfileName);
+        QCOMPARE(ownRoomCount, 5);
 
         QString latestFileName;
         int fileVersion = 0;
@@ -203,17 +215,24 @@ private slots:
         QVERIFY(map()->retrieveMapFileStats(mOtherProfileName, &latestFileName, &fileVersion, &roomId, &areaCount, &roomCount));
 
         QCOMPARE(latestFileName, pathFileName);
-        QCOMPARE(fileVersion, map()->mVersion);
-        // The player room recorded for the profile asked about, not for this one:
+        QCOMPARE(fileVersion, 19);
+        // The player room the file records for the profile asked about, not the
+        // one this map now holds for either profile:
         QCOMPARE(roomId, scmPlayerRoomId);
         // The two areas made above plus the default area every map carries:
         QCOMPARE(areaCount, 3);
         QCOMPARE(roomCount, 4);
 
+        // ...and reading it changed nothing here:
         QCOMPARE(map()->mpRoomDB->getRoomMap().size(), ownRoomCount);
-        QCOMPARE(map()->mRoomIdHash.value(mProfileName), ownPlayerRoom);
+        QCOMPARE(map()->mRoomIdHash.value(mProfileName), 99);
+        QCOMPARE(map()->mRoomIdHash.value(mOtherProfileName), 99);
+        QCOMPARE(map()->mVersion, map()->mDefaultVersion);
     }
 
+    // The pick is by modification time. The names deliberately sort the other
+    // way round, so a read that went by name - in either direction - would name
+    // the wrong file rather than happen to agree.
     void test_theMostRecentlyWrittenMapFileIsTheOneReported()
     {
         buildMapToSave();
@@ -221,26 +240,29 @@ private slots:
             return;
         }
         QVERIFY(QDir().mkpath(otherProfileMapDir()));
-        const QString older = qsl("%1/20260101-01-01-01map").arg(otherProfileMapDir());
-        const QString newer = qsl("%1/20260819-01-01-01map").arg(otherProfileMapDir());
-        QVERIFY(writeMapFile(older));
-        QVERIFY(writeMapFile(newer));
+        const QString first = qsl("%1/20260819-01-01-01map").arg(otherProfileMapDir());
+        const QString second = qsl("%1/20260101-01-01-01map").arg(otherProfileMapDir());
+        QVERIFY(writeMapFile(first));
+        QVERIFY(writeMapFile(second));
 
         // Both were written in the same instant, so say which is which rather
         // than trust the filesystem's timestamp resolution:
-        QFile olderFile(older);
-        QVERIFY(olderFile.open(QIODevice::ReadWrite));
-        QVERIFY(olderFile.setFileTime(QDateTime::currentDateTime().addDays(-30), QFileDevice::FileModificationTime));
-        olderFile.close();
+        QFile firstFile(first);
+        QVERIFY(firstFile.open(QIODevice::ReadWrite));
+        QVERIFY(firstFile.setFileTime(QDateTime::currentDateTime().addDays(-30), QFileDevice::FileModificationTime));
+        firstFile.close();
 
         QString latestFileName;
         QVERIFY(map()->retrieveMapFileStats(mOtherProfileName, &latestFileName, nullptr, nullptr, nullptr, nullptr));
-        QCOMPARE(latestFileName, newer);
+        QCOMPARE(latestFileName, second);
     }
 
-    // A map saved by a newer Mudlet than this one: the version is all that can
-    // be said about it, and saying it is how the preferences dialog knows to
-    // refuse the copy rather than read a format it does not understand.
+    // A map saved by a newer Mudlet than this one: the read stops at the version
+    // rather than try to make sense of a layout it does not know, and the caller
+    // gets the version so it can say so. Which of the two early returns takes it
+    // depends on the build - a release or public test build stops as soon as the
+    // version is past mDefaultVersion, a development one goes on to compare it
+    // against mMaxVersion - but both leave everything after the version unread.
     void test_aMapFromANewerMudletIsReportedByVersionAlone()
     {
         QVERIFY(QDir().mkpath(otherProfileMapDir()));

--- a/test/functional_tests/MapFileStatsTest.cpp
+++ b/test/functional_tests/MapFileStatsTest.cpp
@@ -1,0 +1,273 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Covers TMap::retrieveMapFileStats(), which reads another profile's saved map
+ * far enough to say what it holds without loading it. The preferences' Mapper
+ * tab is its only caller - it fills in the "copy a map from another profile"
+ * list - so there is no Lua route to it, and the tests below call it directly.
+ *
+ * Reading somebody else's file with somebody else's serializer is the whole
+ * point of it: the map it reports on must not become the map it is called on.
+ * The player's room is looked up by profile name, so it also has to be the
+ * requested profile's room rather than the reading profile's.
+ *
+ * Run with: ctest -R MapFileStatsTest -V
+ */
+
+#include <QFileInfo>
+#include <QSaveFile>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapFileStatsTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("MapFileStats-Test");
+    // The profile whose map file is being reported on. It never needs to be a
+    // real profile - only its map directory is ever read.
+    const QString mOtherProfileName = qsl("MapFileStatsOther-Test");
+    static constexpr int scmPlayerRoomId = 3;
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    void deleteProfileDirectory(const QString& profileName) const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+
+    QString otherProfileMapDir() const { return mudlet::getMudletPath(enums::profileMapsPath, mOtherProfileName); }
+
+    // Two areas, four rooms, and a player room recorded against the profile the
+    // file claims to belong to.
+    void buildMapToSave() const
+    {
+        map()->mapClear();
+        TRoomDB* pDB = map()->mpRoomDB.get();
+        const int areaA = pDB->addArea(qsl("Area A"));
+        const int areaB = pDB->addArea(qsl("Area B"));
+        QVERIFY(areaA > 0);
+        QVERIFY(areaB > 0);
+        int id = 1;
+        for (const int areaId : {areaA, areaB}) {
+            for (int i = 0; i < 2; ++i, ++id) {
+                QVERIFY(map()->addRoom(id));
+                QVERIFY(map()->setRoomArea(id, areaId));
+                QVERIFY(map()->setRoomCoordinates(id, i, i, 0));
+            }
+        }
+        map()->mRoomIdHash[mOtherProfileName] = scmPlayerRoomId;
+        // The reading profile's own player room, which must not be the one
+        // reported back for the other profile:
+        map()->mRoomIdHash[mProfileName] = 1;
+    }
+
+    // The same QDataStream setup TMainConsole::saveMap uses
+    bool writeMapFile(const QString& pathFileName) const
+    {
+        QSaveFile file(pathFileName);
+        if (!file.open(QIODevice::WriteOnly)) {
+            return false;
+        }
+        QDataStream out(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            out.setVersion(mudlet::scmQDataStreamFormat_5_12);
+        }
+        return map()->serialize(out) && file.commit();
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+        deleteProfileDirectory(mOtherProfileName);
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the test Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            deleteProfileDirectory(mOtherProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void init()
+    {
+        QDir dir(otherProfileMapDir());
+        if (dir.exists()) {
+            QVERIFY(dir.removeRecursively());
+        }
+    }
+
+    void test_noProfileNameIsRejected() { QVERIFY(!map()->retrieveMapFileStats(QString(), nullptr, nullptr, nullptr, nullptr, nullptr)); }
+
+    void test_profileWithNoSavedMapIsRejected()
+    {
+        QVERIFY2(!QFileInfo::exists(otherProfileMapDir()), "the other profile's map directory should not exist yet");
+        QVERIFY(!map()->retrieveMapFileStats(mOtherProfileName, nullptr, nullptr, nullptr, nullptr, nullptr));
+
+        // ...and an empty map directory is no better than a missing one:
+        QVERIFY(QDir().mkpath(otherProfileMapDir()));
+        QVERIFY(!map()->retrieveMapFileStats(mOtherProfileName, nullptr, nullptr, nullptr, nullptr, nullptr));
+    }
+
+    void test_savedMapIsReportedWithoutDisturbingThisMap()
+    {
+        buildMapToSave();
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+        QVERIFY(QDir().mkpath(otherProfileMapDir()));
+        const QString pathFileName = qsl("%1/20260819-01-01-01map").arg(otherProfileMapDir());
+        QVERIFY(writeMapFile(pathFileName));
+
+        // What this map holds before the read, to compare against afterwards:
+        const int ownRoomCount = map()->mpRoomDB->getRoomMap().size();
+        const int ownPlayerRoom = map()->mRoomIdHash.value(mProfileName);
+
+        QString latestFileName;
+        int fileVersion = 0;
+        int roomId = 0;
+        qsizetype areaCount = 0;
+        qsizetype roomCount = 0;
+        QVERIFY(map()->retrieveMapFileStats(mOtherProfileName, &latestFileName, &fileVersion, &roomId, &areaCount, &roomCount));
+
+        QCOMPARE(latestFileName, pathFileName);
+        QCOMPARE(fileVersion, map()->mVersion);
+        // The player room recorded for the profile asked about, not for this one:
+        QCOMPARE(roomId, scmPlayerRoomId);
+        // The two areas made above plus the default area every map carries:
+        QCOMPARE(areaCount, 3);
+        QCOMPARE(roomCount, 4);
+
+        QCOMPARE(map()->mpRoomDB->getRoomMap().size(), ownRoomCount);
+        QCOMPARE(map()->mRoomIdHash.value(mProfileName), ownPlayerRoom);
+    }
+
+    void test_theMostRecentlyWrittenMapFileIsTheOneReported()
+    {
+        buildMapToSave();
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+        QVERIFY(QDir().mkpath(otherProfileMapDir()));
+        const QString older = qsl("%1/20260101-01-01-01map").arg(otherProfileMapDir());
+        const QString newer = qsl("%1/20260819-01-01-01map").arg(otherProfileMapDir());
+        QVERIFY(writeMapFile(older));
+        QVERIFY(writeMapFile(newer));
+
+        // Both were written in the same instant, so say which is which rather
+        // than trust the filesystem's timestamp resolution:
+        QFile olderFile(older);
+        QVERIFY(olderFile.open(QIODevice::ReadWrite));
+        QVERIFY(olderFile.setFileTime(QDateTime::currentDateTime().addDays(-30), QFileDevice::FileModificationTime));
+        olderFile.close();
+
+        QString latestFileName;
+        QVERIFY(map()->retrieveMapFileStats(mOtherProfileName, &latestFileName, nullptr, nullptr, nullptr, nullptr));
+        QCOMPARE(latestFileName, newer);
+    }
+
+    // A map saved by a newer Mudlet than this one: the version is all that can
+    // be said about it, and saying it is how the preferences dialog knows to
+    // refuse the copy rather than read a format it does not understand.
+    void test_aMapFromANewerMudletIsReportedByVersionAlone()
+    {
+        QVERIFY(QDir().mkpath(otherProfileMapDir()));
+        const QString pathFileName = qsl("%1/20260819-02-02-02map").arg(otherProfileMapDir());
+        QSaveFile file(pathFileName);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        QDataStream out(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            out.setVersion(mudlet::scmQDataStreamFormat_5_12);
+        }
+        const int impossibleVersion = map()->mVersion + 1;
+        out << impossibleVersion;
+        QVERIFY(file.commit());
+
+        QString latestFileName;
+        int fileVersion = 0;
+        qsizetype areaCount = -1;
+        qsizetype roomCount = -1;
+        QVERIFY(map()->retrieveMapFileStats(mOtherProfileName, &latestFileName, &fileVersion, nullptr, &areaCount, &roomCount));
+
+        QCOMPARE(latestFileName, pathFileName);
+        QCOMPARE(fileVersion, impossibleVersion);
+        // Nothing past the version was read, so the counts are untouched:
+        QCOMPARE(areaCount, -1);
+        QCOMPARE(roomCount, -1);
+    }
+};
+
+#include "MapFileStatsTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MapFileStatsTest)

--- a/test/functional_tests/MapRoomGeometryTest.cpp
+++ b/test/functional_tests/MapRoomGeometryTest.cpp
@@ -1,0 +1,296 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Covers the three parts of TMap that answer a question about where a room is
+ * and what colour it should be drawn in:
+ *
+ *   - connectExitStubByDirection(), which picks the nearest room in a direction
+ *     that has a stub pointing back, and is the only one of the three with a Lua
+ *     route (connectExitStub() with a direction and no target room);
+ *   - detectRoomCollisions(), which has no caller at all outside these tests;
+ *   - getColor(), which only T2DMap's painter and the room properties dialog
+ *     call, so nothing reaches its environment-code arithmetic from Lua.
+ *
+ * Run with: ctest -R MapRoomGeometryTest -V
+ */
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <algorithm>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapRoomGeometryTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("MapRoomGeometry-Test");
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+
+    int addRoomAt(const int id, const int areaId, const int x, const int y, const int z) const
+    {
+        return map()->addRoom(id) && map()->setRoomArea(id, areaId) && map()->setRoomCoordinates(id, x, y, z) ? id : 0;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the test Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // Every test starts from an empty map, so the room and area ids it makes are
+    // its own. mapClear() also puts the sixteen default custom colours back, so
+    // each test sees the environment maps a real profile would have.
+    void init() { map()->mapClear(); }
+
+    // The pick is the nearest candidate, and a candidate has to be in the same
+    // area, on the right side, on the same plane in the axes the direction does
+    // not move along, and carry a stub pointing back.
+    void test_exitStubConnectsToTheNearestRoomWithAMatchingStub()
+    {
+        TRoomDB* pDB = map()->mpRoomDB.get();
+        const int areaId = pDB->addArea(qsl("Stub Area"));
+        QVERIFY(areaId > 0);
+        const int otherAreaId = pDB->addArea(qsl("Other Area"));
+        QVERIFY(otherAreaId > 0);
+
+        QCOMPARE(addRoomAt(1, areaId, 0, 0, 0), 1);
+        // no stub back, so it is passed over even though it is the closest:
+        QCOMPARE(addRoomAt(2, areaId, 1, 0, 0), 2);
+        // right direction and has a stub back, but a floor up:
+        QCOMPARE(addRoomAt(3, areaId, 2, 0, 1), 3);
+        // due west, so on the wrong side entirely:
+        QCOMPARE(addRoomAt(4, areaId, -2, 0, 0), 4);
+        // the nearest room that qualifies:
+        QCOMPARE(addRoomAt(5, areaId, 4, 0, 0), 5);
+        // nearer than room 5, but in another area:
+        QCOMPARE(addRoomAt(6, otherAreaId, 3, 0, 0), 6);
+
+        pDB->getRoom(1)->setExitStub(DIR_EAST, true);
+        for (const int id : {3, 4, 5, 6}) {
+            pDB->getRoom(id)->setExitStub(DIR_WEST, true);
+        }
+
+        QCOMPARE(map()->connectExitStubByDirection(1, DIR_EAST), QString());
+        QCOMPARE(pDB->getRoom(1)->getEast(), 5);
+        // ...and the room it reached gets the exit back:
+        QCOMPARE(pDB->getRoom(5)->getWest(), 1);
+        QCOMPARE(pDB->getRoom(6)->getWest(), -1);
+    }
+
+    void test_exitStubConnectionReportsAnUnknownRoom()
+    {
+        const QString error = map()->connectExitStubByDirection(9999, DIR_EAST);
+        QVERIFY2(error.contains(qsl("does not exist")), qPrintable(error));
+    }
+
+    void test_exitStubConnectionReportsAMissingStub()
+    {
+        const int areaId = map()->mpRoomDB->addArea(qsl("Stubless Area"));
+        QVERIFY(areaId > 0);
+        QCOMPARE(addRoomAt(1, areaId, 0, 0, 0), 1);
+
+        const QString error = map()->connectExitStubByDirection(1, DIR_EAST);
+        QVERIFY2(error.contains(qsl("does not have an exit stub")), qPrintable(error));
+        QVERIFY2(error.contains(qsl("east")), qPrintable(error));
+    }
+
+    void test_exitStubConnectionReportsWhenNothingIsInTheWay()
+    {
+        TRoomDB* pDB = map()->mpRoomDB.get();
+        const int areaId = pDB->addArea(qsl("Lonely Area"));
+        QVERIFY(areaId > 0);
+        QCOMPARE(addRoomAt(1, areaId, 0, 0, 0), 1);
+        // Behind, not ahead:
+        QCOMPARE(addRoomAt(2, areaId, -3, 0, 0), 2);
+
+        pDB->getRoom(1)->setExitStub(DIR_EAST, true);
+        pDB->getRoom(2)->setExitStub(DIR_WEST, true);
+
+        const QString error = map()->connectExitStubByDirection(1, DIR_EAST);
+        QVERIFY2(error.contains(qsl("does not have another room in the indicated direction")), qPrintable(error));
+        QCOMPARE(pDB->getRoom(1)->getEast(), -1);
+    }
+
+    // A room always collides with itself, so the answer for a room standing on
+    // its own is a list of one rather than an empty one.
+    void test_roomCollisionsFindRoomsSharingCoordinates()
+    {
+        TRoomDB* pDB = map()->mpRoomDB.get();
+        const int areaId = pDB->addArea(qsl("Crowded Area"));
+        QVERIFY(areaId > 0);
+        const int otherAreaId = pDB->addArea(qsl("Elsewhere"));
+        QVERIFY(otherAreaId > 0);
+
+        QCOMPARE(addRoomAt(1, areaId, 2, 3, 4), 1);
+        QCOMPARE(addRoomAt(2, areaId, 2, 3, 4), 2);
+        // same x and y but a floor away:
+        QCOMPARE(addRoomAt(3, areaId, 2, 3, 5), 3);
+        QCOMPARE(addRoomAt(4, areaId, 9, 9, 9), 4);
+        // exactly on top of room 1, but collisions are an area's own business:
+        QCOMPARE(addRoomAt(5, otherAreaId, 2, 3, 4), 5);
+
+        QList<int> collisions = map()->detectRoomCollisions(1);
+        std::sort(collisions.begin(), collisions.end());
+        QCOMPARE(collisions, QList<int>({1, 2}));
+
+        QCOMPARE(map()->detectRoomCollisions(4), QList<int>({4}));
+    }
+
+    void test_roomCollisionsForAnUnknownRoomAreEmpty() { QVERIFY(map()->detectRoomCollisions(9999).isEmpty()); }
+
+    void test_colorOfAnUnknownRoomIsInvalid() { QVERIFY(!map()->getColor(9999).isValid()); }
+
+    // An environment code the map has no entry for at all falls back to the
+    // first of the sixteen built-in colours. Note that this applies to the
+    // other fifteen codes too, so a room set straight to environment 16 is red
+    // rather than light black - the built-in codes past the first are only
+    // reachable through mEnvColors, which the next test uses.
+    void test_unmappedEnvironmentsFallBackToTheFirstColour()
+    {
+        const int areaId = map()->mpRoomDB->addArea(qsl("Colour Area"));
+        QVERIFY(areaId > 0);
+        QCOMPARE(addRoomAt(1, areaId, 0, 0, 0), 1);
+        QCOMPARE(addRoomAt(2, areaId, 1, 0, 0), 2);
+        QCOMPARE(addRoomAt(3, areaId, 2, 0, 0), 3);
+
+        map()->mpRoomDB->getRoom(1)->environment = 1;
+        map()->mpRoomDB->getRoom(2)->environment = 16;
+        map()->mpRoomDB->getRoom(3)->environment = 999;
+
+        QCOMPARE(map()->getColor(1), mpHost->mRed_2);
+        QCOMPARE(map()->getColor(2), mpHost->mRed_2);
+        QCOMPARE(map()->getColor(3), mpHost->mRed_2);
+    }
+
+    // mEnvColors maps a game's own environment ids onto the colour codes, so
+    // every case below reaches getColor() through that indirection.
+    void test_mappedEnvironmentsResolveThroughTheColourCodes()
+    {
+        const int areaId = map()->mpRoomDB->addArea(qsl("Mapped Colour Area"));
+        QVERIFY(areaId > 0);
+        for (int id = 1; id <= 5; ++id) {
+            QCOMPARE(addRoomAt(id, areaId, id, 0, 0), id);
+            map()->mpRoomDB->getRoom(id)->environment = 50 + id;
+        }
+
+        map()->mEnvColors[51] = 4;    // one of the sixteen
+        map()->mEnvColors[52] = 16;   // the last of the sixteen
+        map()->mEnvColors[53] = 200;  // inside the 6x6x6 colour cube
+        map()->mEnvColors[54] = 240;  // inside the greyscale ramp
+        map()->mEnvColors[55] = 1000; // outside every range there is
+
+        QCOMPARE(map()->getColor(1), mpHost->mBlue_2);
+        QCOMPARE(map()->getColor(2), mpHost->mLightBlack_2);
+        // 200 - 16 = 184; 184 / 36 = 5, (184 - 180) / 6 = 0, 184 - 180 = 4:
+        QCOMPARE(map()->getColor(3), QColor(255, 0, 215, 255));
+        // (240 - 232) * 10 + 8 = 88:
+        QCOMPARE(map()->getColor(4), QColor(88, 88, 88, 255));
+        QVERIFY2(!map()->getColor(5).isValid(), "an unrenderable colour code produced a colour anyway");
+    }
+
+    void test_customEnvironmentColoursWinOverTheFallback()
+    {
+        const int areaId = map()->mpRoomDB->addArea(qsl("Custom Colour Area"));
+        QVERIFY(areaId > 0);
+        QCOMPARE(addRoomAt(1, areaId, 0, 0, 0), 1);
+        QCOMPARE(addRoomAt(2, areaId, 1, 0, 0), 2);
+
+        // Not in mEnvColors, so without a custom colour these would both be
+        // treated as environment 1:
+        map()->mpRoomDB->getRoom(1)->environment = 300;
+        map()->mpRoomDB->getRoom(2)->environment = 20;
+        map()->mCustomEnvColors[300] = QColor(12, 34, 56);
+        map()->mCustomEnvColors[20] = QColor(200, 100, 50);
+
+        QCOMPARE(map()->getColor(1), QColor(12, 34, 56));
+        QCOMPARE(map()->getColor(2), QColor(200, 100, 50));
+    }
+};
+
+#include "MapRoomGeometryTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MapRoomGeometryTest)

--- a/test/functional_tests/MapRoomGeometryTest.cpp
+++ b/test/functional_tests/MapRoomGeometryTest.cpp
@@ -24,9 +24,10 @@
  *   - connectExitStubByDirection(), which picks the nearest room in a direction
  *     that has a stub pointing back, and is the only one of the three with a Lua
  *     route (connectExitStub() with a direction and no target room);
- *   - detectRoomCollisions(), which has no caller at all outside these tests -
- *     what the mapper actually draws collision borders from is
- *     TArea::getCollisionNodes() and the area grid index;
+ *   - detectRoomCollisions(), which has no caller at all outside these tests.
+ *     Nothing else uses it: the mapper's collision borders come from
+ *     TAreaGridIndex::roomsInViewportWithCollisions(), and Lua's
+ *     getCollisionLocationsInArea() from TArea::getCollisionNodes();
  *   - getColor(), which only T2DMap's painter and the room properties dialog
  *     call, so nothing reaches its environment-code arithmetic from Lua.
  *
@@ -87,12 +88,10 @@ private slots:
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
 
-        // A config root of this process's own. Sharing the developer's
-        // ~/.config/mudlet means sharing a profile list, so a second copy of
-        // this test running at the same time is told the name it types is
-        // already in use and never gets an enabled Connect button. Since #9712
-        // the opt-in that makes setupConfig() adopt a directory is
-        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        // A config root of this process's own, so this never reads or writes
+        // the developer's ~/.config/mudlet. Since #9712 the opt-in that makes
+        // setupConfig() adopt a directory is $XDG_CONFIG_HOME/mudlet/profiles,
+        // not the mudlet directory alone.
         QVERIFY(mConfigDir.isValid());
         QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
         mSavedXdg = qgetenv("XDG_CONFIG_HOME");
@@ -151,9 +150,12 @@ private slots:
         QCOMPARE(addRoomAt(5, areaId, 4, 0, 0), 5);
         // nearer than room 5, but in another area:
         QCOMPARE(addRoomAt(6, otherAreaId, 3, 0, 0), 6);
+        // qualifies in every way room 5 does, only further off - so it is the
+        // distance comparison rather than any of the filters that rejects it:
+        QCOMPARE(addRoomAt(7, areaId, 9, 0, 0), 7);
 
         pDB->getRoom(1)->setExitStub(DIR_EAST, true);
-        for (const int id : {3, 4, 5, 6}) {
+        for (const int id : {3, 4, 5, 6, 7}) {
             pDB->getRoom(id)->setExitStub(DIR_WEST, true);
         }
 
@@ -162,6 +164,35 @@ private slots:
         // ...and the room it reached gets the exit back:
         QCOMPARE(pDB->getRoom(5)->getWest(), 1);
         QCOMPARE(pDB->getRoom(6)->getWest(), -1);
+        QCOMPARE(pDB->getRoom(7)->getWest(), -1);
+    }
+
+    // North is the direction worth testing beside east. scmUnitVectors puts
+    // north at -y because that is the drawing direction, while room coordinates
+    // have north at +y - so the candidate test for a direction that moves along
+    // y accepts the offset whose sign DIFFERS from the unit vector's, the
+    // opposite of what the x and z tests do. A room laid out due north has to
+    // be found in spite of that.
+    void test_exitStubConnectsNorthwardsAcrossTheFlippedYAxis()
+    {
+        TRoomDB* pDB = map()->mpRoomDB.get();
+        const int areaId = pDB->addArea(qsl("Northward Area"));
+        QVERIFY(areaId > 0);
+
+        QCOMPARE(addRoomAt(1, areaId, 0, 0, 0), 1);
+        // north of room 1:
+        QCOMPARE(addRoomAt(2, areaId, 0, 3, 0), 2);
+        // south of it, and must not be picked:
+        QCOMPARE(addRoomAt(3, areaId, 0, -2, 0), 3);
+
+        pDB->getRoom(1)->setExitStub(DIR_NORTH, true);
+        pDB->getRoom(2)->setExitStub(DIR_SOUTH, true);
+        pDB->getRoom(3)->setExitStub(DIR_SOUTH, true);
+
+        QCOMPARE(map()->connectExitStubByDirection(1, DIR_NORTH), QString());
+        QCOMPARE(pDB->getRoom(1)->getNorth(), 2);
+        QCOMPARE(pDB->getRoom(2)->getSouth(), 1);
+        QCOMPARE(pDB->getRoom(3)->getSouth(), -1);
     }
 
     void test_exitStubConnectionReportsAnUnknownRoom()
@@ -227,11 +258,13 @@ private slots:
 
     void test_colorOfAnUnknownRoomIsInvalid() { QVERIFY(!map()->getColor(9999).isValid()); }
 
-    // An environment code the map has no entry for at all falls back to the
-    // first of the sixteen built-in colours. Note that this applies to the
-    // other fifteen codes too, so a room set straight to environment 16 is red
-    // rather than light black - the built-in codes past the first are only
-    // reachable through mEnvColors, which the next test uses.
+    // An environment code the map has no entry for in either of its two colour
+    // maps falls back to the first of the sixteen built-in colours. That covers
+    // the other fifteen built-in codes too, so a room set straight to
+    // environment 16 comes out red rather than light black: reaching the
+    // built-in codes past the first takes an mEnvColors entry, which the next
+    // test uses. A custom colour for the code is the other way past the
+    // fallback, which the one after that uses.
     void test_unmappedEnvironmentsFallBackToTheFirstColour()
     {
         const int areaId = map()->mpRoomDB->addArea(qsl("Colour Area"));
@@ -255,7 +288,7 @@ private slots:
     {
         const int areaId = map()->mpRoomDB->addArea(qsl("Mapped Colour Area"));
         QVERIFY(areaId > 0);
-        for (int id = 1; id <= 5; ++id) {
+        for (int id = 1; id <= 6; ++id) {
             QCOMPARE(addRoomAt(id, areaId, id, 0, 0), id);
             map()->mpRoomDB->getRoom(id)->environment = 50 + id;
         }
@@ -265,14 +298,21 @@ private slots:
         map()->mEnvColors[53] = 200;  // inside the 6x6x6 colour cube
         map()->mEnvColors[54] = 240;  // inside the greyscale ramp
         map()->mEnvColors[55] = 1000; // outside every range there is
+        // What a profile using setCustomEnvColor() alongside a game's own
+        // environment ids ends up with, the 257-272 set mapClear() restores
+        // included: the indirection lands on a code that has a custom colour.
+        map()->mEnvColors[56] = 257;
 
         QCOMPARE(map()->getColor(1), mpHost->mBlue_2);
         QCOMPARE(map()->getColor(2), mpHost->mLightBlack_2);
-        // 200 - 16 = 184; 184 / 36 = 5, (184 - 180) / 6 = 0, 184 - 180 = 4:
+        // 200 - 16 = 184; 184 / 36 = 5, (184 - 180) / 6 = 0, 184 - 180 = 4;
+        // then 5 and 4 scale to (5 - 1) * 40 + 95 = 255 and (4 - 1) * 40 + 95 =
+        // 215, while a 0 component stays 0:
         QCOMPARE(map()->getColor(3), QColor(255, 0, 215, 255));
         // (240 - 232) * 10 + 8 = 88:
         QCOMPARE(map()->getColor(4), QColor(88, 88, 88, 255));
         QVERIFY2(!map()->getColor(5).isValid(), "an unrenderable colour code produced a colour anyway");
+        QCOMPARE(map()->getColor(6), map()->mCustomEnvColors.value(257));
     }
 
     void test_customEnvironmentColoursWinOverTheFallback()

--- a/test/functional_tests/MapRoomGeometryTest.cpp
+++ b/test/functional_tests/MapRoomGeometryTest.cpp
@@ -24,7 +24,9 @@
  *   - connectExitStubByDirection(), which picks the nearest room in a direction
  *     that has a stub pointing back, and is the only one of the three with a Lua
  *     route (connectExitStub() with a direction and no target room);
- *   - detectRoomCollisions(), which has no caller at all outside these tests;
+ *   - detectRoomCollisions(), which has no caller at all outside these tests -
+ *     what the mapper actually draws collision borders from is
+ *     TArea::getCollisionNodes() and the area grid index;
  *   - getColor(), which only T2DMap's painter and the room properties dialog
  *     call, so nothing reaches its environment-code arithmetic from Lua.
  *


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `MapDownloadTest` drives `TMap::downloadMap()` and the three slots that finish what it starts - `slot_setDownloadProgress()`, `slot_downloadError()` and `slot_replyFinished()` - against a stub HTTP server on an ephemeral port. It covers the download being saved, parsed and announced with `sysMapDownloadEvent`, both progress-range branches, the four refusal and failure paths, cancellation, the MMP location fallback, and the non-XML file going to `TMainConsole::loadMap()`.
- `MapFileStatsTest` covers `TMap::retrieveMapFileStats()`: which file it picks, what it reports, that the player room is the asked-about profile's rather than the reading profile's, and that reading somebody else's map leaves this one alone.
- `MapRoomGeometryTest` covers `TMap::connectExitStubByDirection()`, `TMap::detectRoomCollisions()` and `TMap::getColor()`'s environment-code arithmetic.
- All three join the existing `functional_map_tests` group binary, so each costs a compile rather than another 250MB link.

#### Motivation for adding to Mudlet
`src/TMap.cpp` is at 60% line coverage, and these eight functions account for about 480 of its uncovered lines - the whole download chain among them. Nothing but a widget starts a download - the mapper's "Download from game", the same button in the preferences' Mapper tab, and the map context menu - and `retrieveMapFileStats()`, `detectRoomCollisions()` and `getColor()` have no Lua entry point either, so a busted spec cannot reach any of it.

#### Other info (issues closed, discussion etc)
Every case was mutation-verified: a guard or assignment in `TMap.cpp` (or `XMLimport.cpp`) was broken, the intended case was confirmed to redden, and the change was reverted. One candidate case was dropped because no mutation could redden it - `slot_setDownloadProgress()`'s "no progress display" guard has no observable effect while no mapper widget exists.

Writing these turned up that cancelling a map download does not stop at the cancel: `slot_replyFinished()` deliberately excludes `OperationCanceledError` from its error exit, so it goes on to write what the aborted reply has left - nothing - over the destination file and hand that to the map reader, which clears the loaded map before failing to parse it. Pressing Abort therefore empties the map. Left alone here, since this PR changes no production code.

**Test case:** `ctest --preset linux-debug -R "MapDownloadTest|MapFileStatsTest|MapRoomGeometryTest"` - 3 passed, 26 cases between them. The whole suite is 118/118 under the AddressSanitizer preset with leak checking on, and the three run clean concurrently and over repeated runs.

Assisted-by: Claude:claude-opus-5
