### PR TITLE
Infra: split the OSC 8 hyperlink managers into model state and view repaint

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -296,11 +296,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         // Connect user input trigger (command submission only, not typing)
         connect(mpCommandLine, &TCommandLine::commandSubmitted, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onUserInput);
 
-        // Connect GA/EOR prompt signal from telnet. Both ends of this are core,
-        // so relocating the connect() itself out of the view belongs to a later
-        // step - what matters here is that the receiver is now the model's, so
-        // the wire outlives this widget rather than dying with it.
-        connect(&(pH->mTelnet), &cTelnet::signal_promptReceived, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onPromptReceived);
+        // Connect GA/EOR prompt signal from telnet. Unique because both ends of
+        // this one outlive the widget that makes it - the sender is the Host's
+        // telnet and the receiver is now the Host's model - so a second main
+        // console built against a live Host would otherwise double-deliver every
+        // prompt and expire links a prompt early. mudlet::addConsoleForNewHost()
+        // refuses to build that second console today, but nothing here says so.
+        connect(&(pH->mTelnet), &cTelnet::signal_promptReceived, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onPromptReceived, Qt::UniqueConnection);
     }
 
     layer = new QWidget(mpMainDisplay);
@@ -2949,8 +2951,8 @@ void TConsole::slot_clearSearchResults()
 // line of the buffer, so whatever this console shows of it is stale. forceUpdate()
 // rather than update() because a plain repaint is served from the pane's cached
 // screen pixmap, which still holds the text that has just been concealed.
-// The panes are null while the constructor is still building them, and stay null
-// for a console whose model outlives it long enough for a timer to fire.
+// The panes are only null in the constructor window - the connection is made
+// some 190 lines before they are built.
 void TConsole::slot_hyperlinkVisibilityChanged()
 {
     if (mUpperPane) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -30,11 +30,9 @@
 #include "ctelnet.h"
 #include "Host.h"
 #include "TCommandLine.h"
-#include "THyperlinkCompactManager.h"
 #include "TDebug.h"
 #include "TDockWidget.h"
 #include "TEvent.h"
-#include "THyperlinkSelectionManager.h"
 #include "THyperlinkVisibilityManager.h"
 #include "TLabel.h"
 #include "TMainConsole.h"
@@ -139,18 +137,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     // before any widget exists), so point its buffer at this view now.
     buffer.setConsole(this);
 
-    mpHyperlinkCompactManager = std::make_unique<THyperlinkCompactManager>();
-    mpHyperlinkSelectionManager = std::make_unique<THyperlinkSelectionManager>(*this);
-    mpHyperlinkVisibilityManager = std::make_unique<THyperlinkVisibilityManager>(this);
-
-    initializeOSC8StyleFeature();
-    initializeOSC8MenuFeature();
-    initializeOSC8TooltipFeature();
-    initializeOSC8DisabledFeature();
-    initializeOSC8SpoilerFeature();
-    initializeOSC8SelectionFeature();
-    initializeOSC8VisibilityFeature();
-    initializeOSC8TitleFeature();
+    // Redraw whichever panes this console has when the model conceals or
+    // reveals a link. Only the main console's buffer is ever translated, so
+    // only it registers tracked links today, but the manager is per model and
+    // this is the view's whole half of the hyperlink split - so every console
+    // gets it rather than the main one alone.
+    connect(&model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::visibilityChanged, this, &TConsole::slot_hyperlinkVisibilityChanged);
 
     auto quitShortcut = new QShortcut(this);
     quitShortcut->setKey(Qt::CTRL | Qt::Key_W);
@@ -302,20 +294,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         // zero-timer at the end of this constructor
 
         // Connect user input trigger (command submission only, not typing)
-        connect(mpCommandLine, &TCommandLine::commandSubmitted, mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::onUserInput);
+        connect(mpCommandLine, &TCommandLine::commandSubmitted, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onUserInput);
 
-        // Connect GA/EOR prompt signal from telnet
-        connect(&(pH->mTelnet), &cTelnet::signal_promptReceived, mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::onPromptReceived);
-
-        // Refresh display when hyperlink visibility changes
-        connect(mpHyperlinkVisibilityManager.get(), &THyperlinkVisibilityManager::visibilityChanged, this, [this]() {
-            if (mUpperPane) {
-                mUpperPane->forceUpdate();
-            }
-            if (mLowerPane) {
-                mLowerPane->forceUpdate();
-            }
-        });
+        // Connect GA/EOR prompt signal from telnet. Both ends of this are core,
+        // so relocating the connect() itself out of the view belongs to a later
+        // step - what matters here is that the receiver is now the model's, so
+        // the wire outlives this widget rather than dying with it.
+        connect(&(pH->mTelnet), &cTelnet::signal_promptReceived, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onPromptReceived);
     }
 
     layer = new QWidget(mpMainDisplay);
@@ -2960,6 +2945,22 @@ void TConsole::slot_clearSearchResults()
     mLowerPane->forceUpdate();
 }
 
+// The view's half of the OSC 8 visibility split: the model has just rewritten a
+// line of the buffer, so whatever this console shows of it is stale. forceUpdate()
+// rather than update() because a plain repaint is served from the pane's cached
+// screen pixmap, which still holds the text that has just been concealed.
+// The panes are null while the constructor is still building them, and stay null
+// for a console whose model outlives it long enough for a timer to fire.
+void TConsole::slot_hyperlinkVisibilityChanged()
+{
+    if (mUpperPane) {
+        mUpperPane->forceUpdate();
+    }
+    if (mLowerPane) {
+        mLowerPane->forceUpdate();
+    }
+}
+
 void TConsole::handleLinesOverflowEvent(const int lineCount)
 {
     if (mType & ~(UserWindow | SubConsole)) {
@@ -3107,111 +3108,4 @@ void TConsole::restoreCommandSearchSettings()
     }
 
     commandSplitter->restoreState(pQSettings->value("commandSearchSplitterState").toByteArray());
-}
-
-void TConsole::initializeOSC8StyleFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    // Register shorthands for style property names
-    mpHyperlinkCompactManager->registerShorthand(qsl("s"), qsl("style"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("c"), qsl("color"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("bg"), qsl("bg"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("b"), qsl("bold"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("i"), qsl("italic"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("u"), qsl("underline"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("o"), qsl("overline"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("st"), qsl("strikethrough"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("tdc"), qsl("text-decoration-color"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("h"), qsl("hover"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("a"), qsl("active"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("f"), qsl("focus"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("fv"), qsl("focus-visible"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("vi"), qsl("visited"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("l"), qsl("link"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("al"), qsl("any-link"));
-    mpHyperlinkCompactManager->registerShorthand(qsl("sl"), qsl("selected"));
-
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("style"));
-}
-
-void TConsole::initializeOSC8MenuFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    // Register shorthand for menu property
-    mpHyperlinkCompactManager->registerShorthand(qsl("m"), qsl("menu"));
-
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("menu"));
-}
-
-void TConsole::initializeOSC8TooltipFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    // Register shorthand for tooltip property
-    mpHyperlinkCompactManager->registerShorthand(qsl("t"), qsl("tooltip"));
-
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("tooltip"));
-}
-
-void TConsole::initializeOSC8VisibilityFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    // Register shorthand for visibility property
-    mpHyperlinkCompactManager->registerShorthand(qsl("v"), qsl("visibility"));
-
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("visibility"));
-}
-
-void TConsole::initializeOSC8SelectionFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    // Register shorthand for selection property
-    mpHyperlinkCompactManager->registerShorthand(qsl("sel"), qsl("selection"));
-
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("selection"));
-}
-
-void TConsole::initializeOSC8SpoilerFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    mpHyperlinkCompactManager->registerShorthand(qsl("sp"), qsl("spoiler"));
-
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("spoiler"));
-}
-
-void TConsole::initializeOSC8DisabledFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    mpHyperlinkCompactManager->registerShorthand(qsl("d"), qsl("disabled"));
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("disabled"));
-}
-
-void TConsole::initializeOSC8TitleFeature()
-{
-    if (!mpHyperlinkCompactManager) {
-        return;
-    }
-
-    mpHyperlinkCompactManager->registerShorthand(qsl("ti"), qsl("title"));
-    mpHyperlinkCompactManager->registerPresetProperty(qsl("title"));
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -137,11 +137,9 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     // before any widget exists), so point its buffer at this view now.
     buffer.setConsole(this);
 
-    // Redraw whichever panes this console has when the model conceals or
-    // reveals a link. Only the main console's buffer is ever translated, so
-    // only it registers tracked links today, but the manager is per model and
-    // this is the view's whole half of the hyperlink split - so every console
-    // gets it rather than the main one alone.
+    // Every console, not just the main one: the manager is per model, and only
+    // the main console's buffer is translated today but nothing here relies on
+    // that.
     connect(&model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::visibilityChanged, this, &TConsole::slot_hyperlinkVisibilityChanged);
 
     auto quitShortcut = new QShortcut(this);
@@ -296,12 +294,10 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
         // Connect user input trigger (command submission only, not typing)
         connect(mpCommandLine, &TCommandLine::commandSubmitted, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onUserInput);
 
-        // Connect GA/EOR prompt signal from telnet. Unique because both ends of
-        // this one outlive the widget that makes it - the sender is the Host's
-        // telnet and the receiver is now the Host's model - so a second main
-        // console built against a live Host would otherwise double-deliver every
-        // prompt and expire links a prompt early. mudlet::addConsoleForNewHost()
-        // refuses to build that second console today, but nothing here says so.
+        // Unique because both ends outlive the widget making the connection -
+        // Host's telnet and Host's model - so a second main console built
+        // against a live Host would double-deliver every prompt and expire links
+        // a prompt early.
         connect(&(pH->mTelnet), &cTelnet::signal_promptReceived, &model().mHyperlinkVisibilityManager, &THyperlinkVisibilityManager::onPromptReceived, Qt::UniqueConnection);
     }
 
@@ -2947,12 +2943,9 @@ void TConsole::slot_clearSearchResults()
     mLowerPane->forceUpdate();
 }
 
-// The view's half of the OSC 8 visibility split: the model has just rewritten a
-// line of the buffer, so whatever this console shows of it is stale. forceUpdate()
-// rather than update() because a plain repaint is served from the pane's cached
-// screen pixmap, which still holds the text that has just been concealed.
-// The panes are only null in the constructor window - the connection is made
-// some 190 lines before they are built.
+// forceUpdate() rather than update(): a plain repaint is served from the pane's
+// cached screen pixmap, which still holds the text just concealed. The panes are
+// only null in the constructor window, before they are built.
 void TConsole::slot_hyperlinkVisibilityChanged()
 {
     if (mUpperPane) {

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -257,9 +257,8 @@ public:
     void setScrolling(const bool state);
     bool getScrolling() const { return mScrollingEnabled; }
 
-    // The three OSC 8 managers are model state, not view state - see
-    // TConsoleModel. The main console shares Host's, so a link concealed while
-    // the profile was open is still concealed in the model once the widget has
+    // Model state, not view state: the main console shares Host's, so a link
+    // concealed while the profile was open stays concealed once the widget has
     // gone.
     THyperlinkCompactManager& getHyperlinkCompactManager() { return mpModel->mHyperlinkCompactManager; }
     THyperlinkSelectionManager& getHyperlinkSelectionManager() { return mpModel->mHyperlinkSelectionManager; }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -153,9 +153,6 @@ class Host;
 class TTextEdit;
 class TCommandLine;
 class TDockWidget;
-class THyperlinkCompactManager;
-class THyperlinkSelectionManager;
-class THyperlinkVisibilityManager;
 class TLabel;
 class TScrollBox;
 class TSplitter;
@@ -260,21 +257,13 @@ public:
     void setScrolling(const bool state);
     bool getScrolling() const { return mScrollingEnabled; }
 
-    THyperlinkCompactManager& getHyperlinkCompactManager()
-    {
-        Q_ASSERT(mpHyperlinkCompactManager);
-        return *mpHyperlinkCompactManager;
-    }
-    THyperlinkSelectionManager& getHyperlinkSelectionManager()
-    {
-        Q_ASSERT(mpHyperlinkSelectionManager);
-        return *mpHyperlinkSelectionManager;
-    }
-    THyperlinkVisibilityManager& getHyperlinkVisibilityManager()
-    {
-        Q_ASSERT(mpHyperlinkVisibilityManager);
-        return *mpHyperlinkVisibilityManager;
-    }
+    // The three OSC 8 managers are model state, not view state - see
+    // TConsoleModel. The main console shares Host's, so a link concealed while
+    // the profile was open is still concealed in the model once the widget has
+    // gone.
+    THyperlinkCompactManager& getHyperlinkCompactManager() { return mpModel->mHyperlinkCompactManager; }
+    THyperlinkSelectionManager& getHyperlinkSelectionManager() { return mpModel->mHyperlinkSelectionManager; }
+    THyperlinkVisibilityManager& getHyperlinkVisibilityManager() { return mpModel->mHyperlinkVisibilityManager; }
 
     void setCmdVisible(bool);
     void changeColors();
@@ -480,25 +469,13 @@ protected:
 private slots:
     void slot_adjustAccessibleNames();
     void slot_clearSearchResults();
+    void slot_hyperlinkVisibilityChanged();
     void focusOnSearchResultAndAnnounce(int searchX, int searchY);
 
 private:
     void createSearchOptionIcon();
     void raiseFontChangeEvent();
     void restoreCommandSearchSettings();
-    void initializeOSC8StyleFeature();
-    void initializeOSC8MenuFeature();
-    void initializeOSC8TooltipFeature();
-    void initializeOSC8VisibilityFeature();
-    void initializeOSC8SelectionFeature();
-    void initializeOSC8SpoilerFeature();
-    void initializeOSC8DisabledFeature();
-    void initializeOSC8TitleFeature();
-
-    // OSC 8 hyperlink managers
-    std::unique_ptr<THyperlinkCompactManager> mpHyperlinkCompactManager;
-    std::unique_ptr<THyperlinkSelectionManager> mpHyperlinkSelectionManager;
-    std::unique_ptr<THyperlinkVisibilityManager> mpHyperlinkVisibilityManager;
 
     ConsoleType mType = UnknownType;
     // the size the last resize reported to Lua

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -85,13 +85,10 @@ struct TConsoleModel
     QPoint mUserCursor;
     bool mIsPromptLine = false;
 
-    // The OSC 8 hyperlink managers. Only their state is here: concealing and
-    // revealing a link rewrite this model's buffer, so they run with or without
-    // a view, while repainting afterwards is the view's job - TConsole observes
-    // THyperlinkVisibilityManager::visibilityChanged and forces both panes to
-    // redraw. Registering a link is not view-free yet: TBuffer reaches the
-    // manager through its own console back-pointer, so the translate path still
-    // needs a widget.
+    // The OSC 8 hyperlink managers. Concealing and revealing rewrite this
+    // model's buffer, so they run with or without a view; repainting afterwards
+    // is the view's job. Registering a link is not view-free yet - TBuffer
+    // reaches the manager through its own console back-pointer.
     //
     // Declared after the buffer so that the manager which writes into it is
     // destroyed first - keep it that way if a field is ever added between them.

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -21,6 +21,9 @@
  ***************************************************************************/
 
 #include "TBuffer.h"
+#include "THyperlinkCompactManager.h"
+#include "THyperlinkSelectionManager.h"
+#include "THyperlinkVisibilityManager.h"
 
 #include <QColor>
 #include <QPoint>
@@ -31,7 +34,8 @@ class Host;
 // The per-console data model: the slice of former TConsole state that the
 // telnet -> trigger pipeline drives without needing a widget. That is the text
 // buffer, the cursor/prompt state Host::runTriggers() updates on every line,
-// and the fg/bg colours colour-triggers match against. Splitting it out of the
+// the fg/bg colours colour-triggers match against, and the OSC 8 hyperlink
+// state the buffer translation registers as it goes. Splitting it out of the
 // widget is what lets the pipeline run with no view at all, which is the point
 // of the Widgets-free core (#8681).
 //
@@ -44,6 +48,7 @@ struct TConsoleModel
 {
     explicit TConsoleModel(Host* pHost)
     : buffer(pHost)
+    , mHyperlinkVisibilityManager(*this)
     {
     }
 
@@ -62,6 +67,16 @@ struct TConsoleModel
     int mEngineCursor = -1;
     QPoint mUserCursor;
     bool mIsPromptLine = false;
+
+    // The OSC 8 hyperlink managers. Only their state is here: concealing a link
+    // rewrites this model's buffer, so it has to run with or without a view,
+    // while repainting after it is the view's job - TConsole observes
+    // THyperlinkVisibilityManager::visibilityChanged and forces both panes to
+    // redraw. mHyperlinkVisibilityManager takes this model by reference, so it
+    // must stay declared after the buffer it works on.
+    THyperlinkCompactManager mHyperlinkCompactManager;
+    THyperlinkSelectionManager mHyperlinkSelectionManager;
+    THyperlinkVisibilityManager mHyperlinkVisibilityManager;
 };
 
 #endif // MUDLET_TCONSOLEMODEL_H

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -68,12 +68,16 @@ struct TConsoleModel
     QPoint mUserCursor;
     bool mIsPromptLine = false;
 
-    // The OSC 8 hyperlink managers. Only their state is here: concealing a link
-    // rewrites this model's buffer, so it has to run with or without a view,
-    // while repainting after it is the view's job - TConsole observes
+    // The OSC 8 hyperlink managers. Only their state is here: concealing and
+    // revealing a link rewrite this model's buffer, so they run with or without
+    // a view, while repainting afterwards is the view's job - TConsole observes
     // THyperlinkVisibilityManager::visibilityChanged and forces both panes to
-    // redraw. mHyperlinkVisibilityManager takes this model by reference, so it
-    // must stay declared after the buffer it works on.
+    // redraw. Registering a link is not view-free yet: TBuffer reaches the
+    // manager through its own console back-pointer, so the translate path still
+    // needs a widget.
+    //
+    // Declared after the buffer so that the manager which writes into it is
+    // destroyed first - keep it that way if a field is ever added between them.
     THyperlinkCompactManager mHyperlinkCompactManager;
     THyperlinkSelectionManager mHyperlinkSelectionManager;
     THyperlinkVisibilityManager mHyperlinkVisibilityManager;

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -36,9 +36,10 @@ THyperlinkCompactManager::THyperlinkCompactManager()
 THyperlinkCompactManager::~THyperlinkCompactManager() = default;
 
 // The shorthand and preset-property tables the OSC 8 compact syntax is parsed
-// against. They used to be filled in by eight TConsole::initializeOSC8*Feature()
-// calls, which left a model built without a view (Host builds the main
-// console's before any widget exists) unable to expand a single shorthand.
+// against. Filled in here rather than by the view: Host builds the main
+// console's model before any widget exists, so anything that waited for a
+// TConsole would leave a model with empty tables and silently stop expanding
+// "s" into "style".
 void THyperlinkCompactManager::registerBuiltInFeatures()
 {
     // Style

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -35,14 +35,11 @@ THyperlinkCompactManager::THyperlinkCompactManager()
 
 THyperlinkCompactManager::~THyperlinkCompactManager() = default;
 
-// The shorthand and preset-property tables the OSC 8 compact syntax is parsed
-// against. Filled in here rather than by the view: Host builds the main
-// console's model before any widget exists, so anything that waited for a
-// TConsole would leave a model with empty tables and silently stop expanding
-// "s" into "style".
+// Filled in here rather than by the view: Host builds the main console's model
+// before any widget exists, and a table left empty stops expanding "s" into
+// "style" without saying so.
 void THyperlinkCompactManager::registerBuiltInFeatures()
 {
-    // Style
     registerShorthand(qsl("s"), qsl("style"));
     registerShorthand(qsl("c"), qsl("color"));
     registerShorthand(qsl("bg"), qsl("bg"));
@@ -62,31 +59,24 @@ void THyperlinkCompactManager::registerBuiltInFeatures()
     registerShorthand(qsl("sl"), qsl("selected"));
     registerPresetProperty(qsl("style"));
 
-    // Menu
     registerShorthand(qsl("m"), qsl("menu"));
     registerPresetProperty(qsl("menu"));
 
-    // Tooltip
     registerShorthand(qsl("t"), qsl("tooltip"));
     registerPresetProperty(qsl("tooltip"));
 
-    // Visibility
     registerShorthand(qsl("v"), qsl("visibility"));
     registerPresetProperty(qsl("visibility"));
 
-    // Selection
     registerShorthand(qsl("sel"), qsl("selection"));
     registerPresetProperty(qsl("selection"));
 
-    // Spoiler
     registerShorthand(qsl("sp"), qsl("spoiler"));
     registerPresetProperty(qsl("spoiler"));
 
-    // Disabled
     registerShorthand(qsl("d"), qsl("disabled"));
     registerPresetProperty(qsl("disabled"));
 
-    // Title
     registerShorthand(qsl("ti"), qsl("title"));
     registerPresetProperty(qsl("title"));
 }

--- a/src/THyperlinkCompactManager.cpp
+++ b/src/THyperlinkCompactManager.cpp
@@ -19,6 +19,8 @@
 
 #include "THyperlinkCompactManager.h"
 
+#include "utils.h"
+
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -28,12 +30,65 @@
 THyperlinkCompactManager::THyperlinkCompactManager()
 : QObject(nullptr)
 {
-    // Pure framework - no feature knowledge!
-    // Features register themselves when they initialize
-    // Note: No QObject parent - ownership managed by unique_ptr in TConsole
+    registerBuiltInFeatures();
 }
 
 THyperlinkCompactManager::~THyperlinkCompactManager() = default;
+
+// The shorthand and preset-property tables the OSC 8 compact syntax is parsed
+// against. They used to be filled in by eight TConsole::initializeOSC8*Feature()
+// calls, which left a model built without a view (Host builds the main
+// console's before any widget exists) unable to expand a single shorthand.
+void THyperlinkCompactManager::registerBuiltInFeatures()
+{
+    // Style
+    registerShorthand(qsl("s"), qsl("style"));
+    registerShorthand(qsl("c"), qsl("color"));
+    registerShorthand(qsl("bg"), qsl("bg"));
+    registerShorthand(qsl("b"), qsl("bold"));
+    registerShorthand(qsl("i"), qsl("italic"));
+    registerShorthand(qsl("u"), qsl("underline"));
+    registerShorthand(qsl("o"), qsl("overline"));
+    registerShorthand(qsl("st"), qsl("strikethrough"));
+    registerShorthand(qsl("tdc"), qsl("text-decoration-color"));
+    registerShorthand(qsl("h"), qsl("hover"));
+    registerShorthand(qsl("a"), qsl("active"));
+    registerShorthand(qsl("f"), qsl("focus"));
+    registerShorthand(qsl("fv"), qsl("focus-visible"));
+    registerShorthand(qsl("vi"), qsl("visited"));
+    registerShorthand(qsl("l"), qsl("link"));
+    registerShorthand(qsl("al"), qsl("any-link"));
+    registerShorthand(qsl("sl"), qsl("selected"));
+    registerPresetProperty(qsl("style"));
+
+    // Menu
+    registerShorthand(qsl("m"), qsl("menu"));
+    registerPresetProperty(qsl("menu"));
+
+    // Tooltip
+    registerShorthand(qsl("t"), qsl("tooltip"));
+    registerPresetProperty(qsl("tooltip"));
+
+    // Visibility
+    registerShorthand(qsl("v"), qsl("visibility"));
+    registerPresetProperty(qsl("visibility"));
+
+    // Selection
+    registerShorthand(qsl("sel"), qsl("selection"));
+    registerPresetProperty(qsl("selection"));
+
+    // Spoiler
+    registerShorthand(qsl("sp"), qsl("spoiler"));
+    registerPresetProperty(qsl("spoiler"));
+
+    // Disabled
+    registerShorthand(qsl("d"), qsl("disabled"));
+    registerPresetProperty(qsl("disabled"));
+
+    // Title
+    registerShorthand(qsl("ti"), qsl("title"));
+    registerPresetProperty(qsl("title"));
+}
 
 void THyperlinkCompactManager::registerShorthand(const QString& shorthand, const QString& fullName)
 {

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -27,8 +27,6 @@
 #include <QString>
 #include <QStringList>
 
-class TConsole;
-
 // Registry entry for preset properties
 struct PresetPropertyEntry {
     PresetPropertyEntry() {}
@@ -51,7 +49,8 @@ class THyperlinkCompactManager : public QObject
     Q_DISABLE_COPY(THyperlinkCompactManager)
 
 public:
-    // Constructor: No QObject parent - ownership managed by unique_ptr in TConsole
+    // No QObject parent: this is a field of the core TConsoleModel, which is not
+    // a QObject and can outlive the console widget that used to own it.
     THyperlinkCompactManager();
     ~THyperlinkCompactManager();
 
@@ -109,6 +108,8 @@ signals:
     void presetsCleared();
 
 private:
+    void registerBuiltInFeatures();
+
     QHash<QString, ShorthandEntry> mShorthandRegistry;
 
     QHash<QString, PresetPropertyEntry> mPresetPropertyRegistry;

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -49,8 +49,6 @@ class THyperlinkCompactManager : public QObject
     Q_DISABLE_COPY(THyperlinkCompactManager)
 
 public:
-    // No QObject parent: this is a field of the core TConsoleModel, which is not
-    // a QObject and outlives the console widget that reaches it.
     THyperlinkCompactManager();
     ~THyperlinkCompactManager();
 

--- a/src/THyperlinkCompactManager.h
+++ b/src/THyperlinkCompactManager.h
@@ -50,7 +50,7 @@ class THyperlinkCompactManager : public QObject
 
 public:
     // No QObject parent: this is a field of the core TConsoleModel, which is not
-    // a QObject and can outlive the console widget that used to own it.
+    // a QObject and outlives the console widget that reaches it.
     THyperlinkCompactManager();
     ~THyperlinkCompactManager();
 

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -26,7 +26,7 @@
 #include <QUrlQuery>
 
 // No QObject parent: this is a field of the core TConsoleModel, which is not a
-// QObject and can outlive the console widget that used to own it.
+// QObject and outlives the console widget that reaches it.
 THyperlinkSelectionManager::THyperlinkSelectionManager()
 : QObject(nullptr)
 {

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -20,14 +20,15 @@
 
 #include "THyperlinkSelectionManager.h"
 #include "LuaLiteral.h"
-#include "TConsole.h"
+#include "utils.h"
 
 #include <QUrl>
 #include <QUrlQuery>
 
-THyperlinkSelectionManager::THyperlinkSelectionManager(TConsole& console)
-: QObject(&console)
-, mpConsole(console)
+// No QObject parent: this is a field of the core TConsoleModel, which is not a
+// QObject and can outlive the console widget that used to own it.
+THyperlinkSelectionManager::THyperlinkSelectionManager()
+: QObject(nullptr)
 {
 }
 

--- a/src/THyperlinkSelectionManager.cpp
+++ b/src/THyperlinkSelectionManager.cpp
@@ -25,8 +25,6 @@
 #include <QUrl>
 #include <QUrlQuery>
 
-// No QObject parent: this is a field of the core TConsoleModel, which is not a
-// QObject and outlives the console widget that reaches it.
 THyperlinkSelectionManager::THyperlinkSelectionManager()
 : QObject(nullptr)
 {

--- a/src/THyperlinkSelectionManager.h
+++ b/src/THyperlinkSelectionManager.h
@@ -28,17 +28,17 @@
 #include <QString>
 #include <QStringList>
 
-class TConsole;
-
 // Manages selection state for OSC 8 hyperlinks
 // Handles group exclusivity (radio buttons) and multi-select (checkboxes)
+// Lives in the core TConsoleModel: which links a group has selected is state the
+// pipeline reads while rewriting a link's command, not anything the view holds.
 class THyperlinkSelectionManager : public QObject
 {
     Q_OBJECT
     Q_DISABLE_COPY(THyperlinkSelectionManager)
 
 public:
-    explicit THyperlinkSelectionManager(TConsole& console);
+    THyperlinkSelectionManager();
     ~THyperlinkSelectionManager();
 
     bool isSelected(const QString& group, const QString& value) const;
@@ -65,9 +65,7 @@ signals:
 
 private:
     QString addSelectedParameter(const QString& command, bool isSelected) const;
-    
-    TConsole& mpConsole;
-    
+
     // Selection state tracking: group -> (value -> selected)
     QHash<QString, QHash<QString, bool>> mSelectionState;
     

--- a/src/THyperlinkVisibilityManager.cpp
+++ b/src/THyperlinkVisibilityManager.cpp
@@ -32,8 +32,8 @@
 
 using namespace std::chrono_literals;
 
-// No QObject parent: this is a field of the core TConsoleModel, which is not a
-// QObject and outlives the console widget that reaches it.
+// No QObject parent - the owning TConsoleModel is not one - so the timers below
+// are parented to this manager and die with the model, not with a widget.
 THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsoleModel& model)
 : QObject(nullptr)
 , mModel(model)
@@ -726,11 +726,9 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
 
 // Gotcha: the screen-reader announcements below are the one view concern still
 // wired straight from this class, so unlike the repaint they no longer stop when
-// the console does. mudlet::closeHost() normally destroys the Host on the very
-// next event-loop turn, too soon for the 100ms timer, but it retries every 50ms
-// for as long as a map operation is running - so closing a profile mid-map-import
-// with a link still pending can announce about a console that has already gone.
-// They move to the frontend with the rest of this file's mudlet:: reach-ins.
+// the console does - closing a profile mid-map-import, where closeHost() keeps
+// retrying every 50ms, can announce about a console that has already gone. They
+// move to the frontend with the rest of this file's mudlet:: reach-ins.
 void THyperlinkVisibilityManager::queueHiddenAnnouncement()
 {
     ++mPendingHiddenCount;

--- a/src/THyperlinkVisibilityManager.cpp
+++ b/src/THyperlinkVisibilityManager.cpp
@@ -20,11 +20,8 @@
 
 #include "THyperlinkVisibilityManager.h"
 #include "TBuffer.h"
-#include "TConsole.h"
-#include "TTextEdit.h"
-#include "Host.h"
+#include "TConsoleModel.h"
 #include "mudlet.h"
-#include "widechar_width.h"
 
 #include <QAccessible>
 #include <QDateTime>
@@ -34,12 +31,12 @@
 
 using namespace std::chrono_literals;
 
-THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsole* pConsole)
+// No QObject parent: this is a field of the core TConsoleModel, which is not a
+// QObject and can outlive the console widget that used to own it.
+THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsoleModel& model)
 : QObject(nullptr)
-, mpConsole(pConsole)
+, mModel(model)
 {
-    Q_ASSERT(pConsole);
-
     mpTimer = new QTimer(this);
     mpTimer->setInterval(100ms); // Check every 100ms for timer-based concealments
     connect(mpTimer, &QTimer::timeout, this, &THyperlinkVisibilityManager::slot_checkTimers);
@@ -632,15 +629,11 @@ void THyperlinkVisibilityManager::stopTimerIfNotNeeded()
 
 void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
 {
-    if (!mpConsole) {
-        return;
-    }
-
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug().noquote() << "[OSC] Concealing link" << link.linkId << "deletesEntireLine:" << link.deletesEntireLine;
 #endif
 
-    TBuffer& buffer = mpConsole->buffer;
+    TBuffer& buffer = mModel.buffer;
 
     if (link.deletesEntireLine) {
         // CRITICAL BUG FIX: Prevent cascade deletion by unregistering ALL links on the target line
@@ -689,14 +682,6 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
                 }
             }
 
-            // Update display
-            if (mpConsole->mUpperPane) {
-                mpConsole->mUpperPane->update();
-            }
-            if (mpConsole->mLowerPane) {
-                mpConsole->mLowerPane->update();
-            }
-
             // Stop timer if no more timer-based links exist
             bool hasTimers = false;
             for (const auto& remainingLink : std::as_const(mTrackedLinks)) {
@@ -728,13 +713,6 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
                 link.isConcealed = true;
 
                 queueHiddenAnnouncement();
-
-                if (mpConsole->mUpperPane) {
-                    mpConsole->mUpperPane->update();
-                }
-                if (mpConsole->mLowerPane) {
-                    mpConsole->mLowerPane->update();
-                }
             }
         }
     }
@@ -765,10 +743,6 @@ void THyperlinkVisibilityManager::slot_announceHiddenLinks()
 
 void THyperlinkVisibilityManager::performReveal(TrackedHyperlink& link)
 {
-    if (!mpConsole) {
-        return;
-    }
-
 #if defined(DEBUG_OSC_PROCESSING)
     qDebug().noquote() << "[OSC] Revealing link" << link.linkId;
 #endif
@@ -778,7 +752,7 @@ void THyperlinkVisibilityManager::performReveal(TrackedHyperlink& link)
         return;
     }
 
-    TBuffer& buffer = mpConsole->buffer;
+    TBuffer& buffer = mModel.buffer;
 
     if (link.lineNumber >= 0 && link.lineNumber < buffer.lineBuffer.size()) {
         QString& lineText = buffer.lineBuffer[link.lineNumber];
@@ -792,13 +766,6 @@ void THyperlinkVisibilityManager::performReveal(TrackedHyperlink& link)
             if (QAccessible::isActive() && mudlet::self()) {
                 //: Screen-reader announcement when a previously hidden OSC 8 link is revealed; %1 is the original link text
                 mudlet::self()->announce(tr("Link revealed: %1").arg(link.originalText), QString(), true);
-            }
-
-            if (mpConsole->mUpperPane) {
-                mpConsole->mUpperPane->update();
-            }
-            if (mpConsole->mLowerPane) {
-                mpConsole->mLowerPane->update();
             }
         }
     }

--- a/src/THyperlinkVisibilityManager.cpp
+++ b/src/THyperlinkVisibilityManager.cpp
@@ -26,13 +26,14 @@
 #include <QAccessible>
 #include <QDateTime>
 #include <QDebug>
+#include <QTimer>
 #include <chrono>
 #include <limits>
 
 using namespace std::chrono_literals;
 
 // No QObject parent: this is a field of the core TConsoleModel, which is not a
-// QObject and can outlive the console widget that used to own it.
+// QObject and outlives the console widget that reaches it.
 THyperlinkVisibilityManager::THyperlinkVisibilityManager(TConsoleModel& model)
 : QObject(nullptr)
 , mModel(model)
@@ -718,6 +719,13 @@ void THyperlinkVisibilityManager::performConcealment(TrackedHyperlink& link)
     }
 }
 
+// Gotcha: the screen-reader announcements below are the one view concern still
+// wired straight from this class, so unlike the repaint they no longer stop when
+// the console does. mudlet::closeHost() normally destroys the Host on the very
+// next event-loop turn, too soon for the 100ms timer, but it retries every 50ms
+// for as long as a map operation is running - so closing a profile mid-map-import
+// with a link still pending can announce about a console that has already gone.
+// They move to the frontend with the rest of this file's mudlet:: reach-ins.
 void THyperlinkVisibilityManager::queueHiddenAnnouncement()
 {
     ++mPendingHiddenCount;

--- a/src/THyperlinkVisibilityManager.h
+++ b/src/THyperlinkVisibilityManager.h
@@ -22,11 +22,11 @@
 
 #include <QObject>
 #include <QMap>
-#include <QTimer>
 #include <QString>
 
 #include "THyperlinkStyling.h"
 
+class QTimer;
 struct TConsoleModel;
 
 struct TrackedHyperlink

--- a/src/THyperlinkVisibilityManager.h
+++ b/src/THyperlinkVisibilityManager.h
@@ -65,11 +65,9 @@ struct TrackedHyperlink
     bool skipFirstOutput = false; // Skip the first output gap after registration
 };
 
-// Tracks which OSC 8 hyperlinks are concealed and when each is due to change.
-// That is model state - concealing rewrites the buffer, and the buffer is the
-// model's - so this lives in the core TConsoleModel alongside it and needs no
-// view. Redrawing after a change is the view's half of the split: this emits
-// visibilityChanged() and TConsole::slot_hyperlinkVisibilityChanged() repaints.
+// Tracks which OSC 8 hyperlinks are concealed and when each is due to change:
+// model state, since concealing rewrites the model's buffer. Redrawing is the
+// view's half - this emits visibilityChanged() and TConsole repaints.
 class THyperlinkVisibilityManager : public QObject
 {
     Q_OBJECT

--- a/src/THyperlinkVisibilityManager.h
+++ b/src/THyperlinkVisibilityManager.h
@@ -23,12 +23,11 @@
 #include <QObject>
 #include <QMap>
 #include <QTimer>
-#include <QPointer>
 #include <QString>
 
 #include "THyperlinkStyling.h"
 
-class TConsole;
+struct TConsoleModel;
 
 struct TrackedHyperlink
 {
@@ -65,12 +64,17 @@ struct TrackedHyperlink
     bool skipFirstOutput = false; // Skip the first output gap after registration
 };
 
+// Tracks which OSC 8 hyperlinks are concealed and when each is due to change.
+// That is model state - concealing rewrites the buffer, and the buffer is the
+// model's - so this lives in the core TConsoleModel alongside it and needs no
+// view. Redrawing after a change is the view's half of the split: this emits
+// visibilityChanged() and TConsole::slot_hyperlinkVisibilityChanged() repaints.
 class THyperlinkVisibilityManager : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit THyperlinkVisibilityManager(TConsole* pConsole);
+    explicit THyperlinkVisibilityManager(TConsoleModel& model);
     ~THyperlinkVisibilityManager() override;
 
     // Returns true if link should start hidden
@@ -106,7 +110,7 @@ private:
 
     void processExpireTriggeredLinks(bool input, bool prompt, bool output);
 
-    QPointer<TConsole> mpConsole;
+    TConsoleModel& mModel;
     QMap<int, TrackedHyperlink> mTrackedLinks;
     QTimer* mpTimer = nullptr;
     QTimer* mpOutputGapTimer = nullptr;

--- a/src/THyperlinkVisibilityManager.h
+++ b/src/THyperlinkVisibilityManager.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QSet>
 #include <QString>
 
 #include "THyperlinkStyling.h"

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     FrontendRefreshSeamTest.cpp
     DetachedWindowMenuShortcutsTest.cpp
     GlyphOverflowTest.cpp
+    HyperlinkModelSplitTest.cpp
     LabelAnchorInteractionTest.cpp
     LabelMovieRefusalTest.cpp
     MainConsoleSelectionTest.cpp
@@ -388,6 +389,10 @@ set_tests_properties(ConnectionDialogCrashTest PROPERTIES TIMEOUT 300)
 # FrontendRefreshSeamTest creates a fresh profile per test method, and one of them waits out the
 # post-load tab indicator refresh before it can prove anything, so it needs a longer timeout
 set_tests_properties(FrontendRefreshSeamTest PROPERTIES TIMEOUT 300)
+
+# HyperlinkModelSplitTest creates a fresh profile per test method, and one of
+# them waits out a deliberately long OSC 8 reveal delay, so it needs a longer timeout
+set_tests_properties(HyperlinkModelSplitTest PROPERTIES TIMEOUT 300)
 
 # NarrowWindowWrapTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(NarrowWindowWrapTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/FrontendRefreshSeamTest.cpp
+++ b/test/functional_tests/FrontendRefreshSeamTest.cpp
@@ -27,12 +27,13 @@
 //    per-tab connection indicator as the socket moves. Cut them and a dropped
 //    profile goes on showing a connected tab. Only the main window's tab bar is
 //    read here; the same slot's detached-window half is not gated.
-//  - THyperlinkVisibilityManager::visibilityChanged reaches the lambda the
-//    TConsole constructor wires for main consoles only, which forces both text
-//    panes to redraw. Cut it and text the model has just concealed can stay on
-//    screen out of the panes' cached pixmap. Only what is drawn is at stake:
-//    hit-testing reads TChar::linkIndex() out of the buffer, so a stale pixmap
-//    cannot leave a dead link clickable.
+//  - THyperlinkVisibilityManager::visibilityChanged reaches
+//    TConsole::slot_hyperlinkVisibilityChanged, which the constructor wires for
+//    every console and which forces both text panes to redraw. Cut it and text
+//    the model has just concealed can stay on screen out of the panes' cached
+//    pixmap. Only what is drawn is at stake: hit-testing reads
+//    TChar::linkIndex() out of the buffer, so a stale pixmap cannot leave a
+//    dead link clickable.
 //
 // Both are read through a second observer attached to the same signal after the
 // production connect. Qt delivers to receivers in connection order, so what the
@@ -307,10 +308,11 @@ private slots:
         // valid, which is why the text is replaced space for space.
         QCOMPARE(console->buffer.lineBuffer.at(lineNumber), qsl("OSCSEAM1(          )OSCSEAM1"));
 
-        // performReveal() calls update() on both panes itself, so counting
-        // paints cannot tell the wire apart from its absence. forceUpdate()
-        // additionally sets mForceUpdate, which is what stops the next paint
-        // short-cutting to the cached screen pixmap instead of re-rendering the
+        // Counting paints cannot tell this wire apart from its absence: half a
+        // dozen unrelated things repaint a pane. mForceUpdate is what proves
+        // forceUpdate() ran rather than a stray update(), because it is the flag
+        // that stops the next paint short-cutting to the cached screen pixmap
+        // instead of re-rendering the line the model has just rewritten.
         console->mUpperPane->mForceUpdate = false;
         console->mLowerPane->mForceUpdate = false;
 

--- a/test/functional_tests/HyperlinkModelSplitTest.cpp
+++ b/test/functional_tests/HyperlinkModelSplitTest.cpp
@@ -1,0 +1,345 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// The three OSC 8 hyperlink managers were fields of the TConsole widget, and
+// THyperlinkVisibilityManager reached back through it fourteen times: twice for
+// the text buffer it conceals and reveals in, and twelve times to repaint the
+// two panes. They are now fields of the core TConsoleModel, which Host co-owns
+// for the main console, and the repaint is the view's alone - the manager emits
+// visibilityChanged() and TConsole::slot_hyperlinkVisibilityChanged() forces
+// both panes to redraw (#8681).
+//
+// What these tests hold down is the half that moved. That the repaint still
+// happens is FrontendRefreshSeamTest's
+// test_aHyperlinkVisibilityChangeForcesBothPanesToRedraw, and is deliberately
+// not repeated here.
+//
+// Two of the cases run against a TConsoleModel that never had a view at all,
+// which is the state Host builds the main console's model in and the state a
+// headless profile would stay in. The third destroys a real profile's view and
+// leaves the model running, which is what a closing profile does for real.
+
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <chrono>
+#include <memory>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TBuffer.h"
+#include "TConsoleModel.h"
+#include "THyperlinkCompactManager.h"
+#include "THyperlinkSelectionManager.h"
+#include "THyperlinkStyling.h"
+#include "THyperlinkVisibilityManager.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class HyperlinkModelSplitTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = qsl("Test-HyperlinkModelSplit");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort;
+
+private slots:
+    void initTestCase()
+    {
+        // Saved before the skip below, because cleanupTestCase() still runs
+        // after a skipped initTestCase() and would otherwise clear a variable
+        // this test never set.
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+    }
+
+    void cleanupTestCase() { mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        // An ephemeral OS-assigned port, so parallel runs across worktrees
+        // cannot collide on a shared fixed one.
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        // QtTest does not run cleanup() when init() fails, so a bare QCOMPARE
+        // here would strand the singleton.
+        if (mudlet::getMudletPath(enums::mainPath) != qsl("%1/mudlet").arg(mConfigDir.path())) {
+            delete mudlet::self();
+            delete mpServer;
+            mpServer = nullptr;
+            QFAIL("the config root was not redirected, so this would run against the developer's own profile list");
+        }
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            // Mudlet writes the profile out as it shuts down, so removing the
+            // directory first only has it recreated. The path has to be read
+            // while the singleton is alive though - getMudletPath() reaches
+            // through self() without checking it.
+            const QString profileDir = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+            delete mudlet::self();
+            QDir(profileDir).removeRecursively();
+        }
+    }
+
+    // One set of managers per model, not one per widget. A rebase that left the
+    // widget building its own would compile and run, and every OSC 8 sequence
+    // would go on working - right up until the model was asked what it holds.
+    void test_theHyperlinkManagersAreTheModelsNotTheViews()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        TMainConsole* console = host->mpConsole;
+        QVERIFY(console);
+
+        TConsoleModel& model = host->mainConsoleModel();
+        QCOMPARE(&console->getHyperlinkCompactManager(), &model.mHyperlinkCompactManager);
+        QCOMPARE(&console->getHyperlinkSelectionManager(), &model.mHyperlinkSelectionManager);
+        QCOMPARE(&console->getHyperlinkVisibilityManager(), &model.mHyperlinkVisibilityManager);
+
+        // Written through the model, read back through the view: the same
+        // object, not two that happen to agree.
+        model.mHyperlinkSelectionManager.setSelected(qsl("splitgroup"), qsl("splitvalue"), true);
+        QVERIFY2(console->getHyperlinkSelectionManager().isSelected(qsl("splitgroup"), qsl("splitvalue")),
+                 "the view and the model are answering from separate selection managers");
+
+        // A user window carries a model of its own, so its managers have to be
+        // its own too - Host's belong to the main console alone.
+        QVERIFY2(host->getLuaInterpreter()->compileAndExecuteScript(qsl("openUserWindow('hyperlinkSplitWindow')\n")), "openUserWindow() did not run");
+        TConsole* subConsole = console->mSubConsoleMap.value(qsl("hyperlinkSplitWindow"));
+        QVERIFY2(subConsole, "the user window was not created");
+        QVERIFY2(&subConsole->getHyperlinkVisibilityManager() != &model.mHyperlinkVisibilityManager, "a user window must not share the main console's tracked hyperlinks");
+        QVERIFY2(!subConsole->getHyperlinkSelectionManager().isSelected(qsl("splitgroup"), qsl("splitvalue")), "a user window must not share the main console's selection state");
+    }
+
+    // Concealing rewrites the buffer, and the buffer is the model's. This drives
+    // it against a model that never had a widget of any kind, which is what the
+    // manager used to refuse to do: performConcealment() and performReveal()
+    // both opened with a null check on the console and returned without touching
+    // anything.
+    void test_aModelWithNoViewConcealsAndRevealsItsOwnBuffer()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+
+        // Not the main console's model, which has a view attached: a model of
+        // this test's own, built the way Host builds one and never handed to a
+        // widget.
+        auto model = std::make_shared<TConsoleModel>(host);
+
+        const QString text = qsl("MODELONLY(HIDDENWORD)MODELONLY");
+        const QString line = text + QChar::LineFeed;
+        model->buffer.append(line, 0, line.size(), QColorConstants::LightGray, QColorConstants::Black, TChar::None, 0);
+        const int lineNumber = model->buffer.getLastLineNumber() - 1;
+        QCOMPARE(model->buffer.lineBuffer.at(lineNumber), text);
+
+        // A conceal-on-click link: registered visible, so registerHyperlink()
+        // answers that the text must not be blanked out yet.
+        Mudlet::HyperlinkStyling styling;
+        styling.visibility.hasVisibilitySettings = true;
+        styling.visibility.action = Mudlet::HyperlinkStyling::VisibilitySettings::Action::Conceal;
+
+        const int linkId = 4242;
+        const int startColumn = text.indexOf(qsl("HIDDENWORD"));
+        const int length = QStringLiteral("HIDDENWORD").size();
+        QVERIFY(startColumn > 0);
+        QVERIFY2(!model->mHyperlinkVisibilityManager.registerHyperlink(linkId, lineNumber, startColumn, length, qsl("HIDDENWORD"), styling),
+                 "a conceal link starts visible, so it must not ask for its text to be replaced");
+
+        model->mHyperlinkVisibilityManager.concealLink(linkId);
+        QVERIFY2(model->mHyperlinkVisibilityManager.isLinkConcealed(linkId), "the view-less model did not record the link as concealed");
+        // Concealment keeps the character count identical so buffer indices stay
+        // valid, which is why the text is replaced space for space.
+        QCOMPARE(model->buffer.lineBuffer.at(lineNumber), qsl("MODELONLY(          )MODELONLY"));
+
+        model->mHyperlinkVisibilityManager.revealLink(linkId);
+        QVERIFY2(!model->mHyperlinkVisibilityManager.isLinkConcealed(linkId), "the view-less model did not record the link as revealed");
+        QCOMPARE(model->buffer.lineBuffer.at(lineNumber), text);
+    }
+
+    // The shorthand and preset-property tables the compact syntax is parsed
+    // against used to be filled in by eight TConsole::initializeOSC8*Feature()
+    // calls from the widget's constructor, so a model with no view held none of
+    // them and "s=..." stayed "s" instead of becoming "style".
+    void test_aModelWithNoViewKnowsTheCompactShorthands()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+
+        auto model = std::make_shared<TConsoleModel>(host);
+        THyperlinkCompactManager& compact = model->mHyperlinkCompactManager;
+
+        QMap<QString, QString> compactParams;
+        compactParams.insert(qsl("s"), qsl("color:red"));
+        compactParams.insert(qsl("v"), qsl("conceal"));
+        compactParams.insert(qsl("notashorthand"), qsl("left alone"));
+
+        const QMap<QString, QString> expanded = compact.expandShorthand(compactParams);
+        QCOMPARE(expanded.value(qsl("style")), qsl("color:red"));
+        QCOMPARE(expanded.value(qsl("visibility")), qsl("conceal"));
+        QVERIFY2(!expanded.contains(qsl("s")), "the shorthand was left unexpanded");
+        QCOMPARE(expanded.value(qsl("notashorthand")), qsl("left alone"));
+
+        QVERIFY2(compact.isPresetProperty(qsl("style")), "a view-less model does not know style can appear in a preset");
+        QVERIFY2(compact.isPresetProperty(qsl("selection")), "a view-less model does not know selection can appear in a preset");
+        QVERIFY2(!compact.isPresetProperty(qsl("notapresetproperty")), "every property is being treated as preset-aware");
+    }
+
+    // The end of it, through the real pipeline: a link registered by feeding an
+    // OSC 8 sequence, revealed by the manager's own 100ms timer, with the widget
+    // that used to own that timer already destroyed. Host co-owns the model, so
+    // the reveal has a buffer to write into and a timer to run on long after the
+    // view is gone.
+    void test_aDelayedRevealCompletesAfterTheViewIsDestroyed()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        host->mEnableOSC8Hyperlinks = true;
+        TMainConsole* console = host->mpConsole;
+        QVERIFY(console);
+
+        // Long enough that closing the profile below cannot eat the whole delay
+        // on a loaded sanitiser runner - the case checks that it has not, rather
+        // than assuming.
+        //
+        // Real escape bytes inside a Lua long-bracket string, rather than Lua's
+        // own "\027" escapes inside a C++ raw string literal: moc stops parsing
+        // a file at a raw string literal it cannot lex and silently emits no
+        // meta-object for whatever follows, which links as an undefined vtable.
+        const QString esc = QString(QChar(0x1B));
+        const QString stringTerminator = esc + QLatin1Char('\\');
+        const QString link = qsl("%1]8;;send:osc8split?config={\"visibility\":{\"action\":\"reveal\",\"delay\":8000}}%2HIDDENWORD%1]8;;%2").arg(esc, stringTerminator);
+        const QString feed = qsl("feedTriggers([==[OSCSPLIT1(%1)OSCSPLIT1\n]==])").arg(link);
+        QVERIFY2(host->getLuaInterpreter()->compileAndExecuteScript(feed), "feedTriggers() did not run, so no hyperlink was ever registered");
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        int lineNumber = -1;
+        QVERIFY2(QTest::qWaitFor(
+                         [&]() {
+                             lineNumber = lineHolding(model->buffer, qsl("OSCSPLIT1"));
+                             return lineNumber >= 0;
+                         },
+                         8000),
+                 "the line carrying the link never reached the buffer");
+        QCOMPARE(model->buffer.lineBuffer.at(lineNumber), qsl("OSCSPLIT1(          )OSCSPLIT1"));
+
+        destroyTheView(host);
+        QCOMPARE(&host->mainConsoleModel(), model.get());
+        QVERIFY2(model->buffer.lineBuffer.at(lineNumber) == qsl("OSCSPLIT1(          )OSCSPLIT1"), "the reveal had already run before the view was destroyed, so this case proves nothing");
+
+        QVERIFY2(QTest::qWaitFor(
+                         [&]() {
+                             return model->buffer.lineBuffer.at(lineNumber) == qsl("OSCSPLIT1(HIDDENWORD)OSCSPLIT1");
+                         },
+                         30000),
+                 "the concealed link never revealed itself once its view had gone");
+    }
+
+private:
+    // Answers rather than asserting: everything after the call dereferences the
+    // host, so a caller has to be able to stop.
+    Host* startProfile()
+    {
+        Host* host = TestProfile::create(mHostname, mLocalhost, mPort);
+        if (!host) {
+            qWarning("no active host available for the test");
+            return nullptr;
+        }
+        QSignalSpy connected(&host->mTelnet, &cTelnet::signal_connected);
+        if (host->mTelnet.getConnectionState() != QAbstractSocket::ConnectedState && !connected.wait(8000)) {
+            qWarning("could not connect to the stub");
+            return nullptr;
+        }
+        return host;
+    }
+
+    // Destroys the main console widget while Host - and the model it co-owns -
+    // live on, which is the window every view-less assertion here needs.
+    void destroyTheView(Host* host)
+    {
+        QPointer<TMainConsole> console = host->mpConsole;
+        // Forcing the close stops TMainConsole::closeEvent() asking whether the
+        // profile should be saved, which would block on a modal dialog here.
+        host->forceClose();
+        QVERIFY2(host->requestClose(), "closing the profile was refused");
+        QTest::qWait(500ms); // the console carries WA_DeleteOnClose
+
+        QVERIFY2(console.isNull(), "the main console view was not destroyed by closing the profile");
+        QVERIFY2(host->mpConsole.isNull(), "the host still points at a main console");
+    }
+
+    static int lineHolding(TBuffer& buffer, const QString& needle)
+    {
+        const int lastLine = buffer.getLastLineNumber();
+        for (int i = lastLine; i >= qMax(0, lastLine - 20); --i) {
+            if (i < buffer.lineBuffer.size() && buffer.lineBuffer.at(i).contains(needle)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    void deleteProfileDirectory()
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mHostname));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+};
+
+#include "HyperlinkModelSplitTest.moc"
+MUDLET_GROUPED_TEST_MAIN(HyperlinkModelSplitTest)

--- a/test/functional_tests/HyperlinkModelSplitTest.cpp
+++ b/test/functional_tests/HyperlinkModelSplitTest.cpp
@@ -30,10 +30,12 @@
 // test_aHyperlinkVisibilityChangeForcesBothPanesToRedraw, and is deliberately
 // not repeated here.
 //
-// Two of the cases run against a TConsoleModel that never had a view at all,
-// which is the state Host builds the main console's model in and the state a
-// headless profile would stay in. The third destroys a real profile's view and
-// leaves the model running, which is what a closing profile does for real.
+// test_aModelWithNoViewConcealsAndRevealsItsOwnBuffer and
+// test_aModelWithNoViewKnowsTheCompactShorthands run against a TConsoleModel
+// that never had a view at all, which is the state Host builds the main
+// console's model in and the state a headless profile would stay in.
+// test_aDelayedRevealCompletesAfterTheViewIsDestroyed destroys a real profile's
+// view and leaves the model running, which is what a closing profile does.
 
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
@@ -136,8 +138,9 @@ private slots:
     }
 
     // One set of managers per model, not one per widget. A rebase that left the
-    // widget building its own would compile and run, and every OSC 8 sequence
-    // would go on working - right up until the model was asked what it holds.
+    // widget building its own would compile, and most OSC 8 behaviour would go
+    // on working, because the translate path reaches the managers through the
+    // console either way.
     void test_theHyperlinkManagersAreTheModelsNotTheViews()
     {
         Host* host = startProfile();
@@ -196,8 +199,12 @@ private slots:
         const int startColumn = text.indexOf(qsl("HIDDENWORD"));
         const int length = QStringLiteral("HIDDENWORD").size();
         QVERIFY(startColumn > 0);
-        QVERIFY2(!model->mHyperlinkVisibilityManager.registerHyperlink(linkId, lineNumber, startColumn, length, qsl("HIDDENWORD"), styling),
-                 "a conceal link starts visible, so it must not ask for its text to be replaced");
+        // The return says whether the caller must blank the text out as it
+        // writes the line, which for a conceal-on-click link is no. Not asserted
+        // on: it is a copy of styling.visibility.isConcealed, so it would read
+        // false here whatever this test asked for. What proves the link was
+        // really tracked is the concealment below actually landing.
+        model->mHyperlinkVisibilityManager.registerHyperlink(linkId, lineNumber, startColumn, length, qsl("HIDDENWORD"), styling);
 
         model->mHyperlinkVisibilityManager.concealLink(linkId);
         QVERIFY2(model->mHyperlinkVisibilityManager.isLinkConcealed(linkId), "the view-less model did not record the link as concealed");
@@ -261,30 +268,35 @@ private slots:
         // meta-object for whatever follows, which links as an undefined vtable.
         const QString esc = QString(QChar(0x1B));
         const QString stringTerminator = esc + QLatin1Char('\\');
-        const QString link = qsl("%1]8;;send:osc8split?config={\"visibility\":{\"action\":\"reveal\",\"delay\":8000}}%2HIDDENWORD%1]8;;%2").arg(esc, stringTerminator);
+        const QString link = qsl("%1]8;;send:osc8split?config={\"visibility\":{\"action\":\"reveal\",\"delay\":20000}}%2HIDDENWORD%1]8;;%2").arg(esc, stringTerminator);
         const QString feed = qsl("feedTriggers([==[OSCSPLIT1(%1)OSCSPLIT1\n]==])").arg(link);
         QVERIFY2(host->getLuaInterpreter()->compileAndExecuteScript(feed), "feedTriggers() did not run, so no hyperlink was ever registered");
 
         std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        // feedTriggers() runs synchronously inside compileAndExecuteScript(), so
+        // the line is normally already there; this only covers a loaded runner.
         int lineNumber = -1;
         QVERIFY2(QTest::qWaitFor(
                          [&]() {
                              lineNumber = lineHolding(model->buffer, qsl("OSCSPLIT1"));
                              return lineNumber >= 0;
                          },
-                         8000),
+                         2000),
                  "the line carrying the link never reached the buffer");
-        QCOMPARE(model->buffer.lineBuffer.at(lineNumber), qsl("OSCSPLIT1(          )OSCSPLIT1"));
+        QCOMPARE(lineTextAt(model->buffer, lineNumber), qsl("OSCSPLIT1(          )OSCSPLIT1"));
 
+        // Closing the profile writes the whole profile, its map and its
+        // preinstalled packages out, which is why the reveal delay above is set
+        // far past anything that save can cost.
         destroyTheView(host);
         QCOMPARE(&host->mainConsoleModel(), model.get());
-        QVERIFY2(model->buffer.lineBuffer.at(lineNumber) == qsl("OSCSPLIT1(          )OSCSPLIT1"), "the reveal had already run before the view was destroyed, so this case proves nothing");
+        QVERIFY2(lineTextAt(model->buffer, lineNumber) == qsl("OSCSPLIT1(          )OSCSPLIT1"), "the reveal had already run before the view was destroyed, so this case proves nothing");
 
         QVERIFY2(QTest::qWaitFor(
                          [&]() {
-                             return model->buffer.lineBuffer.at(lineNumber) == qsl("OSCSPLIT1(HIDDENWORD)OSCSPLIT1");
+                             return lineTextAt(model->buffer, lineNumber) == qsl("OSCSPLIT1(HIDDENWORD)OSCSPLIT1");
                          },
-                         30000),
+                         60000),
                  "the concealed link never revealed itself once its view had gone");
     }
 
@@ -307,7 +319,7 @@ private:
     }
 
     // Destroys the main console widget while Host - and the model it co-owns -
-    // live on, which is the window every view-less assertion here needs.
+    // live on, which is the window the delayed-reveal case needs.
     void destroyTheView(Host* host)
     {
         QPointer<TMainConsole> console = host->mpConsole;
@@ -319,6 +331,16 @@ private:
 
         QVERIFY2(console.isNull(), "the main console view was not destroyed by closing the profile");
         QVERIFY2(host->mpConsole.isNull(), "the host still points at a main console");
+    }
+
+    // The buffer can be trimmed under a poll that runs for a minute, so an
+    // out-of-range index has to read as "not that text" rather than throw.
+    static QString lineTextAt(TBuffer& buffer, const int lineNumber)
+    {
+        if (lineNumber < 0 || lineNumber >= buffer.lineBuffer.size()) {
+            return QString();
+        }
+        return buffer.lineBuffer.at(lineNumber);
     }
 
     static int lineHolding(TBuffer& buffer, const QString& needle)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The three OSC 8 hyperlink managers move from the `TConsole` widget into `TConsoleModel`, so concealing and revealing a link no longer needs a view. `getHyperlink*Manager()` still returns them, so call sites are unchanged.
- `THyperlinkVisibilityManager`'s 14 reach-ins through the widget are gone: 2 buffer accesses now read the model, and 12 inline `update()` calls are replaced by the existing `visibilityChanged()` signal, which the view answers with `forceUpdate()`.
- `THyperlinkCompactManager` now populates its own shorthand tables (eight `TConsole::initializeOSC8*Feature()` methods deleted), and `THyperlinkSelectionManager` loses an unused `TConsole&` member.

#### Motivation for adding to Mudlet

Step 2 of the console-model extraction (#8681, after #9603): the trigger pipeline has to run without a widget, and the managers' "no view, no work" bail-out was exactly what stopped that.

#### Other info (issues closed, discussion etc)

Two deliberate deltas: the repaint connect is made for every console rather than only the main one (`forceUpdate()` is a superset of the old plain `update()`), and the GA/EOR prompt wire is now `Qt::UniqueConnection` since both ends outlive the widget that makes it.

Left alone on purpose: `TBuffer` still needs a widget to *register* a link (that is the TBuffer null-audit sub-PR), the screen-reader announcements move with step 3's `mudlet::` reach-ins, and `removeLinksOnLine()` remains callerless (#10122). `adjustLineNumbers()` gained a caller in `TBuffer::shrinkBuffer()` when #10119 merged - still behind that method's `mpConsole` guard, so trimming is view-gated until the register path moves.

**Test case:** re-run after merging development (#10119 and #10132 both landed under this branch): 138/138 `ctest`, Lua specs 3699 successes / 0 failures - including #10119's own `TrackedLinkTrimTest`. Four new `HyperlinkModelSplitTest` cases plus one in `FrontendRefreshSeamTest`, each proven red when its own wire is cut; the repaint wire stays gated by #10093 alone.

Assisted-by: Claude:claude-opus-5