### PR TITLE
Add: Scripts can tell when Mudlet is not the active application

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -196,6 +196,15 @@ void mudlet::init()
     scmVersion = qsl("Mudlet ") + QString(APP_VERSION) + gitSha;
 
     mShowIconsOnMenuOriginally = !qApp->testAttribute(Qt::AA_DontShowIconsInMenus);
+
+    // Scripts that care whether the player is looking at Mudlet at all - a
+    // speech package holding a microphone open, an away marker, a timer that
+    // should not run while nobody is watching - have had no way to know.
+    // sysProfileFocusChangeEvent answers which profile is in front, which is a
+    // different question and says nothing when the whole application is behind
+    // another window.
+    mApplicationActive = qGuiApp->applicationState() == Qt::ApplicationActive;
+    connect(qGuiApp, &QGuiApplication::applicationStateChanged, this, &mudlet::slot_applicationStateChanged);
     readEarlySettings(*mpSettings);
 
     if (mShowIconsOnMenuCheckedState != Qt::PartiallyChecked) {
@@ -1672,6 +1681,33 @@ void mudlet::slot_packageExporter()
     QWidget* activeConsole = activeHost ? activeHost->mpConsole : nullptr;
     QWidget* referenceWidget = activeConsole ? activeConsole : this;
     utils::forceRepositionDialogOnParentScreen(d, referenceWidget);
+}
+
+// Qt reports several inactive states - suspended, hidden, and plain inactive -
+// and moves between them without the player having done anything. Only the
+// active/not-active distinction is meaningful to a script, so that is what is
+// announced, and only when it changes.
+void mudlet::slot_applicationStateChanged(const Qt::ApplicationState state)
+{
+    const bool nowActive = (state == Qt::ApplicationActive);
+    if (nowActive == mApplicationActive) {
+        return;
+    }
+    mApplicationActive = nowActive;
+
+    // Every profile hears it: this is a fact about the application, not about
+    // which profile is in front, and a profile in a background tab has as much
+    // reason to act on it as the one on screen.
+    TEvent event{};
+    event.mArgumentList << QLatin1String("sysApplicationFocusChangeEvent");
+    // Boolean arguments are carried as "0" for false or "1" for true
+    event.mArgumentList << (nowActive ? QLatin1String("1") : QLatin1String("0"));
+    event.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_BOOLEAN;
+    for (auto pHost : mHostManager) {
+        if (pHost) {
+            pHost->raiseEvent(event);
+        }
+    }
 }
 
 void mudlet::slot_closeCurrentProfile()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -401,6 +401,10 @@ public:
     // Value of QCoreApplication::testAttribute(Qt::AA_DontShowIconsInMenus) on
     // startup which the user may leave as is or force on or off:
     bool mShowIconsOnMenuOriginally = true;
+    // Whether Mudlet was the active application at the last state change, so
+    // sysApplicationFocusChangeEvent is raised on a change of that and not on
+    // every transition Qt reports between its inactive states
+    bool mApplicationActive = true;
     // 2 (of 2) needed to work around a (Windows/MacOs specific QStyleFactory)
     // issue:
     QString mTEXT_ON_BG_STYLESHEET;
@@ -570,6 +574,7 @@ private slots:
 #endif
     void slot_updateShortcuts();
     void slot_windowStateChanged(const Qt::WindowStates);
+    void slot_applicationStateChanged(const Qt::ApplicationState);
     void slot_refreshTabIndicatorsDelayed();
     void slot_telnetConnectionStateChanged();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A new `sysApplicationFocusChangeEvent`, carrying a boolean, raised on every open profile when Mudlet becomes the active application or stops being it.
- Deduplicated: Qt reports several inactive states and moves between them unprompted, so only the active/not-active distinction is announced, and only when it changes.

#### Motivation for adding to Mudlet

`sysProfileFocusChangeEvent` says which profile is in front, which is a different question — every profile can be behind a web browser while one of them is still the front tab. Scripts that care whether anyone is looking at Mudlet at all (a package holding a microphone open, an away marker, an animation that need not run unseen) have had no way to know.

#### Other info (issues closed, discussion etc)

The signal was already in the tree: `TFeatureCallout` has connected to `QGuiApplication::applicationStateChanged` since it was added, to hide its balloon when Mudlet goes to the background. This only lets Lua hear what the C++ already hears.

Raised on every profile rather than only the active one, because it is a fact about the application; a background profile has as much reason to act on it. The event's shape deliberately matches its per-profile neighbour: name, then boolean.

Not covered by a test — the harness has no way to move the application between activation states, the same gap that leaves the macOS microphone permission flow untested. It is 41 lines, and the first consumer will be the speech package in #9982, which will stop listening on it so a microphone is not left open behind another window.

**Test case:** open a profile, then

```lua
lua registerAnonymousEventHandler("sysApplicationFocusChangeEvent", function(_, active) display(active) end)
```

Click another application and back: `false` then `true`, once each. With two profiles open, both print.

Assisted-by: Claude:claude-opus-5