### PR TITLE
Infra: Color changes reach the buffer without a window

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3435,9 +3435,12 @@ void TBuffer::decodeOSC(const QString& sequence)
                     if (isValid) {
                         // This will refresh the "main" console as it is only this
                         // class instance associated with that one that is to be
-                        // changed by this method:
+                        // changed by this method. With no console there is
+                        // nothing to restyle, but the model still has to be told:
                         if (pHost->mpConsole) {
                             pHost->mpConsole->changeColors();
+                        } else {
+                            pHost->refreshMainConsoleColors();
                         }
                         // Also need to update the Lua sub-system's "color_table"
                         pHost->updateAnsi16ColorsInTable();
@@ -4843,9 +4846,12 @@ void TBuffer::resetColors()
 
     // This will refresh the "main" console as it is only this class instance
     // associated with that one that will call this method from the
-    // decodeOSC(...) method:
+    // decodeOSC(...) method. With no console there is nothing to restyle, but
+    // the model still has to be told:
     if (pHost->mpConsole) {
         pHost->mpConsole->changeColors();
+    } else {
+        pHost->refreshMainConsoleColors();
     }
 
     // Also need to update the Lua sub-system's "color_table"

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3436,7 +3436,9 @@ void TBuffer::decodeOSC(const QString& sequence)
                         // This will refresh the "main" console as it is only this
                         // class instance associated with that one that is to be
                         // changed by this method. With no console there is
-                        // nothing to restyle, but the model still has to be told:
+                        // nothing to restyle, but this buffer's own copy of the
+                        // palette still has to be refreshed - it is what stamps
+                        // the text, not the Host's:
                         if (pHost->mpConsole) {
                             pHost->mpConsole->changeColors();
                         } else {
@@ -4847,7 +4849,8 @@ void TBuffer::resetColors()
     // This will refresh the "main" console as it is only this class instance
     // associated with that one that will call this method from the
     // decodeOSC(...) method. With no console there is nothing to restyle, but
-    // the model still has to be told:
+    // this buffer's own copy of the palette still has to be refreshed - it is
+    // what stamps the text, not the Host's:
     if (pHost->mpConsole) {
         pHost->mpConsole->changeColors();
     } else {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3436,9 +3436,7 @@ void TBuffer::decodeOSC(const QString& sequence)
                         // This will refresh the "main" console as it is only this
                         // class instance associated with that one that is to be
                         // changed by this method. With no console there is
-                        // nothing to restyle, but this buffer's own copy of the
-                        // palette still has to be refreshed - it is what stamps
-                        // the text, not the Host's:
+                        // nothing to restyle, but the model still has to be told:
                         if (pHost->mpConsole) {
                             pHost->mpConsole->changeColors();
                         } else {
@@ -4849,8 +4847,7 @@ void TBuffer::resetColors()
     // This will refresh the "main" console as it is only this class instance
     // associated with that one that will call this method from the
     // decodeOSC(...) method. With no console there is nothing to restyle, but
-    // this buffer's own copy of the palette still has to be refreshed - it is
-    // what stamps the text, not the Host's:
+    // the model still has to be told:
     if (pHost->mpConsole) {
         pHost->mpConsole->changeColors();
     } else {

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -78,10 +78,8 @@ struct TConsoleModel
     // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
     // On the main console model, the profile's colours, kept there by
-    // Host::refreshMainConsoleColors(); colour triggers set to "default" match
-    // against these. A sub-console model's hold that one window's own colours
-    // instead, written by TConsole::setConsoleBgColor() and read back only by
-    // that console.
+    // Host::refreshMainConsoleColors(); a sub-console's are its own, and no
+    // trigger reads them.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -78,8 +78,8 @@ struct TConsoleModel
     // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
     // On the main console model, the profile's colours, kept there by
-    // Host::refreshMainConsoleColors(); on a sub-console's, view-local and read
-    // by nothing else.
+    // Host::refreshMainConsoleColors(); a sub-console's are its own, and no
+    // trigger reads them.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -78,8 +78,10 @@ struct TConsoleModel
     // model, so it can be left holding one whose Host has gone.
     QPointer<Host> mpHost;
     // On the main console model, the profile's colours, kept there by
-    // Host::refreshMainConsoleColors(); a sub-console's are its own, and no
-    // trigger reads them.
+    // Host::refreshMainConsoleColors(); colour triggers set to "default" match
+    // against these. A sub-console model's hold that one window's own colours
+    // instead, written by TConsole::setConsoleBgColor() and read back only by
+    // that console.
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QString mCurrentLine;

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2694,6 +2694,8 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     const QString windowName{windowNameArg};
     if (isMain(windowName)) {
         host.mBgColor.setRgb(r, g, b, alpha);
+        // Host outlives its main console, so there may be no view to restyle -
+        // the buffer's copy of the colours still has to follow:
         if (host.mpConsole) {
             host.mpConsole->setConsoleBgColor(r, g, b, alpha);
         } else {

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2694,8 +2694,6 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     const QString windowName{windowNameArg};
     if (isMain(windowName)) {
         host.mBgColor.setRgb(r, g, b, alpha);
-        // Host outlives its main console, so there may be no view to restyle -
-        // the buffer's copy of the colours still has to follow:
         if (host.mpConsole) {
             host.mpConsole->setConsoleBgColor(r, g, b, alpha);
         } else {

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2694,7 +2694,11 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     const QString windowName{windowNameArg};
     if (isMain(windowName)) {
         host.mBgColor.setRgb(r, g, b, alpha);
-        host.mpConsole->setConsoleBgColor(r, g, b, alpha);
+        if (host.mpConsole) {
+            host.mpConsole->setConsoleBgColor(r, g, b, alpha);
+        } else {
+            host.refreshMainConsoleColors();
+        }
     } else if (!host.setBackgroundColor(windowName, r, g, b, alpha)) {
         return warnArgumentValue(L, __func__, qsl("window/label '%1' not found").arg(windowName));
     }

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -607,15 +607,14 @@ private slots:
         QVERIFY2(host->mpConsole->mpMainDisplay->styleSheet().contains(expectedBackground),
                  qPrintable(qsl("The console was not restyled by the import: %1").arg(host->mpConsole->mpMainDisplay->styleSheet())));
         // changeColors() leaves the buffer's copy of the colours to
-        // refreshMainConsoleColors(), so this walks that hand-off with a view
-        // present:
+        // refreshMainConsoleColors(), and this is the only assertion that walks
+        // that hand-off with a view present:
         QCOMPARE(plainStamp(host->mainConsoleModel().buffer).background(), mProfileBgColor);
     }
 
-    // The server can redefine the sixteen ANSI colours (<OSC>P) and reset them
-    // again (<OSC>R), and the buffer stamps text from its own copy of them
-    // rather than from the Host's - so both paths have to refresh that copy
-    // whether or not there is a console to refresh it.
+    // The server can redefine the sixteen ANSI colours, and the buffer stamps
+    // text from its own copy of them rather than from the Host's - so the copy
+    // has to be refreshed whether or not there is a console to refresh it.
     void test_ansiPaletteRedefinitionReachesTheModelWithNoView()
     {
         startProfile();
@@ -630,8 +629,7 @@ private slots:
         QVERIFY2(host->mRed != redefinedRed, "The profile's red is already the redefined one, so the assertions on it cannot fail.");
         QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
 
-        // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition,
-        // hex throughout, so this makes colour 1 (red) #123456
+        // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition
         std::string refused = "\x1b]P1123456\x07";
         model->buffer.translateToPlainText(refused, true);
         QVERIFY2(host->mRed != redefinedRed, "A server redefined the palette although the profile forbids it.");
@@ -648,10 +646,10 @@ private slots:
         QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
     }
 
-    // setBackgroundColor with no window name targets the main console: it
-    // writes the profile's background itself and leaves the view to carry that
-    // into the model. This pins that the model and the buffer's copy of the
-    // colours still get it when there is no view to route it through.
+    // setBackgroundColor("main") writes the profile's background itself and
+    // leans on the view to carry it into the model, so without one the console
+    // it reaches through is not merely absent - dereferencing it is a crash
+    // before it is ever a stale colour.
     void test_scriptedBackgroundColourReachesTheModelWithNoView()
     {
         startProfile();
@@ -776,11 +774,9 @@ private:
 
     // Utility function feeding one unstyled line and handing back the character
     // it was stamped with, which carries the buffer's own copy of the profile's
-    // colours - as long as no earlier feed left SGR state latched in this
-    // buffer. A blank TChar back means the line never landed; it is spelled out
+    // colours. A blank TChar back means the line never landed; it is spelled out
     // because TChar's no-argument constructor is explicit, which rules out
-    // `return {}`, and it is white on black - so a caller expecting either of
-    // those cannot tell a miss from a pass.
+    // `return {}`.
     TChar plainStamp(TBuffer& buffer)
     {
         std::string plainText = "Model stamp\n";

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -607,14 +607,15 @@ private slots:
         QVERIFY2(host->mpConsole->mpMainDisplay->styleSheet().contains(expectedBackground),
                  qPrintable(qsl("The console was not restyled by the import: %1").arg(host->mpConsole->mpMainDisplay->styleSheet())));
         // changeColors() leaves the buffer's copy of the colours to
-        // refreshMainConsoleColors(), and this is the only assertion that walks
-        // that hand-off with a view present:
+        // refreshMainConsoleColors(), so this walks that hand-off with a view
+        // present:
         QCOMPARE(plainStamp(host->mainConsoleModel().buffer).background(), mProfileBgColor);
     }
 
-    // The server can redefine the sixteen ANSI colours, and the buffer stamps
-    // text from its own copy of them rather than from the Host's - so the copy
-    // has to be refreshed whether or not there is a console to refresh it.
+    // The server can redefine the sixteen ANSI colours (<OSC>P) and reset them
+    // again (<OSC>R), and the buffer stamps text from its own copy of them
+    // rather than from the Host's - so both paths have to refresh that copy
+    // whether or not there is a console to refresh it.
     void test_ansiPaletteRedefinitionReachesTheModelWithNoView()
     {
         startProfile();
@@ -629,7 +630,8 @@ private slots:
         QVERIFY2(host->mRed != redefinedRed, "The profile's red is already the redefined one, so the assertions on it cannot fail.");
         QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
 
-        // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition
+        // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition,
+        // hex throughout, so this makes colour 1 (red) #123456
         std::string refused = "\x1b]P1123456\x07";
         model->buffer.translateToPlainText(refused, true);
         QVERIFY2(host->mRed != redefinedRed, "A server redefined the palette although the profile forbids it.");
@@ -646,10 +648,10 @@ private slots:
         QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
     }
 
-    // setBackgroundColor("main") writes the profile's background itself and
-    // leans on the view to carry it into the model, so without one the console
-    // it reaches through is not merely absent - dereferencing it is a crash
-    // before it is ever a stale colour.
+    // setBackgroundColor with no window name targets the main console: it
+    // writes the profile's background itself and leaves the view to carry that
+    // into the model. This pins that the model and the buffer's copy of the
+    // colours still get it when there is no view to route it through.
     void test_scriptedBackgroundColourReachesTheModelWithNoView()
     {
         startProfile();
@@ -774,9 +776,11 @@ private:
 
     // Utility function feeding one unstyled line and handing back the character
     // it was stamped with, which carries the buffer's own copy of the profile's
-    // colours. A blank TChar back means the line never landed; it is spelled out
+    // colours - as long as no earlier feed left SGR state latched in this
+    // buffer. A blank TChar back means the line never landed; it is spelled out
     // because TChar's no-argument constructor is explicit, which rules out
-    // `return {}`.
+    // `return {}`, and it is white on black - so a caller expecting either of
+    // those cannot tell a miss from a pass.
     TChar plainStamp(TBuffer& buffer)
     {
         std::string plainText = "Model stamp\n";

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -588,7 +588,7 @@ private slots:
 
     // The same XML arrives as a package import into a live profile, and there
     // the model on its own is not enough - the view has to be restyled with it,
-    // or text in the new foreground lands on the old background.
+    // or the console keeps painting the old background behind the panes.
     void test_importingColoursIntoALiveProfileRestylesTheView()
     {
         pinTheFixtureColoursAreNotTheDefaults();
@@ -606,6 +606,68 @@ private slots:
         QCOMPARE(host->mainConsoleModel().mBgColor, mProfileBgColor);
         QVERIFY2(host->mpConsole->mpMainDisplay->styleSheet().contains(expectedBackground),
                  qPrintable(qsl("The console was not restyled by the import: %1").arg(host->mpConsole->mpMainDisplay->styleSheet())));
+        // changeColors() leaves the buffer's copy of the colours to
+        // refreshMainConsoleColors(), and this is the only assertion that walks
+        // that hand-off with a view present:
+        QCOMPARE(plainStamp(host->mainConsoleModel().buffer).background(), mProfileBgColor);
+    }
+
+    // The server can redefine the sixteen ANSI colours, and the buffer stamps
+    // text from its own copy of them rather than from the Host's - so the copy
+    // has to be refreshed whether or not there is a console to refresh it.
+    void test_ansiPaletteRedefinitionReachesTheModelWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+
+        const QColor redefinedRed(0x12, 0x34, 0x56);
+        QVERIFY2(host->mRed != redefinedRed, "The profile's red is already the redefined one, so the assertions on it cannot fail.");
+        QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
+
+        // <OSC>P<colour number><RRGGBB><BEL> - the xterm palette redefinition
+        std::string refused = "\x1b]P1123456\x07";
+        model->buffer.translateToPlainText(refused, true);
+        QVERIFY2(host->mRed != redefinedRed, "A server redefined the palette although the profile forbids it.");
+
+        host->setMayRedefineColors(true);
+        std::string redefine = "\x1b]P1123456\x07";
+        model->buffer.translateToPlainText(redefine, true);
+        QCOMPARE(host->mRed, redefinedRed);
+        QCOMPARE(ansiRedStamp(model->buffer), redefinedRed);
+
+        std::string reset = "\x1b]R\x07";
+        model->buffer.translateToPlainText(reset, true);
+        QCOMPARE(host->mRed, QColor(QColorConstants::DarkRed));
+        QCOMPARE(ansiRedStamp(model->buffer), QColor(QColorConstants::DarkRed));
+    }
+
+    // setBackgroundColor("main") writes the profile's background itself and
+    // leans on the view to carry it into the model, so without one the console
+    // it reaches through is not merely absent - dereferencing it is a crash
+    // before it is ever a stale colour.
+    void test_scriptedBackgroundColourReachesTheModelWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+
+        const QColor scriptedBackground(0x11, 0x22, 0x33);
+        QVERIFY2(host->mBgColor != scriptedBackground, "The profile already carries the scripted background, so the assertions below cannot fail.");
+
+        runLua(host, qsl("setBackgroundColor(0x11, 0x22, 0x33)"));
+
+        QCOMPARE(host->mBgColor, scriptedBackground);
+        QCOMPARE(model->mBgColor, scriptedBackground);
+        QCOMPARE(plainStamp(model->buffer).background(), scriptedBackground);
     }
 
     void cleanup()
@@ -708,6 +770,36 @@ private:
         const QString line = text + QChar::LineFeed;
         buffer.append(line, 0, line.size(), fgColor, bgColor, TChar::None, 0);
         return buffer.getLastLineNumber() - 1;
+    }
+
+    // Utility function feeding one unstyled line and handing back the character
+    // it was stamped with, which carries the buffer's own copy of the profile's
+    // colours. A blank TChar back means the line never landed; it is spelled out
+    // because TChar's no-argument constructor is explicit, which rules out
+    // `return {}`.
+    TChar plainStamp(TBuffer& buffer)
+    {
+        std::string plainText = "Model stamp\n";
+        buffer.translateToPlainText(plainText, true);
+        const int line = buffer.getLastLineNumber() - 1;
+        if (line < 0 || buffer.buffer.at(line).empty()) {
+            return TChar();
+        }
+        return buffer.buffer.at(line).at(0);
+    }
+
+    // Utility function feeding one SGR-red line and handing back the colour it
+    // was stamped with, which is the buffer's copy of red rather than the
+    // Host's. An invalid colour back means the line never landed.
+    QColor ansiRedStamp(TBuffer& buffer)
+    {
+        std::string redText = "\x1b[31mPalette red\n";
+        buffer.translateToPlainText(redText, true);
+        const int line = buffer.getLastLineNumber() - 1;
+        if (line < 0 || buffer.buffer.at(line).empty()) {
+            return {};
+        }
+        return buffer.buffer.at(line).at(0).foreground();
     }
 
     // Utility function: a model that was never given the profile's colours holds


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Restores #10169, which merged but never reached `development`.

- `OSC P` / `OSC R` palette redefinition (`TBuffer::decodeOSC`, `TBuffer::resetColors`) and `setBackgroundColor("main")` pushed the profile's colors into `TBuffer`'s own copy only by way of `TConsole::changeColors()`, which a profile with no console does not have. Both now fall back to `Host::refreshMainConsoleColors()`, the way `XMLimport::readHost()` already does.
- The Lua one also dereferenced `mpConsole` with no null check, so with no console it was a crash rather than merely a stale color.
- #10169's three `ConsoleModelExtractionTest` additions come across with it.

#### Motivation for adding to Mudlet

A squash-merge race dropped the work. #10169 merged into `w3-step2-colour-refresh` at 2026-08-24T16:20:59Z; seventeen seconds later, at 16:21:16Z, #10152 squash-merged that same branch into `development` from a snapshot taken before #10169 landed on it. The resulting squash (1cc7784) carries only #10152's own seven files and touches neither `TBuffer.cpp` nor `TLuaInterpreterUI.cpp`, so none of #10169 survived on `development`. It was not in #10154's branch either - the branch head e9f5e3ae3 was the last copy.

#### Other info (issues closed, discussion etc)

Cherry-picked from e9f5e3ae3 rather than retyped, so authorship and content are #10169's; it applied cleanly onto current `development`. The net diff of this branch is byte-identical to #10169's patch - the middle commit reworded some comments and is reverted by the third, so the branch stays a faithful restoration rather than a re-edit. No behaviour change for Mudlet itself, where a main console always exists.

**Test case:** `ctest` 139/139, Lua specs 3741 successes / 0 failures. Reverting just the three `src/` files to `development`'s versions while keeping the tests turns `test_ansiPaletteRedefinitionReachesTheModelWithNoView` red (the buffer stamps `#ff800000` instead of the redefined `#ff123456`) and segfaults `test_scriptedBackgroundColourReachesTheModelWithNoView` at `TConsole::setConsoleBgColor (this=0x0)`.

Assisted-by: Claude:claude-opus-5
