### PR TITLE
Infra: move logging into the core console model so it works without a window

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,7 @@ set(mudlet_SRCS
     TBuffer.cpp
     TCommandLine.cpp
     TConsole.cpp
+    TConsoleModel.cpp
     TDebug.cpp
     TDetachedWindow.cpp
     TDockWidget.cpp

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1941,6 +1941,16 @@ TConsoleModel& Host::mainConsoleModel()
     return *mpMainConsoleModel;
 }
 
+void Host::raiseLoggingAnnouncement(const bool isLogging, const QString& logFileName)
+{
+    emit signal_loggingAnnouncement(isLogging, logFileName);
+}
+
+void Host::raiseLoggingStateChanged(const bool isLogging)
+{
+    emit signal_loggingStateChanged(isLogging);
+}
+
 // The per-line trigger orchestration used to live on the main-console widget
 // (TMainConsole::runTriggers). It drives model state only, so it runs here
 // against the core model and needs no view (#8681).

--- a/src/Host.h
+++ b/src/Host.h
@@ -279,8 +279,18 @@ public:
     // per-line trigger pipeline (runTriggers) can drive it without a view. The
     // view reaches the same instance via TConsole::model().
     TConsoleModel& mainConsoleModel();
+    // Null until the very end of this Host's constructor: the model owns a
+    // TBuffer, and a TBuffer clears itself while being built - so core buffer
+    // code that can run that early has to be able to see "not there yet"
+    // rather than dereference the shared_ptr.
+    TConsoleModel* mainConsoleModelOrNull() const { return mpMainConsoleModel.get(); }
     std::shared_ptr<TConsoleModel> sharedMainConsoleModel();
     void runTriggers(int line);
+    // The log lifecycle lives in the core console model, which is a plain
+    // struct and cannot emit, so it raises the two view-only halves of a
+    // logging change through here.
+    void raiseLoggingAnnouncement(const bool isLogging, const QString& logFileName);
+    void raiseLoggingStateChanged(const bool isLogging);
     void postIrcMessage(const QString&, const QString&, const QString&);
     void enableTimer(const QString&);
     void disableTimer(const QString&);
@@ -912,6 +922,12 @@ signals:
     void signal_showMapperScriptReminder();
     void signal_showUnpackingProgress(const QString& message, const QString& title);
     void signal_hideUnpackingProgress();
+    // Raised where the console widget used to print this itself: while logging
+    // is still off when a log starts and already off when one stops, so the
+    // announcement lands outside the log file exactly as it used to.
+    void signal_loggingAnnouncement(const bool isLogging, const QString& logFileName);
+    // Raised once a logging change has settled, for the frontend's log button.
+    void signal_loggingStateChanged(const bool isLogging);
 
 private slots:
     void slot_purgeTemps();

--- a/src/Host.h
+++ b/src/Host.h
@@ -283,7 +283,7 @@ public:
     // TBuffer, and a TBuffer clears itself while being built - so core buffer
     // code that can run that early has to be able to see "not there yet"
     // rather than dereference the shared_ptr.
-    TConsoleModel* mainConsoleModelOrNull() const { return mpMainConsoleModel.get(); }
+    TConsoleModel* mainConsoleModelOrNull() { return mpMainConsoleModel.get(); }
     std::shared_ptr<TConsoleModel> sharedMainConsoleModel();
     void runTriggers(int line);
     // The log lifecycle lives in the core console model, which is a plain
@@ -922,9 +922,10 @@ signals:
     void signal_showMapperScriptReminder();
     void signal_showUnpackingProgress(const QString& message, const QString& title);
     void signal_hideUnpackingProgress();
-    // Raised where the console widget used to print this itself: while logging
-    // is still off when a log starts and already off when one stops, so the
-    // announcement lands outside the log file exactly as it used to.
+    // Raised while logging is still off when a log starts, and already off when
+    // one stops, so that the frontend's print lands on screen but outside the
+    // log file. That only holds while the connection is direct - a queued one
+    // would deliver it after the flag has moved and log the announcement.
     void signal_loggingAnnouncement(const bool isLogging, const QString& logFileName);
     // Raised once a logging change has settled, for the frontend's log button.
     void signal_loggingStateChanged(const bool isLogging);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5288,18 +5288,14 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
 // This only works on the Main Console for a profile
 void TBuffer::log(int fromLine, int toLine)
 {
-    // The log destination lives on the main console view, which the model this
-    // buffer belongs to can outlive (Host co-owns it), so there is nowhere to
-    // log to once the view has gone. Test this buffer's own back-pointer:
-    // TConsole unbinds it as it starts to tear down, whereas Host::mpConsole
-    // only nulls itself in ~QObject(), i.e. once the widget it still points at
-    // is long since half-destroyed:
-    if (mpConsole.isNull() || mpHost.isNull() || mpHost->mpConsole.isNull()) {
-        return;
-    }
-
-    TBuffer* pB = &mpHost->mpConsole->buffer;
-    if (pB != this || !mpHost->mpConsole->mLogToLogFile) {
+    // The log file, its stream and the on/off flag are all core model state
+    // now, so logging needs a Host but no view whatsoever - which is what lets
+    // a profile with no main console widget write a log at all.
+    // mainConsoleModelOrNull() rather than mainConsoleModel(): a TBuffer clears
+    // itself while it is being constructed, and the main console's one is
+    // constructed before Host has taken hold of the model holding it.
+    TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
+    if (!pModel || this != &pModel->buffer || !pModel->mLogToLogFile) {
         return;
     }
 
@@ -5316,8 +5312,8 @@ void TBuffer::log(int fromLine, int toLine)
     // if we've been called to log the same line - which can happen when the user
     // enters a command after in-game text - then skip recording the last line
     if (fromLine != lastLoggedFromLine && toLine != lastloggedToLine) {
-        mpHost->mpConsole->mLogStream << lastTextToLog;
-        mpHost->mpConsole->mLogStream.flush();
+        pModel->mLogStream << lastTextToLog;
+        pModel->mLogStream.flush();
     }
 
     // record the last log call into a temporary buffer - we'll actually log
@@ -5353,31 +5349,28 @@ void TBuffer::logRemainingOutput()
     lastLoggedFromLine = -1;
     lastloggedToLine = -1;
 
-    // The log file is the view's; see TBuffer::log() on why this buffer's own
-    // back-pointer is the one to test:
-    if (mpConsole.isNull() || mpHost.isNull() || mpHost->mpConsole.isNull()) {
+    // No mLogToLogFile test on purpose: this is called as logging is turned
+    // off, once the flag is already down, and the pending line still has to
+    // reach the file. See TBuffer::log() on the null-model case.
+    TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
+    if (!pModel) {
         return;
     }
 
-    mpHost->mpConsole->mLogStream << pendingText;
-    mpHost->mpConsole->mLogStream.flush();
+    pModel->mLogStream << pendingText;
+    pModel->mLogStream.flush();
 }
 
 // logs a string directly to the log file
 void TBuffer::appendLog(const QString& text)
 {
-    // See TBuffer::log() on why this buffer's own back-pointer is the one to
-    // test for the view still being there:
-    if (mpConsole.isNull() || mpHost.isNull() || mpHost->mpConsole.isNull()) {
+    // See TBuffer::log() on why the model is reached this way:
+    TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
+    if (!pModel || this != &pModel->buffer || !pModel->mLogToLogFile) {
         return;
     }
 
-    TBuffer* pB = &mpHost->mpConsole->buffer;
-    if (pB != this || !mpHost->mpConsole->mLogToLogFile) {
-        return;
-    }
-
-    mpHost->mpConsole->mLogStream << text;
+    pModel->mLogStream << text;
 }
 
 // Rewraps everything from startLine to the end of the buffer, and answers where
@@ -5667,8 +5660,12 @@ void TBuffer::clear()
 {
     // Clearing the display is not gagging: flush any deferred log text before
     // the deleteLines() calls below would discard it, so a received line that
-    // was still pending for logging is not lost from the log file
-    if (!mpConsole.isNull() && !mpHost.isNull() && mpHost->mpConsole && this == &mpHost->mpConsole->buffer && mpHost->mpConsole->mLogToLogFile) {
+    // was still pending for logging is not lost from the log file. See
+    // TBuffer::log() on why the model is reached through the null-tolerant
+    // accessor - this runs from the TBuffer constructor, which the main
+    // console's model is still inside of.
+    TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
+    if (pModel && this == &pModel->buffer && pModel->mLogToLogFile) {
         logRemainingOutput();
 
         // A line whose own trigger calls clearWindow() has been committed and
@@ -5678,10 +5675,10 @@ void TBuffer::clear()
         // are not lost. mCommitLineIndices holds them in display order.
         for (const int commitLineIndex : mCommitLineIndices) {
             if (commitLineIndex >= 0 && commitLineIndex < static_cast<int>(lineBuffer.size())) {
-                mpHost->mpConsole->mLogStream << assembleLog(commitLineIndex, commitLineIndex);
+                pModel->mLogStream << assembleLog(commitLineIndex, commitLineIndex);
             }
         }
-        mpHost->mpConsole->mLogStream.flush();
+        pModel->mLogStream.flush();
 
         lastTextToLog.clear();
         lastLoggedFromLine = -1;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5288,12 +5288,12 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
 // This only works on the Main Console for a profile
 void TBuffer::log(int fromLine, int toLine)
 {
-    // The log file, its stream and the on/off flag are all core model state
-    // now, so logging needs a Host but no view whatsoever - which is what lets
-    // a profile with no main console widget write a log at all.
-    // mainConsoleModelOrNull() rather than mainConsoleModel(): a TBuffer clears
-    // itself while it is being constructed, and the main console's one is
-    // constructed before Host has taken hold of the model holding it.
+    // The log file, its stream and the on/off flag are core model state, so
+    // this needs a Host but no view - which is what lets a profile with no main
+    // console widget write a log at all. The one thing that still notices a
+    // missing view is the HTML timestamp background in bufferToHtml().
+    // See TBuffer::clear() on why the model is reached through the
+    // null-tolerant accessor.
     TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
     if (!pModel || this != &pModel->buffer || !pModel->mLogToLogFile) {
         return;
@@ -5349,11 +5349,14 @@ void TBuffer::logRemainingOutput()
     lastLoggedFromLine = -1;
     lastloggedToLine = -1;
 
-    // No mLogToLogFile test on purpose: this is called as logging is turned
-    // off, once the flag is already down, and the pending line still has to
-    // reach the file. See TBuffer::log() on the null-model case.
+    // No mLogToLogFile test on purpose: both callers have already decided the
+    // pending line must be flushed - toggleLogging() once it has cleared the
+    // flag, clear() while it is still set. The file being open is tested
+    // instead, because a QTextStream written to after its device closed latches
+    // WriteFailed and then silently keeps every later write in its own buffer,
+    // to be replayed into the next log file the moment setDevice() rearms it.
     TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
-    if (!pModel) {
+    if (!pModel || this != &pModel->buffer || !pModel->mLogFile.isOpen()) {
         return;
     }
 
@@ -5660,10 +5663,10 @@ void TBuffer::clear()
 {
     // Clearing the display is not gagging: flush any deferred log text before
     // the deleteLines() calls below would discard it, so a received line that
-    // was still pending for logging is not lost from the log file. See
-    // TBuffer::log() on why the model is reached through the null-tolerant
-    // accessor - this runs from the TBuffer constructor, which the main
-    // console's model is still inside of.
+    // was still pending for logging is not lost from the log file.
+    // mainConsoleModelOrNull() rather than mainConsoleModel() because this runs
+    // from the TBuffer constructor, and the main console's buffer is built
+    // inside the very model Host has not taken hold of yet.
     TConsoleModel* pModel = mpHost.isNull() ? nullptr : mpHost->mainConsoleModelOrNull();
     if (pModel && this == &pModel->buffer && pModel->mLogToLogFile) {
         logRemainingOutput();

--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -35,25 +35,24 @@ TConsoleModel::TConsoleModel(Host* pHost)
 {
 }
 
-// Moved here verbatim from TMainConsole so that a profile with no main console
-// widget can start, write and stop a log: moving only the stream would have
-// left the open/rotate/close half on the widget, and nothing view-less could
-// have opened a file to stream into.
+// Two gotchas in here:
 //
-// Two gotchas carried over with it:
-//
-// - the text written *into* the log file is deliberately translated against the
-//   "TMainConsole" context it came from. The catalogue is keyed on context plus
-//   source text, so re-keying these under TConsoleModel would orphan every
-//   translation they already have. The two messages printed on *screen* stayed
-//   behind in TMainConsole with their own context intact.
-// - QFontInfo(Host::getDisplayFont()) is the same font QWidget::fontInfo() used
-//   to report here, because Host::getDisplayFont() hands back the main
-//   console's own QFont - and unlike the widget call it still answers when
-//   there is no widget.
+// - the strings destined for the log file itself are translated against the
+//   "TMainConsole" context rather than through tr(). The catalogue is keyed on
+//   context plus source text, so re-keying them under TConsoleModel would
+//   orphan every translation they already have. The messages printed on
+//   *screen* live in TMainConsole and keep their context that way.
+// - QFontInfo(Host::getDisplayFont()) is what QWidget::fontInfo() reports for
+//   the main console, because Host::getDisplayFont() hands back that widget's
+//   own QFont - and unlike the widget call it still answers with no widget.
 void TConsoleModel::toggleLogging(bool isMessageEnabled)
 {
-    if (mpHost.isNull()) {
+    // Logging is profile-wide, not per-console: the autolog sentinel, the log
+    // directory and the filename format all live on the Host, and TBuffer
+    // resolves the stream through Host's main model. Running this against any
+    // other model would open a second handle onto the same file and clobber
+    // that profile-wide state.
+    if (mpHost.isNull() || this != mpHost->mainConsoleModelOrNull()) {
         return;
     }
 
@@ -124,18 +123,19 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
         mLogStream.setDevice(&mLogFile);
 
         if (isMessageEnabled) {
+            // The frontend prints this synchronously, and anything printed on
+            // the console once the flag below is up is IMMEDIATELY POSTED into
+            // the log file - so it has to be raised while logging is still off.
             mpHost->raiseLoggingAnnouncement(true, mLogFile.fileName());
-            // This puts text onto console that is IMMEDIATELY POSTED into log file so
-            // must be done BEFORE logging starts - or actually mLogToLogFile gets set!
         }
         mLogToLogFile = true;
     } else {
         QFile::remove(loggingPath);
         mLogToLogFile = false;
         if (isMessageEnabled) {
+            // Likewise raised only once the flag above is down, or the frontend's
+            // print would be posted into the log file it is announcing the end of.
             mpHost->raiseLoggingAnnouncement(false, mLogFile.fileName());
-            // This puts text onto console that is IMMEDIATELY POSTED into log file so
-            // must be done AFTER logging ends - or actually mLogToLogFile gets reset!
         }
     }
 
@@ -145,12 +145,9 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
             QString log;
             QTextStream logStream(&log);
             // No setting a QTextCodec here, they don't work on QString based QTextStreams
-            QStringList fontsList;                                     // List of fonts to become the font-family entry for
-                                                                       // the master css in the header
-            fontsList << QFontInfo(mpHost->getDisplayFont()).family(); // Seems to be the best way to get the
-                                                                       // font in use, as different TConsole
-                                                                       // instances within the same profile
-                                                                       // might have different fonts
+            // The font-family entry for the master css in the header
+            QStringList fontsList;
+            fontsList << QFontInfo(mpHost->getDisplayFont()).family();
             fontsList << qsl("Courier New");
             fontsList << qsl("Monospace");
             fontsList << qsl("Courier");

--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -1,0 +1,256 @@
+/***************************************************************************
+ *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
+ *   Copyright (C) 2014-2022 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TConsoleModel.h"
+
+#include "Host.h"
+#include "mudlet.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QFontInfo>
+
+TConsoleModel::TConsoleModel(Host* pHost)
+: buffer(pHost)
+, mpHost(pHost)
+{
+}
+
+// Moved here verbatim from TMainConsole so that a profile with no main console
+// widget can start, write and stop a log: moving only the stream would have
+// left the open/rotate/close half on the widget, and nothing view-less could
+// have opened a file to stream into.
+//
+// Two gotchas carried over with it:
+//
+// - the text written *into* the log file is deliberately translated against the
+//   "TMainConsole" context it came from. The catalogue is keyed on context plus
+//   source text, so re-keying these under TConsoleModel would orphan every
+//   translation they already have. The two messages printed on *screen* stayed
+//   behind in TMainConsole with their own context intact.
+// - QFontInfo(Host::getDisplayFont()) is the same font QWidget::fontInfo() used
+//   to report here, because Host::getDisplayFont() hands back the main
+//   console's own QFont - and unlike the widget call it still answers when
+//   there is no widget.
+void TConsoleModel::toggleLogging(bool isMessageEnabled)
+{
+    if (mpHost.isNull()) {
+        return;
+    }
+
+    const auto loggingPath = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"));
+    QFile file(loggingPath);
+    const QDateTime logDateTime = QDateTime::currentDateTime();
+    if (!mLogToLogFile) {
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            qWarning() << "TConsoleModel: failed to open autolog file for writing:" << file.errorString();
+            return;
+        }
+        QTextStream out(&file);
+        file.close();
+
+        QString directoryLogFile;
+        QString logFileName;
+        // If no log directory is set, default to Mudlet's replay and log files path
+        if (mpHost->mLogDir == nullptr || mpHost->mLogDir.isEmpty()) {
+            directoryLogFile = mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, mpHost->getName());
+        } else {
+            directoryLogFile = mpHost->mLogDir;
+        }
+        // The format being empty is a signal value that means use a specified
+        // name:
+        if (mpHost->mLogFileNameFormat.isEmpty()) {
+            if (mpHost->mLogFileName.isEmpty()) {
+                // If no log name is set, use the default placeholder
+                //: Must be a valid default filename for a log-file and is used if the user does not enter any other value (Ensure all instances have the same translation {one of two copies}).
+                logFileName = QCoreApplication::translate("TMainConsole", "logfile");
+            } else {
+                // Otherwise a specific name as one is given
+                logFileName = mpHost->mLogFileName;
+            }
+        } else {
+            logFileName = logDateTime.toString(mpHost->mLogFileNameFormat);
+        }
+
+        // The preset file name formats are derived from date/times so that
+        // alphabetical filename and date sort order are the same...
+        const QDir dirLogFile;
+        if (!dirLogFile.exists(directoryLogFile)) {
+            dirLogFile.mkpath(directoryLogFile);
+        }
+
+        mpHost->mIsCurrentLogFileInHtmlFormat = mpHost->mIsNextLogFileInHtmlFormat;
+        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
+            mLogFileName = qsl("%1/%2.html").arg(directoryLogFile, logFileName);
+        } else {
+            mLogFileName = qsl("%1/%2.txt").arg(directoryLogFile, logFileName);
+        }
+        mLogFile.setFileName(mLogFileName);
+        // We do not want to use WriteOnly here:
+        // Append = "The device is opened in append mode so that all data is
+        // written to the end of the file."
+        // WriteOnly = "The device is open for writing. Note that this mode
+        // implies Truncate."
+        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
+            if (!mLogFile.open(QIODevice::ReadWrite)) {
+                qWarning() << "TConsoleModel: failed to open log file for reading/writing:" << mLogFile.errorString();
+                return;
+            }
+        } else {
+            if (!mLogFile.open(QIODevice::Append)) {
+                qWarning() << "TConsoleModel: failed to open log file for appending:" << mLogFile.errorString();
+                return;
+            }
+        }
+        mLogStream.setDevice(&mLogFile);
+
+        if (isMessageEnabled) {
+            mpHost->raiseLoggingAnnouncement(true, mLogFile.fileName());
+            // This puts text onto console that is IMMEDIATELY POSTED into log file so
+            // must be done BEFORE logging starts - or actually mLogToLogFile gets set!
+        }
+        mLogToLogFile = true;
+    } else {
+        QFile::remove(loggingPath);
+        mLogToLogFile = false;
+        if (isMessageEnabled) {
+            mpHost->raiseLoggingAnnouncement(false, mLogFile.fileName());
+            // This puts text onto console that is IMMEDIATELY POSTED into log file so
+            // must be done AFTER logging ends - or actually mLogToLogFile gets reset!
+        }
+    }
+
+    if (mLogToLogFile) {
+        // Logging is being turned on
+        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
+            QString log;
+            QTextStream logStream(&log);
+            // No setting a QTextCodec here, they don't work on QString based QTextStreams
+            QStringList fontsList;                                     // List of fonts to become the font-family entry for
+                                                                       // the master css in the header
+            fontsList << QFontInfo(mpHost->getDisplayFont()).family(); // Seems to be the best way to get the
+                                                                       // font in use, as different TConsole
+                                                                       // instances within the same profile
+                                                                       // might have different fonts
+            fontsList << qsl("Courier New");
+            fontsList << qsl("Monospace");
+            fontsList << qsl("Courier");
+            fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
+
+            logStream << "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
+            logStream << "<html>\n";
+            logStream << " <head>\n";
+            logStream << "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>";
+            // put the charset as early as possible as the parser MUST restart when it
+            // switches away from the ASCII default
+            logStream << "  <meta name='generator' content='" << QCoreApplication::translate("TMainConsole", "Mudlet MUD Client version: %1%2").arg(APP_VERSION, mudlet::self()->mAppBuild) << "'>\n";
+            // Nice to identify what made the file!
+            logStream << "  <title>" << QCoreApplication::translate("TMainConsole", "Mudlet, log from %1 profile").arg(mpHost->getName()) << "</title>\n";
+            // Web-page title
+            logStream << "  <style type='text/css'>\n";
+            logStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(" << mpHost->mFgColor.red() << ","
+                      << mpHost->mFgColor.green() << "," << mpHost->mFgColor.blue() << "); background-color:rgb(" << mpHost->mBgColor.red() << "," << mpHost->mBgColor.green() << ","
+                      << mpHost->mBgColor.blue() << ");}\n";
+            logStream << "        span { white-space: pre-wrap; }\n";
+
+            if (mpHost->getEnableBlinkText()) {
+                logStream << "        @keyframes blink-slow { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }\n";
+                logStream << "        @keyframes blink-fast { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }\n";
+                logStream << "        .blink-slow { animation: blink-slow 2s ease-in-out infinite; }\n";
+                logStream << "        .blink-fast { animation: blink-fast 1s ease-in-out infinite; }\n";
+            }
+
+            logStream << "     -->\n";
+            logStream << "  </style>\n";
+            logStream << "  </head>\n";
+            bool isAtBody = false;
+            bool foundBody = false;
+            while (!mLogStream.atEnd()) {
+                const QString line = mLogStream.readLine();
+                if (line.contains("<body><div>")) {
+                    // Begin writing old log to the current log when the body is
+                    // found.
+                    isAtBody = true;
+                    foundBody = true;
+                } else if (line.contains("</div></body>")) {
+                    // Stop writing to current log once the end of the old log's
+                    // <body> is reached.
+                    isAtBody = false;
+                }
+
+                if (isAtBody) {
+                    logStream << line << "\n";
+                }
+            }
+            if (!foundBody) {
+                logStream << "  <body><div>\n";
+            } else {
+                // Put a horizontal line between separate log sessions
+                logStream << "  </div><hr><div>\n";
+            }
+            logStream
+                    << qsl("<p>%1</p>\n")
+                               .arg(logDateTime.toString(
+                                       //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
+                                       QCoreApplication::translate("TMainConsole", "'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
+            // <div></div> tags required around outside of the body <span></spans> for
+            // strict HTML 4 as we do not use <p></p>s or anything else
+
+            if (!mLogFile.resize(0)) {
+                qWarning() << "TConsoleModel::toggleLogging(...) ERROR - Failed to resize HTML Logfile - it may now be corrupted...!";
+            }
+            mLogStream << log;
+            mLogFile.flush();
+        } else {
+            // File is NOT an HTML one but pure text:
+            // Put a horizontal line between separate log sessions
+            // Unfortunately QLatin1String does not have a repeated() method,
+            // but it does mean we can use non-ASCII/Latin1 characters:
+            // Using 10x U+23AF Horizontal line extension from "Box drawing characters":
+            if (mLogFile.size() > 5) {
+                // Allow a few junk characters ("BOM"???) at the very start of
+                // file to not trigger the insertion of this line:
+                mLogStream << qsl("⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯").repeated(8).append(QChar::LineFeed);
+            }
+            mLogStream << qsl("%1\n").arg(logDateTime.toString(
+                    //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
+                    QCoreApplication::translate("TMainConsole", "'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
+        }
+    } else {
+        // Logging is being turned off
+        buffer.logRemainingOutput();
+        //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
+        const QString endDateTimeLine = logDateTime.toString(QCoreApplication::translate("TMainConsole", "'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'."));
+        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
+            mLogStream << qsl("<p>%1</p>\n").arg(endDateTimeLine);
+            mLogStream << "  </div></body>\n";
+            mLogStream << "</html>\n";
+        } else {
+            // File is NOT an HTML one but pure text:
+            mLogStream << endDateTimeLine << "\n";
+        }
+        mLogFile.flush();
+        mLogFile.close();
+    }
+
+    mpHost->raiseLoggingStateChanged(mLogToLogFile);
+}

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -56,18 +56,22 @@ struct TConsoleModel
     TConsoleModel(const TConsoleModel&) = delete;
     TConsoleModel& operator=(const TConsoleModel&) = delete;
 
-    // Turns logging on when it is off and off when it is on. Lives here rather
-    // than on the main-console widget because a profile with no view still has
-    // to be able to *start* a log, not just write into a stream something else
-    // opened. The two parts of it that genuinely need a view - announcing the
-    // change on the console and re-labelling the log button - are raised as
-    // Host signals for the frontend to act on.
+    // Lives here rather than on the main-console widget because a profile with
+    // no view still has to be able to *start* a log, not just write into a
+    // stream something else opened. The two parts of it that genuinely need a
+    // view - announcing the change on the console and re-labelling the log
+    // button - are raised as Host signals for the frontend to act on.
+    // Everything it touches (the autolog sentinel, the Host's log directory and
+    // filename format) is profile-wide, so it only acts on the Host's own main
+    // model and returns for any other.
     void toggleLogging(bool isMessageEnabled);
 
     // No 'm' prefix on purpose: TConsole::buffer aliases this one by reference and has to keep its name for the rest of the codebase, so the two match.
     TBuffer buffer;
-    // A QPointer because the model outlives its Host in the ordinary teardown
-    // order - mudlet destroys the Host first and the view holds the model up.
+    // A QPointer because Host and view are torn down in either order: quitting
+    // destroys every Host before the consoles' deferred deletes run, while
+    // closing one profile deletes its console first. The view co-owns the
+    // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
     // Only a cache today - the view fills these in through TConsole::changeColors(); refreshing them from the Host after the profile loads moves core-side with the colour sub-PR.
     QColor mBgColor = QColorConstants::Black;
@@ -77,8 +81,10 @@ struct TConsoleModel
     QPoint mUserCursor;
     bool mIsPromptLine = false;
     // The log destination. TBuffer writes into mLogStream directly, and
-    // TMainConsole keeps references aliasing all four so the call sites that
-    // name them are untouched.
+    // TMainConsole keeps references aliasing all four.
+    // mLogStream holds a bare pointer to mLogFile, so the declaration order
+    // here is load-bearing: the stream has to be destroyed - and flush - before
+    // the file it is writing into.
     QFile mLogFile;
     QString mLogFileName;
     QTextStream mLogStream;

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -23,17 +23,21 @@
 #include "TBuffer.h"
 
 #include <QColor>
+#include <QFile>
 #include <QPoint>
+#include <QPointer>
 #include <QString>
+#include <QTextStream>
 
 class Host;
 
 // The per-console data model: the slice of former TConsole state that the
 // telnet -> trigger pipeline drives without needing a widget. That is the text
 // buffer, the cursor/prompt state Host::runTriggers() updates on every line,
-// and the fg/bg colours colour-triggers match against. Splitting it out of the
-// widget is what lets the pipeline run with no view at all, which is the point
-// of the Widgets-free core (#8681).
+// the fg/bg colours colour-triggers match against, and the log lifecycle the
+// buffer writes through. Splitting it out of the widget is what lets the
+// pipeline run with no view at all, which is the point of the Widgets-free
+// core (#8681).
 //
 // The main console's model is co-owned by Host (see Host::sharedMainConsoleModel)
 // so the pipeline outlives the view; sub-consoles own their own model. Every
@@ -42,10 +46,9 @@ class Host;
 // the existing accesses across the codebase are preserved unchanged.
 struct TConsoleModel
 {
-    explicit TConsoleModel(Host* pHost)
-    : buffer(pHost)
-    {
-    }
+    // Defined out of line: mpHost is a QPointer, which needs Host complete, and
+    // this header is included far too widely to drag Host.h along with it.
+    explicit TConsoleModel(Host* pHost);
 
     // A copy would duplicate the whole scrollback and leave a second model
     // claiming the view the original is bound to. Deleting the copy operations
@@ -53,8 +56,19 @@ struct TConsoleModel
     TConsoleModel(const TConsoleModel&) = delete;
     TConsoleModel& operator=(const TConsoleModel&) = delete;
 
+    // Turns logging on when it is off and off when it is on. Lives here rather
+    // than on the main-console widget because a profile with no view still has
+    // to be able to *start* a log, not just write into a stream something else
+    // opened. The two parts of it that genuinely need a view - announcing the
+    // change on the console and re-labelling the log button - are raised as
+    // Host signals for the frontend to act on.
+    void toggleLogging(bool isMessageEnabled);
+
     // No 'm' prefix on purpose: TConsole::buffer aliases this one by reference and has to keep its name for the rest of the codebase, so the two match.
     TBuffer buffer;
+    // A QPointer because the model outlives its Host in the ordinary teardown
+    // order - mudlet destroys the Host first and the view holds the model up.
+    QPointer<Host> mpHost;
     // Only a cache today - the view fills these in through TConsole::changeColors(); refreshing them from the Host after the profile loads moves core-side with the colour sub-PR.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
@@ -62,6 +76,13 @@ struct TConsoleModel
     int mEngineCursor = -1;
     QPoint mUserCursor;
     bool mIsPromptLine = false;
+    // The log destination. TBuffer writes into mLogStream directly, and
+    // TMainConsole keeps references aliasing all four so the call sites that
+    // name them are untouched.
+    QFile mLogFile;
+    QString mLogFileName;
+    QTextStream mLogStream;
+    bool mLogToLogFile = false;
 };
 
 #endif // MUDLET_TCONSOLEMODEL_H

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -54,7 +54,6 @@
 #include <QSizePolicy>
 #include <QTextBoundaryFinder>
 #include <QTextCodec>
-#include <QTextStream>
 #include <QPainter>
 #include <QVideoWidget>
 
@@ -62,8 +61,17 @@
 TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 : TConsole(pH, qsl("main"), TConsole::MainConsole, parent)
 , mClipboard(pH)
+, mLogFile(model().mLogFile)
+, mLogFileName(model().mLogFileName)
+, mLogStream(model().mLogStream)
+, mLogToLogFile(model().mLogToLogFile)
 {
     setFont(pH->getAndClearTempDisplayFont());
+
+    // The log lifecycle runs core-side; announcing the change on this console
+    // and re-labelling the log button are the only parts of it that need a view.
+    connect(pH, &Host::signal_loggingAnnouncement, this, &TMainConsole::slot_loggingAnnouncement, Qt::UniqueConnection);
+    connect(pH, &Host::signal_loggingStateChanged, this, &TMainConsole::slot_loggingStateChanged, Qt::UniqueConnection);
 
     // During first use where mIsDebugConsole IS true mudlet::self() is null
     // then - but we rely on that flag to avoid having to also test for a
@@ -227,206 +235,22 @@ std::optional<QString> TMainConsole::getCmdLineStyleSheet(const QString& name) c
     return {pN->styleSheet()};
 }
 
+// The lifecycle itself is core (TConsoleModel::toggleLogging): this keeps the
+// entry point the toolbar button and the Lua subsystem already call.
 void TMainConsole::toggleLogging(bool isMessageEnabled)
 {
-    const auto loggingPath = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"));
-    QFile file(loggingPath);
-    const QDateTime logDateTime = QDateTime::currentDateTime();
-    if (!mLogToLogFile) {
-        if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            qWarning() << "TMainConsole: failed to open autolog file for writing:" << file.errorString();
-            return;
-        }
-        QTextStream out(&file);
-        file.close();
+    model().toggleLogging(isMessageEnabled);
+}
 
-        QString directoryLogFile;
-        QString logFileName;
-        // If no log directory is set, default to Mudlet's replay and log files path
-        if (mpHost->mLogDir == nullptr || mpHost->mLogDir.isEmpty()) {
-            directoryLogFile = mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, mProfileName);
-        } else {
-            directoryLogFile = mpHost->mLogDir;
-        }
-        // The format being empty is a signal value that means use a specified
-        // name:
-        if (mpHost->mLogFileNameFormat.isEmpty()) {
-            if (mpHost->mLogFileName.isEmpty()) {
-                // If no log name is set, use the default placeholder
-                //: Must be a valid default filename for a log-file and is used if the user does not enter any other value (Ensure all instances have the same translation {one of two copies}).
-                logFileName = tr("logfile");
-            } else {
-                // Otherwise a specific name as one is given
-                logFileName = mpHost->mLogFileName;
-            }
-        } else {
-            logFileName = logDateTime.toString(mpHost->mLogFileNameFormat);
-        }
+void TMainConsole::slot_loggingAnnouncement(const bool isLogging, const QString& logFileName)
+{
+    const QString message = isLogging ? tr("Logging has started. Log file is %1").arg(logFileName) : tr("Logging has been stopped. Log file is %1").arg(logFileName);
+    printSystemMessage(qsl("%1\n").arg(message));
+}
 
-        // The preset file name formats are derived from date/times so that
-        // alphabetical filename and date sort order are the same...
-        const QDir dirLogFile;
-        if (!dirLogFile.exists(directoryLogFile)) {
-            dirLogFile.mkpath(directoryLogFile);
-        }
-
-        mpHost->mIsCurrentLogFileInHtmlFormat = mpHost->mIsNextLogFileInHtmlFormat;
-        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
-            mLogFileName = qsl("%1/%2.html").arg(directoryLogFile, logFileName);
-        } else {
-            mLogFileName = qsl("%1/%2.txt").arg(directoryLogFile, logFileName);
-        }
-        mLogFile.setFileName(mLogFileName);
-        // We do not want to use WriteOnly here:
-        // Append = "The device is opened in append mode so that all data is
-        // written to the end of the file."
-        // WriteOnly = "The device is open for writing. Note that this mode
-        // implies Truncate."
-        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
-            if (!mLogFile.open(QIODevice::ReadWrite)) {
-                qWarning() << "TMainConsole: failed to open log file for reading/writing:" << mLogFile.errorString();
-                return;
-            }
-        } else {
-            if (!mLogFile.open(QIODevice::Append)) {
-                qWarning() << "TMainConsole: failed to open log file for appending:" << mLogFile.errorString();
-                return;
-            }
-        }
-        mLogStream.setDevice(&mLogFile);
-
-        if (isMessageEnabled) {
-            const QString message = qsl("%1\n").arg(tr("Logging has started. Log file is %1").arg(mLogFile.fileName()));
-            printSystemMessage(message);
-            // This puts text onto console that is IMMEDIATELY POSTED into log file so
-            // must be done BEFORE logging starts - or actually mLogToLogFile gets set!
-        }
-        mLogToLogFile = true;
-    } else {
-        QFile::remove(loggingPath);
-        mLogToLogFile = false;
-        if (isMessageEnabled) {
-            const QString message = qsl("%1\n").arg(tr("Logging has been stopped. Log file is %1").arg(mLogFile.fileName()));
-            printSystemMessage(message);
-            // This puts text onto console that is IMMEDIATELY POSTED into log file so
-            // must be done AFTER logging ends - or actually mLogToLogFile gets reset!
-        }
-    }
-
-    if (mLogToLogFile) {
-        // Logging is being turned on
-        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
-            QString log;
-            QTextStream logStream(&log);
-            // No setting a QTextCodec here, they don't work on QString based QTextStreams
-            QStringList fontsList;                  // List of fonts to become the font-family entry for
-                                                    // the master css in the header
-            fontsList << this->fontInfo().family(); // Seems to be the best way to get the
-                                                    // font in use, as different TConsole
-                                                    // instances within the same profile
-                                                    // might have different fonts
-            fontsList << qsl("Courier New");
-            fontsList << qsl("Monospace");
-            fontsList << qsl("Courier");
-            fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
-
-            logStream << "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
-            logStream << "<html>\n";
-            logStream << " <head>\n";
-            logStream << "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>";
-            // put the charset as early as possible as the parser MUST restart when it
-            // switches away from the ASCII default
-            logStream << "  <meta name='generator' content='" << tr("Mudlet MUD Client version: %1%2").arg(APP_VERSION, mudlet::self()->mAppBuild) << "'>\n";
-            // Nice to identify what made the file!
-            logStream << "  <title>" << tr("Mudlet, log from %1 profile").arg(mProfileName) << "</title>\n";
-            // Web-page title
-            logStream << "  <style type='text/css'>\n";
-            logStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(" << mpHost->mFgColor.red() << ","
-                      << mpHost->mFgColor.green() << "," << mpHost->mFgColor.blue() << "); background-color:rgb(" << mpHost->mBgColor.red() << "," << mpHost->mBgColor.green() << ","
-                      << mpHost->mBgColor.blue() << ");}\n";
-            logStream << "        span { white-space: pre-wrap; }\n";
-
-            if (mpHost->getEnableBlinkText()) {
-                logStream << "        @keyframes blink-slow { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }\n";
-                logStream << "        @keyframes blink-fast { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }\n";
-                logStream << "        .blink-slow { animation: blink-slow 2s ease-in-out infinite; }\n";
-                logStream << "        .blink-fast { animation: blink-fast 1s ease-in-out infinite; }\n";
-            }
-
-            logStream << "     -->\n";
-            logStream << "  </style>\n";
-            logStream << "  </head>\n";
-            bool isAtBody = false;
-            bool foundBody = false;
-            while (!mLogStream.atEnd()) {
-                const QString line = mLogStream.readLine();
-                if (line.contains("<body><div>")) {
-                    // Begin writing old log to the current log when the body is
-                    // found.
-                    isAtBody = true;
-                    foundBody = true;
-                } else if (line.contains("</div></body>")) {
-                    // Stop writing to current log once the end of the old log's
-                    // <body> is reached.
-                    isAtBody = false;
-                }
-
-                if (isAtBody) {
-                    logStream << line << "\n";
-                }
-            }
-            if (!foundBody) {
-                logStream << "  <body><div>\n";
-            } else {
-                // Put a horizontal line between separate log sessions
-                logStream << "  </div><hr><div>\n";
-            }
-            logStream
-                    << qsl("<p>%1</p>\n")
-                               //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-                               .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
-            // <div></div> tags required around outside of the body <span></spans> for
-            // strict HTML 4 as we do not use <p></p>s or anything else
-
-            if (!mLogFile.resize(0)) {
-                qWarning() << "TConsole::toggleLogging(...) ERROR - Failed to resize HTML Logfile - it may now be corrupted...!";
-            }
-            mLogStream << log;
-            mLogFile.flush();
-        } else {
-            // File is NOT an HTML one but pure text:
-            // Put a horizontal line between separate log sessions
-            // Unfortunately QLatin1String does not have a repeated() method,
-            // but it does mean we can use non-ASCII/Latin1 characters:
-            // Using 10x U+23AF Horizontal line extension from "Box drawing characters":
-            if (mLogFile.size() > 5) {
-                // Allow a few junk characters ("BOM"???) at the very start of
-                // file to not trigger the insertion of this line:
-                mLogStream << qsl("⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯").repeated(8).append(QChar::LineFeed);
-            }
-            mLogStream
-                    << qsl("%1\n")
-                               //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-                               .arg(logDateTime.toString(tr("'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.")));
-        }
-        logButton->setToolTip(utils::richText(tr("Stop logging game output to log file.")));
-    } else {
-        // Logging is being turned off
-        buffer.logRemainingOutput();
-        //: This is the format argument to QDateTime::toString(...) and needs to follow the rules for that function {literal text must be single quoted} as well as being suitable for the translation locale
-        const QString endDateTimeLine = logDateTime.toString(tr("'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'."));
-        if (mpHost->mIsCurrentLogFileInHtmlFormat) {
-            mLogStream << qsl("<p>%1</p>\n").arg(endDateTimeLine);
-            mLogStream << "  </div></body>\n";
-            mLogStream << "</html>\n";
-        } else {
-            // File is NOT an HTML one but pure text:
-            mLogStream << endDateTimeLine << "\n";
-        }
-        mLogFile.flush();
-        mLogFile.close();
-        logButton->setToolTip(utils::richText(tr("Start logging game output to log file.")));
-    }
+void TMainConsole::slot_loggingStateChanged(const bool isLogging)
+{
+    logButton->setToolTip(utils::richText(isLogging ? tr("Stop logging game output to log file.") : tr("Start logging game output to log file.")));
 }
 
 void TMainConsole::selectCurrentLine(std::string& buf)

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -144,10 +144,14 @@ public:
     QMap<QString, TScrollBox*> mScrollBoxMap;
     mutable QMap<QString, QSize> mCachedWindowSizes;
     TBuffer mClipboard;
-    QFile mLogFile;
-    QString mLogFileName;
-    QTextStream mLogStream;
-    bool mLogToLogFile = false;
+    // The log lifecycle lives in the core console model so a profile with no
+    // view can run one; these four are references aliasing the model's fields,
+    // the way buffer and mFgColor alias theirs, so every call site that names
+    // them is unchanged.
+    QFile& mLogFile;
+    QString& mLogFileName;
+    QTextStream& mLogStream;
+    bool& mLogToLogFile;
     QPointer<QProgressDialog> mpPackageDownloadProgressDialog;
     QPointer<QProgressDialog> mpMapProgressDialog;
     // Outlives Host::closeMapWidget(), which only hides it, so this being
@@ -162,6 +166,13 @@ public slots:
     // =>"Copy Map" in another profile to inform a list of
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
+
+
+private slots:
+    // The two halves of a logging change that need this view: the core model
+    // owns everything else about it.
+    void slot_loggingAnnouncement(const bool isLogging, const QString& logFileName);
+    void slot_loggingStateChanged(const bool isLogging);
 
 
 signals:

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -146,8 +146,10 @@ public:
     TBuffer mClipboard;
     // The log lifecycle lives in the core console model so a profile with no
     // view can run one; these four are references aliasing the model's fields,
-    // the way buffer and mFgColor alias theirs, so every call site that names
-    // them is unchanged.
+    // the way buffer and mFgColor alias theirs. mLogToLogFile and mLogFileName
+    // are what keep TLuaInterpreter::startLogging() compiling unchanged; the
+    // other two are kept so the set does not have to be reasoned about in
+    // halves.
     QFile& mLogFile;
     QString& mLogFileName;
     QTextStream& mLogStream;

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -763,6 +763,42 @@ describe("Tests C++ functions in the Miscallaneous category", function()
         end)
       end)
 
+      -- The HTML log is a whole second document format: its own file
+      -- extension, a CSS header naming the console's own font, a title, and a
+      -- closing tag pair only the stop path writes.
+      describe("Tests the functionality of logging in HTML", function()
+        it("wraps the session in a document naming the console font", function()
+          local logPath
+          local htmlLogging = getConfig("logInHTML")
+          finally(function()
+            startLogging(false)
+            setConfig("logInHTML", htmlLogging)
+            if logPath then
+              os.remove(logPath)
+            end
+          end)
+          setConfig("logInHTML", true)
+
+          logPath = select(3, startLogging(true))
+          assert.is_string(logPath)
+          assert.is_truthy(logPath:match("%.html$"), "an HTML log did not get an .html file name: " .. tostring(logPath))
+
+          echo("mudlet-spec-html-logged-line\n")
+          startLogging(false)
+
+          local contents = readFile(logPath)
+          assert.is_string(contents, "the HTML log file that was closed is not readable")
+          assert.is_true(contains(contents, "<html>"), "the HTML log has no opening document tag")
+          assert.is_true(contains(contents, "</div></body>"), "the HTML log was never closed off when logging stopped")
+          -- getFont() reports the same resolved family the log header is built
+          -- from, so this holds whatever font the profile ended up with
+          assert.is_true(contains(contents, "font-family: '" .. getFont() .. "'"),
+            "the HTML log header does not name the console font")
+          assert.is_true(contains(contents, getProfileName()), "the HTML log title does not name the profile")
+          assert.is_true(contains(contents, "mudlet-spec-html-logged-line"), "the console output did not reach the HTML log")
+        end)
+      end)
+
       -- A received line is held back from the log until the next one commits.
       -- That deferral is what duplicate detection needs, and it is also the
       -- window in which a trigger can still gag the line with deleteLine().

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -17,6 +17,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QFile>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
@@ -53,9 +54,9 @@ void initializeQRCResourcesForConsoleModelExtraction();
 
 using namespace std::chrono_literals;
 
-// The main console's text buffer, cursor/prompt state and fg/bg colours were
-// lifted out of the TConsole widget into a core TConsoleModel that Host
-// co-owns, and the per-line trigger orchestration moved from
+// The main console's text buffer, cursor/prompt state, fg/bg colours and log
+// lifecycle were lifted out of the TConsole widget into a core TConsoleModel
+// that Host co-owns, and the per-line trigger orchestration moved from
 // TMainConsole::runTriggers() to Host::runTriggers() (#8681). The widget keeps
 // the former members as references aliasing the model, so these tests pin down
 // that the aliasing really is one object, that the pipeline runs off the model,
@@ -132,6 +133,10 @@ private slots:
         QCOMPARE(&console->mEngineCursor, &model.mEngineCursor);
         QCOMPARE(&console->mUserCursor, &model.mUserCursor);
         QCOMPARE(&console->mIsPromptLine, &model.mIsPromptLine);
+        QCOMPARE(&console->mLogFile, &model.mLogFile);
+        QCOMPARE(&console->mLogFileName, &model.mLogFileName);
+        QCOMPARE(&console->mLogStream, &model.mLogStream);
+        QCOMPARE(&console->mLogToLogFile, &model.mLogToLogFile);
 
         model.mFgColor = QColorConstants::Svg::orange;
         QCOMPARE(console->mFgColor, QColorConstants::Svg::orange);
@@ -140,6 +145,10 @@ private slots:
 
         model.mUserCursor = QPoint(7, 11);
         QCOMPARE(console->mUserCursor, QPoint(7, 11));
+
+        model.mLogFileName = qsl("aliased-log-name");
+        QCOMPARE(console->mLogFileName, qsl("aliased-log-name"));
+        model.mLogFileName.clear();
 
         host->getLuaInterpreter()->compileAndExecuteScript(qsl("cecho('<white>AliasedBufferWrite\\n')\n"));
         QVERIFY2(joinedBuffer().contains(qsl("AliasedBufferWrite")), "Text echoed through the view must be visible in the model's buffer.");
@@ -347,12 +356,43 @@ private slots:
         QVERIFY2(bufferText.contains(qsl("OSC 8 Hyperlink Examples")), "The OSC 8 documentation examples were not injected into the view-less buffer.");
     }
 
-    // Both logging entry points write to a log file that belongs to the view,
-    // so with none attached they have to do nothing rather than reach for it.
-    // logRemainingOutput() still has to drop the deferred line it would have
-    // written: that state is the buffer's, and leaving it behind would let a
-    // later view replay a line from a finished session.
-    void test_loggingCallsWithNoView()
+    // The log file, its stream and the on/off flag are core model state, so the
+    // announcement and the log button are all a logging change still needs this
+    // view for. TConsoleModel raises both through Host and TMainConsole acts on
+    // them; the announcement has to carry the file that was actually opened.
+    void test_loggingChangeIsAnnouncedByTheView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        auto console = host->mpConsole;
+        // Through TMainConsole::tr() rather than the English literal, so the
+        // assertions hold whatever interface language the run picks up.
+        const QString offerToStart = TMainConsole::tr("Start logging game output to log file.");
+        const QString offerToStop = TMainConsole::tr("Stop logging game output to log file.");
+        QVERIFY2(console->logButton->toolTip().contains(offerToStart), "The log button does not offer to start logging before one has been started.");
+
+        // true = announce the change, which is what the toolbar button asks for
+        console->toggleLogging(true);
+        QVERIFY2(host->mainConsoleModel().mLogToLogFile, "toggleLogging() did not start a log.");
+        const QString logFileName = host->mainConsoleModel().mLogFileName;
+        QVERIFY2(consoleTextContains(TMainConsole::tr("Logging has started. Log file is %1").arg(logFileName)), "Starting a log was not announced on the console.");
+        QVERIFY2(console->logButton->toolTip().contains(offerToStop), "The log button still offers to start logging while a log is running.");
+
+        console->toggleLogging(true);
+        QVERIFY2(!host->mainConsoleModel().mLogToLogFile, "toggleLogging() did not stop the log.");
+        QVERIFY2(consoleTextContains(TMainConsole::tr("Logging has been stopped. Log file is %1").arg(logFileName)), "Stopping a log was not announced on the console.");
+        QVERIFY2(console->logButton->toolTip().contains(offerToStart), "The log button does not offer to start logging again once the log has stopped.");
+
+        QFile::remove(logFileName);
+    }
+
+    // The point of moving the whole lifecycle rather than the stream alone: a
+    // profile with no view has to be able to *start* a log, write to it and
+    // stop it. Every step here runs against the model with the widget gone.
+    void test_loggingRunsWithNoView()
     {
         startProfile();
         auto host = mudlet::self()->getActiveHost();
@@ -362,16 +402,41 @@ private slots:
         std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
         destroyTheView(host);
 
-        model->buffer.appendLog(qsl("view-less appendLog text\n"));
+        // false = no announcement, the way startLogging() calls it from Lua
+        model->toggleLogging(false);
+        QVERIFY2(model->mLogToLogFile, "A view-less profile could not start a log.");
+        const QString logFileName = model->mLogFileName;
+        QVERIFY2(!logFileName.isEmpty(), "Starting a view-less log named no file.");
+        QVERIFY2(QFile::exists(logFileName), "Starting a view-less log opened no file.");
 
-        model->buffer.lastTextToLog = qsl("still pending when the view went away\n");
+        // append() logs the line it completes, so this is the ordinary per-line
+        // path rather than a direct poke at TBuffer::log().
+        appendModelLine(model->buffer, qsl("view-less-logged-line"));
+        model->buffer.appendLog(qsl("view-less-appended-text\n"));
+
+        model->toggleLogging(false);
+        QVERIFY2(!model->mLogToLogFile, "A view-less profile could not stop its log.");
+        QVERIFY2(!model->mLogFile.isOpen(), "Stopping a view-less log left its file open.");
+
+        const QString contents = readFile(logFileName);
+        QVERIFY2(contents.contains(qsl("view-less-appended-text")), "appendLog() never reached the view-less log file.");
+        // The most recent line is held back for duplicate detection and only
+        // written out as logging stops, so finding it proves the view-less stop
+        // flushed as well as the view-less writes landing.
+        QVERIFY2(contents.contains(qsl("view-less-logged-line")), "The line the view-less buffer logged never reached the log file.");
+
+        // The deferred-logging state is the buffer's own, so it has to be
+        // cleared whatever the log did - otherwise a later session replays the
+        // last line of this one.
+        model->buffer.lastTextToLog = qsl("still pending once the session ended\n");
         model->buffer.lastLoggedFromLine = 3;
         model->buffer.lastloggedToLine = 4;
         model->buffer.logRemainingOutput();
-
-        QVERIFY2(model->buffer.lastTextToLog.isEmpty(), "logRemainingOutput() left its pending line behind for a later view to replay.");
+        QVERIFY2(model->buffer.lastTextToLog.isEmpty(), "logRemainingOutput() left its pending line behind for a later session to replay.");
         QCOMPARE(model->buffer.lastLoggedFromLine, -1);
         QCOMPARE(model->buffer.lastloggedToLine, -1);
+
+        QFile::remove(logFileName);
     }
 
     void cleanup()
@@ -473,6 +538,25 @@ private:
         const QString line = text + QChar::LineFeed;
         buffer.append(line, 0, line.size(), QColorConstants::LightGray, QColorConstants::Black, TChar::None, 0);
         return buffer.getLastLineNumber() - 1;
+    }
+
+    // Utility function: the console word-wraps, and joinedBuffer() glues the
+    // pieces back together with a space, so compare with every space removed
+    // rather than betting on where a long line was broken.
+    bool consoleTextContains(const QString& needle)
+    {
+        QString haystack = joinedBuffer();
+        QString wanted = needle;
+        return haystack.remove(QChar::Space).contains(wanted.remove(QChar::Space));
+    }
+
+    QString readFile(const QString& path)
+    {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return QString();
+        }
+        return QString::fromUtf8(file.readAll());
     }
 
     QString luaGlobalString(Host* host, const char* name)

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 #include <QFile>
+#include <QRegularExpression>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
@@ -413,8 +414,11 @@ private slots:
         QVERIFY2(!contents.contains(qsl("user-window-second-line")), "A user window's own text was written into the game log.");
         // The announcements are printed on the console on purpose either side
         // of the logging flag, so neither may end up in the file itself.
-        QVERIFY2(!contents.contains(startAnnouncement.arg(logFileName)), "The start announcement was logged into the file it announced.");
-        QVERIFY2(!contents.contains(stopAnnouncement.arg(logFileName)), "The stop announcement was logged into the file it closed.");
+        // Whitespace-insensitive, because the console wraps a line this long
+        // and the log records it wrapped - a plain contains() would miss it and
+        // pass for the wrong reason.
+        QVERIFY2(!logTextContains(contents, startAnnouncement.arg(logFileName)), "The start announcement was logged into the file it announced.");
+        QVERIFY2(!logTextContains(contents, stopAnnouncement.arg(logFileName)), "The stop announcement was logged into the file it closed.");
 
         QFile::remove(logFileName);
     }
@@ -585,6 +589,16 @@ private:
         QString haystack = joinedBuffer();
         QString wanted = needle;
         return haystack.remove(QChar::Space).contains(wanted.remove(QChar::Space));
+    }
+
+    // Utility function: the console wraps long lines and the log records them
+    // wrapped, so an assertion about a long message has to ignore where the
+    // break landed.
+    static bool logTextContains(const QString& contents, const QString& needle)
+    {
+        QString haystack = contents;
+        QString wanted = needle;
+        return haystack.remove(QRegularExpression(qsl("\\s"))).contains(wanted.remove(QRegularExpression(qsl("\\s"))));
     }
 
     QString readFile(const QString& path)

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -393,7 +393,11 @@ private slots:
         runLua(host, qsl("openUserWindow('logSpy')\n"));
         auto* subConsole = console->mSubConsoleMap.value(qsl("logSpy"));
         QVERIFY2(subConsole, "The user window was not created.");
+        // Two lines, because log() holds each one back until the next commits:
+        // with only one the leak would still be sitting in the sub-console
+        // buffer's deferred slot when logging stopped.
         appendModelLine(subConsole->buffer, qsl("user-window-only-text"));
+        appendModelLine(subConsole->buffer, qsl("user-window-second-line"));
         appendModelLine(host->mainConsoleModel().buffer, qsl("main-console-logged-text"));
 
         console->logButton->click();
@@ -406,6 +410,7 @@ private slots:
         QVERIFY2(!contents.isEmpty(), "The log file that was closed is not readable.");
         QVERIFY2(contents.contains(qsl("main-console-logged-text")), "The main console's line never reached the log file.");
         QVERIFY2(!contents.contains(qsl("user-window-only-text")), "A user window's own text was written into the game log.");
+        QVERIFY2(!contents.contains(qsl("user-window-second-line")), "A user window's own text was written into the game log.");
         // The announcements are printed on the console on purpose either side
         // of the logging flag, so neither may end up in the file itself.
         QVERIFY2(!contents.contains(startAnnouncement.arg(logFileName)), "The start announcement was logged into the file it announced.");

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -146,8 +146,8 @@ private slots:
         model.mUserCursor = QPoint(7, 11);
         QCOMPARE(console->mUserCursor, QPoint(7, 11));
 
-        model.mLogFileName = qsl("aliased-log-name");
-        QCOMPARE(console->mLogFileName, qsl("aliased-log-name"));
+        console->mLogFileName = qsl("aliased-log-name");
+        QCOMPARE(model.mLogFileName, qsl("aliased-log-name"));
         model.mLogFileName.clear();
 
         host->getLuaInterpreter()->compileAndExecuteScript(qsl("cecho('<white>AliasedBufferWrite\\n')\n"));
@@ -372,19 +372,44 @@ private slots:
         // assertions hold whatever interface language the run picks up.
         const QString offerToStart = TMainConsole::tr("Start logging game output to log file.");
         const QString offerToStop = TMainConsole::tr("Stop logging game output to log file.");
+        const QString startAnnouncement = TMainConsole::tr("Logging has started. Log file is %1");
+        const QString stopAnnouncement = TMainConsole::tr("Logging has been stopped. Log file is %1");
+        // The sentinel is what makes logging resume at the next launch
+        // (Host::mLogStatus), so it has to appear and disappear with the log.
+        const QString sentinel = mudlet::getMudletPath(enums::profileDataItemPath, host->getName(), qsl("autolog"));
         QVERIFY2(console->logButton->toolTip().contains(offerToStart), "The log button does not offer to start logging before one has been started.");
 
-        // true = announce the change, which is what the toolbar button asks for
-        console->toggleLogging(true);
-        QVERIFY2(host->mainConsoleModel().mLogToLogFile, "toggleLogging() did not start a log.");
+        // Through the toolbar button rather than toggleLogging() directly: that
+        // is the path asking for the announcement, TConsole::slot_toggleLogging.
+        console->logButton->click();
+        QVERIFY2(host->mainConsoleModel().mLogToLogFile, "Clicking the log button did not start a log.");
         const QString logFileName = host->mainConsoleModel().mLogFileName;
-        QVERIFY2(consoleTextContains(TMainConsole::tr("Logging has started. Log file is %1").arg(logFileName)), "Starting a log was not announced on the console.");
+        QVERIFY2(QFile::exists(sentinel), "Starting a log left no autolog sentinel, so logging would not resume next launch.");
+        QVERIFY2(consoleTextContains(startAnnouncement.arg(logFileName)), "Starting a log was not announced on the console.");
         QVERIFY2(console->logButton->toolTip().contains(offerToStop), "The log button still offers to start logging while a log is running.");
 
-        console->toggleLogging(true);
-        QVERIFY2(!host->mainConsoleModel().mLogToLogFile, "toggleLogging() did not stop the log.");
-        QVERIFY2(consoleTextContains(TMainConsole::tr("Logging has been stopped. Log file is %1").arg(logFileName)), "Stopping a log was not announced on the console.");
+        // A user window's own text must not be interleaved into the game log -
+        // TBuffer::log() runs for every buffer and only the main one may write.
+        runLua(host, qsl("openUserWindow('logSpy')\n"));
+        auto* subConsole = console->mSubConsoleMap.value(qsl("logSpy"));
+        QVERIFY2(subConsole, "The user window was not created.");
+        appendModelLine(subConsole->buffer, qsl("user-window-only-text"));
+        appendModelLine(host->mainConsoleModel().buffer, qsl("main-console-logged-text"));
+
+        console->logButton->click();
+        QVERIFY2(!host->mainConsoleModel().mLogToLogFile, "Clicking the log button again did not stop the log.");
+        QVERIFY2(!QFile::exists(sentinel), "Stopping a log left the autolog sentinel behind, so logging would resume unasked.");
+        QVERIFY2(consoleTextContains(stopAnnouncement.arg(logFileName)), "Stopping a log was not announced on the console.");
         QVERIFY2(console->logButton->toolTip().contains(offerToStart), "The log button does not offer to start logging again once the log has stopped.");
+
+        const QString contents = readFile(logFileName);
+        QVERIFY2(!contents.isEmpty(), "The log file that was closed is not readable.");
+        QVERIFY2(contents.contains(qsl("main-console-logged-text")), "The main console's line never reached the log file.");
+        QVERIFY2(!contents.contains(qsl("user-window-only-text")), "A user window's own text was written into the game log.");
+        // The announcements are printed on the console on purpose either side
+        // of the logging flag, so neither may end up in the file itself.
+        QVERIFY2(!contents.contains(startAnnouncement.arg(logFileName)), "The start announcement was logged into the file it announced.");
+        QVERIFY2(!contents.contains(stopAnnouncement.arg(logFileName)), "The stop announcement was logged into the file it closed.");
 
         QFile::remove(logFileName);
     }
@@ -419,6 +444,13 @@ private slots:
         QVERIFY2(!model->mLogFile.isOpen(), "Stopping a view-less log left its file open.");
 
         const QString contents = readFile(logFileName);
+        QVERIFY2(!contents.isEmpty(), "The view-less log file is not readable.");
+        // The literal half of the format string, so the assertion survives a
+        // translated run: "'Log session starting at 'hh:mm..." -> the quoted run.
+        QVERIFY2(contents.contains(QCoreApplication::translate("TMainConsole", "'Log session starting at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.").section(QChar('\''), 1, 1)),
+                 "The view-less log has no session-start banner.");
+        QVERIFY2(contents.contains(QCoreApplication::translate("TMainConsole", "'Log session ending at 'hh:mm:ss' on 'dddd', 'd' 'MMMM' 'yyyy'.").section(QChar('\''), 1, 1)),
+                 "The view-less log has no session-end banner, so the session was never closed off.");
         QVERIFY2(contents.contains(qsl("view-less-appended-text")), "appendLog() never reached the view-less log file.");
         // The most recent line is held back for duplicate detection and only
         // written out as logging stops, so finding it proves the view-less stop


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The log file, its name, its stream, the on/off flag and `toggleLogging()` move out of the `TMainConsole` widget into the core `TConsoleModel`. The widget keeps all four as references aliasing the model, so every call site that names them is untouched, and `TBuffer`'s six log writes now go to the model instead of reaching through `mpHost->mpConsole`.
- The two halves that genuinely need a view - the "Logging has started/stopped" print and the log button's label - are raised as two new `Host` signals the frontend acts on.
- New coverage: 2 functional cases plus 1 Lua spec, closing the previously untested HTML-log branch.

#### Motivation for adding to Mudlet

Step 2 of the libmudlet console-model extraction (#8681, follows #9603). The *whole* lifecycle had to move rather than just the stream: with only the stream in core, a view-less profile could write into a log but could never open one.

#### Other info (issues closed, discussion etc)

Bugs found while moving, both fixed here: `logRemainingOutput()` was the only log writer without the buffer-identity test, so a sub-console's pending line could be flushed into the main log; and it had no file-is-open test, which matters because a `QTextStream` written to after its device closes latches `WriteFailed` and then silently withholds every later write until `setDevice()` replays them into the *next* log file. `toggleLogging()` is now also guarded to the Host's own main model, since everything it touches (the autolog sentinel, the log directory, the filename format) is profile-wide.

Log-file text is translated against the `TMainConsole` context on purpose - re-keying it would orphan the translations those strings already have (`lupdate` confirms identical context, sources and extracomments). Deliberately left alone: the open-failure path is still silent, and `mudlet::self()` is still dereferenced here - step 3 owns that.

**Test case:** 132/132 ctest and 3688/3688 Lua specs green. Sabotage: 17 cuts across both harnesses, each turning exactly its own assertion red - two assertions were vacuous on the first attempt and were rewritten until they failed.

Assisted-by: Claude:claude-opus-5
