### PR TITLE
Fix: Reject malformed version numbers instead of misreading them

### DIFF
--- a/src/updater/SemVer.cpp
+++ b/src/updater/SemVer.cpp
@@ -38,14 +38,28 @@ namespace dblsqd {
 SemVer::SemVer(const QString& version)
 {
     static const QRegularExpression rx(getRegExp());
-    QRegularExpressionMatch match = rx.match(version);
-    if (match.hasMatch()) {
-        mMajor = match.captured(1).toInt();
-        mMinor = match.captured(2).toInt();
-        mPatch = match.captured(3).toInt();
-        mPrerelease = match.captured(4);
-        mValid = true;
+    const QRegularExpressionMatch match = rx.match(version);
+    if (!match.hasMatch()) {
+        return;
     }
+
+    bool majorOk = false;
+    bool minorOk = false;
+    bool patchOk = false;
+    const int major = match.captured(1).toInt(&majorOk);
+    const int minor = match.captured(2).toInt(&minorOk);
+    const int patch = match.captured(3).toInt(&patchOk);
+    // toInt() reads a component too large for an int back as 0, which would sort
+    // the highest version there is below every other one
+    if (!majorOk || !minorOk || !patchOk) {
+        return;
+    }
+
+    mMajor = major;
+    mMinor = minor;
+    mPatch = patch;
+    mPrerelease = match.captured(4);
+    mValid = true;
 }
 
 /*!
@@ -112,8 +126,10 @@ QString SemVer::getRegExp()
 {
     QString v = qsl("(0|[1-9]\\d*)");
     QString p = qsl("(?:-((?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*))?");
-    QString b = qsl("(?:\\+((?:[0-9A-Za-z-]*)(?:\\.(?:[0-9A-Za-z-][0-9A-Za-z-]*))*))?");
-    return qsl("^") + v + qsl("\\.") + v + qsl("\\.") + v + p + b + qsl("$");
+    QString b = qsl("(?:\\+([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?");
+    // \z rather than $, which matches before a trailing newline as well and so
+    // would read a version out of a string that has a line ending left on it
+    return qsl("\\A") + v + qsl("\\.") + v + qsl("\\.") + v + p + b + qsl("\\z");
 }
 
 } // namespace dblsqd

--- a/test/SemVerTest.cpp
+++ b/test/SemVerTest.cpp
@@ -69,11 +69,14 @@ private slots:
     void aThreeComponentVersionIsReadable();
     void aTwoComponentVersionIsNotSemVerAtAll();
     void malformedVersionsAreRejected();
+    void trailingCharactersAreNotPartOfAVersion();
+    void aComponentTooLargeToStoreIsNotAVersion();
     void componentsAreComparedAsNumbersAndNotAsText();
     void majorOutranksMinorOutranksPatch();
     void aPrereleaseSortsBelowTheReleaseItLeadsTo();
     void ptbBuildsOfOneVersionAreOrderedByTheirDate();
     void buildMetadataDoesNotChangeAVersion();
+    void buildMetadataCannotBeEmpty();
     void anUnreadableVersionNeverCompares();
 };
 
@@ -105,6 +108,43 @@ void SemVerTest::malformedVersionsAreRejected()
     QVERIFY(!version(QStringLiteral("01.2.3")).isValid());
     QVERIFY(!version(QStringLiteral("1.02.3")).isValid());
     QVERIFY(!version(QStringLiteral("1.2.03")).isValid());
+}
+
+// A version is the whole of the string or it is not that version at all. The
+// regexp is what decides this, and a '$' anchor there matches just before a
+// trailing newline as well as at the end - so a version with a line ending left on
+// it would read as valid and then be offered under a spelling nothing is published
+// under.
+void SemVerTest::trailingCharactersAreNotPartOfAVersion()
+{
+    QVERIFY(!version(QStringLiteral("1.2.3\n")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3-ptb-2026-08-08-7c6b5a49\n")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3+build.1\n")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3\r\n")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3 ")).isValid());
+    QVERIFY(!version(QStringLiteral("\n1.2.3")).isValid());
+}
+
+// A component is read into an int, and a number too big for one reads back as 0 -
+// so without a range check the largest version there is sorts below every other
+// one instead of above them, and whichever side of the comparison it lands on gets
+// the update decision backwards
+void SemVerTest::aComponentTooLargeToStoreIsNotAVersion()
+{
+    QVERIFY(!version(QStringLiteral("2147483648.0.0")).isValid());
+    QVERIFY(!version(QStringLiteral("0.2147483648.0")).isValid());
+    QVERIFY(!version(QStringLiteral("0.0.2147483648")).isValid());
+    QVERIFY(!version(QStringLiteral("99999999999.0.0")).isValid());
+
+    // the largest one that does fit is still a version, and still ordered as a number
+    QVERIFY(version(QStringLiteral("2147483647.0.0")).isValid());
+    assertOlder(QStringLiteral("2147483646.0.0"), QStringLiteral("2147483647.0.0"));
+
+    // and one that does not fit compares with nothing, rather than sorting below
+    // the versions it is larger than
+    QVERIFY(!(version(QStringLiteral("2147483648.0.0")) < version(QStringLiteral("2147483647.0.0"))));
+    QVERIFY(!(version(QStringLiteral("2147483647.0.0")) < version(QStringLiteral("2147483648.0.0"))));
+    QVERIFY(!(version(QStringLiteral("99999999999.0.0")) < version(QStringLiteral("1.2.3"))));
 }
 
 // Text ordering puts "4.22.0" below "4.9.0", which would offer every 4.22.0 user
@@ -156,6 +196,23 @@ void SemVerTest::buildMetadataDoesNotChangeAVersion()
 
     // The prerelease still counts when metadata is attached to it
     assertOlder(QStringLiteral("1.2.3-alpha+build.1"), QStringLiteral("1.2.3+build.1"));
+}
+
+// SemVer 2.0 has build metadata as one or more identifiers of at least one
+// character each, so a '+' with nothing after it is a typo rather than a version
+void SemVerTest::buildMetadataCannotBeEmpty()
+{
+    QVERIFY(!version(QStringLiteral("1.2.3+")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3+.build")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3+build.")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3+build..1")).isValid());
+    QVERIFY(!version(QStringLiteral("1.2.3-alpha+")).isValid());
+
+    // metadata that is actually there stays acceptable
+    QVERIFY(version(QStringLiteral("1.2.3+build")).isValid());
+    QVERIFY(version(QStringLiteral("1.2.3+build.1.2")).isValid());
+    QVERIFY(version(QStringLiteral("1.2.3+21AF26D3----117B344092BD")).isValid());
+    QVERIFY(version(QStringLiteral("1.2.3-alpha+build")).isValid());
 }
 
 // std::sort needs a strict weak ordering, and an unreadable version has no place


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A version component too large for an `int` makes the version unreadable rather than silently becoming 0.
- The regexp anchors with `\A`/`\z` instead of `^`/`$`, which also matched around a trailing newline.
- Build metadata has to carry at least one identifier, so `1.2.3+` is a typo rather than a version.

#### Motivation for adding to Mudlet

`toInt()` reads an out-of-range component back as 0, which sorted the highest version there is *below* every other one - and whichever side of the comparison it landed on got the update decision backwards. An unreadable version is honest: `Release::operator<` already falls back to comparing dates, which is what PTB builds rely on.

#### Other info (issues closed, discussion etc)

Closes #10066.

Release versions come from GitHub's `tag_name`, so no shipped version string is affected by the tighter anchors - `4.22.0` and `4.22.0-ptb-2026-08-08-7c6b5a49` both still parse.

**Test case:** covered by three new `SemVerTest` cases; all three fail if `SemVer.cpp` is reverted.

Assisted-by: Claude:claude-opus-5