### PR TITLE
Fix: Variables named with quotes or spaces can now be edited

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -385,27 +385,48 @@ static bool nameSharedWithASibling(TVar* var)
     return false;
 }
 
+// Whether what the saved and hidden bookkeeping holds under a root's name is
+// about that root alone. It keys a variable by the dotted path of names down to
+// it, so a root's own name is its whole key there - and, unlike the lookup above,
+// the key type is no part of that key. Two roots that read alike therefore share
+// one entry, and so do a root with a dot in its name and the member that path
+// names, which is why VarUnit::shouldSave() fences the latter off from the save.
+// The write has to be refused as well: renameVariableBookkeeping() moves the
+// entry, and would carry the other variable's marks off with it.
+static bool rootNameIsSharedBookkeeping(TVar* var)
+{
+    const QString name = var->getName();
+    if (name.contains(QLatin1Char('.'))) {
+        return true;
+    }
+    TVar* parent = var->getParent();
+    if (!parent) {
+        return false;
+    }
+    int matches = 0;
+    for (const TVar* sibling : parent->getChildren(false)) {
+        if (sibling->getName() == name && ++matches > 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Names the Variables view writes through. A key reaches Lua as bytes rather than
 // as text spliced into a chunk to be compiled, so what a key holds is nothing a
 // name has to survive, and whether that name still finds the variable is settled
-// by the lookup below. What is left is two things a root's name has to be:
-//  - a string key. getValue() pushes a root's key itself rather than through
-//    loadKey() as it does every level below, so a table- or function-keyed
-//    global shows no value at all and a write back would commit that blank over
-//    the real one. A number- or a boolean-keyed one does read back, but VarUnit
-//    names a root by its text alone, so _G[7] and _G["7"] are one entry to the
-//    saved and hidden bookkeeping.
-//  - free of dots, because that same bookkeeping keys a member by its dotted
-//    path, which makes _G["dotted.global"] and the member that path names one
-//    entry too. VarUnit::shouldSave() already refuses to save such a global;
-//    renameVariableBookkeeping() would still carry the member's marks off with a
-//    rename, so the write is refused here as well.
+// by the lookup below. Two things are left, and both are about roots: getValue()
+// pushes a root's key itself rather than through loadKey() as it does every level
+// below, and builds only a string, a number or a boolean key - so a table- or
+// function-keyed global shows no value at all, which a write back would commit
+// over the real one - and the bookkeeping under the name has to be the root's own.
 static bool nameTheEditorWritesThrough(TVar* var, const bool asRoot)
 {
     if (!asRoot) {
         return true;
     }
-    return var->getKeyType() == LUA_TSTRING && !var->getName().contains(QLatin1Char('.'));
+    const int keyType = var->getKeyType();
+    return (keyType == LUA_TSTRING || keyType == LUA_TNUMBER || keyType == LUA_TBOOLEAN) && !rootNameIsSharedBookkeeping(var);
 }
 
 // Whether a variable can be written back through the name the variable tree gave

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -20,7 +20,6 @@
  ***************************************************************************/
 
 #include <QDebug>
-#include <QRegularExpression>
 
 #include "LuaInterface.h"
 #include "VarUnit.h"
@@ -386,24 +385,27 @@ static bool nameSharedWithASibling(TVar* var)
     return false;
 }
 
-// Names the Variables view will write back through, which is narrower than what
-// the write paths can reach: they push keys through the C API, which carries any
-// key at all, while a string key holding a quote or a backslash and a root that
-// is not a plain identifier are refused here rather than written (#9908).
+// Names the Variables view writes through. A key reaches Lua as bytes rather than
+// as text spliced into a chunk to be compiled, so what a key holds is nothing a
+// name has to survive, and whether that name still finds the variable is settled
+// by the lookup below. What is left is two things a root's name has to be:
+//  - a string key. getValue() pushes a root's key itself rather than through
+//    loadKey() as it does every level below, so a table- or function-keyed
+//    global shows no value at all and a write back would commit that blank over
+//    the real one. A number- or a boolean-keyed one does read back, but VarUnit
+//    names a root by its text alone, so _G[7] and _G["7"] are one entry to the
+//    saved and hidden bookkeeping.
+//  - free of dots, because that same bookkeeping keys a member by its dotted
+//    path, which makes _G["dotted.global"] and the member that path names one
+//    entry too. VarUnit::shouldSave() already refuses to save such a global;
+//    renameVariableBookkeeping() would still carry the member's marks off with a
+//    rename, so the write is refused here as well.
 static bool nameTheEditorWritesThrough(TVar* var, const bool asRoot)
 {
-    const QString name = var->getName();
-    if (asRoot) {
-        static const QRegularExpression identifier(qsl("^[A-Za-z_][A-Za-z0-9_]*$"));
-        static const QSet<QString> luaKeywords{qsl("and"),   qsl("break"), qsl("do"),  qsl("else"), qsl("elseif"), qsl("end"),    qsl("false"), qsl("for"),  qsl("function"), qsl("if"),   qsl("in"),
-                                               qsl("local"), qsl("nil"),   qsl("not"), qsl("or"),   qsl("repeat"), qsl("return"), qsl("then"),  qsl("true"), qsl("until"),    qsl("while")};
-        // a keyword reads as an identifier but parses as itself
-        return var->getKeyType() == LUA_TSTRING && identifier.match(name).hasMatch() && !luaKeywords.contains(name);
-    }
-    if (var->getKeyType() != LUA_TSTRING) {
+    if (!asRoot) {
         return true;
     }
-    return !name.contains(QLatin1Char('\\')) && !name.contains(QLatin1Char('"')) && !name.contains(QLatin1Char('\n')) && !name.contains(QLatin1Char('\r'));
+    return var->getKeyType() == LUA_TSTRING && !var->getName().contains(QLatin1Char('.'));
 }
 
 // Whether a variable can be written back through the name the variable tree gave
@@ -416,7 +418,7 @@ static bool nameTheEditorWritesThrough(TVar* var, const bool asRoot)
 //    one (#9903). A variable a script has deleted since the tree was built is
 //    not found either.
 //  - no other member of the same table is shown under that name too.
-//  - the name is one the Variables view writes through, see above.
+//  - the root's name is one the Variables view writes through, see above.
 // What the variable holds is not part of the question: a script is free to have
 // changed that since the tree was built, and the name still finds it.
 bool LuaInterface::writableByName(TVar* var)
@@ -725,6 +727,16 @@ bool LuaInterface::renameVar(TVar* var)
                                        << "\": its key is a table or a function, which has no name to change.";
         var->abandonNewName();
         return false;
+    }
+
+    if (var->getNewName() == var->getName() && var->getNewKeyType() == var->getKeyType()) {
+        // The value goes onto the new key and the old key is nil'ed afterwards,
+        // so when the two are one key that pair is a delete. saveVar() arrives
+        // here whenever the user picks a key type its own coercion puts straight
+        // back - a string-keyed variable whose name reads as a number, told to
+        // take a number key.
+        var->clearNewName();
+        return true;
     }
 
     if (!newNameIsFree(var)) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8350,12 +8350,12 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     pItem->setData(0, Qt::UserRole, var->getValueType());
     pItem->setIcon(0, icon);
     mChangingVar = false;
-    // Said on selection rather than when the user tries to save: the value box
-    // filled in above is empty for the same reason, getValue() reaching the
-    // variable by this same name, and without this it reads as a real value.
+    // Said on selection rather than when the user tries to save: getValue() goes
+    // by this same name, so for most of what is refused here the value box filled
+    // in above is empty, and without this it reads as a real value.
     if (!lI->writableByName(var)) {
         //: Warning shown in the editor's Variables view for a variable it cannot write back to Lua. %1 is the name the variable is shown under.
-        showWarning(tr("\"%1\" cannot be changed here: Mudlet has no way to reach it in Lua under the name it is shown with, so anything saved for it would go somewhere else. "
+        showWarning(tr("\"%1\" cannot be changed here: Mudlet cannot safely change it under the name it is shown with, so anything saved for it could go somewhere else. "
                        "Its value may show up blank for the same reason. A script can still change it.")
                             .arg(var->getName().toHtmlEscaped()));
     }

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -572,7 +572,6 @@ private slots:
 
     void testRenameNumericKeyInTable()
     {
-        QSKIP("PENDING: renameVar missing else causes numeric keys to get both [N] and [\"N\"] appended");
         execLua(QStringLiteral("testTbl = {[1] = 'one'}"));
         interface->getVars(false);
         TVar* var = findChild(findChild(interface->getVarUnit()->getBase(), QStringLiteral("testTbl")), QStringLiteral("1"));
@@ -585,7 +584,6 @@ private slots:
 
     void testRenameNumericKeyToZeroInTable()
     {
-        QSKIP("PENDING: renameVar missing else causes numeric keys to get both [N] and [\"N\"] appended");
         execLua(QStringLiteral("testTbl = {[1] = 'one'}"));
         interface->getVars(false);
         TVar* var = findChild(findChild(interface->getVarUnit()->getBase(), QStringLiteral("testTbl")), QStringLiteral("1"));
@@ -598,7 +596,6 @@ private slots:
 
     void testRenameNumericKeyToNegativeInTable()
     {
-        QSKIP("PENDING: renameVar missing else causes numeric keys to get both [N] and [\"N\"] appended");
         execLua(QStringLiteral("testTbl = {[1] = 'one'}"));
         interface->getVars(false);
         TVar* var = findChild(findChild(interface->getVarUnit()->getBase(), QStringLiteral("testTbl")), QStringLiteral("1"));
@@ -623,7 +620,6 @@ private slots:
 
     void testRenameNumericToStringKeyInTable()
     {
-        QSKIP("PENDING: renameVar missing else causes numeric keys to get both [N] and [\"N\"] appended");
         execLua(QStringLiteral("testTbl = {[42] = 'val'}"));
         interface->getVars(false);
         TVar* var = findChild(findChild(interface->getVarUnit()->getBase(), QStringLiteral("testTbl")), QStringLiteral("42"));
@@ -636,14 +632,29 @@ private slots:
 
     void testRenameToSameName()
     {
-        QSKIP("PENDING: renameVar generates self-referencing code instead of no-op for same-name rename");
         execLua(QStringLiteral("sameName = 'val'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), QStringLiteral("sameName"));
         QVERIFY(var);
         var->setNewName(QStringLiteral("sameName"), LUA_TSTRING);
-        interface->renameVar(var);
+        QVERIFY(interface->renameVar(var));
         QCOMPARE(getLuaValue(QStringLiteral("sameName")), QStringLiteral("val"));
+    }
+
+    // The name the editor offers a string-keyed root under can read as a number,
+    // and picking the number key type for it coerces straight back to a string
+    // key - so the rename arrives with nothing to change and must not take the
+    // variable with it.
+    void testRenameOfANumericLookingGlobalToItsOwnKeyKeepsIt()
+    {
+        execLua(QStringLiteral("_G['42'] = 'val'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), QStringLiteral("42"));
+        QVERIFY(var);
+        QVERIFY(interface->writableByName(var));
+        var->setNewName(QStringLiteral("42"), LUA_TSTRING);
+        QVERIFY(interface->renameVar(var));
+        QCOMPARE(getLuaValue(QStringLiteral("_G['42']")), QStringLiteral("val"));
     }
 
     void testRenameDeeplyNested()
@@ -717,9 +728,7 @@ private slots:
         execLua(QStringLiteral("_G[99] = 'rootNum'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), QStringLiteral("99"));
-        if (!var) {
-            QSKIP("Root numeric keys may not be iterated by getVars");
-        }
+        QVERIFY(var);
         interface->deleteVar(var);
         QCOMPARE(getLuaValue(QStringLiteral("_G[99]")), QStringLiteral("nil"));
     }
@@ -895,19 +904,82 @@ private slots:
         QCOMPARE(shownAs42, 2);
     }
 
-    // The Variables view refuses a string key holding a backslash rather than
-    // writing it, even though the write paths reach such a key (#9908).
-    void testNotWritableByNameForAMemberWithABackslashInItsKey()
+    // A key reaches Lua as bytes, so what it holds is not the gate's business
+    // (#9908).
+    void testWritableByNameForAMemberWithABackslashInItsKey()
     {
         execLua(qsl("testTbl = {} testTbl['C:\\\\temp'] = 'value'"));
         interface->getVars(false);
         TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("C:\\temp"));
         QVERIFY2(member, "the walk did not name the member after its key");
-        QVERIFY(!interface->writableByName(member));
+        QVERIFY(interface->writableByName(member));
     }
 
-    // ...and only a plain identifier is a root it writes through: a dot in the
-    // name is what the tree and the save bookkeeping key member paths by.
+    void testWritableByNameForAMemberWithAQuoteInItsKey()
+    {
+        execLua(qsl("testTbl = {} testTbl['he said \"hi\"'] = 'value'"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("he said \"hi\""));
+        QVERIFY2(member, "the walk did not name the member after its key");
+        QVERIFY(interface->writableByName(member));
+    }
+
+    void testWritableByNameForAMemberWithANewlineInItsKey()
+    {
+        execLua(qsl("testTbl = {} testTbl['two\\nlines'] = 'value'"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("two\nlines"));
+        QVERIFY2(member, "the walk did not name the member after its key");
+        QVERIFY(interface->writableByName(member));
+    }
+
+    // ...and a root is named by its key just the same, whatever that key spells
+    void testWritableByNameForAGlobalThatIsNotAnIdentifier()
+    {
+        execLua(qsl("_G['a global with spaces'] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("a global with spaces"));
+        QVERIFY(var);
+        QVERIFY(interface->writableByName(var));
+        QCOMPARE(interface->getValue(var), qsl("value"));
+    }
+
+    void testWritableByNameForAGlobalNamedAfterALuaKeyword()
+    {
+        execLua(qsl("_G['end'] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("end"));
+        QVERIFY(var);
+        QVERIFY(interface->writableByName(var));
+        QCOMPARE(interface->getValue(var), qsl("value"));
+    }
+
+    // Still refused: VarUnit names a root by its text alone, so a mark put on
+    // _G[7] is the same entry as one put on _G["7"] and a rename moves whichever
+    // of the two the bookkeeping happens to hold.
+    void testNotWritableByNameForANumberKeyedGlobal()
+    {
+        execLua(qsl("_G[7] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("7"));
+        QVERIFY(var);
+        QCOMPARE(interface->getValue(var), qsl("value"));
+        QVERIFY(!interface->writableByName(var));
+    }
+
+    void testNotWritableByNameForABooleanKeyedGlobal()
+    {
+        execLua(qsl("_G[true] = 'value'"));
+        interface->getVars(false);
+        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("true"));
+        QVERIFY(var);
+        QCOMPARE(interface->getValue(var), qsl("value"));
+        QVERIFY(!interface->writableByName(var));
+    }
+
+    // Still refused: the saved and hidden bookkeeping keys a member path by the
+    // dots in it, so this global and a member "global" of a table "dotted" are
+    // the same entry to it.
     void testNotWritableByNameForAGlobalWithADotInItsName()
     {
         execLua(qsl("_G['dotted.global'] = 'value'"));
@@ -917,13 +989,52 @@ private slots:
         QVERIFY(!interface->writableByName(var));
     }
 
-    void testNotWritableByNameForANumberKeyedGlobal()
+    // ...and a global whose key is a table or a function, which getValue() has no
+    // way to put back on the stack at all, so the view would be writing the blank
+    // it showed over the real value
+    void testNotWritableByNameForATableOrFunctionKeyedGlobal_data()
     {
-        execLua(qsl("_G[7] = 'value'"));
+        QTest::addColumn<QString>("setup");
+        QTest::addColumn<int>("keyType");
+        QTest::newRow("table key") << qsl("_G[{}] = 'value'") << LUA_TTABLE;
+        QTest::newRow("function key") << qsl("_G[function() end] = 'value'") << LUA_TFUNCTION;
+    }
+
+    void testNotWritableByNameForATableOrFunctionKeyedGlobal()
+    {
+        QFETCH(QString, setup);
+        QFETCH(int, keyType);
+        execLua(setup);
         interface->getVars(false);
-        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("7"));
-        QVERIFY(var);
-        QVERIFY(!interface->writableByName(var));
+        QList<TVar*> matches;
+        for (TVar* root : interface->getVarUnit()->getBase()->getChildren(false)) {
+            if (root->getKeyType() == keyType) {
+                matches.append(root);
+            }
+        }
+        QCOMPARE(matches.size(), 1);
+        QVERIFY(interface->getValue(matches.constFirst()).isEmpty());
+        QVERIFY(!interface->writableByName(matches.constFirst()));
+    }
+
+    // What the gate is for: the Variables view asks it before writing, so a key
+    // it refuses is a key the user cannot edit at all, however well the write
+    // paths handle it.
+    void testAMemberWhoseKeyHoldsAQuoteCanBeEditedAndDeleted()
+    {
+        execLua(qsl("testTbl = {} testTbl['say \"hi\"'] = 'before' testTbl['neighbour'] = 'untouched'"));
+        interface->getVars(false);
+        TVar* member = findChild(findChild(interface->getVarUnit()->getBase(), qsl("testTbl")), qsl("say \"hi\""));
+        QVERIFY(member);
+
+        QVERIFY(interface->writableByName(member));
+        member->setValue(qsl("after"), LUA_TSTRING);
+        QVERIFY(interface->setValue(member));
+        QCOMPARE(getLuaValue(qsl("testTbl['say \"hi\"']")), qsl("after"));
+
+        interface->deleteVar(member);
+        QCOMPARE(getLuaValue(qsl("testTbl['say \"hi\"']")), qsl("nil"));
+        QCOMPARE(getLuaValue(qsl("testTbl.neighbour")), qsl("untouched"));
     }
 
     // The tables above a variable are reached by name too, so an ambiguous name
@@ -945,16 +1056,6 @@ private slots:
             ++checked;
         }
         QCOMPARE(checked, 2);
-    }
-
-    // ...and a keyword reads as an identifier without being one.
-    void testNotWritableByNameForAGlobalNamedAfterALuaKeyword()
-    {
-        execLua(qsl("_G['end'] = 'value'"));
-        interface->getVars(false);
-        TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("end"));
-        QVERIFY(var);
-        QVERIFY(!interface->writableByName(var));
     }
 
     // The tree is built by iterating the tables, which does not consult
@@ -1552,7 +1653,6 @@ private slots:
 
     void testRenameRootStringToNumericKey()
     {
-        QSKIP("PENDING: renameVar always uses string format for root-level renames");
         execLua(QStringLiteral("myvar = 'val'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), QStringLiteral("myvar"));
@@ -1565,13 +1665,10 @@ private slots:
 
     void testRenameRootNumericToStringKey()
     {
-        QSKIP("PENDING: renameVar always uses string format for root-level renames");
         execLua(QStringLiteral("_G[42] = 'val'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), QStringLiteral("42"));
-        if (!var) {
-            QSKIP("Root numeric keys may not be iterated by getVars");
-        }
+        QVERIFY(var);
         var->setNewName(QStringLiteral("myvar"), LUA_TSTRING);
         interface->renameVar(var);
         QCOMPARE(getLuaValue(QStringLiteral("myvar")), QStringLiteral("val"));

--- a/test/TVariableEditorTest.cpp
+++ b/test/TVariableEditorTest.cpp
@@ -954,27 +954,41 @@ private slots:
         QCOMPARE(interface->getValue(var), qsl("value"));
     }
 
-    // Still refused: VarUnit names a root by its text alone, so a mark put on
-    // _G[7] is the same entry as one put on _G["7"] and a rename moves whichever
-    // of the two the bookkeeping happens to hold.
-    void testNotWritableByNameForANumberKeyedGlobal()
+    void testWritableByNameForANumberKeyedGlobal()
     {
         execLua(qsl("_G[7] = 'value'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("7"));
         QVERIFY(var);
+        QVERIFY(interface->writableByName(var));
         QCOMPARE(interface->getValue(var), qsl("value"));
-        QVERIFY(!interface->writableByName(var));
     }
 
-    void testNotWritableByNameForABooleanKeyedGlobal()
+    void testWritableByNameForABooleanKeyedGlobal()
     {
         execLua(qsl("_G[true] = 'value'"));
         interface->getVars(false);
         TVar* var = findChild(interface->getVarUnit()->getBase(), qsl("true"));
         QVERIFY(var);
+        QVERIFY(interface->writableByName(var));
         QCOMPARE(interface->getValue(var), qsl("value"));
-        QVERIFY(!interface->writableByName(var));
+    }
+
+    // ...but not once a global of another key type reads the same. Both are
+    // "7" to the saved and hidden bookkeeping, which the key type is no part
+    // of, so a rename of either takes the other one's marks with it.
+    void testNotWritableByNameWhenTwoGlobalsAreShownUnderOneName()
+    {
+        execLua(qsl("_G[7] = 'number keyed' _G['7'] = 'string keyed'"));
+        interface->getVars(false);
+        int shownAs7 = 0;
+        for (TVar* root : interface->getVarUnit()->getBase()->getChildren(false)) {
+            if (root->getName() == qsl("7")) {
+                ++shownAs7;
+                QVERIFY(!interface->writableByName(root));
+            }
+        }
+        QCOMPARE(shownAs7, 2);
     }
 
     // Still refused: the saved and hidden bookkeeping keys a member path by the

--- a/test/functional_tests/VariableEditorWriteBackTest.cpp
+++ b/test/functional_tests/VariableEditorWriteBackTest.cpp
@@ -247,9 +247,9 @@ private slots:
         execLua(qsl("nulKeyTable = nil nulKeyDecoy = nil"));
     }
 
-    // A global whose name is not an identifier is not reached by that name
-    // either: the write paths put a root into Lua source bare, so a dot in it
-    // reads as an index into whatever global comes before the dot.
+    // A global whose own name holds a dot is not the editor's to write either:
+    // the saved and hidden bookkeeping keys a member by its dotted path, so this
+    // global and the member that path names are one entry to it.
     void test_editingAGlobalWithADotInItsNameLeavesOtherTablesAlone()
     {
         execLua(qsl("dotted = {} _G['dotted.global'] = 'dotted global value' dottedDecoy = 'decoy value'"));
@@ -316,6 +316,48 @@ private slots:
         QVERIFY2(luaHolds(qsl("stringKeyGlobal"), qsl("edited global value")), "editing the global did not reach Lua");
 
         execLua(qsl("stringKeyGlobal = nil stringKeyDecoy = nil"));
+    }
+
+    // A key reaches Lua as bytes, so a quote in one is nothing the view has to
+    // work around (#10114).
+    void test_aMemberWhoseKeyHoldsAQuoteIsEditable()
+    {
+        execLua(qsl("quoteKeyTable = {} quoteKeyTable['say \"hi\"'] = 'quoted member value' quoteKeyDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pMember = findVariableItem({qsl("quoteKeyTable"), qsl("say \"hi\"")});
+        QVERIFY2(pMember, "the Variables view did not show the member under the name Lua gives its key");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("quoteKeyDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pMember);
+        QVERIFY2(!bannerShowing(), "a variable the editor can write must not be reported as one it cannot");
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited member value"));
+        selectVariable(pDecoy);
+        QCOMPARE(luaMemberCount(qsl("quoteKeyTable")), 1);
+        QVERIFY2(luaHolds(qsl("quoteKeyTable['say \"hi\"']"), qsl("edited member value")), "editing the member did not reach Lua");
+
+        execLua(qsl("quoteKeyTable = nil quoteKeyDecoy = nil"));
+    }
+
+    // ...and a global's name is no different, identifier or not.
+    void test_aGlobalWhoseNameIsNotAnIdentifierIsEditable()
+    {
+        execLua(qsl("_G['a global with spaces'] = 'spaced global value' spacedDecoy = 'decoy value'"));
+        mpEditor->repopulateVars();
+
+        QTreeWidgetItem* pGlobal = findVariableItem({qsl("a global with spaces")});
+        QVERIFY2(pGlobal, "the Variables view did not show the global");
+        QTreeWidgetItem* pDecoy = findVariableItem({qsl("spacedDecoy")});
+        QVERIFY2(pDecoy, "the Variables view did not show the variable to click away to");
+
+        selectVariable(pGlobal);
+        QVERIFY2(!bannerShowing(), "a variable the editor can write must not be reported as one it cannot");
+        mpEditor->mpSourceEditorEdbeeDocument->setText(qsl("edited global value"));
+        selectVariable(pDecoy);
+        QVERIFY2(luaHolds(qsl("_G['a global with spaces']"), qsl("edited global value")), "editing the global did not reach Lua");
+
+        execLua(qsl("_G['a global with spaces'] = nil spacedDecoy = nil"));
     }
 
     // Dropping an item somewhere else in the Variables view rearranges the view


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The Variables view refused to write a variable whose key held a quote, a backslash or a newline, and any global that was not a plain non-keyword Lua identifier. Selecting one showed a warning banner, and an edit was silently dropped on the way out. Those names only mattered while the write paths built Lua source, which they stopped doing in #10114.
- Two things are still refused, both about globals: a key that is a table or a function, which `getValue()` cannot read the global back by, so the view would commit the blank it showed over the real value; and a name the saved and hidden bookkeeping does not hold for that global alone - a dot in it reads as a path into a table, and another global of any key type shown under the same text (`_G[7]` beside `_G["7"]`) is the same entry, so a rename carries the other one's marks off.
- `renameVar()` comes with it: a rename onto the key the variable already has wrote the value on and then nil'ed it straight off, deleting it. The view reaches that for a string-keyed variable whose name reads as a number, and relaxing the gate newly reached it for globals.
- 12 tests fail without this - 10 in `TVariableEditorTest`, 2 driving the real editor in `VariableEditorWriteBackTest`. Six `QSKIP`s whose reasons described the pre-#10114 rename are gone, five of them collecting coverage that already passed.

#### Motivation for adding to Mudlet

A table key a script captured from the game - a line holding a quote or a backslash - was a variable players could look at but not touch.

#### Other info (issues closed, discussion etc)

Follow-up to #10114, which flagged this gate as conservatism worth relaxing separately. The banner's wording is adjusted too: for what is still refused, Mudlet can reach the variable, it just cannot change it safely under that name.

**Test case:** `lua t = {} t['say "hi"'] = 'before'` - open the editor's Variables view and select `say "hi"` under `t`. No warning banner; change the value box, click another variable, then `lua display(t)` - the new value is there under the same key.

Suite: TVariableEditorTest 139/139, VariableEditorWriteBackTest 17/17, ctest 132/132.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
