### PR TITLE
Infra: Run Lua specs without rebuilding the worktree

### DIFF
--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -12,6 +12,24 @@ license: GPL-2.0-or-later
 Read this **before** typing a build command, not after one fails. The correct invocation differs
 per platform, and the wrong one is not merely slower — see Pitfalls.
 
+## First: does this need a build at all?
+
+A change confined to `src/mudlet-lua/` needs none. Mudlet reads mudlet-lua from disk at startup,
+so any Mudlet binary already on this machine runs *this* worktree's Lua and specs:
+
+```bash
+.claude/scripts/run-lua-tests.sh /path/to/any/recent/build/src/mudlet
+```
+
+Any `build*/src/mudlet` under this checkout or a sibling worktree will do - `ls -lt` over them
+finds the newest. The script notices a binary from a foreign build tree and shims around it, so
+the Lua under test is always the local one; it prints a `note:` line when it does.
+
+Prefer a binary built within a day or two. An older one fails specs that depend on C++ landed
+since, which reads exactly like a regression in the change under test.
+
+A change touching `src/*.cpp` or `src/*.h` does need a build - carry on below.
+
 ## Use a preset — every platform, one command
 
 `CMakePresets.json` in the repository root encodes the generator, build type and sanitizer

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -14,21 +14,30 @@ per platform, and the wrong one is not merely slower — see Pitfalls.
 
 ## First: does this need a build at all?
 
-A change confined to `src/mudlet-lua/` needs none. Mudlet reads mudlet-lua from disk at startup,
-so any Mudlet binary already on this machine runs *this* worktree's Lua and specs:
+On Linux, a change confined to `src/mudlet-lua/lua/` or `src/mudlet-lua/tests/` needs none. Those
+are read from disk at startup, so a Mudlet binary built anywhere on the machine can run *this*
+worktree's Lua and specs:
 
 ```bash
-.claude/scripts/run-lua-tests.sh /path/to/any/recent/build/src/mudlet
+.claude/scripts/run-lua-tests.sh ../otherworktree/build-linux-debug-nosan/src/mudlet
 ```
 
-Any `build*/src/mudlet` under this checkout or a sibling worktree will do - `ls -lt` over them
-finds the newest. The script notices a binary from a foreign build tree and shims around it, so
-the Lua under test is always the local one; it prints a `note:` line when it does.
+The script detects a binary from another build tree, shims around it with a `note:` line, and
+fails loudly if this worktree's Lua is not what ended up loading.
 
-Prefer a binary built within a day or two. An older one fails specs that depend on C++ landed
-since, which reads exactly like a regression in the change under test.
+These look Lua-only but still need a build:
 
-A change touching `src/*.cpp` or `src/*.h` does need a build - carry on below.
+- `src/packages/` and `src/mudlet-lua/lua/utf8_filenames.lua` are compiled into the binary as Qt
+  resources (`src/mudlet.qrc`), so editing them cannot affect a borrowed binary.
+- On macOS the build copies mudlet-lua into the `.app` bundle and that copy is preferred over
+  `src/`, so a Lua change does need a rebuild there. The script is Linux-only regardless - it
+  drives Mudlet under `xvfb-run`.
+- Anything under `src/*.cpp` or `src/*.h`.
+
+Choose a donor whose branch already contains the C++ the specs rely on - one missing it fails
+specs in a way that reads exactly like a regression in the change under test. Prefer a `-nosan`
+tree: the plain `build/` preset is an AddressSanitizer build, and this script does not pass it
+the `ASAN_OPTIONS` CI uses, so a leak surfaces as a bare non-zero exit with every spec green.
 
 ## Use a preset — every platform, one command
 

--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -6,8 +6,10 @@
 # socket in the state feedTelnet() needs.
 #
 # Usage: .claude/scripts/run-lua-tests.sh [path-to-mudlet-binary]
-# Defaults to the linux-debug-nosan build. Needs the rocks and apt packages
-# that .claude/hooks/session-start.sh installs.
+# Defaults to the linux-debug-nosan build. Any Mudlet binary will do, including
+# one built in another worktree - a Lua-only change needs no build of its own,
+# because mudlet-lua is read from disk at startup. Needs the rocks and apt
+# packages that .claude/hooks/session-start.sh installs.
 #
 # Safe to run concurrently (e.g. one run per worktree): every fixture binds an
 # ephemeral port handed over through this run's private temp directory, only
@@ -21,12 +23,40 @@ TMP="$(mktemp -d /tmp/mudlet-luatests-XXXX)"
 
 [ -x "$BINARY" ] || { echo "no mudlet binary at $BINARY - build first"; exit 1; }
 
-# The binary is run in place; it locates mudlet-lua relative to itself, which
-# works for any build tree inside the repository (build*/src/mudlet).
+WS_GLOBAL="$WS/src/mudlet-lua/lua/LuaGlobal.lua"
+[ -f "$WS_GLOBAL" ] || { echo "no mudlet-lua under $WS - is this a Mudlet checkout?"; exit 1; }
+
+# Mudlet locates mudlet-lua relative to its own executable and takes the first
+# candidate that exists, so a binary borrowed from another build tree would
+# quietly run that tree's Lua library against this worktree's specs - green
+# whatever the change under test did. Detect that and shim around it, rather
+# than making the caller build here.
 BINDIR="$(cd "$(dirname "$BINARY")" && pwd)"
-if [ ! -f "$BINDIR/../../src/mudlet-lua/lua/LuaGlobal.lua" ] && [ ! -f "$BINDIR/mudlet-lua/lua/LuaGlobal.lua" ]; then
-  echo "LuaGlobal.lua is not reachable relative to $BINARY - run a build tree that sits inside the repository"
-  exit 1
+loads_this_worktree() {
+  local candidate
+  # same list, in the same order, as TLuaInterpreter::loadGlobal()
+  for candidate in "$BINDIR/mudlet-lua/lua/LuaGlobal.lua" \
+                   "$BINDIR/../src/mudlet-lua/lua/LuaGlobal.lua" \
+                   "$BINDIR/../../src/mudlet-lua/lua/LuaGlobal.lua" \
+                   "$BINDIR/../../../src/mudlet-lua/lua/LuaGlobal.lua" \
+                   "$BINDIR/../../../mudlet-lua/lua/LuaGlobal.lua"; do
+    [ -f "$candidate" ] || continue
+    # only the first existing candidate is ever loaded, so this one decides it
+    [ "$(readlink -f "$candidate")" = "$(readlink -f "$WS_GLOBAL")" ]
+    return
+  done
+  return 1
+}
+
+if ! loads_this_worktree; then
+  echo "note: $BINARY is not a build of this worktree - running it against $WS/src"
+  mkdir -p "$TMP/shim/build/src"
+  # A hardlink, not a symlink: applicationDirPath() goes through /proc/self/exe,
+  # which would resolve a symlink straight back to the donor build tree. Fall
+  # back to a copy when the donor lives on another filesystem.
+  ln "$BINARY" "$TMP/shim/build/src/mudlet" 2>/dev/null || cp "$BINARY" "$TMP/shim/build/src/mudlet"
+  ln -s "$WS/src" "$TMP/shim/src"
+  BINARY="$TMP/shim/build/src/mudlet"
 fi
 
 FIXTURE_PIDS=()

--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -62,10 +62,13 @@ if ! loads_this_worktree; then
   mkdir -p "$TMP/shim/build/src"
   # A hardlink rather than a symlink: Qt 6.12 derives applicationDirPath() from
   # argv[0], under which either would work, but a hardlink is also correct if it
-  # ever goes back to resolving /proc/self/exe. -p because a bare cp applies the
-  # umask and can drop the execute bit. Copy only when the donor is on another
-  # filesystem, where a hardlink is impossible.
-  ln "$BINARY" "$TMP/shim/build/src/mudlet" 2>/dev/null \
+  # ever goes back to resolving /proc/self/exe. readlink -f first because the
+  # argument may itself be a symlink: hard-linking one stages a link straight back
+  # into the donor tree, which voids that hedge and disagrees with the cp -p
+  # fallback, since cp dereferences. -p because a bare cp applies the umask and can
+  # drop the execute bit. Copy only when the donor is on another filesystem, where
+  # a hardlink is impossible.
+  ln "$(readlink -f "$BINARY")" "$TMP/shim/build/src/mudlet" 2>/dev/null \
     || cp -p "$BINARY" "$TMP/shim/build/src/mudlet" \
     || { echo "could not stage $BINARY into $TMP - out of space, or /tmp not writable"; exit 2; }
   ln -s "$WS/src" "$TMP/shim/src" || { echo "could not link $WS/src into $TMP"; exit 2; }
@@ -150,6 +153,10 @@ export QUIT_MUDLET_AFTER_TESTS=true
 # concurrent runs cannot read each other's.
 export MUDLET_TEST_FAILURE_MARKER="$TMP/busted-tests-failed"
 
+# Names the library this run is meant to be exercising, so MudletBusted_spec.lua
+# can check that it is the one loadGlobal() settled on rather than the donor's.
+export MUDLET_TEST_EXPECTED_LUA_PATH="$(readlink -f "$WS/src/mudlet-lua/lua")"
+
 cd "$WS"
 rc=0
 timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --mirror --offline 2>&1 \
@@ -158,7 +165,8 @@ timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --m
 # loadGlobal() walks on to its next candidate when one fails to run, so a syntax
 # error anywhere in this worktree's mudlet-lua silently hands the whole library
 # over to the donor's LUA_SOURCE_PATH and the suite passes against that instead.
-# The warning it emits on the way past is the only evidence, so treat it as fatal.
+# The warning it emits on the way past names the file and the Lua error, so treat
+# it as fatal. MudletBusted_spec.lua backs this up with a positive check.
 if grep -q "loadGlobal() loading" "$TMP/run.log"; then
   echo "This worktree's mudlet-lua failed to load, so the specs ran against the"
   echo "binary's own copy - the result above is meaningless. The failure was:"

--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -6,10 +6,12 @@
 # socket in the state feedTelnet() needs.
 #
 # Usage: .claude/scripts/run-lua-tests.sh [path-to-mudlet-binary]
-# Defaults to the linux-debug-nosan build. Any Mudlet binary will do, including
-# one built in another worktree - a Lua-only change needs no build of its own,
-# because mudlet-lua is read from disk at startup. Needs the rocks and apt
-# packages that .claude/hooks/session-start.sh installs.
+# Defaults to the linux-debug-nosan build. A binary built in another worktree
+# works too: src/mudlet-lua is read from disk at startup, so a change confined
+# to it needs no build of its own. Only the Lua is this worktree's - the C++,
+# and everything compiled into the binary's Qt resources (src/packages/*, and
+# mudlet-lua/lua/utf8_filenames.lua), still comes from whoever built it. Needs
+# the rocks and apt packages that .claude/hooks/session-start.sh installs.
 #
 # Safe to run concurrently (e.g. one run per worktree): every fixture binds an
 # ephemeral port handed over through this run's private temp directory, only
@@ -22,6 +24,7 @@ BINARY="${1:-$WS/build-linux-debug-nosan/src/mudlet}"
 TMP="$(mktemp -d /tmp/mudlet-luatests-XXXX)"
 
 [ -x "$BINARY" ] || { echo "no mudlet binary at $BINARY - build first"; exit 1; }
+BINARY="$(cd "$(dirname "$BINARY")" && pwd)/$(basename "$BINARY")"
 
 WS_GLOBAL="$WS/src/mudlet-lua/lua/LuaGlobal.lua"
 [ -f "$WS_GLOBAL" ] || { echo "no mudlet-lua under $WS - is this a Mudlet checkout?"; exit 1; }
@@ -34,7 +37,12 @@ WS_GLOBAL="$WS/src/mudlet-lua/lua/LuaGlobal.lua"
 BINDIR="$(cd "$(dirname "$BINARY")" && pwd)"
 loads_this_worktree() {
   local candidate
-  # same list, in the same order, as TLuaInterpreter::loadGlobal()
+  # The Linux subset of loadGlobal()'s candidates, in its order. Omitted: the
+  # macOS-only ../Resources entry, which would come first there, and the two
+  # absolute tail entries LUA_DEFAULT_PATH and LUA_SOURCE_PATH. They sort after
+  # these, so they cannot make this misjudge a Linux binary - but LUA_SOURCE_PATH
+  # is the donor's own source tree, baked in at compile time, so it stays a live
+  # fallback for the whole run. Hence the post-run check at the bottom.
   for candidate in "$BINDIR/mudlet-lua/lua/LuaGlobal.lua" \
                    "$BINDIR/../src/mudlet-lua/lua/LuaGlobal.lua" \
                    "$BINDIR/../../src/mudlet-lua/lua/LuaGlobal.lua" \
@@ -49,14 +57,22 @@ loads_this_worktree() {
 }
 
 if ! loads_this_worktree; then
-  echo "note: $BINARY is not a build of this worktree - running it against $WS/src"
+  echo "note: $BINARY was built elsewhere - running its C++ against this worktree's"
+  echo "      Lua. A C++ change in this worktree is NOT under test."
   mkdir -p "$TMP/shim/build/src"
-  # A hardlink, not a symlink: applicationDirPath() goes through /proc/self/exe,
-  # which would resolve a symlink straight back to the donor build tree. Fall
-  # back to a copy when the donor lives on another filesystem.
-  ln "$BINARY" "$TMP/shim/build/src/mudlet" 2>/dev/null || cp "$BINARY" "$TMP/shim/build/src/mudlet"
-  ln -s "$WS/src" "$TMP/shim/src"
+  # A hardlink rather than a symlink: Qt 6.12 derives applicationDirPath() from
+  # argv[0], under which either would work, but a hardlink is also correct if it
+  # ever goes back to resolving /proc/self/exe. -p because a bare cp applies the
+  # umask and can drop the execute bit. Copy only when the donor is on another
+  # filesystem, where a hardlink is impossible.
+  ln "$BINARY" "$TMP/shim/build/src/mudlet" 2>/dev/null \
+    || cp -p "$BINARY" "$TMP/shim/build/src/mudlet" \
+    || { echo "could not stage $BINARY into $TMP - out of space, or /tmp not writable"; exit 2; }
+  ln -s "$WS/src" "$TMP/shim/src" || { echo "could not link $WS/src into $TMP"; exit 2; }
   BINARY="$TMP/shim/build/src/mudlet"
+  BINDIR="$(cd "$(dirname "$BINARY")" && pwd)"
+  loads_this_worktree || { echo "shim did not take: $BINARY still would not load $WS/src/mudlet-lua"; exit 2; }
+  [ -x "$BINARY" ] || { echo "staged $BINARY is not executable"; exit 2; }
 fi
 
 FIXTURE_PIDS=()
@@ -64,6 +80,11 @@ cleanup() {
   for pid in "${FIXTURE_PIDS[@]:-}"; do
     kill "$pid" 2>/dev/null || true
   done
+  # Nothing here is worth keeping: the fixture logs are cat'd before any early
+  # exit and the run itself is tee'd to stdout. Leaving it behind costs real
+  # disk - a shimmed run parks a ~250MB hardlink that also pins the donor's
+  # inode, so a deleted worktree would stop reclaiming its build.
+  rm -rf "$TMP" "${runtime_dir:-}"
 }
 trap cleanup EXIT
 
@@ -131,7 +152,20 @@ export MUDLET_TEST_FAILURE_MARKER="$TMP/busted-tests-failed"
 
 cd "$WS"
 rc=0
-timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --mirror --offline || rc=$?
+timeout 360 xvfb-run --auto-servernum "$BINARY" --profile "Mudlet self-test" --mirror --offline 2>&1 \
+  | tee "$TMP/run.log" || rc=$?
+
+# loadGlobal() walks on to its next candidate when one fails to run, so a syntax
+# error anywhere in this worktree's mudlet-lua silently hands the whole library
+# over to the donor's LUA_SOURCE_PATH and the suite passes against that instead.
+# The warning it emits on the way past is the only evidence, so treat it as fatal.
+if grep -q "loadGlobal() loading" "$TMP/run.log"; then
+  echo "This worktree's mudlet-lua failed to load, so the specs ran against the"
+  echo "binary's own copy - the result above is meaningless. The failure was:"
+  grep "loadGlobal() loading" "$TMP/run.log"
+  rc=1
+fi
+
 if [ -e "$MUDLET_TEST_FAILURE_MARKER" ]; then
   echo "Lua tests failed - see the busted output above."
   rc=1

--- a/src/mudlet-lua/tests/MudletBusted_spec.lua
+++ b/src/mudlet-lua/tests/MudletBusted_spec.lua
@@ -1,3 +1,29 @@
+-- The spec runner sets this to the mudlet-lua it means to be testing. CI leaves
+-- it unset, where a binary and its Lua always come from the same build.
+local expectedLuaPath = os.getenv("MUDLET_TEST_EXPECTED_LUA_PATH")
+if expectedLuaPath then
+  describe("mudlet-lua under test", function()
+      it("is the copy the runner asked for", function()
+          -- loadGlobal() walks silently past a candidate that is missing,
+          -- unreadable or empty, so a binary borrowed from another build tree can
+          -- fall back to the copy compiled into it and the suite then passes
+          -- against the wrong library entirely. Compare inode and device rather
+          -- than the paths: the runner reaches this worktree's src through a
+          -- symlink when it shims, so the two paths differ even when they agree.
+          local expected = expectedLuaPath .. "/LuaGlobal.lua"
+          local loaded = tostring(luaGlobalPath) .. "/LuaGlobal.lua"
+          local expectedDevice = lfs.attributes(expected, "dev")
+          local expectedInode = lfs.attributes(expected, "ino")
+          local loadedDevice = lfs.attributes(loaded, "dev")
+          local loadedInode = lfs.attributes(loaded, "ino")
+          local what = string.format("loaded %s instead of %s", loaded, expected)
+          assert.is_not_nil(expectedInode, expected .. " is gone, so this guard cannot tell what loaded")
+          assert.equals(expectedDevice, loadedDevice, what)
+          assert.equals(expectedInode, loadedInode, what)
+        end)
+    end)
+end
+
 describe("Mudlet Busted sanity check", function()
     it("runs a simple assert", function()
         assert.truthy("Not nil or false.")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `.claude/scripts/run-lua-tests.sh` accepts a Mudlet binary built in any other worktree and shims it against this one's `src`, so a change confined to `src/mudlet-lua/` needs no build of its own.
- The run now fails if this worktree's Lua is not what actually loaded. `loadGlobal()` advances to its next candidate when one fails to run, and the last candidate is `LUA_SOURCE_PATH` - the donor's own source tree, baked into the binary - so a syntax error here silently handed the whole library over to the donor.
- The `build-mudlet` skill gains a "does this need a build at all?" section, naming what still does need one: `src/packages/` and `mudlet-lua/lua/utf8_filenames.lua` (compiled in as Qt resources), macOS bundles, and any C++.

#### Motivation for adding to Mudlet

A Lua-only change was costing a ~10 minute build and ~8GB of disk for nothing, and the trick to avoid it lived in one person's notes rather than anywhere a contributor or agent would find it.

#### Other info (issues closed, discussion etc)

CI never invokes this script, so the pipeline is unaffected.

**Test case:** from a worktree with no build of its own, run `.claude/scripts/run-lua-tests.sh ../<other-worktree>/build-linux-debug-nosan/src/mudlet` - the suite passes 3687/0. Then append `this is not valid lua ((` to `src/mudlet-lua/lua/StringUtils.lua` and rerun: before this change the suite still reported 3687 successes and exit 0, now it exits 1 and names the file and line.

Assisted-by: Claude:claude-opus-5