### PR TITLE
Infra: Colour changes reach the buffer without a window

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3431,9 +3431,12 @@ void TBuffer::decodeOSC(const QString& sequence)
                     if (isValid) {
                         // This will refresh the "main" console as it is only this
                         // class instance associated with that one that is to be
-                        // changed by this method:
+                        // changed by this method - and with no console, the model
+                        // it would have refreshed on the way:
                         if (pHost->mpConsole) {
                             pHost->mpConsole->changeColors();
+                        } else {
+                            pHost->refreshMainConsoleColors();
                         }
                         // Also need to update the Lua sub-system's "color_table"
                         pHost->updateAnsi16ColorsInTable();
@@ -4839,9 +4842,12 @@ void TBuffer::resetColors()
 
     // This will refresh the "main" console as it is only this class instance
     // associated with that one that will call this method from the
-    // decodeOSC(...) method:
+    // decodeOSC(...) method - and with no console, the model it would have
+    // refreshed on the way:
     if (pHost->mpConsole) {
         pHost->mpConsole->changeColors();
+    } else {
+        pHost->refreshMainConsoleColors();
     }
 
     // Also need to update the Lua sub-system's "color_table"

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3431,8 +3431,8 @@ void TBuffer::decodeOSC(const QString& sequence)
                     if (isValid) {
                         // This will refresh the "main" console as it is only this
                         // class instance associated with that one that is to be
-                        // changed by this method - and with no console, the model
-                        // it would have refreshed on the way:
+                        // changed by this method. With no console there is
+                        // nothing to restyle, but the model still has to be told:
                         if (pHost->mpConsole) {
                             pHost->mpConsole->changeColors();
                         } else {
@@ -4842,8 +4842,8 @@ void TBuffer::resetColors()
 
     // This will refresh the "main" console as it is only this class instance
     // associated with that one that will call this method from the
-    // decodeOSC(...) method - and with no console, the model it would have
-    // refreshed on the way:
+    // decodeOSC(...) method. With no console there is nothing to restyle, but
+    // the model still has to be told:
     if (pHost->mpConsole) {
         pHost->mpConsole->changeColors();
     } else {

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -74,8 +74,8 @@ struct TConsoleModel
     // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
     // On the main console model, the profile's colours, kept there by
-    // Host::refreshMainConsoleColors(); on a sub-console's, view-local and read
-    // by nothing else.
+    // Host::refreshMainConsoleColors(); a sub-console's are its own, and no
+    // trigger reads them.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2694,7 +2694,11 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     const QString windowName{windowNameArg};
     if (isMain(windowName)) {
         host.mBgColor.setRgb(r, g, b, alpha);
-        host.mpConsole->setConsoleBgColor(r, g, b, alpha);
+        if (host.mpConsole) {
+            host.mpConsole->setConsoleBgColor(r, g, b, alpha);
+        } else {
+            host.refreshMainConsoleColors();
+        }
     } else if (!host.setBackgroundColor(windowName, r, g, b, alpha)) {
         return warnArgumentValue(L, __func__, qsl("window/label '%1' not found").arg(windowName));
     }

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -774,14 +774,16 @@ private:
 
     // Utility function feeding one unstyled line and handing back the character
     // it was stamped with, which carries the buffer's own copy of the profile's
-    // colours. A default-constructed TChar back means the line never landed.
+    // colours. A blank TChar back means the line never landed; it is spelled out
+    // because TChar's no-argument constructor is explicit, which rules out
+    // `return {}`.
     TChar plainStamp(TBuffer& buffer)
     {
         std::string plainText = "Model stamp\n";
         buffer.translateToPlainText(plainText, true);
         const int line = buffer.getLastLineNumber() - 1;
         if (line < 0 || buffer.buffer.at(line).empty()) {
-            return {};
+            return TChar();
         }
         return buffer.buffer.at(line).at(0);
     }

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -608,6 +608,36 @@ private slots:
                  qPrintable(qsl("The console was not restyled by the import: %1").arg(host->mpConsole->mpMainDisplay->styleSheet())));
     }
 
+    // The server can redefine the sixteen ANSI colours, and the buffer stamps
+    // text from its own copy of them rather than from the Host's - so the copy
+    // has to be refreshed whether or not there is a console to refresh it.
+    void test_ansiPaletteRedefinitionReachesTheModelWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        host->setMayRedefineColors(true);
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+
+        const QColor redefinedRed(0x12, 0x34, 0x56);
+        QVERIFY2(host->mRed != redefinedRed, "The profile's red is already the redefined one, so the assertions on it cannot fail.");
+        QCOMPARE(ansiRedStamp(model->buffer), host->mRed);
+
+        // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition
+        std::string redefine = "\x1b]P1123456\x07";
+        model->buffer.translateToPlainText(redefine, true);
+        QCOMPARE(host->mRed, redefinedRed);
+        QCOMPARE(ansiRedStamp(model->buffer), redefinedRed);
+
+        std::string reset = "\x1b]R\x07";
+        model->buffer.translateToPlainText(reset, true);
+        QCOMPARE(host->mRed, QColor(QColorConstants::DarkRed));
+        QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
+    }
+
     void cleanup()
     {
         delete mpServer;
@@ -708,6 +738,20 @@ private:
         const QString line = text + QChar::LineFeed;
         buffer.append(line, 0, line.size(), fgColor, bgColor, TChar::None, 0);
         return buffer.getLastLineNumber() - 1;
+    }
+
+    // Utility function feeding one SGR-red line and handing back the colour it
+    // was stamped with, which is the buffer's copy of red rather than the
+    // Host's. An invalid colour back means the line never landed.
+    QColor ansiRedStamp(TBuffer& buffer)
+    {
+        std::string redText = "\x1b[31mPalette red\n";
+        buffer.translateToPlainText(redText, true);
+        const int line = buffer.getLastLineNumber() - 1;
+        if (line < 0 || buffer.buffer.at(line).empty()) {
+            return {};
+        }
+        return buffer.buffer.at(line).at(0).foreground();
     }
 
     // Utility function: a model that was never given the profile's colours holds

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -588,7 +588,7 @@ private slots:
 
     // The same XML arrives as a package import into a live profile, and there
     // the model on its own is not enough - the view has to be restyled with it,
-    // or text in the new foreground lands on the old background.
+    // or the console keeps painting the old background behind the panes.
     void test_importingColoursIntoALiveProfileRestylesTheView()
     {
         pinTheFixtureColoursAreNotTheDefaults();
@@ -606,6 +606,10 @@ private slots:
         QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
         QVERIFY2(host->mpConsole->mpMainDisplay->styleSheet().contains(expectedBackground),
                  qPrintable(qsl("The console was not restyled by the import: %1").arg(host->mpConsole->mpMainDisplay->styleSheet())));
+        // changeColors() leaves the buffer's copy of the colours to
+        // refreshMainConsoleColors(), and this is the only assertion that walks
+        // that hand-off with a view present:
+        QCOMPARE(plainStamp(host->mainConsoleModel().buffer).background(), mProfileBgColor);
     }
 
     // The server can redefine the sixteen ANSI colours, and the buffer stamps
@@ -617,16 +621,20 @@ private slots:
         auto host = mudlet::self()->getActiveHost();
         QVERIFY2(host, "No active host available for the test.");
         QVERIFY2(host->mpConsole, "The active host has no main console.");
-        host->setMayRedefineColors(true);
 
         std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
         destroyTheView(host);
 
         const QColor redefinedRed(0x12, 0x34, 0x56);
         QVERIFY2(host->mRed != redefinedRed, "The profile's red is already the redefined one, so the assertions on it cannot fail.");
-        QCOMPARE(ansiRedStamp(model->buffer), host->mRed);
+        QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
 
         // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition
+        std::string refused = "\x1b]P1123456\x07";
+        model->buffer.translateToPlainText(refused, true);
+        QVERIFY2(host->mRed != redefinedRed, "A server redefined the palette although the profile forbids it.");
+
+        host->setMayRedefineColors(true);
         std::string redefine = "\x1b]P1123456\x07";
         model->buffer.translateToPlainText(redefine, true);
         QCOMPARE(host->mRed, redefinedRed);
@@ -636,6 +644,30 @@ private slots:
         model->buffer.translateToPlainText(reset, true);
         QCOMPARE(host->mRed, QColor(QColorConstants::DarkRed));
         QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
+    }
+
+    // setBackgroundColor("main") writes the profile's background itself and
+    // leans on the view to carry it into the model, so without one the console
+    // it reaches through is not merely absent - dereferencing it is a crash
+    // before it is ever a stale colour.
+    void test_scriptedBackgroundColourReachesTheModelWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+
+        const QColor scriptedBackground(0x11, 0x22, 0x33);
+        QVERIFY2(host->mBgColor != scriptedBackground, "The profile already carries the scripted background, so the assertions below cannot fail.");
+
+        runLua(host, qsl("setBackgroundColor(0x11, 0x22, 0x33)"));
+
+        QCOMPARE(host->mBgColor, scriptedBackground);
+        QCOMPARE(model->mBgColor, scriptedBackground);
+        QCOMPARE(plainStamp(model->buffer).background(), scriptedBackground);
     }
 
     void cleanup()
@@ -738,6 +770,20 @@ private:
         const QString line = text + QChar::LineFeed;
         buffer.append(line, 0, line.size(), fgColor, bgColor, TChar::None, 0);
         return buffer.getLastLineNumber() - 1;
+    }
+
+    // Utility function feeding one unstyled line and handing back the character
+    // it was stamped with, which carries the buffer's own copy of the profile's
+    // colours. A default-constructed TChar back means the line never landed.
+    TChar plainStamp(TBuffer& buffer)
+    {
+        std::string plainText = "Model stamp\n";
+        buffer.translateToPlainText(plainText, true);
+        const int line = buffer.getLastLineNumber() - 1;
+        if (line < 0 || buffer.buffer.at(line).empty()) {
+            return {};
+        }
+        return buffer.buffer.at(line).at(0);
     }
 
     // Utility function feeding one SGR-red line and handing back the colour it


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Two writers of the profile's colours pushed them into `TBuffer`'s own copy only by way of `TConsole::changeColors()`, which a profile with no console does not have:

- `OSC P` and `OSC R`, the xterm palette redefinition a server can send when the profile allows it. The buffer went on stamping text with the old sixteen colours, and ANSI colour triggers went on matching against them.
- `setBackgroundColor("main", ...)` from Lua, which writes `Host::mBgColor` and then dereferenced `mpConsole` with no null check - a crash, not merely a stale colour. Its sibling `Host::setBackgroundColor()` for sub-windows already guarded.

Both now fall back to `Host::refreshMainConsoleColors()`, the same way `XMLimport::readHost()` does.

#### Motivation for adding to Mudlet

Follow-up to #10152, asked for in https://github.com/Mudlet/Mudlet/pull/10152#pullrequestreview-5002976252. Part of the console model extraction in #8681: the model has to carry the profile's colours whether or not a view was ever built to copy them over. These were the last two writers with that shape.

No behaviour change for Mudlet itself, where a main console always exists.

#### Other info (issues closed, discussion etc)

Stacked on #10152 - review the last two commits only, or wait for that one to merge.

**Test case:** three additions to `ConsoleModelExtractionTest`, each verified red on its own cut:

- `test_ansiPaletteRedefinitionReachesTheModelWithNoView` feeds `<OSC>P1123456<BEL>` then `<OSC>R<BEL>` into a viewless model and checks the colour a following SGR-31 line is stamped with. It also pins that the redefinition is refused while the profile forbids it, which nothing in the tree asserted - deleting that gate left the whole suite green.
- `test_scriptedBackgroundColourReachesTheModelWithNoView` runs `setBackgroundColor` against a viewless profile; without the guard the binary segfaults.
- `test_importingColoursIntoALiveProfileRestylesTheView` gained an assertion on the colour text is stamped with. `changeColors()` leaves that to `refreshMainConsoleColors()`, and nothing walked that hand-off with a view present - breaking it left 137 ctest cases and 3699 specs green.

Assisted-by: Claude:claude-opus-5