### PR TITLE
Testing: try out Installer PR 146

### DIFF
--- a/CI/linux.after_success.sh
+++ b/CI/linux.after_success.sh
@@ -40,7 +40,8 @@ then
 
   # We refer to $BUILD_COMMIT in the environment to get the commit data now
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  # TESTING: Use the branch from the developer's repo that is being tested:
+  git clone https://github.com/SlySven/installers.git -b "Fix_ensureOpenSSL_3_libraryIsIncludedInLinuxBuilds" "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/generic-linux"
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Run the CI process using a PR from the Installer repository in order to test: https://github.com/Mudlet/installers/pull/146

#### Motivation for adding to Mudlet
**THIS IS NOT TO BE MERGED INTO THE MUDLET REPOSITORY - IT IS FOR TESTING AN *INSTALLERS* REPOSITORY PULL-REQUEST.**

#### Other info (issues closed, discussion etc)
This is to correct a problem with the lack of inclusion of `libssl.so.3` in Linux AppImages post https://github.com/Mudlet/installers/pull/145.