### PR TITLE
Fix: Renaming a variable no longer loses it or runs its key as Lua

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -386,12 +386,11 @@ static bool nameSharedWithASibling(TVar* var)
     return false;
 }
 
-// The write paths build Lua source out of these names - see setValue() - where a
-// string key goes inside a quoted literal and a root goes in bare. So a key
-// holding a backslash comes back out as an escape sequence, and a root that is
-// not an identifier either fails to parse or, with a dot in it, parses as an
-// index into some other global.
-static bool nameSurvivesGeneratedCode(TVar* var, const bool asRoot)
+// Names the Variables view will write back through, which is narrower than what
+// the write paths can reach: they push keys through the C API, which carries any
+// key at all, while a string key holding a quote or a backslash and a root that
+// is not a plain identifier are refused here rather than written (#9908).
+static bool nameTheEditorWritesThrough(TVar* var, const bool asRoot)
 {
     const QString name = var->getName();
     if (asRoot) {
@@ -417,8 +416,7 @@ static bool nameSurvivesGeneratedCode(TVar* var, const bool asRoot)
 //    one (#9903). A variable a script has deleted since the tree was built is
 //    not found either.
 //  - no other member of the same table is shown under that name too.
-//  - the name is one the generated Lua source can carry back, which is a
-//    narrower thing than the C API can look up.
+//  - the name is one the Variables view writes through, see above.
 // What the variable holds is not part of the question: a script is free to have
 // changed that since the tree was built, and the name still finds it.
 bool LuaInterface::writableByName(TVar* var)
@@ -429,7 +427,7 @@ bool LuaInterface::writableByName(TVar* var)
         return false;
     }
     for (int i = 0; i < vars.size(); ++i) {
-        if (nameSharedWithASibling(vars.at(i)) || !nameSurvivesGeneratedCode(vars.at(i), i == 0)) {
+        if (nameSharedWithASibling(vars.at(i)) || !nameTheEditorWritesThrough(vars.at(i), i == 0)) {
             return false;
         }
     }
@@ -626,141 +624,6 @@ void LuaInterface::deleteVar(TVar* var)
     qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Lua panicked while deleting \"" << var->getName() << "\"; it has not been deleted.";
 }
 
-bool LuaInterface::renameCVar(QList<TVar*> vars)
-{
-    //uses C Api to rename a variable.
-    //dangerous function since you can get an api panic
-    //and trash the stack
-
-    TVar* var = vars.back();
-    // this walks down to the variable a push at a time, so every way out - the
-    // successful one included - owes the caller's Lua stack back. Left as it
-    // was, the leftovers stayed on the profile's live interpreter for good.
-    const int stackTop = lua_gettop(mL);
-    //make the new stack
-    lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
-    if (setjmp(buf) == 0) {
-        int i = 1;
-        int pushCount = 0;
-        int kType;
-        for (; i < vars.size() - 1; i++) {
-            kType = vars[i]->getKeyType();
-            if (kType == LUA_TNUMBER) {
-                lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
-            } else if (kType == LUA_TTABLE) {
-                // registry references are integer refs so must stay toInt()
-                lua_rawgeti(mL, LUA_REGISTRYINDEX, vars[i]->getName().toInt());
-            } else {
-                lua_pushstring(mL, QString(vars[i]->getName()).toUtf8().constData());
-            }
-            lua_gettable(mL, -2);
-            if (lua_isnil(mL, -1)) {
-                //value didn't exist, make it
-                // that one nil, and not lua_pop(mL, -1) - which is
-                // lua_settop(mL, 0) and threw the whole stack away
-                lua_pop(mL, 1);
-                if (kType == LUA_TNUMBER) {
-                    lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
-                } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
-                    lua_rawgeti(mL, LUA_REGISTRYINDEX, vars[i]->getName().toInt());
-                } else {
-                    lua_pushstring(mL, QString(vars[i]->getName()).toUtf8().constData());
-                }
-                lua_newtable(mL);
-                lua_settable(mL, -3);
-                i--; //decrement since we want to reput this table on the stack on next iteration
-            }
-        }
-
-        kType = var->getKeyType();
-        if (kType == LUA_TSTRING) {
-            lua_pushstring(mL, QString(var->getNewName()).toUtf8().constData());
-        } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getNewName().toDouble());
-        } else if (kType == LUA_TTABLE) {
-            lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
-        } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
-                                           << "\". Expected string, number, or table.";
-            lua_settop(mL, stackTop);
-            return false;
-        }
-
-        //put the old value on the stack
-        lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
-        i = 1;
-        for (; i < vars.size() - 1; i++) {
-            kType = vars[i]->getKeyType();
-            if (kType == LUA_TNUMBER) {
-                lua_pushnumber(mL, QString(vars[i]->getName()).toDouble());
-            } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
-                lua_rawgeti(mL, LUA_REGISTRYINDEX, vars[i]->getName().toInt());
-            } else {
-                lua_pushstring(mL, QString(vars[i]->getName()).toUtf8().constData());
-            }
-            lua_gettable(mL, -2);
-            pushCount++;
-        }
-
-        kType = var->getKeyType();
-        if (kType == LUA_TSTRING) {
-            lua_pushstring(mL, QString(var->getName()).toUtf8().constData());
-        } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getName().toDouble());
-        } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
-            lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
-        } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when retrieving old value: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
-                                           << "\". Expected string, number, table, or function.";
-            lua_settop(mL, stackTop);
-            return false;
-        }
-        lua_gettable(mL, -2);
-        pushCount++;
-        //old value is @ -1 now
-        //we want to put our new named key @ -2
-        kType = var->getKeyType();
-        if (kType == LUA_TSTRING) {
-            lua_pushstring(mL, QString(var->getNewName()).toUtf8().constData());
-        } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getNewName().toDouble());
-        } else if (kType == LUA_TTABLE) {
-            lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
-        } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when setting new key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
-                                           << "\". Expected string, number, or table.";
-            lua_settop(mL, stackTop);
-            return false;
-        }
-        pushCount++;
-        lua_insert(mL, -2);
-        lua_settable(mL, -3 - pushCount);
-        //key & value popped
-        //delete it, so we put the old key back on the stack and set to nil
-        kType = var->getKeyType();
-        if (kType == LUA_TSTRING) {
-            lua_pushstring(mL, QString(var->getName()).toUtf8().constData());
-        } else if (kType == LUA_TNUMBER) {
-            lua_pushnumber(mL, var->getName().toDouble());
-        } else if (kType == LUA_TTABLE || kType == LUA_TFUNCTION) {
-            lua_rawgeti(mL, LUA_REGISTRYINDEX, var->getName().toInt());
-        } else {
-            qWarning().noquote().nospace() << "LuaInterface::renameCVar() - Unsupported key type when deleting old key: " << lua_typename(mL, kType) << " for variable \"" << var->getName()
-                                           << "\". Expected string, number, table, or function.";
-            lua_settop(mL, stackTop);
-            return false;
-        }
-        lua_pushnil(mL);
-        lua_settable(mL, -3);
-        var->clearNewName();
-        lua_settop(mL, stackTop);
-        return true;
-    }
-    lua_settop(mL, stackTop);
-    qWarning().noquote().nospace() << "LuaInterface::renameCVar() WARNING - Lua panicked while renaming \"" << var->getName() << "\"; it may be left under either name.";
-    return false;
-}
-
 bool LuaInterface::loadVar(TVar* var)
 {
     //puts the value of a variable on the -1 position of the stack
@@ -836,11 +699,16 @@ bool LuaInterface::newNameIsFree(TVar* var)
     return false;
 }
 
+// Moves a variable onto its new key. Through the C API for the same reason
+// setValue() writes through it: a rename was generated Lua source - "new = old"
+// and "old = nil" - with every key along the path spliced into it as text, so a
+// key holding a quote or a backslash renamed some other member or nothing at
+// all, and a key that closed the subscript ran the rest of itself as Lua.
 bool LuaInterface::renameVar(TVar* var)
 {
     //this assumes anything like reparenting has been done
 
-    QList<TVar*> vars = varOrder(var);
+    const QList<TVar*> vars = varOrder(var);
     if (vars.isEmpty()) {
         // a variable named _G - varOrder() gives it no path
         var->abandonNewName();
@@ -850,9 +718,9 @@ bool LuaInterface::renameVar(TVar* var)
     if (var->isReference()) {
         // A key that is a table or a function of its own is not a name, and the
         // tree names such a member by the number of the registry reference
-        // holding the key. Renaming it to a string is not an operation that
-        // exists: what it did instead was write to a member named by that
-        // number - or, through renameCVar(), delete the member outright.
+        // holding the key, and renaming it to a string is not an operation that
+        // exists - what it did instead was write to a member named by that
+        // number, or delete the member outright.
         qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - not renaming \"" << var->getName() << "\" to \"" << var->getNewName()
                                        << "\": its key is a table or a function, which has no name to change.";
         var->abandonNewName();
@@ -874,89 +742,37 @@ bool LuaInterface::renameVar(TVar* var)
     newNameParts.append(var->getNewName());
     const QString newFullName = newNameParts.join(qsl("."));
 
-    QString oldVariable = vars.at(0)->getName();
-    QString newName;
-    if (vars.size() > 1) {
-        newName = vars[0]->getName();
-    }
-
-    for (int i = 1; i < vars.size(); i++) {
-        const int kType = vars[i]->getKeyType();
-        // numbers and booleans use unquoted subscripts: t[3.14], t[true]
-        if (kType == LUA_TNUMBER || kType == LUA_TBOOLEAN) {
-            oldVariable.append(qsl("[%1]").arg(vars.at(i)->getName()));
-            if (i < vars.size() - 1) {
-                newName.append(qsl("[%1]").arg(vars[i]->getName()));
-            }
-        } else if (kType == LUA_TTABLE) {
-            // a table used as a key part way along the path - the leaf's own key
-            // cannot be one, that is refused above. Only the C API can put such
-            // a key back on the stack, so the whole rename goes through it.
-            if (renameCVar(vars)) {
-                // where it goes, and why the bookkeeping moves here rather than
-                // once the rename is over: see the copying stage below
-                varUnit->renameVariableBookkeeping(var, oldFullName, newFullName);
-                return true;
-            }
+    const int stackTop = lua_gettop(mL);
+    if (setjmp(buf) == 0) {
+        if (!pushOwningTable(vars) || !pushKey(var, var->getName(), var->getKeyType())) {
+            qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - could not reach \"" << var->getName() << "\" to rename it.";
+            lua_settop(mL, stackTop);
             var->abandonNewName();
             return false;
-        } else {
-            // that leaves LUA_TSTRING
-            oldVariable.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
-            if (i < vars.size() - 1) {
-                newName.append(qsl(R"(["%1"])").arg(vars.at(i)->getName()));
-            }
         }
-    }
-
-    if (vars.size() <= 1) {
-        // this variable is at root level on _G
-        newName.append(qsl("_G[\"%1\"]").arg(vars.last()->getNewName()));
-    } else {
-        // this variable is nested in a table
-        if (var->getNewKeyType() == LUA_TNUMBER || var->getNewKeyType() == LUA_TBOOLEAN) {
-            newName.append(qsl("[%1]").arg(vars.last()->getNewName()));
-        } else {
-            newName.append(qsl(R"(["%1"])").arg(vars.last()->getNewName()));
+        // the old key stays on the stack: nil'ing the variable out from under
+        // it is what is left to do once the new key holds the value
+        lua_pushvalue(mL, -1);
+        lua_gettable(mL, -3);
+        if (!pushKey(var, var->getNewName(), var->getNewKeyType())) {
+            qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - could not build the name \"" << var->getNewName() << "\" to rename \"" << var->getName() << "\" to.";
+            lua_settop(mL, stackTop);
+            var->abandonNewName();
+            return false;
         }
-    }
-
-    auto renameCode = qsl("%1 = %2").arg(newName, oldVariable);
-    int error = luaL_loadstring(mL, renameCode.toUtf8().constData());
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\"" << renameCode
-                                       << "\".";
-        var->abandonNewName();
-        return false;
-    }
-    error = lua_pcall(mL, 0, LUA_MULTRET, 0);
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
-                                       << renameCode << "\".";
-        var->abandonNewName();
-        return false;
-    }
-    // here rather than at the end: the variable is under its new name from this
-    // point on, whatever the deleting stage below goes on to do
-    varUnit->renameVariableBookkeeping(var, oldFullName, newFullName);
-
-    //delete it
-    error = luaL_loadstring(mL, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (parsing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
-                                       << renameCode << "\".";
-        // the copy landed, so the variable really is under its new name - only
-        // the old one is still there beside it, which this node does not name
+        lua_insert(mL, -2);
+        lua_settable(mL, -4);
+        lua_pushnil(mL);
+        lua_settable(mL, -3);
+        lua_settop(mL, stackTop);
+        varUnit->renameVariableBookkeeping(var, oldFullName, newFullName);
         var->clearNewName();
         return true;
     }
-    error = lua_pcall(mL, 0, LUA_MULTRET, 0);
-    if (error) {
-        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (executing) error: \"" << lua_tostring(mL, -1) << "\" in code:\n\""
-                                       << renameCode << "\".";
-    }
-    var->clearNewName();
-    return true;
+    lua_settop(mL, stackTop);
+    qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - Lua panicked while renaming \"" << var->getName() << "\"; it may be left under either name.";
+    var->abandonNewName();
+    return false;
 }
 
 // Returns the value for a string/number/boolean datatype, and an empty string for

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -81,7 +81,6 @@ public:
     bool loadValue(lua_State*, TVar*, int);
     bool setValue(TVar*);
     void deleteVar(TVar*);
-    bool renameCVar(QList<TVar*>);
     // false when the rename did not happen - the variable keeps the name it had
     // and the node keeps naming it, which the caller has to tell the user about
     bool renameVar(TVar*);

--- a/test/TLuaInterfaceTest.cpp
+++ b/test/TLuaInterfaceTest.cpp
@@ -663,7 +663,6 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
     // inherit it and vanish from the Variables view.
     void testRenameTakesTheUserHiddenMarkToTheNewName()
     {
-        defineGlobalsTable(); // renaming a global is written as _G["new"] = old
         execLua("hiddenRenamed = 1");
         interface->getVars(false);
         VarUnit* vu = interface->getVarUnit();
@@ -690,7 +689,6 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
     // mark left on the old name saves whatever turns up there instead.
     void testRenameTakesTheSavedMarkToTheNewName()
     {
-        defineGlobalsTable();
         execLua("savedRenamed = 'value'");
         interface->getVars(false);
         VarUnit* vu = interface->getVarUnit();
@@ -711,7 +709,6 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
     // the table can no longer be un-hidden at all.
     void testRenameTakesAHiddenTablesIdentityToTheNewName()
     {
-        defineGlobalsTable();
         execLua("hiddenTableRenamed = {member = 'value'}");
         interface->getVars(true); // the hiding walk Mudlet runs at profile load
         VarUnit* vu = interface->getVarUnit();
@@ -732,7 +729,6 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
     // saved mark was left pointing at a path with no variable at the end of it.
     void testRenamingATableTakesItsMembersSavedMarksWithIt()
     {
-        defineGlobalsTable();
         execLua("renHolder = {a = 'aval'} renHolderOther = 'unrelated'");
         interface->getVars(false);
         VarUnit* vu = interface->getVarUnit();
@@ -875,6 +871,222 @@ private slots: // NOLINT(readability-redundant-access-specifiers)
         QVERIFY(interface->setValue(memberA));
         QCOMPARE(memberAsString(qsl("landmineHolder"), qsl("a")), qsl("written"));
         QVERIFY2(memberAsString(qsl("landmineHolder"), qsl("b")) == qsl("bval"), "the write went to the sibling the rename was refused over");
+    }
+
+    // A rename was generated Lua source with every key along the path spliced
+    // into it inside a quoted literal, and a key holding a quote closes that
+    // literal: neither line parsed, so the rename was dropped.
+    void testRenameMovesAMemberWhoseKeyHoldsAQuote()
+    {
+        execLua(qsl("quoteKeyHolder = {} quoteKeyHolder['a\"b'] = 'keepme'"));
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("quoteKeyHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        TVar* member = members.constFirst();
+        QCOMPARE(member->getName(), qsl("a\"b"));
+
+        member->setNewName(qsl("plain"), LUA_TSTRING);
+        pushSentinels();
+        const int stackBefore = lua_gettop(L);
+        QVERIFY(interface->renameVar(member));
+        QCOMPARE(lua_gettop(L), stackBefore);
+        QVERIFY2(sentinelsIntact(), "the rename unwound past the top it was handed");
+
+        QCOMPARE(memberAsString(qsl("quoteKeyHolder"), qsl("plain")), qsl("keepme"));
+        QCOMPARE(luaMemberCount(qsl("quoteKeyHolder")), 1);
+    }
+
+    // ...and the same for a key part way along the path, which the rename only
+    // passes through on its way to the member being renamed.
+    void testRenameReachesAMemberUnderATableWhoseKeyHoldsAQuote()
+    {
+        execLua(qsl("quotePathHolder = {} quotePathHolder['a\"b'] = {inner = 'keepme'}"));
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("quotePathHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        const QList<TVar*> inners = members.constFirst()->getChildren(false);
+        QCOMPARE(inners.size(), 1);
+        TVar* inner = inners.constFirst();
+        QCOMPARE(inner->getName(), qsl("inner"));
+
+        inner->setNewName(qsl("renamed"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(inner));
+
+        lua_getglobal(L, "quotePathHolder");
+        lua_pushstring(L, "a\"b");
+        lua_gettable(L, -2);
+        lua_pushstring(L, "renamed");
+        lua_gettable(L, -2);
+        QCOMPARE(QString::fromUtf8(lua_tostring(L, -1)), qsl("keepme"));
+        lua_pop(L, 1);
+        lua_pushstring(L, "inner");
+        lua_gettable(L, -2);
+        QVERIFY2(lua_isnil(L, -1), "the name the member was renamed off has to be free");
+        lua_pop(L, 3);
+    }
+
+    // The other half of splicing a key into source: a key that closes the
+    // subscript it is written into leaves the rest of itself parsed as
+    // statements, so a key a script stored - a line captured from the game, say
+    // - ran as Lua when the member holding it was renamed.
+    void testRenameDoesNotRunAKeyAsCode()
+    {
+        execLua(qsl("codeKeyHolder = {} codeKeyHolder['a\"]; evilRan = \"yes\" --'] = 'keepme'"));
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("codeKeyHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+
+        members.constFirst()->setNewName(qsl("plain"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(members.constFirst()));
+
+        lua_getglobal(L, "evilRan");
+        const bool keyRan = !lua_isnil(L, -1);
+        lua_pop(L, 1);
+        QVERIFY2(!keyRan, "a key is data, and renaming the member it belongs to must not run it");
+        QCOMPARE(memberAsString(qsl("codeKeyHolder"), qsl("plain")), qsl("keepme"));
+        QCOMPARE(luaMemberCount(qsl("codeKeyHolder")), 1);
+    }
+
+    // ...and a key holding a backslash became an escape in that literal, so the
+    // rename read one key and nil'ed another - the member it was asked about
+    // stayed where it was, under a name the Variables view had stopped showing.
+    void testRenameMovesAMemberWhoseKeyHoldsABackslash()
+    {
+        execLua(qsl("escapeKeyHolder = {} escapeKeyHolder['a\\\\b'] = 'keepme'"));
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("escapeKeyHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QCOMPARE(members.constFirst()->getName(), qsl("a\\b"));
+
+        members.constFirst()->setNewName(qsl("plain"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(members.constFirst()));
+
+        QCOMPARE(memberAsString(qsl("escapeKeyHolder"), qsl("plain")), qsl("keepme"));
+        QCOMPARE(luaMemberCount(qsl("escapeKeyHolder")), 1);
+    }
+
+    // Renaming a global was written as _G["new"] = old, so it went through
+    // whatever the name _G held at the time rather than through the globals
+    // table itself - and a script is free to have pointed _G somewhere else.
+    void testRenameOfAGlobalDoesNotGoThroughTheNameG()
+    {
+        execLua(qsl("_G = {} strayGlobal = 'keepme'"));
+        interface->getVars(false);
+        TVar* var = findGlobal(qsl("strayGlobal"));
+        QVERIFY(var);
+
+        var->setNewName(qsl("strayGlobalNew"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(var));
+
+        QCOMPARE(globalAsString(qsl("strayGlobalNew")), qsl("keepme"));
+        lua_getglobal(L, "strayGlobal");
+        QVERIFY2(lua_isnil(L, -1), "the name the variable was renamed off has to be free");
+        lua_pop(L, 1);
+        QCOMPARE(luaMemberCount(qsl("_G")), 0);
+    }
+
+    // A table used as a key is only nameable through the registry reference the
+    // tree holds it by, which is why renaming a member underneath one was the
+    // one path that already went through the C API. It goes through the same
+    // walk as every other path now.
+    void testRenameReachesAMemberUnderATableKeyedIntermediate()
+    {
+        execLua("refRenameHolder = {} do local key = {} refRenameHolder[key] = {inner = 'keepme'} end");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("refRenameHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QVERIFY(members.constFirst()->isReference());
+        const QList<TVar*> inners = members.constFirst()->getChildren(false);
+        QCOMPARE(inners.size(), 1);
+        TVar* inner = inners.constFirst();
+        QCOMPARE(inner->getName(), qsl("inner"));
+
+        inner->setNewName(qsl("renamed"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(inner));
+
+        QCOMPARE(luaMemberCount(qsl("refRenameHolder")), 1);
+        QCOMPARE(onlyMembersMemberAsString(qsl("refRenameHolder"), qsl("renamed")), qsl("keepme"));
+        QCOMPARE(onlyMembersMemberAsString(qsl("refRenameHolder"), qsl("inner")), QString());
+    }
+
+    // The editor decides the key type from what the user typed, so the new key
+    // is not always of the type the old one was. Written as the old type, a
+    // name of "five" would be pushed as the number it does not parse to and
+    // land the value on t[0].
+    void testRenameChangesAMembersKeyType()
+    {
+        execLua("keyTypeHolder = {} keyTypeHolder[5] = 'keepme'");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("keyTypeHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QCOMPARE(members.constFirst()->getKeyType(), LUA_TNUMBER);
+
+        members.constFirst()->setNewName(qsl("five"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(members.constFirst()));
+
+        QCOMPARE(memberAsString(qsl("keyTypeHolder"), qsl("five")), qsl("keepme"));
+        QCOMPARE(numberKeyedMemberAsString(qsl("keyTypeHolder"), 5), QString());
+        QCOMPARE(luaMemberCount(qsl("keyTypeHolder")), 1);
+    }
+
+    // A boolean key is named "true" or "false" in the tree, so pushing it as
+    // the text of that name reaches a string key of its own instead - the
+    // rename would report success having moved nothing.
+    void testRenameMovesABooleanKeyedMember()
+    {
+        execLua("boolKeyHolder = {} boolKeyHolder[true] = 'keepme'");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("boolKeyHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> members = holder->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        QCOMPARE(members.constFirst()->getKeyType(), LUA_TBOOLEAN);
+
+        members.constFirst()->setNewName(qsl("plain"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(members.constFirst()));
+
+        QCOMPARE(memberAsString(qsl("boolKeyHolder"), qsl("plain")), qsl("keepme"));
+        QCOMPARE(luaMemberCount(qsl("boolKeyHolder")), 1);
+    }
+
+    // A refused rename is where the generated source left its parse error
+    // behind: the chunk never ran, nothing popped it, and the profile's live
+    // interpreter carried the slot for the rest of the session (#9885).
+    void testARenameThatCannotReachTheVariableLeavesTheStackAsItFoundIt()
+    {
+        execLua("goneHolder = {inner = {member = 'keepme'}}");
+        interface->getVars(false);
+        TVar* holder = findGlobal(qsl("goneHolder"));
+        QVERIFY(holder);
+        const QList<TVar*> inners = holder->getChildren(false);
+        QCOMPARE(inners.size(), 1);
+        const QList<TVar*> members = inners.constFirst()->getChildren(false);
+        QCOMPARE(members.size(), 1);
+        TVar* member = members.constFirst();
+        // a script replaced the table the tree walked, so the path no longer
+        // reaches the member the rename was asked about
+        execLua("goneHolder.inner = 5");
+
+        member->setNewName(qsl("renamed"), LUA_TSTRING);
+        pushSentinels();
+        const int stackBefore = lua_gettop(L);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("could not reach")));
+        QVERIFY(!interface->renameVar(member));
+        QCOMPARE(lua_gettop(L), stackBefore);
+        QVERIFY2(sentinelsIntact(), "the refused rename unwound past the top it was handed");
+        QCOMPARE(member->getName(), qsl("member"));
     }
 
     // The three names below are the cycle a real table of mixed names produced:
@@ -1126,7 +1338,8 @@ private:
     }
 
     // The base library, which these tests do without, is what usually puts the
-    // globals table in _G - and a rename of a global is written as _G["new"].
+    // globals table in _G, and a global of a name only a subscript can write is
+    // made through it.
     void defineGlobalsTable()
     {
         lua_pushvalue(L, LUA_GLOBALSINDEX);

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -895,8 +895,8 @@ private slots:
         QCOMPARE(shownAs42, 2);
     }
 
-    // The write paths put a string key into a quoted Lua literal, where a
-    // backslash starts an escape and reaches a key of its own instead.
+    // The Variables view refuses a string key holding a backslash rather than
+    // writing it, even though the write paths reach such a key (#9908).
     void testNotWritableByNameForAMemberWithABackslashInItsKey()
     {
         execLua(qsl("testTbl = {} testTbl['C:\\\\temp'] = 'value'"));
@@ -906,8 +906,8 @@ private slots:
         QVERIFY(!interface->writableByName(member));
     }
 
-    // ...and a global goes into that source bare, so only an identifier gets
-    // there. One with a dot in it would parse as an index into another global.
+    // ...and only a plain identifier is a root it writes through: a dot in the
+    // name is what the tree and the save bookkeeping key member paths by.
     void testNotWritableByNameForAGlobalWithADotInItsName()
     {
         execLua(qsl("_G['dotted.global'] = 'value'"));
@@ -947,8 +947,7 @@ private slots:
         QCOMPARE(checked, 2);
     }
 
-    // A keyword reads as an identifier but does not parse as one, so the source
-    // the write paths generate for it does not run.
+    // ...and a keyword reads as an identifier without being one.
     void testNotWritableByNameForAGlobalNamedAfterALuaKeyword()
     {
         execLua(qsl("_G['end'] = 'value'"));

--- a/test/functional_tests/XMLexportVariablesTest.cpp
+++ b/test/functional_tests/XMLexportVariablesTest.cpp
@@ -1115,6 +1115,52 @@ private slots:
         QCOMPARE(luaL_dostring(L, "secondSessionTable = nil"), 0);
     }
 
+    // What a package stores when it keeps a line the game sent it (#9992).
+    // Restoring a variable used to be a line of generated Lua source with the
+    // value in a [[...]] literal and the key in a quoted one: a value holding
+    // "]]" closed the literal early, so the line did not parse and the variable
+    // came back missing, and a value beginning with "]]" left the rest of it
+    // parsed as statements - data the profile had saved ran as Lua on load.
+    void test_savedStringHoldingClosingLongBracketsSurvivesAReload()
+    {
+        LuaInterface* lI = mpHost->getLuaInterface();
+        VarUnit* vu = lI->getVarUnit();
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        // long brackets one level up, so the payloads below can hold "]]"
+        QCOMPARE(luaL_dostring(L,
+                               "bracketReload = {} "
+                               "bracketReload.lastQuote = [==[the guard says \"]] and that is that\"]==] "
+                               "bracketReload.note = [==[]] bracketReloadRanAsCode = 'yes' --]==] "
+                               "bracketReload['a\"b'] = 'value under a quoted key'"),
+                 0);
+        vu->savedVars.insert(qsl("bracketReload"));
+
+        const QString xmlPath = mudlet::getMudletPath(enums::profileHomePath, mHostname) + qsl("/bracket-reload-test.xml");
+        auto writer = std::make_shared<XMLexport>(mpHost);
+        QVERIFY2(writer->exportPackage(xmlPath, true, false), "the profile could not be exported");
+        QCOMPARE(luaL_dostring(L, "bracketReload = nil"), 0);
+
+        QFile file(xmlPath);
+        QVERIFY2(file.open(QFile::ReadOnly | QFile::Text), qPrintable(file.errorString()));
+        XMLimport importer(mpHost);
+        auto [imported, importError] = importer.importPackage(&file);
+        file.close();
+        QFile::remove(xmlPath);
+        QVERIFY2(imported, qPrintable(importError));
+
+        QVERIFY2(luaL_dostring(L, "assert(bracketReload.lastQuote == [==[the guard says \"]] and that is that\"]==])") == 0,
+                 "a saved string holding a closing long bracket did not come back as it was saved");
+        QVERIFY2(luaL_dostring(L, "assert(bracketReload.note == [==[]] bracketReloadRanAsCode = 'yes' --]==])") == 0,
+                 "a saved string beginning with a closing long bracket did not come back as it was saved");
+        QVERIFY2(luaL_dostring(L, "assert(bracketReloadRanAsCode == nil)") == 0, "a saved value is data, and loading the profile it was saved in must not run it");
+        QVERIFY2(luaL_dostring(L, "assert(bracketReload['a\"b'] == 'value under a quoted key')") == 0, "a saved member whose key holds a quote did not come back");
+
+        for (const auto& name : {qsl("bracketReload"), qsl("bracketReload.lastQuote"), qsl("bracketReload.note"), qsl("bracketReload.a\"b")}) {
+            vu->savedVars.remove(name);
+        }
+        QCOMPARE(luaL_dostring(L, "bracketReload = nil"), 0);
+    }
+
 private:
     // Returns false rather than asserting: a QVERIFY here would only return from
     // this helper, leaving the caller to dereference a null editor.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `LuaInterface::renameVar()` writes through the Lua C API instead of generating `new = old` / `old = nil` source with every key along the path spliced in as text. A key holding a quote or a backslash renamed the wrong member or nothing at all, a key that closed the subscript ran the rest of itself as Lua, and the failed parse left its error on the profile's live stack for the session.
- Renaming a global goes through the globals table rather than through whatever the name `_G` currently holds, and `renameCVar()` - the C API rename only table-keyed paths ever reached - goes with it.
- 9 unit cases and the save/reload round-trip from #9992; 5 of them fail without this change, the rest pin behaviour the deleted code owned.

#### Motivation for adding to Mudlet
This was the last write path that reached a variable by generating Lua source, so a key a script stored - a line captured from the game, say - could still be lost or run as code.

#### Other info (issues closed, discussion etc)
Closes #9992. That issue's load half was fixed by #9960, which merged hours before it was filed; the round-trip test here is the issue's own payload, verified to fail if `setValue()` is put back on generated source.

Note that the editor's `writableByName()` gate still refuses to write a member whose key holds a quote or a backslash, so today those renames are refused before they reach this code. That refusal is now conservatism rather than a limit of the write paths - worth relaxing separately, which is why nothing here changes it.

**Test case:** `lua t = {}; t[5] = 'keepme'` - rename that member to `five` in the Variables view; it comes back under `t.five`. Suite: TLuaInterfaceTest 59/59, TVariableEditorTest 123/123, ctest 126/126.

Assisted-by: Claude:claude-opus-5