### PR TITLE
Fix: phpTable entries holding false can now be updated and deleted

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -612,8 +612,14 @@ function phpTable(...)
   end
   setmetatable(newTable, {
     __newindex = function(self, key, value)
-      if not self[key] then
-        table.insert(keys, key)
+      -- Only a nil read means the key is absent: `not self[key]` also matched a
+      -- stored false, which appended a second copy of the key to the order list
+      -- and left it undeletable. Assigning nil to an absent key must not
+      -- register one either.
+      if self[key] == nil then
+        if value ~= nil then
+          table.insert(keys, key)
+        end
       elseif value == nil then
         -- Handle item delete
         local count = 1

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -955,6 +955,40 @@ describe("Tests Other.lua functions", function()
     end)
   end)
 
+  describe("Tests the functionality of phpTable", function()
+    -- Collects the entire iteration rather than a keyed table: a duplicated key
+    -- and a key left behind with a nil value are both only visible in the
+    -- sequence the pairs iterator yields.
+    local function entries(t)
+      local collected = {}
+      for key, value in t:pairs() do
+        collected[#collected + 1] = tostring(key) .. "=" .. tostring(value)
+      end
+      return collected
+    end
+
+    it("should yield a key holding false only once after it is overwritten", function()
+      local t = phpTable({ flag = false })
+      assert.is_false(t.flag)
+      t.flag = true
+      assert.same({ "flag=true" }, entries(t))
+    end)
+
+    it("should delete a key holding false when it is assigned nil", function()
+      local t = phpTable({ flag = false })
+      t.flag = nil
+      assert.is_nil(t.flag)
+      assert.same({}, entries(t))
+    end)
+
+    it("should not register a key that never existed when it is assigned nil", function()
+      local t = phpTable({ kept = 1 })
+      t.ghost = nil
+      assert.is_nil(t.ghost)
+      assert.same({ "kept=1" }, entries(t))
+    end)
+  end)
+
     --[[
     TODO:
       remember()
@@ -964,7 +998,6 @@ describe("Tests Other.lua functions", function()
       table.pickle()
       tacle.load()
       table.unpickle()
-      phpTable()
       getColorWildcard()
       lockExit()
       hasExitLock()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `phpTable()`'s `__newindex` now tests `self[key] == nil` rather than `not self[key]` to decide whether a key is new.
- Assigning `nil` to a key that never existed no longer registers one.

#### Motivation for adding to Mudlet

`not self[key]` is true for a stored `false` as well as for an absent key, so overwriting a `false` appended a second copy of that key to the order list. `pairs()` then yielded it twice, and the delete branch - which only removes one entry - could never clear it.

#### Other info (issues closed, discussion etc)

Closes #10137.

**Test case:** `t = phpTable({flag = false}); t.flag = true` then iterate `t:pairs()` - `flag` appears once, and `t.flag = nil` removes it. Three new `Other_spec` cases cover it; all three fail if `Other.lua` is reverted.

Assisted-by: Claude:claude-opus-5