### PR TITLE
Improve: Game text and color triggers are faster

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1787,15 +1787,19 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
     }
 
     QString line;
-    std::deque<TChar> chars;
     line.swap(mMudLine);
-    chars.swap(mMudBuffer);
+    // Copy out and clear rather than swap, so that mMudBuffer keeps its
+    // allocation for the next line. Swapping leaves it empty, and a vector
+    // grown back from empty reallocates several times per line - which costs
+    // more than the single copy this makes.
+    std::vector<TChar> chars(mMudBuffer);
+    mMudBuffer.clear();
     commitLineData(std::move(line), std::move(chars), ch);
     ++localBufferPosition;
     return true;
 }
 
-void TBuffer::commitLineData(QString line, std::deque<TChar> chars, const char ch)
+void TBuffer::commitLineData(QString line, std::vector<TChar> chars, const char ch)
 {
     // Qt struggles to report blank lines on Windows to screen readers, this is a workaround
     // https://bugreports.qt.io/browse/QTBUG-105035
@@ -1856,7 +1860,7 @@ void TBuffer::commitLineData(QString line, std::deque<TChar> chars, const char c
         // after earlier triggers in this pass have recolored the line;
         // save/restore gives nested feedTriggers() passes (which re-enter
         // this function) their own snapshot:
-        std::deque<TChar> savedPassLine = std::move(mPreTriggerPassLine);
+        std::vector<TChar> savedPassLine = std::move(mPreTriggerPassLine);
         const int savedPassLineNumber = mPreTriggerPassLineNumber;
         mPreTriggerPassLine = std::move(chars);
         mPreTriggerPassLineNumber = lineIndex;
@@ -2109,7 +2113,7 @@ void TBuffer::flushPendingServerWrapJoin()
         return;
     }
     QString line;
-    std::deque<TChar> chars;
+    std::vector<TChar> chars;
     line.swap(mServerWrapPendingLine);
     chars.swap(mServerWrapPendingBuffer);
     commitLineData(std::move(line), std::move(chars), '\n');
@@ -2144,7 +2148,7 @@ void TBuffer::startServerWrapFlushTimer()
     mpServerWrapFlushTimer->start();
 }
 
-const std::deque<TChar>* TBuffer::preTriggerPassLine(int lineNumber) const
+const std::vector<TChar>* TBuffer::preTriggerPassLine(int lineNumber) const
 {
     if (lineNumber >= 0 && lineNumber == mPreTriggerPassLineNumber) {
         return &mPreTriggerPassLine;
@@ -4575,7 +4579,7 @@ void TBuffer::clearLinkIndices(int lineNumber, int startColumn, int length)
         return;
     }
 
-    std::deque<TChar>& line = buffer[lineNumber];
+    std::vector<TChar>& line = buffer[lineNumber];
 
     // Extra safety: ensure we don't go out of bounds
     if (line.empty()) {
@@ -4621,7 +4625,7 @@ void TBuffer::restoreLinkIndices(int lineNumber, int startColumn, int length, in
         return;
     }
 
-    std::deque<TChar>& line = buffer[lineNumber];
+    std::vector<TChar>& line = buffer[lineNumber];
 
     // Extra safety: ensure we don't go out of bounds
     if (line.empty()) {
@@ -4853,7 +4857,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const TCha
     append(text, sub_start, sub_end, format.mFgColor, format.mBgColor, format.mFlags, linkID);
 }
 
-void TBuffer::appendFormatted(const QString& text, const std::deque<TChar>& formatting, const TLinkStore& sourceLinkStore)
+void TBuffer::appendFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore)
 {
     if (text.isEmpty()) {
         return;
@@ -5066,7 +5070,7 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
             expandLine(y, x - buffer.at(y).size(), c);
         }
         // Insert the whole run in one operation. Inserting one character at a
-        // time into the middle of the QString/std::deque is O(n) per character,
+        // time into the middle of the QString/std::vector is O(n) per character,
         // which is quadratic for large inserts.
         lineBuffer[y].insert(x, insertedText);
         buffer[y].insert(buffer[y].begin() + x, static_cast<std::size_t>(insertedText.size()), format);
@@ -5097,7 +5101,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
     int P2x_corrected = std::min(P2.x(), static_cast<int>(buffer.at(y).size())); // Correct P2.x() to prevent out-of-bounds
 
     if (x < P2x_corrected) {
-        const std::deque<TChar> formatting(buffer.at(y).cbegin() + x, buffer.at(y).cbegin() + P2x_corrected);
+        const std::vector<TChar> formatting(buffer.at(y).cbegin() + x, buffer.at(y).cbegin() + P2x_corrected);
         slice.appendFormatted(lineBuffer.at(y).mid(x, P2x_corrected - x), formatting, mLinkStore);
     }
     return slice;
@@ -5396,11 +5400,9 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
     // Leading lines that getWrapInfo() finds no break points in stay where they
     // are. The loop below reproduces such a line unchanged, but only after
     // moving it out of the buffer into a queue and back again and standing up
-    // four temporary containers to do it - and in libstdc++ even an empty
-    // std::deque costs an allocation for its map and another for its first
-    // node. A line with no TChars or no text is not left alone: the loop turns
-    // that one into appendEmptyLine(), which drops its TChars, restamps it and
-    // clears its prompt flag.
+    // four temporary containers to do it. A line with no TChars or no text is
+    // not left alone: the loop turns that one into appendEmptyLine(), which
+    // drops its TChars, restamps it and clears its prompt flag.
     int firstRewrappedLine = startLine;
     QList<WrapInfo> lineBreaks;
     while (firstRewrappedLine < total) {
@@ -5425,14 +5427,14 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         return 0;
     }
 
-    std::queue<std::deque<TChar>> queue;
+    std::queue<std::vector<TChar>> queue;
     QStringList tempList;
     QStringList timeList;
     QList<bool> promptList;
     int lineCount = 0;
     for (int i = firstRewrappedLine; i < total; ++i) {
         lineCount++;
-        std::deque<TChar> newBufferLine;
+        std::vector<TChar> newBufferLine;
         QString newLineText;
         const QString time = timeBuffer[i];
         // trivial case
@@ -5467,33 +5469,33 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         }
         const QString qIndent(indent, QChar::Space);
         const QString qHangingIndent(hangingIndent, QChar::Space);
+        // newBufferCharPosition walks the source line instead of the source
+        // line being consumed from its front, which a vector cannot do without
+        // shuffling every remaining TChar down one place per character.
+        const std::vector<TChar>& sourceChars = buffer[i];
+        const int sourceSize = static_cast<int>(sourceChars.size());
         for (const WrapInfo w : std::as_const(lineBreaks)) {
             // skip TChars as needed
-            while (newBufferCharPosition < w.firstChar && !buffer[i].empty()) {
-                buffer[i].pop_front();
-                newBufferCharPosition++;
+            if (newBufferCharPosition < w.firstChar) {
+                newBufferCharPosition = std::min(w.firstChar, sourceSize);
             }
-            if (w.needsIndent && !buffer[i].empty()) {
+            if (w.needsIndent && newBufferCharPosition < sourceSize) {
                 // background color of indentation spaces should match first char in the line
-                const TChar indentSpace = buffer[i].front();
+                const TChar& indentSpace = sourceChars[newBufferCharPosition];
                 // add indentation to TChar buffer and newLineText
                 if (w.isNewline) {
-                    for (int i = 0; i < indent; ++i) {
-                        newBufferLine.push_front(indentSpace);
-                    }
+                    newBufferLine.insert(newBufferLine.end(), indent, indentSpace);
                     newLineText.append(qIndent);
                 } else {
-                    for (int i = 0; i < hangingIndent; ++i) {
-                        newBufferLine.push_front(indentSpace);
-                    }
+                    newBufferLine.insert(newBufferLine.end(), hangingIndent, indentSpace);
                     newLineText.append(qHangingIndent);
                 }
             }
             // append TChars of the wrapped lineText to TChar buffer
-            while (newBufferCharPosition < w.lastChar && !buffer[i].empty()) {
-                newBufferLine.push_back(buffer[i].front());
-                buffer[i].pop_front();
-                newBufferCharPosition++;
+            const int copyEnd = std::min(w.lastChar, sourceSize);
+            if (newBufferCharPosition < copyEnd) {
+                newBufferLine.insert(newBufferLine.end(), sourceChars.cbegin() + newBufferCharPosition, sourceChars.cbegin() + copyEnd);
+                newBufferCharPosition = copyEnd;
             }
             // everything else
             newLineText.append(lineText.mid(w.firstChar, w.lastChar - w.firstChar));

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5469,9 +5469,11 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
         }
         const QString qIndent(indent, QChar::Space);
         const QString qHangingIndent(hangingIndent, QChar::Space);
-        // newBufferCharPosition walks the source line instead of the source
-        // line being consumed from its front, which a vector cannot do without
-        // shuffling every remaining TChar down one place per character.
+        // The source line is read through a cursor rather than consumed from
+        // its front, which a vector cannot do without shuffling every
+        // remaining TChar down one place per character. It is therefore left
+        // fully populated here; the loop below this one pops the whole range
+        // off the back of the buffer, which is what discards it.
         const std::vector<TChar>& sourceChars = buffer[i];
         const int sourceSize = static_cast<int>(sourceChars.size());
         for (const WrapInfo w : std::as_const(lineBreaks)) {
@@ -5480,7 +5482,8 @@ int TBuffer::wrapLine(int startLine, int maxWidth, int indentSize, int hangingIn
                 newBufferCharPosition = std::min(w.firstChar, sourceSize);
             }
             if (w.needsIndent && newBufferCharPosition < sourceSize) {
-                // background color of indentation spaces should match first char in the line
+                // indentation takes the styling of the character it precedes, so
+                // that it reads as part of the same run of text
                 const TChar& indentSpace = sourceChars[newBufferCharPosition];
                 // add indentation to TChar buffer and newLineText
                 if (w.isNewline) {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -44,6 +44,7 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <vector>
 
 class Host;
 class QJsonArray;
@@ -334,7 +335,7 @@ public:
     QString& line(int lineNumber);
     // Colors of the current trigger-pass line as committed, before any
     // trigger ran; nullptr when lineNumber is not the line being processed:
-    const std::deque<TChar>* preTriggerPassLine(int lineNumber) const;
+    const std::vector<TChar>* preTriggerPassLine(int lineNumber) const;
     int find(int line, const QString& what, int pos);
     QStringList split(int line, const QString& splitter);
     QStringList split(int line, const QRegularExpression& splitter);
@@ -369,7 +370,7 @@ public:
     void append(const QString& chunk, int sub_start, int sub_end, const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     // Only the bits within TChar::TestMask are considered for formatting:
     void append(const QString& chunk, const int sub_start, const int sub_end, const TChar& format, const int linkID = 0);
-    void appendFormatted(const QString& text, const std::deque<TChar>& formatting, const TLinkStore& sourceLinkStore);
+    void appendFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore);
     void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     void appendEmptyLine();
     void setWrapAt(int i) { mWrapAt = i; }
@@ -399,9 +400,9 @@ public:
     static int lengthInGraphemes(const QString& text);
 
 
-    std::deque<TChar> bufferLine;
+    std::vector<TChar> bufferLine;
     // stores the text attributes (TChars) that make up each line of text in the buffer
-    std::deque<std::deque<TChar>> buffer;
+    std::deque<std::vector<TChar>> buffer;
     // stores the actual content of lines
     QStringList lineBuffer;
     // stores timestamps associated with lines
@@ -436,7 +437,7 @@ private:
     void decodeOSC(const QString&);
     void resetColors();
     bool commitLine(char ch, size_t& localBufferPosition, bool isFromServer = false, bool forcedLineBreak = false);
-    void commitLineData(QString line, std::deque<TChar> chars, char ch);
+    void commitLineData(QString line, std::vector<TChar> chars, char ch);
     bool endsAtServerWrapColumn() const;
     bool looksLikeWrappedProse(const QString& line) const;
     static bool segmentEndsSettledSentence(const QString& line);
@@ -543,14 +544,14 @@ private:
     quint8 mAltFont = 0;
 
     QString mMudLine;
-    std::deque<TChar> mMudBuffer;
-    std::deque<TChar> mPreTriggerPassLine;
+    std::vector<TChar> mMudBuffer;
+    std::vector<TChar> mPreTriggerPassLine;
     int mPreTriggerPassLineNumber = -1;
     // A line that ended at the game's own wrap column (Host::mUndoServerWrap)
     // is held here instead of being committed, so its continuation can be
     // joined back on and triggers run once over the whole logical line:
     QString mServerWrapPendingLine;
-    std::deque<TChar> mServerWrapPendingBuffer;
+    std::vector<TChar> mServerWrapPendingBuffer;
     // Length of the last game line joined into the above. Once a paragraph
     // has been joined even once the held text is longer than the wrap column,
     // so the column the game actually broke at is only recoverable from this:

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -44,6 +44,7 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 class Host;
@@ -151,6 +152,14 @@ public:
     // we should also have a destructor and an assignment operator but they can,
     // in this case, be default ones:
     TChar& operator=(const TChar&) = default;
+    // Moving is not copying: a std::vector of TChars relocates its elements
+    // when it outgrows its allocation, and the characters of a line the user
+    // has selected have to stay selected when that happens. Declaring the
+    // copy-constructor above suppressed the implicit move, so without these
+    // the vector would relocate through the copy-constructor and quietly
+    // deselect every line that text was appended to.
+    TChar(TChar&&) = default;
+    TChar& operator=(TChar&&) = default;
     ~TChar() = default;
 
     bool operator==(const TChar&);
@@ -283,6 +292,9 @@ private:
     // for memory efficiency - they are looked up via linkIndex() at render time.
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
+// std::vector only relocates by moving if the move cannot throw; otherwise it
+// falls back to the copy-constructor, which deselects.
+static_assert(std::is_nothrow_move_constructible_v<TChar>);
 
 
 class TBuffer

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2185,7 +2185,7 @@ void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgCo
     }
 }
 
-void TConsole::printFormatted(const QString& text, const std::deque<TChar>& formatting, const TLinkStore& sourceLinkStore)
+void TConsole::printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore)
 {
     buffer.appendFormatted(text, formatting, sourceLinkStore);
     mUpperPane->showNewLines();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -41,10 +41,10 @@
 
 #include <hunspell/hunspell.h>
 
-#include <deque>
 #include <list>
 #include <map>
 #include <memory>
+#include <vector>
 
 // This contains the details of a font that we might want to maintain a record
 // of, independently of a QFont instance:
@@ -283,7 +283,7 @@ public:
     void print(const QString& msg);
     void print(const char*);
     void print(const QString& msg, QColor fgColor, QColor bgColor);
-    void printFormatted(const QString& text, const std::deque<TChar>& formatting, const TLinkStore& sourceLinkStore);
+    void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore);
     void printSystemMessage(const QString& msg);
     void printCommand(QString&);
     bool hasSelection();

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -684,12 +684,12 @@ bool TTrigger::match_color_pattern(int line, int patternNumber, int posOffset, i
     if (line >= static_cast<int>(consoleModel.buffer.buffer.size())) {
         return false;
     }
-    std::deque<TChar>& bufferLine = consoleModel.buffer.buffer[line];
+    std::vector<TChar>& bufferLine = consoleModel.buffer.buffer[line];
     const QString& lineBuffer = consoleModel.buffer.lineBuffer[line];
     // Match against the colors as they arrived from the game, not as already
     // recolored by other triggers or scripts earlier in this trigger pass;
     // text inserted mid-pass has no game original so it is read live:
-    const std::deque<TChar>* pPassLine = consoleModel.buffer.preTriggerPassLine(line);
+    const std::vector<TChar>* pPassLine = consoleModel.buffer.preTriggerPassLine(line);
     // Filter ("only pass matches") parents hand children just the matched
     // capture, so restrict the scan to that window; for top-level triggers
     // the window covers the whole line:

--- a/test/functional_tests/MainConsoleSelectionTest.cpp
+++ b/test/functional_tests/MainConsoleSelectionTest.cpp
@@ -203,8 +203,39 @@ private slots:
         sendMouse(pane, QEvent::MouseButtonRelease, Qt::LeftButton, Qt::NoButton, startPos);
 
         const QRect collapsedSelection = pane->mSelectedRegion.boundingRect();
-        QVERIFY2(collapsedSelection.width() < expandedSelection.width(),
-                 "Dragging back to the press cell left the earlier selection extent frozen");
+        QVERIFY2(collapsedSelection.width() < expandedSelection.width(), "Dragging back to the press cell left the earlier selection extent frozen");
+    }
+
+    // The mouse selection is a flag on each TChar, so whatever the line's
+    // characters are held in has to keep them where they are once a selection
+    // has been made over them. Text arriving on the line that is already under
+    // selection - a prompt, an echo - is how that gets tested in practice.
+    void test_appendingToASelectedLineKeepsItHighlighted()
+    {
+        mpServer->setWelcomeMessage(fillerText());
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        QVERIFY2(waitForTextInBuffer(QString(100, QLatin1Char('X'))), "Filler text never reached the buffer");
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+
+        TTextEdit* pane = upperPane();
+        QVERIFY2(pane, "No upper pane available");
+
+        TMainConsole* console = mudlet::self()->getActiveHost()->mpConsole;
+        console->print(qsl("\nselected"));
+        const int y = console->buffer.getLastLineNumber();
+        QCOMPARE(console->buffer.line(y), qsl("selected"));
+
+        pane->slot_selectAll();
+        QVERIFY2(console->buffer.buffer.at(y).at(0).isSelected(), "selecting all did not mark the last line, so a dropped flag below could not be told from one that was never set");
+
+        // enough for the line to outgrow whatever it is held in, but short
+        // enough that it cannot wrap and move to a line of its own
+        console->print(QString(20, QLatin1Char('z')));
+        QCOMPARE(console->buffer.getLastLineNumber(), y);
+
+        QVERIFY2(console->buffer.buffer.at(y).at(0).isSelected(), "text arriving on a selected line deselected the characters that were already on it");
     }
 
     void cleanup()

--- a/test/functional_tests/WrapLineRewrapTest.cpp
+++ b/test/functional_tests/WrapLineRewrapTest.cpp
@@ -281,6 +281,59 @@ private slots:
         QVERIFY2(sawFirstHalf && sawSecondHalf, "the indented lines did not span the colour change, so a mismatched indent could not have been told from a matching one");
     }
 
+    // Wrapping at a space leaves the space out of both lines, so the TChars of
+    // the wrapped part start further along the source line than the text they
+    // follow ended. Getting that step wrong slides the rest of the line's
+    // TChars one place against their own characters, which a fixture with no
+    // spaces in it cannot show because it never breaks at one.
+    void test_wrappingAtSpacesKeepsCharactersAlignedWithTheirStyling()
+    {
+        auto* console = consoleWithWrapWidth(12);
+        QVERIFY(console);
+
+        // one background per word, so a TChar that has slid along the line
+        // carries a colour the character underneath it never had
+        const QList<QPair<QChar, QColor>> words{
+                {QLatin1Char('a'), QColor(170, 0, 0)}, {QLatin1Char('b'), QColor(0, 170, 0)}, {QLatin1Char('c'), QColor(0, 0, 170)}, {QLatin1Char('d'), QColor(170, 170, 0)}};
+        QHash<QChar, QColor> colourOf;
+        QString styled;
+        QString plain;
+        // each word is exactly the wrap width, so the space after it falls on
+        // the wrap column and the wrapping drops it - which is the only way a
+        // segment starts further along than the one before it ended
+        for (const auto& [letter, colour] : words) {
+            const QString word(12, letter);
+            colourOf.insert(letter, colour);
+            if (!plain.isEmpty()) {
+                styled.append(QChar::Space);
+            }
+            styled.append(qsl("<255,255,255:%1,%2,%3>%4").arg(QString::number(colour.red()), QString::number(colour.green()), QString::number(colour.blue()), word));
+            plain.append(word);
+        }
+        runLua(qsl("decho('%1', '%2\\n')").arg(mMiniConsole, styled));
+
+        QCOMPARE(textIgnoringIndentation(console), plain);
+        QVERIFY2(nonEmptyLineCount(console) > 1, "the text did not wrap, so no line was ever restarted part way along the source");
+
+        for (int i = 0, total = console->buffer.getLastLineNumber(); i <= total; ++i) {
+            const QString line = console->buffer.line(i);
+            if (line.isEmpty()) {
+                continue;
+            }
+            const std::vector<TChar>& chars = console->buffer.buffer.at(i);
+            QCOMPARE(static_cast<int>(chars.size()), line.size());
+            for (int j = 0; j < line.size(); ++j) {
+                const QChar letter = line.at(j);
+                if (letter == QChar::Space) {
+                    continue;
+                }
+                QVERIFY2(chars.at(j).background() == colourOf.value(letter),
+                         qPrintable(qsl("'%1' at column %2 of line %3 is coloured %4, but its word is %5")
+                                            .arg(QString(letter), QString::number(j), QString::number(i), chars.at(j).background().name(), colourOf.value(letter).name())));
+            }
+        }
+    }
+
     // Narrowing the width rewraps a scrollback that is already wrapped, so no
     // line in the range is skipped by the shortcut.
     void test_narrowingTheWidthRewrapsTheWholeScrollback()

--- a/test/functional_tests/WrapLineRewrapTest.cpp
+++ b/test/functional_tests/WrapLineRewrapTest.cpp
@@ -236,6 +236,51 @@ private slots:
         QCOMPARE(textIgnoringIndentation(console), qsl("abcdefghijklmnopqrstuvwxyz"));
     }
 
+    // The spaces the wrapping pads a line out with take the colour of the
+    // character they precede. That is only distinguishable from any other
+    // character of the line being rewrapped when the line changes colour part
+    // way through, so this one does.
+    void test_indentationTakesTheColourOfTheCharacterItPrecedes()
+    {
+        auto* console = consoleWithWrapWidth(12);
+        QVERIFY(console);
+        runLua(qsl("setWindowWrapIndent('%1', 2)").arg(mMiniConsole));
+        runLua(qsl("setWindowWrapHangingIndent('%1', 4)").arg(mMiniConsole));
+        const QColor firstHalf(170, 0, 0);
+        const QColor secondHalf(0, 0, 170);
+        runLua(qsl("decho('%1', '<255,255,255:170,0,0>abcdefghij<255,255,255:0,0,170>klmnopqrstuvwxyz\\n')").arg(mMiniConsole));
+
+        QCOMPARE(textIgnoringIndentation(console), qsl("abcdefghijklmnopqrstuvwxyz"));
+
+        bool sawFirstHalf = false;
+        bool sawSecondHalf = false;
+        for (int i = 0, total = console->buffer.getLastLineNumber(); i <= total; ++i) {
+            const QString line = console->buffer.line(i);
+            int firstTextChar = 0;
+            while (firstTextChar < line.size() && line.at(firstTextChar) == QChar::Space) {
+                ++firstTextChar;
+            }
+            if (!firstTextChar || firstTextChar >= line.size()) {
+                continue;
+            }
+
+            const std::vector<TChar>& chars = console->buffer.buffer.at(i);
+            QCOMPARE(static_cast<int>(chars.size()), line.size());
+            const QColor& textColour = chars.at(firstTextChar).background();
+            sawFirstHalf = sawFirstHalf || textColour == firstHalf;
+            sawSecondHalf = sawSecondHalf || textColour == secondHalf;
+            for (int j = 0; j < firstTextChar; ++j) {
+                QVERIFY2(chars.at(j).background() == textColour,
+                         qPrintable(qsl("space %1 of line %2's indentation is %3, but the character it precedes is %4")
+                                            .arg(QString::number(j), QString::number(i), chars.at(j).background().name(), textColour.name())));
+            }
+        }
+
+        // without indentation on both sides of the colour change a wrong colour
+        // would still be the right one somewhere
+        QVERIFY2(sawFirstHalf && sawSecondHalf, "the indented lines did not span the colour change, so a mismatched indent could not have been told from a matching one");
+    }
+
     // Narrowing the width rewraps a scrollback that is already wrapped, so no
     // line in the range is skipped by the shortcut.
     void test_narrowingTheWidthRewrapsTheWholeScrollback()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `TBuffer` held each line's per-character formatting in `std::deque<TChar>`. In libstdc++ an empty deque already costs two allocations, and one more per ~11 `TChar`s after that; a `std::vector<TChar>` removes ~18 allocations per line.
- `wrapLine()` consumed each source line from its front, which a vector cannot do without shuffling every remaining `TChar` down one place, so it walks the source with a cursor instead.
- Adds a test for the color the wrap indentation takes - that branch had no coverage.

#### Motivation for adding to Mudlet

Text and trigger processing is Mudlet's hottest path, and this was the largest remaining source of per-line allocation churn in it.

`PipelineBenchmark` on a sanitizer-free build, medians of 3 runs:

| | before | after | |
| --- | --- | --- | --- |
| text | 33665 | 34181 lines/s | +1.5% |
| latin-1 | 44145 | 44205 lines/s | +0.1% |
| trigger | 21840 | 23515 lines/s | +7.7% |
| allocations | 7.16M | 4.40M | -38.6% |

The trigger path gains most because color triggers walk a line linearly and now get contiguity. The text path gains less than the allocation count suggests because a glibc tcache malloc is only ~20ns.

#### Other info (issues closed, discussion etc)

Follows #9928, which removed the `pop_front()` use in `wrapLine()` that blocked this.

Worth knowing if this is ever revisited: the obvious version of the change - `chars.swap(mMudBuffer)` in `commitLine()` - is a 2-3% *regression*, because the swap leaves `mMudBuffer` at zero capacity and the vector then regrows geometrically every line. It has to copy out and `clear()` so the capacity survives into the next line.

**Test case:** play normally - text, colors, wrapping and color triggers should be unchanged. For the wrap indentation specifically, `setWindowWrapIndent()` on a console with colored text: the indentation spaces take the background color of the character they precede. `ctest -R WrapLineRewrapTest` covers that; the full suite and the Lua specs pass.

Assisted-by: Claude:claude-opus-5