### PR TITLE
Fix: Long profile and character names no longer share one saved password

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -65,6 +65,11 @@ QString credentialFilePath(const QString& profileComponent, const QString& keyCo
     return qsl("%1/profiles/%2/passwords/%3").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), profileComponent, keyComponent);
 }
 
+// The length the old scheme cut a path component to. Its own constant rather than
+// utils::scmMaxPathComponentLength: that one is free to change, while this records what
+// is already written on disk and so can never change.
+constexpr int scmLegacyMaxPathComponentLength = 50;
+
 // How utils::sanitizeForPath() built a path component before it started keeping
 // shortened names distinct, kept so that credentials filed under the old name can
 // still be found. Same role as generateLegacyServiceName() plays for the keychain.
@@ -73,7 +78,7 @@ QString legacyPathComponent(const QString& input)
     static const auto unsafeChars = QRegularExpression(qsl(R"REGEX([/\\:*?"<>|])REGEX"));
     QString sanitized = input;
     sanitized.replace(unsafeChars, qsl("_"));
-    return sanitized.left(50);
+    return sanitized.left(scmLegacyMaxPathComponentLength);
 }
 } // namespace
 
@@ -1446,6 +1451,15 @@ QString CredentialManager::generateLegacyFilePath(const QString& profileName, co
     const QString currentPath = generateFilePath(profileName, key);
 
     if (currentPath.isEmpty()) {
+        return QString();
+    }
+
+    // Two keys this long collide on one legacy file, and they share the profile's
+    // encryption key - so decrypting it proves only that some key in this profile wrote
+    // it, never which. Migrating would hand one key the other's secret and removing would
+    // delete it, so an undecidable file is left alone: the password for a key this long is
+    // re-entered rather than guessed at.
+    if (key.length() > scmLegacyMaxPathComponentLength) {
         return QString();
     }
 

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -1444,8 +1444,9 @@ QString CredentialManager::generateFilePath(const QString& profileName, const QS
 }
 
 // Where a credential was filed while both path components were simply truncated to 50
-// characters. Empty when that is the path in use anyway, so only a profile name or key
-// long enough to have been shortened has anything to migrate.
+// characters. Empty when nothing there can safely be claimed: either that is the path in
+// use anyway, or the key is long enough that another key's credential could be sitting
+// under it.
 QString CredentialManager::generateLegacyFilePath(const QString& profileName, const QString& key)
 {
     const QString currentPath = generateFilePath(profileName, key);
@@ -1454,12 +1455,14 @@ QString CredentialManager::generateLegacyFilePath(const QString& profileName, co
         return QString();
     }
 
-    // Two keys this long collide on one legacy file, and they share the profile's
-    // encryption key - so decrypting it proves only that some key in this profile wrote
-    // it, never which. Migrating would hand one key the other's secret and removing would
-    // delete it, so an undecidable file is left alone: the password for a key this long is
-    // re-entered rather than guessed at.
-    if (key.length() > scmLegacyMaxPathComponentLength) {
+    // Keys this long collide on one legacy file, and they share the profile's encryption
+    // key - so decrypting it proves only that some key in this profile wrote it, never
+    // which. Migrating would hand one key the other's secret and removing would delete it,
+    // so an undecidable file is left alone: the password for a key this long is re-entered
+    // rather than guessed at. The cap itself is on the undecidable side, because a key of
+    // exactly that length came through truncation unchanged and so was already filed at
+    // the same path every longer key was cut down to.
+    if (key.length() >= scmLegacyMaxPathComponentLength) {
         return QString();
     }
 

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -53,6 +53,28 @@ bool keychainDeleteSucceeded(QKeychain::Error error)
 {
     return error == QKeychain::NoError || error == QKeychain::EntryNotFound || error == QKeychain::NoBackendAvailable || error == QKeychain::NotImplemented;
 }
+
+// Reported when a key gets as far as the async API but could not safely become a path
+// component; the wording is what tells a caller its argument was refused rather than
+// its storage having gone wrong
+const auto scmInvalidKeyNameError = qsl("Key name is not valid for credential storage");
+
+// QStandardPaths automatically handles portable mode configuration paths
+QString credentialFilePath(const QString& profileComponent, const QString& keyComponent)
+{
+    return qsl("%1/profiles/%2/passwords/%3").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), profileComponent, keyComponent);
+}
+
+// How utils::sanitizeForPath() built a path component before it started keeping
+// shortened names distinct, kept so that credentials filed under the old name can
+// still be found. Same role as generateLegacyServiceName() plays for the keychain.
+QString legacyPathComponent(const QString& input)
+{
+    static const auto unsafeChars = QRegularExpression(qsl(R"REGEX([/\\:*?"<>|])REGEX"));
+    QString sanitized = input;
+    sanitized.replace(unsafeChars, qsl("_"));
+    return sanitized.left(50);
+}
 } // namespace
 
 CredentialManager::CredentialManager(QObject* parent)
@@ -238,6 +260,17 @@ void CredentialManager::storePassword(const QString& profileName, const QString&
         return;
     }
 
+    // The static API refuses a key that cannot safely become a path component, and this
+    // one has to agree: an over-long or slash-bearing key stored here would be filed
+    // where the static API - the migration and cleanup path - could never look for it.
+    if (!isValidKeyName(key)) {
+        if (callback) {
+            callback(false, scmInvalidKeyNameError);
+        }
+
+        return;
+    }
+
     // Safety check: Don't start new operations during shutdown
     if (QCoreApplication::closingDown()) {
         qWarning() << "CredentialManager: Rejecting storePassword operation during shutdown";
@@ -268,6 +301,17 @@ void CredentialManager::retrievePassword(const QString& profileName, const QStri
     if (profileName.isEmpty() || key.isEmpty()) {
         if (callback) {
             callback(false, QString(), qsl("Profile name and key cannot be empty"));
+        }
+
+        return;
+    }
+
+    // The static API refuses a key that cannot safely become a path component, and this
+    // one has to agree: an over-long or slash-bearing key stored here would be filed
+    // where the static API - the migration and cleanup path - could never look for it.
+    if (!isValidKeyName(key)) {
+        if (callback) {
+            callback(false, QString(), scmInvalidKeyNameError);
         }
 
         return;
@@ -622,6 +666,17 @@ void CredentialManager::removePassword(const QString& profileName, const QString
         if (callback) {
             callback(false, qsl("Profile name and key cannot be empty"));
         }
+        return;
+    }
+
+    // The static API refuses a key that cannot safely become a path component, and this
+    // one has to agree: an over-long or slash-bearing key stored here would be filed
+    // where the static API - the migration and cleanup path - could never look for it.
+    if (!isValidKeyName(key)) {
+        if (callback) {
+            callback(false, scmInvalidKeyNameError);
+        }
+
         return;
     }
 
@@ -1248,9 +1303,18 @@ QString CredentialManager::retrieveCredentialFromFile(const QString& profileName
         // Only log warning if file should exist (not for first-time access)
         if (file.exists()) {
             qWarning() << "CredentialManager: Failed to open existing file for reading:" << filePath << "Error:" << file.errorString();
+            return QString();
         }
 
-        return QString();
+        // Nothing under the current naming, so a credential written while long names
+        // were truncated is moved across on the first read that misses it
+        const QString migrated = readLegacyFileCredential(profileName, key);
+
+        if (!migrated.isEmpty() && storeCredentialToFile(profileName, key, migrated)) {
+            removeLegacyFileCredential(profileName, key);
+        }
+
+        return migrated;
     }
 
     QString encrypted = QString::fromUtf8(file.readAll());
@@ -1280,6 +1344,10 @@ bool CredentialManager::removeCredentialFromFile(const QString& profileName, con
         qWarning() << "CredentialManager: Failed to generate valid file path for removing encrypted credential";
         return false;
     }
+
+    // A credential still filed under the legacy truncated path has to go as well, or
+    // the next read would migrate it and resurrect the password just removed
+    removeLegacyFileCredential(profileName, key);
 
     // Check if file exists before attempting removal
     if (!QFile::exists(filePath)) {
@@ -1367,12 +1435,71 @@ QString CredentialManager::generateFilePath(const QString& profileName, const QS
         return QString();
     }
 
-    QString sanitizedProfile = utils::sanitizeForPath(profileName);
-    QString sanitizedKey = utils::sanitizeForPath(key);
+    return credentialFilePath(utils::sanitizeForPath(profileName), utils::sanitizeForPath(key));
+}
 
-    // QStandardPaths automatically handles portable mode configuration paths
-    QString configPath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-    return qsl("%1/profiles/%2/passwords/%3").arg(configPath, sanitizedProfile, sanitizedKey);
+// Where a credential was filed while both path components were simply truncated to 50
+// characters. Empty when that is the path in use anyway, so only a profile name or key
+// long enough to have been shortened has anything to migrate.
+QString CredentialManager::generateLegacyFilePath(const QString& profileName, const QString& key)
+{
+    const QString currentPath = generateFilePath(profileName, key);
+
+    if (currentPath.isEmpty()) {
+        return QString();
+    }
+
+    const QString legacyPath = credentialFilePath(legacyPathComponent(profileName), legacyPathComponent(key));
+    return legacyPath == currentPath ? QString() : legacyPath;
+}
+
+// Reads what the legacy truncated path holds for this profile. Anything filed there
+// that this profile's key cannot decrypt was written by a profile this one used to
+// collide with, which is why this decrypts rather than just reading the file: whose
+// credential it is is the only thing that distinguishes the two. Empty when there is
+// nothing there for this profile.
+QString CredentialManager::readLegacyFileCredential(const QString& profileName, const QString& key)
+{
+    const QString legacyPath = generateLegacyFilePath(profileName, key);
+
+    if (legacyPath.isEmpty()) {
+        return QString();
+    }
+
+    QFile file(legacyPath);
+
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        if (file.exists()) {
+            qWarning() << "CredentialManager: Failed to open credential file left by the earlier naming scheme:" << legacyPath << "Error:" << file.errorString();
+        }
+
+        return QString();
+    }
+
+    const QString encrypted = QString::fromUtf8(file.readAll());
+    file.close();
+
+    return SecureStringUtils::decryptStringForProfile(encrypted, profileName);
+}
+
+// Deletes the legacy file, but only once it has proved to hold this profile's own
+// credential, so a profile it used to collide with never has its password removed on
+// this one's behalf.
+void CredentialManager::removeLegacyFileCredential(const QString& profileName, const QString& key)
+{
+    QString credential = readLegacyFileCredential(profileName, key);
+    const bool ours = !credential.isEmpty();
+    SecureStringUtils::secureStringClear(credential);
+
+    if (!ours) {
+        return;
+    }
+
+    const QString legacyPath = generateLegacyFilePath(profileName, key);
+
+    if (!QFile::remove(legacyPath)) {
+        qWarning() << "CredentialManager: Failed to remove credential file left by the earlier naming scheme:" << legacyPath;
+    }
 }
 
 bool CredentialManager::isValidKeyName(const QString& key)

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -114,6 +114,9 @@ private:
 
     // Static utility methods for fallback storage
     static QString generateFilePath(const QString& profileName, const QString& key);
+    static QString generateLegacyFilePath(const QString& profileName, const QString& key);
+    static QString readLegacyFileCredential(const QString& profileName, const QString& key);
+    static void removeLegacyFileCredential(const QString& profileName, const QString& key);
     static QString generateServiceName(const QString& profileName, const QString& key);
     static QString generateLegacyServiceName(const QString& profileName, const QString& key);
     static bool isValidKeyName(const QString& key);

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <QApplication>
+#include <QCryptographicHash>
 #include <QEnterEvent>
 #include <QDir>
 #include <QRegularExpression>
@@ -264,16 +265,24 @@ public:
     }
 
     inline static const auto scmfileSystemUnsafeChars = QRegularExpression(qsl(R"REGEX([/\\:*?"<>|])REGEX"));
+    static constexpr int scmMaxPathComponentLength = 50;
+    static constexpr int scmPathComponentDigestLength = 16;
+
     // Sanitize a string for safe use as filename/path component
-    // Replaces filesystem-unsafe characters with underscores and limits length
+    // Replaces filesystem-unsafe characters with underscores and limits length.
+    // Callers file data under the result, so shortening has to keep distinct
+    // inputs distinct: a shortened name carries a digest of the whole input,
+    // since plain truncation made two long profile names share - and overwrite -
+    // one stored password.
     static QString sanitizeForPath(const QString& input)
     {
         QString sanitized = input;
         // Replace filesystem-unsafe characters with underscores
         sanitized.replace(scmfileSystemUnsafeChars, qsl("_"));
         // Limit length to prevent filesystem issues
-        if (sanitized.length() > 50) {
-            sanitized = sanitized.left(50);
+        if (sanitized.length() > scmMaxPathComponentLength) {
+            const QString digest = QString::fromLatin1(QCryptographicHash::hash(input.toUtf8(), QCryptographicHash::Sha256).toHex()).left(scmPathComponentDigestLength);
+            sanitized = qsl("%1-%2").arg(sanitized.left(scmMaxPathComponentLength - scmPathComponentDigestLength - 1), digest);
         }
         return sanitized;
     }

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -57,6 +57,7 @@ private slots:
     void testLongKeyNamesDoNotShareOneCredential();
     void testCredentialsFiledUnderTheTruncatedPathSurvive();
     void testLegacySharedKeyPathOwnershipIsUndecidable();
+    void testLegacyKeyAtTheLengthCapClaimsNoLongerKeysCredential();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
     void testAsyncStoreAndRetrieve();
@@ -369,6 +370,43 @@ void CredentialManagerTest::testLegacySharedKeyPathOwnershipIsUndecidable()
 
     QVERIFY(QFile::remove(legacyPath));
     CredentialManager::removeCredential(profile, firstKey);
+}
+
+// The cap is the boundary, not the far side of it: a key of exactly the legacy 50
+// characters was cut to the same path as every longer key starting with them, because
+// truncation left it unchanged. That file is no more decidably its own than a longer
+// key's is, so it may neither be handed what it holds nor delete it. A profile name long
+// enough to have moved is what brings a key this length past migration at all, hence one
+// here.
+void CredentialManagerTest::testLegacyKeyAtTheLengthCapClaimsNoLongerKeysCredential()
+{
+    const QString shortenedProfile(50, QChar('p'));
+    const QString profile = shortenedProfile + "LongEnoughToHaveBeenShortenedItself";
+    const QString sharedPrefix(50, QChar('K'));
+    const QString keyAtTheCap = sharedPrefix;
+    const QString longerKey = sharedPrefix + "second";
+
+    const QString legacyDir = qsl("%1/profiles/%2/passwords").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), shortenedProfile);
+    QVERIFY(QDir().mkpath(legacyDir));
+
+    // planted the way the old scheme wrote the longer key: both keys cut to the same 50
+    // characters, under the profile name cut to its own first 50
+    const QString legacyPath = qsl("%1/%2").arg(legacyDir, sharedPrefix);
+    QFile legacyFile(legacyPath);
+    QVERIFY(legacyFile.open(QIODevice::WriteOnly | QIODevice::Text));
+    const QString encrypted = SecureStringUtils::encryptStringForProfile("the_longer_keys_secret", profile);
+    QVERIFY(!encrypted.isEmpty());
+    QVERIFY(legacyFile.write(encrypted.toUtf8()) != -1);
+    legacyFile.close();
+
+    QVERIFY2(CredentialManager::retrieveCredential(profile, keyAtTheCap).isEmpty(), "a key at the length cap was handed a longer key's legacy secret");
+
+    // and the removal half, as in the case above
+    QVERIFY(CredentialManager::removeCredential(profile, keyAtTheCap));
+    QVERIFY2(QFile::exists(legacyPath), "removing a key at the length cap deleted a longer key's legacy credential");
+
+    QVERIFY(QFile::remove(legacyPath));
+    CredentialManager::removeCredential(profile, longerKey);
 }
 
 void CredentialManagerTest::testPathTraversalPrevention()

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -18,8 +18,14 @@
  ***************************************************************************/
 
 #include <CredentialManager.h>
+#include <SecureStringUtils.h>
+#include <utils.h>
+
 #include <QtTest/QtTest>
 
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 
 // Hermetic unit tests: MUDLET_TEST_MODE forces encrypted file storage so these run
@@ -47,6 +53,9 @@ private slots:
     void testRemovePassword();
     void testInputSanitization();
     void testOverlongKeyNamesAreRejected();
+    void testLongProfileNamesDoNotShareOneCredential();
+    void testLongKeyNamesDoNotShareOneCredential();
+    void testCredentialsFiledUnderTheTruncatedPathSurvive();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
     void testAsyncStoreAndRetrieve();
@@ -54,6 +63,7 @@ private slots:
     void testAsyncRemovePassword();
     void testCredentialExistsWithoutHandingOverTheSecret();
     void testAsyncEmptyArgumentsAreReportedThroughTheCallback();
+    void testAsyncApiRefusesTheKeysTheStaticApiRefuses();
     void cleanupTestCase();
 
 private:
@@ -224,11 +234,10 @@ void CredentialManagerTest::testInputSanitization()
     CredentialManager::removeCredential(profile, normalKey);
 }
 
-// A key name becomes a path component, and utils::sanitizeForPath truncates one
-// to 50 characters - so any two keys sharing their first 50 resolve to the same
-// file. Storing under the accepted key first is therefore what gives the
-// rejection of the overlong one something to fail at: were the cap dropped, the
-// overlong key would read that same credential straight back rather than nothing.
+// 100 characters is the longest key name the API accepts and one more is refused
+// outright. The accepted key is stored first so that the refusal has something it
+// could damage: the two differ only in that last character, so anything that
+// shortened them to a common path component would put them on one credential.
 void CredentialManagerTest::testOverlongKeyNamesAreRejected()
 {
     const QString profile = "OverlongKeyProfile";
@@ -247,6 +256,82 @@ void CredentialManagerTest::testOverlongKeyNamesAreRejected()
     QCOMPARE(CredentialManager::retrieveCredential(profile, longestAccepted), password);
 
     CredentialManager::removeCredential(profile, longestAccepted);
+}
+
+// A profile name is a path component too, and one long enough to be shortened to fit
+// used to become the same component as any other name starting the same way. Both
+// profiles then wrote to one file, so the one that saved first read back whatever the
+// other had encrypted with its own key - nothing it could decrypt.
+void CredentialManagerTest::testLongProfileNamesDoNotShareOneCredential()
+{
+    const QString sharedPrefix(50, QChar('p'));
+    const QString first = sharedPrefix + "FirstProfile";
+    const QString second = sharedPrefix + "SecondProfile";
+    const QString key = "character";
+
+    QVERIFY(CredentialManager::storeCredential(first, key, "first_secret"));
+    QVERIFY(CredentialManager::storeCredential(second, key, "second_secret"));
+
+    QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("first_secret"));
+    QCOMPARE(CredentialManager::retrieveCredential(second, key), QString("second_secret"));
+
+    CredentialManager::removeCredential(first, key);
+    CredentialManager::removeCredential(second, key);
+}
+
+// Two long keys under one profile share the profile's encryption key, so a shared path
+// component does not even fail closed the way two profiles do: whoever asks for the
+// first key is handed the second key's secret in full
+void CredentialManagerTest::testLongKeyNamesDoNotShareOneCredential()
+{
+    const QString profile = "LongKeyProfile";
+    const QString sharedPrefix(50, QChar('k'));
+    const QString first = sharedPrefix + "first";
+    const QString second = sharedPrefix + "second";
+
+    QVERIFY(CredentialManager::storeCredential(profile, first, "first_secret"));
+    QVERIFY(CredentialManager::storeCredential(profile, second, "second_secret"));
+
+    QCOMPARE(CredentialManager::retrieveCredential(profile, first), QString("first_secret"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, second), QString("second_secret"));
+
+    CredentialManager::removeCredential(profile, first);
+    CredentialManager::removeCredential(profile, second);
+}
+
+// An installed Mudlet has credentials on disk under the shortened path, so the file is
+// written here the way that Mudlet wrote it rather than through the API. It has to come
+// back, and it has to stop being reachable by the name it used to collide with - which
+// is what storing for the neighbouring profile afterwards checks.
+void CredentialManagerTest::testCredentialsFiledUnderTheTruncatedPathSurvive()
+{
+    const QString sharedPrefix(50, QChar('t'));
+    const QString profile = sharedPrefix + "FiledBeforeTheRename";
+    const QString neighbour = sharedPrefix + "StoredAfterwards";
+    const QString key = "character";
+
+    const QString legacyDir = qsl("%1/profiles/%2/passwords").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), sharedPrefix);
+    QVERIFY(QDir().mkpath(legacyDir));
+
+    QFile legacyFile(qsl("%1/%2").arg(legacyDir, key));
+    QVERIFY(legacyFile.open(QIODevice::WriteOnly | QIODevice::Text));
+    const QString encrypted = SecureStringUtils::encryptStringForProfile("saved_long_ago", profile);
+    QVERIFY(!encrypted.isEmpty());
+    QVERIFY(legacyFile.write(encrypted.toUtf8()) != -1);
+    legacyFile.close();
+
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("saved_long_ago"));
+
+    QVERIFY(CredentialManager::storeCredential(neighbour, key, "the_neighbour"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("saved_long_ago"));
+    QCOMPARE(CredentialManager::retrieveCredential(neighbour, key), QString("the_neighbour"));
+
+    // and removing it takes the shortened file with it, so the next read cannot bring
+    // the removed password back
+    QVERIFY(CredentialManager::removeCredential(profile, key));
+    QVERIFY(CredentialManager::retrieveCredential(profile, key).isEmpty());
+
+    CredentialManager::removeCredential(neighbour, key);
 }
 
 void CredentialManagerTest::testPathTraversalPrevention()
@@ -508,6 +593,75 @@ void CredentialManagerTest::testAsyncEmptyArgumentsAreReportedThroughTheCallback
     }
 }
 
+// The dialogs store through the async API while migration and cleanup read through the
+// static one, so a key only one of them accepts is a credential that can be written and
+// never reached again. Which complaint comes back matters too: without the check these
+// keys either store happily or fail somewhere further down for an unrelated reason.
+void CredentialManagerTest::testAsyncApiRefusesTheKeysTheStaticApiRefuses()
+{
+    CredentialManager manager;
+    const QString profile = "AsyncKeyValidationProfile";
+    const QString refusal = "not valid";
+
+    const QStringList refused = {QString(101, QChar('k')), "keys/with/separators", "keys\\with\\separators", "..", "key_with|a_pipe"};
+
+    for (const QString& key : refused) {
+        QVERIFY2(!CredentialManager::storeCredential(profile, key, "secret"), qPrintable(key));
+        QVERIFY2(CredentialManager::retrieveCredential(profile, key).isEmpty(), qPrintable(key));
+
+        // Each of these starts at the answer the unguarded code gives, so a callback that
+        // never runs reads as a failure rather than as agreement
+        bool stored = true;
+        QString storeError;
+        manager.storePassword(profile, key, "secret", [&](bool success, const QString& error) {
+            stored = success;
+            storeError = error;
+        });
+        QVERIFY2(!stored, qPrintable(key));
+        QVERIFY2(storeError.contains(refusal), qPrintable(storeError));
+
+        bool retrieved = true;
+        QString password = "not overwritten";
+        QString retrieveError;
+        manager.retrievePassword(profile, key, [&](bool success, QString value, const QString& error) {
+            retrieved = success;
+            password = value;
+            retrieveError = error;
+        });
+        QVERIFY2(!retrieved, qPrintable(key));
+        QVERIFY(password.isEmpty());
+        QVERIFY2(retrieveError.contains(refusal), qPrintable(retrieveError));
+
+        bool removed = true;
+        QString removeError;
+        manager.removePassword(profile, key, [&](bool success, const QString& error) {
+            removed = success;
+            removeError = error;
+        });
+        QVERIFY2(!removed, qPrintable(key));
+        QVERIFY2(removeError.contains(refusal), qPrintable(removeError));
+
+        bool answered = false;
+        bool present = true;
+        manager.credentialExists(profile, key, [&](bool value) {
+            answered = true;
+            present = value;
+        });
+        QVERIFY(answered);
+        QVERIFY2(!present, qPrintable(key));
+    }
+
+    // a key both APIs accept still works, so the check is not simply refusing everything
+    const QString accepted = "reconnect";
+    bool stored = false;
+    manager.storePassword(profile, accepted, "async_secret", [&](bool success, const QString&) {
+        stored = success;
+    });
+    QVERIFY(stored);
+    QCOMPARE(CredentialManager::retrieveCredential(profile, accepted), QString("async_secret"));
+    CredentialManager::removeCredential(profile, accepted);
+}
+
 void CredentialManagerTest::cleanupTestCase()
 {
     // Clean up test passwords
@@ -535,6 +689,19 @@ void CredentialManagerTest::cleanupTestCase()
     CredentialManager::removeCredential("AsyncRemovalProfile", "password");
     CredentialManager::removeCredential("AsyncExistsProfile", "password");
     CredentialManager::removeCredential("OverlongKeyProfile", QString(100, QChar('k')));
+    CredentialManager::removeCredential("AsyncKeyValidationProfile", "reconnect");
+
+    const QString longProfilePrefix(50, QChar('p'));
+    CredentialManager::removeCredential(longProfilePrefix + "FirstProfile", "character");
+    CredentialManager::removeCredential(longProfilePrefix + "SecondProfile", "character");
+
+    const QString longKeyPrefix(50, QChar('k'));
+    CredentialManager::removeCredential("LongKeyProfile", longKeyPrefix + "first");
+    CredentialManager::removeCredential("LongKeyProfile", longKeyPrefix + "second");
+
+    const QString truncatedPrefix(50, QChar('t'));
+    CredentialManager::removeCredential(truncatedPrefix + "FiledBeforeTheRename", "character");
+    CredentialManager::removeCredential(truncatedPrefix + "StoredAfterwards", "character");
 }
 
 #include "CredentialManagerTest.moc"

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -56,6 +56,7 @@ private slots:
     void testLongProfileNamesDoNotShareOneCredential();
     void testLongKeyNamesDoNotShareOneCredential();
     void testCredentialsFiledUnderTheTruncatedPathSurvive();
+    void testLegacySharedKeyPathOwnershipIsUndecidable();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
     void testAsyncStoreAndRetrieve();
@@ -332,6 +333,42 @@ void CredentialManagerTest::testCredentialsFiledUnderTheTruncatedPathSurvive()
     QVERIFY(CredentialManager::retrieveCredential(profile, key).isEmpty());
 
     CredentialManager::removeCredential(neighbour, key);
+}
+
+// Migration decides whose a legacy credential is by decrypting it, which separates two
+// profiles but cannot separate two keys inside one - they share that profile's encryption
+// key, so the file reads back cleanly whichever key asked. Two keys long enough to have
+// been cut to the same path are therefore undecidable, and the file has to be left where
+// it is: migrating it hands the second key the first one's secret, and removing it deletes
+// a credential that was never this key's to delete.
+void CredentialManagerTest::testLegacySharedKeyPathOwnershipIsUndecidable()
+{
+    const QString profile = "SharedLegacyKeyProfile";
+    const QString sharedPrefix(50, QChar('L'));
+    const QString firstKey = sharedPrefix + "first";
+    const QString secondKey = sharedPrefix + "second";
+
+    const QString legacyDir = qsl("%1/profiles/%2/passwords").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), profile);
+    QVERIFY(QDir().mkpath(legacyDir));
+
+    // planted the way the old scheme wrote it: both keys cut to their shared first 50
+    const QString legacyPath = qsl("%1/%2").arg(legacyDir, sharedPrefix);
+    QFile legacyFile(legacyPath);
+    QVERIFY(legacyFile.open(QIODevice::WriteOnly | QIODevice::Text));
+    const QString encrypted = SecureStringUtils::encryptStringForProfile("first_secret", profile);
+    QVERIFY(!encrypted.isEmpty());
+    QVERIFY(legacyFile.write(encrypted.toUtf8()) != -1);
+    legacyFile.close();
+
+    QVERIFY2(CredentialManager::retrieveCredential(profile, secondKey).isEmpty(), "a second key was handed the first key's legacy secret");
+
+    // and the removal half: the file is still there afterwards, rather than having been
+    // deleted on behalf of a key that never wrote it
+    QVERIFY(CredentialManager::removeCredential(profile, secondKey));
+    QVERIFY2(QFile::exists(legacyPath), "removing a second key deleted the first key's legacy credential");
+
+    QVERIFY(QFile::remove(legacyPath));
+    CredentialManager::removeCredential(profile, firstKey);
 }
 
 void CredentialManagerTest::testPathTraversalPrevention()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `utils::sanitizeForPath()` cut a path component to 50 characters, so two long profile names - or two long keys under one profile - resolved to the same credential file. A shortened name now carries a digest of the whole input.
- A credential already filed under the old truncated name is moved across on the first read that misses it, and only after it decrypts with that profile's own key, so a profile it used to collide with never has its password migrated or removed.
- The async credential API now applies the same key validation the static one does; it accepted names that could never be read back afterwards.

#### Motivation for adding to Mudlet

Two profiles whose names share their first 50 characters wrote to one password file and overwrote each other. Two long keys under one profile are worse: they share the profile's encryption key, so asking for the first handed back the second's secret in full rather than failing closed.

#### Other info (issues closed, discussion etc)

Closes #10064, closes #10065.

`sanitizeForPath()` has two other callers, and the new shortening reaches both. Neither loses data, but they are worth a reviewer's eye:

- `dlgTriggerEditor::profileSettingsPrefix()` - a profile whose name is over 50 characters gets a new QSettings key, so its editor pane state resets once. It had the same collision bug, which this also fixes.
- `T2DMap`'s area-image export - the *suggested* filename for an area name over 50 characters now ends in a 16-character digest. Cosmetic and editable in the save dialog, but uglier than before.

**Test case:** create two profiles whose names share their first 50 characters, save a password in each, reconnect to both. Four new `CredentialManagerTest` cases cover it; all four fail if the fix is reverted.

Assisted-by: Claude:claude-opus-5