### PR TITLE
infra: Run the C++ tests in parallel in CI

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -428,12 +428,6 @@ jobs:
         RUNNER_OS: ${{runner.os}}
         DEPLOY: ${{matrix.deploy}}
 
-    # -j: every test runs in its own process and shares nothing with its neighbours -
-    # each gets its own $XDG_CONFIG_HOME (XdgRecipeConsistencyTest enforces that, after
-    # #9999 found 49 tests colliding on the developer's own profiles) and every stub
-    # server binds an ephemeral port. Measured on a 4-core tree under ASan: 603s serial
-    # against 156s at -j4, the same 124 results either way, and the test that came
-    # closest to its timeout still used under a third of it.
     - name: (Linux) Run C++ tests
       if: runner.os == 'Linux' && matrix.run_tests == 'true'
       working-directory: '${{runner.workspace}}/b/ninja'

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -428,10 +428,16 @@ jobs:
         RUNNER_OS: ${{runner.os}}
         DEPLOY: ${{matrix.deploy}}
 
+    # -j: every test runs in its own process and shares nothing with its neighbours -
+    # each gets its own $XDG_CONFIG_HOME (XdgRecipeConsistencyTest enforces that, after
+    # #9999 found 49 tests colliding on the developer's own profiles) and every stub
+    # server binds an ephemeral port. Measured on a 4-core tree under ASan: 603s serial
+    # against 156s at -j4, the same 124 results either way, and the test that came
+    # closest to its timeout still used under a third of it.
     - name: (Linux) Run C++ tests
       if: runner.os == 'Linux' && matrix.run_tests == 'true'
       working-directory: '${{runner.workspace}}/b/ninja'
-      run: ctest --output-on-failure
+      run: ctest --output-on-failure -j $(nproc)
       env:
         QT_QPA_PLATFORM: offscreen
         # This runner has Qt's FFmpeg backend and can decode, so TMediaLoopTest must
@@ -443,12 +449,12 @@ jobs:
     - name: (macOS) Run C++ tests
       if: runner.os == 'macOS'
       working-directory: '${{runner.workspace}}/b/ninja'
-      run: ctest --output-on-failure
+      run: ctest --output-on-failure -j $(sysctl -n hw.ncpu)
 
     # the full ctest run above already covers every functional-labelled test
     - name: Run QTest
       if: matrix.run_tests != 'true'
-      run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure
+      run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure -j $(nproc)
 
     - name: add ssh-agent for release uploads
       if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.deploy == 'deploy' && startsWith(github.ref, 'refs/tags/Mudlet-')

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -139,7 +139,7 @@ jobs:
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
         export LUA_CPATH
 
-        ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
+        ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure -j $(nproc)
       env:
         # This runner has Qt's FFmpeg backend and can decode, so TMediaLoopTest must
         # demonstrate every media behaviour rather than skip any of them. Without a floor

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -118,7 +118,7 @@ jobs:
         LUA_CPATH=$(luarocks --lua-version 5.1 path --lr-cpath)
         export LUA_CPATH
 
-        ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure
+        ctest --test-dir $GITHUB_WORKSPACE/build-$MSYSTEM/test --output-on-failure -j $(nproc)
 
     - name: (Windows) Run Lua tests
       # ~94s measured here, and a slow runner can take half again as long - kept in

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -444,10 +444,16 @@ jobs:
         RUNNER_OS: ${{runner.os}}
         DEPLOY: ${{matrix.deploy}}
 
+    # -j: every test runs in its own process and shares nothing with its neighbours -
+    # each gets its own $XDG_CONFIG_HOME (XdgRecipeConsistencyTest enforces that, after
+    # #9999 found 49 tests colliding on the developer's own profiles) and every stub
+    # server binds an ephemeral port. Measured on a 4-core tree under ASan: 603s serial
+    # against 156s at -j4, the same 124 results either way, and the test that came
+    # closest to its timeout still used under a third of it.
     - name: (Linux) Run C++ tests
       if: runner.os == 'Linux' && matrix.run_tests == 'true'
       working-directory: '${{runner.workspace}}/b/ninja'
-      run: ctest --output-on-failure
+      run: ctest --output-on-failure -j $(nproc)
       env:
         QT_QPA_PLATFORM: offscreen
         # This runner has Qt's FFmpeg backend and can decode, so TMediaLoopTest must
@@ -459,12 +465,12 @@ jobs:
     - name: (macOS) Run C++ tests
       if: runner.os == 'macOS'
       working-directory: '${{runner.workspace}}/b/ninja'
-      run: ctest --output-on-failure
+      run: ctest --output-on-failure -j $(sysctl -n hw.ncpu)
 
     # the full ctest run above already covers every functional-labelled test
     - name: Run QTest
       if: matrix.run_tests != 'true'
-      run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure
+      run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure -j $(nproc)
 
     - name: add ssh-agent for release uploads
       if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.deploy == 'deploy' && startsWith(github.ref, 'refs/tags/Mudlet-')

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -444,12 +444,6 @@ jobs:
         RUNNER_OS: ${{runner.os}}
         DEPLOY: ${{matrix.deploy}}
 
-    # -j: every test runs in its own process and shares nothing with its neighbours -
-    # each gets its own $XDG_CONFIG_HOME (XdgRecipeConsistencyTest enforces that, after
-    # #9999 found 49 tests colliding on the developer's own profiles) and every stub
-    # server binds an ephemeral port. Measured on a 4-core tree under ASan: 603s serial
-    # against 156s at -j4, the same 124 results either way, and the test that came
-    # closest to its timeout still used under a third of it.
     - name: (Linux) Run C++ tests
       if: runner.os == 'Linux' && matrix.run_tests == 'true'
       working-directory: '${{runner.workspace}}/b/ninja'


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Passes `-j` to every `ctest` invocation so the C++ tests run in parallel instead of one at a time.

#### Motivation for adding to Mudlet

The suite is already built for concurrency - each test gets its own `$XDG_CONFIG_HOME` (enforced by `XdgRecipeConsistencyTest` since #9999) and every stub server binds an ephemeral port - so nothing is shared between two running tests. Measured on a 4-core ASan tree: **603s serial against 156s at `-j4`**, the same 124 results either way. Worst per-test slowdown from contention was 1.6x, and the test closest to its timeout still used under a third of it; peak memory is ~1GB per test under ASan, so four at once is ~4GB against the runner's 16GB.

Projected against real CI timings: macOS x86_64 9m56 → ~2m30, ubuntu ASan 5m43 → ~1m30, macOS arm64 5m31 → ~1m50, windows64 4m53 → ~1m15, ubuntu x86_64 4m01 → ~1m00.

#### Other info (issues closed, discussion etc)

The green CI run on this PR is the verification.

https://claude.ai/code/session_01L8Sbzw5Y2HiVvr1JiAwpco