### PR TITLE
fix: a pasted link no longer runs a different link's command

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4872,7 +4872,13 @@ int TBuffer::remapLinkId(const TLinkStore& sourceLinkStore, const int sourceLink
         return destLinkId;
     }
 
-    destLinkId = mLinkStore.addLinks(sourceLinkStore.getLinksConst(sourceLinkId), sourceLinkStore.getHintsConst(sourceLinkId), mpHost);
+    // a reference of this store's own, so freeing either store's leaves the other link working
+    QVector<int> luaReference;
+    for (const int sourceReference : sourceLinkStore.getReference(sourceLinkId)) {
+        luaReference.append(mpHost && sourceReference > 0 ? mpHost->mLuaInterpreter.duplicateLuaRegistryIndex(sourceReference) : 0);
+    }
+
+    destLinkId = mLinkStore.addLinks(sourceLinkStore.getLinksConst(sourceLinkId), sourceLinkStore.getHintsConst(sourceLinkId), mpHost, luaReference, sourceLinkStore.getExpireName(sourceLinkId));
     if (sourceLinkStore.hasStyling(sourceLinkId)) {
         mLinkStore.setStyling(destLinkId, sourceLinkStore.getStyling(sourceLinkId));
     }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4857,6 +4857,28 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const TCha
     append(text, sub_start, sub_end, format.mFgColor, format.mBgColor, format.mFlags, linkID);
 }
 
+// A link index only means anything to the store that issued it, so an index from
+// another buffer is registered here and swapped for one of ours. The caller owns
+// remappedLinkIds, so one source index maps to one of ours for the whole of the
+// text being brought over, however many separate runs of it that text has.
+int TBuffer::remapLinkId(const TLinkStore& sourceLinkStore, const int sourceLinkId, QHash<int, int>& remappedLinkIds)
+{
+    if (sourceLinkId <= 0) {
+        return 0;
+    }
+
+    int destLinkId = remappedLinkIds.value(sourceLinkId);
+    if (destLinkId > 0) {
+        return destLinkId;
+    }
+
+    destLinkId = mLinkStore.addLinks(sourceLinkStore.getLinksConst(sourceLinkId), sourceLinkStore.getHintsConst(sourceLinkId), mpHost);
+    if (sourceLinkStore.hasStyling(sourceLinkId)) {
+        mLinkStore.setStyling(destLinkId, sourceLinkStore.getStyling(sourceLinkId));
+    }
+    return remappedLinkIds.insert(sourceLinkId, destLinkId).value();
+}
+
 void TBuffer::appendFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore)
 {
     if (text.isEmpty()) {
@@ -4878,8 +4900,7 @@ void TBuffer::appendFormatted(const QString& text, const std::vector<TChar>& for
     const int lastLineLength = lineBuffer.at(lastLineBeforeWrap).size();
 
     bool firstChar = lineBuffer.back().isEmpty();
-    int oldSourceLinkId = 0;
-    int destLinkId = 0;
+    QHash<int, int> remappedLinkIds;
     const qsizetype length = std::max(text.size(), static_cast<qsizetype>(formatting.size()));
     const TChar defaultChar;
 
@@ -4897,16 +4918,7 @@ void TBuffer::appendFormatted(const QString& text, const std::vector<TChar>& for
 
         const TChar& srcChar = (i < static_cast<qsizetype>(formatting.size())) ? formatting.at(i) : defaultChar;
 
-        const int sourceLinkId = srcChar.linkIndex();
-        if (sourceLinkId && (oldSourceLinkId != sourceLinkId)) {
-            destLinkId = mLinkStore.addLinks(sourceLinkStore.getLinksConst(sourceLinkId), sourceLinkStore.getHintsConst(sourceLinkId), mpHost);
-            if (sourceLinkStore.hasStyling(sourceLinkId)) {
-                mLinkStore.setStyling(destLinkId, sourceLinkStore.getStyling(sourceLinkId));
-            }
-            oldSourceLinkId = sourceLinkId;
-        } else if (!sourceLinkId) {
-            destLinkId = 0;
-        }
+        const int destLinkId = remapLinkId(sourceLinkStore, srcChar.linkIndex(), remappedLinkIds);
 
         lineBuffer.back().append(ch);
         TChar destChar(srcChar);
@@ -5128,11 +5140,19 @@ void TBuffer::paste(QPoint& P, const TBuffer& chunk)
         y = getLastLineNumber();
     }
 
+    // Copying a link index across verbatim would resolve it against whatever
+    // this store holds at that id, which is a different link or none at all
+    QHash<int, int> remappedLinkIds;
     for (int cx = 0, total = static_cast<int>(chunk.buffer.at(0).size()); cx < total; ++cx) {
         // Character at a time because insertInLine() applies a single TChar to
         // the whole run it is given, and every character here can differ
         QPoint P_current(x + cx, y);
-        insertInLine(P_current, QString(chunk.lineBuffer.at(0).at(cx)), chunk.buffer.at(0).at(cx));
+        insertInLine(P_current,
+                     QString(chunk.lineBuffer.at(0).at(cx)),
+                     TChar(chunk.buffer.at(0).at(cx).mFgColor,
+                           chunk.buffer.at(0).at(cx).mBgColor,
+                           chunk.buffer.at(0).at(cx).mFlags,
+                           remapLinkId(chunk.mLinkStore, chunk.buffer.at(0).at(cx).linkIndex(), remappedLinkIds)));
     }
 }
 

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -434,6 +434,7 @@ private:
     inline QList<WrapInfo> getWrapInfo(const QString& lineText, bool isNewline, const int maxWidth, const int indent, const int hangingIndent);
     void shrinkBuffer();
     void syncPreTriggerPassLine(int y);
+    int remapLinkId(const TLinkStore& sourceLinkStore, int sourceLinkId, QHash<int, int>& remappedLinkIds);
     int calculateWrapPosition(int lineNumber, int begin, int end);
     void handleNewLine();
     void translateToPlainTextInner(std::string& incoming, bool isFromServer);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7030,6 +7030,15 @@ void TLuaInterpreter::freeLuaRegistryIndex(int index)
 }
 
 // No documentation available in wiki - internal function
+// A second reference to the same value, for a copy that has to own one of its
+// own: freeing either reference leaves the other one working.
+int TLuaInterpreter::duplicateLuaRegistryIndex(int index)
+{
+    lua_rawgeti(pGlobalLua, LUA_REGISTRYINDEX, index);
+    return luaL_ref(pGlobalLua, LUA_REGISTRYINDEX);
+}
+
+// No documentation available in wiki - internal function
 // Looks for argument types in an 'event' that have stored
 // data in the lua registry, and frees this data.
 void TLuaInterpreter::freeAllInLuaRegistry(TEvent event)

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -790,6 +790,7 @@ public:
     // check new functions against https://www.linguistic-antipatterns.com when creating them
 
     void freeLuaRegistryIndex(int index);
+    int duplicateLuaRegistryIndex(int index);
     void freeAllInLuaRegistry(TEvent);
 
     // Called from Host::raiseEvent(), to unblock a waitForEvent() on that event.

--- a/test/functional_tests/PastedLinkStateTest.cpp
+++ b/test/functional_tests/PastedLinkStateTest.cpp
@@ -139,7 +139,7 @@ private slots:
         mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("createMiniConsole('%1', 0, 110, 300, 100)\n"
                                                                  "echoLink('%1', 'OWN', [[send('MINE')]], 'own hint')\n"
                                                                  "echo('%1', '\\none\\ntwo\\nthree\\n')\n"
-                                                                 "echoLink('%2', [[send('look')]], 'hint')\n"
+                                                                 "echoLink('%2', [[send('pasted')]], 'hint')\n"
                                                                  "echo('\\n')")
                                                                      .arg(targetName, mLinkText));
         qApp->processEvents();
@@ -161,7 +161,7 @@ private slots:
         QVERIFY2(pastedId != ownId, "the pasted characters point at the target's own link id");
         const QString pastedCommands = pTarget->getLinkStore().getLinksConst(pastedId).join(QChar::Space);
         QVERIFY2(!pastedCommands.contains(qsl("send('MINE')")), "the pasted link resolves to the destination's own command");
-        QVERIFY2(pastedCommands.contains(qsl("send('look')")), "the pasted link does not resolve to the command it was copied from");
+        QVERIFY2(pastedCommands.contains(qsl("send('pasted')")), "the pasted link does not resolve to the command it was copied from");
     }
 
     // One source link can occupy more than one run of characters, with plain
@@ -276,10 +276,94 @@ private slots:
         QVERIFY2(pConsole->getLinkStore().getLinksConst(id).isEmpty(), "an unreferenced link survived its line being trimmed away, so the store grows for the life of the profile");
     }
 
+    // A link whose command is a Lua function carries only a registry reference,
+    // so a copy that drops it looks like a link and runs nothing.
+    void test_aPastedFunctionLinkKeepsAReferenceOfItsOwn()
+    {
+        const QString targetName = qsl("pastedFunctionLink");
+        mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("createMiniConsole('%1', 0, 220, 300, 100)\n"
+                                                                 "echo('%1', 'one\\ntwo\\nthree\\n')\n"
+                                                                 "echoLink('FNLINK', function() send('fromFunction') end, 'fnhint')\n"
+                                                                 "echo('\\n')")
+                                                                     .arg(targetName));
+        qApp->processEvents();
+
+        auto* pTarget = mpHost->mpConsole->mSubConsoleMap.value(targetName);
+        QVERIFY2(pTarget, "the target miniconsole was not created");
+        QVERIFY2(selectLinkRunInMainConsole(), "echoLink() put no link-bearing character in the main console");
+
+        const QPoint selectionStart = mpHost->mpConsole->P_begin;
+        const int sourceId = mpHost->mpConsole->buffer.buffer.at(selectionStart.y()).at(selectionStart.x()).linkIndex();
+        const int sourceReference = mpHost->mpConsole->buffer.mLinkStore.getReference(sourceId).value(0);
+        QVERIFY2(sourceReference > 0, "echoLink() given a function registered no Lua reference, so this test covers nothing");
+
+        mpHost->mpConsole->copy();
+        QVERIFY(pTarget->moveCursor(0, 0));
+        pTarget->paste();
+        qApp->processEvents();
+
+        const int pastedId = pastedLinkId(pTarget);
+        QVERIFY2(pastedId > 0, "paste() carried no link index across, so this test covers nothing");
+        const int pastedReference = pTarget->getLinkStore().getReference(pastedId).value(0);
+        QVERIFY2(pastedReference > 0, "the pasted link holds no Lua reference, so clicking it runs an empty command");
+        QVERIFY2(pastedReference != sourceReference, "the pasted link shares the source's registry reference, so freeing either would break the other");
+    }
+
+    // Only MXP gives a link an expire group, so the source is seeded directly.
+    // appendFormatted() is the path copy() itself takes to build the slice.
+    void test_aCopiedLinkKeepsItsExpireGroup()
+    {
+        TBuffer source(mpHost);
+        const int sourceId = source.mLinkStore.addLinks(QStringList{qsl("send('expiring')")}, QStringList{qsl("hint")}, mpHost, QVector<int>(), qsl("expgroup"));
+        QVERIFY(sourceId > 0);
+
+        TBuffer destination(mpHost);
+        const std::vector<TChar> formatting(4, TChar(Qt::white, Qt::black, TChar::None, sourceId));
+        destination.appendFormatted(qsl("LINK"), formatting, source.mLinkStore);
+
+        const int destinationId = copiedLinkId(destination);
+        QVERIFY2(destinationId > 0, "the copied characters carry no link index, so this test covers nothing");
+        QCOMPARE(destination.mLinkStore.getExpireName(destinationId), qsl("expgroup"));
+
+        destination.mLinkStore.expireLinks(qsl("expgroup"), mpHost);
+        QVERIFY2(destination.mLinkStore.getLinksConst(destinationId).isEmpty(), "the copied link outlived an expireLinks() of the group it was copied with");
+    }
+
+    void test_aCopiedLinkKeepsItsStyling()
+    {
+        TBuffer source(mpHost);
+        const int sourceId = source.mLinkStore.addLinks(QStringList{qsl("send('styled')")}, QStringList{qsl("hint")}, mpHost);
+        Mudlet::HyperlinkStyling styling;
+        styling.hasCustomStyling = true;
+        styling.isBold = true;
+        source.mLinkStore.setStyling(sourceId, styling);
+
+        TBuffer destination(mpHost);
+        const std::vector<TChar> formatting(4, TChar(Qt::white, Qt::black, TChar::None, sourceId));
+        destination.appendFormatted(qsl("LINK"), formatting, source.mLinkStore);
+
+        const int destinationId = copiedLinkId(destination);
+        QVERIFY2(destinationId > 0, "the copied characters carry no link index, so this test covers nothing");
+        QVERIFY2(destination.mLinkStore.hasStyling(destinationId), "the copied link lost the styling the source had");
+        QVERIFY2(destination.mLinkStore.getStyling(destinationId).isBold, "the copied link's styling did not come across intact");
+    }
+
 private:
     TConsole* miniconsole() const { return mpHost->mpConsole->mSubConsoleMap.value(mMiniName); }
 
     // Highest link index still present in a console's buffer, 0 for none
+    static int copiedLinkId(const TBuffer& destination)
+    {
+        for (const auto& line : destination.buffer) {
+            for (const TChar& character : line) {
+                if (character.linkIndex() > 0) {
+                    return character.linkIndex();
+                }
+            }
+        }
+        return 0;
+    }
+
     int pastedLinkId(TConsole* pConsole) const
     {
         int found = 0;
@@ -297,7 +381,9 @@ private:
     bool selectLinkRunInMainConsole() const
     {
         const auto& mainBuffer = mpHost->mpConsole->buffer;
-        for (int y = 0, lines = static_cast<int>(mainBuffer.buffer.size()); y < lines; ++y) {
+        // backwards: every case before this one left its own link-bearing line
+        // higher up, and copying that one tests whatever it happened to hold
+        for (int y = static_cast<int>(mainBuffer.buffer.size()) - 1; y >= 0; --y) {
             const auto& line = mainBuffer.buffer.at(y);
             int from = -1;
             int to = -1;

--- a/test/functional_tests/PastedLinkStateTest.cpp
+++ b/test/functional_tests/PastedLinkStateTest.cpp
@@ -18,17 +18,18 @@
  ***************************************************************************/
 
 /*
- * TBuffer::clearLinkState() has a fast path that skips its work when the buffer
- * has no link state to clear. paste() is why that test cannot be "did this
- * buffer's own store ever issue an id": it inserts source TChars verbatim
- * (TBuffer::paste() -> insertInLine()), unlike appendFormatted() which
- * re-registers ids through the destination's store. So a buffer can hold
- * linkIndex > 0 characters while its own TLinkStore has issued nothing, and the
- * hover path acts on such an index without checking store membership - which
- * seeds state that then has to be cleaned up like any other.
+ * A link index only means anything to the TLinkStore that issued it. paste()
+ * registers the source's links through the destination's store and writes the
+ * ids that store hands back, as appendFormatted() does for the append path, so
+ * a pasted link carries its own command rather than resolving against whatever
+ * the destination happens to hold at that index.
  *
- * The busted suite structurally cannot reach this: no Lua function reports link
- * state, only clearVisitedLinks() sets it.
+ * TBuffer::clearLinkState() also has a fast path that skips its work when the
+ * buffer has no link state to clear, and these tests pin that a pasted id is
+ * cleaned up like any other once its line goes away.
+ *
+ * The busted suite structurally cannot reach any of this: no Lua function
+ * reports a link's command, hint or state, and only clearVisitedLinks() sets it.
  */
 
 #include <QSignalSpy>
@@ -111,18 +112,114 @@ private slots:
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
     }
 
-    // Pins the fact the fast path cannot assume away: a pasted link id lives in a
-    // buffer whose own store never issued it, so "this store is pristine" does not
-    // imply "this buffer has no links".
-    void test_pastedLinkIdLandsInABufferWhoseStoreIssuedNothing()
+    // The id the pasted characters carry has to be one the destination's own
+    // store issued, holding the source link's command - not an index copied
+    // across that resolves against a store which never heard of it.
+    void test_pastedLinkIsRegisteredInTheDestinationsOwnStore()
     {
         pasteLinkIntoMiniconsole();
 
         auto* pMini = miniconsole();
         QVERIFY2(pMini, "the miniconsole was not created");
         QVERIFY2(pMini->buffer.lineBuffer.join(QChar::LineFeed).contains(mLinkText), "the link text never reached the miniconsole, so copy()/paste() did not run");
-        QVERIFY2(pastedLinkId(pMini) > 0, "paste() carried no link index across, so this test covers nothing");
-        QVERIFY2(pMini->getLinkStore().pristine(), "the miniconsole's own store issued an id - paste() took appendBuffer()'s re-registering branch, not the verbatim one");
+        const int pastedId = pastedLinkId(pMini);
+        QVERIFY2(pastedId > 0, "paste() carried no link index across, so this test covers nothing");
+        QVERIFY2(!pMini->getLinkStore().pristine(), "the miniconsole's own store issued nothing, so the pasted index came across verbatim");
+        QVERIFY2(pMini->getLinkStore().getLinksConst(pastedId).join(QChar::Space).contains(qsl("send('look')")), "the id the pasted characters carry does not hold the source link's command");
+        QVERIFY2(pMini->getLinkStore().getHintsConst(pastedId).join(QChar::Space).contains(qsl("hint")), "the source link's hint did not come across with it");
+    }
+
+    // The issue as a player meets it: the destination already has a link of its
+    // own, and ids start at 1 in every store, so a verbatim index lands on it.
+    // Its own miniconsole, so the id it hands out does not depend on what an
+    // earlier case left in the shared one.
+    void test_pastedLinkDoesNotRunTheDestinationsOwnCommand()
+    {
+        const QString targetName = qsl("pastedLinkCollide");
+        mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("createMiniConsole('%1', 0, 110, 300, 100)\n"
+                                                                 "echoLink('%1', 'OWN', [[send('MINE')]], 'own hint')\n"
+                                                                 "echo('%1', '\\none\\ntwo\\nthree\\n')\n"
+                                                                 "echoLink('%2', [[send('look')]], 'hint')\n"
+                                                                 "echo('\\n')")
+                                                                     .arg(targetName, mLinkText));
+        qApp->processEvents();
+
+        auto* pTarget = mpHost->mpConsole->mSubConsoleMap.value(targetName);
+        QVERIFY2(pTarget, "the target miniconsole was not created");
+        const int ownId = pTarget->getLinkStore().getCurrentLinkID();
+        QVERIFY2(ownId > 0, "the target's own echoLink() registered nothing, so there is no id to collide with");
+        QVERIFY2(pTarget->getLinkStore().getLinksConst(ownId).join(QChar::Space).contains(qsl("send('MINE')")), "the target's own link is not the one we think it is");
+
+        QVERIFY2(selectLinkRunInMainConsole(), "echoLink() put no link-bearing character in the main console");
+        mpHost->mpConsole->copy();
+        QVERIFY(pTarget->moveCursor(0, 0));
+        pTarget->paste();
+        qApp->processEvents();
+
+        const int pastedId = pastedLinkId(pTarget);
+        QVERIFY2(pastedId > 0, "paste() carried no link index across, so this test covers nothing");
+        QVERIFY2(pastedId != ownId, "the pasted characters point at the target's own link id");
+        const QString pastedCommands = pTarget->getLinkStore().getLinksConst(pastedId).join(QChar::Space);
+        QVERIFY2(!pastedCommands.contains(qsl("send('MINE')")), "the pasted link resolves to the destination's own command");
+        QVERIFY2(pastedCommands.contains(qsl("send('look')")), "the pasted link does not resolve to the command it was copied from");
+    }
+
+    // One source link can occupy more than one run of characters, with plain
+    // text between them - insertText() into the middle of a link does that.
+    // Remembering only the previous character's link leaves the second run
+    // carrying the gap's zero, so the resumed half stops being a link at all.
+    void test_aLinkResumedAfterPlainTextKeepsItsCommand()
+    {
+        const QString targetName = qsl("pastedLinkResumed");
+        mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("createMiniConsole('%1', 0, 220, 300, 100)\n"
+                                                                 "echo('%1', 'one\\ntwo\\nthree\\n')\n"
+                                                                 "echoLink('RESUMEDLINK', [[send('resumed')]], 'resumed hint')\n"
+                                                                 "echo('\\n')")
+                                                                     .arg(targetName));
+        qApp->processEvents();
+
+        // split the link's own run with characters carrying no link index
+        auto& mainBuffer = mpHost->mpConsole->buffer;
+        int splitLine = -1;
+        int splitColumn = -1;
+        for (int y = 0, lines = static_cast<int>(mainBuffer.buffer.size()); y < lines && splitLine < 0; ++y) {
+            const int at = mainBuffer.lineBuffer.at(y).indexOf(qsl("RESUMEDLINK"));
+            if (at >= 0) {
+                splitLine = y;
+                splitColumn = at + 5;
+            }
+        }
+        QVERIFY2(splitLine >= 0, "the link text never reached the main console");
+        QPoint splitAt(splitColumn, splitLine);
+        TChar plain;
+        QVERIFY2(mainBuffer.insertInLine(splitAt, qsl("--"), plain), "could not split the link's run");
+
+        const int sourceId = mainBuffer.buffer.at(splitLine).at(splitColumn - 1).linkIndex();
+        QVERIFY2(sourceId > 0, "the characters before the split are not linked, so this test covers nothing");
+        QCOMPARE(mainBuffer.buffer.at(splitLine).at(splitColumn).linkIndex(), 0);
+        QVERIFY2(mainBuffer.buffer.at(splitLine).at(splitColumn + 2).linkIndex() == sourceId, "the link does not resume after the inserted text, so this test covers nothing");
+
+        mpHost->mpConsole->P_begin = QPoint(splitColumn - 5, splitLine);
+        mpHost->mpConsole->P_end = QPoint(splitColumn + 8, splitLine);
+        mpHost->mpConsole->copy();
+
+        auto* pTarget = mpHost->mpConsole->mSubConsoleMap.value(targetName);
+        QVERIFY2(pTarget, "the target miniconsole was not created");
+        QVERIFY(pTarget->moveCursor(0, 0));
+        pTarget->paste();
+        qApp->processEvents();
+
+        const auto& pastedLine = pTarget->buffer.buffer.at(0);
+        const int leadingId = pastedLine.at(0).linkIndex();
+        QVERIFY2(leadingId > 0, "the pasted run carries no link index at all");
+        // the two characters between the halves carry no link, and must not be
+        // handed an id of their own - a zero index is what "not a link" means
+        QCOMPARE(pastedLine.at(5).linkIndex(), 0);
+        QCOMPARE(pastedLine.at(6).linkIndex(), 0);
+        const int resumedId = pastedLine.at(7).linkIndex();
+        QVERIFY2(resumedId > 0, "the half of the link after the inserted text lost its link index");
+        QCOMPARE(resumedId, leadingId);
+        QVERIFY2(pTarget->getLinkStore().getLinksConst(resumedId).join(QChar::Space).contains(qsl("send('resumed')")), "the resumed half does not resolve to the source link's command");
     }
 
     // The regression itself: state seeded off a pasted id has to be cleaned up


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `TBuffer::paste()` registers the source's links in the destination's own store and writes the ids that store issues, instead of copying the source's indices across verbatim.
- That registration, previously only in `appendFormatted()`, is now a shared `remapLinkId()` helper.
- Fixes a second defect in `appendFormatted()` found while extracting it: it tracked only the previous character's link, so a link split into two runs by plain text lost its second half.

#### Motivation for adding to Mudlet

Pasting a copied link into a console could silently wire it to a different link's command, so clicking it sent something the player never chose.

#### Other info (issues closed, discussion etc)

Fixes #10115

A link index only means anything to the `TLinkStore` that issued it, and ids start at 1 in every store — so a transplanted index is a collision, not a rare case. `appendFormatted()` already re-registered ids properly, which is why the bug depended on cursor position: `TConsole::paste()` only takes the verbatim path when the cursor is above the last line, and goes through `appendBuffer()` → `appendFormatted()` otherwise. The same script was right or wrong according to where the cursor sat.

The second defect is independent of pasting and was live on the append path too. Its guard read:

```cpp
if (sourceLinkId && (oldSourceLinkId != sourceLinkId)) { ... }
else if (!sourceLinkId) { destLinkId = 0; }
```

For a link occupying two runs with plain text between them, the resumed run matched neither branch, so `destLinkId` kept the zero the gap left behind. `insertText()` into the middle of a link produces exactly that pattern.

A link whose command is a Lua function is carried across by duplicating its registry reference rather than sharing it. The reference is an owned handle — `addLinks()` frees it when it recycles an id, and `removeLinkById()` frees it too — so one index in two stores has two owners: letting the destination's line scroll away returns that index to Lua while the source link still points at it, and the next `luaL_ref` reissues it. `lua_rawgeti()` plus `luaL_ref()` gives the copy its own reference to the same function.

Behaviour worth noting: non-adjacent runs of one source link now share a destination id, where each run used to be registered separately — source ids 6/7/6 arrive as 1,2,1 rather than 1,2,3. Styling or expiring one run therefore reaches the other, which matches them having been one link in the source.

**Test case:** three cases in `PastedLinkStateTest`, verified non-vacuous by running them against unmodified `development` — each fails there on its own assertion, and all pass with the patch:

- `test_pastedLinkIsRegisteredInTheDestinationsOwnStore` — the id the pasted characters carry holds the source's command and hint
- `test_pastedLinkDoesNotRunTheDestinationsOwnCommand` — with a link already in the destination, the pasted one gets a different id and does not resolve to the destination's command
- `test_aLinkResumedAfterPlainTextKeepsItsCommand` — both halves of a split link keep the same id, and the plain characters between them get none
- `test_aPastedFunctionLinkKeepsAReferenceOfItsOwn` — the pasted copy of a function link holds a registry reference, and not the source's own
- `test_aCopiedLinkKeepsItsExpireGroup` — a copied link keeps its expire group and is reaped by an `expireLinks()` of it
- `test_aCopiedLinkKeepsItsStyling` — the styling copy, which nothing covered before

Full functional suite passes, 138/138. Both scenarios manually verified on macOS: pasting a copied link into a miniconsole that has a link of its own fires the copied command with the copied hint in its tooltip, and clicking the far half of a link split by inserted text runs that link's command.

*Written with AI assistance. Assisted-by: Claude:claude-opus-5*

