### PR TITLE
Infra: Give the Lua test suite room on slow macOS and Windows runners

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -650,8 +650,9 @@ jobs:
 
     - name: (macOS) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
-      # The suite alone can run past a minute on the slower Intel runners
-      timeout-minutes: 3
+      # ~100s on a healthy Intel runner and measured at 172s on a slow one, so a
+      # tighter limit fails on runner speed rather than on anything the suite did
+      timeout-minutes: 6
       run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror --offline
       env:
         AUTORUN_BUSTED_TESTS: 'true'

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -148,8 +148,9 @@ jobs:
         MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK: 1
 
     - name: (Windows) Run Lua tests
-      # The suite alone can run past two minutes on a slow runner, as on the other platforms.
-      timeout-minutes: 3
+      # ~94s measured here, and a slow runner can take half again as long - kept in
+      # step with the other platforms
+      timeout-minutes: 6
       shell: msys2 {0}
       env:
         AUTORUN_BUSTED_TESTS: 'true'

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -121,8 +121,9 @@ jobs:
         ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
 
     - name: (Windows) Run Lua tests
-      # The suite alone can run past two minutes on a slow runner, as on the other platforms.
-      timeout-minutes: 3
+      # ~94s measured here, and a slow runner can take half again as long - kept in
+      # step with the other platforms
+      timeout-minutes: 6
       shell: msys2 {0}
       env:
         AUTORUN_BUSTED_TESTS: 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -696,8 +696,9 @@ jobs:
 
     - name: (macOS) Run Lua tests
       if: matrix.run_tests == 'true' && runner.os == 'macOS'
-      # The suite alone can run past a minute on the slower Intel runners
-      timeout-minutes: 3
+      # ~100s on a healthy Intel runner and measured at 172s on a slow one, so a
+      # tighter limit fails on runner speed rather than on anything the suite did
+      timeout-minutes: 6
       run: ~/Desktop/Mudlet.app/Contents/MacOS/mudlet --profile "Mudlet self-test" --mirror --offline
       env:
         AUTORUN_BUSTED_TESTS: 'true'


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Raises `timeout-minutes` on the Lua test step from 3 to 6 on macOS and Windows, matching Linux.

#### Motivation for adding to Mudlet

The macOS step gave 3 minutes to a suite that takes ~100s on a healthy Intel runner. On #10081 a runner came up 1.2-1.5x slower across every test unrelated to that PR - TMediaLoopTest 13.78s -> 16.18s, TDiscordModeTest 7.84s -> 11.06s, DialogTeardownTest 3.86s -> 5.86s, total ctest 456s -> 597s - which stretched the suite to 171.7s. All 3427 specs passed; the step was killed a few seconds later during shutdown.

At 3 minutes the step measures runner speed, not the suite. Windows had the same 3 minutes for a ~94s suite, so it is raised with it.

Measured suite times: macOS arm64 62s, macOS Intel 100s (172s on a slow runner), Windows 94s. Linux has been at 6 for a while.

This does not slow CI down - a step that finishes only uses the time it needs. It only changes when a genuinely hung run gets killed.

Assisted-by: Claude:claude-opus-5
