### PR TITLE
Infra: Fix null checks CodeQL flagged as missing in functional tests

### DIFF
--- a/test/functional_tests/ConnectionDialogCrashTest.cpp
+++ b/test/functional_tests/ConnectionDialogCrashTest.cpp
@@ -123,6 +123,7 @@ private:
     void rightClickBelowTheLastItem(QAbstractScrollArea* view) const
     {
         auto* viewport = view->viewport();
+        QVERIFY(viewport);
         const QPoint pos(viewport->width() / 2, viewport->height() - 4);
         QContextMenuEvent event(QContextMenuEvent::Mouse, pos, viewport->mapToGlobal(pos));
         QApplication::sendEvent(viewport, &event);

--- a/test/functional_tests/NarrowWindowWrapTest.cpp
+++ b/test/functional_tests/NarrowWindowWrapTest.cpp
@@ -198,6 +198,7 @@ private slots:
         mpServer->setWelcomeMessage(qsl("HELLO\r\n"));
         startProfile();
         auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
         QVERIFY2(waitForMainConsoleText(qsl("HELLO")), "Welcome text never reached the buffer");
 
         // leave a single column free of the screen width the insert wraps at -
@@ -265,6 +266,7 @@ private slots:
     {
         startProfile();
         auto* host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
         runLua(qsl("setWindowWrap(80)"));
         QCOMPARE(host->mWrapAt, 80);
 
@@ -312,6 +314,7 @@ private:
     void runLua(const QString& script)
     {
         auto host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
         host->getLuaInterpreter()->compileAndExecuteScript(script);
     }
 

--- a/test/functional_tests/WrapLineRewrapTest.cpp
+++ b/test/functional_tests/WrapLineRewrapTest.cpp
@@ -417,6 +417,7 @@ private:
     void runLua(const QString& script)
     {
         auto host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
         host->getLuaInterpreter()->compileAndExecuteScript(script);
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Adds a `QVERIFY()` guard on 5 call sites CodeQL's `cpp/inconsistent-null-check` flagged as unchecked (`viewport()` in `ConnectionDialogCrashTest`, `getActiveHost()` in `NarrowWindowWrapTest` and `WrapLineRewrapTest`) - every other call site in these files already checks its result the same way.

#### Motivation for adding to Mudlet
CodeQL flagged 42 alerts for this rule; auditing each showed 37 were false positives (the QTest `QVERIFY(ptr)` macro isn't recognized by the heuristic as a null check), which were dismissed on the alert list with an explanation. These 5 were genuinely missing the guard other call sites in the same file have.

#### Other info (issues closed, discussion etc)
Verified by building `functional_profile_tests`/`functional_window_tests` and running `ConnectionDialogCrashTest`, `NarrowWindowWrapTest`, and `WrapLineRewrapTest` - all pass.

**Test case:** run the three affected functional tests; they should pass identically to before, since the added checks only guard against a null that isn't expected in practice.