### PR TITLE
Fix: Remove two always-true size checks in MXP frame layout

### DIFF
--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -464,10 +464,10 @@ QRect TMxpFrameManager::calculateFrameGeometry(TMxpFrame* frame, TMxpFrame* pare
     // Add small padding compensation for character-based frames to ensure full character visibility
     // This accounts for any internal widget padding or text rendering margins
     if (isCharacterHeight || isCharacterWidth) {
-        if (isCharacterWidth && frameWidth > 0) {
+        if (isCharacterWidth) {
             frameWidth += 4; // Add 4px horizontal padding for character visibility
         }
-        if (isCharacterHeight && frameHeight > 0) {
+        if (isCharacterHeight) {
             frameHeight += 4; // Add 4px vertical padding for character visibility
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `TMxpFrameManager::calculateFrameGeometry()` had `frameWidth > 0` and `frameHeight > 0` checks guarding the character-based padding compensation. Both are always true: `frameWidth`/`frameHeight` are unconditionally clamped to at least 50/30 earlier in the same function, with nothing in between that could reduce them.
- Removed both dead conditions, flagged by CodeQL's `constant-comparison` check. No behavior change.

#### Motivation for adding to Mudlet
Cleans up dead conditions found while triaging open code-scanning alerts.

#### Other info (issues closed, discussion etc)
**Test case:** open an MXP-enabled game session that creates character-sized frames (e.g. with an explicit title) and confirm frame sizing/padding is unchanged from before.