### PR TITLE
Fix: Console output no longer slows down as the window gets bigger

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1988,11 +1988,22 @@ std::tuple<bool, QString, int, int> TConsole::getSelection()
     return {true, text, start, length};
 }
 
+// The four callers below rewrite the text of an existing selection rather than
+// appending to the buffer, so the lines they touched are all that has to be
+// redrawn. They used to force a whole-screen repaint of both panes, which cost a
+// full relayout per coloured echo - see markLinesDirty().
+void TConsole::markSelectionDirty()
+{
+    const int firstLine = std::min(P_begin.y(), P_end.y());
+    const int lastLine = std::max(P_begin.y(), P_end.y());
+    mUpperPane->markLinesDirty(firstLine, lastLine);
+    mLowerPane->markLinesDirty(firstLine, lastLine);
+}
+
 void TConsole::setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference)
 {
     buffer.applyLink(P_begin, P_end, linkFunction, linkHint, linkReference);
-    mUpperPane->forceUpdate();
-    mLowerPane->forceUpdate();
+    markSelectionDirty();
 }
 
 // Set or Reset ALL the specified (but not others)
@@ -2000,8 +2011,7 @@ void TConsole::setDisplayAttributes(const TChar::AttributeFlags attributes, cons
 {
     mFormatCurrent.setAllDisplayAttributes((mFormatCurrent.allDisplayAttributes() & ~(attributes)) | (b ? attributes : TChar::None));
     buffer.applyAttribute(P_begin, P_end, attributes, b);
-    mUpperPane->forceUpdate();
-    mLowerPane->forceUpdate();
+    markSelectionDirty();
 }
 
 void TConsole::setFgColor(int r, int g, int b)
@@ -2018,16 +2028,14 @@ void TConsole::setBgColor(const QColor& newColor)
 {
     mFormatCurrent.setBackground(newColor);
     buffer.applyBgColor(P_begin, P_end, newColor);
-    mUpperPane->forceUpdate();
-    mLowerPane->forceUpdate();
+    markSelectionDirty();
 }
 
 void TConsole::setFgColor(const QColor& newColor)
 {
     mFormatCurrent.setForeground(newColor);
     buffer.applyFgColor(P_begin, P_end, newColor);
-    mUpperPane->forceUpdate();
-    mLowerPane->forceUpdate();
+    markSelectionDirty();
 }
 
 void TConsole::setCommandBgColor(int r, int g, int b, int a)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2002,16 +2002,18 @@ void TConsole::markSelectionDirty()
 
 void TConsole::setLink(const QStringList& linkFunction, const QStringList& linkHint, const QVector<int> linkReference)
 {
-    buffer.applyLink(P_begin, P_end, linkFunction, linkHint, linkReference);
-    markSelectionDirty();
+    if (buffer.applyLink(P_begin, P_end, linkFunction, linkHint, linkReference)) {
+        markSelectionDirty();
+    }
 }
 
 // Set or Reset ALL the specified (but not others)
 void TConsole::setDisplayAttributes(const TChar::AttributeFlags attributes, const bool b)
 {
     mFormatCurrent.setAllDisplayAttributes((mFormatCurrent.allDisplayAttributes() & ~(attributes)) | (b ? attributes : TChar::None));
-    buffer.applyAttribute(P_begin, P_end, attributes, b);
-    markSelectionDirty();
+    if (buffer.applyAttribute(P_begin, P_end, attributes, b)) {
+        markSelectionDirty();
+    }
 }
 
 void TConsole::setFgColor(int r, int g, int b)
@@ -2027,15 +2029,17 @@ void TConsole::setBgColor(int r, int g, int b, int a)
 void TConsole::setBgColor(const QColor& newColor)
 {
     mFormatCurrent.setBackground(newColor);
-    buffer.applyBgColor(P_begin, P_end, newColor);
-    markSelectionDirty();
+    if (buffer.applyBgColor(P_begin, P_end, newColor)) {
+        markSelectionDirty();
+    }
 }
 
 void TConsole::setFgColor(const QColor& newColor)
 {
     mFormatCurrent.setForeground(newColor);
-    buffer.applyFgColor(P_begin, P_end, newColor);
-    markSelectionDirty();
+    if (buffer.applyFgColor(P_begin, P_end, newColor)) {
+        markSelectionDirty();
+    }
 }
 
 void TConsole::setCommandBgColor(int r, int g, int b, int a)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -279,6 +279,9 @@ public:
     int getLastLineNumber();
     void refresh();
     void refreshView() const;
+    // Repaint just the lines the current selection covers, for the callers that
+    // change their text where it stands instead of appending new text.
+    void markSelectionDirty();
     void raiseMudletMousePressOrReleaseEvent(QMouseEvent*, const bool);
     void setFontSize(int);
     void setFontName(const QString& fontName);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -141,6 +141,32 @@ void TTextEdit::forceUpdate()
     update();
 }
 
+void TTextEdit::markLinesDirty(const int firstLine, const int lastLine)
+{
+    if (firstLine < 0 || lastLine < firstLine) {
+        return;
+    }
+    mDirtyFirstLine = (mDirtyFirstLine < 0) ? firstLine : std::min(mDirtyFirstLine, firstLine);
+    mDirtyLastLine = (mDirtyLastLine < 0) ? lastLine : std::max(mDirtyLastLine, lastLine);
+
+    if (mFontHeight <= 0 || mScreenHeight <= 0) {
+        // Too early to work out where the lines sit, so fall back to the whole
+        // pane rather than leave the change unpainted.
+        update();
+        return;
+    }
+
+    const int lineOffset = imageTopLine();
+    const int top = std::max(0, firstLine - lineOffset);
+    const int bottom = std::min(mScreenHeight - 1, lastLine - lineOffset);
+    if (bottom < top) {
+        // Off-screen for this pane. The range stays recorded because the pane
+        // may scroll onto it before the next paint.
+        return;
+    }
+    update(QRect(0, top * mFontHeight, width(), (bottom - top + 1) * mFontHeight));
+}
+
 void TTextEdit::needUpdate(int y1, int y2)
 {
     if (!mIsTailMode) {
@@ -1177,14 +1203,26 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     // the bottom cell - descenders and underscores do at many font sizes - has
     // somewhere to go instead of being cut off by the edge of the pixmap.
     const int pixmapHeight = (mScreenHeight + 1) * mFontHeight;
-    QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * dpr, pixmapHeight * dpr);
-    pixmap.setDevicePixelRatio(dpr);
-    pixmap.fill(Qt::transparent);
+    const QSize surfaceSize(static_cast<int>(mScreenWidth * mFontWidth * dpr), static_cast<int>(pixmapHeight * dpr));
+    // Building a pane-sized pixmap costs the same whether one line changed or
+    // all of them did, so it is only done when there is no buffer to reuse -
+    // the pane changed size or resolution, or nothing has been painted yet.
+    bool bufferWasJustCleared = false;
+    if (mRenderBuffer.size() != surfaceSize || !qFuzzyCompare(mRenderBuffer.devicePixelRatio(), dpr)) {
+        mRenderBuffer = QPixmap(surfaceSize);
+        mRenderBuffer.setDevicePixelRatio(dpr);
+        mRenderBuffer.fill(Qt::transparent);
+        bufferWasJustCleared = true;
+    }
+    QPixmap& pixmap = mRenderBuffer;
 
     QPainter p(&pixmap);
     // Setting the font here isn't academic as the text IS drawn with THIS painter (p)
     p.setFont(painter.font());
-    p.setCompositionMode(QPainter::CompositionMode_SourceOver);
+    // Source rather than SourceOver for the cache blits below: they have to
+    // overwrite whatever a reused buffer still holds from an earlier frame, and
+    // over a freshly cleared buffer the two modes produce identical pixels.
+    p.setCompositionMode(QPainter::CompositionMode_Source);
 
     int y_top = r.top() / mFontHeight;
     int y_bottom = r.bottom() / mFontHeight;
@@ -1213,11 +1251,15 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
         reusedCachedScreenContent = true;
         from = y_top;
         noScroll = true;
-        if (!mForceUpdate && !mMouseTracking) {
-            noCopy = true;
-        } else {
+        if (mForceUpdate || mMouseTracking) {
             y_bottom = mScreenHeight;
             mScrollVector = 0;
+        } else if (mDirtyFirstLine < 0) {
+            // A purely cosmetic repaint - hover, selection - which must not
+            // overwrite the cached screen with its transient state. A pending
+            // in-place change is the opposite: it HAS to reach the cache, or
+            // the next paint would seed from stale ink and lose it.
+            noCopy = true;
         }
     }
     const int scrolledRows = qAbs(mScrollVector);
@@ -1236,12 +1278,31 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     }
 
     const int lastRow = mScreenHeight - 1;
-    const int drawFrom = qMax(0, from);
+    int drawFrom = qMax(0, from);
     // One row past the dirty region: the last dirty row's ink can spill into the
     // row below, which would otherwise be left showing the ink of whatever used
     // to be on that last row.
-    const int drawTo = qMin(y_bottom + 1, lastRow);
+    int drawTo = qMin(y_bottom + 1, lastRow);
+    // Rows carrying text that changed where it stands. The cache still holds
+    // their old ink, so they join the band whatever the scroll shortcut decided
+    // - which is what makes recolouring a line cost a line instead of a screen.
+    if (mDirtyFirstLine >= 0) {
+        const int dirtyTop = std::max(0, mDirtyFirstLine - lineOffset);
+        const int dirtyBottom = std::min(lastRow, mDirtyLastLine - lineOffset);
+        if (dirtyBottom >= dirtyTop) {
+            drawFrom = std::min(drawFrom, dirtyTop);
+            drawTo = std::max(drawTo, dirtyBottom);
+        }
+    }
     const bool bottomRowIsRepainted = drawTo == lastRow;
+
+    // Neither cache blit ran, so everything outside the band about to be redrawn
+    // is still the previous frame's ink rather than the transparency a newly
+    // allocated pixmap would have started with.
+    if (!reusedCachedScreenContent && !bufferWasJustCleared) {
+        p.setCompositionMode(QPainter::CompositionMode_Source);
+        p.fillRect(QRect(0, 0, mScreenWidth * mFontWidth, pixmapHeight), Qt::transparent);
+    }
 
     //delete non used characters.
     //needed for horizontal scrolling because there sometimes characters didn't get cleared
@@ -1318,11 +1379,20 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
     painter.drawPixmap(0, 0, pixmap);
     if (!noCopy) {
-        mScreenMap = pixmap;
+        // Swapped rather than assigned: leaving the two sharing one buffer would
+        // make the next paint's QPainter deep-copy the whole surface before it
+        // could draw a single glyph, which is the cost being avoided here.
+        mScreenMap.swap(mRenderBuffer);
     }
     mScrollVector = 0;
     mLastRenderedOffset = lineOffset;
     mForceUpdate = false;
+    if (!noCopy) {
+        // noCopy left the cache untouched, so the change has not been preserved
+        // anywhere yet and the range has to stay pending for the next paint.
+        mDirtyFirstLine = -1;
+        mDirtyLastLine = -1;
+    }
 
     const bool shouldBeRegistered = shouldRegisterBlinkClient(mEnableBlinkText, mHasBlinkingContent, mIsBlinkClientRegistered, reusedCachedScreenContent);
     if (auto* pMudlet = mudlet::self()) {

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -68,6 +68,11 @@ public:
     void drawForeground(QPainter&, const QRect&);
     void showNewLines();
     void forceUpdate();
+    // Records that the text of these buffer lines changed where it stands,
+    // rather than the whole screen being untrustworthy. Unlike forceUpdate()
+    // this keeps the scroll shortcut: the rows the lines land on simply join
+    // the band that gets redrawn.
+    void markLinesDirty(const int firstLine, const int lastLine);
     void needUpdate(int, int);
     void scrollTo(int);
     void scrollH(int);
@@ -270,6 +275,15 @@ private:
     int mScreenHeight;
     // currently viewed screen area
     QPixmap mScreenMap;
+    // What each paint draws into, swapped with mScreenMap once the frame is
+    // finished. Two buffers rather than one because a QPixmap shared with
+    // mScreenMap would deep-copy itself the moment a QPainter opened on it,
+    // which is exactly the full-surface copy this reuse exists to avoid.
+    QPixmap mRenderBuffer;
+    // Buffer lines whose text changed where it stands, so the cached screen
+    // cannot be trusted for the rows they land on. -1 for "none pending".
+    int mDirtyFirstLine = -1;
+    int mDirtyLastLine = -1;
     int mScreenWidth = 100;
     int mScreenOffset = 0;
     int mMaxHRange = 0;

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -46,6 +46,8 @@ INVARIANTS = (
     "corpus_version",
     "display_rows_per_paint",
     "display_cols_per_paint",
+    "display_tail_small_cells",
+    "display_tail_large_cells",
 )
 
 # Gated by default: throughput (lines/sec) for the text and trigger pipelines,

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     DetachedWindowToolBarIconSizeTest.cpp
     PastedLinkStateTest.cpp
     ProfileSwitchMiniconsoleTest.cpp
+    RecolouredLineCacheTest.cpp
     TrackedLinkTrimTest.cpp
     ProfileSwitchShortcutTest.cpp
     SubCommandLineLifetimeTest.cpp

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -132,6 +132,16 @@ private:
     static constexpr int kDisplayPaints = 200;
     static constexpr int kDisplayPasses = 5;
 
+    // A cramped window and a roomy one, so that benchDisplayTail() can report
+    // whether one paint's cost follows the pane's area or the single line that
+    // actually changed. Both have to be sizes the main window will really adopt;
+    // the pass asserts that the row counts came out far enough apart to compare.
+    static constexpr int kDisplayTailSmallWidth = 640;
+    static constexpr int kDisplayTailSmallHeight = 400;
+    static constexpr int kDisplayTailLargeWidth = 1600;
+    static constexpr int kDisplayTailLargeHeight = 1000;
+    static constexpr int kDisplayTailPaints = 400;
+
     enum class LineShape {
         Prompt,
         Damage,
@@ -815,8 +825,129 @@ private slots:
         emitMetric("display_lines_per_sec", paintsPerSec * rows);
     }
 
+    // benchDisplay() above measures the worst case, a full redraw every paint. A
+    // console following a game does the opposite: one line arrives and the rest
+    // of the screen is already drawn, which is what drawForeground()'s scroll
+    // shortcut exists for. What this measures is how much per-paint cost SURVIVES
+    // that shortcut - and specifically whether it scales with the pane's area
+    // rather than with the one line that changed, which is what makes a game feel
+    // slower in a maximised window than in a small one.
+    void benchDisplayTail()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(noTriggersAreRunningYet(host));
+
+        host->mTelnet.loopbackTest(mCorpus);
+        const int bufferedLines = host->mpConsole->buffer.getLastLineNumber();
+        QVERIFY2(bufferedLines > 1000, qPrintable(qsl("console buffer only holds %1 lines - the pipeline did not process the corpus").arg(bufferedLines)));
+
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY(pane);
+
+        TailResult small;
+        measureTailPaints(pane, bufferedLines, kDisplayTailSmallWidth, kDisplayTailSmallHeight, small);
+        QVERIFY2(!QTest::currentTestFailed(), "the small-window pass did not produce a usable measurement");
+
+        TailResult large;
+        measureTailPaints(pane, bufferedLines, kDisplayTailLargeWidth, kDisplayTailLargeHeight, large);
+        QVERIFY2(!QTest::currentTestFailed(), "the large-window pass did not produce a usable measurement");
+
+        // Without a real size difference between the two passes there is no ratio
+        // worth reporting - the window refused to resize, and every number below
+        // would read as a flat 1.0 whatever the paint path does.
+        QVERIFY2(large.cells > small.cells * 2.0,
+                 qPrintable(qsl("the large pane draws %1 cells against the small pane's %2, which is too close to compare - the main window did not take one of the two sizes")
+                                    .arg(large.cells)
+                                    .arg(small.cells)));
+
+        emitMetric("display_tail_small_paint_ms", small.paintMs);
+        emitMetric("display_tail_large_paint_ms", large.paintMs);
+        // Cells drawn at each size: invariants, because two builds that drew
+        // differently sized screens did not do the same work.
+        emitMetric("display_tail_small_cells", static_cast<qint64>(small.cells));
+        emitMetric("display_tail_large_cells", static_cast<qint64>(large.cells));
+        // The headline pair. area_ratio is how much bigger the surface got;
+        // cost_ratio is how much dearer one paint got with it. A paint path that
+        // really only redraws the line that changed holds cost_ratio near 1.0
+        // while area_ratio climbs.
+        emitMetric("display_tail_area_ratio", large.cells / small.cells);
+        emitMetric("display_tail_cost_ratio", large.paintMs / small.paintMs);
+    }
+
 private:
     enum class DefaultPackages { Skip, Install };
+
+    struct TailResult
+    {
+        double paintMs = 0.0;
+        // Character cells on screen. Proportional to the painted pixel area, and
+        // unlike a pixel count it does not move with the platform's font metrics.
+        double cells = 0.0;
+        int rows = 0;
+    };
+
+    // One line of new text per paint at a given window size, which is the shape
+    // of a console following a game rather than one being scrolled through.
+    // Fills `result` rather than returning it so that the QVERIFY macros - which
+    // expand to a bare `return` - can be used here at all; the caller checks
+    // QTest::currentTestFailed() afterwards.
+    void measureTailPaints(TTextEdit* pane, const int bufferedLines, const int windowWidth, const int windowHeight, TailResult& result)
+    {
+        // Sized through the main window for the reason benchDisplay() gives: a
+        // pane resized on its own stays clipped by its unchanged parents.
+        mudlet::self()->resize(windowWidth, windowHeight);
+        // Outside every timed region below. It has to run for the resize to reach
+        // the pane at all, and it is also the only thing that can fire the
+        // scroll-stopped timer, whose slot forces a full redraw.
+        qApp->processEvents();
+
+        result.rows = pane->getScreenHeight();
+        QVERIFY2(result.rows > 1, qPrintable(qsl("the display pane draws %1 rows, which is too few to describe a console").arg(result.rows)));
+        result.cells = static_cast<double>(result.rows) * pane->getColumnCount();
+
+        // Far enough into the buffer that imageTopLine() clears the threshold
+        // below which drawForeground() gives up on the scroll shortcut, and with
+        // room for every paint of every pass to land on real text.
+        const int firstLine = result.rows + 16;
+        QVERIFY2(bufferedLines > firstLine + kDisplayTailPaints,
+                 qPrintable(qsl("%1 buffered lines cannot feed %2 single-line paints below a %3-row screen").arg(bufferedLines).arg(kDisplayTailPaints).arg(result.rows)));
+
+        QPixmap target(pane->size());
+        target.fill(Qt::magenta);
+
+        // Two warm-up paints, not one: the first leaves tail mode and is drawn
+        // under the forced full redraw that transition asks for, and only the
+        // second establishes the last-rendered offset that the scroll shortcut
+        // differences against.
+        pane->scrollTo(firstLine);
+        pane->render(&target);
+        pane->scrollTo(firstLine + 1);
+        pane->render(&target);
+        QVERIFY2(frameHasContent(target.toImage()), "the rendered frame is a single flat colour - nothing was drawn, so the timings below would describe an empty widget");
+
+        // The shortcut only runs while consecutive paints scroll by less than a
+        // screenful, and imageTopLine() is the offset it differences to decide
+        // that. Prove a one-line step really moves it by one line: if it did not,
+        // this would quietly time full redraws and measure benchDisplay() again.
+        const int beforeTop = pane->imageTopLine();
+        pane->scrollTo(firstLine + 2);
+        const int afterTop = pane->imageTopLine();
+        QVERIFY2(afterTop - beforeTop == 1, qPrintable(qsl("a one-line scroll moved the top line by %1, so these paints would not be the incremental ones this measures").arg(afterTop - beforeTop)));
+        QVERIFY2(beforeTop > 10, qPrintable(qsl("the top line is %1, close enough to the start of the buffer that drawForeground() forces full redraws").arg(beforeTop)));
+
+        double best = std::numeric_limits<double>::max();
+        for (int pass = 0; pass < kDisplayPasses; ++pass) {
+            QElapsedTimer timer;
+            timer.start();
+            for (int i = 0; i < kDisplayTailPaints; ++i) {
+                pane->scrollTo(firstLine + i);
+                pane->render(&target);
+            }
+            best = std::min(best, timer.nsecsElapsed() / 1.0e9);
+        }
+        result.paintMs = (best / kDisplayTailPaints) * 1000.0;
+    }
 
     // Called before the benchmark installs any of its own, so anything running
     // came from elsewhere and would be timed as pipeline cost.

--- a/test/functional_tests/RecolouredLineCacheTest.cpp
+++ b/test/functional_tests/RecolouredLineCacheTest.cpp
@@ -1,0 +1,240 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TMainConsole.h"
+#include "TTextEdit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// setFgColor() and its siblings rewrite the colours of an existing selection
+// rather than appending to the buffer. They used to answer that by forcing a
+// whole-screen repaint of both panes, which is what made every coloured echo
+// cost a full relayout; they now mark only the lines the selection covers.
+//
+// The hazard that swap introduces is invisible in the buffer, which holds the
+// new colour either way: the recoloured row has to reach the pane's CACHED
+// screen pixmap. If it only ever reaches the widget, the next paint - which
+// seeds itself from that cache - silently restores the old colour. So the
+// assertion that matters here is not that the recolour shows up, but that it is
+// still there after later output has scrolled the line and forced the cache to
+// be the source of those pixels.
+class RecolouredLineCacheTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    const QString mpHostname = "Test-Recolour";
+    QString mpPort; // assigned the stub's actual ephemeral port in init()
+    const QString mpLocalhost = "localhost";
+
+    // Nothing else on screen is this colour, so counting it is enough to say
+    // whether the recoloured line is being drawn.
+    static QColor markerColor() { return QColor(255, 0, 255); }
+
+    // Antialiasing means few pixels land on the exact colour, so match the
+    // marker by its shape - strong red and blue, little green - rather than
+    // demanding equality.
+    static int countMarkerPixels(const QImage& frame)
+    {
+        int count = 0;
+        for (int y = 0; y < frame.height(); ++y) {
+            for (int x = 0; x < frame.width(); ++x) {
+                const QColor pixel = frame.pixelColor(x, y);
+                if (pixel.red() > 150 && pixel.blue() > 150 && pixel.green() < 80) {
+                    ++count;
+                }
+            }
+        }
+        return count;
+    }
+
+    QString fillerText() const
+    {
+        const QString line = QString(100, QLatin1Char('X'));
+        QString message;
+        for (int i = 0; i < 80; ++i) {
+            message.append(line);
+            message.append(QStringLiteral("\r\n"));
+        }
+        return message;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+    }
+
+    void cleanupTestCase() { mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mpLocalhost, 0);
+        mpPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mpHostname);
+    }
+
+    void test_recolouredLineSurvivesTheScrollThatFollowsIt()
+    {
+        mpServer->setWelcomeMessage(fillerText());
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        QVERIFY2(waitForTextInBuffer(QString(100, QLatin1Char('X'))), "Filler text never reached the buffer");
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY(host);
+        auto console = host->mpConsole;
+        QVERIFY(console);
+        TTextEdit* pane = console->mUpperPane;
+        QVERIFY(pane);
+
+        const int screenRows = pane->getScreenHeight();
+        QVERIFY2(screenRows > 12, qPrintable(qsl("the pane draws only %1 rows, too few to scroll a line without losing it off the top").arg(screenRows)));
+
+        // A row in the UPPER half, so the partial render below can be aimed
+        // somewhere else entirely.
+        const int topLine = pane->imageTopLine();
+        const int targetLine = topLine + 3;
+        QVERIFY2(targetLine < console->buffer.getLastLineNumber(), "not enough buffered lines to pick one to recolour");
+
+        // Warm the pane's cached screen with the pre-recolour picture, so what
+        // the checks below see really is the cache being reused rather than a
+        // first paint drawing everything from the buffer.
+        QPixmap warmUp(pane->size());
+        warmUp.fill(Qt::darkGray);
+        pane->render(&warmUp);
+        QCOMPARE(countMarkerPixels(warmUp.toImage()), 0);
+
+        // Exactly the path Lua's fg() / setFgColor() takes.
+        QVERIFY2(console->moveCursor(0, targetLine), "could not put the user cursor on the line to recolour");
+        QVERIFY2(console->selectSection(0, console->buffer.line(targetLine).size()), "could not select the line to recolour");
+        console->setFgColor(markerColor());
+
+        // A partial repaint aimed at the BOTTOM of the pane - nowhere near the
+        // line just recoloured. Only the dirty-line range can pull that line
+        // into this frame; without it the cache keeps the old colour and the
+        // full render below never gets a chance to recover it.
+        const int rowHeight = std::max(1, pane->height() / screenRows);
+        const QRect elsewhere(0, pane->height() - (2 * rowHeight), pane->width(), 2 * rowHeight);
+        QPixmap partialFrame(pane->size());
+        partialFrame.fill(Qt::darkGray);
+        pane->render(&partialFrame, QPoint(), QRegion(elsewhere));
+
+        // Nothing scrolled, so this frame is served almost entirely from the
+        // cached screen - which is the point. If the recolour never reached the
+        // cache, the old colour is what comes back.
+        QPixmap finalFrame(pane->size());
+        finalFrame.fill(Qt::darkGray);
+        pane->render(&finalFrame);
+
+        QVERIFY2(countMarkerPixels(finalFrame.toImage()) > 0,
+                 "recolouring a line left no trace in the pane's cached screen, so the next paint served the old colour back - the dirty-line range was not honoured");
+    }
+
+private:
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        auto host = TestProfile::create(hostname, address, port);
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    bool waitForTextInBuffer(const QString& text, int timeoutMs = 5000)
+    {
+        auto console = mudlet::self()->getActiveHost()->mpConsole;
+        return QTest::qWaitFor(
+                [&]() {
+                    for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+                        if (console->buffer.line(i) == text) {
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+                timeoutMs);
+    }
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, profileName);
+        deleteDirectory(path);
+    }
+
+    void deleteDirectory(const QString& path)
+    {
+        QDir dir(path);
+        if (!dir.exists()) {
+            return;
+        }
+        dir.removeRecursively();
+    }
+
+private slots:
+    void cleanup()
+    {
+        const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mpHostname);
+        delete mudlet::self();
+        delete mpServer;
+        mpServer = nullptr;
+        deleteDirectory(profilePath);
+    }
+};
+
+#include "RecolouredLineCacheTest.moc"
+MUDLET_GROUPED_TEST_MAIN(RecolouredLineCacheTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `drawForeground()` allocated and cleared a pane-sized `QPixmap` on *every* repaint. At a maximized window on a HiDPI display that is a ~53MB allocation and clear per paint, thousands of page faults before a single glyph is drawn. The buffer is now reused between frames and swapped with the cached screen, so neither pixmap is ever shared when the next paint opens a `QPainter` on it.
- `setFgColor()`, `setBgColor()`, `setDisplayAttributes()` and `setLink()` are handed the exact line range they changed, then discarded it and forced a whole-screen repaint of **both** panes. Every colored echo therefore relaid out the entire console. They now mark only the lines the selection covers, which join the redraw band without disqualifying the scroll shortcut.
- Marking is gated on the `bool` the `TBuffer::apply*` calls already return, so an empty selection marks nothing (caught in review by @vadi2): `cecho()` deselects before every colour segment, and the unguarded call put buffer line 0 into the band, widening a same-frame recolour from 3 of 34 rows to 33 of 34. With the gate, both cases measure 3 of 34.

Measured on a 13.4Mpx pane: **12.17ms → 6.81ms → 4.05ms** per paint. Rows redrawn per paint fell from 51.5 of 89 to 7. An 85-room speedwalk at full screen went from **3.4s to 1.9s**. That was timed against a game server running on the same machine as Mudlet, so the walk figures contain no network latency and are purely client-side cost; against a remote server the same saving would be a smaller share of the total.

#### Motivation for adding to Mudlet

Console output got slower the larger the window was, so anyone playing maximized paid for their screen size on every line the game sent - worst on HiDPI displays, where the surface is four times the pixels.

#### Other info (issues closed, discussion etc)

Complementary to #10171, which is open at the same time and also targets console performance, but at the other end of the pipeline: that one cuts allocation churn getting text *into* `TBuffer`, this one cuts the cost of getting it back *out* onto the screen. Together they address both halves of why colored text is expensive - #10171 makes the per-line walk that color triggers do contiguous, while this found that the repaint `setFgColor()` forced was the far larger cost at the display end. They are measured on different `PipelineBenchmark` metrics (`text_*`/`trigger_*` there, the new `display_tail_*` here) and do not overlap semantically. The only likely merge friction is a few lines apart in `TConsole.h`, where its `printFormatted` signature change sits close to the `markSelectionDirty()` declaration added here; keeping both lines is the resolution.

Also checked against the other open PRs touching `TTextEdit.cpp` - #9688 and #9060. Both conflict with `development` already (they are 131 and 700 commits behind), and test-merging each against this branch produces an identical conflict set to test-merging it against `development`, so this change adds none of its own.

Found by measurement rather than inspection; several plausible-looking causes were ruled out along the way, which is why `PipelineBenchmark` gains `benchDisplayTail`. It measures the incremental one-line-at-a-time case at two pane sizes and reports how much of a paint's cost tracks the pane's *area* rather than what changed. The existing display benchmark deliberately measures full redraws, so this class of regression was invisible to it.

`RecolouredLineCacheTest` covers the hazard the second change introduces: the new color has to reach the pane's cached screen pixmap, not only the widget, or the following paint seeds from that cache and serves the old color back. It was confirmed to fail against a build with the dirty-line range disabled.

Field measurement on this branch, from GMCP-driven speedwalks against a local server (a fuller map profile than the 1.9s figure above, so the absolute times differ): the same ~85-room walk costs 2.3s at quarter-window vs 3.3s at full screen, with the mapper open or closed making no difference and the walk script's own echoes accounting for only ~0.1s of it. Two things fell out of chasing those numbers. First, a speedwalk timer stopped in a GMCP handler measures processing, not visual arrival - buffer timestamps confirmed a walk's final text is painted the same frame it is processed, so there is no hidden render backlog to subtract. Second, ~12ms/room of window-size-dependent paint cost remains inside the receive loop even with this PR: each room event's repaint runs between packets, and a paint still in progress delays processing the next packet. That remainder is the target of a planned follow-up which frame-caps console repaints (the same ~16ms throttle idea `T2DMap` already contains for mouse-wheel zoom), so rapid output batches several lines per frame instead of paying one paint per event.

What remains of a paint is now ~87% two unavoidable full-surface blits, rather than work proportional to the screen. Shrinking those would mean `QWidget::scroll()` so the backing store shifts instead of the frame being recomposed - a separate and riskier change, left for later.

**Test case:** maximize the main window and send a lot of output quickly (a long speedwalk, or `for i=1,500 do cecho("<green>line "..i.."<reset>\n") end`). It should no longer be slower than the same output in a small window. Check that colored text keeps its color as it scrolls, that scrolling up and back down shows no stale text, and that a console background image still renders. Also check that a script that recolours a line (`selectString()` + `fg()`) in the same frame as a `cecho()` still repaints only the recoloured line's rows.

Assisted-by: Claude:claude-opus-5, Claude:claude-fable-5
