### PR TITLE
Fix: Label updates got slower as their text grew

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -37,6 +37,29 @@
 
 using namespace std::chrono_literals;
 
+// A case-insensitive text.contains("<a ") answers the same, but it case-folds every
+// character it walks, and Lua UIs echo into labels on every prompt. Any whitespace
+// counts as the separator because HTML allows any; the styling pass in setText()
+// recognises only the ASCII ones, so an anchor split by a non-breaking space comes
+// out clickable but unstyled.
+static bool containsAnchorTag(const QString& text)
+{
+    qsizetype from = 0;
+    while (true) {
+        const qsizetype at = text.indexOf(QLatin1Char('<'), from);
+        // Too near the end for a tag name and a separator, and every later '<' is
+        // nearer still, so there is nothing left to find
+        if (at < 0 || at + 2 >= text.size()) {
+            return false;
+        }
+        const char16_t tagName = text.at(at + 1).unicode();
+        if ((tagName == u'a' || tagName == u'A') && text.at(at + 2).isSpace()) {
+            return true;
+        }
+        from = at + 1;
+    }
+}
+
 TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
 : QLabel(pW)
 , mpHost(pH)
@@ -71,9 +94,11 @@ TLabel::~TLabel()
 
 void TLabel::setText(const QString& text)
 {
+    const bool hasAnchor = containsAnchorTag(text);
+
     // Enable TextBrowserInteraction only when the label contains hyperlinks
     // This prevents Qt's default context menu from appearing on labels without links
-    if (text.contains(qsl("<a "), Qt::CaseInsensitive)) {
+    if (hasAnchor) {
         setTextInteractionFlags(Qt::TextBrowserInteraction);
     } else {
         setTextInteractionFlags(Qt::NoTextInteraction);
@@ -82,7 +107,7 @@ void TLabel::setText(const QString& text)
     // If we have link styling configured and the text contains HTML links,
     // we need to inject inline styles because QTextDocument doesn't use
     // widget stylesheets or QPalette for link colors when a stylesheet exists
-    if ((!mLinkColor.isEmpty() || !mLinkVisitedColor.isEmpty()) && text.contains(qsl("<a "), Qt::CaseInsensitive)) {
+    if ((!mLinkColor.isEmpty() || !mLinkVisitedColor.isEmpty()) && hasAnchor) {
         QString styledText = text;
 
         // Replace all <a href="..."> tags with <a href="..." style="...">
@@ -90,7 +115,7 @@ void TLabel::setText(const QString& text)
         // because Mudlet's HTML generation (via echo(), setLabelText(), etc.) consistently
         // uses this format. User-provided HTML outside this pattern will still render as
         // clickable links (Qt handles that), but won't receive custom styling.
-        QRegularExpression anchorRegex(qsl("<a\\s+href=([\"'][^\"']*[\"'])([^>]*)>"));
+        static const QRegularExpression anchorRegex(qsl("<a\\s+href=([\"'][^\"']*[\"'])([^>]*)>"));
         QRegularExpressionMatchIterator it = anchorRegex.globalMatch(styledText);
 
         // Process matches in reverse order to avoid offset issues
@@ -194,7 +219,7 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 {
     // If the label has rich text with potential hyperlinks, let QLabel handle the event first
     // QLabel will emit linkActivated if a link was clicked
-    if (!text().isEmpty() && textFormat() == Qt::RichText && text().contains(qsl("<a "), Qt::CaseInsensitive)) {
+    if (!text().isEmpty() && textFormat() == Qt::RichText && containsAnchorTag(text())) {
         QLabel::mousePressEvent(event);
         // If QLabel didn't accept the event, then it wasn't a link click
         if (event->isAccepted()) {
@@ -226,7 +251,7 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
     // If the label has rich text with potential hyperlinks, let QLabel handle the event first
-    if (!text().isEmpty() && textFormat() == Qt::RichText && text().contains(qsl("<a "), Qt::CaseInsensitive)) {
+    if (!text().isEmpty() && textFormat() == Qt::RichText && containsAnchorTag(text())) {
         QLabel::mouseReleaseEvent(event);
         // If QLabel accepted the event, it was handling a link click
         if (event->isAccepted()) {
@@ -314,7 +339,7 @@ void TLabel::setClickThrough(bool clickthrough)
         setTextInteractionFlags(Qt::NoTextInteraction);
     } else {
         // Re-enable text interaction only if the current text has hyperlinks
-        if (text().contains(qsl("<a "), Qt::CaseInsensitive)) {
+        if (containsAnchorTag(text())) {
             setTextInteractionFlags(Qt::TextBrowserInteraction);
         } else {
             setTextInteractionFlags(Qt::NoTextInteraction);
@@ -369,7 +394,7 @@ void TLabel::clearVisitedLinks()
     mVisitedLinks.clear();
 
     QString currentText = text();
-    if (!currentText.isEmpty() && currentText.contains(qsl("<a "), Qt::CaseInsensitive)) {
+    if (!currentText.isEmpty() && containsAnchorTag(currentText)) {
         setText(currentText);
     }
 }
@@ -386,7 +411,7 @@ void TLabel::slot_linkActivated(const QString& link)
         // Refresh the label to update link colors
         // We need to re-apply the current text to trigger the styling update
         QString currentText = text();
-        if (!currentText.isEmpty() && currentText.contains(qsl("<a "), Qt::CaseInsensitive)) {
+        if (!currentText.isEmpty() && containsAnchorTag(currentText)) {
             setText(currentText);
         }
     }

--- a/src/mudlet-lua/tests/GeyserLabel_spec.lua
+++ b/src/mudlet-lua/tests/GeyserLabel_spec.lua
@@ -1261,6 +1261,18 @@ describe("Tests Geyser.Label font, link style and tooltip", function()
       end)
     end)
 
+    -- getLabelText() answers with the text after the styling pass has rewritten
+    -- it, which is the only readable trace the injected colour leaves
+    it("colours an anchor whichever whitespace follows its tag name", function()
+      label:setLinkStyle("#00ffff", "#ff00ff")
+
+      label:echo([[<a href='https://example.com'>go</a>]])
+      assert.is_truthy(getLabelText("glfLink"):find("#00ffff", 1, true))
+
+      label:echo("<a\nhref='https://example.com'>go</a>")
+      assert.is_truthy(getLabelText("glfLink"):find("#00ffff", 1, true))
+    end)
+
     pending("Geyser.Label:setLinkStyle reporting whether the styling reached the label - the three wrappers discard the nil and error message their global answers with, and Mudlet has no link style getter")
   end)
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 set(WINDOW_GROUP_TEST_SOURCES
     CopyAsImageTest.cpp
     GlyphOverflowTest.cpp
+    LabelAnchorInteractionTest.cpp
     LabelMovieRefusalTest.cpp
     MainConsoleSelectionTest.cpp
     MainWindowSizeReportTest.cpp

--- a/test/functional_tests/LabelAnchorInteractionTest.cpp
+++ b/test/functional_tests/LabelAnchorInteractionTest.cpp
@@ -1,0 +1,221 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * A label only gets Qt's text-browser interaction - and with it clickable links
+ * and a context menu - when its text carries an anchor, so which texts count as
+ * carrying one decides which links work. Neither the interaction flags nor a
+ * synthesised click on a link are reachable from Lua, so both have to be asked of
+ * the TLabel directly.
+ *
+ * Run with: ctest -R LabelAnchorInteractionTest -V
+ */
+
+#include <QSignalSpy>
+#include <QtTest/QtTest>
+#include <QTextDocument>
+#include <chrono>
+
+#include "PortableModeTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLabel.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class LabelAnchorInteractionTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("LabelAnchorInteraction-Test-Host");
+    QString mPort;
+    const QString mLocalhost = qsl("localhost");
+    const QString mLabelName = qsl("anchorInteractionLabel");
+    // a configuration directory of its own, so the profile this opens is never
+    // one of the developer's
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdgConfigHome;
+
+    TLabel* label() const { return mpHost->mpConsole->mLabelMap.value(mLabelName); }
+
+    // Where the label's only word of text sits, so a synthesised click lands on
+    // the link rather than the empty space around it
+    QPoint linkCentre() const
+    {
+        QTextDocument document;
+        document.setHtml(label()->text());
+        document.setDefaultFont(label()->font());
+        return QPoint(static_cast<int>(document.idealWidth()) / 2, static_cast<int>(document.size().height()) / 2);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - cannot redirect the config dir for this test");
+        }
+        QVERIFY(mConfigDir.isValid());
+        // setupConfig() only adopts $XDG_CONFIG_HOME once the profiles
+        // directory under it is there to be adopted
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdgConfigHome = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->serverPort() != 0, "the telnet stub did not start listening");
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::getQSettings()->setValue(qsl("uiTourShown"), true);
+        mudlet::getQSettings()->sync();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        QDir(path).removeRecursively();
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(1000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        mpHost = mudlet::self()->getActiveHost();
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        auto [created, createMessage] = mpHost->createLabel(qsl("main"), mLabelName, 10, 10, 200, 40, true, false);
+        QVERIFY2(created, qPrintable(createMessage));
+        QVERIFY(label());
+    }
+
+    void cleanupTestCase()
+    {
+        if (mpHost && mpHost->mpConsole) {
+            mpHost->mpConsole->deleteLabel(mLabelName);
+        }
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+            QDir(path).removeRecursively();
+            delete mudlet::self();
+        }
+        if (mSavedXdgConfigHome.isEmpty()) {
+            qunsetenv("XDG_CONFIG_HOME");
+        } else {
+            qputenv("XDG_CONFIG_HOME", mSavedXdgConfigHome);
+        }
+    }
+
+    void test_whichTextsCountAsCarryingAnAnchor_data()
+    {
+        QTest::addColumn<QString>("text");
+        QTest::addColumn<bool>("interactive");
+
+        QTest::newRow("plain text") << qsl("just some words") << false;
+        QTest::newRow("markup with no anchor") << qsl("<b>bold</b> and <i>italic</i>") << false;
+        QTest::newRow("anchor") << qsl("<a href='https://example.com'>go</a>") << true;
+        QTest::newRow("anchor in upper case") << qsl("<A HREF='https://example.com'>go</A>") << true;
+        QTest::newRow("anchor after other markup") << qsl("<b>x</b> <a href='https://example.com'>go</a>") << true;
+        // HTML lets any whitespace follow the tag name, and Qt renders these as
+        // links, so a label carrying one has to be told it has a link in it
+        QTest::newRow("anchor split by a newline") << qsl("<a\nhref='https://example.com'>go</a>") << true;
+        QTest::newRow("anchor split by a tab") << qsl("<a\thref='https://example.com'>go</a>") << true;
+        QTest::newRow("upper case anchor split by a newline") << qsl("<A\nHREF='https://example.com'>go</A>") << true;
+        // an anchor needs attributes, and a bare "<a" cannot be the start of one
+        QTest::newRow("anchor tag name only") << qsl("truncated at <a") << false;
+        QTest::newRow("a word starting with a") << qsl("<abbr title='x'>ab</abbr>") << false;
+        QTest::newRow("consecutive angle brackets") << qsl("<<a href='https://example.com'>go</a>") << true;
+    }
+
+    void test_whichTextsCountAsCarryingAnAnchor()
+    {
+        QFETCH(QString, text);
+        QFETCH(bool, interactive);
+
+        // start from a text of the other kind, so a flag left over from the
+        // previous row cannot pass this one
+        label()->setText(interactive ? qsl("nothing here") : qsl("<a href='https://example.com'>go</a>"));
+        label()->setText(text);
+
+        // the whole flag set, not just the link bit: leaving the label selectable
+        // would bring back the context menu these flags exist to keep away
+        QCOMPARE(label()->textInteractionFlags(), interactive ? Qt::TextBrowserInteraction : Qt::NoTextInteraction);
+    }
+
+    void test_aLinkSplitByWhitespaceIsClickable()
+    {
+        // no link style configured, which is the default: with one, the styling
+        // pass rewrites the tag and puts the plain "<a " back into the text
+        label()->resetLinkStyle();
+        label()->setText(qsl("<a\nhref='https://example.com'>go</a>"));
+
+        QSignalSpy activated(label(), &QLabel::linkActivated);
+        QTest::mouseClick(label(), Qt::LeftButton, Qt::NoModifier, linkCentre());
+        QCOMPARE(activated.count(), 1);
+        QCOMPARE(activated.first().first().toString(), qsl("https://example.com"));
+    }
+
+    void test_clickthroughRoundTripKeepsALinkSplitByWhitespaceClickable()
+    {
+        label()->resetLinkStyle();
+        label()->setText(qsl("<a\nhref='https://example.com'>go</a>"));
+        label()->setClickThrough(true);
+        label()->setClickThrough(false);
+
+        QCOMPARE(label()->textInteractionFlags(), Qt::TextBrowserInteraction);
+    }
+};
+
+#include "LabelAnchorInteractionTest.moc"
+MUDLET_GROUPED_TEST_MAIN(LabelAnchorInteractionTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `TLabel` asked whether a label carries a hyperlink with `contains("<a ", Qt::CaseInsensitive)` in six places - once per `setText()`, and again on every mouse press and release. Case-folding every character is the bulk of what those calls do, and Lua UIs echo into labels constantly. One scan for the `<` now answers for all six.
- That rule also wanted a literal space after the tag name, so `<a\nhref='...'>` was rendered as a link by Qt but was neither styled nor clickable. Any whitespace counts now, as HTML allows.

#### Motivation for adding to Mudlet
Since 4.20.0 every `echo()` into a label has cost a case-folded pass over the whole text. One `echo()`, no return to the event loop, official Linux builds:

| label text | 4.17.2 | 4.18.0 | 4.22.0 | development | this PR |
| --- | --- | --- | --- | --- | --- |
| 2.9 KB | 0.002 ms | 0.001 ms | 0.011 ms | 0.011 ms | 0.002 ms |
| 172 KB | 0.009 ms | 0.008 ms | 0.494 ms | 0.636 ms | 0.044 ms |
| 690 KB | 0.033 ms | 0.034 ms | 1.707 ms | 2.140 ms | 0.150 ms |

#### Other info (issues closed, discussion etc)
Regressed by #8527, first shipped in 4.20.0. Found while trying to reproduce #10019, but it does **not** explain that report - at that reporter's ~3 KB map the scan is worth ~10 µs - so this does not close it.

Covered by `LabelAnchorInteractionTest` (15 cases, 5 fail on development, including the click and the `disableClickthrough()` round-trip) and one case in `GeyserLabel_spec.lua` (fails on development). Full suite green: 116/116 functional, 3498 busted successes.

**Test case:** `createLabel("l", 10, 10, 200, 40, 1)` then `echo("l", "<a\nhref='https://mudlet.org'>click</a>")` - the link is dead on development, clickable with this change.

Assisted-by: Claude:claude-opus-5
