### PR TITLE
Infra: Catch memory leaks from Lua argument errors in CI

### DIFF
--- a/.github/workflows/lua-error-strands.yml
+++ b/.github/workflows/lua-error-strands.yml
@@ -1,0 +1,34 @@
+# lua_error() longjmps in Lua 5.1, so it unwinds the C stack without running a
+# single C++ destructor. PRs #9602 and #9605 removed the LeakSanitizer
+# suppression hiding that class and cleared every site then present, but that
+# sweep was a one-off - nothing re-runs it, so a Lua function added afterwards
+# reintroduces the bug silently. LeakSanitizer only catches it when a spec
+# happens to exercise the raising path, which for a new function is usually
+# never. This job re-runs the audit on every change instead.
+name: lua_error strands
+
+on:
+  push:
+    branches: [master, development, release-*]
+    tags: [Mudlet-*]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lua-error-strands:
+    name: Check for heap objects stranded across lua_error()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Lua
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y lua5.1
+
+      - name: Self-test the scanner
+        # A scanner that has quietly stopped matching anything would pass the
+        # step below on a tree full of strands, so prove it still fails on a
+        # known-bad fixture before trusting it on the real source.
+        run: lua5.1 CI/test-check-lua-error-strands.lua
+
+      - name: Scan src/
+        run: lua5.1 CI/check-lua-error-strands.lua

--- a/.github/workflows/lua-error-strands.yml
+++ b/.github/workflows/lua-error-strands.yml
@@ -4,15 +4,26 @@
 # sweep was a one-off - nothing re-runs it, so a Lua function added afterwards
 # reintroduces the bug silently. LeakSanitizer only catches it when a spec
 # happens to exercise the raising path, which for a new function is usually
-# never. This job re-runs the audit on every change instead.
-name: lua_error strands
+# never. See CI/check-lua-error-strands.lua.
+name: Check lua_error strands
 
 on:
   push:
     branches: [master, development, release-*]
     tags: [Mudlet-*]
   pull_request:
+    paths:
+      - 'src/**.cpp'
+      - 'src/**.h'
+      - 'CI/check-lua-error-strands.lua'
+      - 'CI/test-check-lua-error-strands.lua'
+      - 'CI/lua-error-strand-fixtures/**'
+      - '.github/workflows/lua-error-strands.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lua-error-strands:
@@ -21,14 +32,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Lua
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y lua5.1
+      - name: Install Lua 5.1.5
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: "5.1.5"
 
       - name: Self-test the scanner
-        # A scanner that has quietly stopped matching anything would pass the
-        # step below on a tree full of strands, so prove it still fails on a
-        # known-bad fixture before trusting it on the real source.
-        run: lua5.1 CI/test-check-lua-error-strands.lua
+        # A scanner that has quietly stopped matching anything reports a clean
+        # tree and looks identical to success, so prove it still fails on a
+        # known-bad fixture before trusting the scan below.
+        run: lua CI/test-check-lua-error-strands.lua
 
       - name: Scan src/
-        run: lua5.1 CI/check-lua-error-strands.lua
+        run: lua CI/check-lua-error-strands.lua

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -267,13 +267,13 @@ local function scanFile(path)
     end
     if signature:match("lua_State%s*%*") and signature:match("%(") and not line:match("^%s*//")
        and not signature:match("%)%s*;%s*$") and not line:match("^%s*%*") then
-      local depth, bodyStart = 0, nil
+      local bodyStart = nil
       for j = signatureEnd, math.min(signatureEnd + 4, n) do
         if lines[j]:match("{") then bodyStart = j; break end
       end
       if bodyStart then
         functionsScanned = functionsScanned + 1
-        depth = 0
+        local depth = 0
         local live = {}   -- varname -> {line=, type=}
         local free = {}   -- declared empty, so owning nothing until something fills it
         local scopes = {} -- depth -> list of varnames declared at that depth

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -33,10 +33,10 @@ local RAISERS = {
   "luaL_optstring", "luaL_optlstring", "luaL_optnumber", "luaL_optinteger",
 }
 
--- A raiser paired with the non-raising checker that makes its raise dead.
--- #9605's mechanism: a caller validates with check*Arg() first and returns on
--- failure, so by the time the paired raiser runs its own check cannot fail.
--- Both calls have to name the same argument position for the pairing to hold.
+-- A raiser paired with the non-raising checker that makes its raise dead: a
+-- caller that validates with check*Arg() first and returns on failure leaves
+-- the paired raiser's own check unable to fail. Both calls have to name the
+-- same argument position for the pairing to hold.
 local PAIRED_CHECKER = {
   parseCommandOrFunction = "checkCommandOrFunctionArg",
   parseHintsTable = "checkHintsTable",
@@ -63,8 +63,9 @@ local OWNING_TEMPORARIES = {
   "%.trimmed%s*%(", "%.simplified%s*%(", "%.join%s*%(", "%.split%s*%(",
 }
 
--- An initialiser that cannot have allocated: literal storage, the shared null,
--- or Qt's shared empty buffer.
+-- Whether an initialiser can be trusted not to have allocated. QStringLiteral
+-- data is in the binary, and a default-constructed or empty Qt container is a
+-- shared singleton, so none of them own a buffer to strand.
 local function initialiserIsFree(init)
   if not init or init:match("^%s*$") then
     return true                                   -- default-constructed
@@ -152,7 +153,6 @@ local function scanFile(path)
     -- A function taking lua_State*. clang-format keeps these on one line.
     if line:match("lua_State%s*%*") and line:match("%(") and not line:match("^%s*//")
        and not line:match(";%s*$") and not line:match("^%s*%*") then
-      -- find the body's opening brace
       local depth, bodyStart = 0, nil
       for j = i, math.min(i + 4, n) do
         if lines[j]:match("{") then bodyStart = j; break end
@@ -166,9 +166,7 @@ local function scanFile(path)
           local body = lines[j]
           local code = body:gsub("//.*$", "")
 
-          -- a raise: report everything still live, plus owning temporaries
           local raiser, raiserArgs = findRaiser(code)
-          -- a raise the caller has already gated on cannot fire
           if raiser and raiserArgs and PAIRED_CHECKER[raiser] then
             local checker = PAIRED_CHECKER[raiser]
             local wanted = positionArg(raiserArgs)
@@ -187,8 +185,8 @@ local function scanFile(path)
           end
           if raiser and j > bodyStart then
             for name, info in pairs(live) do
-              -- #9605's exclusion: when the guard that reaches this raise is
-              -- <var>.isEmpty(), the variable is the shared empty buffer here
+              -- when the guard reaching this raise is <var>.isEmpty(), the
+              -- variable is the shared empty buffer and owns nothing
               local guarded = false
               for back = math.max(bodyStart, j - 6), j do
                 if lines[back]:match("%f[%w]" .. name .. "%f[%W]%s*%.%s*isEmpty%s*%(%s*%)") then
@@ -213,7 +211,6 @@ local function scanFile(path)
             end
           end
 
-          -- declarations
           for _, ty in ipairs(OWNING_TYPES) do
             local pat = "^%s*[a-zA-Z:<>,%s]-%f[%w]" .. ty:gsub("%p", "%%%0") .. "%f[%W]%s+([%w_]+)%s*(.*)$"
             local varname, rest = code:match(pat)

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -26,7 +26,7 @@ Exits 1 when anything is found.
 local RAISERS = {
   "getVerifiedString", "getVerifiedInt", "getVerifiedBool", "getVerifiedFloat",
   "getVerifiedDouble", "getVerifiedStringOrInteger",
-  "parseCommandOrFunction", "parseHintsTable",
+  "parseCommandOrFunction", "parseHintsTable", "parseCommandsOrFunctionsTable",
   "lua_error", "luaL_error", "luaL_argerror", "luaL_typerror",
   "luaL_checkstring", "luaL_checklstring", "luaL_checknumber", "luaL_checkinteger",
   "luaL_checkstack", "luaL_checktype", "luaL_checkany", "luaL_checkudata",
@@ -40,6 +40,7 @@ local RAISERS = {
 local PAIRED_CHECKER = {
   parseCommandOrFunction = "checkCommandOrFunctionArg",
   parseHintsTable = "checkHintsTable",
+  parseCommandsOrFunctionsTable = "checkCommandsOrFunctionsTable",
   getVerifiedString = "checkStringArg",
   getVerifiedInt = "checkIntArg",
   getVerifiedBool = "checkBoolArg",
@@ -52,6 +53,24 @@ local PAIRED_CHECKER = {
 -- soon as they hold anything.
 local OWNING_TYPES = {
   "QString", "QStringList", "QByteArray", "std::string", "TMediaData",
+}
+
+-- Initialisers that hand back heap-owning data, so an `auto` local holding one
+-- is tracked even though its type is never spelled out.
+local OWNING_INITIALISERS = {
+  -- getVerifiedInt/Float/Double/Bool hand back scalars, so only the two that
+  -- return a QString belong here
+  "getVerifiedString%s*%(", "getVerifiedStringOrInteger%s*%(",
+  "lua_tostring%s*%(", "QString::fromUtf8%s*%(",
+  "QString%s*[{(]", "QStringList%s*[{(]", "QByteArray%s*[{(]",
+  "%.toUtf8%s*%(", "%.arg%s*%(", "%.split%s*%(", "%.join%s*%(",
+}
+
+-- Calls that fill a container declared empty, turning a free local into an
+-- owning one partway through the function.
+local FILLING_OPERATIONS = {
+  "%s*<<%s*", "%s*%+=%s*", "%.append%s*%(", "%.push_back%s*%(",
+  "%.insert%s*%(", "%.prepend%s*%(", "%.replace%s*%(",
 }
 
 -- Expressions that produce an owning temporary when passed straight into a
@@ -85,12 +104,26 @@ end
 -- comment cut. Brace depth is what scopes every tracked variable, so a "{" in
 -- a message or a URL inside a // comment would otherwise leak a scope and
 -- silence every later raise in the function.
-local function codeOnly(line)
+local function codeOnly(line, inBlockComment)
   local out, k, n = {}, 1, #line
   while k <= n do
     local c = line:sub(k, k)
-    if c == "/" and line:sub(k + 1, k + 1) == "/" then
+    if inBlockComment then
+      if c == "*" and line:sub(k + 1, k + 1) == "/" then
+        inBlockComment = false
+        k = k + 1
+      end
+      out[#out + 1] = " "
+      k = k + 1
+    elseif c == "/" and line:sub(k + 1, k + 1) == "/" then
       break
+    elseif c == "/" and line:sub(k + 1, k + 1) == "*" then
+      inBlockComment = true
+      k = k + 2
+    -- a digit separator (1'000) is not a character literal
+    elseif c == "'" and line:sub(k - 1, k - 1):match("[%w_]") then
+      out[#out + 1] = c
+      k = k + 1
     elseif c == '"' or c == "'" then
       -- R"(...)" raw strings end at )" rather than at the next quote
       local raw = c == '"' and line:sub(k - 1, k - 1) == "R"
@@ -119,7 +152,7 @@ local function codeOnly(line)
       k = k + 1
     end
   end
-  return table.concat(out)
+  return table.concat(out), inBlockComment
 end
 
 -- The argument list of a call to `name`, parenthesis-balanced. Returning the
@@ -228,18 +261,36 @@ local function scanFile(path)
         functionsScanned = functionsScanned + 1
         depth = 0
         local live = {}   -- varname -> {line=, type=}
+        local free = {}   -- declared empty, so owning nothing until something fills it
         local scopes = {} -- depth -> list of varnames declared at that depth
+        local emptyGuards = {} -- depth -> varname the enclosing if() proved empty
+        local inBlockComment = false
         local j = bodyStart
         repeat
           local body = lines[j]
-          local code = codeOnly(body)
+          local code
+          code, inBlockComment = codeOnly(body, inBlockComment)
 
-          local raiser, raiserArgs = findRaiser(code)
+          -- A raiser's arguments can wrap. Join forward while the parentheses
+          -- are unbalanced so a temporary on a continuation line is still seen.
+          local raiseText = code
+          if select(2, code:gsub("%(", "")) > select(2, code:gsub("%)", "")) then
+            local open = select(2, code:gsub("%(", "")) - select(2, code:gsub("%)", ""))
+            local k = j
+            while open > 0 and k < n and k - j < 4 do
+              k = k + 1
+              local more = codeOnly(lines[k], false)
+              raiseText = raiseText .. " " .. more
+              open = open + select(2, more:gsub("%(", "")) - select(2, more:gsub("%)", ""))
+            end
+          end
+
+          local raiser, raiserArgs = findRaiser(raiseText)
           if raiser and raiserArgs and PAIRED_CHECKER[raiser] then
             local checker = PAIRED_CHECKER[raiser]
             local wanted = positionArg(raiserArgs)
             for back = bodyStart, j - 1 do
-              local checkerArgs = argsOfCall(codeOnly(lines[back]), checker)
+              local checkerArgs = argsOfCall(codeOnly(lines[back], false), checker)
               if checkerArgs and wanted ~= "" and positionArg(checkerArgs) == wanted then
                 raiser = nil
                 break
@@ -248,13 +299,13 @@ local function scanFile(path)
           end
           if raiser and j > bodyStart then
             for name, info in pairs(live) do
-              -- when the guard reaching this raise is <var>.isEmpty(), the
-              -- variable is the shared empty buffer and owns nothing
+              -- Inside `if (x.isEmpty()) { ... }` the variable really is the
+              -- shared empty buffer. Outside it - and the idiom here is to
+              -- return from that block - x is proven NON-empty, so the guard
+              -- has to be scoped to the block rather than to nearby lines.
               local guarded = false
-              for back = math.max(bodyStart, j - 6), j do
-                if lines[back]:match("%f[%w]" .. name .. "%f[%W]%s*%.%s*isEmpty%s*%(%s*%)") then
-                  guarded = true
-                end
+              for _, guardedName in pairs(emptyGuards) do
+                if guardedName == name then guarded = true end
               end
               if not guarded then
               findings[#findings + 1] = {
@@ -274,12 +325,44 @@ local function scanFile(path)
             end
           end
 
+          local emptyGuarded = code:match("if%s*%(%s*([%w_]+)%s*%.%s*isEmpty%s*%(%s*%)%s*%)")
+          if emptyGuarded and code:match("{%s*$") then
+            emptyGuards[depth + 1] = emptyGuarded
+          end
+
+          -- a container declared empty starts owning as soon as something fills it
+          for name, info in pairs(free) do
+            for _, op in ipairs(FILLING_OPERATIONS) do
+              if code:match("%f[%w]" .. name .. "%f[%W]" .. op) then
+                live[name] = {line = j, type = info.type}
+                scopes[info.depth] = scopes[info.depth] or {}
+                table.insert(scopes[info.depth], name)
+                free[name] = nil
+                break
+              end
+            end
+          end
+
+          local autoName, autoInit = code:match("^%s*[a-zA-Z:%s]-%f[%w]auto%f[%W]%s*[%*&]?%s*([%w_]+)%s*=%s*(.*)$")
+          if autoName then
+            for _, pat in ipairs(OWNING_INITIALISERS) do
+              if autoInit:match(pat) then
+                live[autoName] = {line = j, type = "auto"}
+                scopes[depth] = scopes[depth] or {}
+                table.insert(scopes[depth], autoName)
+                break
+              end
+            end
+          end
+
           for _, ty in ipairs(OWNING_TYPES) do
             local pat = "^%s*[a-zA-Z:<>,%s]-%f[%w]" .. ty:gsub("%p", "%%%0") .. "%f[%W]%s+([%w_]+)%s*(.*)$"
             local varname, rest = code:match(pat)
             if varname and not code:match("%f[%w]static%f[%W]")
                and not code:match("%f[%w]return%f[%W]") and varname ~= "const" then
-              if not initialiserIsFree(rest) then
+              if initialiserIsFree(rest) then
+                free[varname] = {line = j, type = ty, depth = depth}
+              else
                 live[varname] = {line = j, type = ty}
                 scopes[depth] = scopes[depth] or {}
                 table.insert(scopes[depth], varname)
@@ -298,9 +381,10 @@ local function scanFile(path)
               depth = depth + 1
             elseif c == "}" then
               if scopes[depth] then
-                for _, v in ipairs(scopes[depth]) do live[v] = nil end
+                for _, v in ipairs(scopes[depth]) do live[v] = nil; free[v] = nil end
                 scopes[depth] = nil
               end
+              emptyGuards[depth] = nil
               depth = depth - 1
             end
           end

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -81,29 +81,77 @@ local function initialiserIsFree(init)
       or false
 end
 
--- Returns the raiser's name and the span of its argument list, so a temporary
--- built from the raiser's *result* - getVerifiedString(...).trimmed() - is not
--- mistaken for one built inside its arguments.
+-- A line with its string and character literals blanked and its trailing
+-- comment cut. Brace depth is what scopes every tracked variable, so a "{" in
+-- a message or a URL inside a // comment would otherwise leak a scope and
+-- silence every later raise in the function.
+local function codeOnly(line)
+  local out, k, n = {}, 1, #line
+  while k <= n do
+    local c = line:sub(k, k)
+    if c == "/" and line:sub(k + 1, k + 1) == "/" then
+      break
+    elseif c == '"' or c == "'" then
+      -- R"(...)" raw strings end at )" rather than at the next quote
+      local raw = c == '"' and line:sub(k - 1, k - 1) == "R"
+      out[#out + 1] = c
+      k = k + 1
+      while k <= n do
+        local d = line:sub(k, k)
+        if raw then
+          if d == ")" and line:sub(k + 1, k + 1) == '"' then
+            out[#out + 1] = '")'
+            k = k + 2
+            break
+          end
+        elseif d == "\\" then
+          k = k + 1
+        elseif d == c then
+          out[#out + 1] = c
+          k = k + 1
+          break
+        end
+        out[#out + 1] = " "
+        k = k + 1
+      end
+    else
+      out[#out + 1] = c
+      k = k + 1
+    end
+  end
+  return table.concat(out)
+end
+
+-- The argument list of a call to `name`, parenthesis-balanced. Returning the
+-- span rather than the rest of the line is what stops a temporary built from a
+-- raiser's *result* - getVerifiedString(...).trimmed() - being read as one
+-- built inside its arguments.
+local function argsOfCall(line, name)
+  local s, e = line:find(name, 1, true)
+  while s do
+    local before = s > 1 and line:sub(s - 1, s - 1) or " "
+    if not before:match("[%w_]") and line:sub(e + 1, e + 1) == "(" then
+      local depth, k = 0, e + 1
+      while k <= #line do
+        local c = line:sub(k, k)
+        if c == "(" then depth = depth + 1
+        elseif c == ")" then
+          depth = depth - 1
+          if depth == 0 then return line:sub(e + 2, k - 1) end
+        end
+        k = k + 1
+      end
+      return line:sub(e + 2)   -- arguments continue on the next line
+    end
+    s, e = line:find(name, e + 1, true)
+  end
+  return nil
+end
+
 local function findRaiser(line)
   for _, name in ipairs(RAISERS) do
-    local s, e = line:find(name, 1, true)
-    while s do
-      local before = s > 1 and line:sub(s - 1, s - 1) or " "
-      if not before:match("[%w_]") and line:sub(e + 1, e + 1) == "(" then
-        local depth, k = 0, e + 1
-        while k <= #line do
-          local c = line:sub(k, k)
-          if c == "(" then depth = depth + 1
-          elseif c == ")" then
-            depth = depth - 1
-            if depth == 0 then return name, line:sub(e + 2, k - 1) end
-          end
-          k = k + 1
-        end
-        return name, line:sub(e + 2)   -- arguments continue on the next line
-      end
-      s, e = line:find(name, e + 1, true)
-    end
+    local args = argsOfCall(line, name)
+    if args then return name, args end
   end
   return nil, nil
 end
@@ -117,28 +165,30 @@ local function owningTemporaryIn(line)
   return nil
 end
 
--- The position argument shared by a checker and its raiser: the third, after
--- the lua_State and the function name.
+-- The argument position a checker or raiser is talking about: the third field,
+-- after the lua_State and the function name. Getting this wrong is not a near
+-- miss - every call in a file shares __func__ as its second field, so reading
+-- that one instead makes the pairing test below always succeed, and one
+-- unrelated check*Arg() line then silences the whole function.
 local function positionArg(args)
-  local n, seen = 0, nil
-  local depth, current = 0, {}
+  local fields, depth, current = {}, 0, {}
   for k = 1, #args do
     local c = args:sub(k, k)
     if c == "(" or c == "<" then depth = depth + 1 end
     if c == ")" or c == ">" then depth = depth - 1 end
     if c == "," and depth == 0 then
-      n = n + 1
-      if n == 2 then seen = table.concat(current) break end
+      fields[#fields + 1] = table.concat(current)
       current = {}
     else
       current[#current + 1] = c
     end
   end
-  if not seen and n < 2 then seen = table.concat(current) end
-  return (seen or ""):gsub("^%s*", ""):gsub("%s*$", "")
+  fields[#fields + 1] = table.concat(current)
+  return (fields[3] or ""):gsub("^%s*", ""):gsub("%s*$", "")
 end
 
 local findings = {}
+local functionsScanned = 0
 
 local function scanFile(path)
   local fh = io.open(path, "r")
@@ -175,28 +225,24 @@ local function scanFile(path)
         if lines[j]:match("{") then bodyStart = j; break end
       end
       if bodyStart then
+        functionsScanned = functionsScanned + 1
         depth = 0
         local live = {}   -- varname -> {line=, type=}
         local scopes = {} -- depth -> list of varnames declared at that depth
         local j = bodyStart
         repeat
           local body = lines[j]
-          local code = body:gsub("//.*$", "")
+          local code = codeOnly(body)
 
           local raiser, raiserArgs = findRaiser(code)
           if raiser and raiserArgs and PAIRED_CHECKER[raiser] then
             local checker = PAIRED_CHECKER[raiser]
             local wanted = positionArg(raiserArgs)
             for back = bodyStart, j - 1 do
-              local prior = lines[back]:gsub("//.*$", "")
-              local pname, pargs = findRaiser(prior)
-              local cs, ce = prior:find(checker, 1, true)
-              if cs and prior:sub(ce + 1, ce + 1) == "(" then
-                local inner = prior:sub(ce + 2)
-                if wanted ~= "" and positionArg(inner) == wanted then
-                  raiser = nil
-                  break
-                end
+              local checkerArgs = argsOfCall(codeOnly(lines[back]), checker)
+              if checkerArgs and wanted ~= "" and positionArg(checkerArgs) == wanted then
+                raiser = nil
+                break
               end
             end
           end
@@ -269,7 +315,11 @@ end
 
 local targets = {...}
 if #targets == 0 then
-  local pipe = io.popen("ls src/*.cpp 2>/dev/null")
+  -- find, not a glob: src/ has subdirectories (src/updater, src/crash_reporter)
+  -- and the workflow's paths filter watches src/**, so a glob would let a file
+  -- trigger the job and then never be read. Headers are scanned too, for the
+  -- same reason - they are watched, and can carry inline bodies.
+  local pipe = io.popen("find src \\( -name '*.cpp' -o -name '*.h' \\) 2>/dev/null")
   for f in pipe:lines() do targets[#targets + 1] = f end
   pipe:close()
 end
@@ -301,4 +351,5 @@ if #findings > 0 then
   print("building the object, or pass a plain literal instead of a QString temporary.")
   os.exit(1)
 end
-print("No heap objects stranded across a lua_error() raise.")
+print(("No heap objects stranded across a lua_error() raise (%d files, %d functions scanned).")
+      :format(#targets, functionsScanned))

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -142,7 +142,10 @@ local findings = {}
 
 local function scanFile(path)
   local fh = io.open(path, "r")
-  if not fh then return end
+  if not fh then
+    io.stderr:write(("could not read %s\n"):format(path))
+    os.exit(2)
+  end
   local lines = {}
   for line in fh:lines() do lines[#lines + 1] = line end
   fh:close()
@@ -150,11 +153,25 @@ local function scanFile(path)
   local i, n = 1, #lines
   while i <= n do
     local line = lines[i]
-    -- A function taking lua_State*. clang-format keeps these on one line.
-    if line:match("lua_State%s*%*") and line:match("%(") and not line:match("^%s*//")
-       and not line:match(";%s*$") and not line:match("^%s*%*") then
+    -- A definition's parameter list can wrap, so gather lines until the
+    -- parentheses balance before looking for the lua_State*. ColumnLimit is
+    -- 200 and clang-format keeps these on one line today, but a scanner that
+    -- goes quiet on a shape it cannot parse is worse than one that is noisy.
+    local signature, signatureEnd = line, i
+    if line:match("^[%w_]") and line:match("%(") then
+      local open = select(2, line:gsub("%(", "")) - select(2, line:gsub("%)", ""))
+      local k = i
+      while open > 0 and k < n and k - i < 6 do
+        k = k + 1
+        signature = signature .. " " .. lines[k]
+        open = open + select(2, lines[k]:gsub("%(", "")) - select(2, lines[k]:gsub("%)", ""))
+      end
+      signatureEnd = k
+    end
+    if signature:match("lua_State%s*%*") and signature:match("%(") and not line:match("^%s*//")
+       and not signature:match("%)%s*;%s*$") and not line:match("^%s*%*") then
       local depth, bodyStart = 0, nil
-      for j = i, math.min(i + 4, n) do
+      for j = signatureEnd, math.min(signatureEnd + 4, n) do
         if lines[j]:match("{") then bodyStart = j; break end
       end
       if bodyStart then
@@ -255,6 +272,14 @@ if #targets == 0 then
   local pipe = io.popen("ls src/*.cpp 2>/dev/null")
   for f in pipe:lines() do targets[#targets + 1] = f end
   pipe:close()
+end
+
+-- Finding nothing to scan reads exactly like a clean tree, so say so instead.
+-- Run from the wrong directory, this is the whole difference between a check
+-- and a green tick that means nothing.
+if #targets == 0 then
+  io.stderr:write("no C++ sources to scan - run this from the repository root\n")
+  os.exit(2)
 end
 
 for _, f in ipairs(targets) do scanFile(f) end

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -155,6 +155,16 @@ local function codeOnly(line, inBlockComment)
   return table.concat(out), inBlockComment
 end
 
+-- Lua patterns have no alternation, so the control-flow keywords a definition
+-- must not start with are tested one at a time.
+local CONTROL_KEYWORDS = {"if", "while", "for", "switch", "return", "else", "catch", "do", "case"}
+local function KEYWORD_LINE(line)
+  for _, kw in ipairs(CONTROL_KEYWORDS) do
+    if line:match("^%s*" .. kw .. "%f[%W]") then return true end
+  end
+  return false
+end
+
 -- The argument list of a call to `name`, parenthesis-balanced. Returning the
 -- span rather than the rest of the line is what stops a temporary built from a
 -- raiser's *result* - getVerifiedString(...).trimmed() - being read as one
@@ -241,7 +251,11 @@ local function scanFile(path)
     -- 200 and clang-format keeps these on one line today, but a scanner that
     -- goes quiet on a shape it cannot parse is worse than one that is noisy.
     local signature, signatureEnd = line, i
-    if line:match("^[%w_]") and line:match("%(") then
+    -- Indentation is allowed: an inline member in a header is indented, and
+    -- the scan covers headers. Control-flow keywords are excluded so an
+    -- `if (...)` spanning lines is not mistaken for a definition.
+    if line:match("^%s*[%w_]") and line:match("%(")
+       and not KEYWORD_LINE(line) then
       local open = select(2, line:gsub("%(", "")) - select(2, line:gsub("%)", ""))
       local k = i
       while open > 0 and k < n and k - i < 6 do
@@ -264,6 +278,12 @@ local function scanFile(path)
         local free = {}   -- declared empty, so owning nothing until something fills it
         local scopes = {} -- depth -> list of varnames declared at that depth
         local emptyGuards = {} -- depth -> varname the enclosing if() proved empty
+        -- check*Arg() calls currently in force, keyed "checker@position".
+        -- gatesAtDepth drops them again when their block closes: a checker
+        -- inside a branch that has since ended does not dominate the raise, so
+        -- it cannot vouch for it.
+        local gates = {}
+        local gatesAtDepth = {}
         local inBlockComment = false
         local j = bodyStart
         repeat
@@ -289,12 +309,8 @@ local function scanFile(path)
           if raiser and raiserArgs and PAIRED_CHECKER[raiser] then
             local checker = PAIRED_CHECKER[raiser]
             local wanted = positionArg(raiserArgs)
-            for back = bodyStart, j - 1 do
-              local checkerArgs = argsOfCall(codeOnly(lines[back], false), checker)
-              if checkerArgs and wanted ~= "" and positionArg(checkerArgs) == wanted then
-                raiser = nil
-                break
-              end
+            if wanted ~= "" and gates[checker .. "@" .. wanted] then
+              raiser = nil
             end
           end
           if raiser and j > bodyStart then
@@ -322,6 +338,19 @@ local function scanFile(path)
                 detail = ("%s builds an owning temporary inside %s()'s arguments")
                          :format(temp, raiser),
               }
+            end
+          end
+
+          for _, checker in pairs(PAIRED_CHECKER) do
+            local checkerArgs = argsOfCall(code, checker)
+            if checkerArgs then
+              local pos = positionArg(checkerArgs)
+              if pos ~= "" then
+                local key = checker .. "@" .. pos
+                gates[key] = true
+                gatesAtDepth[depth] = gatesAtDepth[depth] or {}
+                table.insert(gatesAtDepth[depth], key)
+              end
             end
           end
 
@@ -385,6 +414,10 @@ local function scanFile(path)
                 scopes[depth] = nil
               end
               emptyGuards[depth] = nil
+              if gatesAtDepth[depth] then
+                for _, key in ipairs(gatesAtDepth[depth]) do gates[key] = nil end
+                gatesAtDepth[depth] = nil
+              end
               depth = depth - 1
             end
           end

--- a/CI/check-lua-error-strands.lua
+++ b/CI/check-lua-error-strands.lua
@@ -1,0 +1,282 @@
+#!/usr/bin/env lua
+--[[
+Finds heap-owning C++ objects left alive across a lua_error() raise.
+
+lua_error() longjmps in Lua 5.1, so it unwinds the C stack without running a
+single C++ destructor. Any QString, QByteArray, QStringList, std::string or
+TMediaData still in scope at the raise leaks its buffer. PRs #9602 and #9605
+removed the LSan suppression hiding that class and cleared all 377 sites then
+present, but the sweep was a one-off: nothing re-runs it, so a file added
+afterwards reintroduces the bug silently. LeakSanitizer only catches it if a
+spec happens to exercise the raising path, which for a freshly added Lua
+function is usually never.
+
+Only functions taking a lua_State* are considered: those are the only frames
+a longjmp can unwind. Closing the call graph over every function name instead
+produces thousands of false hits.
+
+Usage: lua CI/check-lua-error-strands.lua [file.cpp ...]
+       (no arguments scans src/*.cpp)
+Exits 1 when anything is found.
+]]
+
+-- Helpers that raise on the caller's behalf, plus the raw raisers. The
+-- check*Arg() family is deliberately absent: those return a bool and are the
+-- non-raising counterparts callers are meant to use when they hold anything.
+local RAISERS = {
+  "getVerifiedString", "getVerifiedInt", "getVerifiedBool", "getVerifiedFloat",
+  "getVerifiedDouble", "getVerifiedStringOrInteger",
+  "parseCommandOrFunction", "parseHintsTable",
+  "lua_error", "luaL_error", "luaL_argerror", "luaL_typerror",
+  "luaL_checkstring", "luaL_checklstring", "luaL_checknumber", "luaL_checkinteger",
+  "luaL_checkstack", "luaL_checktype", "luaL_checkany", "luaL_checkudata",
+  "luaL_optstring", "luaL_optlstring", "luaL_optnumber", "luaL_optinteger",
+}
+
+-- A raiser paired with the non-raising checker that makes its raise dead.
+-- #9605's mechanism: a caller validates with check*Arg() first and returns on
+-- failure, so by the time the paired raiser runs its own check cannot fail.
+-- Both calls have to name the same argument position for the pairing to hold.
+local PAIRED_CHECKER = {
+  parseCommandOrFunction = "checkCommandOrFunctionArg",
+  parseHintsTable = "checkHintsTable",
+  getVerifiedString = "checkStringArg",
+  getVerifiedInt = "checkIntArg",
+  getVerifiedBool = "checkBoolArg",
+  getVerifiedFloat = "checkNumberArg",
+  getVerifiedDouble = "checkNumberArg",
+  getVerifiedStringOrInteger = "checkStringOrIntegerArg",
+}
+
+-- Types whose default-constructed state is free but which own heap memory as
+-- soon as they hold anything.
+local OWNING_TYPES = {
+  "QString", "QStringList", "QByteArray", "std::string", "TMediaData",
+}
+
+-- Expressions that produce an owning temporary when passed straight into a
+-- raising call - the sub-case a declaration scan cannot see, because there is
+-- no named local to find.
+local OWNING_TEMPORARIES = {
+  "%.toUtf8%s*%(", "%.toLatin1%s*%(", "%.toLocal8Bit%s*%(",
+  "%.toStdString%s*%(", "%.arg%s*%(", "%.toLower%s*%(", "%.toUpper%s*%(",
+  "%.trimmed%s*%(", "%.simplified%s*%(", "%.join%s*%(", "%.split%s*%(",
+}
+
+-- An initialiser that cannot have allocated: literal storage, the shared null,
+-- or Qt's shared empty buffer.
+local function initialiserIsFree(init)
+  if not init or init:match("^%s*$") then
+    return true                                   -- default-constructed
+  end
+  init = init:gsub("^%s*[=({]%s*", ""):gsub("%s*[;)}]%s*$", "")
+  if init:match("^%s*$") then return true end
+  return init:match('^qsl%s*%(')
+      or init:match('^QStringLiteral%s*%(')
+      or init:match('^""$')
+      or init:match('^QString%s*%(%s*%)$')
+      or init:match('^QByteArray%s*%(%s*%)$')
+      or init:match('^QStringList%s*%(%s*%)$')
+      or false
+end
+
+-- Returns the raiser's name and the span of its argument list, so a temporary
+-- built from the raiser's *result* - getVerifiedString(...).trimmed() - is not
+-- mistaken for one built inside its arguments.
+local function findRaiser(line)
+  for _, name in ipairs(RAISERS) do
+    local s, e = line:find(name, 1, true)
+    while s do
+      local before = s > 1 and line:sub(s - 1, s - 1) or " "
+      if not before:match("[%w_]") and line:sub(e + 1, e + 1) == "(" then
+        local depth, k = 0, e + 1
+        while k <= #line do
+          local c = line:sub(k, k)
+          if c == "(" then depth = depth + 1
+          elseif c == ")" then
+            depth = depth - 1
+            if depth == 0 then return name, line:sub(e + 2, k - 1) end
+          end
+          k = k + 1
+        end
+        return name, line:sub(e + 2)   -- arguments continue on the next line
+      end
+      s, e = line:find(name, e + 1, true)
+    end
+  end
+  return nil, nil
+end
+
+local function owningTemporaryIn(line)
+  for _, pat in ipairs(OWNING_TEMPORARIES) do
+    if line:match(pat) then
+      return (pat:gsub("%%%.", "."):gsub("%%s%*", ""):gsub("%%%(", "()"))
+    end
+  end
+  return nil
+end
+
+-- The position argument shared by a checker and its raiser: the third, after
+-- the lua_State and the function name.
+local function positionArg(args)
+  local n, seen = 0, nil
+  local depth, current = 0, {}
+  for k = 1, #args do
+    local c = args:sub(k, k)
+    if c == "(" or c == "<" then depth = depth + 1 end
+    if c == ")" or c == ">" then depth = depth - 1 end
+    if c == "," and depth == 0 then
+      n = n + 1
+      if n == 2 then seen = table.concat(current) break end
+      current = {}
+    else
+      current[#current + 1] = c
+    end
+  end
+  if not seen and n < 2 then seen = table.concat(current) end
+  return (seen or ""):gsub("^%s*", ""):gsub("%s*$", "")
+end
+
+local findings = {}
+
+local function scanFile(path)
+  local fh = io.open(path, "r")
+  if not fh then return end
+  local lines = {}
+  for line in fh:lines() do lines[#lines + 1] = line end
+  fh:close()
+
+  local i, n = 1, #lines
+  while i <= n do
+    local line = lines[i]
+    -- A function taking lua_State*. clang-format keeps these on one line.
+    if line:match("lua_State%s*%*") and line:match("%(") and not line:match("^%s*//")
+       and not line:match(";%s*$") and not line:match("^%s*%*") then
+      -- find the body's opening brace
+      local depth, bodyStart = 0, nil
+      for j = i, math.min(i + 4, n) do
+        if lines[j]:match("{") then bodyStart = j; break end
+      end
+      if bodyStart then
+        depth = 0
+        local live = {}   -- varname -> {line=, type=}
+        local scopes = {} -- depth -> list of varnames declared at that depth
+        local j = bodyStart
+        repeat
+          local body = lines[j]
+          local code = body:gsub("//.*$", "")
+
+          -- a raise: report everything still live, plus owning temporaries
+          local raiser, raiserArgs = findRaiser(code)
+          -- a raise the caller has already gated on cannot fire
+          if raiser and raiserArgs and PAIRED_CHECKER[raiser] then
+            local checker = PAIRED_CHECKER[raiser]
+            local wanted = positionArg(raiserArgs)
+            for back = bodyStart, j - 1 do
+              local prior = lines[back]:gsub("//.*$", "")
+              local pname, pargs = findRaiser(prior)
+              local cs, ce = prior:find(checker, 1, true)
+              if cs and prior:sub(ce + 1, ce + 1) == "(" then
+                local inner = prior:sub(ce + 2)
+                if wanted ~= "" and positionArg(inner) == wanted then
+                  raiser = nil
+                  break
+                end
+              end
+            end
+          end
+          if raiser and j > bodyStart then
+            for name, info in pairs(live) do
+              -- #9605's exclusion: when the guard that reaches this raise is
+              -- <var>.isEmpty(), the variable is the shared empty buffer here
+              local guarded = false
+              for back = math.max(bodyStart, j - 6), j do
+                if lines[back]:match("%f[%w]" .. name .. "%f[%W]%s*%.%s*isEmpty%s*%(%s*%)") then
+                  guarded = true
+                end
+              end
+              if not guarded then
+              findings[#findings + 1] = {
+                file = path, line = j, kind = "local",
+                detail = ("%s %s (declared line %d) is live across %s()")
+                         :format(info.type, name, info.line, raiser),
+              }
+              end
+            end
+            local temp = raiserArgs and owningTemporaryIn(raiserArgs)
+            if temp then
+              findings[#findings + 1] = {
+                file = path, line = j, kind = "temporary",
+                detail = ("%s builds an owning temporary inside %s()'s arguments")
+                         :format(temp, raiser),
+              }
+            end
+          end
+
+          -- declarations
+          for _, ty in ipairs(OWNING_TYPES) do
+            local pat = "^%s*[a-zA-Z:<>,%s]-%f[%w]" .. ty:gsub("%p", "%%%0") .. "%f[%W]%s+([%w_]+)%s*(.*)$"
+            local varname, rest = code:match(pat)
+            if varname and not code:match("%f[%w]static%f[%W]")
+               and not code:match("%f[%w]return%f[%W]") and varname ~= "const" then
+              if not initialiserIsFree(rest) then
+                live[varname] = {line = j, type = ty}
+                scopes[depth] = scopes[depth] or {}
+                table.insert(scopes[depth], varname)
+              end
+              break
+            end
+          end
+
+          -- Brace tracking, so a variable dies with its block. Braces are
+          -- walked in text order: "} else if (...) {" closes the previous
+          -- branch's scope before opening the next one, and counting all the
+          -- opens first would keep that branch's locals alive into it.
+          for k = 1, #code do
+            local c = code:sub(k, k)
+            if c == "{" then
+              depth = depth + 1
+            elseif c == "}" then
+              if scopes[depth] then
+                for _, v in ipairs(scopes[depth]) do live[v] = nil end
+                scopes[depth] = nil
+              end
+              depth = depth - 1
+            end
+          end
+          j = j + 1
+        until depth <= 0 or j > n
+        i = j - 1
+      end
+    end
+    i = i + 1
+  end
+end
+
+local targets = {...}
+if #targets == 0 then
+  local pipe = io.popen("ls src/*.cpp 2>/dev/null")
+  for f in pipe:lines() do targets[#targets + 1] = f end
+  pipe:close()
+end
+
+for _, f in ipairs(targets) do scanFile(f) end
+
+table.sort(findings, function(a, b)
+  if a.file ~= b.file then return a.file < b.file end
+  return a.line < b.line
+end)
+
+for _, f in ipairs(findings) do
+  print(("%s:%d: %s"):format(f.file, f.line, f.detail))
+end
+
+if #findings > 0 then
+  print("")
+  print(("%d heap object(s) stranded across a lua_error() raise."):format(#findings))
+  print("lua_error() longjmps past C++ destructors, so each one leaks.")
+  print("Validate with the non-raising checkStringArg()/checkIntArg() family before")
+  print("building the object, or pass a plain literal instead of a QString temporary.")
+  os.exit(1)
+end
+print("No heap objects stranded across a lua_error() raise.")

--- a/CI/lua-error-strand-fixtures/bad.cpp
+++ b/CI/lua-error-strand-fixtures/bad.cpp
@@ -28,3 +28,15 @@ int TLuaInterpreter::strandsUnderAWrappedSignature(
     const QString name{lua_tostring(L, 1)};
     return lua_error(L);
 }
+
+// A pre-gate on a different argument must not suppress: argument 1 is checked,
+// argument 2 is not, so getVerifiedString can still raise while key is live.
+int TLuaInterpreter::preGateOnAnotherArgument(lua_State* L)
+{
+    if (!checkStringArg(L, __func__, 1, "key")) {
+        return lua_error(L);
+    }
+    const QString key{lua_tostring(L, 1)};
+    const QString value = getVerifiedString(L, __func__, 2, "value");
+    return 0;
+}

--- a/CI/lua-error-strand-fixtures/bad.cpp
+++ b/CI/lua-error-strand-fixtures/bad.cpp
@@ -1,15 +1,34 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
 // Fixture: every shape the scanner must catch. Not compiled.
 int TLuaInterpreter::strandsALocal(lua_State* L)
 {
     const QString name = getVerifiedString(L, __func__, 1, "name");
-    const int id = getVerifiedInt(L, __func__, 2, "id");
+    const int id = getVerifiedInt(L, __func__, 2, "id");  // STRAND
     return 0;
 }
 
 int TLuaInterpreter::strandsATemporary(lua_State* L)
 {
     const QString funcName = qsl("stt.init");
-    const QString path = getVerifiedString(L, funcName.toUtf8().constData(), 1, "path");
+    const QString path = getVerifiedString(L, funcName.toUtf8().constData(), 1, "path");  // STRAND
     return 0;
 }
 
@@ -17,7 +36,7 @@ int TLuaInterpreter::strandsAcrossARawRaise(lua_State* L)
 {
     const QByteArray payload{lua_tostring(L, 1)};
     if (somethingIsWrong()) {
-        return lua_error(L);
+        return lua_error(L);  // STRAND
     }
     return 0;
 }
@@ -26,7 +45,7 @@ int TLuaInterpreter::strandsUnderAWrappedSignature(
         lua_State* L)
 {
     const QString name{lua_tostring(L, 1)};
-    return lua_error(L);
+    return lua_error(L);  // STRAND
 }
 
 // A pre-gate on a different argument must not suppress: argument 1 is checked,
@@ -37,7 +56,7 @@ int TLuaInterpreter::preGateOnAnotherArgument(lua_State* L)
         return lua_error(L);
     }
     const QString key{lua_tostring(L, 1)};
-    const QString value = getVerifiedString(L, __func__, 2, "value");
+    const QString value = getVerifiedString(L, __func__, 2, "value");  // STRAND
     return 0;
 }
 
@@ -49,14 +68,14 @@ int TLuaInterpreter::emptyGuardThenRaise(lua_State* L)
     if (name.isEmpty()) {
         return warnArgumentValue(L, __func__, "empty");
     }
-    const int id = getVerifiedInt(L, __func__, 2, "id");
+    const int id = getVerifiedInt(L, __func__, 2, "id");  // STRAND
     return 0;
 }
 
 int TLuaInterpreter::strandsAnAutoLocal(lua_State* L)
 {
     auto name = getVerifiedString(L, __func__, 1, "name");
-    const int id = getVerifiedInt(L, __func__, 2, "id");
+    const int id = getVerifiedInt(L, __func__, 2, "id");  // STRAND
     return 0;
 }
 
@@ -64,7 +83,7 @@ int TLuaInterpreter::strandsAContainerFilledAfterDeclaration(lua_State* L)
 {
     QStringList results;
     results << QString::fromUtf8(lua_tostring(L, 1));
-    const int id = getVerifiedInt(L, __func__, 2, "id");
+    const int id = getVerifiedInt(L, __func__, 2, "id");  // STRAND
     return 0;
 }
 
@@ -73,7 +92,7 @@ int TLuaInterpreter::strandsAcrossTheThirdTableParser(lua_State* L)
     const QString windowName{lua_tostring(L, 1)};
     QStringList commandList;
     QVector<int> luaReferences;
-    parseCommandsOrFunctionsTable(L, __func__, 2, commandList, luaReferences);
+    parseCommandsOrFunctionsTable(L, __func__, 2, commandList, luaReferences);  // STRAND
     return 0;
 }
 
@@ -87,7 +106,7 @@ int TLuaInterpreter::gateInsideABranch(lua_State* L)
         }
     }
     const QString key{lua_tostring(L, 1)};
-    const QString value = getVerifiedString(L, __func__, 2, "value");
+    const QString value = getVerifiedString(L, __func__, 2, "value");  // STRAND
     return 0;
 }
 
@@ -97,6 +116,14 @@ class Indented
             lua_State* L)
     {
         const QString name{lua_tostring(L, 1)};
-        return lua_error(L);
+        return lua_error(L);  // STRAND
     }
 };
+
+int TLuaInterpreter::braceInsideABlockComment(lua_State* L)
+{
+    const QString name{lua_tostring(L, 1)};
+    /* a block comment with a stray } in it, which would close this function's
+       scope early and drop every variable tracked in it */
+    return lua_error(L);  // STRAND
+}

--- a/CI/lua-error-strand-fixtures/bad.cpp
+++ b/CI/lua-error-strand-fixtures/bad.cpp
@@ -40,3 +40,39 @@ int TLuaInterpreter::preGateOnAnotherArgument(lua_State* L)
     const QString value = getVerifiedString(L, __func__, 2, "value");
     return 0;
 }
+
+// isEmpty() as an early-return guard leaves the variable proven NON-empty, so
+// the raise below it still strands.
+int TLuaInterpreter::emptyGuardThenRaise(lua_State* L)
+{
+    const QString name = getVerifiedString(L, __func__, 1, "name");
+    if (name.isEmpty()) {
+        return warnArgumentValue(L, __func__, "empty");
+    }
+    const int id = getVerifiedInt(L, __func__, 2, "id");
+    return 0;
+}
+
+int TLuaInterpreter::strandsAnAutoLocal(lua_State* L)
+{
+    auto name = getVerifiedString(L, __func__, 1, "name");
+    const int id = getVerifiedInt(L, __func__, 2, "id");
+    return 0;
+}
+
+int TLuaInterpreter::strandsAContainerFilledAfterDeclaration(lua_State* L)
+{
+    QStringList results;
+    results << QString::fromUtf8(lua_tostring(L, 1));
+    const int id = getVerifiedInt(L, __func__, 2, "id");
+    return 0;
+}
+
+int TLuaInterpreter::strandsAcrossTheThirdTableParser(lua_State* L)
+{
+    const QString windowName{lua_tostring(L, 1)};
+    QStringList commandList;
+    QVector<int> luaReferences;
+    parseCommandsOrFunctionsTable(L, __func__, 2, commandList, luaReferences);
+    return 0;
+}

--- a/CI/lua-error-strand-fixtures/bad.cpp
+++ b/CI/lua-error-strand-fixtures/bad.cpp
@@ -21,3 +21,10 @@ int TLuaInterpreter::strandsAcrossARawRaise(lua_State* L)
     }
     return 0;
 }
+
+int TLuaInterpreter::strandsUnderAWrappedSignature(
+        lua_State* L)
+{
+    const QString name{lua_tostring(L, 1)};
+    return lua_error(L);
+}

--- a/CI/lua-error-strand-fixtures/bad.cpp
+++ b/CI/lua-error-strand-fixtures/bad.cpp
@@ -76,3 +76,27 @@ int TLuaInterpreter::strandsAcrossTheThirdTableParser(lua_State* L)
     parseCommandsOrFunctionsTable(L, __func__, 2, commandList, luaReferences);
     return 0;
 }
+
+// A checker inside a branch that has closed again does not dominate the raise,
+// so it cannot vouch for it.
+int TLuaInterpreter::gateInsideABranch(lua_State* L)
+{
+    if (lua_gettop(L) > 2) {
+        if (!checkStringArg(L, __func__, 2, "value")) {
+            return lua_error(L);
+        }
+    }
+    const QString key{lua_tostring(L, 1)};
+    const QString value = getVerifiedString(L, __func__, 2, "value");
+    return 0;
+}
+
+class Indented
+{
+    static int wrappedAndIndented(
+            lua_State* L)
+    {
+        const QString name{lua_tostring(L, 1)};
+        return lua_error(L);
+    }
+};

--- a/CI/lua-error-strand-fixtures/bad.cpp
+++ b/CI/lua-error-strand-fixtures/bad.cpp
@@ -1,0 +1,23 @@
+// Fixture: every shape the scanner must catch. Not compiled.
+int TLuaInterpreter::strandsALocal(lua_State* L)
+{
+    const QString name = getVerifiedString(L, __func__, 1, "name");
+    const int id = getVerifiedInt(L, __func__, 2, "id");
+    return 0;
+}
+
+int TLuaInterpreter::strandsATemporary(lua_State* L)
+{
+    const QString funcName = qsl("stt.init");
+    const QString path = getVerifiedString(L, funcName.toUtf8().constData(), 1, "path");
+    return 0;
+}
+
+int TLuaInterpreter::strandsAcrossARawRaise(lua_State* L)
+{
+    const QByteArray payload{lua_tostring(L, 1)};
+    if (somethingIsWrong()) {
+        return lua_error(L);
+    }
+    return 0;
+}

--- a/CI/lua-error-strand-fixtures/good.cpp
+++ b/CI/lua-error-strand-fixtures/good.cpp
@@ -1,3 +1,22 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
 // Fixture: shapes that are safe and must NOT be reported. Not compiled.
 int TLuaInterpreter::literalNameIsFree(lua_State* L)
 {

--- a/CI/lua-error-strand-fixtures/good.cpp
+++ b/CI/lua-error-strand-fixtures/good.cpp
@@ -1,0 +1,51 @@
+// Fixture: shapes that are safe and must NOT be reported. Not compiled.
+int TLuaInterpreter::literalNameIsFree(lua_State* L)
+{
+    const char* funcName = "stt.init";
+    const QString path = getVerifiedString(L, funcName, 1, "path");
+    return 0;
+}
+
+int TLuaInterpreter::qslIsStaticStorage(lua_State* L)
+{
+    const QString label = qsl("main");
+    const int id = getVerifiedInt(L, __func__, 1, "id");
+    return 0;
+}
+
+int TLuaInterpreter::temporaryOnTheResultIsFine(lua_State* L)
+{
+    const QString text = getVerifiedString(L, __func__, 1, "text").trimmed();
+    return 0;
+}
+
+int TLuaInterpreter::emptinessIsTheRaiseCondition(lua_State* L)
+{
+    const QString direction = dirToString(L, 2);
+    if (direction.isEmpty()) {
+        return lua_error(L);
+    }
+    return 0;
+}
+
+int TLuaInterpreter::declaredInABranchThatDoesNotRaise(lua_State* L)
+{
+    if (lua_isstring(L, 1)) {
+        const QString existingName{lua_tostring(L, 1)};
+        return warnArgumentValue(L, __func__, "no");
+    } else {
+        return lua_error(L);
+    }
+}
+
+int TLuaInterpreter::preGatedRaiseIsDead(lua_State* L)
+{
+    if (!checkCommandOrFunctionArg(L, __func__, commandPos)) {
+        return lua_error(L);
+    }
+    const QString windowName{lua_tostring(L, 1)};
+    QString command;
+    int luaReference = 0;
+    parseCommandOrFunction(L, __func__, commandPos, command, luaReference);
+    return 0;
+}

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -50,6 +50,8 @@ local mustCatch = {
   {59, "an auto-typed local holding a QString"},
   {67, "a container declared empty and filled afterwards"},
   {76, "parseCommandsOrFunctionsTable raises like its two siblings"},
+  {90, "a checker inside a closed branch does not dominate the raise"},
+  {100, "a wrapped signature that is also indented, as inline members are"},
 }
 
 local badOutput, badStatus = run("bad.cpp")

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -38,21 +38,22 @@ local function check(condition, message)
   if not condition then failures[#failures + 1] = message end
 end
 
--- every shape the scanner must catch, keyed by the line of the raise (not of
--- the declaration, which is where it is tempting to point)
-local mustCatch = {
-  {5,  "a local QString live across the next argument's getVerifiedString"},
-  {12, "a QByteArray temporary inside the raiser's own argument list"},
-  {20, "a QByteArray live across a raw lua_error"},
-  {29, "a local live in a function whose signature wraps onto a second line"},
-  {40, "a pre-gate on a different argument must not suppress the raise"},
-  {52, "an isEmpty() early-return guard leaves the variable non-empty, not free"},
-  {59, "an auto-typed local holding a QString"},
-  {67, "a container declared empty and filled afterwards"},
-  {76, "parseCommandsOrFunctionsTable raises like its two siblings"},
-  {90, "a checker inside a closed branch does not dominate the raise"},
-  {100, "a wrapped signature that is also indented, as inline members are"},
-}
+-- Every line of bad.cpp marked "// STRAND" must be reported. Deriving the
+-- expectations from the fixture rather than listing line numbers here means an
+-- edit to the fixture cannot silently stop checking a shape - which listing
+-- them did twice while this was being written.
+local mustCatch = {}
+for line in io.lines(fixtures .. "/bad.cpp") do
+  mustCatch[#mustCatch + 1] = line
+end
+do
+  local marked = {}
+  for number, text in ipairs(mustCatch) do
+    if text:match("//%s*STRAND%s*$") then marked[#marked + 1] = number end
+  end
+  mustCatch = marked
+end
+check(#mustCatch > 0, "bad.cpp has no // STRAND markers - nothing would be checked")
 
 local badOutput, badStatus = run("bad.cpp")
 -- The property the whole workflow rests on, and the only one the text
@@ -60,9 +61,19 @@ local badOutput, badStatus = run("bad.cpp")
 check(badStatus == 1,
       ("bad.cpp exited %s, not 1 - the scanner no longer fails CI on a finding")
       :format(tostring(badStatus)))
-for _, want in ipairs(mustCatch) do
-  check(badOutput:match("bad%.cpp:" .. want[1] .. ":"),
-        ("bad.cpp:%d not reported - %s"):format(want[1], want[2]))
+for _, number in ipairs(mustCatch) do
+  check(badOutput:match("bad%.cpp:" .. number .. ":"),
+        ("bad.cpp:%d is marked // STRAND but was not reported"):format(number))
+end
+
+-- and nothing beyond them: an unmarked finding is either a new shape that wants
+-- a marker, or a false positive
+for number in badOutput:gmatch("bad%.cpp:(%d+):") do
+  local wanted = false
+  for _, marked in ipairs(mustCatch) do
+    if tonumber(number) == marked then wanted = true end
+  end
+  check(wanted, ("bad.cpp:%s was reported but carries no // STRAND marker"):format(number))
 end
 
 local goodOutput, goodStatus = run("good.cpp")
@@ -71,6 +82,14 @@ check(goodStatus == 0,
       :format(tostring(goodStatus)))
 check(goodOutput:match("No heap objects stranded"),
       "good.cpp reported a finding, so the scanner has false positives:\n" .. goodOutput)
+
+-- A file the scanner never entered is "clean" for the wrong reason, and reads
+-- exactly like a real pass. Truncating this fixture during an edit produced
+-- precisely that, so hold it to having actually scanned something.
+local goodFunctions = tonumber(goodOutput:match("(%d+) functions scanned")) or 0
+check(goodFunctions >= 6,
+      ("good.cpp scanned %d functions, expected at least 6 - it is passing because it was not read")
+      :format(goodFunctions))
 
 if #failures > 0 then
   print("Scanner self-test FAILED:")

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -28,11 +28,13 @@ local function check(condition, message)
   if not condition then failures[#failures + 1] = message end
 end
 
--- every shape the scanner must catch, and the line it sits on in bad.cpp
+-- every shape the scanner must catch, keyed by the line of the raise (not of
+-- the declaration, which is where it is tempting to point)
 local mustCatch = {
   {5,  "a local QString live across the next argument's getVerifiedString"},
   {12, "a QByteArray temporary inside the raiser's own argument list"},
   {20, "a QByteArray live across a raw lua_error"},
+  {29, "a local live in a function whose signature wraps onto a second line"},
 }
 
 local badOutput = run("bad.cpp")

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -11,8 +11,13 @@ local here = arg[0]:match("^(.*)/[^/]*$") or "."
 local scanner = here .. "/check-lua-error-strands.lua"
 local fixtures = here .. "/lua-error-strand-fixtures"
 
+-- arg[-1] is the interpreter the standalone lua binary was invoked as, so the
+-- scanner runs under the same one whether that is "lua" (CI, via
+-- gh-actions-lua) or "lua5.1" (Debian and Ubuntu packages).
+local interpreter = arg[-1] or "lua"
+
 local function run(file)
-  local pipe = io.popen(("lua5.1 %q %q 2>&1"):format(scanner, fixtures .. "/" .. file))
+  local pipe = io.popen(("%q %q %q 2>&1"):format(interpreter, scanner, fixtures .. "/" .. file))
   local out = pipe:read("*a")
   pipe:close()
   return out

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -46,6 +46,10 @@ local mustCatch = {
   {20, "a QByteArray live across a raw lua_error"},
   {29, "a local live in a function whose signature wraps onto a second line"},
   {40, "a pre-gate on a different argument must not suppress the raise"},
+  {52, "an isEmpty() early-return guard leaves the variable non-empty, not free"},
+  {59, "an auto-typed local holding a QString"},
+  {67, "a container declared empty and filled afterwards"},
+  {76, "parseCommandsOrFunctionsTable raises like its two siblings"},
 }
 
 local badOutput, badStatus = run("bad.cpp")

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -1,0 +1,51 @@
+#!/usr/bin/env lua
+--[[
+Self-test for check-lua-error-strands.lua.
+
+A scanner that has quietly stopped matching anything reports a clean tree and
+looks exactly like success, so CI runs this first: the bad fixture must produce
+one finding per known shape, and the good fixture must produce none.
+]]
+
+local here = arg[0]:match("^(.*)/[^/]*$") or "."
+local scanner = here .. "/check-lua-error-strands.lua"
+local fixtures = here .. "/lua-error-strand-fixtures"
+
+local function run(file)
+  local pipe = io.popen(("lua5.1 %q %q 2>&1"):format(scanner, fixtures .. "/" .. file))
+  local out = pipe:read("*a")
+  pipe:close()
+  return out
+end
+
+local failures = {}
+local function check(condition, message)
+  if not condition then failures[#failures + 1] = message end
+end
+
+-- every shape the scanner must catch, and the line it sits on in bad.cpp
+local mustCatch = {
+  {5,  "a local QString live across the next argument's getVerifiedString"},
+  {12, "a QByteArray temporary inside the raiser's own argument list"},
+  {20, "a QByteArray live across a raw lua_error"},
+}
+
+local badOutput = run("bad.cpp")
+for _, want in ipairs(mustCatch) do
+  check(badOutput:match("bad%.cpp:" .. want[1] .. ":"),
+        ("bad.cpp:%d not reported - %s"):format(want[1], want[2]))
+end
+
+local goodOutput = run("good.cpp")
+check(goodOutput:match("No heap objects stranded"),
+      "good.cpp reported a finding, so the scanner has false positives:\n" .. goodOutput)
+
+if #failures > 0 then
+  print("Scanner self-test FAILED:")
+  for _, f in ipairs(failures) do print("  - " .. f) end
+  print("\nbad.cpp output was:\n" .. badOutput)
+  os.exit(1)
+end
+
+print(("Scanner self-test passed: %d bad shapes caught, good fixture clean.")
+      :format(#mustCatch))

--- a/CI/test-check-lua-error-strands.lua
+++ b/CI/test-check-lua-error-strands.lua
@@ -11,16 +11,26 @@ local here = arg[0]:match("^(.*)/[^/]*$") or "."
 local scanner = here .. "/check-lua-error-strands.lua"
 local fixtures = here .. "/lua-error-strand-fixtures"
 
--- arg[-1] is the interpreter the standalone lua binary was invoked as, so the
--- scanner runs under the same one whether that is "lua" (CI, via
--- gh-actions-lua) or "lua5.1" (Debian and Ubuntu packages).
-local interpreter = arg[-1] or "lua"
+-- arg[-1] is the argv entry immediately before the script, so the scanner runs
+-- under the same interpreter as this test - "lua" from gh-actions-lua, or
+-- "lua5.1" from a Debian package. A flag there (lua -W test.lua) would be
+-- picked up instead, so fall back on anything that is not a path.
+local interpreter = arg[-1]
+if not interpreter or interpreter:match("^%-") then interpreter = "lua" end
+
+-- Single quotes, not Lua's %q: %q escapes " and \ but leaves $ and backticks
+-- for the shell to expand.
+local function shellQuote(text)
+  return "'" .. text:gsub("'", "'\\''") .. "'"
+end
 
 local function run(file)
-  local pipe = io.popen(("%q %q %q 2>&1"):format(interpreter, scanner, fixtures .. "/" .. file))
+  local command = ("%s %s %s 2>&1; echo EXIT:$?"):format(
+    shellQuote(interpreter), shellQuote(scanner), shellQuote(fixtures .. "/" .. file))
+  local pipe = io.popen(command)
   local out = pipe:read("*a")
   pipe:close()
-  return out
+  return out, tonumber(out:match("EXIT:(%d+)%s*$"))
 end
 
 local failures = {}
@@ -35,15 +45,24 @@ local mustCatch = {
   {12, "a QByteArray temporary inside the raiser's own argument list"},
   {20, "a QByteArray live across a raw lua_error"},
   {29, "a local live in a function whose signature wraps onto a second line"},
+  {40, "a pre-gate on a different argument must not suppress the raise"},
 }
 
-local badOutput = run("bad.cpp")
+local badOutput, badStatus = run("bad.cpp")
+-- The property the whole workflow rests on, and the only one the text
+-- assertions below cannot see: findings have to make the scanner fail.
+check(badStatus == 1,
+      ("bad.cpp exited %s, not 1 - the scanner no longer fails CI on a finding")
+      :format(tostring(badStatus)))
 for _, want in ipairs(mustCatch) do
   check(badOutput:match("bad%.cpp:" .. want[1] .. ":"),
         ("bad.cpp:%d not reported - %s"):format(want[1], want[2]))
 end
 
-local goodOutput = run("good.cpp")
+local goodOutput, goodStatus = run("good.cpp")
+check(goodStatus == 0,
+      ("good.cpp exited %s, not 0 - a clean file is being failed")
+      :format(tostring(goodStatus)))
 check(goodOutput:match("No heap objects stranded"),
       "good.cpp reported a finding, so the scanner has false positives:\n" .. goodOutput)
 

--- a/src/TLuaInterpreterMMCP.cpp
+++ b/src/TLuaInterpreterMMCP.cpp
@@ -447,7 +447,20 @@ int TLuaInterpreter::mmcpStartServer(lua_State* L)
 
     int port = pHost->getMMCPPort();
     if (lua_gettop(L) > 0) {
-        port = getVerifiedInt(L, sFunc, 1, qsl("port number {default = %1}").arg(pHost->getMMCPPort()).toUtf8().constData(), true);
+        // The description is built from the default port, so it cannot be a
+        // plain literal - and a QByteArray alive inside getVerifiedInt() would
+        // be stranded by its lua_error() longjmp. Check in an inner scope that
+        // ends before the raise, which is where the message has already been
+        // pushed onto the Lua stack anyway.
+        bool portIsValid = false;
+        {
+            const QByteArray portDescription = qsl("port number {default = %1}").arg(pHost->getMMCPPort()).toUtf8();
+            portIsValid = checkIntArg(L, sFunc, 1, portDescription.constData(), true);
+        }
+        if (!portIsValid) {
+            return lua_error(L);
+        }
+        port = lua_tointeger(L, 1);
         if (port > 65535 || port < 1) {
             return warnArgumentValue(L, sFunc, qsl("invalid port number %1 given, if supplied it must be in range 1 to 65535").arg(port));
         }

--- a/src/TLuaInterpreterMMCP.cpp
+++ b/src/TLuaInterpreterMMCP.cpp
@@ -458,7 +458,7 @@ int TLuaInterpreter::mmcpStartServer(lua_State* L)
         if (!portIsValid) {
             return lua_error(L);
         }
-        port = lua_tointeger(L, 1);
+        port = static_cast<int>(lua_tointeger(L, 1));
         if (port > 65535 || port < 1) {
             return warnArgumentValue(L, sFunc, qsl("invalid port number %1 given, if supplied it must be in range 1 to 65535").arg(port));
         }

--- a/src/TLuaInterpreterMMCP.cpp
+++ b/src/TLuaInterpreterMMCP.cpp
@@ -447,11 +447,9 @@ int TLuaInterpreter::mmcpStartServer(lua_State* L)
 
     int port = pHost->getMMCPPort();
     if (lua_gettop(L) > 0) {
-        // The description is built from the default port, so it cannot be a
-        // plain literal - and a QByteArray alive inside getVerifiedInt() would
-        // be stranded by its lua_error() longjmp. Check in an inner scope that
-        // ends before the raise, which is where the message has already been
-        // pushed onto the Lua stack anyway.
+        // The inner scope matters: the description cannot be a plain literal,
+        // and a QByteArray still alive at lua_error()'s longjmp would be
+        // stranded. checkIntArg() has already pushed the message by then.
         bool portIsValid = false;
         {
             const QByteArray portDescription = qsl("port number {default = %1}").arg(pHost->getMMCPPort()).toUtf8();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `CI/check-lua-error-strands.lua` fails CI when a C++ heap object is left alive across a `lua_error()` raise. It scans only functions taking a `lua_State*` - the frames a longjmp can unwind - and applies #9605's exclusions: `qsl()`/`QStringLiteral` and default-constructed locals own nothing, a variable whose own `isEmpty()` is the raise condition is the shared empty buffer, a local in a branch that never reaches the raise is out of scope, `getVerifiedString(...).trimmed()` builds its temporary after the raiser returns, and a raise the caller already gated on with the non-raising `check*Arg()` counterpart cannot fire.
- `CI/test-check-lua-error-strands.lua` runs first in the workflow. A scanner that has quietly stopped matching reports a clean tree and looks identical to success, so the known-bad fixture has to fail before the real scan is trusted.
- `mmcpStartServer()` is fixed - the one live site the scan found. Its port description is built with `.arg()` and handed straight into `getVerifiedInt()`, so the raise strands both the QString and the QByteArray.

#### Motivation for adding to Mudlet

`lua_error()` longjmps past every C++ destructor; #9602 unsuppressed that leak class and #9605 cleared all 377 sites by hand, but nothing re-runs that audit, and LeakSanitizer only catches a strand when a spec happens to exercise the raising path - which for a newly added Lua function is usually never.

#### Other info (issues closed, discussion etc)

Follows up #9602 and #9605. Calibration: **206** findings on #9605's parent commit across exactly the files that PR edited, **0** on its result and on development today (401 files, 692 functions), and **2** on #9982 - both of which I had already proven real with AddressSanitizer before writing this, at the same lines.

`mmcpStartServer()` is unreachable from Lua today (its registration block is commented out), which is why no spec ever found it; the fix is a mechanical transcription of `getVerifiedInt()` with the description scoped so it dies before the raise, and it compiles clean, but there is no runtime path to exercise it.

The job uses the same `leafo/gh-actions-lua` action and `paths:`/`concurrency:` shape as `check-mpackages.yml`. It costs ~0.5s of actual work and runs alongside the build legs, so it adds nothing to PR latency.

It is advisory - not in `development`'s required contexts. That is deliberate while it has a `paths:` filter: a required check behind one leaves every PR that doesn't touch `src/**` waiting forever on a status that never reports. Making it required means dropping the filter and having the job exit early itself. The `push:` trigger has no filter, so `development` gets a full scan after every merge either way.

**Test case:** `lua CI/test-check-lua-error-strands.lua` then `lua CI/check-lua-error-strands.lua` from the repository root - the first must report 9 shapes caught, the second a clean tree. To see it bite, add `const QString x{lua_tostring(L, 1)};` above any `lua_error(L)` in a `lua_State*` function and re-run.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
