### PR TITLE
Infra: Gate four untested console behaviours with specs

### DIFF
--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -120,9 +120,11 @@ describe("Tests MXP handling", function()
   end)
 
   -- <DEST> hands the game a print sink other than the main window: everything
-  -- between it and </DEST> goes into the named frame's own console, and nothing
-  -- of it may reach main. The frame's console is a miniconsole registered under
-  -- the frame's name, so Lua can read it back like any other window.
+  -- between it and </DEST> goes into the named frame's own console, which is a
+  -- miniconsole registered under the frame's name so Lua can read it back like
+  -- any other window. A frame name that does not resolve is not an error - the
+  -- tag still counts as handled and the text goes to main with only a qWarning
+  -- - so a red spec here is worth checking the frame name over first.
   describe("Tests output redirected into an MXP frame", function()
     local frame = "mxpSpecDestFrame"
 
@@ -134,6 +136,18 @@ describe("Tests MXP handling", function()
       return getLines(frame, 0, lineCount + 1)
     end
 
+    -- the frame line the needle is on, so a redirect that ran two segments
+    -- together on one line can be told from one that kept the break
+    local function frameLineWith(needle)
+      for lineNumber = 0, getLineCount(frame) do
+        local line = getLines(frame, lineNumber, lineNumber + 1)[1]
+        if line and line:find(needle, 1, true) then
+          return lineNumber, line
+        end
+      end
+      return nil
+    end
+
     local function holds(lines, needle)
       for _, line in ipairs(lines) do
         if line:find(needle, 1, true) then
@@ -143,12 +157,23 @@ describe("Tests MXP handling", function()
       return false
     end
 
-    local function mainLinesFrom(firstLine)
-      return getLines("main", firstLine, getLastLineNumber("main") + 1)
+    -- a redirect that leaked would put its text among the last few main lines,
+    -- and looking back from the end rather than from a saved index keeps that
+    -- true whether or not the main buffer trimmed in between
+    local function mainRecentlyHolds(needle)
+      local lastLine = getLastLineNumber("main")
+      for lineNumber = lastLine, math.max(0, lastLine - 20), -1 do
+        local line = getLines("main", lineNumber, lineNumber + 1)[1]
+        if line and line:find(needle, 1, true) then
+          return true
+        end
+      end
+      return false
     end
 
     -- the colour of the first character of the run of text holding the needle,
-    -- read off the main window
+    -- read off the main window. selectSection() works on the line the cursor is
+    -- on and counts columns from zero, where string.find() counts from one
     local function mainColourOf(needle)
       local lastLine = getLastLineNumber("main")
       for lineNumber = lastLine, math.max(0, lastLine - 20), -1 do
@@ -157,7 +182,10 @@ describe("Tests MXP handling", function()
         if at then
           moveCursor("main", 0, lineNumber)
           selectSection("main", at - 1, 1)
-          return getTextFormat("main").foreground
+          local colour = getTextFormat("main").foreground
+          -- a selection left behind is what a later replace() would act on
+          deselect("main")
+          return colour
         end
       end
       return nil
@@ -171,6 +199,9 @@ describe("Tests MXP handling", function()
       -- a frame left open would sit in the main window's layout for every later
       -- spec file, and its console would stay in the window registry
       feedTriggers(('<FRAME %s ACTION="close">'):format(frame) .. "\n")
+      -- closeFrame() answers true for a name it never had, so the only proof
+      -- the main window got its width back is the console being gone
+      assert.is_nil(windowType(frame))
     end)
 
     it("gives the frame a console of its own", function()
@@ -178,22 +209,34 @@ describe("Tests MXP handling", function()
     end)
 
     it("puts the redirected text in the frame and not in the main window", function()
-      local mark = getLineCount("main")
       assert.is_true(feedTriggers(('<DEST %s>MXPDEST1 routed away</DEST>'):format(frame) .. "\n"))
-      assert.is_true(holds(frameLines(), "MXPDEST1 routed away"), table.concat(frameLines(), "|"))
-      assert.is_false(holds(mainLinesFrom(mark), "MXPDEST1"))
+      local _, routed = frameLineWith("MXPDEST1")
+      assert.are.equal("MXPDEST1 routed away", routed, table.concat(frameLines(), "|"))
+      assert.is_false(mainRecentlyHolds("MXPDEST1"))
     end)
 
     it("keeps a line break inside the redirect in the frame too", function()
-      local mark = getLineCount("main")
       assert.is_true(feedTriggers(('<DEST %s>MXPDEST2 first'):format(frame) .. "\nMXPDEST2 second</DEST>\n"))
-      local lines = frameLines()
-      assert.is_true(holds(lines, "MXPDEST2 first"), table.concat(lines, "|"))
-      assert.is_true(holds(lines, "MXPDEST2 second"), table.concat(lines, "|"))
-      assert.is_false(holds(mainLinesFrom(mark), "MXPDEST2"))
+      local shown = table.concat(frameLines(), "|")
+      local firstIndex, firstLine = frameLineWith("MXPDEST2 first")
+      local secondIndex, secondLine = frameLineWith("MXPDEST2 second")
+      assert.is_truthy(firstIndex, shown)
+      assert.is_truthy(secondIndex, shown)
+      -- whole lines and adjacent indexes: a redirect that dropped the break
+      -- would still hold both strings, just run together on one line
+      assert.are.equal("MXPDEST2 first", firstLine, shown)
+      assert.are.equal("MXPDEST2 second", secondLine, shown)
+      assert.are.equal(firstIndex + 1, secondIndex, shown)
+      assert.is_false(mainRecentlyHolds("MXPDEST2"))
     end)
 
+    -- </DEST> resets the text format to the profile's own colours rather than
+    -- restoring whatever was in force, so colour set before the redirect does
+    -- not survive it either
     it("does not let colour set inside the redirect follow the text back to main", function()
+      -- the colour below is never closed by hand, so if the reset under test is
+      -- the thing severed the main console would stay red for every later spec
+      finally(function() feedTriggers("\027[0m\n") end)
       assert.is_true(feedTriggers("MXPDEST3 plain\n"))
       local plainColour = mainColourOf("MXPDEST3 plain")
       assert.is_truthy(plainColour)

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -110,6 +110,13 @@ describe("Tests MXP handling", function()
     it("resolves a custom entity to its non-ASCII value", function()
       assertLineShown("\27[1z<!ENTITY storm \"Гроза\">The &storm; rages", "The Гроза rages")
     end)
+
+    -- <HR> is not written out, it is fed back through the parser as a rule of
+    -- its own, so its width is the window's wrap column with a forty column floor
+    it("draws a horizontal rule as wide as the window wraps", function()
+      local width = math.max(getWindowWrap("main"), 40)
+      assertLineShown("\27[1zMXPRULE1<HR>MXPRULE2", ("-"):rep(width))
+    end)
   end)
 
   -- <DEST> hands the game a print sink other than the main window: everything

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -112,4 +112,87 @@ describe("Tests MXP handling", function()
     end)
   end)
 
+  -- <DEST> hands the game a print sink other than the main window: everything
+  -- between it and </DEST> goes into the named frame's own console, and nothing
+  -- of it may reach main. The frame's console is a miniconsole registered under
+  -- the frame's name, so Lua can read it back like any other window.
+  describe("Tests output redirected into an MXP frame", function()
+    local frame = "mxpSpecDestFrame"
+
+    local function frameLines()
+      local lineCount = getLineCount(frame)
+      if not lineCount or lineCount < 1 then
+        return {}
+      end
+      return getLines(frame, 0, lineCount + 1)
+    end
+
+    local function holds(lines, needle)
+      for _, line in ipairs(lines) do
+        if line:find(needle, 1, true) then
+          return true
+        end
+      end
+      return false
+    end
+
+    local function mainLinesFrom(firstLine)
+      return getLines("main", firstLine, getLastLineNumber("main") + 1)
+    end
+
+    -- the colour of the first character of the run of text holding the needle,
+    -- read off the main window
+    local function mainColourOf(needle)
+      local lastLine = getLastLineNumber("main")
+      for lineNumber = lastLine, math.max(0, lastLine - 20), -1 do
+        local line = getLines("main", lineNumber, lineNumber + 1)[1]
+        local at = line and line:find(needle, 1, true)
+        if at then
+          moveCursor("main", 0, lineNumber)
+          selectSection("main", at - 1, 1)
+          return getTextFormat("main").foreground
+        end
+      end
+      return nil
+    end
+
+    setup(function()
+      feedTriggers(('<FRAME Name="%s" Align="right" Width="20%%" Height="30%%">'):format(frame) .. "\n")
+    end)
+
+    teardown(function()
+      -- a frame left open would sit in the main window's layout for every later
+      -- spec file, and its console would stay in the window registry
+      feedTriggers(('<FRAME %s ACTION="close">'):format(frame) .. "\n")
+    end)
+
+    it("gives the frame a console of its own", function()
+      assert.are.equal("miniconsole", windowType(frame))
+    end)
+
+    it("puts the redirected text in the frame and not in the main window", function()
+      local mark = getLineCount("main")
+      assert.is_true(feedTriggers(('<DEST %s>MXPDEST1 routed away</DEST>'):format(frame) .. "\n"))
+      assert.is_true(holds(frameLines(), "MXPDEST1 routed away"), table.concat(frameLines(), "|"))
+      assert.is_false(holds(mainLinesFrom(mark), "MXPDEST1"))
+    end)
+
+    it("keeps a line break inside the redirect in the frame too", function()
+      local mark = getLineCount("main")
+      assert.is_true(feedTriggers(('<DEST %s>MXPDEST2 first'):format(frame) .. "\nMXPDEST2 second</DEST>\n"))
+      local lines = frameLines()
+      assert.is_true(holds(lines, "MXPDEST2 first"), table.concat(lines, "|"))
+      assert.is_true(holds(lines, "MXPDEST2 second"), table.concat(lines, "|"))
+      assert.is_false(holds(mainLinesFrom(mark), "MXPDEST2"))
+    end)
+
+    it("does not let colour set inside the redirect follow the text back to main", function()
+      assert.is_true(feedTriggers("MXPDEST3 plain\n"))
+      local plainColour = mainColourOf("MXPDEST3 plain")
+      assert.is_truthy(plainColour)
+      assert.is_true(feedTriggers(('<DEST %s>'):format(frame) .. "\027[31mMXPDEST4 red in the frame</DEST>MXPDEST4 back in main\n"))
+      assert.is_true(holds(frameLines(), "MXPDEST4 red in the frame"))
+      assert.are.same(plainColour, mainColourOf("MXPDEST4 back in main"))
+    end)
+  end)
 end)

--- a/src/mudlet-lua/tests/TBufferOSC_spec.lua
+++ b/src/mudlet-lua/tests/TBufferOSC_spec.lua
@@ -322,15 +322,49 @@ describe("Tests TBuffer OSC sequence handling", function()
 
   end)
 
-  -- Text carrying "!osc8-docs" is an easter egg rather than output: the phrase
-  -- itself is swallowed and a banner of worked OSC 8 examples is written into
-  -- the MAIN console's buffer, whichever buffer the phrase arrived in. The
-  -- injection is debounced to a second so that a command echoed locally and the
-  -- game's echo of it back cannot print the banner twice, which is why the
-  -- specs below wait that window out before they start.
-  describe("Tests the !osc8-docs documentation helper", function()
-    local function mainLinesFrom(firstLine)
-      return getLines("main", firstLine, getLastLineNumber("main") + 1)
+  -- A line written through TBuffer::appendLine() that holds the documentation
+  -- phrase is dropped whole, and a banner of worked OSC 8 examples goes into
+  -- the main console's buffer instead - whichever console the line was written
+  -- to. Paths that do not reach appendLine() print the phrase as ordinary text:
+  -- anything the game sends, and an echo from inside a trigger. The injection
+  -- is debounced to a second of wall clock and the timestamp it keeps lives on
+  -- the main buffer, so each spec here waits that window out before it starts.
+  -- The phrase is built rather than written out below, and kept out of the
+  -- describe and it names, so busted's own report cannot set it off.
+  describe("Tests the OSC 8 documentation helper phrase", function()
+    local phrase = "!osc8-" .. "docs"
+    local otherWindow = "osc8DocsSpecWindow"
+    -- pumpEvents() is inert outside test mode, so the debounce window below
+    -- never elapses and the second injection would be suppressed
+    local testMode = os.getenv("MUDLET_TEST_MODE")
+
+    setup(function()
+      createMiniConsole(otherWindow, 0, 0, 200, 100)
+    end)
+
+    teardown(function()
+      deleteMiniConsole(otherWindow)
+    end)
+
+    -- everything main has been told since the marker line, found by scanning
+    -- back for the marker rather than by holding on to an index: sixty lines of
+    -- banner can push the main buffer over its limit, and the trim that follows
+    -- moves every absolute index
+    local function mainSinceMarker(marker)
+      local lastLine = getLastLineNumber("main")
+      local reversed = {}
+      for lineNumber = lastLine, math.max(0, lastLine - 300), -1 do
+        local line = getLines("main", lineNumber, lineNumber + 1)[1] or ""
+        if line:find(marker, 1, true) then
+          local ordered = {}
+          for index = #reversed, 1, -1 do
+            ordered[#ordered + 1] = reversed[index]
+          end
+          return ordered
+        end
+        reversed[#reversed + 1] = line
+      end
+      return nil
     end
 
     local function someLineHolds(lines, needle)
@@ -343,32 +377,52 @@ describe("Tests TBuffer OSC sequence handling", function()
     end
 
     it("writes the worked examples into the main console", function()
+      if not testMode then
+        pending("waiting out the injection debounce needs MUDLET_TEST_MODE")
+        return
+      end
       pumpEvents(1100)
-      local firstLine = getLineCount("main")
-      echo("!osc8-docs")
-      local injected = mainLinesFrom(firstLine)
+      echo("OSCDOCSMARKA\n")
+      echo("OSCDOCS1 " .. phrase .. " OSCDOCS2")
+      local injected = mainSinceMarker("OSCDOCSMARKA")
+      assert.is_truthy(injected, "the marker line the examples follow is gone")
       assert.is_true(#injected > 10, "only " .. #injected .. " lines were injected")
       assert.is_true(someLineHolds(injected, "OSC 8 Hyperlink Examples"), table.concat(injected, "\n"))
       assert.is_true(someLineHolds(injected, "wiki.mudlet.org"), table.concat(injected, "\n"))
-      -- the phrase is consumed, not displayed
-      assert.is_false(someLineHolds(injected, "!osc8-docs"))
+      -- what was written goes whole, not just the phrase out of the middle of it
+      assert.is_false(someLineHolds(injected, "OSCDOCS1"))
+      assert.is_false(someLineHolds(injected, "OSCDOCS2"))
     end)
 
-    it("does not write them a second time inside the debounce window", function()
+    it("writes them into main whichever window they were asked for in", function()
+      if not testMode then
+        pending("waiting out the injection debounce needs MUDLET_TEST_MODE")
+        return
+      end
       pumpEvents(1100)
-      local firstLine = getLineCount("main")
-      echo("!osc8-docs")
-      local afterFirst = getLineCount("main")
-      assert.is_true(afterFirst > firstLine + 10, "the first injection did not happen")
-      echo("!osc8-docs")
-      assert.are.equal(afterFirst, getLineCount("main"))
+      clearWindow(otherWindow)
+      echo("OSCDOCSMARKB\n")
+      echo(otherWindow, phrase)
+      local injected = mainSinceMarker("OSCDOCSMARKB")
+      assert.is_truthy(injected, "the marker line the examples follow is gone")
+      assert.is_true(someLineHolds(injected, "OSC 8 Hyperlink Examples"), table.concat(injected, "\n"))
+      -- and nothing at all in the window the phrase was written to
+      assert.are.equal("", getLines(otherWindow, 0, 1)[1] or "")
+      -- the debounce timestamp lives on the main buffer, so the window the
+      -- phrase arrived in does not get a window of its own
+      echo(phrase)
+      assert.are.equal(#injected, #mainSinceMarker("OSCDOCSMARKB"))
     end)
   end)
 
-  -- A hyperlink can carry visibility instructions, and the only one that runs
-  -- without a mouse is a delayed reveal: the link is written concealed - its
-  -- text replaced by as many spaces - and the visibility manager's timer puts
-  -- the text and the clickable indices back when the delay is up.
+  -- Of the three visibility actions a link can carry, a delayed reveal is the
+  -- only one that completes without a click: concealment waits to be clicked
+  -- before its timer even starts, and reveal-then-conceal only gets through its
+  -- reveal half unattended. The link is written concealed and the visibility
+  -- manager puts its text back on the first tick of its 100ms poll past the
+  -- delay, so the wait below is not the delay itself. The manager also restores
+  -- the link indices at the same time, which no Lua call can read back - that
+  -- half of the reveal is left to a functional test.
   describe("Tests OSC 8 hyperlink visibility expiry", function()
     local function lineHolding(needle)
       local lastLine = getLastLineNumber("main")
@@ -382,11 +436,17 @@ describe("Tests TBuffer OSC sequence handling", function()
     end
 
     it("reveals a link that was written concealed once its delay is up", function()
+      if not os.getenv("MUDLET_TEST_MODE") then
+        -- pumpEvents() is inert outside test mode, so the reveal never fires
+        pending("waiting for the reveal timer needs MUDLET_TEST_MODE")
+        return
+      end
       local link = "\027]8;;send:osc8reveal?config={\"visibility\":{\"action\":\"reveal\",\"delay\":250}}\027\\HIDDENWORD\027]8;;\027\\"
       assert.is_true(feedTriggers("OSCREVEAL1(" .. link .. ")OSCREVEAL1\n"))
       local lineNumber, concealed = lineHolding("OSCREVEAL1")
       assert.is_truthy(lineNumber, "the line carrying the link never reached the buffer")
-      -- HIDDENWORD is ten characters, so ten spaces stand in for it
+      -- concealment keeps the character count identical so buffer indices stay
+      -- valid, which is why the text is replaced space for space
       assert.equals("OSCREVEAL1(          )OSCREVEAL1", concealed)
       pumpEvents(700)
       assert.equals("OSCREVEAL1(HIDDENWORD)OSCREVEAL1", getLines("main", lineNumber, lineNumber + 1)[1])

--- a/src/mudlet-lua/tests/TBufferOSC_spec.lua
+++ b/src/mudlet-lua/tests/TBufferOSC_spec.lua
@@ -322,5 +322,75 @@ describe("Tests TBuffer OSC sequence handling", function()
 
   end)
 
+  -- Text carrying "!osc8-docs" is an easter egg rather than output: the phrase
+  -- itself is swallowed and a banner of worked OSC 8 examples is written into
+  -- the MAIN console's buffer, whichever buffer the phrase arrived in. The
+  -- injection is debounced to a second so that a command echoed locally and the
+  -- game's echo of it back cannot print the banner twice, which is why the
+  -- specs below wait that window out before they start.
+  describe("Tests the !osc8-docs documentation helper", function()
+    local function mainLinesFrom(firstLine)
+      return getLines("main", firstLine, getLastLineNumber("main") + 1)
+    end
+
+    local function someLineHolds(lines, needle)
+      for _, line in ipairs(lines) do
+        if line:find(needle, 1, true) then
+          return true
+        end
+      end
+      return false
+    end
+
+    it("writes the worked examples into the main console", function()
+      pumpEvents(1100)
+      local firstLine = getLineCount("main")
+      echo("!osc8-docs")
+      local injected = mainLinesFrom(firstLine)
+      assert.is_true(#injected > 10, "only " .. #injected .. " lines were injected")
+      assert.is_true(someLineHolds(injected, "OSC 8 Hyperlink Examples"), table.concat(injected, "\n"))
+      assert.is_true(someLineHolds(injected, "wiki.mudlet.org"), table.concat(injected, "\n"))
+      -- the phrase is consumed, not displayed
+      assert.is_false(someLineHolds(injected, "!osc8-docs"))
+    end)
+
+    it("does not write them a second time inside the debounce window", function()
+      pumpEvents(1100)
+      local firstLine = getLineCount("main")
+      echo("!osc8-docs")
+      local afterFirst = getLineCount("main")
+      assert.is_true(afterFirst > firstLine + 10, "the first injection did not happen")
+      echo("!osc8-docs")
+      assert.are.equal(afterFirst, getLineCount("main"))
+    end)
+  end)
+
+  -- A hyperlink can carry visibility instructions, and the only one that runs
+  -- without a mouse is a delayed reveal: the link is written concealed - its
+  -- text replaced by as many spaces - and the visibility manager's timer puts
+  -- the text and the clickable indices back when the delay is up.
+  describe("Tests OSC 8 hyperlink visibility expiry", function()
+    local function lineHolding(needle)
+      local lastLine = getLastLineNumber("main")
+      for lineNumber = lastLine, math.max(0, lastLine - 20), -1 do
+        local line = getLines("main", lineNumber, lineNumber + 1)[1]
+        if line and line:find(needle, 1, true) then
+          return lineNumber, line
+        end
+      end
+      return nil
+    end
+
+    it("reveals a link that was written concealed once its delay is up", function()
+      local link = "\027]8;;send:osc8reveal?config={\"visibility\":{\"action\":\"reveal\",\"delay\":250}}\027\\HIDDENWORD\027]8;;\027\\"
+      assert.is_true(feedTriggers("OSCREVEAL1(" .. link .. ")OSCREVEAL1\n"))
+      local lineNumber, concealed = lineHolding("OSCREVEAL1")
+      assert.is_truthy(lineNumber, "the line carrying the link never reached the buffer")
+      -- HIDDENWORD is ten characters, so ten spaces stand in for it
+      assert.equals("OSCREVEAL1(          )OSCREVEAL1", concealed)
+      pumpEvents(700)
+      assert.equals("OSCREVEAL1(HIDDENWORD)OSCREVEAL1", getLines("main", lineNumber, lineNumber + 1)[1])
+    end)
+  end)
 
 end)

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -5669,10 +5669,9 @@ describe("Console buffer size", function()
     assert.is_true(lineCount <= 310, "line count was " .. lineCount)
   end)
 
-  -- The trim is what tells scripts their saved line indexes have moved, and the
-  -- only way they can hear about it is sysBufferShrinkEvent. The window name is
-  -- read off the console the buffer belongs to and the count is the batch
-  -- deletion size, so both arguments are engine state reached through the view.
+  -- The trim is what tells scripts their saved line indexes have moved, and
+  -- sysBufferShrinkEvent is the only way they can hear about it: it names the
+  -- console the lines went from and says how many went.
   it("raises sysBufferShrinkEvent naming the window the lines went from", function()
     clearWindow(console)
     assert.is_true(setConsoleBufferSize(console, 100, 10))
@@ -5680,23 +5679,29 @@ describe("Console buffer size", function()
     local handlerId = registerAnonymousEventHandler("sysBufferShrinkEvent", function(_, windowName, removedLines)
       seen[#seen + 1] = {window = windowName, removed = removedLines}
     end)
+    finally(function() killAnonymousEventHandler(handlerId) end)
     for lineNumber = 1, 200 do
       echo(console, ("shrink line %d\n"):format(lineNumber))
     end
     killAnonymousEventHandler(handlerId)
-    assert.is_true(#seen > 0, "the buffer was trimmed but no sysBufferShrinkEvent arrived")
+    local named = 0
     for _, event in ipairs(seen) do
-      assert.are.equal(console, event.window)
-      -- the count arrives as a number, not as the text it is built from
-      assert.are.equal("number", type(event.removed))
-      assert.are.equal(10, event.removed)
+      if event.window == console then
+        named = named + 1
+        -- the count arrives as a number, not as the text it is built from
+        assert.are.equal("number", type(event.removed))
+        assert.are.equal(10, event.removed)
+      end
     end
+    assert.is_true(named > 0, ("%d trims were announced, none of them naming %s"):format(#seen, console))
   end)
 
   -- The count the event carries is the amount every surviving index moved by.
-  -- Neither cursor is renumbered with them - that is the known limitation the
-  -- event exists to work around - so a script that ignores it is left pointing
-  -- at whatever text has since moved under its index.
+  -- The cursor moveCursor() sets is not moved with them: it keeps the index it
+  -- was given rather than following the line it was parked on. The engine's own
+  -- cursor is left behind too, but no Lua call reads that one back. That is the
+  -- known limitation the event exists to work around, so a script that ignores
+  -- it is left pointing at whatever text has since moved under its index.
   it("shifts the lines under a saved index down by the count the event reports", function()
     clearWindow(console)
     assert.is_true(setConsoleBufferSize(console, 100, 10))
@@ -5713,6 +5718,7 @@ describe("Console buffer size", function()
         trimmed = trimmed + removedLines
       end
     end)
+    finally(function() killAnonymousEventHandler(handlerId) end)
     for lineNumber = 1, 35 do
       echo(console, ("filler line %d\n"):format(lineNumber))
     end

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -5669,6 +5669,64 @@ describe("Console buffer size", function()
     assert.is_true(lineCount <= 310, "line count was " .. lineCount)
   end)
 
+  -- The trim is what tells scripts their saved line indexes have moved, and the
+  -- only way they can hear about it is sysBufferShrinkEvent. The window name is
+  -- read off the console the buffer belongs to and the count is the batch
+  -- deletion size, so both arguments are engine state reached through the view.
+  it("raises sysBufferShrinkEvent naming the window the lines went from", function()
+    clearWindow(console)
+    assert.is_true(setConsoleBufferSize(console, 100, 10))
+    local seen = {}
+    local handlerId = registerAnonymousEventHandler("sysBufferShrinkEvent", function(_, windowName, removedLines)
+      seen[#seen + 1] = {window = windowName, removed = removedLines}
+    end)
+    for lineNumber = 1, 200 do
+      echo(console, ("shrink line %d\n"):format(lineNumber))
+    end
+    killAnonymousEventHandler(handlerId)
+    assert.is_true(#seen > 0, "the buffer was trimmed but no sysBufferShrinkEvent arrived")
+    for _, event in ipairs(seen) do
+      assert.are.equal(console, event.window)
+      -- the count arrives as a number, not as the text it is built from
+      assert.are.equal("number", type(event.removed))
+      assert.are.equal(10, event.removed)
+    end
+  end)
+
+  -- The count the event carries is the amount every surviving index moved by.
+  -- Neither cursor is renumbered with them - that is the known limitation the
+  -- event exists to work around - so a script that ignores it is left pointing
+  -- at whatever text has since moved under its index.
+  it("shifts the lines under a saved index down by the count the event reports", function()
+    clearWindow(console)
+    assert.is_true(setConsoleBufferSize(console, 100, 10))
+    for lineNumber = 1, 90 do
+      echo(console, ("kept line %d\n"):format(lineNumber))
+    end
+    local savedIndex = getLastLineNumber(console) - 20
+    local savedText = getLines(console, savedIndex, savedIndex + 1)[1]
+    assert.is_truthy(savedText and savedText:find("kept line", 1, true), tostring(savedText))
+    moveCursor(console, 0, savedIndex)
+    local trimmed = 0
+    local handlerId = registerAnonymousEventHandler("sysBufferShrinkEvent", function(_, windowName, removedLines)
+      if windowName == console then
+        trimmed = trimmed + removedLines
+      end
+    end)
+    for lineNumber = 1, 35 do
+      echo(console, ("filler line %d\n"):format(lineNumber))
+    end
+    killAnonymousEventHandler(handlerId)
+    assert.is_true(trimmed > 0, "the buffer never trimmed, so nothing moved")
+    assert.are_not.equal(savedText, getLines(console, savedIndex, savedIndex + 1)[1])
+    assert.are.equal(savedText, getLines(console, savedIndex - trimmed, savedIndex - trimmed + 1)[1])
+    -- the cursor stayed on the index it was given, not on the line it was on
+    assert.are.equal(savedIndex, getLineNumber(console))
+    moveCursor(console, 0, savedIndex - trimmed)
+    selectCurrentLine(console)
+    assert.are.equal(savedText, getSelection(console))
+  end)
+
   it("useMaximum raises the main console to the buffer maximum", function()
     -- the main console has to be named for this one: with three arguments the
     -- first is read as a window name, so the four argument form only lines up


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Ten busted specs for four behaviours that ran under the suite with nothing asserting them:

- `sysBufferShrinkEvent` - raised 369 times in an instrumented run, asserted nowhere. The window it names, the count it carries, the index shift that count describes, and the cursor that does not follow it
- the `!osc8-docs` banner injection - only its negative was pinned. Which buffer it writes into, that the line carrying the phrase goes whole, and the one-second debounce
- MXP `<DEST>` redirect and `<HR>` - all three of the MXP translate path's console reach-ins had never executed
- an OSC 8 link with a delayed reveal, the only visibility action that runs without a mouse

Every spec was checked by severing the C++ it guards, rebuilding, and confirming it goes red:

| Spec | Severed | Observed failure |
| --- | --- | --- |
| shrink event names the window | `raiseEvent(bufferShrinkEvent)` | `the buffer was trimmed but no sysBufferShrinkEvent arrived` |
| " | window arg forced to `"main"` | `11 trims were announced, none of them naming bufferSizeConsole-...` |
| " | count arg `mBatchDeleteSize - 1` | `(number) 9` / expected `(number) 10` |
| index shift matches the count | count arg `mBatchDeleteSize - 1` | `'kept line 74'` / expected `'kept line 71'` |
| " | `mUserCursor` renumbered by the trim | `(number) 40` / expected `(number) 70` |
| examples reach main | `injectOSC8DocumentationExamples()` | `only 1 lines were injected` |
| " | `return` after injecting dropped | `OSCDOCS1` printed alongside the banner |
| main gets them from any window | `mainBuffer` bound to `*this` | banner never reached main |
| " | `return` after injecting dropped | window held `'!osc8-docs'` / expected `''` |
| " | 1s debounce removed | `(number) 115` / expected `(number) 58` |
| link reveals after its delay | `performReveal()` in `slot_checkTimers` | `'OSCREVEAL1(          )...'` / expected `'...(HIDDENWORD)...'` |
| " | `registerHyperlink()` reach-in | link never written concealed |
| frame has a console of its own | `mSubConsoleMap.insert(frame->name, ...)` | `(nil)` / expected `'miniconsole'` |
| redirect lands in the frame | `flushPendingDestinationContent()` | frame stayed empty |
| line break kept in the frame | `commitLine()` DEST routing | `MXPDEST2 first` missing |
| " | DEST break swallowed, flushed as one | `'MXPDEST2 firstMXPDEST2 second'` / expected `'MXPDEST2 first'` |
| colour does not follow text out | `resetCurrentTextFormat()` | `{128,0,0}` / expected `{192,192,192}` |
| `<HR>` is drawn | `insertText()`'s `translateToPlainText` | `no line reads "-----..."` |

#### Motivation for adding to Mudlet

These crossings are on the cut surface of the libmudlet console-model extraction (#9011). Each one is engine code reaching through the console widget, and each could be ported wrongly today without a single test going red - which is what these specs change.

#### Other info (issues closed, discussion etc)

Specs only, no engine changes. Suite goes 3497 -> 3507 successes, 0 failures.

One thing found along the way and left alone, since this PR touches no C++: the comment at `src/TBuffer.cpp:4839` says the injection debounce is there to "prevent duplicate injection from echo + server response", but text the game sends never reaches `appendLine()` at all, so that cannot be what it guards.

Two halves are deliberately not covered here and want a functional test: the repaint `THyperlinkVisibilityManager::visibilityChanged` drives, and `restoreLinkIndices()`, neither of which any Lua call can read back.

**Test case:** `.claude/scripts/run-lua-tests.sh`, or run Mudlet and echo `!osc8-docs` into any window - the examples appear in the main console and the phrase itself does not.

Assisted-by: Claude:claude-opus-5