### PR TITLE
Fix: Databases are still created when a unique constraint names a column that isn't there

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -449,6 +449,10 @@ local lua_reserved_words = {
 ---   sheet asks for is made as usual. The indexes the sheet already has are left
 ---   alone in that case, since what is left of _index is no longer the whole set
 ---   it asked for.
+---   A _unique entry naming a column the sheet does not have is skipped and warned
+---   about the same way, but that one costs more than an index would: the sheet is
+---   then built without the uniqueness it asked for, so db:add takes rows the
+---   constraint would have refused.
 function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
@@ -571,6 +575,66 @@ function db:create(db_name, sheets, force)
       if is_unique_valid == false then
         is_valid = false
         table.insert(msgs, "db:create - "..sheet_name.." - "..msg)
+      end
+
+      -- the readers of _unique want the list: the loop below walks it with ipairs,
+      -- and db:merge_unique measures it with #, which on a string gives the length
+      -- of the column name rather than one constraint and raises. db.__schema is
+      -- only written here, so normalising once covers both
+      if type(options._unique) == "string" then
+        options._unique = { options._unique }
+      end
+
+      if type(options._unique) == "table" then
+        -- the two forms reach the database by different routes, so what counts as a
+        -- column the sheet has differs too: a compound entry is written into the
+        -- CREATE TABLE for sqlite to resolve, which matches names case-insensitively
+        -- and knows the _row_id every sheet is given, while a single column name is
+        -- attached by an exact-match lookup in db:_build_create_table_sql
+        local resolvable = { _row_id = true }
+        for column_name in pairs(columns) do
+          resolvable[column_name:lower()] = true
+        end
+
+        local wanted = {}
+
+        for _, unique_entry in ipairs(options._unique) do
+          local compound = type(unique_entry) == "table"
+          local unique_columns = compound and unique_entry or {unique_entry}
+          local unknown_column
+
+          for _, column_name in ipairs(unique_columns) do
+            if not unknown_column and type(column_name) == "string" then
+              local known = compound and resolvable[column_name:lower()] or columns[column_name] ~= nil
+              if not known then
+                unknown_column = column_name
+              end
+            end
+          end
+
+          -- a UNIQUE naming a column sqlite cannot resolve is refused, and takes the
+          -- whole CREATE TABLE with it, leaving no sheet at all. Dropping the
+          -- constraint keeps the sheet, at the price of db:add then taking the
+          -- duplicates it was meant to refuse; the single-column form was never
+          -- attached in the first place, so there it only adds the message
+          if compound and #unique_entry == 0 then
+            table.insert(warnings, "db:create - "..sheet_name.." - _unique has an entry with no "..
+              "column names in it: that constraint is skipped.")
+          elseif not unknown_column then
+            wanted[#wanted + 1] = unique_entry
+          elseif unknown_column == "_row_id" then
+            table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\" on its own, "..
+              "which is the key every sheet is given rather than one of its own columns: that "..
+              "constraint is skipped.")
+          else
+            table.insert(warnings, "db:create - "..sheet_name.." - _unique names \""..unknown_column..
+              "\", which is not one of the sheet's columns: that constraint is skipped.")
+          end
+        end
+
+        -- nil rather than an empty list, so db:merge_unique can still tell a sheet
+        -- with no unique index from one with several by which of its asserts fires
+        options._unique = #wanted > 0 and wanted or nil
       end
     end
 
@@ -2499,8 +2563,9 @@ function db.Database:_drop(s_name)
 
   local schema = db.__schema[self._db_name][s_name]
 
-  -- _index and _unique can each be a single column name (a string) or a list of
-  -- them, so normalise to a list before iterating to drop the matching indexes.
+  -- db:create normalises _index and _unique to a list before they reach
+  -- db.__schema, which is written nowhere else: the string form only arrives here
+  -- from a schema built by hand
   local index_groups = { schema.options._index, schema.options._unique }
   for _, group in pairs(index_groups) do
     if type(group) == "string" then

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -450,9 +450,10 @@ local lua_reserved_words = {
 ---   alone in that case, since what is left of _index is no longer the whole set
 ---   it asked for.
 ---   A _unique entry naming a column the sheet does not have is skipped and warned
----   about the same way, but that one costs more than an index would: the sheet is
----   then built without the uniqueness it asked for, so db:add takes rows the
----   constraint would have refused.
+---   about the same way, but that one costs more than an index would: a sheet made
+---   from scratch is built without the uniqueness it asked for, so db:add takes rows
+---   the constraint would have refused. A sheet that already carries the constraint
+---   keeps it, for the same reason its indexes are left alone.
 function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
@@ -472,6 +473,7 @@ function db:create(db_name, sheets, force)
     local columns = {}
     local options = {}
     local has_skipped_index = false
+    local has_skipped_unique = false
 
     -- the sheet was provided in {"column1", "column2"} format
     if sheet[1] ~= nil then
@@ -593,7 +595,11 @@ function db:create(db_name, sheets, force)
         -- attached by an exact-match lookup in db:_build_create_table_sql
         local resolvable = { _row_id = true }
         for column_name in pairs(columns) do
-          resolvable[column_name:lower()] = true
+          -- the keyed form takes every key that is not an option for a column
+          -- name, numbers included, and a number has no :lower()
+          if type(column_name) == "string" then
+            resolvable[column_name:lower()] = true
+          end
         end
 
         local wanted = {}
@@ -605,7 +611,13 @@ function db:create(db_name, sheets, force)
 
           for _, column_name in ipairs(unique_columns) do
             if not unknown_column and type(column_name) == "string" then
-              local known = compound and resolvable[column_name:lower()] or columns[column_name] ~= nil
+              local known
+              if compound then
+                known = resolvable[column_name:lower()] ~= nil
+              else
+                known = columns[column_name] ~= nil
+              end
+
               if not known then
                 unknown_column = column_name
               end
@@ -618,15 +630,18 @@ function db:create(db_name, sheets, force)
           -- duplicates it was meant to refuse; the single-column form was never
           -- attached in the first place, so there it only adds the message
           if compound and #unique_entry == 0 then
+            has_skipped_unique = true
             table.insert(warnings, "db:create - "..sheet_name.." - _unique has an entry with no "..
               "column names in it: that constraint is skipped.")
           elseif not unknown_column then
             wanted[#wanted + 1] = unique_entry
           elseif unknown_column == "_row_id" then
-            table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\" on its own, "..
-              "which is the key every sheet is given rather than one of its own columns: that "..
-              "constraint is skipped.")
+            has_skipped_unique = true
+            table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\", the key "..
+              "every sheet is given, which is unique already: that constraint is skipped. Putting it "..
+              "in a compound entry instead makes one that can never refuse a row.")
           else
+            has_skipped_unique = true
             table.insert(warnings, "db:create - "..sheet_name.." - _unique names \""..unknown_column..
               "\", which is not one of the sheet's columns: that constraint is skipped.")
           end
@@ -705,7 +720,12 @@ function db:create(db_name, sheets, force)
       end
     end
 
-    schema[sheet_name] = { columns = columns, options = options, has_skipped_index = has_skipped_index }
+    schema[sheet_name] = {
+      columns = columns,
+      options = options,
+      has_skipped_index = has_skipped_index,
+      has_skipped_unique = has_skipped_unique,
+    }
   end
 
   assert(is_valid, table.concat(msgs, "\n"))
@@ -932,8 +952,12 @@ function db:_migrate(db_name, s_name, force)
       end
     end
 
-    -- If the table-level constraints have changed, we need to recreate the table
-    if table_constraints_changed then
+    -- If the table-level constraints have changed, we need to recreate the table.
+    -- Not when db:create dropped a _unique entry naming a column the sheet does not
+    -- have: rebuilding to match what is left of _unique would take a uniqueness rule
+    -- the live table has today off a typo, and the create that spells the column
+    -- right again cannot put it back over the duplicates the meantime let in.
+    if table_constraints_changed and not schema.has_skipped_unique then
       -- Commit any pending transaction before table recreation
       db:echo_sql("COMMIT")
       conn:commit()

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -454,6 +454,9 @@ local lua_reserved_words = {
 ---   from scratch is built without the uniqueness it asked for, so db:add takes rows
 ---   the constraint would have refused. A sheet that already carries the constraint
 ---   keeps it, for the same reason its indexes are left alone.
+---   Naming _row_id in a _unique entry of several columns is warned about but kept,
+---   since a sheet's _row_id is unique on its own and the constraint is therefore
+---   one that can never refuse a row.
 function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
@@ -608,17 +611,19 @@ function db:create(db_name, sheets, force)
           local compound = type(unique_entry) == "table"
           local unique_columns = compound and unique_entry or {unique_entry}
           local unknown_column
+          local names_row_id
 
           for _, column_name in ipairs(unique_columns) do
-            if not unknown_column and type(column_name) == "string" then
+            if type(column_name) == "string" then
               local known
               if compound then
                 known = resolvable[column_name:lower()] ~= nil
+                names_row_id = names_row_id or column_name:lower() == "_row_id"
               else
                 known = columns[column_name] ~= nil
               end
 
-              if not known then
+              if not known and not unknown_column then
                 unknown_column = column_name
               end
             end
@@ -634,12 +639,22 @@ function db:create(db_name, sheets, force)
             table.insert(warnings, "db:create - "..sheet_name.." - _unique has an entry with no "..
               "column names in it: that constraint is skipped.")
           elseif not unknown_column then
+            -- sqlite takes a compound entry naming _row_id, and the constraint can
+            -- then never refuse a row, since a sheet's key is unique on its own. It
+            -- is kept anyway: dropping it would change the sheet's SQL and put every
+            -- database that has one through db:_migrate's table rebuild
+            if names_row_id then
+              table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\" among "..
+                "the columns of an entry, and a sheet's _row_id is unique already, so that constraint "..
+                "can never refuse a row: drop it, or name the columns you meant.")
+            end
+
             wanted[#wanted + 1] = unique_entry
           elseif unknown_column == "_row_id" then
             has_skipped_unique = true
             table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\", the key "..
-              "every sheet is given, which is unique already: that constraint is skipped. Putting it "..
-              "in a compound entry instead makes one that can never refuse a row.")
+              "every sheet is given, which is unique already: that constraint is skipped. Naming it "..
+              "in a compound entry makes one that can never refuse a row either.")
           else
             has_skipped_unique = true
             table.insert(warnings, "db:create - "..sheet_name.." - _unique names \""..unknown_column..

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -2548,6 +2548,9 @@ describe("Tests DB.lua functions", function()
           _unique = "name",
         }
       })
+      -- db:create stores the list form, so the string _drop still accepts has to be
+      -- put back by hand to be reached at all
+      db.__schema["dropstrtestingonly"].pets.options._unique = "name"
       local ok, err = pcall(function() sdb:_drop("pets") end)
       db:close("dropstrtestingonly")
       os.remove(getMudletHomeDir() .. "/Database_dropstrtestingonly.db")
@@ -3770,6 +3773,177 @@ describe("Tests db:create with a single column name as _index", function()
     assert.is_table(mydb)
     assert.is_truthy(string.find(warnings, '_index names "_row_id"', 1, true))
     assert.are.same({}, indexNames("people"))
+  end)
+end)
+
+describe("Tests db:create with _unique naming unknown columns", function()
+  local dbName = "uniqueskipstestingonly"
+  local dbFile = getMudletHomeDir() .. "/Database_" .. dbName .. ".db"
+
+  -- db:create reports a constraint it cannot make through printError and carries
+  -- on, so what it says is collected rather than caught
+  local function createCollectingWarnings(sheets)
+    local collected = {}
+    -- through _G: a spec file's globals are its own, so plain assignment would
+    -- leave db:create with the printError it already has
+    local originalPrintError = _G.printError
+    _G.printError = function(msg) collected[#collected + 1] = msg end
+    finally(function() _G.printError = originalPrintError end)
+
+    local result = db:create(dbName, sheets)
+    _G.printError = originalPrintError
+    return result, table.concat(collected, "\n")
+  end
+
+  local function tableSql(sheetName)
+    local cursor = db.__conn[dbName]:execute(
+      "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = '" .. sheetName .. "'"
+    )
+    local row = cursor:fetch({}, "a")
+    cursor:close()
+    return row and row.sql
+  end
+
+  local function indexNames(sheetName)
+    local cursor = db.__conn[dbName]:execute(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = '" .. sheetName .. "' AND sql IS NOT NULL"
+    )
+    local names = {}
+    local row = cursor:fetch({}, "a")
+    while row do
+      names[#names + 1] = row.name
+      row = cursor:fetch({}, "a")
+    end
+    cursor:close()
+    table.sort(names)
+    return names
+  end
+
+  after_each(function()
+    -- a db:create that raises part way through leaves a cursor open, and closing
+    -- then raises as well. Forget just this database in that case, so a regression
+    -- here costs this block's specs rather than every db spec that runs after it.
+    if not pcall(function() db:close(dbName) end) then
+      db.__conn[dbName] = nil
+    end
+    os.remove(dbFile)
+  end)
+
+  it("warns about a column the sheet does not have and accepts the sheet (form 1)", function()
+    local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = "nosuchcol"}})
+    assert.is_table(mydb)
+    assert.is_truthy(string.find(warnings, '_unique names "nosuchcol", which is not one of the sheet\'s columns: that constraint is skipped', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    local rows = db:fetch(mydb.people)
+    assert.are.equal(2, #rows)
+  end)
+
+  it("warns about an unknown column in a compound constraint and still builds the table (form 2)", function()
+    local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = {{"name", "nosuchcol"}}}})
+    assert.is_table(mydb)
+    assert.is_truthy(string.find(warnings, '_unique names "nosuchcol", which is not one of the sheet\'s columns: that constraint is skipped', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    local rows = db:fetch(mydb.people)
+    assert.are.equal(2, #rows)
+  end)
+
+  it("still enforces a valid _unique constraint", function()
+    local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = "name"}})
+    assert.is_table(mydb)
+    assert.are.equal("", warnings)
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    local ok, _ = db:add(mydb.people, {name = "Bob"})
+    assert.is_nil(ok)
+    local rows = db:fetch(mydb.people)
+    assert.are.equal(1, #rows)
+  end)
+
+  it("leaves a compound constraint that only differs in case alone", function()
+    -- sqlite resolves the names in a UNIQUE(...) itself, and does it
+    -- case-insensitively, so this constraint is real and enforced: reading the
+    -- sheet's columns with an exact-match lookup would throw away a working rule
+    local mydb, warnings = createCollectingWarnings({people = {Name = "", City = "", _unique = {{"name", "city"}}}})
+    assert.are.equal("", warnings)
+    assert.is_true(db:add(mydb.people, {Name = "Bob", City = "Ankh-Morpork"}))
+    assert.is_nil(db:add(mydb.people, {Name = "Bob", City = "Ankh-Morpork"}))
+    assert.are.equal(1, #db:fetch(mydb.people))
+  end)
+
+  it("leaves a compound constraint naming _row_id alone", function()
+    -- _row_id is a column of the table even though no sheet definition names it,
+    -- so sqlite takes this constraint. Skipping it would change the sheet's SQL
+    -- and put every database that has one through db:_migrate's table rebuild
+    local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = {{"name", "_row_id"}}}})
+    assert.are.equal("", warnings)
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("name", "_row_id")', 1, true))
+  end)
+
+  it("warns about _row_id given on its own, which is never applied", function()
+    -- the single-column form is attached by matching the sheet's own columns, and
+    -- _row_id is not among them, so this asked for a rule that was never made
+    local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = "_row_id"}})
+    assert.is_truthy(string.find(warnings, '_unique names "_row_id" on its own', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.are.equal(2, #db:fetch(mydb.people))
+  end)
+
+  it("warns about an entry with no column names in it and still builds the table", function()
+    -- UNIQUE("") is refused by sqlite the same way an unknown column is, so an
+    -- empty entry costs the whole sheet - including the entries that were fine
+    local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = {{"name"}, {}}}})
+    assert.is_truthy(string.find(warnings, "_unique has an entry with no column names in it", 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_nil(db:add(mydb.people, {name = "Bob"}))
+    assert.are.equal(1, #db:fetch(mydb.people))
+  end)
+
+  it("keeps the entries that are fine when another one is skipped", function()
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "nosuchcol"}, "city"}}})
+    assert.is_truthy(string.find(warnings, '_unique names "nosuchcol"', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob", city = "Ankh-Morpork"}))
+    assert.is_nil(db:add(mydb.people, {name = "Ada", city = "Ankh-Morpork"}))
+    assert.are.equal(1, #db:fetch(mydb.people))
+  end)
+
+  it("gives a single column name the same SQL as the one-entry list", function()
+    -- the two are documented as meaning the same thing, and the shape they build
+    -- is what db:_migrate compares a sheet against: a single name that turned into
+    -- a table constraint would rebuild every existing sheet on the next db:create
+    db:create(dbName, {people = {name = "", _unique = "name"}})
+    local stringForm = tableSql("people")
+    db:close(dbName)
+    os.remove(dbFile)
+
+    db:create(dbName, {people = {name = "", _unique = {"name"}}})
+    assert.are.equal(stringForm, tableSql("people"))
+  end)
+
+  it("lets db:merge_unique read a single column name", function()
+    -- db:merge_unique measures _unique with #, so before db:create stored the list
+    -- form it counted the letters of the column name and refused the sheet
+    local mydb = db:create(dbName, {people = {name = "", city = "", _unique = "name"}})
+    db:add(mydb.people, {name = "Ada", city = "Boston"})
+    db:merge_unique(mydb.people, {{name = "Ada", city = "Rome"}, {name = "Bram", city = "Denver"}})
+
+    local byName = {}
+    for _, row in ipairs(db:fetch(mydb.people)) do
+      byName[row.name] = row.city
+    end
+    assert.are.same({Ada = "Rome", Bram = "Denver"}, byName)
+  end)
+
+  it("leaves the sheet's indexes to be pruned as usual when a constraint is skipped", function()
+    -- unlike a skipped _index, a skipped _unique must not stop db:create pruning:
+    -- what is left of _index is still the whole set the sheet asked for
+    createCollectingWarnings({people = {name = "", city = "", _unique = "nosuchcol", _index = {"name", "city"}}})
+    assert.are.equal(2, #indexNames("people"))
+    db:close(dbName)
+
+    createCollectingWarnings({people = {name = "", city = "", _unique = "nosuchcol", _index = "city"}})
+    assert.are.same({db:_index_name("people", "city")}, indexNames("people"))
   end)
 end)
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3871,13 +3871,18 @@ describe("Tests db:create with _unique naming unknown columns", function()
     assert.are.equal(1, #db:fetch(mydb.people))
   end)
 
-  it("leaves a compound constraint naming _row_id alone", function()
-    -- _row_id is a column of the table even though no sheet definition names it,
-    -- so sqlite takes this constraint. Skipping it would change the sheet's SQL
-    -- and put every database that has one through db:_migrate's table rebuild
+  it("warns about a compound constraint naming _row_id but leaves it alone", function()
+    -- _row_id is a column of the table even though no sheet definition names it, so
+    -- sqlite takes this constraint - and it can then never refuse a row. Skipping it
+    -- would change the sheet's SQL and put every database that has one through
+    -- db:_migrate's table rebuild, so the warning is all this can do about it
     local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = {{"name", "_row_id"}}}})
-    assert.are.equal("", warnings)
+    assert.is_truthy(string.find(warnings, '_unique names "_row_id" among the columns of an entry', 1, true))
+    assert.is_truthy(string.find(warnings, "can never refuse a row", 1, true))
     assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("name", "_row_id")', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.are.equal(2, #db:fetch(mydb.people))
   end)
 
   it("warns about _row_id given on its own, which is never applied", function()
@@ -3885,9 +3890,9 @@ describe("Tests db:create with _unique naming unknown columns", function()
     -- _row_id is not among them, so this asked for a rule that was never made
     local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = "_row_id"}})
     assert.is_truthy(string.find(warnings, '_unique names "_row_id", the key every sheet is given, which is unique already', 1, true))
-    -- the compound spelling is the one shape this message must not send anyone to:
-    -- it is taken silently and can never refuse a row
-    assert.is_truthy(string.find(warnings, "can never refuse a row", 1, true))
+    -- the compound spelling is not the fix, and the message has to say so rather
+    -- than leave it looking like one
+    assert.is_truthy(string.find(warnings, "can never refuse a row either", 1, true))
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
     assert.are.equal(2, #db:fetch(mydb.people))

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3884,7 +3884,10 @@ describe("Tests db:create with _unique naming unknown columns", function()
     -- the single-column form is attached by matching the sheet's own columns, and
     -- _row_id is not among them, so this asked for a rule that was never made
     local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = "_row_id"}})
-    assert.is_truthy(string.find(warnings, '_unique names "_row_id" on its own', 1, true))
+    assert.is_truthy(string.find(warnings, '_unique names "_row_id", the key every sheet is given, which is unique already', 1, true))
+    -- the compound spelling is the one shape this message must not send anyone to:
+    -- it is taken silently and can never refuse a row
+    assert.is_truthy(string.find(warnings, "can never refuse a row", 1, true))
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
     assert.are.equal(2, #db:fetch(mydb.people))
@@ -3944,6 +3947,34 @@ describe("Tests db:create with _unique naming unknown columns", function()
 
     createCollectingWarnings({people = {name = "", city = "", _unique = "nosuchcol", _index = "city"}})
     assert.are.same({db:_index_name("people", "city")}, indexNames("people"))
+  end)
+
+  it("leaves the constraint a sheet already has alone when a later db:create misspells it", function()
+    -- what is left of _unique is not the set the sheet asked for, so rebuilding the
+    -- live table to match it would take a uniqueness rule off a typo - and the create
+    -- that spells the column right again cannot put it back over the duplicates the
+    -- meantime let in
+    local mydb = createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "city"}}}})
+    assert.is_true(db:add(mydb.people, {name = "Ada", city = "London"}))
+    assert.is_nil(db:add(mydb.people, {name = "Ada", city = "London"}))
+
+    local typoed, warnings = createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "citty"}}}})
+    assert.is_truthy(string.find(warnings, '_unique names "citty"', 1, true))
+    assert.is_nil(db:add(typoed.people, {name = "Ada", city = "London"}))
+    assert.are.equal(1, #db:fetch(typoed.people))
+
+    local fixed = createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "city"}}}})
+    assert.is_nil(db:add(fixed.people, {name = "Ada", city = "London"}))
+    assert.are.equal(1, #db:fetch(fixed.people))
+  end)
+
+  it("takes a sheet that gave one of its columns a number for a name", function()
+    -- the keyed form takes every key that is not an option for a column name, so
+    -- this sheet really does have a column called 2, which _unique cannot name
+    local mydb, warnings = createCollectingWarnings({people = {name = "", [2] = "extra", _unique = "name"}})
+    assert.are.equal("", warnings)
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_nil(db:add(mydb.people, {name = "Bob"}))
   end)
 end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `db:create` no longer hands back a handle for a sheet that was never made: a `_unique` entry naming a column sqlite cannot resolve is dropped from the wanted set and reported through `printError`, and everything else the sheet asks for is created as usual.
- One unresolvable column costs the whole entry, since a `UNIQUE` on the rest of its columns is not the constraint that was asked for.
- A sheet that already carries the constraint keeps it. Skipping an entry holds `db:_migrate`'s constraint rebuild off, the way a skipped `_index` already holds off index pruning - otherwise a typo would take a live uniqueness rule off the table, and the create that spells the column right again could not put it back over the duplicates the meantime let in.
- Naming `_row_id` among the columns of an entry is warned about but kept: sqlite takes that constraint and it can then never refuse a row, so it is worth saying, while dropping it would change the sheet's SQL and put every database that has one through `db:_migrate`'s rebuild.
- What counts as resolvable differs by form, because the two reach the database by different routes: a compound entry is written into the `CREATE TABLE` for sqlite to resolve, which matches names case-insensitively and knows the `_row_id` every sheet is given; a single column name is attached by an exact-match lookup, so only that form warns about a case mismatch or about `_row_id`.
- An entry with no column names in it is skipped too - `UNIQUE("")` loses the sheet the same way an unknown column does.
- Malformed `_unique` *shapes* are still hard errors; only the unresolvable-column case is downgraded.
- Normalizing the single-column string form to a list also lets `db:merge_unique` read it, which it could not before: it measures `_unique` with `#`, which on a string counted the letters of the column name.

#### Motivation for adding to Mudlet

`_index` has been checked against the sheet's columns since #10033, `_unique` never was. The compound form put `UNIQUE("name", "nosuchcol")` into the `CREATE TABLE`, sqlite refused the statement, and nothing said so - the user found out from a `LuaSQL: no such table` on their next `db:add`, in a tab that is hidden unless opened.

#### Other info (issues closed, discussion etc)

Closes #10058.

Backwards compatibility, which is the whole question on this file: the string form already applied no constraint, so skipping it changes nothing a script can observe and only adds the message; the compound form left no table at all, so nothing can depend on it. Refusing the create outright would break scripts that run today, which is what #10038 and #10049 were about. The case-insensitive and `_row_id` handling exist for the same reason - both of those build a constraint that works today, so skipping them would have destroyed a live uniqueness rule and put every existing database through `db:_migrate`'s table rebuild.

This removes the only known trigger for #10059 (`db:_migrate` never checks whether its `CREATE TABLE` succeeded), which stays open as a guard against future ones.

Thirteen specs added; seven are red against `development`, four are red against this PR's first cut (the live constraint, a numeric column key, and the two `_row_id` warnings), and the two that guard the case-mismatch and `_row_id` shapes are red against an exact-match implementation of this same fix. Full Lua suite: 3700 passed, 0 failed.

**Test case:** `db:create("test", {people = {name = "", _unique = {{"name", "nosuchcol"}}}})` - the error console shows `_unique names "nosuchcol", which is not one of the sheet's columns: that constraint is skipped.`, and the returned db is usable (`db:add` / `db:fetch` work). Before, `db:add` returned nil with `LuaSQL: no such table: people`.

Assisted-by: antigravity:gemini-3.1-pro-high
Assisted-by: Claude:claude-opus-5