### PR TITLE
Infra: Free up CI cache space so builds stop starting from scratch

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -1,7 +1,9 @@
 # DUPLICATE WORKFLOW: This file is paired with build-mudlet.yml
 # Changes here likely need to be mirrored there as well, apart from the ccache
 # handling: caches here are scoped to their own pull request ref and keyed per
-# commit, so there is never a key to delete before saving one.
+# commit, so there is never a key to delete before saving one. The generations
+# an earlier push left behind are retired by cleanup-caches.yml instead, which
+# runs in the base repository and so has a writable token even for a fork.
 name: 🔨 Build Mudlet - PR
 on:
   pull_request:
@@ -91,7 +93,14 @@ jobs:
       with:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
-        cache: true
+        # Deliberately uncached: the Qt tree is 335MB on Linux and 389MB on macOS,
+        # and a copy per runner image, module set and ref took over 40% of the
+        # repository's 10GB cache quota - more than every ccache put together.
+        # Fetching it afresh costs 25-35s a job. Leaving it cached cost far more
+        # than that, because a quota with no headroom has GitHub evicting by
+        # least-recently-used, and a dropped branch ccache is a 20 minute cold
+        # rebuild rather than a 30 second download.
+        cache: false
         modules: qt5compat qtmultimedia qtspeech
 
     - name: Cache Lua build

--- a/.github/workflows/build-mudlet-win-pr.yml
+++ b/.github/workflows/build-mudlet-win-pr.yml
@@ -1,7 +1,9 @@
 # DUPLICATE WORKFLOW: This file is paired with build-mudlet-win.yml
 # Changes here likely need to be mirrored there as well, apart from the ccache
 # handling: caches here are scoped to their own pull request ref and keyed per
-# commit, so there is never a key to delete before saving one.
+# commit, so there is never a key to delete before saving one. The generations
+# an earlier push left behind are retired by cleanup-caches.yml instead, which
+# runs in the base repository and so has a writable token even for a fork.
 name: 🔨 Build Mudlet - PR (windows)
 on:
   pull_request:

--- a/.github/workflows/build-mudlet-win.yml
+++ b/.github/workflows/build-mudlet-win.yml
@@ -193,10 +193,18 @@ jobs:
     # fine - the loser's save is refused and the next push heals it - but the
     # branch has no cache at all between this step and the save, so a run
     # cancelled in between leaves the next build cold.
+
+    # A PTB is a scheduled run of this workflow on development, so its key is
+    # the development key rather than one of its own. It restores at ~98.5% and
+    # then contributes 6-9 of ~550 objects back, none of which the next PTB can
+    # reuse - the differing ones are the app-build.txt resource. Not worth
+    # reopening the delete-to-save hole above on the branch key once a night.
     # Git bash rather than the msys2 shell the build steps use: gh ships with
     # the runner image and is on the native PATH.
     - name: Delete the previous ccache entry
-      if: always() && steps.restore-ccache.outputs.cache-primary-key != ''
+      if: >-
+        always() && steps.restore-ccache.outputs.cache-primary-key != ''
+        && github.event_name != 'schedule' && github.event.inputs.scheduled != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -212,7 +220,7 @@ jobs:
         fi
 
     - name: Save ccache
-      if: always()
+      if: always() && github.event_name != 'schedule' && github.event.inputs.scheduled != 'true'
       uses: actions/cache/save@v6
       with:
         path: ${{runner.workspace}}/ccache

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -83,7 +83,14 @@ jobs:
       with:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
-        cache: true
+        # Deliberately uncached: the Qt tree is 335MB on Linux and 389MB on macOS,
+        # and a copy per runner image, module set and ref took over 40% of the
+        # repository's 10GB cache quota - more than every ccache put together.
+        # Fetching it afresh costs 25-35s a job. Leaving it cached cost far more
+        # than that, because a quota with no headroom has GitHub evicting by
+        # least-recently-used, and a dropped branch ccache is a 20 minute cold
+        # rebuild rather than a 30 second download.
+        cache: false
         modules: qt5compat qtmultimedia qtspeech
 
     - name: Cache Lua build
@@ -383,8 +390,16 @@ jobs:
     # fine - the loser's save is refused and the next push heals it - but the
     # branch has no cache at all between this step and the save, so a run
     # cancelled in between leaves the next build cold.
+
+    # A PTB is a scheduled run of this workflow on development, so its key is
+    # the development key rather than one of its own. It restores at ~98.5% and
+    # then contributes 6-9 of ~550 objects back, none of which the next PTB can
+    # reuse - the differing ones are the app-build.txt resource. Not worth
+    # reopening the delete-to-save hole above on the branch key once a night.
     - name: Delete the previous ccache entry
-      if: always() && steps.restore-ccache.outputs.cache-primary-key != ''
+      if: >-
+        always() && steps.restore-ccache.outputs.cache-primary-key != ''
+        && github.event_name != 'schedule' && github.event.inputs.scheduled != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -400,7 +415,7 @@ jobs:
         fi
 
     - name: Save ccache
-      if: always()
+      if: always() && github.event_name != 'schedule' && github.event.inputs.scheduled != 'true'
       uses: actions/cache/save@v6
       with:
         path: ${{runner.workspace}}/ccache

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -7,7 +7,10 @@ on:
   pull_request_target:
     types: [closed]
   schedule:
-    - cron: '0 4 * * *'
+    # Hourly, not daily: a pull request pushed twice in an afternoon holds both
+    # generations of its ccache until this runs, and a generation is well over a
+    # gigabyte across the four build jobs - a tenth of the quota per stale push.
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -51,48 +54,75 @@ jobs:
           exit 1
         fi
 
-  stale-per-commit-ccache:
-    name: Sweep stale per-commit ccache entries
+  superseded-per-commit-ccache:
+    name: Sweep superseded and idle per-commit ccache entries
     if: github.event_name != 'pull_request_target' && github.repository_owner == 'Mudlet'
     runs-on: ubuntu-latest
     steps:
-    - name: Delete per-commit ccache entries not used in 48 hours
+    - name: Delete per-commit ccache entries a newer push has replaced
       shell: bash
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Only entries whose key ends in a 40 character commit hash qualify, so
-        # nothing keyed per branch or tag is ever touched, and neither is any
-        # cache that is not a ccache one. An open pull request left idle for two
-        # days does lose its own entry, and falls back to the branch entry its
-        # first build used.
+        # Only pull request entries whose key ends in a 40 character commit hash
+        # qualify, so nothing keyed per branch or tag is ever touched, and
+        # neither is any cache that is not a ccache one.
+        #
+        # Two reasons to delete. "superseded" is the one that matters: the pull
+        # request workflows key per commit, so every push leaves a full matrix
+        # of entries behind that no later build can ever hit, and the newest
+        # generation is the only one worth keeping. The pull request workflows
+        # cannot do this themselves - most open pull requests come from forks,
+        # where GITHUB_TOKEN is read-only whatever the permissions block asks
+        # for, so the delete has to happen here in the base repository.
+        # "idle" then retires the last generation of a pull request nobody has
+        # pushed to in two days; its next build falls back to the branch entry.
+        #
+        # Both exist because the alternative is GitHub's own eviction, which
+        # picks by least-recently-used across the whole 10GB quota and is just
+        # as likely to drop the development ccache a cold build would need.
         cutoff="$(( $(date -u +%s) - 48 * 3600 ))"
-        entries="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" --jq '
-          .actions_caches[]
-          | select(.key | test("^ccache-.*-[0-9a-f]{40}$"))
-          | [.id, (.last_accessed_at | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)]
-          | @tsv')"
-        ids="$(printf '%s\n' "${entries}" | awk -v cutoff="${cutoff}" '$2 < cutoff {print $1}')"
+        caches="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches?per_page=100" \
+          --jq '.actions_caches[]' | jq -s '.')"
+        # jq -s above, rather than gh's own --slurp: --paginate applies --jq per
+        # page, and grouping has to see every page at once.
+        doomed="$(printf '%s' "${caches}" | jq -r --argjson cutoff "${cutoff}" '
+          def ts: sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601;
+          [ .[]
+            | select(.ref | startswith("refs/pull/"))
+            | select(.key | test("^ccache-.*-[0-9a-f]{40}$")) ]
+          | group_by([.ref, (.key | sub("-[0-9a-f]{40}$"; ""))])
+          | map(
+              sort_by(.created_at | ts) | reverse | to_entries
+              | map(.value as $entry
+                    | if .key > 0 then [$entry.id, "superseded", $entry.key]
+                      elif ($entry.last_accessed_at | ts) < $cutoff
+                      then [$entry.id, "idle", $entry.key]
+                      else empty end))
+          | flatten(1) | .[] | @tsv')"
+        total="$(printf '%s' "${caches}" | jq '[.[] | select(.key | test("^ccache-.*-[0-9a-f]{40}$"))] | length')"
         # Both counts, so that a sweep with nothing to do reads differently from
         # one whose filter has stopped matching anything at all.
-        echo "$(printf '%s' "${entries}" | grep -c '' || true) per-commit ccache entries, $(printf '%s' "${ids}" | grep -c '' || true) of them not used in 48 hours"
-        if [ -z "${ids}" ]; then
+        echo "${total} per-commit ccache entries, $(printf '%s' "${doomed}" | grep -c '' || true) of them superseded or idle"
+        if [ -z "${doomed}" ]; then
           exit 0
         fi
         gone=0
         failed=0
-        for id in ${ids}; do
+        while IFS=$'\t' read -r id why key; do
+          [ -n "${id}" ] || continue
           # A 404 means the entry went away between the listing and here, which
           # is the wanted end state: GitHub evicts constantly under this quota.
           if response="$(gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${id}" 2>&1)" \
             || [[ "${response}" == *"HTTP 404"* ]]; then
+            echo "${why}: ${key}"
             gone=$(( gone + 1 ))
           else
-            echo "::warning::could not delete cache ${id}: ${response}"
+            echo "::warning::could not delete cache ${id} (${key}): ${response}"
             failed=$(( failed + 1 ))
           fi
-        done
-        echo "${gone} stale cache(s) gone"
+        done <<< "${doomed}"
+        echo "${gone} cache(s) gone"
         if [ "${failed}" -gt 0 ]; then
           echo "::error::${failed} cache(s) survived deletion"
           exit 1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,8 @@ jobs:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
         arch: win64_mingw73
-        cache: true
+        # uncached for the same reason as the step below
+        cache: false
         modules: qt5compat qtmultimedia
 
     - name: (Linux/macOS) Install Qt
@@ -62,7 +63,14 @@ jobs:
       with:
         version: ${{matrix.qt}}
         dir: ${{runner.workspace}}
-        cache: true
+        # Deliberately uncached: the Qt tree is 335MB on Linux and 389MB on macOS,
+        # and a copy per runner image, module set and ref took over 40% of the
+        # repository's 10GB cache quota - more than every ccache put together.
+        # Fetching it afresh costs 25-35s a job. Leaving it cached cost far more
+        # than that, because a quota with no headroom has GitHub evicting by
+        # least-recently-used, and a dropped branch ccache is a 20 minute cold
+        # rebuild rather than a 30 second download.
+        cache: false
         modules: qt5compat qtmultimedia
 
     - name: Restore Boost cache


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Stop caching the Qt install. At 335MB on Linux and 389MB on macOS, a copy per runner image, module set and ref took over 40% of the 10GB quota - more than every ccache put together - to save the 25-35s that fetching it costs.
- Sweep a pull request's superseded per-commit ccache entries hourly, rather than waiting for the 48 hour idle rule that never fired because GitHub's own eviction always got there first. It runs in the base repository because most pull requests come from forks, where `GITHUB_TOKEN` is read-only whatever the permissions block asks for.
- Skip the ccache save on PTB runs: a scheduled build is a development build, restores at ~98.5% on development's own key, and hands back 6-9 of ~550 objects that no later build can hit.

#### Motivation for adding to Mudlet

The repository sat at 9.95GB of its 10GB quota, so GitHub evicted by least-recently-used continuously and 13% of development build jobs started cold - ~23 minutes against ~5 warm - which made each run re-save a full-size copy under its own ref and evict still more.

#### Other info (issues closed, discussion etc)

Left for later, deliberately: `release-5.0` holds a near-duplicate 2.55GB of caches while sitting 3 commits behind development and 0 ahead, and nothing sets `CCACHE_MAXSIZE`, so the saved caches are creeping up (macOS x86_64 went 549MB to 738MB over the afternoon this was measured).

`actionlint` with `shellcheck` reports the same 116 findings before and after this change - all pre-existing `runner.workspace` and `macos-15-intel` noise from an outdated actionlint - so nothing here is newly flagged. The rewritten sweep was also run against the live cache list with the deletes stubbed out, where it correctly picked out two superseded generations that PR #10099 was holding from pushes 30 minutes apart, and left the newest alone.

**Test case:** `gh api repos/Mudlet/Mudlet/actions/cache/usage` should fall from ~9.9GB towards ~5.5GB over a day of builds, and `Restore ccache` on development should stop logging `Cache not found for input keys`. The hourly sweep logs `superseded: <key>` for each entry it retires.