### PR TITLE
Fix: Rename a shadowed loop variable in the trigger editor's script view

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8596,9 +8596,9 @@ void dlgTriggerEditor::slot_scriptsSelected(QTreeWidgetItem* pItem)
         const QString name = pT->getName();
         QStringList eventHandlerList = pT->getEventHandlerList();
         for (const QString& handler : std::as_const(eventHandlerList)) {
-            auto pItem = new QListWidgetItem(mpScriptsMainArea->listWidget_script_registered_event_handlers);
-            pItem->setText(handler);
-            mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
+            auto pHandlerItem = new QListWidgetItem(mpScriptsMainArea->listWidget_script_registered_event_handlers);
+            pHandlerItem->setText(handler);
+            mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pHandlerItem);
         }
         const QString script = pT->getScript();
         clearDocument(mpSourceEditorEdbee, script);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- In `dlgTriggerEditor::slot_scriptsSelected()`, a loop declared its own `pItem` that shadowed the enclosing function's `QTreeWidgetItem* pItem` parameter, tripping a CodeQL `declaration-hides-parameter` alert.
- Renamed the loop-local variable to `pHandlerItem`. The outer `pItem` was never needed inside the loop and is correctly referenced again afterwards, so this is a pure rename with no behavior change.

#### Motivation for adding to Mudlet
Cleans up a confusing (CodeQL-flagged) naming collision found while triaging open code-scanning alerts.

#### Other info (issues closed, discussion etc)
**Test case:** open the trigger editor, select a script that has registered event handlers, and confirm the handler list and script details still populate correctly (unchanged from before).