### PR TITLE
Fix: Turning off NEW-ENVIRON mid-session now stops sending data to the game

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2694,9 +2694,9 @@ void cTelnet::sendMNESValue(const QString& var, const QMap<QString, QPair<bool, 
         }
     } else {
         // RFC 1572: If a "type" is not followed by a VALUE (e.g., by another VAR,
-        // USERVAR, or IAC SE) then that variable is undefined.
+        // USERVAR, or IAC SE) then that variable is undefined. A VAL with nothing
+        // after it would instead say the variable is defined and merely empty.
         output += prepareNewEnvironData(var).toStdString();
-        output += NEW_ENVIRON_VAL;
 
         qDebug() << "WE send that we do not maintain NEW_ENVIRON (MNES) VAR" << var;
     }
@@ -3741,8 +3741,11 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
         }
         option = telnetCommand[2];
 
-        // NEW_ENVIRON
-        if (option == OPT_NEW_ENVIRON && enableNewEnviron) {
+        // NEW_ENVIRON. The negotiated flag alone is not enough: turning the
+        // preference off mid-session leaves the option negotiated, and answering
+        // a SEND then hands the game the variables the player just withheld. The
+        // INFO path gates on the same pair, so both halves stop together.
+        if (option == OPT_NEW_ENVIRON && enableNewEnviron && mpHost->mEnableNEWENVIRON) {
             QByteArray payload = QByteArray::fromRawData(telnetCommand.c_str(), telnetCommand.size());
 
             if (telnetCommand.size() < 6) {

--- a/test/functional_tests/TelnetNewEnvironTest.cpp
+++ b/test/functional_tests/TelnetNewEnvironTest.cpp
@@ -585,6 +585,48 @@ private slots:
         QVERIFY2(newEnvironReplies().isEmpty(), "Mudlet kept answering NEW_ENVIRON after the game withdrew it");
     }
 
+    // Turning the protocol off mid-session is the player withdrawing it rather
+    // than the game: nothing renegotiates, so the option stays negotiated and
+    // only the preference says no. The INFO half already stops on that pair of
+    // flags and the answer to a SEND has to stop with it.
+    void test_nothingIsAnsweredOncePlayerTurnsTheProtocolOff()
+    {
+        enableNewEnviron();
+        requestSend({});
+        QCOMPARE(newEnvironReplies().size(), 1);
+
+        mpHost->mEnableNEWENVIRON = false;
+        QVERIFY2(mpHost->mTelnet.isNewEnvironEnabled(), "the option renegotiated itself, so this is no longer the mid-session case");
+
+        mpServer->forgetReceived();
+        requestSend({});
+        QVERIFY2(newEnvironReplies().isEmpty(), "a bare SEND was answered after the player turned NEW-ENVIRON off");
+
+        mpServer->forgetReceived();
+        requestSend(named(NEW_ENVIRON_USERVAR, "CHARSET"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "a named SEND was answered after the player turned NEW-ENVIRON off");
+
+        mpServer->forgetReceived();
+        mpHost->mAdvertiseScreenReader = true;
+        mpHost->mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "an INFO went out after the player turned NEW-ENVIRON off");
+
+        // MNES rides on the same telnet option through the same request handler,
+        // so it falls silent on the same preference.
+        mpServer->forgetReceived();
+        mpHost->mEnableMNES = true;
+        requestSend(named(NEW_ENVIRON_VAR, "CLIENT_NAME"));
+        QVERIFY2(newEnvironReplies().isEmpty(), "MNES answered a SEND after the player turned NEW-ENVIRON off");
+
+        // The control: the same request over the same connection is answered once
+        // the preference is back, so none of the silence above is a capture that
+        // quietly died.
+        mpServer->forgetReceived();
+        mpHost->mEnableNEWENVIRON = true;
+        requestSend(named(NEW_ENVIRON_VAR, "CLIENT_NAME"));
+        QCOMPARE(newEnvironReplies().size(), 1);
+    }
+
     // A preference the game has already been told about is worth an INFO when it
     // changes, carrying the new value under the same type the original answer
     // used - anything else and the game files the update under a second name.
@@ -686,9 +728,11 @@ private slots:
     }
 
     // Under MNES a name outside that set is not Mudlet's to answer at all, while
-    // one inside it that Mudlet chooses not to supply is answered as maintained
-    // but empty. IPADDRESS reaches the second path by being in the MNES name list
-    // and absent from the data map.
+    // one inside it that Mudlet does not maintain comes back undefined. RFC 1572
+    // spells the two apart: a name with no VAL after it is undefined, while a VAL
+    // with nothing after it says the variable exists and is merely empty.
+    // IPADDRESS reaches the second path by being in the MNES name list and absent
+    // from the data map.
     void test_mnesAnswersOnlyMnesNames()
     {
         mpHost->mEnableMNES = true;
@@ -705,7 +749,7 @@ private slots:
         QCOMPARE(addressReply.size(), 1);
         const EnvironVariable address = addressReply.first();
         QCOMPARE(address.name, QByteArray("IPADDRESS"));
-        QVERIFY2(address.hasValue, "IPADDRESS was reported as a name MNES does not know rather than one Mudlet does not fill in");
+        QVERIFY2(!address.hasValue, "IPADDRESS came back with a VAL, which tells the game Mudlet maintains the variable and it happens to be empty");
         QVERIFY2(address.value.isEmpty(), "Mudlet supplied an IP address, which it deliberately does not do");
 
         mpServer->forgetReceived();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The NEW-ENVIRON request handler now gates on the preference as well as the negotiated option, which takes MNES with it.
- MNES answers a variable it does not maintain as undefined rather than as defined-but-empty.

#### Motivation for adding to Mudlet

Nothing renegotiates when the player turns the preference off, so the option stayed negotiated and `SEND` requests were still answered with exactly the variables the player had just withheld. The `INFO` path already gated on both flags; the request handler did not.

Separately, a variable Mudlet deliberately does not supply (`IPADDRESS`) came back as a `VAL` with nothing after it, which per RFC 1572 says the variable exists and happens to be empty. Undefined is no `VAL` at all.

#### Other info (issues closed, discussion etc)

Closes #10071, closes #10072.

**Test case:** connect to a game that uses NEW-ENVIRON, then untick it in the preferences mid-session - nothing further is sent, and re-ticking resumes it on the same connection. Covered by a new `TelnetNewEnvironTest` case plus a corrected assertion in `test_mnesAnswersOnlyMnesNames`; both fail if `ctelnet.cpp` is reverted.

Assisted-by: Claude:claude-opus-5