### PR TITLE
Fix: Clearer errors when using a database after closing it

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -238,12 +238,21 @@ end
 --
 -- error() rather than assert() throughout: assert would build the message on every
 -- healthy call, and these sit on trigger-driven write paths.
-local function db_no_connection_message(action, db_name)
-  -- a table that is not a sheet or field reference carries no _db_name, so it lands
+--
+-- expected is a parameter because the sites do not agree on what they take: a sheet at
+-- most of them, a field at db:set and db:aggregate, a database name at db:_migrate, the
+-- handle itself at the db.Database methods. No one phrase is true at all of them, and a
+-- phrase that named several would have to deny a field reference is a field reference.
+local A_SHEET = "a sheet, as in mydb.sheetname"
+local A_FIELD = "a field, as in mydb.sheetname.fieldname"
+local A_DATABASE = "a database handle, as in what db:create returned"
+
+local function db_no_connection_message(action, db_name, expected)
+  -- something that is not what this site takes carries no name to look up, so it lands
   -- on the same missing connection by a different route: saying "closed" there would
   -- name a cause that is not the one the caller has to fix
   if not db_name then
-    return "can not "..action.." the database: that is not a sheet or field reference."
+    return "can not "..action.." the database: expected "..expected.."."
   end
 
   -- likewise a name that was never created at all, where hunting for a db:close call
@@ -587,7 +596,9 @@ function db:create(db_name, sheets, force)
     -- read-only profile directory or a full disk both produce: without this the
     -- setautocommit below is the nil index instead
     local conn, err = db.__env:connect(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")
-    assert(conn, "db:create could not open the database file for "..db_name..": "..tostring(err))
+    if not conn then
+      error("db:create could not open the database file for "..db_name..": "..tostring(err), 2)
+    end
 
     db.__conn[db_name] = conn
     conn:setautocommit(false)
@@ -712,7 +723,7 @@ function db:_migrate(db_name, s_name, force)
   -- db:create is the only caller outside the specs and it has a live connection by
   -- the time it gets here, so this only fires for a script calling db:_migrate
   -- directly. Note the first argument is a database name, not a sheet
-  if not conn then error(db_no_connection_message("migrate", db_name), 2) end
+  if not conn then error(db_no_connection_message("migrate", db_name, "a database name"), 2) end
 
   local schema = db.__schema[db_name][s_name]
 
@@ -1295,7 +1306,7 @@ function db:add(sheet, ...)
   if not conn then
     -- printed as well as returned, the way the SQL failure below is: the callers
     -- of db:add that check the result are outnumbered by the ones that do not
-    local msg = db_no_connection_message("add to", db_name)
+    local msg = db_no_connection_message("add to", db_name, A_SHEET)
     printError(msg, true, false)
     return nil, msg
   end
@@ -1349,7 +1360,7 @@ function db:fetch_sql(sheet, sql)
   -- "local results = db:fetch(...)  if results and results[1] then update else add end"
   -- reads a nil as "not there yet" and inserts, so a closed database would silently
   -- take the insert branch every time round instead of stopping
-  if not conn then error(db_no_connection_message("fetch from", db_name), 2) end
+  if not conn then error(db_no_connection_message("fetch from", db_name, A_SHEET), 2) end
 
   db:echo_sql(sql)
   local cur = conn:execute(sql)
@@ -1412,9 +1423,13 @@ end
 --- @see db:fetch_sql
 function db:fetch(sheet, query, order_by, descending)
   local s_name = sheet._sht_name
-  -- db:fetch_sql's guard is too late for this one: the concatenation below reaches a
-  -- nil sheet name first and dies there instead of saying what was passed in
-  if not s_name then error(db_no_connection_message("fetch from", sheet._db_name), 2) end
+  -- a table with no sheet name is not a sheet whatever else it carries, so its
+  -- _db_name is no more to be trusted than the rest of it
+  local db_name = s_name and sheet._db_name or nil
+
+  -- db:fetch_sql's own argument guard is too late for this one: the concatenation
+  -- below reaches a nil sheet name first and dies there
+  if not s_name then error(db_no_connection_message("fetch from", db_name, A_SHEET), 2) end
 
   local sql = "SELECT * FROM " .. s_name
 
@@ -1439,6 +1454,11 @@ function db:fetch(sheet, query, order_by, descending)
 
     sql = sql .. " ORDER BY " .. db:_sql_columns(o)
   end
+
+  -- the closed database is checked here rather than left to db:fetch_sql, whose own
+  -- guard would raise without naming a line: the return below is a tail call, so this
+  -- frame is already gone when its error(msg, 2) goes looking for level 2
+  if not db.__conn[db_name] then error(db_no_connection_message("fetch from", db_name, A_SHEET), 2) end
 
   return db:fetch_sql(sheet, sql)
 end
@@ -1471,7 +1491,7 @@ function db:aggregate(field, fn, query, distinct)
 
   -- the connection check goes last: a bad field reference is the more useful complaint
   local conn = db.__conn[db_name]
-  if not conn then error(db_no_connection_message("aggregate over", db_name), 2) end
+  if not conn then error(db_no_connection_message("aggregate over", db_name, A_FIELD), 2) end
 
   local sql_chunks = { "SELECT", fn, "(", distinct and "DISTINCT" or "", field.name, ")", "AS", fn, "FROM", s_name }
 
@@ -1548,7 +1568,7 @@ function db:delete(sheet, query)
   assert(query, "must pass a query argument to db:delete()")
 
   local conn = db.__conn[db_name]
-  if not conn then error(db_no_connection_message("delete from", db_name), 2) end
+  if not conn then error(db_no_connection_message("delete from", db_name, A_SHEET), 2) end
 
   if type(query) == "number" then
     query = "_row_id = " .. tostring(query)
@@ -1633,7 +1653,7 @@ function db:merge_unique(sheet, tables)
 
   -- ahead of the schema lookup below, which indexes db.__schema[nil] for a table that
   -- is not a sheet and dies there before this can say so
-  if not db.__conn[db_name] then error(db_no_connection_message("merge into", db_name), 2) end
+  if not db.__conn[db_name] then error(db_no_connection_message("merge into", db_name, A_SHEET), 2) end
 
   local unique_options = db.__schema[db_name][s_name].options._unique
   assert(unique_options, "db:merge_unique only works on a sheet with a unique index.")
@@ -1697,7 +1717,7 @@ function db:update(sheet, tbl)
   local s_name = sheet._sht_name
 
   local conn = db.__conn[db_name]
-  if not conn then error(db_no_connection_message("update", db_name), 2) end
+  if not conn then error(db_no_connection_message("update", db_name, A_SHEET), 2) end
 
   local sql_chunks = { "UPDATE", s_name, "SET" }
 
@@ -1771,7 +1791,7 @@ function db:set(field, value, query)
   local s_name = field.sheet
 
   local conn = db.__conn[db_name]
-  if not conn then error(db_no_connection_message("set a field in", db_name), 2) end
+  if not conn then error(db_no_connection_message("set a field in", db_name, A_FIELD), 2) end
 
   local sql_update = [[UPDATE %s SET "%s" = %s]]
   if query then
@@ -2349,7 +2369,7 @@ function db.Database:_begin()
   -- without this the flag would be set on a database with nothing behind it, and the
   -- reopen would quietly reset it, turning the caller's transaction into autocommit
   if not db.__conn[self._db_name] then
-    return false, db_no_connection_message("begin a transaction on", self._db_name)
+    return false, db_no_connection_message("begin a transaction on", self._db_name, A_DATABASE)
   end
 
   db.__autocommit[self._db_name] = false
@@ -2364,7 +2384,7 @@ end
 function db.Database:_commit()
   local conn = db.__conn[self._db_name]
   if not conn then
-    return false, db_no_connection_message("commit", self._db_name)
+    return false, db_no_connection_message("commit", self._db_name, A_DATABASE)
   end
 
   -- db:create turns the driver's own autocommit off, so nothing lands until a
@@ -2385,7 +2405,7 @@ end
 function db.Database:_rollback()
   local conn = db.__conn[self._db_name]
   if not conn then
-    return false, db_no_connection_message("roll back", self._db_name)
+    return false, db_no_connection_message("roll back", self._db_name, A_DATABASE)
   end
 
   local rolled_back, err = conn:rollback()
@@ -2403,7 +2423,7 @@ end
 --- @return string message Why the transaction was not ended, empty when it was.
 function db.Database:_end()
   if not db.__conn[self._db_name] then
-    return false, db_no_connection_message("end a transaction on", self._db_name)
+    return false, db_no_connection_message("end a transaction on", self._db_name, A_DATABASE)
   end
 
   db.__autocommit[self._db_name] = true
@@ -2414,7 +2434,7 @@ end
 
 function db.Database:_drop(s_name)
   local conn = db.__conn[self._db_name]
-  if not conn then error(db_no_connection_message("drop a sheet from", self._db_name), 2) end
+  if not conn then error(db_no_connection_message("drop a sheet from", self._db_name, A_DATABASE), 2) end
 
   local schema = db.__schema[self._db_name][s_name]
 

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -213,6 +213,49 @@ function db:_isActiveDBName(db_name)
 end
 
 
+-- NOT LUADOC
+-- db:close takes the connection away but leaves db.__schema behind, so every sheet,
+-- field and database handle a script is still holding keeps working right up to the
+-- moment it needs the connection, and then indexes a nil. Nothing routes through a
+-- single choke point, so each site that reaches into db.__conn has to notice for
+-- itself; the callers of this function are the authoritative list of them.
+--
+-- Every one of those sites raised before these guards existed, and all but one still
+-- does. THE RULE IS THAT NAMING THE CAUSE MUST NOT MAKE A LOUD FAILURE QUIET, not
+-- that every site should answer the same way:
+--
+--   * db:add is the one that returns, because it alone already answers nil plus a
+--     printed message when its INSERT fails, and packages do check that result.
+--   * db:fetch_sql looks like it should match db:add, and must not. Its SQL-failure
+--     path returns a BARE nil - no message, no print - and a query that matched
+--     nothing returns an empty table, not nil. Handing back nil for a closed
+--     database would make the fetch-then-add upsert that db:merge_unique itself
+--     writes silently take the insert branch and loop forever.
+--   * db.Database:_commit and _rollback answer false plus a message, the contract
+--     #10068 gave them to match db:close. They are not a third opinion, just an
+--     older one.
+--   * everything else raises, which is what it did before.
+--
+-- error() rather than assert() throughout: assert would build the message on every
+-- healthy call, and these sit on trigger-driven write paths.
+local function db_no_connection_message(action, db_name)
+  -- a table that is not a sheet or field reference carries no _db_name, so it lands
+  -- on the same missing connection by a different route: saying "closed" there would
+  -- name a cause that is not the one the caller has to fix
+  if not db_name then
+    return "can not "..action.." the database: that is not a sheet or field reference."
+  end
+
+  -- likewise a name that was never created at all, where hunting for a db:close call
+  -- that does not exist is the wrong place to send someone
+  if not db.__schema[db_name] then
+    return "can not "..action.." "..db_name..": no database by that name has been created."
+  end
+
+  return "can not "..action.." "..db_name.." because the database is closed."
+end
+
+
 local VALIDATION_OPTIONS = {
   "ABORT",
   "FAIL",
@@ -540,8 +583,14 @@ function db:create(db_name, sheets, force)
   end
 
   if not db:_isActiveDBName(db_name) then
-    db.__conn[db_name] = db.__env:connect(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")
-    db.__conn[db_name]:setautocommit(false)
+    -- the driver answers nil plus a reason for a file it can not open, which a
+    -- read-only profile directory or a full disk both produce: without this the
+    -- setautocommit below is the nil index instead
+    local conn, err = db.__env:connect(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")
+    assert(conn, "db:create could not open the database file for "..db_name..": "..tostring(err))
+
+    db.__conn[db_name] = conn
+    conn:setautocommit(false)
     db.__autocommit[db_name] = true
   end
 
@@ -660,6 +709,11 @@ end
 -- it is not capable of removing indexes, columns, or sheets after they have been defined.
 function db:_migrate(db_name, s_name, force)
   local conn = db.__conn[db_name]
+  -- db:create is the only caller outside the specs and it has a live connection by
+  -- the time it gets here, so this only fires for a script calling db:_migrate
+  -- directly. Note the first argument is a database name, not a sheet
+  if not conn then error(db_no_connection_message("migrate", db_name), 2) end
+
   local schema = db.__schema[db_name][s_name]
 
   local current_columns = {}
@@ -1228,12 +1282,24 @@ end
 ---     {name="Richard Clark"}
 ---   )
 ---   </pre>
+--- @return boolean result true when the rows went in, nil when the insert failed. A
+---   multi-row call stops at the first row the database refuses, so earlier rows of
+---   that same call are left in the transaction uncommitted rather than rolled back.
+--- @return string message Why the insert failed, absent when it did not.
 function db:add(sheet, ...)
   local db_name = sheet._db_name
   local s_name = sheet._sht_name
   assert(s_name, "First argument to db:add must be a proper Sheet object.")
 
   local conn = db.__conn[db_name]
+  if not conn then
+    -- printed as well as returned, the way the SQL failure below is: the callers
+    -- of db:add that check the result are outnumbered by the ones that do not
+    local msg = db_no_connection_message("add to", db_name)
+    printError(msg, true, false)
+    return nil, msg
+  end
+
   local sql_insert = "INSERT INTO %s %s VALUES %s"
 
   for _, t in ipairs({ ... }) do
@@ -1273,10 +1339,17 @@ end
 ---   db:fetch_sql(mydb.kills, "SELECT distinct area FROM kills")
 ---   </pre>
 ---
+--- @return table results The matching rows, an empty table when the query matched nothing,
+---   or nil when the SQL could not run. Raises when the database is closed.
 --- @see db:fetch
 function db:fetch_sql(sheet, sql)
   local db_name = sheet._db_name
   local conn = db.__conn[db_name]
+  -- raises rather than answering nil, which db:merge_unique below shows the reason for:
+  -- "local results = db:fetch(...)  if results and results[1] then update else add end"
+  -- reads a nil as "not there yet" and inserts, so a closed database would silently
+  -- take the insert branch every time round instead of stopping
+  if not conn then error(db_no_connection_message("fetch from", db_name), 2) end
 
   db:echo_sql(sql)
   local cur = conn:execute(sql)
@@ -1334,9 +1407,14 @@ end
 ---   )
 ---   </pre>
 ---
+--- @return table results The matching rows, an empty table when the query matched nothing,
+---   or nil when the SQL could not run. Raises when the database is closed.
 --- @see db:fetch_sql
 function db:fetch(sheet, query, order_by, descending)
   local s_name = sheet._sht_name
+  -- db:fetch_sql's guard is too late for this one: the concatenation below reaches a
+  -- nil sheet name first and dies there instead of saying what was passed in
+  if not s_name then error(db_no_connection_message("fetch from", sheet._db_name), 2) end
 
   local sql = "SELECT * FROM " .. s_name
 
@@ -1388,10 +1466,12 @@ end
 function db:aggregate(field, fn, query, distinct)
   local db_name = field.database
   local s_name = field.sheet
-  local conn = db.__conn[db_name]
-
   assert(type(field) == "table", "Field must be a field reference.")
   assert(field.name, "Field must be a real field reference.")
+
+  -- the connection check goes last: a bad field reference is the more useful complaint
+  local conn = db.__conn[db_name]
+  if not conn then error(db_no_connection_message("aggregate over", db_name), 2) end
 
   local sql_chunks = { "SELECT", fn, "(", distinct and "DISTINCT" or "", field.name, ")", "AS", fn, "FROM", s_name }
 
@@ -1465,9 +1545,11 @@ function db:delete(sheet, query)
   local db_name = sheet._db_name
   local s_name = sheet._sht_name
 
-  local conn = db.__conn[db_name]
-
   assert(query, "must pass a query argument to db:delete()")
+
+  local conn = db.__conn[db_name]
+  if not conn then error(db_no_connection_message("delete from", db_name), 2) end
+
   if type(query) == "number" then
     query = "_row_id = " .. tostring(query)
   elseif type(query) == "table" and not query._isExp then
@@ -1549,6 +1631,10 @@ function db:merge_unique(sheet, tables)
   local db_name = sheet._db_name
   local s_name = sheet._sht_name
 
+  -- ahead of the schema lookup below, which indexes db.__schema[nil] for a table that
+  -- is not a sheet and dies there before this can say so
+  if not db.__conn[db_name] then error(db_no_connection_message("merge into", db_name), 2) end
+
   local unique_options = db.__schema[db_name][s_name].options._unique
   assert(unique_options, "db:merge_unique only works on a sheet with a unique index.")
   assert(#unique_options == 1, "db:merge_unique only works on a sheet with a single unique index.")
@@ -1611,6 +1697,7 @@ function db:update(sheet, tbl)
   local s_name = sheet._sht_name
 
   local conn = db.__conn[db_name]
+  if not conn then error(db_no_connection_message("update", db_name), 2) end
 
   local sql_chunks = { "UPDATE", s_name, "SET" }
 
@@ -1684,6 +1771,7 @@ function db:set(field, value, query)
   local s_name = field.sheet
 
   local conn = db.__conn[db_name]
+  if not conn then error(db_no_connection_message("set a field in", db_name), 2) end
 
   local sql_update = [[UPDATE %s SET "%s" = %s]]
   if query then
@@ -2254,8 +2342,18 @@ db.__DatabaseMT = {
 
 
 
+--- Holds back every write on this database until the next commit.
+--- @return boolean result Returns true in case of success and false otherwise.
+--- @return string message Why the transaction was not opened, empty when it was.
 function db.Database:_begin()
+  -- without this the flag would be set on a database with nothing behind it, and the
+  -- reopen would quietly reset it, turning the caller's transaction into autocommit
+  if not db.__conn[self._db_name] then
+    return false, db_no_connection_message("begin a transaction on", self._db_name)
+  end
+
   db.__autocommit[self._db_name] = false
+  return true, ""
 end
 
 
@@ -2264,11 +2362,9 @@ end
 --- @return boolean result Returns true in case of success and false otherwise.
 --- @return string message Why the work was not committed, empty when it was.
 function db.Database:_commit()
-  -- db:close drops the connection but keeps the schema, so a database handle
-  -- stays usable with nothing left behind it to commit on
   local conn = db.__conn[self._db_name]
   if not conn then
-    return false, "can not commit "..self._db_name.." because the database is closed."
+    return false, db_no_connection_message("commit", self._db_name)
   end
 
   -- db:create turns the driver's own autocommit off, so nothing lands until a
@@ -2289,7 +2385,7 @@ end
 function db.Database:_rollback()
   local conn = db.__conn[self._db_name]
   if not conn then
-    return false, "can not roll back "..self._db_name.." because the database is closed."
+    return false, db_no_connection_message("roll back", self._db_name)
   end
 
   local rolled_back, err = conn:rollback()
@@ -2302,14 +2398,24 @@ end
 
 
 
+--- Lets writes on this database commit on their own again.
+--- @return boolean result Returns true in case of success and false otherwise.
+--- @return string message Why the transaction was not ended, empty when it was.
 function db.Database:_end()
+  if not db.__conn[self._db_name] then
+    return false, db_no_connection_message("end a transaction on", self._db_name)
+  end
+
   db.__autocommit[self._db_name] = true
+  return true, ""
 end
 
 
 
 function db.Database:_drop(s_name)
   local conn = db.__conn[self._db_name]
+  if not conn then error(db_no_connection_message("drop a sheet from", self._db_name), 2) end
+
   local schema = db.__schema[self._db_name][s_name]
 
   -- _index and _unique can each be a single column name (a string) or a list of

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -2160,6 +2160,182 @@ describe("Tests DB.lua functions", function()
     end)
   end)
 
+  -- db:close leaves db.__schema in place, so every sheet, field and database
+  -- handle a script is holding outlives the connection. Each of these used to
+  -- die on "attempt to index local 'conn' (a nil value)" instead of saying what
+  -- was wrong. Which of them raises and which returns is deliberate - read the
+  -- comment on db_no_connection_message in DB.lua before making them uniform.
+  describe("Tests every call site against a closed database", function()
+    local dbName = "connguardtestingonly"
+    local sheet, field
+
+    before_each(function()
+      os.remove(getMudletHomeDir() .. "/Database_" .. dbName .. ".db")
+      mydb = db:create(dbName, {
+        sheet = {name = "", city = "", kills = 0, _index = {"city"}, _unique = {"name"}}
+      })
+      db:add(mydb.sheet, {name = "Ada", city = "Boston", kills = 3})
+      sheet, field = mydb.sheet, mydb.sheet.kills
+      db:close(dbName)
+    end)
+
+    after_each(function()
+      os.remove(getMudletHomeDir() .. "/Database_" .. dbName .. ".db")
+      mydb, sheet, field = nil, nil, nil
+    end)
+
+    local function assert_names_the_database(msg)
+      assert.is_string(msg)
+      assert.is_true(string.find(msg, "closed", 1, true) ~= nil)
+      assert.is_true(string.find(msg, dbName, 1, true) ~= nil)
+    end
+
+    -- db:add is the only site that returns rather than raising, because it alone
+    -- already answers nil plus a printed message when its INSERT fails
+    it("db:add answers nil and says which database is closed", function()
+      local ok, msg = db:add(sheet, {name = "Bram"})
+      assert.is_nil(ok)
+      assert_names_the_database(msg)
+    end)
+
+    it("db:add prints the message as well as returning it", function()
+      local realPrintError, collected = printError, {}
+      _G.printError = function(msg) collected[#collected + 1] = msg end
+      finally(function() _G.printError = realPrintError end)
+
+      db:add(sheet, {name = "Bram"})
+      assert.are.equal(1, #collected)
+      assert_names_the_database(collected[1])
+    end)
+
+    -- these two return false plus a message, the contract #10068 gave _commit and
+    -- _rollback to match db:close
+    it("_begin answers false rather than silently setting the autocommit flag", function()
+      local ok, msg = mydb:_begin()
+      assert.is_false(ok)
+      assert_names_the_database(msg)
+      assert.is_true(db.__autocommit[dbName])
+    end)
+
+    it("_end answers false and says which database is closed", function()
+      local ok, msg = mydb:_end()
+      assert.is_false(ok)
+      assert_names_the_database(msg)
+    end)
+
+    -- everything else raises, which is what it did before these guards existed.
+    -- db:fetch_sql in particular must NOT answer nil - see the upsert spec below
+    local raising = {
+      {"db:fetch_sql", "fetch", function() db:fetch_sql(sheet, "SELECT * FROM sheet") end},
+      {"db:fetch", "fetch", function() db:fetch(sheet) end},
+      {"db:aggregate", "aggregate", function() db:aggregate(field, "sum") end},
+      {"db:delete", "delete", function() db:delete(sheet, db:eq(sheet.name, "Ada")) end},
+      {"db:update", "update", function() db:update(sheet, {_row_id = 1, kills = 9}) end},
+      {"db:set", "set", function() db:set(field, 5) end},
+      {"db:merge_unique", "merge", function() db:merge_unique(sheet, {{name = "Ada", kills = 1}}) end},
+      {"db:_migrate", "migrate", function() db:_migrate(dbName, "sheet", false) end},
+      {"db.Database:_drop", "drop", function() mydb:_drop("sheet") end},
+    }
+
+    for _, case in ipairs(raising) do
+      local label, action, call = case[1], case[2], case[3]
+      it(label .. " raises an error naming the closed database", function()
+        local ok, err = pcall(call)
+        assert.is_false(ok)
+        assert_names_the_database(err)
+        assert.is_true(string.find(err, action, 1, true) ~= nil)
+        assert.is_nil(string.find(err, "attempt to index", 1, true))
+      end)
+    end
+
+    -- db:get_database keeps handing out handles for a closed database, so the
+    -- guards have to hold for a sheet obtained after the close as well as before
+    it("holds for a sheet taken out after the close", function()
+      local later = db:get_database(dbName).sheet
+      local ok, msg = db:add(later, {name = "Bram"})
+      assert.is_nil(ok)
+      assert_names_the_database(msg)
+    end)
+
+    -- this is the whole reason db:fetch_sql raises instead of answering nil. It is
+    -- the shape db:merge_unique itself is written in, so it is the shape scripts
+    -- copy: a nil reads as "not there yet", and the insert branch runs forever
+    it("stops the fetch-then-add upsert instead of letting it take the insert branch", function()
+      local branch
+      local ok = pcall(function()
+        local results = db:fetch(sheet, db:eq(sheet.name, "Ada"))
+        if results and results[1] then
+          branch = "UPDATE"
+        else
+          branch = "INSERT"
+          db:add(sheet, {name = "Ada"})
+        end
+      end)
+
+      assert.is_false(ok)
+      assert.is_nil(branch)
+    end)
+
+    -- a table that is not a sheet has no _db_name, so it reaches the same missing
+    -- connection by a different route and must not be told the database is closed
+    it("blames the argument, not the database, for a table that is not a sheet", function()
+      local notASheet = {
+        {"db:fetch_sql", function() db:fetch_sql({}, "SELECT * FROM sheet") end},
+        {"db:fetch", function() db:fetch({}) end},
+        {"db:delete", function() db:delete({}, true) end},
+        {"db:merge_unique", function() db:merge_unique({}, {}) end},
+      }
+
+      for _, case in ipairs(notASheet) do
+        local ok, err = pcall(case[2])
+        assert.is_false(ok, case[1] .. " did not raise")
+        assert.is_true(string.find(err, "not a sheet or field reference", 1, true) ~= nil,
+          case[1] .. " said: " .. tostring(err))
+        assert.is_nil(string.find(err, "closed", 1, true))
+      end
+    end)
+
+    -- a name that was never created reaches the same missing connection again, and
+    -- "closed" would send someone hunting for a db:close call that does not exist
+    it("says never created rather than closed for a database that never existed", function()
+      local ok, err = pcall(function() db:_migrate("neveropenedtestingonly", "sheet", false) end)
+      assert.is_false(ok)
+      assert.is_true(string.find(err, "no database by that name has been created", 1, true) ~= nil)
+      assert.is_nil(string.find(err, "closed", 1, true))
+    end)
+
+    -- db:add checks its own first argument before it reaches the connection, and
+    -- that message is the more useful one, so it stays in front
+    it("db:add still blames a bad sheet argument before the connection", function()
+      local ok, err = pcall(function() db:add({}, {name = "Bram"}) end)
+      assert.is_false(ok)
+      assert.is_true(string.find(err, "must be a proper Sheet object", 1, true) ~= nil)
+    end)
+
+    it("db:aggregate still blames a bad field reference before the connection", function()
+      local ok, err = pcall(function() db:aggregate({}, "sum") end)
+      assert.is_false(ok)
+      assert.is_true(string.find(err, "Field must be a real field reference.", 1, true) ~= nil)
+    end)
+
+    -- the guards must not stand in the way of the healthy path once it is back
+    it("db:create reopens the database and the guards stand aside", function()
+      local reopened = db:create(dbName, {
+        sheet = {name = "", city = "", kills = 0, _index = {"city"}, _unique = {"name"}}
+      })
+      assert.is_true(db:add(reopened.sheet, {name = "Bram", city = "Chicago", kills = 7}))
+      assert.are.equal(10, db:aggregate(reopened.sheet.kills, "sum"))
+      assert.are.equal(2, #db:fetch(reopened.sheet))
+      assert.is_true(reopened:_begin())
+      db:set(reopened.sheet.kills, 1)
+      assert.is_true(reopened:_rollback())
+      assert.is_true(reopened:_end())
+      db:delete(reopened.sheet, db:eq(reopened.sheet.name, "Bram"))
+      assert.are.equal(1, #db:fetch(reopened.sheet))
+      db:close(dbName)
+    end)
+  end)
+
   describe("Tests db:update and db:set edge cases", function()
     before_each(function()
       mydb = db:create("updatetestingonly", {

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -2245,6 +2245,10 @@ describe("Tests DB.lua functions", function()
         assert_names_the_database(err)
         assert.is_true(string.find(err, action, 1, true) ~= nil)
         assert.is_nil(string.find(err, "attempt to index", 1, true))
+        -- the position prefix is the caller's own line, and it is not free: an
+        -- error(msg, 2) reached through a tail call has no frame left to name
+        assert.is_true(string.find(err, ":%d+: can not ") ~= nil,
+          label .. " did not name the line that called it: " .. tostring(err))
       end)
     end
 
@@ -2289,7 +2293,7 @@ describe("Tests DB.lua functions", function()
       for _, case in ipairs(notASheet) do
         local ok, err = pcall(case[2])
         assert.is_false(ok, case[1] .. " did not raise")
-        assert.is_true(string.find(err, "not a sheet or field reference", 1, true) ~= nil,
+        assert.is_true(string.find(err, "expected a sheet, as in mydb.sheetname", 1, true) ~= nil,
           case[1] .. " said: " .. tostring(err))
         assert.is_nil(string.find(err, "closed", 1, true))
       end
@@ -2333,6 +2337,104 @@ describe("Tests DB.lua functions", function()
       db:delete(reopened.sheet, db:eq(reopened.sheet.name, "Bram"))
       assert.are.equal(1, #db:fetch(reopened.sheet))
       db:close(dbName)
+    end)
+  end)
+
+  -- the connection guards double as the wrong-argument message, because something that
+  -- is not what the site takes carries no database name to look up. So what they say
+  -- has to hold on an open database too, which is where that slip is actually made
+  describe("Tests the message for an argument of the wrong kind", function()
+    local dbName = "argkindtestingonly"
+
+    before_each(function()
+      os.remove(getMudletHomeDir() .. "/Database_" .. dbName .. ".db")
+      mydb = db:create(dbName, {sheet = {name = "", kills = 0}})
+      db:add(mydb.sheet, {name = "Ada", kills = 3})
+    end)
+
+    after_each(function()
+      db:close(dbName)
+      os.remove(getMudletHomeDir() .. "/Database_" .. dbName .. ".db")
+      mydb = nil
+    end)
+
+    -- mydb.sheet.field where mydb.sheet belongs is the easy slip, and the answer has
+    -- to name what the site wanted rather than deny a field reference is one
+    it("asks for a sheet rather than denying a field reference is one", function()
+      local field = mydb.sheet.kills
+      assert.are.equal("kills", field.name)
+      assert.is_true(db:_isActiveDBName(dbName))
+
+      local sheetSites = {
+        {"db:fetch", function() db:fetch(field) end},
+        {"db:fetch_sql", function() db:fetch_sql(field, "SELECT * FROM sheet") end},
+        {"db:delete", function() db:delete(field, true) end},
+        {"db:update", function() db:update(field, {_row_id = 1}) end},
+        {"db:merge_unique", function() db:merge_unique(field, {}) end},
+      }
+
+      for _, case in ipairs(sheetSites) do
+        local ok, err = pcall(case[2])
+        assert.is_false(ok, case[1] .. " did not raise")
+        assert.is_true(string.find(err, "expected a sheet, as in mydb.sheetname", 1, true) ~= nil,
+          case[1] .. " said: " .. tostring(err))
+        assert.is_nil(string.find(err, "closed", 1, true))
+      end
+    end)
+
+    -- a table carrying the name of a database that is open is still not a sheet, so the
+    -- guard must not answer "closed" on the strength of a _db_name it found there
+    it("does not call an open database closed on the strength of a stray _db_name", function()
+      local ok, err = pcall(function() db:fetch({_db_name = dbName}) end)
+      assert.is_false(ok)
+      assert.is_true(string.find(err, "expected a sheet, as in mydb.sheetname", 1, true) ~= nil,
+        tostring(err))
+      assert.is_nil(string.find(err, "closed", 1, true))
+    end)
+
+    -- db:set and db:aggregate want a field where most sites want a sheet. db:set is the
+    -- one that reaches this branch, db:aggregate having its own field check in front
+    it("asks for a field at the sites that take one", function()
+      local ok, err = pcall(function() db:set({}, 1, true) end)
+      assert.is_false(ok)
+      assert.is_true(string.find(err, "expected a field, as in mydb.sheetname.fieldname", 1, true) ~= nil,
+        tostring(err))
+    end)
+
+    -- the last two kinds: db:_migrate takes a database name rather than either, and the
+    -- db.Database methods take the handle db:create handed back
+    it("asks for a database name, and for a handle, at the sites that take those", function()
+      local ok, err = pcall(function() db:_migrate(nil, "sheet", false) end)
+      assert.is_false(ok)
+      assert.is_true(string.find(err, "expected a database name", 1, true) ~= nil, tostring(err))
+
+      local committed, msg = db.Database._commit({})
+      assert.is_false(committed)
+      assert.is_true(string.find(msg, "expected a database handle", 1, true) ~= nil, tostring(msg))
+    end)
+  end)
+
+  -- db:create is the one site where the connection is not missing but refused, which
+  -- is why the environment has to be stubbed to reach it
+  describe("Tests db:create when the driver refuses the file", function()
+    local dbName = "refusedfiletestingonly"
+
+    it("names the database it could not open, and the line that asked for it", function()
+      local realEnv = db.__env
+      db.__env = {connect = function() return nil, "unable to open database file" end}
+      finally(function() db.__env = realEnv end)
+
+      local ok, err = pcall(function() db:create(dbName, {sheet = {name = ""}}) end)
+      assert.is_false(ok)
+      assert.is_nil(string.find(err, "attempt to index", 1, true))
+      assert.is_true(string.find(err, "could not open the database file for " .. dbName, 1, true) ~= nil,
+        tostring(err))
+      assert.is_true(string.find(err, "unable to open database file", 1, true) ~= nil, tostring(err))
+
+      -- error(msg, 2), not assert: assert would concatenate the message on every
+      -- healthy create, and would then blame DB.lua's own line instead of this one
+      assert.is_true(string.find(err, ":%d+: db:create could not open") ~= nil, tostring(err))
+      assert.is_nil(string.find(err, "DB.lua:", 1, true))
     end)
   end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `db:close` takes the connection away but leaves the schema, so sheet and database handles outlive it. #10068 fixed `db.Database:_commit` and `_rollback`; the rest still died on `attempt to index local 'conn' (a nil value)`. They all name the database now.
- All but one site still raises, exactly as before - naming the cause must not make a loud failure quiet. `db:add` alone returns nil plus a printed message, matching what it already does when an INSERT fails. `db:fetch_sql` deliberately does *not* follow it: a no-match fetch returns an empty table and its SQL-failure path returns a bare nil, so answering nil for a closed database would make the fetch-then-add upsert that `db:merge_unique` itself is written in silently take the insert branch and loop forever.
- Two sites beyond the ones #10068 listed: `db:merge_unique`, and `db:create` itself, where a file the driver refuses - a read-only profile directory or a full disk - produced the same nil index.

#### Motivation for adding to Mudlet

A raw nil-index traceback tells a script author nothing about what they did. Naming the database, and saying whether it is closed, was never created, or was not a sheet at all, does.

#### Other info (issues closed, discussion etc)

Follow-up to #10068, which deferred these sites.

Compatibility: scanned all 224 packages in mudlet-package-repository. No Lua caller of `db:close` or `_closeAll` anywhere, and none in `src/` either, so no shipped package can reach these paths. No caller at all of `db:aggregate`, `db:set`, `db:merge_unique`, `_drop`, `_migrate`, `_begin` or `_end`. `db:delete` and `db:set` return nothing today, so a falsy return there would have been invisible at all 17 of their call sites - which is why they raise instead. The five return-value consumers (cofudlet and ShipDB on `db:add`, ShipDB on `db:update`, cofudlet on `db:fetch_sql` in an and/or chain) are all preserved.

`error()` rather than `assert()` at the raising sites, so the message is not built on every healthy call - these sit on trigger-driven write paths.

Left alone deliberately, each its own bug rather than part of this one: `db:aggregate` still raw-nil-indexes on a malformed *query*; `db:close`'s "already closed" branch does not clear `db.__conn`, leaving a dead handle that passes every guard; `db.Database:_drop` and `db:merge_unique` swallow SQL failures.

**Test case:** `db:create` a database, `db:close` it, then use the handle you still hold - `db:add`, `db:fetch`, `db:delete` and the rest each name the database instead of dying on a nil index.

21 new specs in `DB_spec.lua`. Fail-without-fix against `development`'s `DB.lua` with the new specs in place: `304 successes / 14 failures / 3 errors`. Four pass either way and are the anti-vacuity controls, including the upsert spec, which pins against a falsy `db:fetch` rather than against `development` - reverting only `db:fetch_sql` to answer nil fails it along with 3 others, and replacing "closed" in the message fails 14.

@Delwing tagging you as the most recent hand in `DB.lua` (#10033) - the raise-vs-return split is the part worth a second opinion.

Assisted-by: Claude:claude-opus-5