### PR TITLE
Infra: Build Linux and macOS releases with newer compilers

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -59,7 +59,7 @@ jobs:
           - os: ubuntu-22.04
             buildname: 'ubuntu / gcc / lua tests + leak detection'
             compiler: gcc_64
-            gcc_compiler_version: 10
+            gcc_compiler_version: 12
             qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
@@ -72,7 +72,7 @@ jobs:
             qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
-          - os: macos-14
+          - os: macos-15
             buildname: 'macos (arm64) / c++, lua tests'
             compiler: clang_64
             qt: '6.11.1'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -40,7 +40,7 @@ jobs:
           - os: ubuntu-22.04
             buildname: 'ubuntu / gcc / lua tests + leak detection'
             compiler: gcc_64
-            gcc_compiler_version: 10
+            gcc_compiler_version: 12
             qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
@@ -64,7 +64,7 @@ jobs:
             qt: '6.11.1'
             deploy: 'deploy'
             run_tests: 'true'
-          - os: macos-14
+          - os: macos-15
             buildname: 'macos (arm64) / c++, lua tests'
             compiler: clang_64
             qt: '6.11.1'


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Linux deploy leg: `gcc_compiler_version` 10 → 12, staying on the `ubuntu-22.04` runner.
- macOS arm64 leg: `macos-14` → `macos-15`. Both macOS deploy legs now share one runner and one toolchain (Xcode 16.4 / AppleClang 17.0.0) — the Intel leg was already on `macos-15-intel`.
- Mirrored in `build-mudlet-pr.yml`. No other legs changed.

#### Motivation for adding to Mudlet
The shipped Linux build uses GCC 10.5, and the two macOS deploy legs currently ship binaries built by different compiler major versions — AppleClang 15.0.0 for arm64 against 17.0.0 for Intel.

#### Other info (issues closed, discussion etc)
Fixes #10082, as amended in that discussion: `macos-15` rather than `macos-26`, so the bundled Homebrew libraries move one macOS release instead of twelve.

Neither change affects supported OS versions:

- **Linux** — `g++-12` comes from Ubuntu 22.04's own archive and leaves `libstdc++6` at 12.3.0 (`GLIBCXX_3.4.30`). The shipped AppImage already requires `GLIBC_2.35` and `GLIBCXX_3.4.29`, so GCC 12 lands inside the floor the artifact already has.
- **macOS** — `CMAKE_OSX_DEPLOYMENT_TARGET` stays at 13.0, so Mudlet's own binary and the Qt frameworks are unaffected.

On performance, `PipelineBenchmark` put GCC 12 ahead of GCC 10 by about 10% on `text_lines_per_sec` and 5-8% on the trigger and defaults phases, consistent across both run orders. That was measured with GCC 12.4.0 on Ubuntu 24.04 arm64 rather than CI's GCC 12.3.0 on ubuntu-22.04 x86_64, so it indicates the direction rather than being a CI-exact figure.

The further bump from GCC 12 to 14 will be handled in the PR that moves Linux to the `ubuntu-24.04` runner and addresses #10087.

**Test case:** CI should stay green on all legs. In the build logs the Linux deploy leg should report `GNU 12.3.0` rather than `GNU 10.5.0`, and both macOS legs should report `AppleClang 17.0.0` — arm64 previously reported 15.0.0.
