### PR TITLE
Fix: Keep the loaded map when a download is canceled or returns no map

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -84,27 +84,43 @@ void restoreLabelOutlineColorFromUserData(TMapLabel& label, int labelId, QMap<QS
     }
 }
 
+enum class MapFileCheckResult { ValidMap, NotAMap, ParseError };
+
+struct MapFileCheck
+{
+    MapFileCheckResult result;
+    QString errorString;
+};
+
 // A file holds map data only if its root element is <map>. XMLimport reads a
 // <MudletPackage> document as a package, and anything else - a game's HTML "no
 // map here" page answered with a 200, say - as a well-formed document full of
 // elements it does not recognise: either way it reports success having put no
-// rooms on the map it was asked to fill.
-bool fileHoldsMapData(QFile& file)
+// rooms on the map it was asked to fill. A file that is not XML at all is told
+// apart from those, so that a damaged map is not reported as somebody else's
+// web page.
+MapFileCheck fileHoldsMapData(QFile& file)
 {
     const qint64 startPosition = file.pos();
-    bool result = false;
+    MapFileCheck check{MapFileCheckResult::NotAMap, QString()};
     QXmlStreamReader reader(&file);
     while (!reader.atEnd()) {
         if (reader.readNext() == QXmlStreamReader::StartElement) {
             // XML allows only one root element, so the first start element is it
-            result = (reader.name() == qsl("map"));
+            check.result = (reader.name() == qsl("map")) ? MapFileCheckResult::ValidMap : MapFileCheckResult::NotAMap;
             break;
         }
     }
+
+    if (reader.hasError()) {
+        check.result = MapFileCheckResult::ParseError;
+        check.errorString = reader.errorString();
+    }
+
     // The reader buffers ahead, so the parse proper has to be given the file
     // back where it was rather than where the scan above left it
     file.seek(startPosition);
-    return result;
+    return check;
 }
 } // anonymous namespace
 
@@ -2677,21 +2693,45 @@ bool TMap::readXmlMapFile(QFile& file, QString* errMsg)
         return false;
     }
 
-    if (!fileHoldsMapData(file)) {
-        if (errMsg) {
-            //: Error returned by the loadMap() Lua function. %1 is the path and name of the file that was read
-            *errMsg = tr("loadMap: the file:\n"
-                         "\"%1\"\n"
-                         "does not contain a map, so the current map has been left as it was.")
-                              .arg(file.fileName());
+    const MapFileCheck check = fileHoldsMapData(file);
+    if (check.result != MapFileCheckResult::ValidMap) {
+        // Both wordings are built before either is used: which one is wanted turns on what
+        // was wrong with the file, and where it goes turns on who asked, and keeping those
+        // two questions apart is what stops this being four near-identical branches
+        QString luaMessage;
+        QString consoleMessage;
+
+        if (check.result == MapFileCheckResult::ParseError) {
+            //: Error returned by the loadMap() Lua function. %1 is the path and name of the file that was read, %2 is the reason the XML parser gave
+            luaMessage = tr("loadMap: the file:\n"
+                            "\"%1\"\n"
+                            "is damaged or unreadable (%2), so the current map has been left as it was.")
+                                 .arg(file.fileName(), check.errorString);
+            //: Shown in the main console. %1 is the path and name of the file that was read, %2 is the reason the XML parser gave
+            consoleMessage = tr("[ ERROR ] - The file:\n"
+                                "\"%1\"\n"
+                                "is damaged or unreadable (%2) - so the current map has been\n"
+                                "left as it was.")
+                                     .arg(file.fileName(), check.errorString);
         } else {
+            //: Error returned by the loadMap() Lua function. %1 is the path and name of the file that was read
+            luaMessage = tr("loadMap: the file:\n"
+                            "\"%1\"\n"
+                            "does not contain a map, so the current map has been left as it was.")
+                                 .arg(file.fileName());
             //: Shown in the main console. %1 is the path and name of the file that was read
-            postMessage(tr("[ ERROR ] - The file:\n"
-                           "\"%1\"\n"
-                           "does not contain a map - a game with no map to offer can answer a\n"
-                           "download with an error page instead of one - so the current map has\n"
-                           "been left as it was.")
-                                .arg(file.fileName()));
+            consoleMessage = tr("[ ERROR ] - The file:\n"
+                                "\"%1\"\n"
+                                "does not contain a map - a game with no map to offer can answer a\n"
+                                "download with an error page instead of one - so the current map has\n"
+                                "been left as it was.")
+                                     .arg(file.fileName());
+        }
+
+        if (errMsg) {
+            *errMsg = luaMessage;
+        } else {
+            postMessage(consoleMessage);
         }
         return false;
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -49,6 +49,7 @@
 #include <QPixmap>
 #include <QSaveFile>
 #include <QSizeF>
+#include <QXmlStreamReader>
 #include <chrono>
 
 using namespace std::chrono_literals;
@@ -81,6 +82,29 @@ void restoreLabelOutlineColorFromUserData(TMapLabel& label, int labelId, QMap<QS
             qWarning("TMap: Failed to parse outline color data for label %d, expected 4 parts but got %lld", labelId, colorParts.size());
         }
     }
+}
+
+// A file holds map data only if its root element is <map>. XMLimport reads a
+// <MudletPackage> document as a package, and anything else - a game's HTML "no
+// map here" page answered with a 200, say - as a well-formed document full of
+// elements it does not recognise: either way it reports success having put no
+// rooms on the map it was asked to fill.
+bool fileHoldsMapData(QFile& file)
+{
+    const qint64 startPosition = file.pos();
+    bool result = false;
+    QXmlStreamReader reader(&file);
+    while (!reader.atEnd()) {
+        if (reader.readNext() == QXmlStreamReader::StartElement) {
+            // XML allows only one root element, so the first start element is it
+            result = (reader.name() == qsl("map"));
+            break;
+        }
+    }
+    // The reader buffers ahead, so the parse proper has to be given the file
+    // back where it was rather than where the scan above left it
+    file.seek(startPosition);
+    return result;
 }
 } // anonymous namespace
 
@@ -2567,7 +2591,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     if (localFileName.isEmpty()) {
-        if (url.toString().endsWith(QLatin1String("xml"))) {
+        if (url.toString().endsWith(QLatin1String("xml"), Qt::CaseInsensitive)) {
             mLocalMapFileName = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
         } else {
             mLocalMapFileName = mudlet::getMudletPath(enums::profileMapPathFileName, mProfileName, qsl("map.dat"));
@@ -2650,6 +2674,25 @@ bool TMap::readXmlMapFile(QFile& file, QString* errMsg)
     Host* pHost = mpHost;
     bool isLocalImport = false;
     if (!pHost) {
+        return false;
+    }
+
+    if (!fileHoldsMapData(file)) {
+        if (errMsg) {
+            //: Error returned by the loadMap() Lua function. %1 is the path and name of the file that was read
+            *errMsg = tr("loadMap: the file:\n"
+                         "\"%1\"\n"
+                         "does not contain a map, so the current map has been left as it was.")
+                              .arg(file.fileName());
+        } else {
+            //: Shown in the main console. %1 is the path and name of the file that was read
+            postMessage(tr("[ ERROR ] - The file:\n"
+                           "\"%1\"\n"
+                           "does not contain a map - a game with no map to offer can answer a\n"
+                           "download with an error page instead of one - so the current map has\n"
+                           "been left as it was.")
+                                .arg(file.fileName()));
+        }
         return false;
     }
 
@@ -2761,12 +2804,13 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
         qWarning() << "TMap::slot_replyFinished( QNetworkReply * ) ERROR - received argument was not the expected stored pointer.";
     }
 
-    if (reply->error() != QNetworkReply::NoError && reply->error() != QNetworkReply::OperationCanceledError) {
-        // Don't report on any errors here as we've already done so in slot_downloadError(...) previously.
+    if (reply->error() != QNetworkReply::NoError) {
+        // Nothing to report here: slot_downloadError(...) has already done so
+        // for a failure, and slot_downloadCancel() for a cancel. Either way the
+        // reply has nothing to give, and writing that over the destination file
+        // and handing it to the map reader would cost the loaded map.
         cleanup();
         return;
-        // else was QNetworkReply::OperationCanceledError and we already handle
-        // THAT in slot_downloadCancel()
     }
     // Separate the two kinds of files to gain QSaveFile's atomic write behavior
     QSaveFile writeFile(mLocalMapFileName);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2591,7 +2591,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     if (localFileName.isEmpty()) {
-        if (url.toString().endsWith(QLatin1String("xml"), Qt::CaseInsensitive)) {
+        if (url.path().endsWith(QLatin1String("xml"), Qt::CaseInsensitive)) {
             mLocalMapFileName = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
         } else {
             mLocalMapFileName = mudlet::getMudletPath(enums::profileMapPathFileName, mProfileName, qsl("map.dat"));

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -2065,6 +2065,7 @@ describe("Tests saveMap and loadMap", function()
   local savePath = mapDirectory .. "/mapper_spec_roundtrip.dat"
   local brokenXmlPath = getMudletHomeDir() .. "/mapper_spec_broken.xml"
   local notAMapXmlPath = getMudletHomeDir() .. "/mapper_spec_notamap.xml"
+  local notXmlPath = getMudletHomeDir() .. "/mapper_spec_notxml.xml"
 
   -- saveMap() with no arguments writes a timestamped file of its own choosing,
   -- so the only way to clear up after it is to spot what appeared
@@ -2143,6 +2144,7 @@ describe("Tests saveMap and loadMap", function()
     os.remove(savePath)
     os.remove(brokenXmlPath)
     os.remove(notAMapXmlPath)
+    os.remove(notXmlPath)
     -- snapshot whatever map the rest of the suite left behind, so that the
     -- teardown can hand it back untouched
     assert.is_true(saveMap(backupPath), "the map to be replaced could not be saved first")
@@ -2158,6 +2160,7 @@ describe("Tests saveMap and loadMap", function()
     os.remove(savePath)
     os.remove(brokenXmlPath)
     os.remove(notAMapXmlPath)
+    os.remove(notXmlPath)
   end)
 
   describe("Tests the saveMap argument contract", function()
@@ -2285,6 +2288,27 @@ describe("Tests saveMap and loadMap", function()
       assert.is_string(message)
       assert.is_truthy(message:find("does not contain a map", 1, true))
       assert.is_true(roomExists(keeper), "the loaded map was thrown away for a file that holds no map")
+    end)
+
+    -- a damaged map file, as against somebody else's document: both are refused before
+    -- the map is cleared, but a player whose own map will not parse needs to be told
+    -- that rather than that the file was never a map
+    it("refuses a file that is not XML at all, keeping the one that is loaded", function()
+      local file = assert(io.open(notXmlPath, "w"))
+      file:write("garbage")
+      file:close()
+
+      deleteMap()
+      local keeper = createRoomID()
+      addRoom(keeper)
+      assert.is_true(roomExists(keeper))
+
+      local ok, message = loadMap(notXmlPath)
+      assert.is_nil(ok)
+      assert.is_string(message)
+      assert.is_truthy(message:find("damaged or unreadable", 1, true))
+      assert.is_falsy(message:find("does not contain a map", 1, true))
+      assert.is_true(roomExists(keeper), "the loaded map was thrown away for a file that is not XML")
     end)
   end)
 

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -2064,6 +2064,7 @@ describe("Tests saveMap and loadMap", function()
   local backupPath = mapDirectory .. "/mapper_spec_backup.dat"
   local savePath = mapDirectory .. "/mapper_spec_roundtrip.dat"
   local brokenXmlPath = getMudletHomeDir() .. "/mapper_spec_broken.xml"
+  local notAMapXmlPath = getMudletHomeDir() .. "/mapper_spec_notamap.xml"
 
   -- saveMap() with no arguments writes a timestamped file of its own choosing,
   -- so the only way to clear up after it is to spot what appeared
@@ -2141,6 +2142,7 @@ describe("Tests saveMap and loadMap", function()
     os.remove(backupPath)
     os.remove(savePath)
     os.remove(brokenXmlPath)
+    os.remove(notAMapXmlPath)
     -- snapshot whatever map the rest of the suite left behind, so that the
     -- teardown can hand it back untouched
     assert.is_true(saveMap(backupPath), "the map to be replaced could not be saved first")
@@ -2155,6 +2157,7 @@ describe("Tests saveMap and loadMap", function()
     os.remove(backupPath)
     os.remove(savePath)
     os.remove(brokenXmlPath)
+    os.remove(notAMapXmlPath)
   end)
 
   describe("Tests the saveMap argument contract", function()
@@ -2229,10 +2232,12 @@ describe("Tests saveMap and loadMap", function()
     end)
   end)
 
-  -- Careful with the order of anything added here: a load that fails still
-  -- empties the map first, both for a missing binary file (TMainConsole::loadMap
-  -- clears before it restores) and for an XML one (TMap::readXmlMapFile clears
-  -- before it parses), so none of these leave a map behind for the next spec.
+  -- Careful with the order of anything added here: a load that fails can still
+  -- have emptied the map first, both for a missing binary file
+  -- (TMainConsole::loadMap clears before it restores) and for a map document
+  -- that will not parse (TMap::readXmlMapFile clears before it parses), so most
+  -- of these leave no map behind for the next spec. A file that is not a map
+  -- document at all is the exception: it is refused before the clear.
   describe("Tests the loadMap argument contract", function()
     it("hard-errors on a path that is not a string", function()
       assert.has_error(function() loadMap({}) end)
@@ -2259,6 +2264,27 @@ describe("Tests saveMap and loadMap", function()
       assert.is_nil(ok)
       assert.is_string(message)
       assert.is_truthy(message:find("failure to import XML map file", 1, true))
+    end)
+
+    it("refuses an XML file that holds no map, keeping the one that is loaded", function()
+      -- what a game with no map to offer answers a map download with: a page
+      -- saying so, which is well-formed XML full of elements the map reader
+      -- does not know. Every one of them parses, so the reader used to count
+      -- that as a successful import - of nothing, over the loaded map.
+      local file = assert(io.open(notAMapXmlPath, "w"))
+      file:write("<html><body>Not found</body></html>")
+      file:close()
+
+      deleteMap()
+      local keeper = createRoomID()
+      addRoom(keeper)
+      assert.is_true(roomExists(keeper))
+
+      local ok, message = loadMap(notAMapXmlPath)
+      assert.is_nil(ok)
+      assert.is_string(message)
+      assert.is_truthy(message:find("does not contain a map", 1, true))
+      assert.is_true(roomExists(keeper), "the loaded map was thrown away for a file that holds no map")
     end)
   end)
 

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -205,8 +205,13 @@ private:
         }
         const QList<QByteArray> requestLine = buffer.left(buffer.indexOf("\r\n")).split(' ');
         mBuffers.remove(socket);
-        const QString path = requestLine.size() > 1 ? QString::fromUtf8(requestLine.at(1)) : QString();
-        mRequestedPaths << path;
+        const QString target = requestLine.size() > 1 ? QString::fromUtf8(requestLine.at(1)) : QString();
+        mRequestedPaths << target;
+
+        // Routes are keyed by path, the way a real server matches: a request carrying a
+        // query string is the same resource, and a test that asserts the query was sent
+        // reads it back out of requestedPaths() instead.
+        const QString path = target.left(target.indexOf(QLatin1Char('?')) < 0 ? target.size() : target.indexOf(QLatin1Char('?')));
 
         if (!mRoutes.contains(path)) {
             socket->write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
@@ -665,6 +670,45 @@ private slots:
 
         // A download with no local name of its own and an URL ending in "xml"
         // lands on the profile's map.xml, inside this test's own config root:
+        const QString stored = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
+        QFile file(stored);
+        QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(qsl("the downloaded map was not saved to %1").arg(stored)));
+        QCOMPARE(file.readAll(), scmMapXml);
+
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+        QCOMPARE(pMap->mpRoomDB->getAreaNamesMap().value(1), qsl("Downloaded Area"));
+        TRoom* pRoom = pMap->mpRoomDB->getRoom(1);
+        QVERIFY(pRoom);
+        QCOMPARE(pRoom->name, qsl("Entrance"));
+        QCOMPARE(pRoom->getEast(), 2);
+
+        QVERIFY2(consoleShows(qsl("Map download initiated")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(consoleShows(qsl("map downloaded and stored")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(mapDownloadEventCountIs(1), "sysMapDownloadEvent was not raised exactly once for a successful download");
+        QVERIFY(!pMap->hasActiveTransferProgress());
+    }
+
+    // The suffix decides which reader the download goes to, so it has to be read off the
+    // path: the whole URL string ends in the query, not in ".xml", and an MMP location
+    // carrying one was stored as map.dat and handed to the binary loader - which clears
+    // the map before it fails. Pre-dates the case-insensitivity fix above; same line.
+    void test_downloadedXmlMapWithQueryIsSavedAndParsed()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        pMap->mapClear();
+        QVERIFY(pMap->mpRoomDB->isEmpty());
+
+        QSignalSpy startSpy(pMap, &TMap::signal_mapTransferProgressStart);
+        QSignalSpy disableCancelSpy(pMap, &TMap::signal_mapProgressDisableCancel);
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml?foo=bar"))), "the map download never finished");
+
+        QCOMPARE(mpMapServer->requestedPaths(), QStringList{qsl("/map.xml?foo=bar")});
+        QCOMPARE(startSpy.count(), 1);
+        QCOMPARE(startSpy.at(0).at(0).toString(), qsl("Map download"));
+        QVERIFY2(startSpy.at(0).at(1).toString().contains(mProfileName), "the progress label does not name the profile the map is for");
+        QCOMPARE(disableCancelSpy.count(), 1);
+
         const QString stored = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
         QFile file(stored);
         QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(qsl("the downloaded map was not saved to %1").arg(stored)));

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -850,13 +850,9 @@ private slots:
     //
     // QNetworkReply::abort() delivers finished() synchronously, so the whole
     // chain has unwound by the time slot_downloadCancel() returns - no waiting
-    // needed. It unwinds through the save-and-parse path rather than the error
-    // one, since slot_replyFinished() deliberately excludes a cancel from its
-    // error exit: what reaches the destination file is whatever the aborted
-    // reply still has to give, which is nothing, and the empty result is then
-    // handed to the map reader. So a second, different error line - about the
-    // parse - does follow, which is why the assertion below names the download
-    // error rather than looking for the absence of errors.
+    // needed. It unwinds through slot_replyFinished()'s error exit, which a
+    // cancel takes like any other error: nothing is written, nothing is parsed,
+    // and no further line reaches the console.
     void test_cancelStopsTheDownloadWithoutReportingAnError()
     {
         TMap* pMap = mpHost->mpMap.data();
@@ -877,6 +873,37 @@ private slots:
         QVERIFY2(mapDownloadEventCountIs(0), "a canceled download raised sysMapDownloadEvent");
 
         QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after a canceled one was refused, so the import flag was left set");
+    }
+
+    // Taking that exit is what leaves the profile's map where it was - in
+    // memory and on disk. Writing the aborted reply's nothing over the
+    // destination file and handing that to the reader, which clears the map
+    // before it parses, cost the map every time a download was called off.
+    void test_cancelLeavesTheLoadedMapAndItsFileAlone()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        const QString stored = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download that gives this test a map to keep never finished");
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+
+        // The stalled route promises far more than it sends, so the download is
+        // still in flight when it is called off - as a user's Abort finds it:
+        pMap->downloadMap(mpMapServer->url(qsl("/stalled.xml")));
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return mpMapServer->requestedPaths().contains(qsl("/stalled.xml"));
+                         },
+                         10000),
+                 "the download to be canceled never reached the server");
+
+        pMap->slot_downloadCancel();
+
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+        QVERIFY2(pMap->mpRoomDB->getRoom(1), "the canceled download took the loaded map with it");
+        QFile file(stored);
+        QVERIFY2(file.open(QIODevice::ReadOnly), qPrintable(qsl("the canceled download removed %1").arg(stored)));
+        QCOMPARE(file.readAll(), scmMapXml);
+        QVERIFY2(mapDownloadEventCountIs(1), "the canceled download raised a download event of its own");
     }
 
     void test_undownloadableDestinationIsReported()
@@ -922,6 +949,31 @@ private slots:
         QVERIFY2(mapDownloadEventCountIs(0), "a map that failed to parse still raised sysMapDownloadEvent");
         QVERIFY(!pMap->hasActiveTransferProgress());
         QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after an unparseable one was refused, so the import flag was left set");
+    }
+
+    // A game with no map to offer can answer with a page saying so rather than
+    // with a status a download counts as a failure, and an HTML page is
+    // well-formed XML: every element in it parses, none of them means anything
+    // to the map reader, and the reader used to clear the map, find nothing to
+    // put back, and report a successful download of no rooms at all.
+    void test_aDownloadThatIsNotAMapLeavesTheMapAloneAndIsReported()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        mpMapServer->serve(qsl("/notamap.xml"), QByteArrayLiteral("<html><body>Not found</body></html>"));
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download that gives this test a map to keep never finished");
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+        forgetMapDownloadEvents();
+
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/notamap.xml"))), "the map download never finished");
+
+        // The answer still lands on the destination file, which is a scratch
+        // copy of the download; the map itself is what has to survive it:
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+        QVERIFY2(pMap->mpRoomDB->getRoom(1), "a download that was not a map at all emptied the map");
+        QVERIFY2(consoleShows(qsl("does not contain a map")), qPrintable(consoleTextSinceMark()));
+        QVERIFY2(mapDownloadEventCountIs(0), "a download that was not a map at all raised sysMapDownloadEvent");
+        QVERIFY(!pMap->hasActiveTransferProgress());
+        QVERIFY2(runDownload(mpMapServer->url(qsl("/map.xml"))), "the download after one that was not a map was refused, so the import flag was left set");
     }
 
     // Everything above watches TMap's progress signals, which keep firing with
@@ -1167,6 +1219,47 @@ private slots:
         QCOMPARE(pRoom->z(), 5);
         QVERIFY2(consoleShows(qsl("map downloaded and stored")), qPrintable(consoleTextSinceMark()));
         QVERIFY2(mapDownloadEventCountIs(1), "the binary path did not raise sysMapDownloadEvent");
+    }
+
+    // The name a download is saved under is what decides which reader parses
+    // it, so the suffix has to be read the same way in both places. An MMP map
+    // location ending in an uppercase .XML used to be stored as map.dat and
+    // handed to the binary loader, which reads the XML header as a format
+    // version.
+    //
+    // Down here with the binary case rather than up with the XML ones because
+    // of what it pins: the loader this download must not reach is the one that
+    // creates the mapper widget, so a regression would take every
+    // standalone-progress test above with it.
+    void test_anUppercaseXmlUrlIsSavedAndParsedAsXml()
+    {
+        TMap* pMap = mpHost->mpMap.data();
+        pMap->mapClear();
+        mpMapServer->serve(qsl("/MAP.XML"), scmMapXml);
+        const QString xmlDestination = mudlet::getMudletPath(enums::profileXmlMapPathFileName, mProfileName);
+        const QString binaryDestination = mudlet::getMudletPath(enums::profileMapPathFileName, mProfileName, qsl("map.dat"));
+        QFile::remove(xmlDestination);
+        QFile::remove(binaryDestination);
+
+        // Not runDownload(): the mapper the case above created owns the
+        // progress display from here on, and that one ends without the close
+        // signal runDownload() waits for - only the standalone display emits it.
+        pMap->downloadMap(mpMapServer->url(qsl("/MAP.XML")));
+        const bool finished = QTest::qWaitFor(
+                [pMap]() {
+                    return !pMap->hasActiveTransferProgress();
+                },
+                15000);
+
+        // Which file it landed on first: naming the destination the download
+        // was given says what went wrong, where a download that did not finish
+        // only says that something did.
+        QVERIFY2(QFileInfo::exists(xmlDestination), "a map from an uppercase .XML URL was not stored as the profile's XML map");
+        QVERIFY2(!QFileInfo::exists(binaryDestination), "a map from an uppercase .XML URL was stored as a binary map file");
+        QVERIFY2(finished, "the map download never finished");
+        QCOMPARE(pMap->mpRoomDB->getRoomMap().size(), 2);
+        QCOMPARE(pMap->mpRoomDB->getAreaNamesMap().value(1), qsl("Downloaded Area"));
+        QVERIFY2(mapDownloadEventCountIs(1), "a map from an uppercase .XML URL was not parsed as one");
     }
 
     // The mapper's map-save-failed indicator, which nothing but


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A canceled download now takes `slot_replyFinished()`'s error exit like any other failure, so nothing is written over the destination file and nothing is parsed.
- `readXmlMapFile()` checks the root element is `<map>` before it clears anything, and says so when the file holds no map.
- The `.xml` suffix that decides which reader a download goes to is matched case-insensitively.

#### Motivation for adding to Mudlet

Three ways a map download could throw away a map the player already had: pressing Abort, a game answering with a "no map here" page instead of a map (well-formed XML, so every element parsed and none meant anything - the import "succeeded" with no rooms), and an MMP map location spelled `.XML`, which was stored as `map.dat` and fed to the binary loader.

#### Other info (issues closed, discussion etc)

Closes #10076, closes #10077, closes #10078.

**Test case:** with a map loaded, `downloadMap()` against a URL that returns an HTML page - the map survives and the console reports that the file does not contain a map. Same for pressing Abort mid-download. Covered by three new `MapDownloadTest` cases and a new `Mapper_spec` case; all three fail if `TMap.cpp` is reverted.

Assisted-by: Claude:claude-opus-5