### PR TITLE
Fix: a skipped _unique no longer freezes the sheet's other constraints

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -867,6 +867,51 @@ end
 
 
 
+-- The pieces a CREATE TABLE body, or a UNIQUE column list, is written in: split
+-- on the commas outside any brackets, so a compound UNIQUE stays in one piece.
+-- The commas are counted off a copy with the quoted parts blanked out, which is
+-- what keeps a comma inside a name or a default value from being one of them,
+-- and both copies are returned since the caller reads names off the text and
+-- searches the blanked one.
+local function split_on_commas(text, searchable)
+  local pieces = {}
+  local depth, piece_start = 0, 1
+
+  local function add(stop_at)
+    pieces[#pieces + 1] = { text = text:sub(piece_start, stop_at), scan = searchable:sub(piece_start, stop_at) }
+  end
+
+  for position = 1, #searchable do
+    local char = searchable:sub(position, position)
+    if char == "(" then
+      depth = depth + 1
+    elseif char == ")" then
+      depth = depth - 1
+    elseif char == "," and depth == 0 then
+      add(position - 1)
+      piece_start = position + 1
+    end
+  end
+  add(#text)
+
+  return pieces
+end
+
+
+-- The column name a piece of a CREATE TABLE opens with. This module quotes every
+-- name it writes, but a sheet whose table was not written by it need not: reading
+-- quoted names only reduces each of that table's UNIQUEs to the same empty name,
+-- and a sheet whose rules all look alike is one that can be told it is losing a
+-- rule it is not. A name written in some other way sqlite takes, [name] among
+-- them, does come back empty, which no expected CREATE TABLE ever holds, so that
+-- sheet is left as it is rather than losing a rule to a misreading.
+local function leading_column_name(text)
+  local trimmed = text:match("^%s*(.-)%s*$")
+
+  return trimmed:match('^"([^"]*)"') or trimmed:match("^([%w_$]+)") or ""
+end
+
+
 -- The columns each UNIQUE in a CREATE TABLE covers, sorted and counted. Sorted
 -- because sqlite enforces the same rule whichever order they are written in, and
 -- without the ON CONFLICT clause because that is a _violations change, which
@@ -888,27 +933,8 @@ local function unique_targets(sql)
   end
   local searchable = content:gsub('"[^"]*"', blank):gsub("'[^']*'", blank)
 
-  -- split on the commas between the body's own parts: a compound UNIQUE's column
-  -- list is bracketed, so tracking the depth keeps it in one piece
-  local parts = {}
-  local depth, part_start = 0, 1
-  for position = 1, #searchable do
-    local char = searchable:sub(position, position)
-    if char == "(" then
-      depth = depth + 1
-    elseif char == ")" then
-      depth = depth - 1
-    elseif char == "," and depth == 0 then
-      parts[#parts + 1] = part_start
-      part_start = position + 1
-    end
-  end
-  parts[#parts + 1] = part_start
-
-  for index, start_at in ipairs(parts) do
-    local stop_at = (parts[index + 1] or #content + 2) - 2
-    local text = content:sub(start_at, stop_at)
-    local scan = searchable:sub(start_at, stop_at)
+  for _, part in ipairs(split_on_commas(content, searchable)) do
+    local text, scan = part.text, part.scan
 
     local start, stop = scan:find("unique", 1, true)
     while start and (scan:sub(start - 1, start - 1):match("[%w_]") or scan:sub(stop + 1, stop + 1):match("[%w_]")) do
@@ -921,16 +947,22 @@ local function unique_targets(sql)
       -- column-level one covers the column it is written on, which is the name
       -- the part opens with
       local columns = {}
-      local column_list = text:match("^%s*%((.-)%)", stop + 1)
-      for column_name in (column_list or text):gmatch('"([^"]*)"') do
-        columns[#columns + 1] = column_name
-        if not column_list then
-          break
+      local list_start, list_stop = scan:find("^%s*%b()", stop + 1)
+
+      if list_start then
+        local list_text = text:sub(list_start, list_stop):match("^%s*%((.*)%)$")
+        local list_scan = scan:sub(list_start, list_stop):match("^%s*%((.*)%)$")
+        for _, entry in ipairs(split_on_commas(list_text, list_scan)) do
+          columns[#columns + 1] = leading_column_name(entry.text)
         end
+      else
+        columns[1] = leading_column_name(text)
       end
 
       table.sort(columns)
-      local target = table.concat(columns, ",")
+      -- "\0" rather than a comma, which a column name can hold: joining on one
+      -- makes a column called a,b compare equal to a UNIQUE over a and b
+      local target = table.concat(columns, "\0")
       counts[target] = (counts[target] or 0) + 1
     end
   end
@@ -1072,7 +1104,10 @@ function db:_migrate(db_name, s_name, force)
             -- db.Sheet's __index raises for a column the schema has no entry for
             local removes_a_column = false
             for column_name in pairs(current_columns) do
-              if column_name ~= "_row_id" and not schema.columns[column_name] then
+              -- against nil rather than for truth: a column declared with a default
+              -- of false is one the sheet has, and reading it as one that is going
+              -- costs the sheet the very rule this guard is here to keep
+              if column_name ~= "_row_id" and schema.columns[column_name] == nil then
                 removes_a_column = true
                 break
               end
@@ -1103,7 +1138,9 @@ function db:_migrate(db_name, s_name, force)
       -- Check if we're deleting columns that contain data (unless force flag is set)
       local redundant_columns = {}
       for k, _ in pairs(current_columns) do
-        if not schema.columns[k] and k ~= "_row_id" then
+        -- against nil rather than for truth, for the reason the guard above gives:
+        -- a column defaulting to false is declared, so it is not redundant
+        if schema.columns[k] == nil and k ~= "_row_id" then
           redundant_columns[#redundant_columns + 1] = k
         end
       end
@@ -1133,9 +1170,9 @@ function db:_migrate(db_name, s_name, force)
       end
 
       if unique_lost_to_column_removal then
-        printError("db:create - "..s_name.." - the uniqueness this sheet enforced goes with the "..
-          "column this db:create removes, and what is left of _unique cannot put it back: spell "..
-          "the skipped entries right before removing the column.", true, false)
+        printError("db:create - "..s_name.." - removing a column rebuilds this sheet from what is "..
+          "left of _unique, so the uniqueness it enforces today is lost whichever column that rule "..
+          "sits on: spell the skipped entries right before removing a column.", true, false)
       end
 
       -- Build the list of columns to preserve (only columns that exist in both current and new schema)

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -452,9 +452,14 @@ local lua_reserved_words = {
 ---   A _unique entry naming a column the sheet does not have is skipped and warned
 ---   about the same way, but that one costs more than an index would: a sheet made
 ---   from scratch is built without the uniqueness it asked for, so db:add takes rows
----   the constraint would have refused. A sheet that already carries the constraint
----   keeps it, for the same reason its indexes are left alone.
----   Naming _row_id in a _unique entry of several columns is warned about but kept,
+---   the constraint would have refused. A sheet that already enforces that uniqueness
+---   keeps it and is warned about again, since taking a rule off a typo is not
+---   something a later, correct db:create can undo. The two therefore differ until
+---   the entry is spelled right; everything else the sheet asks for, a constraint it
+---   does not have yet and a _violations change among it, is applied either way.
+---   The one case where an existing sheet does lose the rule is a db:create that
+---   also drops a column, since removing a column is itself a rebuild.
+---   Naming _row_id in a _unique entry written as a list is warned about but kept,
 ---   since a sheet's _row_id is unique on its own and the constraint is therefore
 ---   one that can never refuse a row.
 function db:create(db_name, sheets, force)
@@ -598,11 +603,10 @@ function db:create(db_name, sheets, force)
         -- attached by an exact-match lookup in db:_build_create_table_sql
         local resolvable = { _row_id = true }
         for column_name in pairs(columns) do
-          -- the keyed form takes every key that is not an option for a column
-          -- name, numbers included, and a number has no :lower()
-          if type(column_name) == "string" then
-            resolvable[column_name:lower()] = true
-          end
+          -- the keyed form takes every key that is not an option for a column name,
+          -- numbers included, and sqlite resolves UNIQUE("2") against a column
+          -- called 2 the same as it resolves any other name
+          resolvable[tostring(column_name):lower()] = true
         end
 
         local wanted = {}
@@ -632,20 +636,23 @@ function db:create(db_name, sheets, force)
           -- a UNIQUE naming a column sqlite cannot resolve is refused, and takes the
           -- whole CREATE TABLE with it, leaving no sheet at all. Dropping the
           -- constraint keeps the sheet, at the price of db:add then taking the
-          -- duplicates it was meant to refuse; the single-column form was never
-          -- attached in the first place, so there it only adds the message
+          -- duplicates it was meant to refuse; the single-column form never reached
+          -- sqlite to be refused, so on a new sheet it only adds the message. On a
+          -- sheet that exists either form can cost a rule the table enforces today,
+          -- which is what has_skipped_unique carries to db:_migrate
           if compound and #unique_entry == 0 then
             has_skipped_unique = true
             table.insert(warnings, "db:create - "..sheet_name.." - _unique has an entry with no "..
               "column names in it: that constraint is skipped.")
           elseif not unknown_column then
-            -- sqlite takes a compound entry naming _row_id, and the constraint can
-            -- then never refuse a row, since a sheet's key is unique on its own. It
-            -- is kept anyway: dropping it would change the sheet's SQL and put every
-            -- database that has one through db:_migrate's table rebuild
+            -- sqlite takes an entry naming _row_id, and the constraint can then never
+            -- refuse a row, since a sheet's key is unique on its own. It is kept
+            -- anyway: dropping it would change the sheet's SQL for no gain, and the
+            -- has_skipped_unique route out of the rebuild is not free either, since a
+            -- sheet with one would then never have its constraints reconciled again
             if names_row_id then
-              table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\" among "..
-                "the columns of an entry, and a sheet's _row_id is unique already, so that constraint "..
+              table.insert(warnings, "db:create - "..sheet_name.." - _unique names \"_row_id\" in an "..
+                "entry written as a list, and a sheet's _row_id is unique already, so that constraint "..
                 "can never refuse a row: drop it, or name the columns you meant.")
             end
 
@@ -860,6 +867,33 @@ end
 
 
 
+-- Whether rebuilding a table to match the schema would leave it without a
+-- uniqueness rule it carries today. Only what a constraint covers is compared:
+-- db:create can drop a whole _unique entry but never half of one, so a difference
+-- in ON CONFLICT alone is a _violations change, which costs no uniqueness. A
+-- column-level UNIQUE reaches here without its column name, so those are counted
+-- rather than named.
+local function drops_a_unique(expected_constraints, actual_constraints)
+  local function targets(constraints)
+    local counts = {}
+    for constraint in constraints:gmatch("[^|]+") do
+      local target = constraint:gsub("%s+on%s+conflict%s+%w+$", "")
+      counts[target] = (counts[target] or 0) + 1
+    end
+    return counts
+  end
+
+  local expected = targets(expected_constraints)
+  for target, count in pairs(targets(actual_constraints)) do
+    if (expected[target] or 0) < count then
+      return true
+    end
+  end
+
+  return false
+end
+
+
 local function count_rows(conn, s_name)
   local count_cursor, count_err = conn:execute("SELECT COUNT(*) as cnt FROM " .. s_name);
   if count_cursor == nil then
@@ -951,6 +985,7 @@ function db:_migrate(db_name, s_name, force)
     db:echo_sql(get_actual_sql)
     local sql_cur, sql_err = conn:execute(get_actual_sql)
     local table_constraints_changed = false
+    local would_drop_a_unique = false
 
     if sql_cur and type(sql_cur) ~= "number" then
       local sql_row = sql_cur:fetch({}, "a")
@@ -963,16 +998,44 @@ function db:_migrate(db_name, s_name, force)
 
         if expected_constraints ~= actual_constraints then
           table_constraints_changed = true
+          -- what is left of _unique after db:create skipped an entry is not the set
+          -- the sheet asked for, so a rebuild that costs uniqueness costs it off a
+          -- typo - and the create that spells the column right again cannot put the
+          -- rule back over the duplicates the meantime let in. Everything else the
+          -- rebuild would do, adding a constraint or changing _violations among it,
+          -- is still applied: freezing those too loses the sheet changes it asked
+          -- for and says nothing about them
+          if schema.has_skipped_unique and drops_a_unique(expected_constraints, actual_constraints) then
+            -- removing a column is a rebuild in its own right, further down and from
+            -- the same pruned _unique, so holding this one back would only move where
+            -- the rule is lost - and leaving the column instead is worse, since
+            -- db.Sheet's __index raises for a column the schema has no entry for
+            local removes_a_column = false
+            for column_name in pairs(current_columns) do
+              if column_name ~= "_row_id" and not schema.columns[column_name] then
+                removes_a_column = true
+                break
+              end
+            end
+
+            would_drop_a_unique = not removes_a_column
+
+            if would_drop_a_unique then
+              printError("db:create - "..s_name.." - the uniqueness this sheet already enforces is "..
+                "kept rather than rebuilt to match what is left of _unique: spell the skipped "..
+                "entries right and it is applied then.", true, false)
+            else
+              printError("db:create - "..s_name.." - the uniqueness this sheet enforces goes with "..
+                "the column this db:create removes, and what is left of _unique cannot put it back: "..
+                "spell the skipped entries right before removing the column.", true, false)
+            end
+          end
         end
       end
     end
 
-    -- If the table-level constraints have changed, we need to recreate the table.
-    -- Not when db:create dropped a _unique entry naming a column the sheet does not
-    -- have: rebuilding to match what is left of _unique would take a uniqueness rule
-    -- the live table has today off a typo, and the create that spells the column
-    -- right again cannot put it back over the duplicates the meantime let in.
-    if table_constraints_changed and not schema.has_skipped_unique then
+    -- If the table-level constraints have changed, we need to recreate the table
+    if table_constraints_changed and not would_drop_a_unique then
       -- Commit any pending transaction before table recreation
       db:echo_sql("COMMIT")
       conn:commit()
@@ -1096,7 +1159,8 @@ function db:_migrate(db_name, s_name, force)
         end
       end
     else
-      -- No table definition change, proceed with normal column migration
+      -- No table definition change to apply - either there was none, or applying it
+      -- would have cost the sheet a uniqueness rule it enforces today
       local missing = {}
 
     for k, v in pairs(schema.columns) do

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -454,11 +454,11 @@ local lua_reserved_words = {
 ---   from scratch is built without the uniqueness it asked for, so db:add takes rows
 ---   the constraint would have refused. A sheet that already enforces that uniqueness
 ---   keeps it and is warned about again, since taking a rule off a typo is not
----   something a later, correct db:create can undo. The two therefore differ until
----   the entry is spelled right; everything else the sheet asks for, a constraint it
----   does not have yet and a _violations change among it, is applied either way.
----   The one case where an existing sheet does lose the rule is a db:create that
----   also drops a column, since removing a column is itself a rebuild.
+---   something a later, correct db:create can undo: its constraints are then left
+---   exactly as they are, a constraint it has newly asked for and a change to
+---   _violations among them, until the entry is spelled right. A db:create that
+---   loses the sheet nothing is applied as usual, and one that also drops a column
+---   does lose the rule, since removing a column is a rebuild in its own right.
 ---   Naming _row_id in a _unique entry written as a list is warned about but kept,
 ---   since a sheet's _row_id is unique on its own and the constraint is therefore
 ---   one that can never refuse a row.
@@ -867,24 +867,83 @@ end
 
 
 
--- Whether rebuilding a table to match the schema would leave it without a
--- uniqueness rule it carries today. Only what a constraint covers is compared:
--- db:create can drop a whole _unique entry but never half of one, so a difference
--- in ON CONFLICT alone is a _violations change, which costs no uniqueness. A
--- column-level UNIQUE reaches here without its column name, so those are counted
--- rather than named.
-local function drops_a_unique(expected_constraints, actual_constraints)
-  local function targets(constraints)
-    local counts = {}
-    for constraint in constraints:gmatch("[^|]+") do
-      local target = constraint:gsub("%s+on%s+conflict%s+%w+$", "")
-      counts[target] = (counts[target] or 0) + 1
-    end
+-- The columns each UNIQUE in a CREATE TABLE covers, sorted and counted. Sorted
+-- because sqlite enforces the same rule whichever order they are written in, and
+-- without the ON CONFLICT clause because that is a _violations change, which
+-- costs no uniqueness. db:_extract_table_constraints is no use for this: it drops
+-- the column name of a column-level UNIQUE, so a rule moving from one column to
+-- another looks to it like no change at all.
+local function unique_targets(sql)
+  local counts = {}
+  local content = normalize_sql(sql or ""):match("^create table [^(]+%((.+)%)$")
+  if not content then
     return counts
   end
 
-  local expected = targets(expected_constraints)
-  for target, count in pairs(targets(actual_constraints)) do
+  -- a column name and a default value are both quoted, and either can hold a
+  -- comma, a bracket or the word itself, so the scan runs over a copy with the
+  -- quoted parts blanked out. Same-length blanks keep the offsets lined up
+  local function blank(quoted)
+    return (" "):rep(#quoted)
+  end
+  local searchable = content:gsub('"[^"]*"', blank):gsub("'[^']*'", blank)
+
+  -- split on the commas between the body's own parts: a compound UNIQUE's column
+  -- list is bracketed, so tracking the depth keeps it in one piece
+  local parts = {}
+  local depth, part_start = 0, 1
+  for position = 1, #searchable do
+    local char = searchable:sub(position, position)
+    if char == "(" then
+      depth = depth + 1
+    elseif char == ")" then
+      depth = depth - 1
+    elseif char == "," and depth == 0 then
+      parts[#parts + 1] = part_start
+      part_start = position + 1
+    end
+  end
+  parts[#parts + 1] = part_start
+
+  for index, start_at in ipairs(parts) do
+    local stop_at = (parts[index + 1] or #content + 2) - 2
+    local text = content:sub(start_at, stop_at)
+    local scan = searchable:sub(start_at, stop_at)
+
+    local start, stop = scan:find("unique", 1, true)
+    while start and (scan:sub(start - 1, start - 1):match("[%w_]") or scan:sub(stop + 1, stop + 1):match("[%w_]")) do
+      -- a column called unique_id is not one
+      start, stop = scan:find("unique", stop + 1, true)
+    end
+
+    if start then
+      -- a table-level UNIQUE names its columns in the brackets that follow, a
+      -- column-level one covers the column it is written on, which is the name
+      -- the part opens with
+      local columns = {}
+      local column_list = text:match("^%s*%((.-)%)", stop + 1)
+      for column_name in (column_list or text):gmatch('"([^"]*)"') do
+        columns[#columns + 1] = column_name
+        if not column_list then
+          break
+        end
+      end
+
+      table.sort(columns)
+      local target = table.concat(columns, ",")
+      counts[target] = (counts[target] or 0) + 1
+    end
+  end
+
+  return counts
+end
+
+
+-- Whether rebuilding a table to match the schema would leave it without a
+-- uniqueness rule it carries today.
+local function drops_a_unique(expected_sql, actual_sql)
+  local expected = unique_targets(expected_sql)
+  for target, count in pairs(unique_targets(actual_sql)) do
     if (expected[target] or 0) < count then
       return true
     end
@@ -986,6 +1045,7 @@ function db:_migrate(db_name, s_name, force)
     local sql_cur, sql_err = conn:execute(get_actual_sql)
     local table_constraints_changed = false
     local would_drop_a_unique = false
+    local unique_lost_to_column_removal = false
 
     if sql_cur and type(sql_cur) ~= "number" then
       local sql_row = sql_cur:fetch({}, "a")
@@ -1005,7 +1065,7 @@ function db:_migrate(db_name, s_name, force)
           -- rebuild would do, adding a constraint or changing _violations among it,
           -- is still applied: freezing those too loses the sheet changes it asked
           -- for and says nothing about them
-          if schema.has_skipped_unique and drops_a_unique(expected_constraints, actual_constraints) then
+          if schema.has_skipped_unique and drops_a_unique(expected_sql, actual_sql) then
             -- removing a column is a rebuild in its own right, further down and from
             -- the same pruned _unique, so holding this one back would only move where
             -- the rule is lost - and leaving the column instead is worse, since
@@ -1025,9 +1085,9 @@ function db:_migrate(db_name, s_name, force)
                 "kept rather than rebuilt to match what is left of _unique: spell the skipped "..
                 "entries right and it is applied then.", true, false)
             else
-              printError("db:create - "..s_name.." - the uniqueness this sheet enforces goes with "..
-                "the column this db:create removes, and what is left of _unique cannot put it back: "..
-                "spell the skipped entries right before removing the column.", true, false)
+              -- said once the rebuild is past the guard that can still halt it, so
+              -- this reports what happened rather than what was about to
+              unique_lost_to_column_removal = true
             end
           end
         end
@@ -1070,6 +1130,12 @@ function db:_migrate(db_name, s_name, force)
         assert(not not_blank[1] or force,
                "db:_migrate halted due to data present in undefined columns: " .. table.concat(not_blank, ", ") ..
                "\nuse force option to drop anyway.")
+      end
+
+      if unique_lost_to_column_removal then
+        printError("db:create - "..s_name.." - the uniqueness this sheet enforced goes with the "..
+          "column this db:create removes, and what is left of _unique cannot put it back: spell "..
+          "the skipped entries right before removing the column.", true, false)
       end
 
       -- Build the list of columns to preserve (only columns that exist in both current and new schema)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -3854,8 +3854,7 @@ describe("Tests db:create with _unique naming unknown columns", function()
     assert.is_table(mydb)
     assert.are.equal("", warnings)
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
-    local ok, _ = db:add(mydb.people, {name = "Bob"})
-    assert.is_nil(ok)
+    assert.is_nil(db:add(mydb.people, {name = "Bob"}))
     local rows = db:fetch(mydb.people)
     assert.are.equal(1, #rows)
   end)
@@ -3877,7 +3876,7 @@ describe("Tests db:create with _unique naming unknown columns", function()
     -- would change the sheet's SQL and put every database that has one through
     -- db:_migrate's table rebuild, so the warning is all this can do about it
     local mydb, warnings = createCollectingWarnings({people = {name = "", _unique = {{"name", "_row_id"}}}})
-    assert.is_truthy(string.find(warnings, '_unique names "_row_id" among the columns of an entry', 1, true))
+    assert.is_truthy(string.find(warnings, '_unique names "_row_id" in an entry written as a list', 1, true))
     assert.is_truthy(string.find(warnings, "can never refuse a row", 1, true))
     assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("name", "_row_id")', 1, true))
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
@@ -3975,11 +3974,91 @@ describe("Tests db:create with _unique naming unknown columns", function()
 
   it("takes a sheet that gave one of its columns a number for a name", function()
     -- the keyed form takes every key that is not an option for a column name, so
-    -- this sheet really does have a column called 2, which _unique cannot name
+    -- this sheet really does have a column called 2. The single-column form cannot
+    -- name it, since that one is matched against the keys themselves
     local mydb, warnings = createCollectingWarnings({people = {name = "", [2] = "extra", _unique = "name"}})
     assert.are.equal("", warnings)
     assert.is_true(db:add(mydb.people, {name = "Bob"}))
     assert.is_nil(db:add(mydb.people, {name = "Bob"}))
+  end)
+
+  it("lets a compound entry name a column whose name is a number", function()
+    -- sqlite resolves UNIQUE("2") against that column like any other, so reading
+    -- the sheet's columns as strings only is what would throw away a working rule
+    local mydb, warnings = createCollectingWarnings({people = {name = "", [2] = "extra", _unique = {{"2"}}}})
+    assert.are.equal("", warnings)
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("2")', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_nil(db:add(mydb.people, {name = "Ada"}))
+  end)
+
+  it("still applies a constraint the sheet does not have yet when another entry is skipped", function()
+    -- keeping what a sheet already enforces is about not losing uniqueness, so it
+    -- has to leave everything else the sheet asks for alone: hold the lot back and
+    -- one typo quietly costs the sheet every constraint change it makes from then on
+    createCollectingWarnings({people = {name = "", city = ""}})
+
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _unique = {"nosuchcol", "name"}}})
+    assert.is_truthy(string.find(warnings, '_unique names "nosuchcol"', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Ada", city = "London"}))
+    assert.is_nil(db:add(mydb.people, {name = "Ada", city = "Paris"}))
+    assert.are.equal(1, #db:fetch(mydb.people))
+  end)
+
+  it("still applies a _violations change when another entry is skipped", function()
+    createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "city"}}, _violations = "FAIL"}})
+    createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "city"}, "nosuchcol"}, _violations = "IGNORE"}})
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("name", "city") ON CONFLICT IGNORE', 1, true))
+  end)
+
+  it("still applies a constraint when the skipped entry could never have made one", function()
+    -- _row_id on its own was never attached to anything, so the sheet has nothing to
+    -- lose by it and no reason for it to hold back the entry that is fine
+    createCollectingWarnings({people = {name = "", city = ""}})
+
+    local mydb = createCollectingWarnings({people = {name = "", city = "", _unique = {"name", "_row_id"}}})
+    assert.is_true(db:add(mydb.people, {name = "Bob"}))
+    assert.is_nil(db:add(mydb.people, {name = "Bob"}))
+  end)
+
+  it("says so when it keeps the uniqueness a sheet already has", function()
+    -- the create-time warning names the entry it skipped, which reads as though the
+    -- rest of _unique went in: what the sheet is left enforcing has to be said too
+    createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "city"}}}})
+
+    local _, warnings = createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "citty"}}}})
+    assert.is_truthy(string.find(warnings, "the uniqueness this sheet already enforces is kept", 1, true))
+  end)
+
+  it("says so when removing a column takes the uniqueness with it", function()
+    -- removing a column is a rebuild of its own further down, from the same pruned
+    -- _unique, so the rule goes anyway. Holding that rebuild back instead would
+    -- leave the sheet a column its schema has no entry for, which reading it raises on
+    createCollectingWarnings({people = {name = "", city = "", notes = "", _unique = "name"}})
+
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _unique = "nmae"}})
+    assert.is_truthy(string.find(warnings, "goes with the column this db:create removes", 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Ada"}))
+    assert.is_true(db:add(mydb.people, {name = "Ada"}))
+    assert.are.equal(2, #db:fetch(mydb.people))
+  end)
+
+  it("warns about a single column name that only differs in case", function()
+    -- the single-column form is attached by exact match, so unlike a compound entry
+    -- a difference in case really does leave the sheet without the constraint
+    local mydb, warnings = createCollectingWarnings({people = {Name = "", _unique = "name"}})
+    assert.is_truthy(string.find(warnings, '_unique names "name", which is not one of the sheet\'s columns', 1, true))
+    assert.is_true(db:add(mydb.people, {Name = "Bob"}))
+    assert.is_true(db:add(mydb.people, {Name = "Bob"}))
+  end)
+
+  it("leaves db:merge_unique reporting a sheet with no unique index at all", function()
+    -- _unique is set back to nil rather than an empty list when nothing survives, so
+    -- db:merge_unique reaches the assert that names the real problem
+    local mydb = createCollectingWarnings({people = {name = "", _unique = "nosuchcol"}})
+    local ok, err = pcall(function() db:merge_unique(mydb.people, {{name = "Ada"}}) end)
+    assert.is_false(ok)
+    assert.is_truthy(string.find(err, "only works on a sheet with a unique index", 1, true))
   end)
 end)
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -4030,17 +4030,80 @@ describe("Tests db:create with _unique naming unknown columns", function()
     assert.is_truthy(string.find(warnings, "the uniqueness this sheet already enforces is kept", 1, true))
   end)
 
-  it("says so when removing a column takes the uniqueness with it", function()
+  it("says so when removing a column costs the sheet its uniqueness", function()
     -- removing a column is a rebuild of its own further down, from the same pruned
     -- _unique, so the rule goes anyway. Holding that rebuild back instead would
-    -- leave the sheet a column its schema has no entry for, which reading it raises on
+    -- leave the sheet a column its schema has no entry for, which reading it raises on.
+    -- notes is what goes here and the rule that is lost is on name, which stays, so
+    -- what the message may not say is that the rule went with the column
     createCollectingWarnings({people = {name = "", city = "", notes = "", _unique = "name"}})
 
     local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", _unique = "nmae"}})
-    assert.is_truthy(string.find(warnings, "goes with the column this db:create removes", 1, true))
+    assert.is_truthy(string.find(warnings, "removing a column rebuilds this sheet from what is left of _unique", 1, true))
+    assert.is_falsy(string.find(warnings, "goes with the column", 1, true))
     assert.is_true(db:add(mydb.people, {name = "Ada"}))
     assert.is_true(db:add(mydb.people, {name = "Ada"}))
     assert.are.equal(2, #db:fetch(mydb.people))
+  end)
+
+  it("keeps the uniqueness of a sheet with a column that defaults to false", function()
+    -- a column is looked up rather than tested for truth: one declared with a default
+    -- of false is a column the sheet has, and reading it as one that is on its way out
+    -- lets the rebuild past the guard with the very rule the guard is there to keep
+    createCollectingWarnings({people = {name = "", city = "", active = false, _unique = {{"name", "city"}}}})
+
+    local mydb, warnings = createCollectingWarnings({people = {name = "", city = "", active = false,
+      _unique = {{"name", "citty"}}}})
+    assert.is_truthy(string.find(warnings, "the uniqueness this sheet already enforces is kept", 1, true))
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("name", "city")', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Ada", city = "London"}))
+    assert.is_nil(db:add(mydb.people, {name = "Ada", city = "London"}))
+  end)
+
+  it("still applies a constraint to a sheet with a column that defaults to false", function()
+    -- the same lookup on the other side of the guard: a column that is staying must
+    -- not be read as redundant either, or the rebuild this guard lets through halts
+    -- on the data that column holds
+    local mydb = createCollectingWarnings({people = {name = "", city = "", active = false, _unique = "name"}})
+    assert.is_true(db:add(mydb.people, {name = "Ada", city = "London", active = true}))
+
+    local gained = createCollectingWarnings({people = {name = "", city = "", active = false,
+      _unique = {"name", {"name", "city"}, "nosuchcol"}}})
+    assert.is_table(gained)
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("name", "city")', 1, true))
+    assert.are.equal(1, #db:fetch(gained.people))
+  end)
+
+  it("keeps the uniqueness of a column whose name holds a comma", function()
+    -- each UNIQUE is reduced to the columns it covers, and joining those on a comma
+    -- makes a column called a,b read as a UNIQUE over a and b: one rule then counts
+    -- as the other and the sheet's own goes
+    local mydb = createCollectingWarnings({people = {["a,b"] = "", a = "", b = "", _unique = "a,b"}})
+    assert.is_true(db:add(mydb.people, {["a,b"] = "x", a = "1", b = "2"}))
+    assert.is_nil(db:add(mydb.people, {["a,b"] = "x", a = "3", b = "4"}))
+
+    local kept, warnings = createCollectingWarnings({people = {["a,b"] = "", a = "", b = "",
+      _unique = {{"a", "b"}, "nosuchcol"}}})
+    assert.is_truthy(string.find(warnings, "the uniqueness this sheet already enforces is kept", 1, true))
+    assert.is_nil(db:add(kept.people, {["a,b"] = "x", a = "5", b = "6"}))
+    assert.are.equal(1, #db:fetch(kept.people))
+  end)
+
+  it("reads the uniqueness of a sheet whose table this module did not write", function()
+    -- such a table need not quote its column names, and reading quoted names only
+    -- reduces every UNIQUE it has to the same empty one: a sheet whose rules all look
+    -- alike is a sheet that can be told it is losing one it is not
+    createCollectingWarnings({people = {a = "", b = ""}})
+    db.__conn[dbName]:execute("DROP TABLE people")
+    db.__conn[dbName]:execute('CREATE TABLE people ("_row_id" INTEGER PRIMARY KEY AUTOINCREMENT, ' ..
+      'a TEXT NULL DEFAULT "" UNIQUE ON CONFLICT FAIL, b TEXT NULL DEFAULT "")')
+
+    local mydb, warnings = createCollectingWarnings({people = {a = "", b = "",
+      _unique = {"a", {"a", "b"}, "nosuchcol"}}})
+    assert.is_falsy(string.find(warnings, "the uniqueness this sheet already enforces is kept", 1, true))
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("a", "b")', 1, true))
+    assert.is_true(db:add(mydb.people, {a = "1", b = "2"}))
+    assert.is_nil(db:add(mydb.people, {a = "1", b = "3"}))
   end)
 
   it("warns about a single column name that only differs in case", function()

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -4052,6 +4052,43 @@ describe("Tests db:create with _unique naming unknown columns", function()
     assert.is_true(db:add(mydb.people, {Name = "Bob"}))
   end)
 
+  it("keeps a constraint a later db:create moves to another column", function()
+    -- both are column-level UNIQUEs, which the sheet's SQL carries without naming
+    -- the column they sit on: counting them would read the move as no change and
+    -- let the rule the sheet enforces today go
+    local mydb = createCollectingWarnings({people = {name = "", city = "", _unique = "name"}})
+    assert.is_true(db:add(mydb.people, {name = "Ada", city = "London"}))
+    assert.is_nil(db:add(mydb.people, {name = "Ada", city = "Paris"}))
+
+    -- the compound entry is what makes the sheet's SQL differ at all: two
+    -- column-level UNIQUEs on their own compare equal whichever column they sit on,
+    -- so the rule would survive by accident rather than by being kept
+    local moved = createCollectingWarnings({people = {name = "", city = "",
+      _unique = {"city", {"name", "city"}, "nmae"}}})
+    assert.is_nil(db:add(moved.people, {name = "Ada", city = "Berlin"}))
+    assert.are.equal(1, #db:fetch(moved.people))
+  end)
+
+  it("reads a compound constraint written the other way round as the same one", function()
+    -- sqlite enforces UNIQUE("city", "name") and UNIQUE("name", "city") alike, so
+    -- comparing them as written would hold back a sheet that lost nothing
+    createCollectingWarnings({people = {name = "", city = "", _unique = {{"name", "city"}}, _violations = "FAIL"}})
+    createCollectingWarnings({people = {name = "", city = "", _unique = {{"city", "name"}, "nmae"}, _violations = "IGNORE"}})
+    assert.is_truthy(string.find(tableSql("people"), "ON CONFLICT IGNORE", 1, true))
+  end)
+
+  it("still applies a second constraint to a sheet that already has one", function()
+    -- the sheet keeps what it has and gains what it asked for, which only works if
+    -- the two constraint sets are compared entry by entry rather than as a whole
+    createCollectingWarnings({people = {name = "", city = "", town = "", _unique = {{"name", "city"}}}})
+
+    local mydb = createCollectingWarnings({people = {name = "", city = "", town = "",
+      _unique = {{"name", "city"}, {"city", "town"}, "nmae"}}})
+    assert.is_truthy(string.find(tableSql("people"), 'UNIQUE("city", "town")', 1, true))
+    assert.is_true(db:add(mydb.people, {name = "Ada", city = "London", town = "Bow"}))
+    assert.is_nil(db:add(mydb.people, {name = "Bram", city = "London", town = "Bow"}))
+  end)
+
   it("leaves db:merge_unique reporting a sheet with no unique index at all", function()
     -- _unique is set back to nil rather than an empty list when nothing survives, so
     -- db:merge_unique reaches the assert that names the real problem


### PR DESCRIPTION
Follow-up to #10144, which introduced two regressions against the behaviour before it.

`has_skipped_unique` was a per-sheet flag driving a per-constraint decision: one `_unique` entry `db:create` could not make stopped `db:_migrate` applying **any** constraint change to that sheet. Both of these worked before #10144 and stopped working after it:

```lua
-- a valid entry alongside a bad one is never attached
db:create(name, {people = {name = "", city = ""}})              -- earlier run
db:create(name, {people = {name = "", city = "", _unique = {"nosuchcol", "name"}}})
-- before #10144: UNIQUE on name, duplicate refused. After: no UNIQUE, duplicate accepted.

-- a _violations change is silently dropped
db:create(name, {people = {..., _unique = {{"name", "city"}}, _violations = "FAIL"}})
db:create(name, {people = {..., _unique = {{"name", "city"}, "nosuchcol"}, _violations = "IGNORE"}})
-- before: ON CONFLICT IGNORE. After: still FAIL, and nothing says so.
```

The only warning either printed named the bad entry, so a script author reads it as "one of my constraints was dropped" while the rest went in - and on a fresh database it really does go in, so the two diverge silently.

The rebuild is now suppressed only when it would actually cost the sheet a uniqueness rule it enforces today, and says so when it does. Working that out needs the CREATE TABLE itself rather than `db:_extract_table_constraints`, which reports a column-level `UNIQUE` without the column it sits on - two of those compare equal whichever columns they cover, so a rule moving from one column to another reads as no change at all. Each `UNIQUE` is reduced to the columns it covers, sorted, so the same compound rule written the other way round is recognised rather than rebuilt.

Removing a column is a rebuild of its own further down, from the same pruned `_unique`, so the rule goes with it there; holding that back instead would leave the sheet a column its schema has no entry for, which reading the sheet raises on. That case gets its own warning, printed once the rebuild is past the guard that can still halt it.

Also fixed: a compound entry naming a column whose name is a number (`{people = {[2] = "extra", _unique = {{"2"}}}}`) was skipped as unknown, though sqlite resolves `UNIQUE("2")` like any other name. That was a regression too.

Every behaviour above was A/B'd against the pre-#10144 code and against #10144 as merged. 11 new specs: 9 go red by name against #10144's `DB.lua`, and the other two are pinned by cutting the specific line they cover. Full suite 3723/0/0.

Assisted-by: Claude:claude-opus-5
