### PR TITLE
Infra: Match color triggers against the profile's colors without a window

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1941,18 +1941,23 @@ TConsoleModel& Host::mainConsoleModel()
     return *mpMainConsoleModel;
 }
 
-// The profile's default colours are what a colour trigger matches "the default
-// colour" against, and the main console's model is where the trigger engine
-// reads them. They are not known when the model is built - this Host still
-// holds the built-in defaults at that point - so they have to be pushed in once
-// the profile has been read, and again whenever they change. Doing that here
-// rather than from TConsole::changeColors() is what lets a profile with no view
-// (a headless one, or one whose console has gone) still match against the
-// colours the profile actually configured.
+// A colour trigger set to "the default colour" matches against the main console
+// model's pair (TTrigger::match_color_pattern), so every writer of mFgColor and
+// mBgColor owes this call afterwards. The view's restyle
+// (TConsole::changeColors()) makes it as a side effect of restyling itself;
+// making it here too is what lets a profile whose console has not been built
+// yet, or never will be (#8681), match against the colours the profile actually
+// configured. Seeding the model when it is constructed would achieve nothing:
+// this Host still holds the built-in defaults at that point.
+// For the main console only - a sub-console model owns its own colours.
 void Host::refreshMainConsoleColors()
 {
     mpMainConsoleModel->mFgColor = mFgColor;
     mpMainConsoleModel->mBgColor = mBgColor;
+    // The pair above is what triggers match; the buffer's own copy is what text
+    // arriving with no SGR sequence gets stamped with. changeColors() refreshes
+    // both, so this has to as well or a view-less profile has them disagreeing.
+    mpMainConsoleModel->buffer.updateColors();
 }
 
 // The per-line trigger orchestration used to live on the main-console widget

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1941,22 +1941,18 @@ TConsoleModel& Host::mainConsoleModel()
     return *mpMainConsoleModel;
 }
 
-// A colour trigger set to "the default colour" matches against the main console
-// model's pair (TTrigger::match_color_pattern), so every writer of mFgColor and
-// mBgColor owes this call afterwards. The view's restyle
-// (TConsole::changeColors()) makes it as a side effect of restyling itself;
-// making it here too is what lets a profile whose console has not been built
-// yet, or never will be (#8681), match against the colours the profile actually
-// configured. Seeding the model when it is constructed would achieve nothing:
-// this Host still holds the built-in defaults at that point.
-// For the main console only - a sub-console model owns its own colours.
+// Every writer of mFgColor/mBgColor owes this call: the model's pair is what a
+// colour trigger matching "the default colour" compares against
+// (TTrigger::match_color_pattern), and it is the only copy a profile with no
+// console has. Seeding it in the model's constructor would not do - this Host
+// still holds the built-in defaults at that point. Main console only; a
+// sub-console model owns its colours outright.
 void Host::refreshMainConsoleColors()
 {
     mpMainConsoleModel->mFgColor = mFgColor;
     mpMainConsoleModel->mBgColor = mBgColor;
-    // The pair above is what triggers match; the buffer's own copy is what text
-    // arriving with no SGR sequence gets stamped with. changeColors() refreshes
-    // both, so this has to as well or a view-less profile has them disagreeing.
+    // Two copies to keep in step: the pair above is what triggers match, the
+    // buffer's is what unstyled text gets stamped with.
     mpMainConsoleModel->buffer.updateColors();
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1941,18 +1941,14 @@ TConsoleModel& Host::mainConsoleModel()
     return *mpMainConsoleModel;
 }
 
-// Every writer of mFgColor/mBgColor owes this call: the model's pair is what a
-// colour trigger matching "the default colour" compares against
-// (TTrigger::match_color_pattern), and it is the only copy a profile with no
-// console has. Seeding it in the model's constructor would not do - this Host
-// still holds the built-in defaults at that point. Main console only; a
-// sub-console model owns its colours outright.
+// A colour trigger matching "the default colour" compares against the model's
+// pair, so it has to carry the profile's colours whether or not a console was
+// ever built to copy them over. Seeding them in the model's constructor would
+// not do - this Host still holds the built-in defaults at that point.
 void Host::refreshMainConsoleColors()
 {
     mpMainConsoleModel->mFgColor = mFgColor;
     mpMainConsoleModel->mBgColor = mBgColor;
-    // Two copies to keep in step: the pair above is what triggers match, the
-    // buffer's is what unstyled text gets stamped with.
     mpMainConsoleModel->buffer.updateColors();
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1941,6 +1941,20 @@ TConsoleModel& Host::mainConsoleModel()
     return *mpMainConsoleModel;
 }
 
+// The profile's default colours are what a colour trigger matches "the default
+// colour" against, and the main console's model is where the trigger engine
+// reads them. They are not known when the model is built - this Host still
+// holds the built-in defaults at that point - so they have to be pushed in once
+// the profile has been read, and again whenever they change. Doing that here
+// rather than from TConsole::changeColors() is what lets a profile with no view
+// (a headless one, or one whose console has gone) still match against the
+// colours the profile actually configured.
+void Host::refreshMainConsoleColors()
+{
+    mpMainConsoleModel->mFgColor = mFgColor;
+    mpMainConsoleModel->mBgColor = mBgColor;
+}
+
 // The per-line trigger orchestration used to live on the main-console widget
 // (TMainConsole::runTriggers). It drives model state only, so it runs here
 // against the core model and needs no view (#8681).

--- a/src/Host.h
+++ b/src/Host.h
@@ -280,6 +280,7 @@ public:
     // view reaches the same instance via TConsole::model().
     TConsoleModel& mainConsoleModel();
     std::shared_ptr<TConsoleModel> sharedMainConsoleModel();
+    void refreshMainConsoleColors();
     void runTriggers(int line);
     void postIrcMessage(const QString&, const QString&, const QString&);
     void enableTimer(const QString&);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1157,9 +1157,9 @@ void TConsole::changeColors()
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
         }
-        // A MainConsole's mBgColor/mFgColor are references onto the model Host
-        // co-owns, so this is the same write as `mBgColor = mpHost->mBgColor`;
-        // keep it a call so the core-side refresh remains its one definition:
+        // The same write as `mBgColor = mpHost->mBgColor` - a MainConsole's pair
+        // are references onto the model - made as a call so the sync has one
+        // definition:
         mpHost->refreshMainConsoleColors();
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1157,9 +1157,9 @@ void TConsole::changeColors()
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
         }
-        // For a MainConsole mBgColor/mFgColor are references onto the model Host
-        // co-owns, so this restyle and the core-side refresh write the very same
-        // two fields:
+        // A MainConsole's mBgColor/mFgColor are references onto the model Host
+        // co-owns, so this is the same write as `mBgColor = mpHost->mBgColor`;
+        // keep it a call so the core-side refresh remains its one definition:
         mpHost->refreshMainConsoleColors();
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1157,8 +1157,10 @@ void TConsole::changeColors()
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
         }
-        mBgColor = mpHost->mBgColor;
-        mFgColor = mpHost->mFgColor;
+        // For a MainConsole mBgColor/mFgColor are references onto the model Host
+        // co-owns, so this restyle and the core-side refresh write the very same
+        // two fields:
+        mpHost->refreshMainConsoleColors();
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;
         mFormatCurrent.setColors(mpHost->mFgColor, mpHost->mBgColor);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1157,9 +1157,8 @@ void TConsole::changeColors()
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
         }
-        // The same write as `mBgColor = mpHost->mBgColor` - a MainConsole's pair
-        // are references onto the model - made as a call so the sync has one
-        // definition:
+        // A MainConsole's mBgColor/mFgColor are references onto the model, so
+        // this writes them too:
         mpHost->refreshMainConsoleColors();
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;
@@ -1169,7 +1168,10 @@ void TConsole::changeColors()
         Q_ASSERT_X(false, "TConsole::changeColors()", "invalid TConsole type detected");
     }
 
-    buffer.updateColors();
+    if (mType != MainConsole) {
+        // refreshMainConsoleColors() above already did this one
+        buffer.updateColors();
+    }
     if (mType & (MainConsole | Buffer)) {
         buffer.mWrapAt = mpHost->mWrapAt;
         buffer.mWrapIndent = mpHost->mWrapIndentCount;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -379,10 +379,10 @@ public:
     QColor& mFgColor;
     QColor mSystemMessageFgColor = QColorConstants::Red;
     QColor mCommandBgColor = QColorConstants::Black;
-    // Black rather than mBgColor: this is captured once and never updated, so it
-    // never really tracked the console background - and now that the model is
-    // handed the profile's colours before a console is built, taking mBgColor
-    // would quietly change what system messages are drawn on.
+    // Black rather than mBgColor: captured once and never updated, so it never
+    // tracked the background anyway, and the model now carries the profile's
+    // colours before a console exists - copying would change what system
+    // messages are drawn on.
     QColor mSystemMessageBgColor = QColorConstants::Black;
     QColor mCommandFgColor = QColor(213, 195, 0);
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -379,7 +379,11 @@ public:
     QColor& mFgColor;
     QColor mSystemMessageFgColor = QColorConstants::Red;
     QColor mCommandBgColor = QColorConstants::Black;
-    QColor mSystemMessageBgColor = mBgColor;
+    // Black rather than mBgColor: this is captured once and never updated, so it
+    // never really tracked the console background - and now that the model is
+    // handed the profile's colours before a console is built, taking mBgColor
+    // would quietly change what system messages are drawn on.
+    QColor mSystemMessageBgColor = QColorConstants::Black;
     QColor mCommandFgColor = QColor(213, 195, 0);
 
     //1 = unclicked/up; 2 = clicked/down, 0 is NOT valid:

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -379,10 +379,9 @@ public:
     QColor& mFgColor;
     QColor mSystemMessageFgColor = QColorConstants::Red;
     QColor mCommandBgColor = QColorConstants::Black;
-    // Black rather than mBgColor: captured once and never updated, so it never
-    // tracked the background anyway, and the model now carries the profile's
-    // colours before a console exists - copying would change what system
-    // messages are drawn on.
+    // Not mBgColor: captured once and never updated, so it only ever held the
+    // built-in default - which the model can now have replaced with the
+    // profile's before the console is built.
     QColor mSystemMessageBgColor = QColorConstants::Black;
     QColor mCommandFgColor = QColor(213, 195, 0);
 

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -55,7 +55,12 @@ struct TConsoleModel
 
     // No 'm' prefix on purpose: TConsole::buffer aliases this one by reference and has to keep its name for the rest of the codebase, so the two match.
     TBuffer buffer;
-    // Only a cache today - the view fills these in through TConsole::changeColors(); refreshing them from the Host after the profile loads moves core-side with the colour sub-PR.
+    // What a colour trigger matches "the default colour" against. The main
+    // console's pair mirrors the profile's Host::mFgColor/mBgColor, which are
+    // only known once the profile has been read - later than this model is
+    // built - so Host::refreshMainConsoleColors() pushes them in at that point
+    // and on every later change. Sub-console models own theirs outright
+    // (TConsole::setConsoleBgColor()).
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -73,13 +73,10 @@ struct TConsoleModel
     // closing one profile deletes its console first. The view co-owns the
     // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
-    // The MAIN console model's pair is what a colour trigger matches "the
-    // default colour" against; it mirrors the profile's Host::mFgColor/mBgColor,
-    // which are only known once the profile has been read - later than this
-    // model is built - so Host::refreshMainConsoleColors() lands them here. A
-    // sub-console model's pair is view-local (background through
-    // TConsole::setConsoleBgColor(), the foreground is never written) and no
-    // trigger consults it.
+    // On the main console model these mirror the profile's colours, put here by
+    // Host::refreshMainConsoleColors(); a sub-console's are view-local
+    // (TConsole::setConsoleBgColor(); the foreground is never written) and no
+    // trigger reads them.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -73,10 +73,9 @@ struct TConsoleModel
     // closing one profile deletes its console first. The view co-owns the
     // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
-    // On the main console model these mirror the profile's colours, put here by
-    // Host::refreshMainConsoleColors(); a sub-console's are view-local
-    // (TConsole::setConsoleBgColor(); the foreground is never written) and no
-    // trigger reads them.
+    // On the main console model, the profile's colours, kept there by
+    // Host::refreshMainConsoleColors(); on a sub-console's, view-local and read
+    // by nothing else.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -55,12 +55,13 @@ struct TConsoleModel
 
     // No 'm' prefix on purpose: TConsole::buffer aliases this one by reference and has to keep its name for the rest of the codebase, so the two match.
     TBuffer buffer;
-    // What a colour trigger matches "the default colour" against. The main
-    // console's pair mirrors the profile's Host::mFgColor/mBgColor, which are
-    // only known once the profile has been read - later than this model is
-    // built - so Host::refreshMainConsoleColors() pushes them in at that point
-    // and on every later change. Sub-console models own theirs outright
-    // (TConsole::setConsoleBgColor()).
+    // The MAIN console model's pair is what a colour trigger matches "the
+    // default colour" against; it mirrors the profile's Host::mFgColor/mBgColor,
+    // which are only known once the profile has been read - later than this
+    // model is built - so Host::refreshMainConsoleColors() lands them here. A
+    // sub-console model's pair is view-local (background through
+    // TConsole::setConsoleBgColor(), the foreground is never written) and no
+    // trigger consults it.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -712,8 +712,8 @@ bool TTrigger::match_color_pattern(int line, int patternNumber, int posOffset, i
 
     for (auto it = bufferLine.begin() + start; pos < end; ++it, ++pos) {
         const TChar& character = (pPassLine && pos < static_cast<int>(pPassLine->size())) ? (*pPassLine)[pos] : *it;
-        // This now allows matching against the current default colours (-1) and
-        // allows ONE of the foreground or background to NOT be considered (-2)
+        // This now allows matching against the current default colours (-2) and
+        // allows ONE of the foreground or background to NOT be considered (-1)
         // Ideally we should base the matching on only the ANSI code but not
         // all parts of the text come from the Server and can be determined to
         // have come from a decoded ANSI code number:

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1213,6 +1213,10 @@ void XMLimport::readHost(Host* pHost)
 
     pHost->setUserBorders(borders);
     pHost->loadPackageInfo();
+    // The profile's colours are only settled now, and a profile is loaded before
+    // it has a view - so this is the only chance the console model gets to be
+    // told what "the default colour" means for colour-trigger matching:
+    pHost->refreshMainConsoleColors();
 }
 
 bool XMLimport::readHostColorElement(Host* pHost, QStringView elementName)

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1213,9 +1213,11 @@ void XMLimport::readHost(Host* pHost)
 
     pHost->setUserBorders(borders);
     pHost->loadPackageInfo();
-    // The profile's colours are only settled now, and a profile is loaded before
-    // it has a view - so this is the only chance the console model gets to be
-    // told what "the default colour" means for colour-trigger matching:
+    // The profile's colours are only settled now, and the console that would
+    // otherwise hand them to the model (TConsole::changeColors()) is not built
+    // until after the load - so without this a colour trigger matching "the
+    // default colour" uses the built-in default for the whole of that window,
+    // and forever on a profile that never gets a view:
     pHost->refreshMainConsoleColors();
 }
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -27,7 +27,7 @@
 #include "LuaInterface.h"
 #include "CredentialManager.h"
 #include "SecureStringUtils.h"
-#include "TConsole.h"
+#include "TMainConsole.h"
 #include "TMap.h"
 #include "TRoomDB.h"
 #include "TRoom.h"
@@ -1213,9 +1213,13 @@ void XMLimport::readHost(Host* pHost)
 
     pHost->setUserBorders(borders);
     pHost->loadPackageInfo();
-    // The profile's colours only settle here, and its console is not built
-    // until after the load - so nothing else would put them in the model:
-    pHost->refreshMainConsoleColors();
+    // A package import comes through here too, into a profile that does have a
+    // console - and that one needs the whole restyle, not just the model:
+    if (pHost->mpConsole) {
+        pHost->mpConsole->changeColors();
+    } else {
+        pHost->refreshMainConsoleColors();
+    }
 }
 
 bool XMLimport::readHostColorElement(Host* pHost, QStringView elementName)

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1213,11 +1213,8 @@ void XMLimport::readHost(Host* pHost)
 
     pHost->setUserBorders(borders);
     pHost->loadPackageInfo();
-    // The profile's colours are only settled now, and the console that would
-    // otherwise hand them to the model (TConsole::changeColors()) is not built
-    // until after the load - so without this a colour trigger matching "the
-    // default colour" uses the built-in default for the whole of that window,
-    // and forever on a profile that never gets a view:
+    // The profile's colours only settle here, and its console is not built
+    // until after the load - so nothing else would put them in the model:
     pHost->refreshMainConsoleColors();
 }
 

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -29,7 +29,9 @@
 #include "TConsoleModel.h"
 #include "TLuaInterpreter.h"
 #include "TMainConsole.h"
+#include "TTrigger.h"
 #include "TelnetServerStub.h"
+#include "XMLimport.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
@@ -70,8 +72,14 @@ private:
     QByteArray mSavedXdg;
     TelnetServerStub* mpServer = nullptr;
     const QString mHostname = "Test-ConsoleModelExtraction";
+    const QString mColourHostname = "Test-ConsoleModelColours";
     const QString mLocalhost = "localhost";
     QString mPort;
+    // Neither of these is a built-in default (a model starts out light grey on
+    // black), so a model still holding a default was plainly never given the
+    // profile's colours.
+    const QColor mProfileFgColor{0xFF, 0x00, 0xFF};
+    const QColor mProfileBgColor{0x00, 0x00, 0x80};
 
 private slots:
     void initTestCase()
@@ -374,11 +382,91 @@ private slots:
         QCOMPARE(model->buffer.lastloggedToLine, -1);
     }
 
+    // A profile's colours are only known once its save has been read, and
+    // loading one happens before any view exists - the console is built later,
+    // in slot_connectionDialogueFinished(). So the load itself has to leave the
+    // colours in the model; nothing view-side is there to supply them, and
+    // seeding them when the model is constructed cannot work either, because
+    // Host still holds the built-in defaults at that point.
+    void test_profileLoadFillsTheModelColoursWithNoView()
+    {
+        const QString saveFolder = mudlet::getMudletPath(enums::profileXmlFilesPath, mColourHostname);
+        QVERIFY2(QDir().mkpath(saveFolder), "Could not create the seeded profile's save directory.");
+        writeProfileColourSave(qsl("%1profileColours.xml").arg(saveFolder));
+
+        Host* host = mudlet::self()->loadProfile(mColourHostname, false);
+        QVERIFY2(host, "The seeded profile was not loaded.");
+        QVERIFY2(host->mLoadedOk, "The seeded profile save was not read, so its colours never reached Host either.");
+        QVERIFY2(host->mpConsole.isNull(), "loadProfile() built a view, so this no longer tests the view-less path.");
+        QCOMPARE(host->mFgColor, mProfileFgColor);
+        QCOMPARE(host->mBgColor, mProfileBgColor);
+
+        QCOMPARE(host->mainConsoleModel().mFgColor, mProfileFgColor);
+        QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
+    }
+
+    // What the model's colours are for: a "match the default foreground colour"
+    // trigger resolves "default" through the model as it matches, so a model the
+    // profile's colours never reached matches against the built-in default
+    // instead. The trigger is deliberately made before the colours change - a
+    // colour pattern also snapshots the colour it was built with, and one made
+    // afterwards would match on that snapshot whatever the model held.
+    void test_colourTriggerMatchesTheProfileColoursWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        runLua(host,
+               qsl("colourTriggerHit = 'none'\n"
+                   "tempAnsiColorTrigger(%1, %2, [[colourTriggerHit = line]])\n")
+                       .arg(QString::number(TTrigger::scmDefault), QString::number(TTrigger::scmIgnored)));
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+        // Closing the profile emergency-stops the trigger engine
+        // (Host::closeChildren()), which a profile that simply never had a view
+        // would not do:
+        host->reenableAllTriggers();
+
+        // Reading the profile's settings back in is what a profile load does
+        // with the <Host> element of its save:
+        importProfileColours(host);
+        QCOMPARE(host->mFgColor, mProfileFgColor);
+
+        const int fedLine = appendModelLine(model->buffer, qsl("ProfileColour delta"), mProfileFgColor, mProfileBgColor);
+        host->runTriggers(fedLine);
+
+        QCOMPARE(luaGlobalString(host, "colourTriggerHit"), qsl("ProfileColour delta"));
+    }
+
+    // The other half of the same wire: the profile preferences write Host's
+    // colours and then restyle the console, and the model has to come out of
+    // that carrying them too, or colour triggers go on matching the colours the
+    // user just replaced.
+    void test_restylingTheViewKeepsTheModelColoursInStep()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        QVERIFY2(host->mainConsoleModel().mFgColor != mProfileFgColor, "The model already holds the colour under test, so this cannot tell whether it was given it.");
+
+        host->mFgColor = mProfileFgColor;
+        host->mBgColor = mProfileBgColor;
+        host->mpConsole->changeColors();
+
+        QCOMPARE(host->mainConsoleModel().mFgColor, mProfileFgColor);
+        QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
+    }
+
     void cleanup()
     {
         delete mpServer;
         mpServer = nullptr;
         deleteProfileDirectory(mHostname);
+        deleteProfileDirectory(mColourHostname);
         delete mudlet::self();
     }
 
@@ -468,11 +556,48 @@ private:
 
     // Utility function appending one whole line - only a line feed starts a new
     // buffer line - and handing back the index it landed on.
-    int appendModelLine(TBuffer& buffer, const QString& text)
+    int appendModelLine(TBuffer& buffer, const QString& text, const QColor& fgColor = QColorConstants::LightGray, const QColor& bgColor = QColorConstants::Black)
     {
         const QString line = text + QChar::LineFeed;
-        buffer.append(line, 0, line.size(), QColorConstants::LightGray, QColorConstants::Black, TChar::None, 0);
+        buffer.append(line, 0, line.size(), fgColor, bgColor, TChar::None, 0);
         return buffer.getLastLineNumber() - 1;
+    }
+
+    // Utility function writing the smallest profile save readHost() accepts:
+    // every attribute it does not find it defaults, so only the two colour
+    // elements have to be spelled out. They are written exactly as
+    // XMLexport::exportHost() writes them, alpha attribute included.
+    void writeProfileColourSave(const QString& filePath)
+    {
+        QFile file(filePath);
+        QVERIFY2(file.open(QFile::WriteOnly | QFile::Text), qPrintable(qsl("Could not write the profile save %1.").arg(filePath)));
+        QTextStream out(&file);
+        out << qsl("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                   "<MudletPackage version=\"1.001\">\n"
+                   "  <HostPackage>\n"
+                   "    <Host>\n"
+                   "      <mFgColor>%1</mFgColor>\n"
+                   "      <mBgColor alpha=\"%2\">%3</mBgColor>\n"
+                   "    </Host>\n"
+                   "  </HostPackage>\n"
+                   "</MudletPackage>\n")
+                        .arg(mProfileFgColor.name(), QString::number(mProfileBgColor.alpha()), mProfileBgColor.name());
+    }
+
+    // Utility function reading a profile's Host settings into a live profile,
+    // which is what loading a profile does with the <Host> element of its save.
+    void importProfileColours(Host* host)
+    {
+        QTemporaryDir importDir;
+        QVERIFY2(importDir.isValid(), "Could not create a directory to write the profile save into.");
+        const QString filePath = qsl("%1/profileColours.xml").arg(importDir.path());
+        writeProfileColourSave(filePath);
+
+        QFile file(filePath);
+        QVERIFY2(file.open(QFile::ReadOnly | QFile::Text), "Could not read back the profile save just written.");
+        XMLimport importer(host);
+        const auto [success, message] = importer.importPackage(&file);
+        QVERIFY2(success, qPrintable(qsl("Reading the profile save failed: %1").arg(message)));
     }
 
     QString luaGlobalString(Host* host, const char* name)

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -77,9 +77,6 @@ private:
     const QString mColourHostname = "Test-ConsoleModelColours";
     const QString mLocalhost = "localhost";
     QString mPort;
-    // Neither of these is a built-in default (a model starts out light grey on
-    // black), so a model still holding a default was plainly never given the
-    // profile's colours.
     const QColor mProfileFgColor{0xFF, 0x00, 0xFF};
     const QColor mProfileBgColor{0x00, 0x00, 0x80};
 
@@ -489,12 +486,8 @@ private slots:
         QFile::remove(logFileName);
     }
 
-    // A profile's colours are only known once its save has been read, and
-    // loading one happens before any view exists - the console is built later,
-    // by mudlet::addConsoleForNewHost(). So the load itself has to leave the
-    // colours in the model; nothing view-side is there to supply them, and
-    // seeding them when the model is constructed cannot work either, because
-    // Host still holds the built-in defaults at that point.
+    // A profile is loaded before it has a view, so the load itself has to leave
+    // the colours in the model - nothing view-side is there to supply them.
     void test_profileLoadFillsTheModelColoursWithNoView()
     {
         pinTheFixtureColoursAreNotTheDefaults();
@@ -517,10 +510,8 @@ private slots:
         QCOMPARE(model.mFgColor, mProfileFgColor);
         QCOMPARE(model.mBgColor, mProfileBgColor);
 
-        // The pair above is what triggers match against; text that arrives with
-        // no SGR sequence is stamped with the buffer's own copy of the same two
-        // colours, and the load has to have landed those too or the model
-        // disagrees with itself.
+        // The buffer keeps its own copy of the same two colours - what unstyled
+        // text is stamped with - and the load has to have landed those too:
         std::string plainText = "ProfileColour plain\n";
         model.buffer.translateToPlainText(plainText, true);
         const int plainLine = model.buffer.getLastLineNumber() - 1;
@@ -530,11 +521,10 @@ private slots:
     }
 
     // What the model's colours are for: a "match the default foreground colour"
-    // trigger resolves "default" through the model as it matches, so a model the
-    // profile's colours never reached matches against the built-in default
-    // instead. The trigger is deliberately made before the colours change - a
-    // colour pattern also snapshots the colour it was built with, and one made
-    // afterwards would match on that snapshot whatever the model held.
+    // trigger resolves "default" through the model as it matches. The trigger is
+    // made before the colours change on purpose - a colour pattern also
+    // snapshots the colour it was built with, and one made afterwards would
+    // match on that snapshot whatever the model held.
     void test_colourTriggerMatchesTheProfileColoursWithNoView()
     {
         startProfile();
@@ -542,10 +532,9 @@ private slots:
         QVERIFY2(host, "No active host available for the test.");
         QVERIFY2(host->mpConsole, "The active host has no main console.");
 
-        // The trigger body records the matched text rather than the whole line,
-        // so a match on some other part of the line cannot satisfy the
-        // assertions. Long brackets have to be levelled: plain [[ ]] would end
-        // at the first ]] inside matches[1].
+        // matches[1] rather than line, so a match elsewhere on the line cannot
+        // satisfy the assertions. The long bracket has to be levelled: plain
+        // [[ ]] would end at the first ]] inside matches[1].
         runLua(host,
                qsl("colourTriggerHit = 'none'\n"
                    "tempAnsiColorTrigger(%1, %2, [==[colourTriggerHit = matches[1]]==])\n")
@@ -557,10 +546,9 @@ private slots:
         // profile that simply never had a view would not do:
         host->reenableAllTriggers();
 
-        // Magenta is not the default colour yet - a new profile is still on the
-        // built-in defaults - so this line must not match. That is what proves
-        // the match further down turns on the model rather than on the colour
-        // the pattern snapshotted when it was built:
+        // Magenta is not the default yet, so this line must not match - which is
+        // what proves the match below turns on the model and not on the
+        // pattern's snapshot:
         QCOMPARE(model->mFgColor, QColorConstants::LightGray);
         const int staleLine = appendModelLine(model->buffer, qsl("ProfileColour before"), mProfileFgColor, mProfileBgColor);
         host->runTriggers(staleLine);
@@ -575,11 +563,10 @@ private slots:
         QCOMPARE(luaGlobalString(host, "colourTriggerHit"), qsl("ProfileColour delta"));
     }
 
-    // The other half of the same wire: the profile preferences write Host's
-    // colours and then restyle the console, and the model has to come out of
-    // that carrying them too, or colour triggers go on matching the colours the
-    // user just replaced. Driven both ways, so the model is shown to track the
-    // profile rather than to have been set to one colour once.
+    // The other half of the same wire: the preferences write Host's colours and
+    // restyle the console, and the model has to come out of that carrying them
+    // too. Driven both ways, so it is shown to track rather than to have been
+    // set once.
     void test_restylingTheViewKeepsTheModelColoursInStep()
     {
         pinTheFixtureColoursAreNotTheDefaults();
@@ -707,9 +694,8 @@ private:
         return buffer.getLastLineNumber() - 1;
     }
 
-    // Utility function pinning what makes the colour assertions mean anything:
-    // a model that was never given the profile's colours holds these two, so an
-    // assertion written against a colour that happened to be one of them would
+    // Utility function: a model that was never given the profile's colours holds
+    // the built-in pair, so an assertion written against either of those would
     // pass whether the refresh ran or not.
     void pinTheFixtureColoursAreNotTheDefaults()
     {
@@ -717,12 +703,11 @@ private:
         QVERIFY2(mProfileBgColor != QColorConstants::Black, "The background colour under test is the built-in default, so the assertions on it cannot fail.");
     }
 
-    // Utility function writing the smallest profile save readHost() accepts -
-    // the colour elements exactly as XMLexport::exportHost() writes them. Note
-    // the import is not surgical: readHost() reads a missing boolean attribute
-    // as "off", so putting this into a live profile also turns some three dozen
-    // of its settings off and zeroes its borders. Harmless where only the
-    // colours are asserted on, a trap for any other use.
+    // Utility function writing the smallest profile save readHost() accepts, the
+    // colour elements spelled as XMLexport::exportHost() writes them. Not
+    // surgical: readHost() reads a missing boolean attribute as "off", so
+    // importing this into a live profile also turns some three dozen of its
+    // settings off and zeroes its borders.
     void writeProfileColourSave(const QString& filePath)
     {
         QFile file(filePath);
@@ -742,10 +727,9 @@ private:
         QVERIFY2(out.status() == QTextStream::Ok && file.error() == QFile::NoError, qPrintable(qsl("Writing the profile save %1 failed: %2").arg(filePath, file.errorString())));
     }
 
-    // Utility function reading a profile's Host settings into a live profile,
-    // which is what loading a profile does with the <Host> element of its save.
-    // importPackage() only reports XML well-formedness, so the colour it was
-    // asked for is checked here rather than left to each caller.
+    // Utility function reading a profile's Host settings into a live profile, as
+    // a profile load does. importPackage() only reports XML well-formedness, so
+    // the colour it was asked for is checked here rather than by each caller.
     void importProfileColours(Host* host)
     {
         QTemporaryDir importDir;

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -117,6 +117,7 @@ private slots:
         mudlet::self()->init();
         mudlet::self()->setStorePasswordsSecurely(false);
         deleteProfileDirectory(mHostname);
+        deleteProfileDirectory(mColourHostname);
     }
 
     // The view's members must be the model's fields, not copies of them: same
@@ -384,25 +385,42 @@ private slots:
 
     // A profile's colours are only known once its save has been read, and
     // loading one happens before any view exists - the console is built later,
-    // in slot_connectionDialogueFinished(). So the load itself has to leave the
+    // by mudlet::addConsoleForNewHost(). So the load itself has to leave the
     // colours in the model; nothing view-side is there to supply them, and
     // seeding them when the model is constructed cannot work either, because
     // Host still holds the built-in defaults at that point.
     void test_profileLoadFillsTheModelColoursWithNoView()
     {
+        pinTheFixtureColoursAreNotTheDefaults();
         const QString saveFolder = mudlet::getMudletPath(enums::profileXmlFilesPath, mColourHostname);
         QVERIFY2(QDir().mkpath(saveFolder), "Could not create the seeded profile's save directory.");
-        writeProfileColourSave(qsl("%1profileColours.xml").arg(saveFolder));
+        const QString savePath = qsl("%1profileColours.xml").arg(saveFolder);
+        writeProfileColourSave(savePath);
+        // loadProfile() reports a profile with no save at all as loaded fine, so
+        // a save that never landed would read as a bare colour mismatch below:
+        QVERIFY2(QFileInfo(savePath).size() > 0, "The seeded profile save is missing or empty.");
 
         Host* host = mudlet::self()->loadProfile(mColourHostname, false);
         QVERIFY2(host, "The seeded profile was not loaded.");
-        QVERIFY2(host->mLoadedOk, "The seeded profile save was not read, so its colours never reached Host either.");
+        QVERIFY2(host->mProfileLoadError.isEmpty(), qPrintable(qsl("Reading the seeded profile save failed: %1").arg(host->mProfileLoadError)));
         QVERIFY2(host->mpConsole.isNull(), "loadProfile() built a view, so this no longer tests the view-less path.");
         QCOMPARE(host->mFgColor, mProfileFgColor);
         QCOMPARE(host->mBgColor, mProfileBgColor);
 
-        QCOMPARE(host->mainConsoleModel().mFgColor, mProfileFgColor);
-        QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
+        TConsoleModel& model = host->mainConsoleModel();
+        QCOMPARE(model.mFgColor, mProfileFgColor);
+        QCOMPARE(model.mBgColor, mProfileBgColor);
+
+        // The pair above is what triggers match against; text that arrives with
+        // no SGR sequence is stamped with the buffer's own copy of the same two
+        // colours, and the load has to have landed those too or the model
+        // disagrees with itself.
+        std::string plainText = "ProfileColour plain\n";
+        model.buffer.translateToPlainText(plainText, true);
+        const int plainLine = model.buffer.getLastLineNumber() - 1;
+        QVERIFY2(plainLine >= 0, "The plain text never reached the view-less buffer.");
+        QCOMPARE(model.buffer.line(plainLine), qsl("ProfileColour plain"));
+        QCOMPARE(model.buffer.buffer.at(plainLine).at(0).foreground(), mProfileFgColor);
     }
 
     // What the model's colours are for: a "match the default foreground colour"
@@ -418,22 +436,32 @@ private slots:
         QVERIFY2(host, "No active host available for the test.");
         QVERIFY2(host->mpConsole, "The active host has no main console.");
 
+        // The trigger body records the matched text rather than the whole line,
+        // so a match on some other part of the line cannot satisfy the
+        // assertions. Long brackets have to be levelled: plain [[ ]] would end
+        // at the first ]] inside matches[1].
         runLua(host,
                qsl("colourTriggerHit = 'none'\n"
-                   "tempAnsiColorTrigger(%1, %2, [[colourTriggerHit = line]])\n")
+                   "tempAnsiColorTrigger(%1, %2, [==[colourTriggerHit = matches[1]]==])\n")
                        .arg(QString::number(TTrigger::scmDefault), QString::number(TTrigger::scmIgnored)));
 
         std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
         destroyTheView(host);
-        // Closing the profile emergency-stops the trigger engine
-        // (Host::closeChildren()), which a profile that simply never had a view
-        // would not do:
+        // Closing the profile emergency-stops the trigger engine, which a
+        // profile that simply never had a view would not do:
         host->reenableAllTriggers();
 
-        // Reading the profile's settings back in is what a profile load does
-        // with the <Host> element of its save:
+        // Magenta is not the default colour yet - a new profile is still on the
+        // built-in defaults - so this line must not match. That is what proves
+        // the match further down turns on the model rather than on the colour
+        // the pattern snapshotted when it was built:
+        QCOMPARE(model->mFgColor, QColorConstants::LightGray);
+        const int staleLine = appendModelLine(model->buffer, qsl("ProfileColour before"), mProfileFgColor, mProfileBgColor);
+        host->runTriggers(staleLine);
+        QCOMPARE(luaGlobalString(host, "colourTriggerHit"), qsl("none"));
+
         importProfileColours(host);
-        QCOMPARE(host->mFgColor, mProfileFgColor);
+        QCOMPARE(model->mFgColor, mProfileFgColor);
 
         const int fedLine = appendModelLine(model->buffer, qsl("ProfileColour delta"), mProfileFgColor, mProfileBgColor);
         host->runTriggers(fedLine);
@@ -444,14 +472,17 @@ private slots:
     // The other half of the same wire: the profile preferences write Host's
     // colours and then restyle the console, and the model has to come out of
     // that carrying them too, or colour triggers go on matching the colours the
-    // user just replaced.
+    // user just replaced. Driven both ways, so the model is shown to track the
+    // profile rather than to have been set to one colour once.
     void test_restylingTheViewKeepsTheModelColoursInStep()
     {
+        pinTheFixtureColoursAreNotTheDefaults();
         startProfile();
         auto host = mudlet::self()->getActiveHost();
         QVERIFY2(host, "No active host available for the test.");
         QVERIFY2(host->mpConsole, "The active host has no main console.");
-        QVERIFY2(host->mainConsoleModel().mFgColor != mProfileFgColor, "The model already holds the colour under test, so this cannot tell whether it was given it.");
+        QCOMPARE(host->mainConsoleModel().mFgColor, QColorConstants::LightGray);
+        QCOMPARE(host->mainConsoleModel().mBgColor, QColorConstants::Black);
 
         host->mFgColor = mProfileFgColor;
         host->mBgColor = mProfileBgColor;
@@ -459,6 +490,13 @@ private slots:
 
         QCOMPARE(host->mainConsoleModel().mFgColor, mProfileFgColor);
         QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
+
+        host->mFgColor = QColorConstants::LightGray;
+        host->mBgColor = QColorConstants::Black;
+        host->mpConsole->changeColors();
+
+        QCOMPARE(host->mainConsoleModel().mFgColor, QColorConstants::LightGray);
+        QCOMPARE(host->mainConsoleModel().mBgColor, QColorConstants::Black);
     }
 
     void cleanup()
@@ -563,10 +601,22 @@ private:
         return buffer.getLastLineNumber() - 1;
     }
 
-    // Utility function writing the smallest profile save readHost() accepts:
-    // every attribute it does not find it defaults, so only the two colour
-    // elements have to be spelled out. They are written exactly as
-    // XMLexport::exportHost() writes them, alpha attribute included.
+    // Utility function pinning what makes the colour assertions mean anything:
+    // a model that was never given the profile's colours holds these two, so an
+    // assertion written against a colour that happened to be one of them would
+    // pass whether the refresh ran or not.
+    void pinTheFixtureColoursAreNotTheDefaults()
+    {
+        QVERIFY2(mProfileFgColor != QColorConstants::LightGray, "The foreground colour under test is the built-in default, so the assertions on it cannot fail.");
+        QVERIFY2(mProfileBgColor != QColorConstants::Black, "The background colour under test is the built-in default, so the assertions on it cannot fail.");
+    }
+
+    // Utility function writing the smallest profile save readHost() accepts -
+    // the colour elements exactly as XMLexport::exportHost() writes them. Note
+    // the import is not surgical: readHost() reads a missing boolean attribute
+    // as "off", so putting this into a live profile also turns some three dozen
+    // of its settings off and zeroes its borders. Harmless where only the
+    // colours are asserted on, a trap for any other use.
     void writeProfileColourSave(const QString& filePath)
     {
         QFile file(filePath);
@@ -582,10 +632,14 @@ private:
                    "  </HostPackage>\n"
                    "</MudletPackage>\n")
                         .arg(mProfileFgColor.name(), QString::number(mProfileBgColor.alpha()), mProfileBgColor.name());
+        out.flush();
+        QVERIFY2(out.status() == QTextStream::Ok && file.error() == QFile::NoError, qPrintable(qsl("Writing the profile save %1 failed: %2").arg(filePath, file.errorString())));
     }
 
     // Utility function reading a profile's Host settings into a live profile,
     // which is what loading a profile does with the <Host> element of its save.
+    // importPackage() only reports XML well-formedness, so the colour it was
+    // asked for is checked here rather than left to each caller.
     void importProfileColours(Host* host)
     {
         QTemporaryDir importDir;
@@ -598,6 +652,8 @@ private:
         XMLimport importer(host);
         const auto [success, message] = importer.importPackage(&file);
         QVERIFY2(success, qPrintable(qsl("Reading the profile save failed: %1").arg(message)));
+        QCOMPARE(host->mFgColor, mProfileFgColor);
+        QCOMPARE(host->mBgColor, mProfileBgColor);
     }
 
     QString luaGlobalString(Host* host, const char* name)

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -486,8 +486,6 @@ private slots:
         QFile::remove(logFileName);
     }
 
-    // A profile is loaded before it has a view, so the load itself has to leave
-    // the colours in the model - nothing view-side is there to supply them.
     void test_profileLoadFillsTheModelColoursWithNoView()
     {
         pinTheFixtureColoursAreNotTheDefaults();
@@ -510,8 +508,8 @@ private slots:
         QCOMPARE(model.mFgColor, mProfileFgColor);
         QCOMPARE(model.mBgColor, mProfileBgColor);
 
-        // The buffer keeps its own copy of the same two colours - what unstyled
-        // text is stamped with - and the load has to have landed those too:
+        // The buffer's own copy of the pair is what unstyled text is stamped
+        // with, so the load has to have landed that too:
         std::string plainText = "ProfileColour plain\n";
         model.buffer.translateToPlainText(plainText, true);
         const int plainLine = model.buffer.getLastLineNumber() - 1;
@@ -520,11 +518,9 @@ private slots:
         QCOMPARE(model.buffer.buffer.at(plainLine).at(0).foreground(), mProfileFgColor);
     }
 
-    // What the model's colours are for: a "match the default foreground colour"
-    // trigger resolves "default" through the model as it matches. The trigger is
-    // made before the colours change on purpose - a colour pattern also
-    // snapshots the colour it was built with, and one made afterwards would
-    // match on that snapshot whatever the model held.
+    // The trigger is made before the colours change on purpose - a colour
+    // pattern also snapshots the colour it was built with, and one made
+    // afterwards would match on that snapshot whatever the model held.
     void test_colourTriggerMatchesTheProfileColoursWithNoView()
     {
         startProfile();
@@ -547,7 +543,7 @@ private slots:
         host->reenableAllTriggers();
 
         // Magenta is not the default yet, so this line must not match - which is
-        // what proves the match below turns on the model and not on the
+        // what proves the match below turns on the model rather than on the
         // pattern's snapshot:
         QCOMPARE(model->mFgColor, QColorConstants::LightGray);
         const int staleLine = appendModelLine(model->buffer, qsl("ProfileColour before"), mProfileFgColor, mProfileBgColor);
@@ -563,10 +559,8 @@ private slots:
         QCOMPARE(luaGlobalString(host, "colourTriggerHit"), qsl("ProfileColour delta"));
     }
 
-    // The other half of the same wire: the preferences write Host's colours and
-    // restyle the console, and the model has to come out of that carrying them
-    // too. Driven both ways, so it is shown to track rather than to have been
-    // set once.
+    // Driven both ways, so the model is shown to track the restyle rather than
+    // to have been set once.
     void test_restylingTheViewKeepsTheModelColoursInStep()
     {
         pinTheFixtureColoursAreNotTheDefaults();
@@ -590,6 +584,28 @@ private slots:
 
         QCOMPARE(host->mainConsoleModel().mFgColor, QColorConstants::LightGray);
         QCOMPARE(host->mainConsoleModel().mBgColor, QColorConstants::Black);
+    }
+
+    // The same XML arrives as a package import into a live profile, and there
+    // the model on its own is not enough - the view has to be restyled with it,
+    // or text in the new foreground lands on the old background.
+    void test_importingColoursIntoALiveProfileRestylesTheView()
+    {
+        pinTheFixtureColoursAreNotTheDefaults();
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        QVERIFY2(!host->mpConsole->mBgImageMode, "A background image is set, so the console is not styled by colour here.");
+
+        const QString expectedBackground = qsl("rgba(%1,%2,%3,%4)").arg(mProfileBgColor.red()).arg(mProfileBgColor.green()).arg(mProfileBgColor.blue()).arg(mProfileBgColor.alpha());
+        QVERIFY2(!host->mpConsole->mpMainDisplay->styleSheet().contains(expectedBackground), "The console already carries the imported background, so the assertion below cannot fail.");
+
+        importProfileColours(host);
+
+        QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
+        QVERIFY2(host->mpConsole->mpMainDisplay->styleSheet().contains(expectedBackground),
+                 qPrintable(qsl("The console was not restyled by the import: %1").arg(host->mpConsole->mpMainDisplay->styleSheet())));
     }
 
     void cleanup()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Host::refreshMainConsoleColors()` pushes the profile's foreground and background into the main console model - and into the buffer's own copy of them - and `XMLimport::readHost()` calls it once the profile's save has been read.
- `TConsole::changeColors()` routes through the same method, so the GUI path keeps its behaviour and the sync has one definition.
- Three `ConsoleModelExtractionTest` cases, each proven red when its own wire is cut.

#### Motivation for adding to Mudlet

Step 2 of the console-model extraction (#8681): a colour trigger set to "the default colour" matches against the model's pair, which only the view ever filled in - so a profile whose console is not built yet, or never will be, matched against the built-in defaults instead of the colours the profile configured.

#### Other info (issues closed, discussion etc)

`TConsole::mSystemMessageBgColor` is pinned to black rather than copying `mBgColor`. It is captured once at construction and never updated, so it never really tracked the console background - and now that the model carries the profile's colours before a console exists, copying would quietly change what system messages are drawn on.

This is the fix deferred from #9603's review: seeding the colours when the model is constructed cannot work, because the Host still holds the built-in defaults at that point.

**Test case:** `ctest` 137/137, Lua specs 3699 successes / 0 failures. The three new cases each go red on their own cut: dropping the `XMLimport` call reddens the two load-path ones, dropping `buffer.updateColors()` reddens only the plain-text colour assertion, and dropping the `changeColors()` call reddens the restyle one.

Assisted-by: Claude:claude-opus-5
