### PR TITLE
Improve: Pathfinding no longer slows down as your map grows

### DIFF
--- a/src/TAstar.h
+++ b/src/TAstar.h
@@ -64,7 +64,13 @@ class distance_heuristic : public boost::astar_heuristic<Graph, CostType>
 {
 public:
     typedef typename boost::graph_traits<Graph>::vertex_descriptor Vertex;
-    distance_heuristic(LocMap l, Vertex goal)
+    // The location map is held by reference, not copied: on a large map it is
+    // tens of megabytes (35MB at 2.3 million rooms) and a copy per search costs
+    // more than the search does. That makes the caller responsible for the
+    // referent outliving the heuristic - fine while every user builds one as a
+    // local for the duration of a single search, but storing one across calls
+    // would leave it dangling the next time initGraph() rebuilds locations.
+    distance_heuristic(const LocMap& l, Vertex goal)
     : m_location(l)
     , m_goal(goal)
     {}
@@ -82,7 +88,7 @@ public:
     }
 
 private:
-    LocMap m_location;
+    const LocMap& m_location;
     Vertex m_goal;
 };
 

--- a/src/TAstar.h
+++ b/src/TAstar.h
@@ -64,16 +64,22 @@ class distance_heuristic : public boost::astar_heuristic<Graph, CostType>
 {
 public:
     typedef typename boost::graph_traits<Graph>::vertex_descriptor Vertex;
-    // The location map is held by reference, not copied: on a large map it is
-    // tens of megabytes (35MB at 2.3 million rooms) and a copy per search costs
-    // more than the search does. That makes the caller responsible for the
-    // referent outliving the heuristic - fine while every user builds one as a
-    // local for the duration of a single search, but storing one across calls
-    // would leave it dangling the next time initGraph() rebuilds locations.
+    // The location map is held by reference, not copied: it is one entry per
+    // room, so on a large map a copy per search costs more than the search does
+    // (35MB on the 2.3 million room map this was measured against). Every
+    // caller passes TMap::locations, which outlives any heuristic built from it
+    // and survives initGraph() - that only clear()s the vector, so the object
+    // itself is never destroyed. The hazard is therefore staleness rather than
+    // a dangling reference: a heuristic kept across an initGraph() would read
+    // coordinates for renumbered rooms, so do not store one.
     distance_heuristic(const LocMap& l, Vertex goal)
     : m_location(l)
     , m_goal(goal)
     {}
+
+    // Binding a temporary here would leave m_location dangling on the first
+    // call, so make it a compile error rather than something to remember.
+    distance_heuristic(const LocMap&&, Vertex) = delete;
 
     CostType operator()(Vertex u)
     {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -850,22 +850,15 @@ void TMap::initGraph()
         boost::add_vertex(g);
     }
 
-    // searchGraph() keeps its per-room state between searches, so this is the
-    // one place it can go stale: rebuilding the graph renumbers the vertices,
-    // and a leftover mSearchTouched would then have the next search "restore"
-    // indices that now mean different rooms. That is safe because this function
-    // is the only place g is cleared or given vertices, and findPath() is its
-    // only caller - so room deletion, area deletion and a map reload all reach
-    // it through the mMapGraphNeedsUpdate flag rather than touching the graph
-    // themselves. Reinitialise rather than merely resize, or entries below the
-    // old room count survive.
-    mSearchPredecessor.resize(roomCount);
-    for (unsigned int i = 0; i < roomCount; ++i) {
-        mSearchPredecessor[i] = i;
-    }
-    mSearchDistance.assign(roomCount, std::numeric_limits<cost>::max());
-    mSearchState.assign(roomCount, 0);
-    mSearchTouched.clear();
+    // searchGraph() keeps its per-room state between searches, so a rebuild has
+    // to put that state back in step with the graph. This function is the only
+    // one that clears g or gives it vertices, which makes it the only place the
+    // state can go stale - room deletion, area deletion and a map reload all
+    // arrive here through mMapGraphNeedsUpdate rather than touching the graph
+    // themselves. A surviving mSearchTouched would be worse than merely wrong:
+    // the next search restores the rooms it names, so an entry past a shrunken
+    // roomCount is an out-of-bounds write.
+    resetSearchState(roomCount);
 
     // Now identify the routes between rooms, and pick out the best edges of parallel ones
     for (auto l : locations) {
@@ -918,6 +911,20 @@ void TMap::initGraph()
              << "other NOT usable rooms and found:" << edgeCount << "distinct, usable edges in:" << _time.nsecsElapsed() * 1.0e-6 << "ms.";
 }
 
+// Put every room back to "not yet reached". Refills the three per-room vectors
+// rather than only resizing them, or stale values below the old room count
+// survive a rebuild that shrank the map.
+void TMap::resetSearchState(const std::size_t roomCount)
+{
+    mSearchPredecessor.resize(roomCount);
+    for (std::size_t i = 0; i < roomCount; ++i) {
+        mSearchPredecessor[i] = i;
+    }
+    mSearchDistance.assign(roomCount, std::numeric_limits<cost>::max());
+    mSearchState.assign(roomCount, 0);
+    mSearchTouched.clear();
+}
+
 // A* from one room to another, leaving the route in mSearchPredecessor.
 //
 // boost::astar_search() would do the same job, but before it looks at a single
@@ -928,17 +935,30 @@ void TMap::initGraph()
 // searches instead and only the rooms the last search wrote to are put back.
 bool TMap::searchGraph(const vertex start, const vertex goal)
 {
-    // mSearchState values: a room not yet reached is 0, one waiting in the
-    // frontier is 1, and one already expanded is 2.
+    // A room not yet reached is 0, one that has been reached is stateFrontier,
+    // and one already expanded is stateExpanded - though a re-opened room drops
+    // back to stateFrontier. Only 0 and stateExpanded are ever tested: writing
+    // stateFrontier is what stops a room being listed in mSearchTouched twice.
     static constexpr quint8 stateFrontier = 1;
     static constexpr quint8 stateExpanded = 2;
 
-    for (const vertex touched : mSearchTouched) {
-        mSearchPredecessor[touched] = touched;
-        mSearchDistance[touched] = std::numeric_limits<cost>::max();
-        mSearchState[touched] = 0;
+    // A search that finds nothing has to settle every room it can reach, so one
+    // getPath() to an unreachable room leaves the touched list naming most of the
+    // map - 8 bytes a room, held for the rest of the session, where the old code
+    // freed its scratch after every search. Past half the map give the memory
+    // back and refill instead; the list has stopped being the smaller job by
+    // then anyway, though the point where that happens was not measured.
+    if (mSearchTouched.size() > mSearchPredecessor.size() / 2) {
+        resetSearchState(mSearchPredecessor.size());
+        std::vector<vertex>().swap(mSearchTouched);
+    } else {
+        for (const vertex touched : mSearchTouched) {
+            mSearchPredecessor[touched] = touched;
+            mSearchDistance[touched] = std::numeric_limits<cost>::max();
+            mSearchState[touched] = 0;
+        }
+        mSearchTouched.clear();
     }
-    mSearchTouched.clear();
 
     const WeightMap weights = boost::get(boost::edge_weight, g);
     distance_heuristic<mygraph_t, cost, std::vector<location>> heuristic(locations, goal);
@@ -1094,6 +1114,17 @@ bool TMap::findPath(int from, int to)
     if (static_cast<std::size_t>(start) >= vertexCount || static_cast<std::size_t>(goal) >= vertexCount) {
         qWarning().nospace().noquote() << "TMap::findPath(" << from << "," << to << ") FAIL: start or target vertex outside of graph range (vertexCount=" << vertexCount << ").";
         return false;
+    }
+
+    // The check above is what keeps searchGraph()'s unchecked indexing in range,
+    // so the search state has to be the same size as the graph for it to mean
+    // anything. Sizing it is initGraph()'s job and nothing else adds vertices,
+    // but boost::add_edge() on a vecS graph grows one silently to fit an
+    // out-of-range index, which would part the two without saying so.
+    if (mSearchPredecessor.size() != vertexCount) {
+        qWarning().nospace().noquote() << "TMap::findPath(" << from << "," << to << ") WARN: search state (" << mSearchPredecessor.size() << ") is out of step with the graph (" << vertexCount
+                                       << ") - resetting it.";
+        resetSearchState(vertexCount);
     }
 
     if (!searchGraph(start, goal)) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -50,6 +50,12 @@
 #include <QSaveFile>
 #include <QSizeF>
 #include <chrono>
+#include <limits>
+#include <queue>
+
+#ifndef Q_MOC_RUN
+#include <boost/range/iterator_range.hpp>
+#endif
 
 using namespace std::chrono_literals;
 
@@ -844,6 +850,23 @@ void TMap::initGraph()
         boost::add_vertex(g);
     }
 
+    // searchGraph() keeps its per-room state between searches, so this is the
+    // one place it can go stale: rebuilding the graph renumbers the vertices,
+    // and a leftover mSearchTouched would then have the next search "restore"
+    // indices that now mean different rooms. That is safe because this function
+    // is the only place g is cleared or given vertices, and findPath() is its
+    // only caller - so room deletion, area deletion and a map reload all reach
+    // it through the mMapGraphNeedsUpdate flag rather than touching the graph
+    // themselves. Reinitialise rather than merely resize, or entries below the
+    // old room count survive.
+    mSearchPredecessor.resize(roomCount);
+    for (unsigned int i = 0; i < roomCount; ++i) {
+        mSearchPredecessor[i] = i;
+    }
+    mSearchDistance.assign(roomCount, std::numeric_limits<cost>::max());
+    mSearchState.assign(roomCount, 0);
+    mSearchTouched.clear();
+
     // Now identify the routes between rooms, and pick out the best edges of parallel ones
     for (auto l : locations) {
         unsigned const int source = l.id;
@@ -893,6 +916,76 @@ void TMap::initGraph()
     mMapGraphNeedsUpdate = false;
     qDebug() << "TMap::initGraph() INFO: built graph with:" << locations.size() << "(" << roomCount << ") locations(roomCount), and discarded" << unUsableRoomSet.count()
              << "other NOT usable rooms and found:" << edgeCount << "distinct, usable edges in:" << _time.nsecsElapsed() * 1.0e-6 << "ms.";
+}
+
+// A* from one room to another, leaving the route in mSearchPredecessor.
+//
+// boost::astar_search() would do the same job, but before it looks at a single
+// exit it resets one entry per room in the WHOLE map - four property maps' worth
+// - so a two-room walk on a 2.3 million room map pays for 2.3 million rooms.
+// Measured on Ssaliss' Aetherspace map that fixed toll is ~55ms, an order of
+// magnitude more than an ordinary search costs. Here the state lives across
+// searches instead and only the rooms the last search wrote to are put back.
+bool TMap::searchGraph(const vertex start, const vertex goal)
+{
+    // mSearchState values: a room not yet reached is 0, one waiting in the
+    // frontier is 1, and one already expanded is 2.
+    static constexpr quint8 stateFrontier = 1;
+    static constexpr quint8 stateExpanded = 2;
+
+    for (const vertex touched : mSearchTouched) {
+        mSearchPredecessor[touched] = touched;
+        mSearchDistance[touched] = std::numeric_limits<cost>::max();
+        mSearchState[touched] = 0;
+    }
+    mSearchTouched.clear();
+
+    const WeightMap weights = boost::get(boost::edge_weight, g);
+    distance_heuristic<mygraph_t, cost, std::vector<location>> heuristic(locations, goal);
+
+    typedef std::pair<cost, vertex> frontierEntry;
+    std::priority_queue<frontierEntry, std::vector<frontierEntry>, std::greater<frontierEntry>> frontier;
+
+    mSearchDistance[start] = 0;
+    mSearchState[start] = stateFrontier;
+    mSearchTouched.push_back(start);
+    frontier.push({heuristic(start), start});
+
+    while (!frontier.empty()) {
+        const vertex current = frontier.top().second;
+        frontier.pop();
+        if (mSearchState[current] == stateExpanded) {
+            // A cheaper route to this room was found after it was queued, so
+            // the frontier holds it more than once; this is the stale copy.
+            continue;
+        }
+        mSearchState[current] = stateExpanded;
+        if (current == goal) {
+            return true;
+        }
+
+        for (const auto& exit : boost::make_iterator_range(boost::out_edges(current, g))) {
+            const vertex neighbour = boost::target(exit, g);
+            const cost throughCurrent = mSearchDistance[current] + boost::get(weights, exit);
+            if (throughCurrent >= mSearchDistance[neighbour]) {
+                continue;
+            }
+            if (mSearchState[neighbour] == 0) {
+                mSearchTouched.push_back(neighbour);
+            }
+            mSearchDistance[neighbour] = throughCurrent;
+            mSearchPredecessor[neighbour] = current;
+            // An already expanded room goes back into the frontier: the
+            // heuristic measures map coordinates while the costs are room
+            // weights, so the two need not agree and a better route to a room
+            // already left behind can still turn up. boost::astar_search()
+            // re-opens rooms for the same reason.
+            mSearchState[neighbour] = stateFrontier;
+            frontier.push({throughCurrent + heuristic(neighbour), neighbour});
+        }
+    }
+
+    return false;
 }
 
 bool TMap::findPath(int from, int to)
@@ -1003,111 +1096,101 @@ bool TMap::findPath(int from, int to)
         return false;
     }
 
-    std::vector<vertex> p(vertexCount);
-    // Somehow p is an ascending, monotonic series of numbers start at 0, it
-    // seems we have a redundant indirection in play there as p[0]=0, p[1]=1,..., p[n]=n ...!
-    std::vector<cost> d(vertexCount);
-    try {
-        astar_search(g, start, distance_heuristic<mygraph_t, cost, std::vector<location>>(locations, goal), predecessor_map(&p[0]).distance_map(&d[0]).visitor(astar_goal_visitor<vertex>(goal)));
-    } catch (const found_goal&) {
-        qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: time elapsed in A*:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
-        t.restart();
-        if (!roomidToIndex.contains(to)) {
-            qDebug() << "TMap::findPath(" << from << "," << to << ") FAIL: target room not in map graph!";
-            return false;
-        }
-
-        vertex currentVertex = roomidToIndex.value(to);
-        unsigned int currentRoomId = (locations.at(currentVertex)).id;
-
-        // We step through the found path BACKWARDS so advance (well retard)
-        // the "previous" one first, and it will be the SOURCE vertex for the
-        // edge and current will be the TARGET vertex:
-        vertex previousVertex = currentVertex;
-        do {
-            previousVertex = p[currentVertex];
-            if (previousVertex == currentVertex) {
-                qDebug() << "TMap::findPath(" << from << "," << to << ") WARN: unable to build a path in:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
-                mPathList.clear();
-                mDirList.clear();
-                mWeightList.clear(); // Reset any partial results...
-                return false;
-            }
-            const unsigned int previousRoomId = (locations.at(previousVertex)).id;
-            QPair<unsigned int, unsigned int> const edgeRoomIdPair = qMakePair(previousRoomId, currentRoomId);
-            const route r = edgeHash.value(edgeRoomIdPair);
-            mPathList.prepend(currentRoomId);
-            Q_ASSERT_X(r.cost > 0, "TMap::findPath()", "broken path {QPair made from source and target roomIds for a path step NOT found in QHash table of all possible steps.}");
-            // Above was found to be triggered by the situation described in:
-            // https://bugs.launchpad.net/mudlet/+bug/1263447 on 2015-07-17 but
-            // this is because previousVertex was the same as currentVertex after
-            // the "previousVertex = p[currentVertex]" operation at the start of
-            // the do{} loop - added a test for this so should bail out if it
-            // happens - Slysven
-            mWeightList.prepend(r.cost);
-            switch (r.direction) {
-                /*
-                 * Do not translate the directions into the user's locale here,
-                 * that is to be done in the profile specific doSpeedwalk()
-                 * function of the mapper package as the language of the MUD
-                 * need not be the native language of the user - translating
-                 * them here makes the mapper harder to code as it has to
-                 * accommodate all the possible languages the GUI of Mudlet was
-                 * configured to support!
-                 */
-            case DIR_NORTH:
-                mDirList.prepend(qsl("n"));
-                break;
-            case DIR_NORTHEAST:
-                mDirList.prepend(qsl("ne"));
-                break;
-            case DIR_EAST:
-                mDirList.prepend(qsl("e"));
-                break;
-            case DIR_SOUTHEAST:
-                mDirList.prepend(qsl("se"));
-                break;
-            case DIR_SOUTH:
-                mDirList.prepend(qsl("s"));
-                break;
-            case DIR_SOUTHWEST:
-                mDirList.prepend(qsl("sw"));
-                break;
-            case DIR_WEST:
-                mDirList.prepend(qsl("w"));
-                break;
-            case DIR_NORTHWEST:
-                mDirList.prepend(qsl("nw"));
-                break;
-            case DIR_UP:
-                mDirList.prepend(qsl("up"));
-                break;
-            case DIR_DOWN:
-                mDirList.prepend(qsl("down"));
-                break;
-            case DIR_IN:
-                mDirList.prepend(qsl("in"));
-                break;
-            case DIR_OUT:
-                mDirList.prepend(qsl("out"));
-                break;
-            case DIR_OTHER:
-                mDirList.prepend(r.specialExitName);
-                break;
-            default:
-                qWarning().nospace().noquote() << "TMap::findPath(" << from << ", " << to << ") WARNING - found route between rooms (from id: " << previousRoomId << ", to id: " << currentRoomId
-                                               << ") with an invalid DIR_xxxx code: " << r.direction << " - the path will not be valid!";
-            }
-            currentVertex = previousVertex;
-            currentRoomId = previousRoomId;
-        } while (currentVertex != start);
-
-        qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: found path in:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
-        return true;
+    if (!searchGraph(start, goal)) {
+        qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: did NOT find path in:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
+        return false;
     }
 
-    qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: did NOT find path in:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
-    return false;
+    qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: time elapsed in A*:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
+    t.restart();
+
+    vertex currentVertex = goal;
+    unsigned int currentRoomId = (locations.at(currentVertex)).id;
+
+    // We step through the found path BACKWARDS so advance (well retard)
+    // the "previous" one first, and it will be the SOURCE vertex for the
+    // edge and current will be the TARGET vertex:
+    vertex previousVertex = currentVertex;
+    do {
+        previousVertex = mSearchPredecessor[currentVertex];
+        if (previousVertex == currentVertex) {
+            qDebug() << "TMap::findPath(" << from << "," << to << ") WARN: unable to build a path in:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
+            mPathList.clear();
+            mDirList.clear();
+            mWeightList.clear(); // Reset any partial results...
+            return false;
+        }
+        const unsigned int previousRoomId = (locations.at(previousVertex)).id;
+        QPair<unsigned int, unsigned int> const edgeRoomIdPair = qMakePair(previousRoomId, currentRoomId);
+        const route r = edgeHash.value(edgeRoomIdPair);
+        mPathList.prepend(currentRoomId);
+        Q_ASSERT_X(r.cost > 0, "TMap::findPath()", "broken path {QPair made from source and target roomIds for a path step NOT found in QHash table of all possible steps.}");
+        // Above was found to be triggered by the situation described in:
+        // https://bugs.launchpad.net/mudlet/+bug/1263447 on 2015-07-17 but
+        // this is because previousVertex was the same as currentVertex after
+        // the "previousVertex = p[currentVertex]" operation at the start of
+        // the do{} loop - added a test for this so should bail out if it
+        // happens - Slysven
+        mWeightList.prepend(r.cost);
+        switch (r.direction) {
+            /*
+             * Do not translate the directions into the user's locale here,
+             * that is to be done in the profile specific doSpeedwalk()
+             * function of the mapper package as the language of the MUD
+             * need not be the native language of the user - translating
+             * them here makes the mapper harder to code as it has to
+             * accommodate all the possible languages the GUI of Mudlet was
+             * configured to support!
+             */
+        case DIR_NORTH:
+            mDirList.prepend(qsl("n"));
+            break;
+        case DIR_NORTHEAST:
+            mDirList.prepend(qsl("ne"));
+            break;
+        case DIR_EAST:
+            mDirList.prepend(qsl("e"));
+            break;
+        case DIR_SOUTHEAST:
+            mDirList.prepend(qsl("se"));
+            break;
+        case DIR_SOUTH:
+            mDirList.prepend(qsl("s"));
+            break;
+        case DIR_SOUTHWEST:
+            mDirList.prepend(qsl("sw"));
+            break;
+        case DIR_WEST:
+            mDirList.prepend(qsl("w"));
+            break;
+        case DIR_NORTHWEST:
+            mDirList.prepend(qsl("nw"));
+            break;
+        case DIR_UP:
+            mDirList.prepend(qsl("up"));
+            break;
+        case DIR_DOWN:
+            mDirList.prepend(qsl("down"));
+            break;
+        case DIR_IN:
+            mDirList.prepend(qsl("in"));
+            break;
+        case DIR_OUT:
+            mDirList.prepend(qsl("out"));
+            break;
+        case DIR_OTHER:
+            mDirList.prepend(r.specialExitName);
+            break;
+        default:
+            qWarning().nospace().noquote() << "TMap::findPath(" << from << ", " << to << ") WARNING - found route between rooms (from id: " << previousRoomId << ", to id: " << currentRoomId
+                                           << ") with an invalid DIR_xxxx code: " << r.direction << " - the path will not be valid!";
+        }
+        currentVertex = previousVertex;
+        currentRoomId = previousRoomId;
+    } while (currentVertex != start);
+
+    qDebug() << "TMap::findPath(" << from << "," << to << ") INFO: found path in:" << t.nsecsElapsed() * 1.0e-6 << "ms.";
+    return true;
 }
 
 bool TMap::serialize(QDataStream& ofs, int saveVersion)

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -301,16 +301,6 @@ public:
     mygraph_t g;
     QHash<QPair<unsigned int, unsigned int>, route> edgeHash; // For Mudlet to decode BGL edges
     std::vector<location> locations;
-    // Per-room search state, sized to the graph and kept between searches - see
-    // searchGraph(). mSearchTouched lists every room the last search wrote to,
-    // which is what lets the next one put the defaults back without walking the
-    // whole map. initGraph() has to reinitialise all four when it rebuilds the
-    // graph, for the reason given there.
-    std::vector<vertex> mSearchPredecessor;
-    std::vector<cost> mSearchDistance;
-    std::vector<quint8> mSearchState;
-    std::vector<vertex> mSearchTouched;
-    bool searchGraph(const vertex start, const vertex goal);
     bool mMapGraphNeedsUpdate = true;
     bool mNewMove = true;
 
@@ -405,6 +395,25 @@ public slots:
 
 
 private:
+    // Puts the per-room search state back to its defaults at the given room
+    // count, sizing it to match.
+    void resetSearchState(const std::size_t roomCount);
+
+    // A* from start to goal, leaving the route in mSearchPredecessor - see the
+    // definition for why this exists rather than boost::astar_search().
+    bool searchGraph(const vertex start, const vertex goal);
+
+    // Per-room search state, kept between searches instead of being rebuilt for
+    // each one. The first three hold one entry per room and are refilled by
+    // initGraph(); mSearchTouched is instead a list of just the rooms the last
+    // search wrote to, which is what lets the next one restore the defaults
+    // without walking the whole map. initGraph() must put all four back in step
+    // with the graph, for the reason given there.
+    std::vector<vertex> mSearchPredecessor;
+    std::vector<cost> mSearchDistance;
+    std::vector<quint8> mSearchState;
+    std::vector<vertex> mSearchTouched;
+
     // Held for the whole of a map operation that pumps the event loop, so that
     // mapOperationInProgress() can tell anything re-entered from that pump that
     // this map is on the stack. Nested operations are counted, not flagged: an

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -301,6 +301,16 @@ public:
     mygraph_t g;
     QHash<QPair<unsigned int, unsigned int>, route> edgeHash; // For Mudlet to decode BGL edges
     std::vector<location> locations;
+    // Per-room search state, sized to the graph and kept between searches - see
+    // searchGraph(). mSearchTouched lists every room the last search wrote to,
+    // which is what lets the next one put the defaults back without walking the
+    // whole map. initGraph() has to reinitialise all four when it rebuilds the
+    // graph, for the reason given there.
+    std::vector<vertex> mSearchPredecessor;
+    std::vector<cost> mSearchDistance;
+    std::vector<quint8> mSearchState;
+    std::vector<vertex> mSearchTouched;
+    bool searchGraph(const vertex start, const vertex goal);
     bool mMapGraphNeedsUpdate = true;
     bool mNewMove = true;
 

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -1629,8 +1629,10 @@ describe("Tests mapper functions against a shared fixture", function()
       -- Guarantee a clean routing graph even if an assertion above failed.
       setExitWeightFilter(nil)
       setExitWeight(rA1, "east", 0)
-      lockRoom(rA2, false)
       lockExit(rA1, "east", false)
+      for _, id in ipairs({rA2, rB1, rB2, rG1, rSandA, rSandB}) do
+        lockRoom(id, false)
+      end
     end)
 
     it("finds the shortest route and fills the speedwalk globals", function()
@@ -1701,6 +1703,106 @@ describe("Tests mapper functions against a shared fixture", function()
       local ok = getPath(rA1, rA3)
       assert.is_true(ok)
       assert.are.same({tostring(rA4), tostring(rA5), tostring(rA3)}, speedWalkPath)
+    end)
+
+    -- Every case above edits the map first, so each one searches a graph that
+    -- has just been rebuilt. These four do not, which is what puts them on the
+    -- state findPath() carries from one search to the next.
+
+    it("does not inherit the previous search's state", function()
+      local firstOk = getPath(rA1, rA3)
+      assert.is_true(firstOk)
+      assert.are.same({tostring(rA2), tostring(rA3)}, speedWalkPath)
+
+      -- Reversed, so the second search has to better the rooms the first one
+      -- had already settled rather than reaching fresh ones.
+      local ok, weight = getPath(rA3, rA1)
+      assert.is_true(ok)
+      assert.are.equal(2, weight)
+      assert.are.same({"w", "w"}, speedWalkDir)
+      assert.are.same({tostring(rA2), tostring(rA1)}, speedWalkPath)
+    end)
+
+    it("does not inherit the state of a search that found nothing", function()
+      -- Giving up means settling every room reachable from the start, so this
+      -- leaves behind the largest amount of state a search on this map can.
+      local failedOk = getPath(rA1, rSandA)
+      assert.is_false(failedOk)
+
+      local ok, weight = getPath(rA1, rA3)
+      assert.is_true(ok)
+      assert.are.equal(2, weight)
+      assert.are.same({tostring(rA2), tostring(rA3)}, speedWalkPath)
+    end)
+
+    it("does not reuse the old room numbering after the graph is rebuilt", function()
+      local firstOk = getPath(rA1, rB2)
+      assert.is_true(firstOk)
+
+      -- Locking rooms drops them from the graph, so the rooms left are
+      -- renumbered and the numbers the search above recorded no longer name the
+      -- rooms they did. Fewer rooms than before is the case that matters: a
+      -- surviving number can then be past the end of the state itself.
+      for _, id in ipairs({rA2, rB1, rB2, rG1, rSandA, rSandB}) do
+        lockRoom(id, true)
+      end
+
+      local ok, weight = getPath(rA1, rA3)
+      assert.is_true(ok)
+      assert.are.equal(3, weight)
+      assert.are.same({tostring(rA4), tostring(rA5), tostring(rA3)}, speedWalkPath)
+    end)
+  end)
+
+  describe("Tests pathfinding where the weights disagree with the coordinates", function()
+    -- A* is steered by straight-line distance to the target but pays in exit
+    -- weights, and nothing makes the two agree. rX sits right beside the target
+    -- and is reached early over a costly exit; the cheap way to it only turns up
+    -- later, through rY, which is the wrong way entirely as the crow flies. The
+    -- route through rZ is there to be beaten: it wins unless the better price
+    -- for rX is carried forward to the target.
+    local areaWeighted
+    local rWStart, rX, rY, rZ, rWGoal
+
+    setup(function()
+      areaWeighted = addAreaName("MapperSpecWeighted")
+
+      local function makeRoom(x, y)
+        local id = createRoomID()
+        addRoom(id)
+        setRoomArea(id, areaWeighted)
+        setRoomCoordinates(id, x, y, 0)
+        return id
+      end
+
+      rWGoal = makeRoom(0, 0)
+      rX = makeRoom(1, 0)
+      rZ = makeRoom(0, 10)
+      rY = makeRoom(0, 20)
+      rWStart = makeRoom(0, 30)
+
+      -- One-way throughout, so the graph is exactly the one the weights
+      -- describe and no return exit offers a cheaper way round.
+      setExit(rWStart, rX, "southeast"); setExitWeight(rWStart, "southeast", 10)
+      setExit(rWStart, rZ, "southwest"); setExitWeight(rWStart, "southwest", 5)
+      setExit(rWStart, rY, "south"); setExitWeight(rWStart, "south", 1)
+      setExit(rY, rX, "southeast"); setExitWeight(rY, "southeast", 1)
+      setExit(rZ, rWGoal, "south"); setExitWeight(rZ, "south", 20)
+      setExit(rX, rWGoal, "west"); setExitWeight(rX, "west", 20)
+    end)
+
+    teardown(function()
+      for _, id in ipairs({rWStart, rX, rY, rZ, rWGoal}) do
+        deleteRoom(id)
+      end
+      deleteArea("MapperSpecWeighted")
+    end)
+
+    it("takes the cheapest route even though a nearer room was settled first", function()
+      local ok, weight = getPath(rWStart, rWGoal)
+      assert.is_true(ok)
+      assert.are.equal(22, weight)
+      assert.are.same({tostring(rY), tostring(rX), tostring(rWGoal)}, speedWalkPath)
     end)
   end)
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -191,9 +191,11 @@ add_functional_test_binary(UndoServerWrapReplay UndoServerWrapReplay.cpp)
 # also registers it with ctest.
 option(REGISTER_PERF_BENCHMARK "Register the report-only PipelineBenchmark with ctest (it is built either way)" OFF)
 add_functional_test_binary(PipelineBenchmark PipelineBenchmark.cpp)
-# The A* speedwalk search's companion. Never registered with ctest at all: it
-# needs a map file too big to commit, handed to it in MUDLET_BENCH_MAP, and
-# skips without one.
+# Report-only baseline for the A* speedwalk search and the graph rebuild that
+# feeds it, run as
+#   MUDLET_BENCH_MAP=/path/to/map.dat QT_QPA_PLATFORM=offscreen ./PathfindBenchmark
+# Never registered with ctest at all, because the map it needs is far too big to
+# commit and it skips without one.
 add_functional_test_binary(PathfindBenchmark PathfindBenchmark.cpp)
 if(REGISTER_PERF_BENCHMARK)
     add_test(NAME PipelineBenchmark COMMAND $<TARGET_FILE:PipelineBenchmark>)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -191,6 +191,10 @@ add_functional_test_binary(UndoServerWrapReplay UndoServerWrapReplay.cpp)
 # also registers it with ctest.
 option(REGISTER_PERF_BENCHMARK "Register the report-only PipelineBenchmark with ctest (it is built either way)" OFF)
 add_functional_test_binary(PipelineBenchmark PipelineBenchmark.cpp)
+# The A* speedwalk search's companion. Never registered with ctest at all: it
+# needs a map file too big to commit, handed to it in MUDLET_BENCH_MAP, and
+# skips without one.
+add_functional_test_binary(PathfindBenchmark PathfindBenchmark.cpp)
 if(REGISTER_PERF_BENCHMARK)
     add_test(NAME PipelineBenchmark COMMAND $<TARGET_FILE:PipelineBenchmark>)
     # large corpus fed repeatedly, so allow a generous timeout

--- a/test/functional_tests/PathfindBenchmark.cpp
+++ b/test/functional_tests/PathfindBenchmark.cpp
@@ -29,7 +29,9 @@
  *
  *   MUDLET_BENCH_MAP=/path/to/map.dat QT_QPA_PLATFORM=offscreen ./PathfindBenchmark
  *
- * Scenarios walk between rooms of the busiest Z level of the busiest area, at
+ * Set MUDLET_BENCH_AREA to pin a particular area instead of the busiest one.
+ *
+ * Scenarios walk between rooms of the busiest Z level of the chosen area, at
  * increasing separations, because A* cost scales with how much of the graph the
  * frontier has to sweep - and the whole question is how much of the per-search
  * cost is that sweep and how much is a fixed toll paid on every search
@@ -45,7 +47,6 @@
 #include <clocale>
 #include <cstdio>
 #include <limits>
-#include <queue>
 
 #include "PortableModeTestHelper.h"
 #include "ProfileTestHelper.h"
@@ -75,9 +76,10 @@
 #endif
 
 // Prototype of the per-vertex arrays A* could keep between searches. A map
-// over one of them remembers every vertex it wrote to, so the next search puts
-// the defaults back for just those rather than for every room on the map -
-// which is the whole of what astar_search() does before it looks at an edge.
+// over one of them records each write, so the next search puts the defaults
+// back for just those rather than for every room on the map - which is the
+// whole of what astar_search() does before it looks at an edge. Repeat writes
+// are recorded again, so the touched list counts writes, not distinct rooms.
 template <typename Value>
 class ScratchMap
 {
@@ -135,11 +137,13 @@ private:
     struct Scenario
     {
         const char* name;
-        // Separation between the two rooms, in map units along one axis.
+        // Added to BOTH the x and y of the start room, so the target of
+        // {"near", 10} is 10 map units away on each axis, not 10 in total.
         int offset;
     };
 
-    // 0 means "the far corner of the level", the longest walk it can hold.
+    // 0 means "the room nearest the far corner". The start is the middle of
+    // the level, so that is about a half-diagonal, not its longest walk.
     static constexpr Scenario kScenarios[] = {
             {"adjacent", 1},
             {"near", 10},
@@ -299,9 +303,9 @@ private slots:
                 continue;
             }
 
-            // One untimed search first: it settles any lazily-grown property
-            // map inside BGL, and proves the pair really is connected before
-            // the timings claim to describe a successful search.
+            // One untimed search first, so the timed passes cannot be the run
+            // that faults in whatever the first search touches, and so a failed
+            // search is caught here rather than silently timed as a success.
             QVERIFY2(pMap->findPath(startId, targetId),
                      qPrintable(qsl("scenario \"%1\" found no path from %2 to %3, so its timings would describe a failed search")
                                         .arg(QString::fromUtf8(scenario.name), QString::number(startId), QString::number(targetId))));
@@ -310,24 +314,37 @@ private slots:
             double best = std::numeric_limits<double>::max();
             for (int pass = 0; pass < kPasses; ++pass) {
                 timer.restart();
-                pMap->findPath(startId, targetId);
+                const bool found = pMap->findPath(startId, targetId);
                 best = std::min(best, timer.nsecsElapsed() / 1.0e6);
+                // These are the repeats, so they are the passes running on state
+                // the previous search left behind. A pass that stopped finding
+                // the route would otherwise be reported as a faster one.
+                QVERIFY2(found, qPrintable(qsl("scenario \"%1\" pass %2 found no path the first search found").arg(QString::fromUtf8(scenario.name), QString::number(pass))));
+                QCOMPARE(pMap->mPathList.size(), steps);
             }
 
             const QString prefix = qsl("path_%1").arg(QString::fromUtf8(scenario.name));
             emitMetric(qsl("%1_ms").arg(prefix), best);
-            // Workload invariants: a build that walked a different distance, or
-            // found a different route, did not do the same work.
+            // Workload invariant: a build that walked a different distance, or
+            // to a different room, did not do the same work. Two routes of equal
+            // length through different rooms would pass this.
             emitMetric(qsl("%1_steps").arg(prefix), static_cast<qint64>(steps));
             emitMetric(qsl("%1_target_room").arg(prefix), static_cast<qint64>(targetId));
         }
 
-        // Where a search's fixed toll goes. findPath() allocates two
-        // vertex-sized vectors of its own, and astar_search() then writes four
-        // property maps for every vertex in the WHOLE map - both before it has
-        // looked at a single edge - so a two-room walk on a 2.3M room map pays
-        // for 2.3M rooms. Measured on the shortest scenario, where the search
-        // proper is a couple of vertices and everything else is that toll.
+        // Where the fixed toll used to go. findPath() allocated two vertex-sized
+        // vectors of its own and handed them to astar_search(), which writes four
+        // property maps for every vertex in the WHOLE map before it looks at a
+        // single edge - so a two-room walk paid for every room. Run on the
+        // shortest scenario, where the search proper is a couple of vertices and
+        // everything else is that toll.
+        //
+        // These describe the shape of that cost rather than reproducing what it
+        // totalled: they report the best of several passes, so the arrays are
+        // warm by then, and the heuristic no longer copies the location list per
+        // search because that fix lives in the shared header this includes. For
+        // the end-to-end figure compare path_adjacent_ms against a build made
+        // without this change.
         {
             const int targetId = nearestTo(byCoordinate, centreX + 1, centreY, maxX - minX);
             const auto vertexCount = static_cast<std::size_t>(boost::num_vertices(pMap->g));
@@ -356,8 +373,8 @@ private slots:
             emitMetric("toll_astar_search_ms", bestSearch);
 
             // Same search, but with every per-vertex array allocated once and
-            // handed in: astar_search() still writes all 2.3M entries, it just
-            // no longer faults in fresh pages to do it.
+            // handed in: astar_search() still writes one entry per vertex, it
+            // just no longer faults in fresh pages to do it.
             std::vector<TMap::vertex> predecessor(vertexCount);
             std::vector<cost> distance(vertexCount);
             std::vector<cost> rank(vertexCount);
@@ -416,57 +433,8 @@ private slots:
             emitMetric("toll_astar_no_init_ms", bestNoInit);
             emitMetric("toll_astar_no_init_touched", static_cast<qint64>(touched.size()));
 
-            // And the same search written out by hand over the same persistent
-            // arrays: a binary heap with lazy deletion, no BGL scaffolding, and
-            // so nothing at all that is sized by the map rather than by the
-            // search.
-            const boost::property_map<TMap::mygraph_t, boost::edge_weight_t>::type weights = boost::get(boost::edge_weight, pMap->g);
-            distance_heuristic<TMap::mygraph_t, cost, std::vector<location>> heuristic(pMap->locations, goal);
-            typedef std::pair<cost, TMap::vertex> queueEntry;
-            std::priority_queue<queueEntry, std::vector<queueEntry>, std::greater<queueEntry>> open;
-            double bestManual = std::numeric_limits<double>::max();
-            std::size_t manualExamined = 0;
-            for (int pass = 0; pass < kPasses; ++pass) {
-                timer.restart();
-                for (const std::size_t index : touched) {
-                    predecessor[index] = index;
-                    distance[index] = infinite;
-                    rank[index] = infinite;
-                    colour[index] = boost::white_color;
-                }
-                touched.clear();
-                open = {};
-                manualExamined = 0;
-                distance[start] = 0;
-                touched.push_back(start);
-                open.push({heuristic(start), start});
-                while (!open.empty()) {
-                    const TMap::vertex u = open.top().second;
-                    open.pop();
-                    if (colour[u] == boost::black_color) {
-                        continue;
-                    }
-                    colour[u] = boost::black_color;
-                    touched.push_back(u);
-                    ++manualExamined;
-                    if (u == goal) {
-                        break;
-                    }
-                    for (const auto& edge : boost::make_iterator_range(boost::out_edges(u, pMap->g))) {
-                        const TMap::vertex v = boost::target(edge, pMap->g);
-                        const cost through = distance[u] + boost::get(weights, edge);
-                        if (through < distance[v]) {
-                            distance[v] = through;
-                            predecessor[v] = u;
-                            touched.push_back(v);
-                            open.push({through + heuristic(v), v});
-                        }
-                    }
-                }
-                bestManual = std::min(bestManual, timer.nsecsElapsed() / 1.0e6);
-            }
-            emitMetric("toll_astar_manual_ms", bestManual);
-            emitMetric("toll_astar_manual_examined", static_cast<qint64>(manualExamined));
+            // What replaced all of this is not measured again here: it is what
+            // findPath() now runs, so the path_* timings above are already it.
         }
 
         if (const qint64 peakRssKb = readPeakRssKb(); peakRssKb > 0) {
@@ -510,8 +478,10 @@ private:
         return bestZ;
     }
 
-    // The room at (x, y) if the level holds one, else the nearest in an
-    // outward ring search, so a level with holes in it still yields a pair.
+    // The room at (x, y) if the level holds one, else one found by an outward
+    // ring search, so a level with holes in it still yields a pair. The rings
+    // are square, so this is nearest by Chebyshev distance, and ties within a
+    // ring go to the lowest room id.
     static int nearestTo(const QHash<QPair<int, int>, int>& byCoordinate, int x, int y, int maxRadius)
     {
         if (const auto it = byCoordinate.constFind({x, y}); it != byCoordinate.constEnd()) {

--- a/test/functional_tests/PathfindBenchmark.cpp
+++ b/test/functional_tests/PathfindBenchmark.cpp
@@ -1,0 +1,566 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Report-only performance baseline for TMap::findPath(), the A* speedwalk
+ * search, and for the TMap::initGraph() rebuild that feeds it.
+ *
+ * Report-only means nothing is asserted on timing: the gate is a before/after
+ * comparison of two builds of this binary on the same machine, so a busy
+ * machine invalidates a run rather than failing it. The map is supplied rather
+ * than generated because the interesting workload is a real pathological one
+ * far too big to commit:
+ *
+ *   MUDLET_BENCH_MAP=/path/to/map.dat QT_QPA_PLATFORM=offscreen ./PathfindBenchmark
+ *
+ * Scenarios walk between rooms of the busiest Z level of the busiest area, at
+ * increasing separations, because A* cost scales with how much of the graph the
+ * frontier has to sweep - and the whole question is how much of the per-search
+ * cost is that sweep and how much is a fixed toll paid on every search
+ * regardless of how far apart the two rooms are.
+ */
+
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <algorithm>
+#include <clocale>
+#include <cstdio>
+#include <limits>
+#include <queue>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include <boost/range/iterator_range.hpp>
+
+#include "TArea.h"
+#include "TAstar.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define BENCH_BUILD_ASAN 1
+#endif
+#endif
+#if !defined(BENCH_BUILD_ASAN) && defined(__SANITIZE_ADDRESS__)
+#define BENCH_BUILD_ASAN 1
+#endif
+#ifndef BENCH_BUILD_ASAN
+#define BENCH_BUILD_ASAN 0
+#endif
+
+// Prototype of the per-vertex arrays A* could keep between searches. A map
+// over one of them remembers every vertex it wrote to, so the next search puts
+// the defaults back for just those rather than for every room on the map -
+// which is the whole of what astar_search() does before it looks at an edge.
+template <typename Value>
+class ScratchMap
+{
+public:
+    typedef std::size_t key_type;
+    typedef Value value_type;
+    typedef Value& reference;
+    typedef boost::read_write_property_map_tag category;
+
+    ScratchMap(std::vector<Value>& store, std::vector<std::size_t>& touched)
+    : mpStore(&store)
+    , mpTouched(&touched)
+    {
+    }
+
+    std::vector<Value>* mpStore;
+    std::vector<std::size_t>* mpTouched;
+};
+
+template <typename Value>
+inline Value get(const ScratchMap<Value>& map, std::size_t key)
+{
+    return (*map.mpStore)[key];
+}
+
+template <typename Value>
+inline void put(const ScratchMap<Value>& map, std::size_t key, const Value& value)
+{
+    (*map.mpStore)[key] = value;
+    map.mpTouched->push_back(key);
+}
+
+extern void qInitResources_mudlet();
+extern void qInitResources_qm();
+extern void qInitResources_additional_splash_screens();
+extern void qInitResources_mudlet_fonts_common();
+extern void qInitResources_mudlet_fonts_posix();
+static void initializeQRCResources();
+
+class PathfindBenchmark : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = qsl("Pathfind-Benchmark-Host");
+    const QString mLocalhost = qsl("localhost");
+    quint16 mPort = 0;
+    QString mMapPath;
+
+    static constexpr int kPasses = 5;
+
+    struct Scenario
+    {
+        const char* name;
+        // Separation between the two rooms, in map units along one axis.
+        int offset;
+    };
+
+    // 0 means "the far corner of the level", the longest walk it can hold.
+    static constexpr Scenario kScenarios[] = {
+            {"adjacent", 1},
+            {"near", 10},
+            {"mid", 100},
+            {"far", 400},
+            {"corner", 0},
+    };
+
+    static void emitMetric(const char* name, double value) { std::printf("METRIC %s %.3f\n", name, value); }
+
+    static void emitMetric(const char* name, qint64 value) { std::printf("METRIC %s %lld\n", name, value); }
+
+    static void emitMetric(const QString& name, double value) { emitMetric(name.toUtf8().constData(), value); }
+
+    static void emitMetric(const QString& name, qint64 value) { emitMetric(name.toUtf8().constData(), value); }
+
+    static qint64 readPeakRssKb()
+    {
+#if defined(Q_OS_LINUX)
+        QFile status(qsl("/proc/self/status"));
+        if (!status.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return 0;
+        }
+        const QString text = QString::fromLatin1(status.readAll());
+        for (const QString& line : text.split(QChar::LineFeed)) {
+            if (line.startsWith(qsl("VmHWM:"))) {
+                return QStringView{line}.mid(6).trimmed().split(QChar::Space).constFirst().toLongLong();
+            }
+        }
+#endif
+        return 0;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        mMapPath = qEnvironmentVariable("MUDLET_BENCH_MAP");
+        if (mMapPath.isEmpty()) {
+            QSKIP("MUDLET_BENCH_MAP is not set - point it at a saved Mudlet map file to run this benchmark");
+        }
+        if (!QFileInfo::exists(mMapPath)) {
+            QFAIL(qPrintable(qsl("MUDLET_BENCH_MAP points at \"%1\", which does not exist").arg(mMapPath)));
+        }
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        std::setlocale(LC_NUMERIC, "C");
+        initializeQRCResources();
+        emitMetric("build_asan", static_cast<qint64>(BENCH_BUILD_ASAN));
+    }
+
+    void cleanupTestCase() { mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = mpServer->serverPort();
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+    }
+
+    void cleanup()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        deleteProfileDirectory();
+        delete mudlet::self();
+    }
+
+    void benchFindPath()
+    {
+        mudlet::self()->mSkipDefaultPackageInstall = true;
+        Host* host = TestProfile::create(mHostname, mLocalhost, QString::number(mPort));
+        QVERIFY(host);
+        QSignalSpy connected(&(host->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connected.wait(3000), "could not connect to the stub");
+
+        host->showHideOrCreateMapper(false);
+        QVERIFY(host->mpMap);
+        TMap* pMap = host->mpMap.data();
+
+        QElapsedTimer timer;
+        timer.start();
+        QVERIFY2(pMap->restore(mMapPath), qPrintable(qsl("could not restore the map at \"%1\"").arg(mMapPath)));
+        emitMetric("map_restore_seconds", timer.nsecsElapsed() / 1.0e9);
+
+        emitMetric("map_rooms", static_cast<qint64>(pMap->mpRoomDB->size()));
+        emitMetric("map_areas", static_cast<qint64>(pMap->mpRoomDB->getAreaMap().size()));
+
+        const int areaId = chooseArea(pMap);
+        TArea* pArea = pMap->mpRoomDB->getArea(areaId);
+        QVERIFY2(pArea, "the chosen area is not in the map");
+        const int zLevel = chooseZLevel(pArea);
+        const QSet<int> roomsOnLevel = pArea->getRoomsForZ(zLevel);
+        QVERIFY2(!roomsOnLevel.isEmpty(), "the chosen Z level holds no rooms");
+
+        emitMetric("bench_area_id", static_cast<qint64>(areaId));
+        emitMetric("bench_z_level", static_cast<qint64>(zLevel));
+        emitMetric("bench_rooms_on_z_level", static_cast<qint64>(roomsOnLevel.size()));
+
+        // The graph is rebuilt from scratch whenever the map is touched, and
+        // the first findPath() after that pays for it, so it is timed on its
+        // own rather than being hidden inside the first scenario.
+        timer.restart();
+        pMap->initGraph();
+        emitMetric("init_graph_ms", timer.nsecsElapsed() / 1.0e6);
+        emitMetric("graph_vertices", static_cast<qint64>(pMap->roomidToIndex.size()));
+
+        QHash<QPair<int, int>, int> byCoordinate;
+        byCoordinate.reserve(roomsOnLevel.size());
+        int minX = std::numeric_limits<int>::max();
+        int maxX = std::numeric_limits<int>::min();
+        int minY = std::numeric_limits<int>::max();
+        int maxY = std::numeric_limits<int>::min();
+        for (const int roomId : roomsOnLevel) {
+            TRoom* pRoom = pMap->mpRoomDB->getRoom(roomId);
+            if (!pRoom) {
+                continue;
+            }
+            // Ties break on the lower room id so the picks are identical on
+            // every run, which QSet iteration order alone would not give.
+            const QPair<int, int> key{pRoom->x(), pRoom->y()};
+            const auto it = byCoordinate.constFind(key);
+            if (it == byCoordinate.constEnd() || roomId < it.value()) {
+                byCoordinate.insert(key, roomId);
+            }
+            minX = std::min(minX, pRoom->x());
+            maxX = std::max(maxX, pRoom->x());
+            minY = std::min(minY, pRoom->y());
+            maxY = std::max(maxY, pRoom->y());
+        }
+        emitMetric("bench_span_x", static_cast<qint64>(maxX - minX));
+        emitMetric("bench_span_y", static_cast<qint64>(maxY - minY));
+
+        const int centreX = (minX + maxX) / 2;
+        const int centreY = (minY + maxY) / 2;
+        const int startId = nearestTo(byCoordinate, centreX, centreY, maxX - minX);
+        QVERIFY2(startId > 0, "no room found near the middle of the chosen Z level");
+        emitMetric("bench_start_room", static_cast<qint64>(startId));
+
+        for (const Scenario& scenario : kScenarios) {
+            const int targetId = (scenario.offset == 0) ? nearestTo(byCoordinate, maxX, maxY, maxX - minX) : nearestTo(byCoordinate, centreX + scenario.offset, centreY + scenario.offset, maxX - minX);
+            QVERIFY2(targetId > 0, qPrintable(qsl("scenario \"%1\" found no target room").arg(QString::fromUtf8(scenario.name))));
+            if (targetId == startId) {
+                continue;
+            }
+
+            // One untimed search first: it settles any lazily-grown property
+            // map inside BGL, and proves the pair really is connected before
+            // the timings claim to describe a successful search.
+            QVERIFY2(pMap->findPath(startId, targetId),
+                     qPrintable(qsl("scenario \"%1\" found no path from %2 to %3, so its timings would describe a failed search")
+                                        .arg(QString::fromUtf8(scenario.name), QString::number(startId), QString::number(targetId))));
+            const int steps = pMap->mPathList.size();
+
+            double best = std::numeric_limits<double>::max();
+            for (int pass = 0; pass < kPasses; ++pass) {
+                timer.restart();
+                pMap->findPath(startId, targetId);
+                best = std::min(best, timer.nsecsElapsed() / 1.0e6);
+            }
+
+            const QString prefix = qsl("path_%1").arg(QString::fromUtf8(scenario.name));
+            emitMetric(qsl("%1_ms").arg(prefix), best);
+            // Workload invariants: a build that walked a different distance, or
+            // found a different route, did not do the same work.
+            emitMetric(qsl("%1_steps").arg(prefix), static_cast<qint64>(steps));
+            emitMetric(qsl("%1_target_room").arg(prefix), static_cast<qint64>(targetId));
+        }
+
+        // Where a search's fixed toll goes. findPath() allocates two
+        // vertex-sized vectors of its own, and astar_search() then writes four
+        // property maps for every vertex in the WHOLE map - both before it has
+        // looked at a single edge - so a two-room walk on a 2.3M room map pays
+        // for 2.3M rooms. Measured on the shortest scenario, where the search
+        // proper is a couple of vertices and everything else is that toll.
+        {
+            const int targetId = nearestTo(byCoordinate, centreX + 1, centreY, maxX - minX);
+            const auto vertexCount = static_cast<std::size_t>(boost::num_vertices(pMap->g));
+            const TMap::vertex start = pMap->roomidToIndex.value(startId);
+            const TMap::vertex goal = pMap->roomidToIndex.value(targetId);
+            double bestAlloc = std::numeric_limits<double>::max();
+            double bestSearch = std::numeric_limits<double>::max();
+            for (int pass = 0; pass < kPasses; ++pass) {
+                timer.restart();
+                std::vector<TMap::vertex> p(vertexCount);
+                std::vector<cost> d(vertexCount);
+                const double allocMs = timer.nsecsElapsed() / 1.0e6;
+                timer.restart();
+                try {
+                    boost::astar_search(pMap->g,
+                                        start,
+                                        distance_heuristic<TMap::mygraph_t, cost, std::vector<location>>(pMap->locations, goal),
+                                        boost::predecessor_map(&p[0]).distance_map(&d[0]).visitor(astar_goal_visitor<TMap::vertex>(goal)));
+                } catch (const found_goal&) {
+                }
+                const double searchMs = timer.nsecsElapsed() / 1.0e6;
+                bestAlloc = std::min(bestAlloc, allocMs);
+                bestSearch = std::min(bestSearch, searchMs);
+            }
+            emitMetric("toll_scratch_alloc_ms", bestAlloc);
+            emitMetric("toll_astar_search_ms", bestSearch);
+
+            // Same search, but with every per-vertex array allocated once and
+            // handed in: astar_search() still writes all 2.3M entries, it just
+            // no longer faults in fresh pages to do it.
+            std::vector<TMap::vertex> predecessor(vertexCount);
+            std::vector<cost> distance(vertexCount);
+            std::vector<cost> rank(vertexCount);
+            std::vector<boost::default_color_type> colour(vertexCount);
+            double bestWarm = std::numeric_limits<double>::max();
+            for (int pass = 0; pass < kPasses; ++pass) {
+                timer.restart();
+                try {
+                    boost::astar_search(pMap->g,
+                                        start,
+                                        distance_heuristic<TMap::mygraph_t, cost, std::vector<location>>(pMap->locations, goal),
+                                        boost::predecessor_map(&predecessor[0]).distance_map(&distance[0]).rank_map(&rank[0]).color_map(&colour[0]).visitor(astar_goal_visitor<TMap::vertex>(goal)));
+                } catch (const found_goal&) {
+                }
+                bestWarm = std::min(bestWarm, timer.nsecsElapsed() / 1.0e6);
+            }
+            emitMetric("toll_astar_warm_ms", bestWarm);
+
+            // And with no initialisation pass at all: the arrays start out at
+            // their defaults and only the vertices the previous search touched
+            // are put back, so the cost is the search and nothing else.
+            constexpr cost infinite = std::numeric_limits<cost>::max();
+            std::vector<std::size_t> touched;
+            for (std::size_t i = 0; i < vertexCount; ++i) {
+                predecessor[i] = i;
+                distance[i] = infinite;
+                rank[i] = infinite;
+                colour[i] = boost::white_color;
+            }
+            const ScratchMap<TMap::vertex> predecessorMap(predecessor, touched);
+            const ScratchMap<cost> distanceMap(distance, touched);
+            const ScratchMap<cost> rankMap(rank, touched);
+            const ScratchMap<boost::default_color_type> colourMap(colour, touched);
+            double bestNoInit = std::numeric_limits<double>::max();
+            for (int pass = 0; pass < kPasses; ++pass) {
+                timer.restart();
+                for (const std::size_t index : touched) {
+                    predecessor[index] = index;
+                    distance[index] = infinite;
+                    rank[index] = infinite;
+                    colour[index] = boost::white_color;
+                }
+                touched.clear();
+                put(distanceMap, start, cost(0));
+                put(rankMap, start, distance_heuristic<TMap::mygraph_t, cost, std::vector<location>>(pMap->locations, goal)(start));
+                try {
+                    boost::astar_search_no_init(
+                            pMap->g,
+                            start,
+                            distance_heuristic<TMap::mygraph_t, cost, std::vector<location>>(pMap->locations, goal),
+                            boost::predecessor_map(predecessorMap).distance_map(distanceMap).rank_map(rankMap).color_map(colourMap).visitor(astar_goal_visitor<TMap::vertex>(goal)));
+                } catch (const found_goal&) {
+                }
+                bestNoInit = std::min(bestNoInit, timer.nsecsElapsed() / 1.0e6);
+            }
+            emitMetric("toll_astar_no_init_ms", bestNoInit);
+            emitMetric("toll_astar_no_init_touched", static_cast<qint64>(touched.size()));
+
+            // And the same search written out by hand over the same persistent
+            // arrays: a binary heap with lazy deletion, no BGL scaffolding, and
+            // so nothing at all that is sized by the map rather than by the
+            // search.
+            const boost::property_map<TMap::mygraph_t, boost::edge_weight_t>::type weights = boost::get(boost::edge_weight, pMap->g);
+            distance_heuristic<TMap::mygraph_t, cost, std::vector<location>> heuristic(pMap->locations, goal);
+            typedef std::pair<cost, TMap::vertex> queueEntry;
+            std::priority_queue<queueEntry, std::vector<queueEntry>, std::greater<queueEntry>> open;
+            double bestManual = std::numeric_limits<double>::max();
+            std::size_t manualExamined = 0;
+            for (int pass = 0; pass < kPasses; ++pass) {
+                timer.restart();
+                for (const std::size_t index : touched) {
+                    predecessor[index] = index;
+                    distance[index] = infinite;
+                    rank[index] = infinite;
+                    colour[index] = boost::white_color;
+                }
+                touched.clear();
+                open = {};
+                manualExamined = 0;
+                distance[start] = 0;
+                touched.push_back(start);
+                open.push({heuristic(start), start});
+                while (!open.empty()) {
+                    const TMap::vertex u = open.top().second;
+                    open.pop();
+                    if (colour[u] == boost::black_color) {
+                        continue;
+                    }
+                    colour[u] = boost::black_color;
+                    touched.push_back(u);
+                    ++manualExamined;
+                    if (u == goal) {
+                        break;
+                    }
+                    for (const auto& edge : boost::make_iterator_range(boost::out_edges(u, pMap->g))) {
+                        const TMap::vertex v = boost::target(edge, pMap->g);
+                        const cost through = distance[u] + boost::get(weights, edge);
+                        if (through < distance[v]) {
+                            distance[v] = through;
+                            predecessor[v] = u;
+                            touched.push_back(v);
+                            open.push({through + heuristic(v), v});
+                        }
+                    }
+                }
+                bestManual = std::min(bestManual, timer.nsecsElapsed() / 1.0e6);
+            }
+            emitMetric("toll_astar_manual_ms", bestManual);
+            emitMetric("toll_astar_manual_examined", static_cast<qint64>(manualExamined));
+        }
+
+        if (const qint64 peakRssKb = readPeakRssKb(); peakRssKb > 0) {
+            emitMetric("peak_rss_kb", peakRssKb);
+        }
+    }
+
+private:
+    int chooseArea(TMap* pMap) const
+    {
+        if (const int pinned = qEnvironmentVariableIntValue("MUDLET_BENCH_AREA"); pinned != 0) {
+            return pinned;
+        }
+        int bestId = 0;
+        int bestCount = -1;
+        const QMap<int, TArea*>& areas = pMap->mpRoomDB->getAreaMap();
+        for (auto it = areas.constBegin(); it != areas.constEnd(); ++it) {
+            if (!it.value()) {
+                continue;
+            }
+            const int count = it.value()->getAreaRooms().size();
+            if (count > bestCount) {
+                bestCount = count;
+                bestId = it.key();
+            }
+        }
+        return bestId;
+    }
+
+    static int chooseZLevel(TArea* pArea)
+    {
+        int bestZ = 0;
+        int bestCount = -1;
+        for (int z = pArea->min_z; z <= pArea->max_z; ++z) {
+            const int count = pArea->getRoomsForZ(z).size();
+            if (count > bestCount) {
+                bestCount = count;
+                bestZ = z;
+            }
+        }
+        return bestZ;
+    }
+
+    // The room at (x, y) if the level holds one, else the nearest in an
+    // outward ring search, so a level with holes in it still yields a pair.
+    static int nearestTo(const QHash<QPair<int, int>, int>& byCoordinate, int x, int y, int maxRadius)
+    {
+        if (const auto it = byCoordinate.constFind({x, y}); it != byCoordinate.constEnd()) {
+            return it.value();
+        }
+        for (int radius = 1; radius <= maxRadius; ++radius) {
+            int best = 0;
+            for (int dx = -radius; dx <= radius; ++dx) {
+                for (int dy = -radius; dy <= radius; ++dy) {
+                    if (std::max(std::abs(dx), std::abs(dy)) != radius) {
+                        continue;
+                    }
+                    const auto it = byCoordinate.constFind({x + dx, y + dy});
+                    if (it != byCoordinate.constEnd() && (best == 0 || it.value() < best)) {
+                        best = it.value();
+                    }
+                }
+            }
+            if (best > 0) {
+                return best;
+            }
+        }
+        return 0;
+    }
+
+    void deleteProfileDirectory()
+    {
+        const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        QDir dir(path);
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+};
+
+static void initializeQRCResources()
+{
+#ifdef INCLUDE_VARIABLE_SPLASH_SCREEN
+    qInitResources_additional_splash_screens();
+#endif
+#ifdef INCLUDE_FONTS
+    qInitResources_mudlet_fonts_common();
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+    qInitResources_mudlet_fonts_posix();
+#endif
+#endif
+    qInitResources_mudlet();
+    qInitResources_qm();
+}
+
+#include "PathfindBenchmark.moc"
+QTEST_MAIN(PathfindBenchmark)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`boost::astar_search()` resets four property maps over every room in the map before it looks at a single exit, and `distance_heuristic` copied the whole location list on each search, so `findPath()` cost the same ~56ms whether the walk was 1 step or 500. It now runs an A* that keeps its per-room state between searches and resets only the rooms the previous one touched, so the cost scales with how far you walk rather than with how big your map is.

#### Motivation for adding to Mudlet

Speedwalking on a large map paid a fixed ~56ms stall on every path, even between two adjacent rooms.

#### Other info (issues closed, discussion etc)

Measured on Ssaliss' Aetherspace map (2,330,079 rooms), best of 5 on an otherwise idle machine:

| walk | before | after |
| --- | --- | --- |
| adjacent (1 step) | 56.7ms | 0.003ms |
| near (10 steps) | 56.9ms | 0.004ms |
| mid (100 steps) | 58.0ms | 0.014ms |
| far (400 steps) | 59.5ms | 0.120ms |
| corner (500 steps) | 60.1ms | 0.141ms |

All five routes come back with exactly the same number of steps as before, which is the check that rules out "faster because it found worse routes". The 1-step and 10-step figures are not distinguishable from timer noise.

Worth a reviewer's attention:

- `searchGraph()` keeps state across calls, so `initGraph()` has to put it back in step. That is safe because `initGraph()` is the only place the graph is cleared or given vertices, and every room, area and map mutation reaches it through `mMapGraphNeedsUpdate`. `findPath()` now also checks the state is the same size as the graph before indexing it unchecked.
- One `getPath()` to an unreachable room settles every room it can reach, so the touched list would end up holding 8 bytes a room for the rest of the session where the old code freed its scratch after each search. Past half the map it hands the memory back and refills instead.
- `distance_heuristic` now holds its location map by `const&` instead of by value, trading a 35MB copy per search for a lifetime dependency; binding a temporary is a compile error.
- Where two routes tie on cost, which one comes back can differ from before. Route identity was never stable anyway - `initGraph()` inserts edges in `QHash` order, so it already varied between runs of the same binary.

`PathfindBenchmark` is included but deliberately never registered with ctest: it needs a map far too large to commit, handed to it in `MUDLET_BENCH_MAP`, and skips without one. It keeps the rejected alternatives (stock `astar_search`, warm property maps, `astar_search_no_init`) measurable, which is why `found_goal` and `astar_goal_visitor` stay in `TAstar.h`.

**Test case:** open a large map and `getPath(a, b)` between two adjacent rooms and between two far-apart ones - both return the same routes as before at a fraction of the time, which `TMap::findPath()` logs as "time elapsed in A*" in the debug console.

Every pathfinding spec edited the map first, so each one searched a freshly rebuilt graph and none of them reached the state this PR introduces. Four new `Mapper_spec.lua` cases do, and each was confirmed to fail with the matching line cut: removing the reset fails the two reuse cases, refusing to re-open a settled room fails the weights-disagree case (it returns a route costing 25 instead of 22), and letting the touched list survive a rebuild writes index 14 into a 10-entry vector. Suite is 3722 successes / 0 failures / 0 errors.

Assisted-by: Claude:claude-opus-5
