### PR TITLE
Fix: Turning a container's auto save back on saves its layout again

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -1100,12 +1100,7 @@ function Adjustable.Container:type_delete()
         self:detach()
     end
     self:disconnect()
-    -- not disableAutoSave(), which kills an already nil handler and errors
-    if self.autoSaveHandler then
-        killAnonymousEventHandler(self.autoSaveHandler)
-        self.autoSaveHandler = nil
-    end
-    self.autoSave = false
+    self:disableAutoSave()
     -- a container recreated under the same name has taken over the registration,
     -- so only unregister while it is still ours
     if Adjustable.Container.all[self.name] == self then
@@ -1269,10 +1264,13 @@ function Adjustable.Container:enableAutoSave()
     self.autoSaveHandler = self.autoSaveHandler or registerAnonymousEventHandler("sysExitEvent", function() self:save() end)
 end
 
---- disableAutoSave function to disable a before enabled autoSave
+--- disableAutoSave function to turn autoSave off, whether or not it was enabled
 function Adjustable.Container:disableAutoSave()
     self.autoSave = false
-    killAnonymousEventHandler(self.autoSaveHandler)
+    if self.autoSaveHandler then
+        killAnonymousEventHandler(self.autoSaveHandler)
+        self.autoSaveHandler = nil
+    end
 end
 
 --- constructor for the Adjustable Container

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -328,11 +328,15 @@ describe("Tests functionality of Adjustable.Container", function()
         x = 0, y = 0, width = 100, height = 100,
         autoLoad = false,
       })
-      assert.is_not_nil(saving.autoSaveHandler)
+      local handler = saving.autoSaveHandler
+      assert.is_not_nil(handler)
       saving:delete()
       -- left registered, the handler would write a deleted container's geometry
       -- back out at exit, over whatever took its name in the meantime
       assert.is_nil(saving.autoSaveHandler)
+      -- killAnonymousEventHandler answers falsy for an id it no longer holds,
+      -- which is how a killed registration is told apart from a blanked field
+      assert.is_falsy(killAnonymousEventHandler(handler))
       assert.is_false(saving.autoSave)
     end)
 
@@ -1756,7 +1760,6 @@ describe("Tests Adjustable.Container borders, persistence and menu items", funct
       assert.is_false(container.autoSave)
       -- the handler is really gone rather than only flagged off
       assert.is_false(handlerAlive(handler))
-      container.autoSaveHandler = nil
     end)
 
     it("keeps the one handler it already has rather than stacking a second", function()
@@ -1766,16 +1769,36 @@ describe("Tests Adjustable.Container borders, persistence and menu items", funct
       container:enableAutoSave()
       assert.are.equal(handler, container.autoSaveHandler)
       container:disableAutoSave()
-      container.autoSaveHandler = nil
     end)
 
-    -- disableAutoSave kills the handler but leaves its id on the container, and
-    -- enableAutoSave only registers when autoSaveHandler is nil. Turning auto
-    -- saving off and on again therefore leaves the container claiming autoSave
-    -- is true with nothing registered behind it, so its layout is silently not
-    -- written at exit. Recorded rather than asserted, so that fixing it does
-    -- not have to fight a spec.
-    pending("Adjustable.Container:enableAutoSave registering again after disableAutoSave - the killed handler's id is left behind, so the second enable short-circuits and nothing saves on exit")
+    it("registers a different, live handler again after disableAutoSave", function()
+      local container = make("gapAutoSaveReenable")
+      container:enableAutoSave()
+      local firstHandler = container.autoSaveHandler
+      assert.is_not_nil(firstHandler)
+
+      container:disableAutoSave()
+      assert.is_false(handlerAlive(firstHandler))
+      assert.is_nil(container.autoSaveHandler)
+
+      container:enableAutoSave()
+      local secondHandler = container.autoSaveHandler
+      assert.is_true(container.autoSave)
+      assert.are_not.equal(firstHandler, secondHandler)
+      assert.is_true(handlerAlive(secondHandler))
+      container:disableAutoSave()
+    end)
+
+    it("does not error when disableAutoSave is called twice in a row", function()
+      local container = make("gapAutoSaveTwice")
+      -- starting from autoSave off means even the first call has no handler
+      assert.has_no.errors(function() container:disableAutoSave() end)
+      container:enableAutoSave()
+      container:disableAutoSave()
+      assert.has_no.errors(function() container:disableAutoSave() end)
+      assert.is_false(container.autoSave)
+      assert.is_nil(container.autoSaveHandler)
+    end)
   end)
 
   describe("Adjustable.Container lock styles", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Adjustable.Container:disableAutoSave()` now clears the handler id it just killed, so a later `enableAutoSave()` registers a live handler again instead of short-circuiting on the dead one
- It is also safe to call when auto save was never on, which is why `type_delete()` can call it rather than open-coding the same kill
- Two specs replace the `pending()` that recorded the bug

#### Motivation for adding to Mudlet

Turning auto saving off and on again left the container reporting auto save as on with nothing registered behind it, so its layout was silently never written at exit.

#### Other info (issues closed, discussion etc)

Closes #10051

**Test case:** create an `Adjustable.Container` with auto save, `disableAutoSave()`, then `enableAutoSave()`, and check `container.autoSaveHandler` holds a new id that `killAnonymousEventHandler` recognises. Spec suite: 3489 successes / 0 failures with the fix; reverting only the product `.lua` fails exactly the two new specs.

Assisted-by: opencode:x-preview-f-free
Assisted-by: Claude:claude-opus-5