### PR TITLE
Infra: Stop qtkeychain build from dirtying its submodule on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,15 @@ if(APPLE)
     CHECK_FILE "3rdparty/qtkeychain/CMakeLists.txt"
     SUBMODULE_PATH "3rdparty/qtkeychain"
     READABLE_NAME "QtKeychain")
+  # Building qtkeychain's translations runs lupdate, which rewrites the .ts
+  # files inside the submodule whenever a source is newer than them, so the
+  # submodule shows as modified after every checkout. Mudlet neither bundles
+  # nor loads those catalogues, so skip them. The normal variable overrides the
+  # option() in the subdirectory (CMP0077) and is unset afterwards so the
+  # generic name cannot leak into other 3rdparty projects.
+  set(BUILD_TRANSLATIONS OFF)
   add_subdirectory(3rdparty/qtkeychain)
+  unset(BUILD_TRANSLATIONS)
 endif()
 
 git_submodule_init(


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Set `BUILD_TRANSLATIONS OFF` before `add_subdirectory(3rdparty/qtkeychain)` (the macOS-only path), so qtkeychain's `lupdate`/`lrelease` steps are no longer generated.

#### Motivation for adding to Mudlet
qtkeychain's `lupdate` rewrites the seven `translations/qtkeychain_*.ts` files inside the submodule whenever a source is newer than them, so every macOS checkout ends up with ` m 3rdparty/qtkeychain` in `git status` for no reason. Mudlet never bundles or loads those catalogues.

#### Other info (issues closed, discussion etc)
Only affects macOS, the one platform that builds qtkeychain from source. Relies on CMP0077 (both projects' minimum CMake is well past 3.13); the variable is unset after the subdirectory so the generic name cannot leak into other 3rdparty projects.

**Test case:** On macOS: `git -C 3rdparty/qtkeychain checkout -- translations`, then `cmake --preset macos-debug-nosan && cmake --build --preset macos-debug-nosan --target qt6keychain`. `git -C 3rdparty/qtkeychain status` stays clean, and `ninja -C build-macos-debug-nosan -t targets all | grep -E '^(translations|messages):'` prints nothing.