### PR TITLE
Fix: Discord button works again in a detached window

### DIFF
--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1010,6 +1010,7 @@ void TDetachedWindow::createToolBar()
 
 
     mpButtonDiscord->addAction(mpActionDiscord);
+    mpButtonDiscord->setDefaultAction(mpActionDiscord);
 
     // Map and other tools
     mpActionMapper = new QAction(QIcon(qsl(":/icons/applications-internet.png")), tr("Map"), this);

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -56,6 +56,7 @@ public:
     int getProfileCount() const { return mProfileConsoleMap.size(); }
 
     void updateToolbarForProfile(Host* pHost);
+    void updateDiscordNamedIcon();
     void setReattaching(bool reattaching) { mIsReattaching = reattaching; }
     void refreshTabBar();                             // Update tab text to account for CDC identifiers
     void updateWindowMenu();                          // Update the window menu with current window list
@@ -175,7 +176,6 @@ private:
     void connectToolBarActions();
     void updateToolBarActions();
     void updateWindowTitle();
-    void updateDiscordNamedIcon();
     void updateTabIndicator(int tabIndex = -1);                            // -1 means current tab
     void updateDockWidgetVisibilityForProfile(const QString& profileName); // Show/hide docked widgets based on active profile
     void restoreWindowGeometry();

--- a/src/TLuaInterpreterDiscord.cpp
+++ b/src/TLuaInterpreterDiscord.cpp
@@ -362,15 +362,12 @@ int TLuaInterpreter::setDiscordGameUrl(lua_State* L)
     // in order to respect privacy.
     mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
-    const bool isActiveHost = (pMudlet->mpCurrentActiveHost == &host);
     const int args = lua_gettop(L);
 
     if (!args) { // no args, blank the invite URL and game name
         host.setDiscordInviteURL(QString());
         host.setDiscordGameName(QString());
-        if (isActiveHost) {
-            pMudlet->updateDiscordNamedIcon();
-        }
+        pMudlet->updateDiscordNamedIcon();
         lua_pushboolean(L, true);
         return 1;
     }
@@ -392,9 +389,7 @@ int TLuaInterpreter::setDiscordGameUrl(lua_State* L)
     } else {
         host.setDiscordGameName(QString());
     }
-    if (isActiveHost) {
-        pMudlet->updateDiscordNamedIcon();
-    }
+    pMudlet->updateDiscordNamedIcon();
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4583,6 +4583,14 @@ void mudlet::slot_mudletDiscord()
 
 void mudlet::updateDiscordNamedIcon()
 {
+    // Each detached window owns its own copy of these actions and shows its own
+    // profile's game, so refreshing the main window's pair is not enough
+    for (const auto& detachedWindow : std::as_const(mDetachedWindows)) {
+        if (detachedWindow) {
+            detachedWindow->updateDiscordNamedIcon();
+        }
+    }
+
     Host* pHost = getActiveHost();
 
     if (!pHost) {

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     GlyphOverflowTest.cpp
     LabelMovieRefusalTest.cpp
     MainConsoleSelectionTest.cpp
+    DetachedWindowDiscordButtonTest.cpp
     MainWindowSizeReportTest.cpp
     DetachedWindowOwnershipTest.cpp
     MxpFramePlacementTest.cpp

--- a/test/functional_tests/DetachedWindowDiscordButtonTest.cpp
+++ b/test/functional_tests/DetachedWindowDiscordButtonTest.cpp
@@ -1,0 +1,321 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The game's Discord button in a detached window is a QToolButton holding a
+ * QAction, and everything the user sees of it - the icon, the game's name, and
+ * the click doing anything - comes from that action being the button's *default*
+ * action rather than merely one of its actions. Without that the button falls
+ * back to its own bare "Discord" text with no icon and swallows clicks.
+ *
+ * The last two cases cover the other half: each detached window owns its own copy
+ * of the Discord actions, so an update that only refreshes the main window's pair
+ * leaves the detached button showing the name the game had at detach time.
+ *
+ * Run with: ctest -R DetachedWindowDiscordButtonTest -V
+ */
+
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QDesktopServices>
+#include <QPointer>
+#include <QToolButton>
+#include <QtTest/QtTest>
+
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TDetachedWindow.h"
+#include "TLuaInterpreter.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+// Stands in for the web browser: openWebPage() ends in QDesktopServices::openUrl(),
+// which would otherwise launch one on the test machine
+class UrlCatcher : public QObject
+{
+    Q_OBJECT
+
+public:
+    QUrl mLastUrl;
+
+public slots:
+    void slot_openUrl(const QUrl& url) { mLastUrl = url; }
+};
+
+class DetachedWindowDiscordButtonTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    UrlCatcher mUrlCatcher;
+    QPointer<TDetachedWindow> mpDetachedWindow;
+    QString mPort;
+    const QString mLocalhost = qsl("localhost");
+    const QString mFirstHostname = qsl("DetachedWindowDiscord-First");
+    const QString mSecondHostname = qsl("DetachedWindowDiscord-Second");
+    // updateDiscordNamedIcon() elides the game name at 90px, so every name used
+    // here has to render narrower than that or the equality asserts below fail
+    const QString mGameName = qsl("Achaea");
+    const QString mInviteUrl = qsl("https://discord.gg/mudlet-discord-button-test");
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own, so that a second copy of this test
+        // running at the same time does not share a profile list with it
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QDesktopServices::setUrlHandler(qsl("https"), &mUrlCatcher, "slot_openUrl");
+
+        deleteProfileDirectory(mFirstHostname);
+        deleteProfileDirectory(mSecondHostname);
+
+        // Two of them, because slot_tabDetachRequested() refuses index 0
+        startProfile(mFirstHostname);
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+        startProfile(mSecondHostname);
+    }
+
+    void cleanupTestCase()
+    {
+        QDesktopServices::unsetUrlHandler(qsl("https"));
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory(mFirstHostname);
+            deleteProfileDirectory(mSecondHostname);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // The game's Discord details are what the button reads, so they have to be in
+    // place before the detach builds that window's toolbar
+    void init()
+    {
+        Host* pHost = mudlet::self()->getHostManager().getHost(mSecondHostname);
+        QVERIFY(pHost);
+        pHost->setDiscordGameName(mGameName);
+        pHost->setDiscordInviteURL(mInviteUrl);
+        mUrlCatcher.mLastUrl.clear();
+
+        mpDetachedWindow = detachSecondProfile();
+    }
+
+    void cleanup()
+    {
+        if (mudlet::self()->getDetachedWindows().contains(mSecondHostname)) {
+            mudlet::self()->slot_tabReattachRequested(mSecondHostname);
+        }
+    }
+
+    void test_theDiscordButtonShowsTheGamesNameAndIcon()
+    {
+        QToolButton* pButton = discordButton();
+        QVERIFY(pButton);
+
+        QVERIFY2(pButton->defaultAction(), "the Discord button has no default action, so it shows neither the game's name nor an icon and ignores clicks");
+        QCOMPARE(pButton->defaultAction()->objectName(), qsl("openDiscord"));
+        QCOMPARE(pButton->text(), mGameName);
+        QVERIFY2(!pButton->icon().isNull(), "the Discord button has no icon");
+
+        QAction* pMudletChat = mudletChatAction();
+        QVERIFY(pMudletChat);
+        QVERIFY2(pMudletChat->isVisible(), "the game has its own invite, so the separate Mudlet chat button should be showing");
+    }
+
+    // The common case: most profiles have no invite of their own, and this branch
+    // could never run before the button started accepting clicks at all
+    void test_withNoInviteTheButtonOpensMudletsOwnDiscord()
+    {
+        QToolButton* pButton = discordButton();
+        QVERIFY(pButton);
+
+        Host* pHost = mudlet::self()->getHostManager().getHost(mSecondHostname);
+        QVERIFY(pHost);
+        pHost->setDiscordInviteURL(QString());
+        mudlet::self()->updateDiscordNamedIcon();
+
+        QAction* pMudletChat = mudletChatAction();
+        QVERIFY(pMudletChat);
+        QVERIFY2(!pMudletChat->isVisible(), "with no invite of its own there is nothing for the separate Mudlet chat button to add");
+
+        pButton->click();
+
+        // mudlet::mMudletDiscordInvite, which is private
+        QCOMPARE(mUrlCatcher.mLastUrl, QUrl(qsl("https://www.mudlet.org/chat")));
+    }
+
+    void test_clickingTheDiscordButtonOpensTheGamesInvite()
+    {
+        QToolButton* pButton = discordButton();
+        QVERIFY(pButton);
+
+        pButton->click();
+
+        QCOMPARE(mUrlCatcher.mLastUrl, QUrl(mInviteUrl));
+    }
+
+    // Driven through the real GMCP entry point rather than a stand-in for it, so
+    // that cutting the wiring anywhere along that path fails here
+    void test_theButtonFollowsALaterGameNameChange()
+    {
+        QToolButton* pButton = discordButton();
+        QVERIFY(pButton);
+
+        Host* pHost = mudlet::self()->getHostManager().getHost(mSecondHostname);
+        QVERIFY(pHost);
+        pHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"game":"Avalon"})"));
+
+        QCOMPARE(pHost->getDiscordGameName(), qsl("Avalon"));
+        QCOMPARE(pButton->text(), qsl("Avalon"));
+    }
+
+    // The same refresh reached from Lua, which a detached profile's own scripts use
+    void test_theButtonFollowsSetDiscordGameUrl()
+    {
+        QToolButton* pButton = discordButton();
+        QVERIFY(pButton);
+
+        Host* pHost = mudlet::self()->getHostManager().getHost(mSecondHostname);
+        QVERIFY(pHost);
+
+        QVERIFY(pHost->getLuaInterpreter()->compileAndExecuteScript(qsl("setDiscordGameUrl('https://discord.gg/lusternia', 'Lusternia')")));
+
+        QCOMPARE(pHost->getDiscordGameName(), qsl("Lusternia"));
+        QCOMPARE(pButton->text(), qsl("Lusternia"));
+
+        // Detached windows are parentless, so this can only reach the main one
+        QToolButton* pMainButton = mudlet::self()->findChild<QToolButton*>(qsl("discord"));
+        QVERIFY(pMainButton);
+        QVERIFY2(pMainButton->text() != qsl("Lusternia"), "a detached profile's game name was painted onto the main window's button");
+
+        QVERIFY(pHost->getLuaInterpreter()->compileAndExecuteScript(qsl("setDiscordGameUrl()")));
+
+        QCOMPARE(pButton->text(), qsl("Discord"));
+        QVERIFY(!mudletChatAction()->isVisible());
+    }
+
+private:
+    // The action rather than the toolbar widget it produced: QToolBarLayout only
+    // syncs that widget's visibility while laying out, which the offscreen
+    // platform does not do, so the widget reads hidden even when the action is not
+    QAction* mudletChatAction() const
+    {
+        if (!mpDetachedWindow) {
+            QTest::qFail("no detached window to look for a Mudlet chat action in", __FILE__, __LINE__);
+            return nullptr;
+        }
+        QAction* pAction = mpDetachedWindow->findChild<QAction*>(qsl("mudlet_discord"));
+        if (!pAction) {
+            QTest::qFail("the detached window's toolbar has no Mudlet chat action", __FILE__, __LINE__);
+        }
+        return pAction;
+    }
+
+    QToolButton* discordButton() const
+    {
+        if (!mpDetachedWindow) {
+            QTest::qFail("no detached window to look for a Discord button in", __FILE__, __LINE__);
+            return nullptr;
+        }
+        QToolButton* pButton = mpDetachedWindow->findChild<QToolButton*>(qsl("discord"));
+        if (!pButton) {
+            QTest::qFail("the detached window's toolbar has no Discord button", __FILE__, __LINE__);
+        }
+        return pButton;
+    }
+
+    TDetachedWindow* detachSecondProfile()
+    {
+        if (!mudlet::self()->getDetachedWindows().isEmpty()) {
+            QTest::qFail("a detached window was left over from an earlier test", __FILE__, __LINE__);
+            return nullptr;
+        }
+
+        mudlet::self()->slot_tabDetachRequested(1, QPoint(200, 200));
+
+        TDetachedWindow* pDetachedWindow = mudlet::self()->getDetachedWindows().value(mSecondHostname);
+        if (!pDetachedWindow) {
+            // Whichever profile sits at tab 1 is the one that detaches, so say
+            // which one was expected rather than only that nothing appeared
+            QTest::qFail(qPrintable(qsl("detaching tab 1 produced no window for '%1' - the tab order is not what this test assumes").arg(mSecondHostname)), __FILE__, __LINE__);
+        }
+        return pDetachedWindow;
+    }
+
+    void startProfile(const QString& hostname)
+    {
+        auto host = TestProfile::create(hostname, mLocalhost, mPort);
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy connectionSpy(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!connectionSpy.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+};
+
+#include "DetachedWindowDiscordButtonTest.moc"
+MUDLET_GROUPED_TEST_MAIN(DetachedWindowDiscordButtonTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The detached window's Discord button had its action added but never set as the *default* action, so it drew its own bare "Discord" text, showed no icon, and swallowed clicks.
- Discord refreshes now reach detached windows - each owns its own copy of the actions, so an update that only touched the main window's pair left the detached button stale.
- `setDiscordGameUrl()` no longer skips the refresh when the calling profile is not the main window's active host.

#### Motivation for adding to Mudlet

A detached profile's Discord button was unusable: wrong label, no icon, and nothing happened on click.

#### Other info (issues closed, discussion etc)

Closes #10100.

New `DetachedWindowDiscordButtonTest` covers five behaviours, and each of the three parts is A/B-proven: with all three reverted all 5 cases fail; reverting only the `mudlet.cpp` part fails the GMCP case; reverting only the `TLuaInterpreterDiscord.cpp` part fails the Lua case. 126/126 ctest, 3638 Lua spec successes.

**Test case:** connect a profile to a game offering a Discord invite (e.g. `mg.morgengrauen.info`), connect a second profile, then drag the first out into its own window. Its Discord button should show the game's name and icon, and open the game's invite on click.

Assisted-by: Claude:claude-opus-5