### PR TITLE
infrastructure: keep asking for window activation so the key sequence tests stop flaking

### DIFF
--- a/test/TKeySequenceEditTest.cpp
+++ b/test/TKeySequenceEditTest.cpp
@@ -20,6 +20,7 @@
 #include "TKeySequenceEdit.h"
 #include "utils.h"
 
+#include <QApplication>
 #include <QLineEdit>
 #include <QSignalSpy>
 #include <QVBoxLayout>
@@ -34,10 +35,15 @@ static constexpr const char* activationUnavailableMessage = "the window never be
 // MUDLET_REQUIRE_WINDOW_ACTIVATION because every display it runs against can
 // activate a window, so a skip there would be hiding a regression rather than
 // reporting an environment - the same floor MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK
-// puts under the media tests.
+// puts under the media tests. qWaitForWindowActive() only polls, so a transient
+// denial of activation timed the wait out on the macOS CI leg (#10116) - keep
+// asking, as DetachedWindowMenuShortcutsTest already does.
 #define REQUIRE_WINDOW_ACTIVATION(window)                                                                                                                                                              \
     do {                                                                                                                                                                                               \
-        if (!QTest::qWaitForWindowActive(&(window))) {                                                                                                                                                 \
+        if (!QTest::qWaitFor([&]() {                                                                                                                                                                   \
+                (window).activateWindow();                                                                                                                                                             \
+                return QApplication::activeWindow() == &(window);                                                                                                                                      \
+            })) {                                                                                                                                                                                      \
             if (qEnvironmentVariableIsSet("MUDLET_REQUIRE_WINDOW_ACTIVATION")) {                                                                                                                       \
                 QFAIL(activationUnavailableMessage);                                                                                                                                                   \
             }                                                                                                                                                                                          \


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `REQUIRE_WINDOW_ACTIVATION` in `TKeySequenceEditTest` now re-asserts activation while it waits, instead of showing the window once and polling.
- Matches how `DetachedWindowMenuShortcutsTest` already waits for the same failure mode.

#### Motivation for adding to Mudlet
The two focus-traversal cases call `window.show()` and then `QTest::qWaitForWindowActive()`, which polls without ever asking again — neither call site calls `activateWindow()` at all. So a transient denial of activation on the macOS CI leg times the wait out and fails the case, because ctest deliberately escalates a missed activation from `QSKIP` to `QFAIL`.

#### Other info (issues closed, discussion etc)
Fixes #10116.

What denied activation is not identified, and the issue records why the obvious candidates don't survive the logs: none of the 15 tests overlapping the failing case creates a window, the run wasn't slower overall (697s against 694s across the 124 tests common to both runs), and the same leg passes the same test well inside the timeout on neighbouring runs. So this fixes the shape of the wait rather than guessing at the denier — which is the conclusion `DetachedWindowMenuShortcutsTest` already reached, where the comment reads *"keep asking rather than claiming activation once and losing it to a late arrival"*.

An intermittent failure can't be shown fixed by observing green runs, so the failure mode was reproduced directly instead. With a second window holding activation:

```
setup: thief holds activation? yes
OLD  qWaitForWindowActive(target)       -> TIMED OUT
NEW  qWaitFor + activateWindow(target)  -> activated
```

Unchanged: the Linux-only `offscreen` property and the native macOS focus coverage it protects, the `MUDLET_REQUIRE_WINDOW_ACTIVATION` fail-don't-skip policy, and the 5s budget, since `qWaitFor()`'s default timeout matches `qWaitForWindowActive()`'s.

**Test case:** `ctest -R TKeySequenceEditTest` on macOS or Windows, where the test runs against the real window server — both traversal cases should pass. On Linux it runs under `offscreen`, which synthesises activation, so it passes there either way.
