### PR TITLE
Fix: MSDP values containing control codes no longer go missing

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4056,6 +4056,10 @@ void TLuaInterpreter::msdp2Lua(const char* src)
 
     QByteArray script;
     bool no_array_marker_bug = false;
+    // Measured as the name is written rather than recomputed from varList at the
+    // strip: a name holding a byte JSON has to escape is longer in script than
+    // the raw name is, and the strip then leaves part of the prefix behind.
+    int topLevelPrefixLength = 0;
     for (int i = 0; i < textLength; ++i) {
         switch (transcodedSrc.at(i)) {
         case MSDP_TABLE_OPEN:
@@ -4103,11 +4107,15 @@ void TLuaInterpreter::msdp2Lua(const char* src)
                 if (!varList.empty()) {
                     QString token = varList.front();
                     token = token.remove(QLatin1Char('\"'));
-                    script = script.replace(0, varList.front().toUtf8().size() + 3, QByteArray());
+                    script = script.replace(0, topLevelPrefixLength, QByteArray());
                     mpHost->processDiscordMSDP(token, script);
                     setMSDPTable(token, script);
                     varList.clear();
                     script.clear();
+                    // the quote above closed the value just flushed - this one
+                    // opens the name starting now, which the first variable of a
+                    // subnegotiation gets from that same append
+                    script.append('\"');
                 }
             }
             last = MSDP_VAR;
@@ -4117,6 +4125,9 @@ void TLuaInterpreter::msdp2Lua(const char* src)
         case MSDP_VAL:
             if (last == MSDP_VAR) {
                 script.append("\":");
+                if (!nest && varList.empty()) {
+                    topLevelPrefixLength = script.size();
+                }
             }
             if (last == MSDP_VAL) {
                 no_array_marker_bug = true;
@@ -4136,10 +4147,12 @@ void TLuaInterpreter::msdp2Lua(const char* src)
             // "a\\b" used to arrive as a backspace
             script.append('\\');
             script.append('\\');
+            lastVar.append(transcodedSrc.at(i));
             break;
         case '\"':
             script.append('\\');
             script.append('\"');
+            lastVar.append(transcodedSrc.at(i));
             break;
         default:
             if (static_cast<unsigned char>(transcodedSrc.at(i)) < 0x20) {
@@ -4161,7 +4174,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
     if (!varList.empty()) {
         QString token = varList.front();
         token = token.remove(QLatin1Char('\"'));
-        script = script.replace(0, token.toUtf8().size() + 3, QByteArray());
+        script = script.replace(0, topLevelPrefixLength, QByteArray());
         if (no_array_marker_bug) {
             if (!script.startsWith('[')) {
                 script.prepend('[');

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4018,6 +4018,28 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
     lua_settop(L, callerStackTop);
 }
 
+// MSDP values may hold any byte except NUL, IAC and its own six markers, so a
+// control code in one is legal payload. JSON cannot carry a raw control character
+// inside a string (RFC 8259) and yajl rejects the whole document rather than the
+// one value, so an unescaped one takes every variable in its table with it.
+static QByteArray jsonEscapedControlByte(const char byte)
+{
+    switch (byte) {
+    case '\b':
+        return QByteArrayLiteral("\\b");
+    case '\t':
+        return QByteArrayLiteral("\\t");
+    case '\n':
+        return QByteArrayLiteral("\\n");
+    case '\f':
+        return QByteArrayLiteral("\\f");
+    case '\r':
+        return QByteArrayLiteral("\\r");
+    default:
+        return QByteArrayLiteral("\\u00") + QByteArray::number(static_cast<unsigned char>(byte), 16).rightJustified(2, '0');
+    }
+}
+
 // No documentation available in wiki - internal function
 // src is in Mud Server encoding and may need transcoding
 // Includes MSDP code originally from recv_sb_msdp(...) in TinTin++'s telopt.c,
@@ -4110,6 +4132,9 @@ void TLuaInterpreter::msdp2Lua(const char* src)
             last = MSDP_VAL;
             break;
         case '\\':
+            // both, or the decoder reads whatever follows as an escape sequence:
+            // "a\\b" used to arrive as a backspace
+            script.append('\\');
             script.append('\\');
             break;
         case '\"':
@@ -4117,7 +4142,12 @@ void TLuaInterpreter::msdp2Lua(const char* src)
             script.append('\"');
             break;
         default:
-            script.append(transcodedSrc.at(i));
+            if (static_cast<unsigned char>(transcodedSrc.at(i)) < 0x20) {
+                script.append(jsonEscapedControlByte(transcodedSrc.at(i)));
+            } else {
+                script.append(transcodedSrc.at(i));
+            }
+            // a Lua table key rather than JSON, so it takes the byte as sent
             lastVar.append(transcodedSrc.at(i));
             break;
         }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3864,10 +3864,6 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 return;
             }
 
-            rawData = rawData.replace(TN_BELL, QByteArray("\\\\007"));
-
-            rawData = rawData.replace("\x1b", QByteArray("\\\\027"));
-
             // rawData is in the Mud Server's encoding, trim off the Telnet suboption
             // bytes from beginning (3) and end (2):
             rawData = rawData.mid(3, static_cast<int>(rawData.size()) - 5);

--- a/src/mudlet-lua/tests/Telnet_spec.lua
+++ b/src/mudlet-lua/tests/Telnet_spec.lua
@@ -199,6 +199,49 @@ describe("Tests MSDP subnegotiation handling", function()
     assert.equals("north", msdp.MSDPROOM.EXITS)
     assert.equals("line one\nline two", msdp.MSDPROOM.DESC)
   end)
+
+    -- The specification restricts a name to [A-Za-z_][A-Za-z0-9_]*, so none of the
+    -- names below is one a conforming server can send. They are here because the
+    -- prefix strip sized itself from the raw name while the JSON carried the escaped
+    -- one, so a name that grew when escaped left part of its own prefix behind and
+    -- took the variable down with it.
+    it("keeps a variable whose name carries a control code", function()
+      for _, case in ipairs({{"MSDPNTAB", 9}, {"MSDPNCR", 13}, {"MSDPNBEL", 7}}) do
+        local name = case[1] .. string.char(case[2]) .. "X"
+        feedMsdp(VAR .. name .. VAL .. "value")
+        assert.equals("value", msdp[name], (name:gsub("%c", "?")) .. " went missing, so the strip and the escaped name disagree")
+      end
+    end)
+
+    it("keeps a variable whose name carries a backslash", function()
+      -- two bytes longer once escaped, and the key is the byte the game sent rather
+      -- than the escape the JSON needed
+      feedMsdp(VAR .. "MSDPNSLASHX" .. "\\Y" .. VAL .. "value")
+      assert.equals("value", msdp["MSDPNSLASHX\\Y"])
+    end)
+
+    it("keeps a non-ASCII value as the bytes the game sent", function()
+      -- char is signed on some targets, so every byte >= 0x80 reads as below 0x20 at
+      -- the escape test and arrives as \u00xx mojibake without the cast there
+      -- decimal escapes: Lua 5.1 has no \x form, and "\xC3" there is a literal
+      -- x, C, 3 - which would make this spec pass on ASCII and prove nothing
+      feedMsdp(VAR .. "MSDPUTF8" .. VAL .. "caf\195\169")
+      assert.equals("caf\195\169", msdp.MSDPUTF8)
+    end)
+
+    it("keeps every variable of a batched update, as a string", function()
+      -- a server answering REPORT sends many at once. Flushing one variable threw
+      -- away the opening quote of the next name, so a numeric value came back a
+      -- number and a non-numeric one went missing entirely.
+      feedMsdp(VAR .. "MSDPB1" .. VAL .. "1200"
+               .. VAR .. "MSDPB2" .. VAL .. "1500"
+               .. VAR .. "MSDPB3" .. VAL .. "Market Square"
+               .. VAR .. "MSDPB4" .. VAL .. "a rat")
+      assert.equals("1200", msdp.MSDPB1)
+      assert.equals("1500", msdp.MSDPB2, "a numeric value mid-batch came back as a " .. type(msdp.MSDPB2))
+      assert.equals("Market Square", msdp.MSDPB3, "a non-numeric value mid-batch went missing")
+      assert.equals("a rat", msdp.MSDPB4)
+    end)
 end)
 
 describe("Tests addSupportedTelnetOption", function()

--- a/src/mudlet-lua/tests/Telnet_spec.lua
+++ b/src/mudlet-lua/tests/Telnet_spec.lua
@@ -145,6 +145,62 @@ describe("Tests telnet subnegotiation handling", function()
   end)
 end)
 
+describe("Tests MSDP subnegotiation handling", function()
+  -- MSDP forbids only NUL, IAC and its own six markers inside a value, so every
+  -- other control code is legal payload the game means to send. Mudlet turns the
+  -- payload into JSON for the Lua decoder, which rejects the whole document
+  -- rather than one value if a control character arrives unescaped.
+  local VAR, VAL = "<01>", "<02>"
+  local TABLE_OPEN, TABLE_CLOSE = "<03>", "<04>"
+
+  local function feedMsdp(payload)
+    local ok, msg = feedTelnet("<T_IAC><T_SB><O_MSDP>" .. payload .. "<T_IAC><T_SE>")
+    assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
+  end
+
+  it("keeps a value carrying a control code, as the byte the game sent", function()
+    local cases = {
+      {"MSDPCTLBEL", "a<BELL>b", 7},
+      {"MSDPCTLTAB", "a<HTAB>b", 9},
+      {"MSDPCTLLF", "a<LF>b", 10},
+      {"MSDPCTLVT", "a<VTAB>b", 11},
+      {"MSDPCTLCR", "a<CR>b", 13},
+      {"MSDPCTLESC", "a<ESC>b", 27},
+    }
+    for _, case in ipairs(cases) do
+      local name, payload, byte = case[1], case[2], case[3]
+      feedMsdp(VAR .. name .. VAL .. payload)
+      assert.is_table(msdp, "no MSDP variable was registered at all")
+      assert.is_not_nil(msdp[name], name .. " went missing, so its control code reached the decoder unescaped")
+      -- the byte itself, not text describing it: BEL and ESC used to arrive as a
+      -- literal "\007" and "\027", which is not what the game sent
+      assert.equals("a" .. string.char(byte) .. "b", msdp[name], name .. " did not arrive as the byte the game sent")
+    end
+  end)
+
+  it("does not read a backslash in a value as an escape sequence", function()
+    -- a lone backslash reached the decoder as the start of an escape, so "a\\b"
+    -- arrived as an "a" followed by a backspace
+    feedMsdp(VAR .. "MSDPSLASH" .. VAL .. "a\\b")
+    assert.equals("a\\b", msdp.MSDPSLASH)
+  end)
+
+  it("keeps the rest of a table when one value carries a control code", function()
+    -- the case that bites in play: a room description with a newline in it used
+    -- to take the room's name and exits down with it
+    feedMsdp(VAR .. "MSDPROOM" .. VAL .. TABLE_OPEN
+             .. VAR .. "NAME" .. VAL .. "The Hall"
+             .. VAR .. "DESC" .. VAL .. "line one<LF>line two"
+             .. VAR .. "EXITS" .. VAL .. "north"
+             .. TABLE_CLOSE)
+
+    assert.is_table(msdp.MSDPROOM, "the whole table went missing, not only the value holding the newline")
+    assert.equals("The Hall", msdp.MSDPROOM.NAME)
+    assert.equals("north", msdp.MSDPROOM.EXITS)
+    assert.equals("line one\nline two", msdp.MSDPROOM.DESC)
+  end)
+end)
+
 describe("Tests addSupportedTelnetOption", function()
   -- Only the argument contract is reachable. What the call changes is the
   -- reply cTelnet writes back when the server offers that option - IAC DO


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `msdp2Lua()` now escapes control characters as JSON requires at the point it emits a value byte, replacing the two codes `ctelnet.cpp` pre-substituted.
- A lone backslash in a value is escaped, so it no longer turns the following character into an escape sequence.
- Three specs in `Telnet_spec.lua`: the control-code range, the backslash, and a table whose other fields used to vanish.

#### Motivation for adding to Mudlet

MSDP allows any byte in a value except NUL, IAC and its own six markers, but Mudlet transcribed the payload into JSON without escaping control characters - so the decoder rejected the whole document and every variable in that value's table went missing.

#### Other info (issues closed, discussion etc)

Fixes #10136.

The [specification](https://tintin.mudhalla.net/protocols/msdp/) is explicit about what a value may hold: *"For ease of parsing, variables and values cannot contain the NUL, MSDP_VAL, MSDP_VAR, MSDP_TABLE_OPEN, MSDP_TABLE_CLOSE, MSDP_ARRAY_OPEN, MSDP_ARRAY_CLOSE, or IAC byte."* Everything else is legal payload. It defines no escaping mechanism, and nowhere asks a client to transform a value before passing it to a script.

`ctelnet.cpp` special-cased exactly two codes, substituting BEL and ESC for the literal text `\007` and `\027` - a representation the protocol does not have. Those substitutions are gone; the escaping happens where the JSON is built, covering everything below `0x20`, and the byte the game sent reaches the script.

Measured through the real subnegotiation handler:

| value sent | before | after |
| --- | --- | --- |
| `a<LF>b`, `<CR>`, `<TAB>`, `<VTAB>` | variable missing | the byte, delivered |
| `a<BEL>b` | `a\007b` | `0x07` |
| `<ESC>[31mred<ESC>[0m` | `\027[31m…` | `0x1B` |
| `a\b` | `a` + backspace | `a\b` |
| table with `<LF>` in one field | `nil` - whole table lost | all three fields |

This ground has been covered before, one character at a time: #2515 (closed as not planned, still reproduces), #3788 (BEL, via PR #3794), #5290 and #6893 (quotes, via PR #6974). Escaping the range rather than the reported code is what stops it recurring.

**Behaviour change worth a changelog note:** BEL and ESC now arrive as bytes rather than as the text `\007`/`\027`, so a script parsing the old form needs updating. Realms of Despair uses BEL as a separator inside a value.

Also worth recording: the transcribe-to-JSON-text design is why this bug class exists at all. Building the value with `QJsonDocument`, or handing Lua a tree directly, would make it structurally impossible - but `parseJSON()` is shared with GMCP and takes text, so that is a refactor for its own PR.

**Test case:** in an offline profile, feed a subnegotiation with a control code in a value:

```lua
feedTelnet("<T_IAC><T_SB><O_MSDP><01>ROOM<02><03><01>NAME<02>The Hall<01>DESC<02>line one<LF>line two<01>EXITS<02>north<04><T_IAC><T_SE>")
```

Then check `msdp.ROOM`: it should be a table holding `NAME`, `DESC` and `EXITS`. Before this it was `nil`. Specs report 16 successes with the fix, 13 successes and 3 failures without it.

Two changes a script can see:

- A value carrying BEL or ESC now arrives as that byte. It used to arrive as the four-character text `\007` or `\027`.
- A variable in the middle of a batched update now behaves like any other MSDP variable: it arrives, and it arrives as a string. A numeric-looking one used to arrive as a Lua number and a non-numeric one went missing entirely.

Also closes item 1 of #10189 — unavoidably, since the same expression sizes the prefix for every top-level variable, so it cannot be right for an escaped name without also being right mid-batch. Item 2 is untouched.

Assisted-by: Claude:claude-opus-5

