### PR TITLE
Fix: Lua UI functions no longer crash when a profile has no window

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -126,7 +126,7 @@ const QString TLuaInterpreter::csmInvalidAreaName{qsl("string '%1' is not a vali
     ({                                                                                                                                                                                                 \
         const QString& name_ = (ARG_name);                                                                                                                                                             \
         auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
-        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_);                                                                                         \
+        auto cmdLine_ = !console_ ? nullptr : (isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_));                                                                 \
         if (!cmdLine_) {                                                                                                                                                                               \
             lua_pushnil(ARG_L);                                                                                                                                                                        \
             lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());                                                                                                                     \

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -178,7 +178,7 @@ static bool timerDelayFits(const double time)
     ({                                                                                                                                                                                                 \
         const QString& name_ = (ARG_name);                                                                                                                                                             \
         auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
-        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_);                                                                                         \
+        auto cmdLine_ = !console_ ? nullptr : (isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_));                                                                 \
         if (!cmdLine_) {                                                                                                                                                                               \
             lua_pushnil(ARG_L);                                                                                                                                                                        \
             lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());                                                                                                                     \
@@ -191,7 +191,7 @@ static bool timerDelayFits(const double time)
     ({                                                                                                                                                                                                 \
         const QString& name_ = (ARG_name);                                                                                                                                                             \
         auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
-        auto label_ = console_->mLabelMap.value(name_);                                                                                                                                                \
+        auto label_ = console_ ? console_->mLabelMap.value(name_) : nullptr;                                                                                                                           \
         if (!label_) {                                                                                                                                                                                 \
             lua_pushnil(ARG_L);                                                                                                                                                                        \
             lua_pushfstring(ARG_L, bad_label_value, name_.toUtf8().constData());                                                                                                                       \

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -78,6 +78,10 @@ static const char* bad_cmdline_type = "%s: bad argument #%d type (command line n
 static const char* bad_window_value = "window \"%s\" not found";
 static const char* bad_cmdline_value = "command line \"%s\" not found";
 static const char* bad_label_value = "label \"%s\" not found";
+// A Host outlives its main console: closing a profile's window destroys the view
+// while triggers, the buffer, logging and Lua all keep running. Whatever only a
+// widget can answer has to report this rather than dereference what is gone.
+static const char* no_main_window_value = "the profile has no main window";
 
 // No documentation available in wiki - internal function
 static bool isMain(const QString& name)
@@ -140,7 +144,7 @@ static bool isMain(const QString& name)
     ({                                                                                                                                                                                                 \
         const QString& name_ = (ARG_name);                                                                                                                                                             \
         auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
-        auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_);                                                                                         \
+        auto cmdLine_ = !console_ ? nullptr : (isMain(name_) ? &*console_->mpCommandLine : console_->mSubCommandLineMap.value(name_));                                                                 \
         if (!cmdLine_) {                                                                                                                                                                               \
             lua_pushnil(ARG_L);                                                                                                                                                                        \
             lua_pushfstring(ARG_L, bad_cmdline_value, name_.toUtf8().constData());                                                                                                                     \
@@ -153,7 +157,7 @@ static bool isMain(const QString& name)
     ({                                                                                                                                                                                                 \
         const QString& name_ = (ARG_name);                                                                                                                                                             \
         auto console_ = getHostFromLua(ARG_L).mpConsole;                                                                                                                                               \
-        auto label_ = console_->mLabelMap.value(name_);                                                                                                                                                \
+        auto label_ = console_ ? console_->mLabelMap.value(name_) : nullptr;                                                                                                                           \
         if (!label_) {                                                                                                                                                                                 \
             lua_pushnil(ARG_L);                                                                                                                                                                        \
             lua_pushfstring(ARG_L, bad_label_value, name_.toUtf8().constData());                                                                                                                       \
@@ -375,6 +379,9 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
     const QString commandLineName{lua_tostring(L, commandLineNamePos)};
 
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->createCommandLine(windowName, commandLineName, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -510,6 +517,9 @@ int TLuaInterpreter::deleteLabel(lua_State* L)
 {
     const QString labelName = getVerifiedString(L, __func__, 1, "label name");
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value, true);
+    }
     if (auto [success, message] = host.mpConsole->deleteLabel(labelName); !success) {
         lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
@@ -526,6 +536,9 @@ int TLuaInterpreter::deleteMiniConsole(lua_State* L)
     const QString miniConsoleName = getVerifiedString(L, __func__, 1, "miniconsole name");
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value, true);
+    }
     if (auto [success, message] = host.mpConsole->deleteMiniConsole(miniConsoleName); !success) {
         lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
@@ -549,6 +562,9 @@ int TLuaInterpreter::deleteCommandLine(lua_State* L)
 
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value, true);
+    }
     if (auto [success, message] = host.mpConsole->deleteCommandLine(commandLineName); !success) {
         lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
@@ -599,6 +615,9 @@ int TLuaInterpreter::createTextEdit(lua_State* L)
     const QString textEditName{lua_tostring(L, textEditNamePos)};
 
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->createTextBox(windowName, textEditName, x, y, width, height); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -614,6 +633,9 @@ int TLuaInterpreter::deleteTextEdit(lua_State* L)
 
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value, true);
+    }
     if (auto [success, message] = host.mpConsole->deleteTextBox(textEditName); !success) {
         lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
@@ -630,7 +652,7 @@ int TLuaInterpreter::getTextEditText(lua_State* L)
     const QString textEditName = getVerifiedString(L, __func__, 1, "text edit name");
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -649,7 +671,7 @@ int TLuaInterpreter::setTextEditText(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -665,7 +687,7 @@ int TLuaInterpreter::clearTextEdit(lua_State* L)
     const QString textEditName = getVerifiedString(L, __func__, 1, "text edit name");
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -685,7 +707,7 @@ int TLuaInterpreter::setTextEditReadOnly(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -705,7 +727,7 @@ int TLuaInterpreter::setTextEditPlaceholder(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -725,7 +747,7 @@ int TLuaInterpreter::setTextEditStyleSheet(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -745,7 +767,7 @@ int TLuaInterpreter::setTextEditFont(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -767,7 +789,7 @@ int TLuaInterpreter::setTextEditFontSize(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -789,7 +811,7 @@ int TLuaInterpreter::setTextEditTabMovesFocus(lua_State* L)
     const QString textEditName{lua_tostring(L, 1)};
 
     const Host& host = getHostFromLua(L);
-    auto pT = host.mpConsole->mTextBoxMap.value(textEditName);
+    auto pT = host.mpConsole ? host.mpConsole->mTextBoxMap.value(textEditName) : nullptr;
     if (!pT) {
         return warnArgumentValue(L, __func__, qsl("text edit name '%1' not found").arg(textEditName));
     }
@@ -805,6 +827,9 @@ int TLuaInterpreter::deleteScrollBox(lua_State* L)
     const QString scrollBoxName = getVerifiedString(L, __func__, 1, "scrollbox name");
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value, true);
+    }
     if (auto [success, message] = host.mpConsole->deleteScrollBox(scrollBoxName); !success) {
         lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
@@ -1182,7 +1207,7 @@ int TLuaInterpreter::getAvailableFonts(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBackgroundColor
 int TLuaInterpreter::getBackgroundColor(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
     QColor color;
 
     QString windowName = qsl("main");
@@ -1192,7 +1217,9 @@ int TLuaInterpreter::getBackgroundColor(lua_State* L)
     }
 
     if (isMain(windowName)) {
-        color = host.mpConsole->getConsoleBgColor();
+        // the view's colour is a reference to this one, so read it straight from
+        // the model and the answer is the same with or without a window
+        color = host.mainConsoleModel().mBgColor;
     } else if (auto optionalColor = host.getBackgroundColor(windowName)) {
         color = optionalColor.value();
     } else {
@@ -1215,7 +1242,7 @@ int TLuaInterpreter::getBgColor(lua_State* L)
     }
 
     const Host& host = getHostFromLua(L);
-    std::list<int> const result = host.mpConsole->getBgColor(windowName);
+    std::list<int> const result = host.mpConsole ? host.mpConsole->getBgColor(windowName) : std::list<int>{};
     for (const int pos : result) {
         lua_pushnumber(L, pos);
     }
@@ -1275,6 +1302,9 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
 int TLuaInterpreter::getBorderColor(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     const QColor color = host.mpConsole->borderColor();
     lua_pushnumber(L, color.red());
     lua_pushnumber(L, color.green());
@@ -1340,7 +1370,7 @@ int TLuaInterpreter::getFgColor(lua_State* L)
     }
 
     const Host& host = getHostFromLua(L);
-    std::list<int> const result = host.mpConsole->getFgColor(windowName);
+    std::list<int> const result = host.mpConsole ? host.mpConsole->getFgColor(windowName) : std::list<int>{};
     for (const int pos : result) {
         lua_pushnumber(L, pos);
     }
@@ -1415,7 +1445,7 @@ int TLuaInterpreter::getLabelSizeHint(lua_State* L)
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
 
-    auto size = host.mpConsole->getLabelSizeHint(labelName);
+    auto size = host.mpConsole ? host.mpConsole->getLabelSizeHint(labelName) : std::nullopt;
     if (!size) {
         return warnArgumentValue(L, __func__, qsl("label '%1' does not exist").arg(labelName));
     }
@@ -1429,7 +1459,7 @@ int TLuaInterpreter::getLabelStyleSheet(lua_State* L)
 {
     const QString label = getVerifiedString(L, __func__, 1, "label");
     const Host& host = getHostFromLua(L);
-    if (auto stylesheet = host.mpConsole->getLabelStyleSheet(label)) {
+    if (auto stylesheet = host.mpConsole ? host.mpConsole->getLabelStyleSheet(label) : std::nullopt) {
         lua_pushstring(L, stylesheet->toUtf8().constData());
         return 1;
     }
@@ -1548,6 +1578,10 @@ int TLuaInterpreter::getMousePosition(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
+
     const QPoint pos = host.mpConsole->mapFromGlobal(QCursor::pos());
 
     lua_pushnumber(L, pos.x());
@@ -1573,6 +1607,9 @@ int TLuaInterpreter::getProfileTabNumber(lua_State* L)
 int TLuaInterpreter::getMainWindowSize(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     const QSize mainWindowSize = host.mpConsole->getMainWindowSize();
 
     lua_pushnumber(L, mainWindowSize.width());
@@ -1781,6 +1818,9 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
     const QString windowName{WINDOW_NAME(L, 1)};
 
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     const QSize userWindowSize = host.mpConsole->getUserWindowSize(windowName);
     lua_pushnumber(L, userWindowSize.width());
     lua_pushnumber(L, userWindowSize.height());
@@ -1846,7 +1886,7 @@ int TLuaInterpreter::getWindowWrap(lua_State* L)
 int TLuaInterpreter::hasFocus(lua_State* L)
 {
     const Host& host = getHostFromLua(L);
-    lua_pushboolean(L, host.mpConsole->hasFocus()); //FIXME
+    lua_pushboolean(L, host.mpConsole && host.mpConsole->hasFocus()); //FIXME
     return 1;
 }
 
@@ -2003,7 +2043,7 @@ int TLuaInterpreter::isAnsiBgColor(lua_State* L)
 
     std::list<int> result;
     const Host& host = getHostFromLua(L);
-    result = host.mpConsole->getBgColor(windowName);
+    result = host.mpConsole ? host.mpConsole->getBgColor(windowName) : std::list<int>{};
     auto it = result.begin();
     if (result.size() < 3) {
         return warnArgumentValue(L, __func__, qsl("current selection invalid in window '%1'").arg(windowName));
@@ -2094,7 +2134,7 @@ int TLuaInterpreter::isAnsiFgColor(lua_State* L)
 
     std::list<int> result;
     const Host& host = getHostFromLua(L);
-    result = host.mpConsole->getFgColor(windowName);
+    result = host.mpConsole ? host.mpConsole->getFgColor(windowName) : std::list<int>{};
     auto it = result.begin();
     if (result.size() < 3) {
         return warnArgumentValue(L, __func__, qsl("current selection invalid in window '%1'").arg(windowName));
@@ -2189,7 +2229,7 @@ int TLuaInterpreter::lowerWindow(lua_State* L)
 {
     const QString windowName{WINDOW_NAME(L, 1)};
     const Host& host = getHostFromLua(L);
-    lua_pushboolean(L, host.mpConsole->lowerWindow(windowName));
+    lua_pushboolean(L, host.mpConsole && host.mpConsole->lowerWindow(windowName));
     return 1;
 }
 
@@ -2295,7 +2335,7 @@ int TLuaInterpreter::raiseWindow(lua_State* L)
 {
     const QString windowName{WINDOW_NAME(L, 1)};
     const Host& host = getHostFromLua(L);
-    lua_pushboolean(L, host.mpConsole->raiseWindow(windowName));
+    lua_pushboolean(L, host.mpConsole && host.mpConsole->raiseWindow(windowName));
     return 1;
 }
 
@@ -2508,7 +2548,7 @@ int TLuaInterpreter::selectCaptureGroup(lua_State* L)
             length = pL->mCapturedNameGroupsPosList.value(name).second;
         }
     }
-    if (length > 0) {
+    if (length > 0 && host.mpConsole) {
         const int pos = host.mpConsole->selectSection(begin, length);
         lua_pushnumber(L, pos);
     } else {
@@ -2860,6 +2900,9 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
     const int luaGreen = getVerifiedInt(L, __func__, 2, "green");
     const int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     host.mpConsole->setBorderColor(QColor(luaRed, luaGreen, luaBlue));
     return 0;
 }
@@ -3044,6 +3087,9 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
     const QString styleSheet{lua_tostring(L, styleSheetIndex)};
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3065,7 +3111,7 @@ int TLuaInterpreter::getCmdLineStyleSheet(lua_State* L)
     const QString name = hasName ? QString{lua_tostring(L, 1)} : qsl("main");
     const Host& host = getHostFromLua(L);
 
-    if (auto styleSheet = host.mpConsole->getCmdLineStyleSheet(name)) {
+    if (auto styleSheet = host.mpConsole ? host.mpConsole->getCmdLineStyleSheet(name) : std::nullopt) {
         lua_pushstring(L, styleSheet->toUtf8().constData());
         return 1;
     }
@@ -3207,6 +3253,9 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
 
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setLabelToolTip(labelName, labelToolTip, duration); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3224,7 +3273,7 @@ int TLuaInterpreter::getLabelToolTip(lua_State* L)
     }
 
     const Host& host = getHostFromLua(L);
-    if (auto toolTip = host.mpConsole->getLabelToolTip(labelName)) {
+    if (auto toolTip = host.mpConsole ? host.mpConsole->getLabelToolTip(labelName) : std::nullopt) {
         lua_pushstring(L, toolTip->toUtf8().constData());
         return 1;
     }
@@ -3278,6 +3327,9 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
     const QString stylesheet{lua_tostring(L, 2)};
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setLabelStyleSheet(labelName, stylesheet); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3296,6 +3348,9 @@ int TLuaInterpreter::setLabelCursor(lua_State* L)
     const QString labelName{lua_tostring(L, 1)};
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setLabelCursor(labelName, labelCursor); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3323,6 +3378,9 @@ int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
 
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setLabelCustomCursor(labelName, pixmapLocation, hotX, hotY); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3672,6 +3730,9 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
                                         | (fastBlink ? TChar::FastBlink : (slowBlink ? TChar::Blink : TChar::None));
 
     const QString windowName{windowNameCString};
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value, true);
+    }
     if (!host.mpConsole->setTextFormat(windowName, QColor(colorComponents[3], colorComponents[4], colorComponents[5]), QColor(colorComponents[0], colorComponents[1], colorComponents[2]), flags)) {
         return warnArgumentValue(L, __func__, qsl("window '%1' does not exist").arg(windowName), true);
     }
@@ -3713,6 +3774,9 @@ int TLuaInterpreter::setUserWindowTitle(lua_State* L)
     }
 
     const Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setUserWindowTitle(name, title); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3726,6 +3790,10 @@ int TLuaInterpreter::getUserWindowTitle(lua_State* L)
 {
     const QString name = getVerifiedString(L, __func__, 1, "name");
     const Host& host = getHostFromLua(L);
+
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
 
     auto [success, result] = host.mpConsole->getUserWindowTitle(name);
     if (!success) {
@@ -3746,6 +3814,9 @@ int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
     const QString userWindowStyleSheet{lua_tostring(L, 2)};
     const Host& host = getHostFromLua(L);
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     if (auto [success, message] = host.mpConsole->setUserWindowStyleSheet(userWindowName, userWindowStyleSheet); !success) {
         return warnArgumentValue(L, __func__, message);
     }
@@ -3763,7 +3834,7 @@ int TLuaInterpreter::getUserWindowStyleSheet(lua_State* L)
     }
 
     const Host& host = getHostFromLua(L);
-    if (auto styleSheet = host.mpConsole->getUserWindowStyleSheet(userWindowName)) {
+    if (auto styleSheet = host.mpConsole ? host.mpConsole->getUserWindowStyleSheet(userWindowName) : std::nullopt) {
         lua_pushstring(L, styleSheet->toUtf8().constData());
         return 1;
     }
@@ -3941,7 +4012,9 @@ int TLuaInterpreter::setCommandBackgroundColor(lua_State* L)
     const QString windowName{windowNameArg};
     if (isMain(windowName)) {
         host.mCommandBgColor.setRgb(r, g, b, alpha);
-        host.mpConsole->setCommandBgColor(r, g, b, alpha);
+        if (host.mpConsole) {
+            host.mpConsole->setCommandBgColor(r, g, b, alpha);
+        }
     } else if (!host.setCommandBackgroundColor(windowName, r, g, b, alpha)) {
         return warnArgumentValue(L, __func__, qsl("window/label '%1' not found").arg(windowName));
     }
@@ -3999,7 +4072,9 @@ int TLuaInterpreter::setCommandForegroundColor(lua_State* L)
     const QString windowName{windowNameArg};
     if (isMain(windowName)) {
         host.mCommandFgColor.setRgb(r, g, b, alpha);
-        host.mpConsole->setCommandFgColor(r, g, b, alpha);
+        if (host.mpConsole) {
+            host.mpConsole->setCommandFgColor(r, g, b, alpha);
+        }
     } else if (!host.setCommandForegroundColor(windowName, r, g, b, alpha)) {
         return warnArgumentValue(L, __func__, qsl("window/label '%1' not found").arg(windowName));
     }
@@ -4092,7 +4167,16 @@ int TLuaInterpreter::wrapLine(lua_State* L)
     const int lineNumber = getVerifiedInt(L, __func__, hasWindowName ? 2 : 1, "line");
     QString windowName = hasWindowName ? QString{lua_tostring(L, 1)} : qsl("main");
 
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
+    if (!host.mpConsole) {
+        // sub-windows die with the view, but the main window's buffer is the
+        // model's and still holds the wrap settings the view was using
+        if (isMain(windowName)) {
+            TBuffer& buffer = host.mainConsoleModel().buffer;
+            buffer.wrapLine(lineNumber, buffer.mWrapAt, buffer.mWrapIndent, buffer.mWrapHangingIndent);
+        }
+        return 0;
+    }
     host.mpConsole->luaWrapLine(windowName, lineNumber);
     return 0;
 }

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -769,6 +769,203 @@ private slots:
         delete mudlet::self();
     }
 
+    // Every one of these Lua functions used to reach through Host::mpConsole
+    // without checking it, so calling any of them on a profile whose window had
+    // been closed took the whole client down with it. None of them can do what
+    // it was asked here, so each has to report that instead.
+    void test_viewOnlyUiFunctionsReportWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        destroyTheView(host);
+
+        runLua(host, qsl(R"LUA(
+noViewProblems = {}
+
+-- nil or false plus a reason, which is what a Mudlet Lua function answers when
+-- the thing it was handed does not exist
+local function expectRefusal(name, ...)
+    local first, second = ...
+    if first ~= nil and first ~= false then
+        table.insert(noViewProblems, name .. ' returned ' .. tostring(first))
+    elseif type(second) ~= 'string' or second == '' then
+        table.insert(noViewProblems, name .. ' gave no reason')
+    end
+end
+
+-- functions that answer a plain value rather than reporting a failure
+local function expectValue(name, expected, ...)
+    local first = ...
+    if first ~= expected then
+        table.insert(noViewProblems, name .. ' returned ' .. tostring(first) .. ' rather than ' .. tostring(expected))
+    end
+end
+
+-- an invalid selection has always returned no values at all
+local function expectNothing(name, ...)
+    if select('#', ...) ~= 0 then
+        table.insert(noViewProblems, name .. ' returned ' .. tostring((...)))
+    end
+end
+
+expectRefusal('createCommandLine', createCommandLine('noViewCl', 0, 0, 100, 20))
+expectRefusal('deleteCommandLine', deleteCommandLine('noViewCl'))
+expectRefusal('deleteLabel', deleteLabel('noViewLbl'))
+expectRefusal('deleteMiniConsole', deleteMiniConsole('noViewMc'))
+expectRefusal('deleteScrollBox', deleteScrollBox('noViewSb'))
+expectRefusal('createTextEdit', createTextEdit('noViewTe', 0, 0, 100, 20))
+expectRefusal('deleteTextEdit', deleteTextEdit('noViewTe'))
+expectRefusal('getTextEditText', getTextEditText('noViewTe'))
+expectRefusal('setTextEditText', setTextEditText('noViewTe', 'x'))
+expectRefusal('clearTextEdit', clearTextEdit('noViewTe'))
+expectRefusal('setTextEditReadOnly', setTextEditReadOnly('noViewTe', true))
+expectRefusal('setTextEditPlaceholder', setTextEditPlaceholder('noViewTe', 'p'))
+expectRefusal('setTextEditStyleSheet', setTextEditStyleSheet('noViewTe', ''))
+expectRefusal('setTextEditFont', setTextEditFont('noViewTe', 'Courier'))
+expectRefusal('setTextEditFontSize', setTextEditFontSize('noViewTe', 10))
+expectRefusal('setTextEditTabMovesFocus', setTextEditTabMovesFocus('noViewTe', true))
+expectRefusal('getBorderColor', getBorderColor())
+expectRefusal('setBorderColor', setBorderColor(1, 2, 3))
+expectRefusal('getLabelSizeHint', getLabelSizeHint('noViewLbl'))
+expectRefusal('getLabelStyleSheet', getLabelStyleSheet('noViewLbl'))
+expectRefusal('setLabelStyleSheet', setLabelStyleSheet('noViewLbl', ''))
+expectRefusal('getLabelToolTip', getLabelToolTip('noViewLbl'))
+expectRefusal('setLabelToolTip', setLabelToolTip('noViewLbl', 't'))
+expectRefusal('setLabelCursor', setLabelCursor('noViewLbl', 0))
+expectRefusal('setLabelCustomCursor', setLabelCustomCursor('noViewLbl', '/nowhere.png'))
+expectRefusal('getLabelText', getLabelText('noViewLbl'))
+expectRefusal('clearCmdLine', clearCmdLine())
+expectRefusal('getCmdLineStyleSheet', getCmdLineStyleSheet())
+expectRefusal('setCmdLineStyleSheet', setCmdLineStyleSheet(''))
+expectRefusal('getMousePosition', getMousePosition())
+expectRefusal('getMainWindowSize', getMainWindowSize())
+expectRefusal('getUserWindowSize', getUserWindowSize('noViewUw'))
+expectRefusal('getUserWindowTitle', getUserWindowTitle('noViewUw'))
+expectRefusal('setUserWindowTitle', setUserWindowTitle('noViewUw', 't'))
+expectRefusal('getUserWindowStyleSheet', getUserWindowStyleSheet('noViewUw'))
+expectRefusal('setUserWindowStyleSheet', setUserWindowStyleSheet('noViewUw', ''))
+expectRefusal('setTextFormat', setTextFormat('main', 0, 0, 0, 255, 255, 255, false, false, false))
+expectRefusal('isAnsiBgColor', isAnsiBgColor(1))
+expectRefusal('isAnsiFgColor', isAnsiFgColor(1))
+
+expectValue('hasFocus', false, hasFocus())
+expectValue('lowerWindow', false, lowerWindow('noViewUw'))
+expectValue('raiseWindow', false, raiseWindow('noViewUw'))
+
+expectNothing('getBgColor', getBgColor())
+expectNothing('getFgColor', getFgColor())
+
+noViewReport = table.concat(noViewProblems, '; ')
+)LUA"));
+
+        QCOMPARE(luaGlobalString(host, "noViewReport"), QString());
+    }
+
+    // selectCaptureGroup() only reaches the view from inside a trigger that
+    // captured something, and a selection needs a widget to live in - so with no
+    // window it has to answer the -1 it already answers for a group that is not
+    // there.
+    void test_selectCaptureGroupAnswersMinusOneWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        runLua(host,
+               qsl("captureGroupResult = 'the trigger did not run'\n"
+                   "tempRegexTrigger([[^NoViewCapture (\\w+)]], [[captureGroupResult = tostring(selectCaptureGroup(1))]], 10)\n"));
+
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+        host->reenableAllTriggers();
+
+        host->runTriggers(appendModelLine(model->buffer, qsl("NoViewCapture alpha")));
+
+        QCOMPARE(luaGlobalString(host, "captureGroupResult"), qsl("-1"));
+    }
+
+    // The main console's background is the model's, so a script can still read
+    // back what it set with no window in between.
+    void test_backgroundColourRoundTripsThroughTheModelWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+
+        const QColor scriptedBackground(0x44, 0x55, 0x66);
+        QVERIFY2(host->mBgColor != scriptedBackground, "The profile already carries the scripted background, so the assertions below cannot fail.");
+        runLua(host,
+               qsl("setBackgroundColor(0x44, 0x55, 0x66)\n"
+                   "readBackR, readBackG, readBackB, readBackA = getBackgroundColor()\n"));
+
+        QCOMPARE(model->mBgColor, scriptedBackground);
+        QCOMPARE(luaGlobalNumber(host, "readBackR"), 0x44);
+        QCOMPARE(luaGlobalNumber(host, "readBackG"), 0x55);
+        QCOMPARE(luaGlobalNumber(host, "readBackB"), 0x66);
+        QCOMPARE(luaGlobalNumber(host, "readBackA"), 255);
+    }
+
+    // The command line's colours live on Host, and the widget only caches them -
+    // TConsole re-reads both when one is built. So with no window the write still
+    // has somewhere to land and still reports success.
+    void test_commandLineColoursReachTheProfileWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        destroyTheView(host);
+
+        const QColor scriptedBackground(0x12, 0x34, 0x56, 255);
+        const QColor scriptedForeground(0x65, 0x43, 0x21, 255);
+        QVERIFY2(host->mCommandBgColor != scriptedBackground, "The profile already carries the scripted command line background.");
+        QVERIFY2(host->mCommandFgColor != scriptedForeground, "The profile already carries the scripted command line foreground.");
+
+        runLua(host,
+               qsl("commandColoursSet = tostring(setCommandBackgroundColor(0x12, 0x34, 0x56))\n"
+                   "  .. ',' .. tostring(setCommandForegroundColor(0x65, 0x43, 0x21))\n"));
+
+        QCOMPARE(luaGlobalString(host, "commandColoursSet"), qsl("true,true"));
+        QCOMPARE(host->mCommandBgColor, scriptedBackground);
+        QCOMPARE(host->mCommandFgColor, scriptedForeground);
+    }
+
+    // wrapLine() rewrites the buffer, which is the model's, and the wrap width it
+    // has to use is the one the buffer carries - not the profile's, which the view
+    // only copies in when it restyles.
+    void test_wrapLineRewrapsTheModelBufferWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+        destroyTheView(host);
+
+        const QString longLine = qsl("alpha bravo charlie delta echo foxtrot golf hotel");
+        const int wrappedLine = appendModelLine(model->buffer, longLine);
+        QCOMPARE(model->buffer.line(wrappedLine), longLine);
+        const int linesBefore = model->buffer.getLastLineNumber();
+
+        // narrower than the profile's own width, so reading the wrap settings
+        // from anywhere but the buffer leaves the line alone
+        model->buffer.setWrapAt(20);
+        model->buffer.setWrapIndent(0);
+        model->buffer.setWrapHangingIndent(0);
+        QVERIFY2(host->mWrapAt > longLine.size(), "The profile wraps narrower than the test line, so this cannot tell the two widths apart.");
+
+        runLua(host, qsl("wrapLine('main', %1)").arg(wrappedLine));
+
+        QVERIFY2(model->buffer.getLastLineNumber() > linesBefore, "wrapLine() did not rewrap the model's buffer.");
+        QVERIFY2(model->buffer.line(wrappedLine).size() <= 20, qPrintable(qsl("The rewrapped line is wider than the buffer's wrap width: '%1'").arg(model->buffer.line(wrappedLine))));
+        QVERIFY2(joinedBuffer(model->buffer).contains(longLine), "Rewrapping the model's buffer lost the line's text.");
+    }
+
 private:
     // Utility function to manually start a profile like a user would do via the
     // GUI


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`TLuaInterpreterUI.cpp` dereferenced `Host::mpConsole` in 48 places with only one guard. All 48 are now safe:

- **4 model-relevant** - answered from the console model instead: `getBackgroundColor()`, `setCommandBackgroundColor()`, `setCommandForegroundColor()`, `wrapLine()`.
- **43 pure-view** (labels, borders, stylesheets, cursors, geometry, focus) - return their existing failure value, or report `the profile has no main window` where none existed.

The `COMMANDLINE` and `LABEL` macros were fixed in all three files that duplicate them, to stop the copies diverging.

#### Motivation for adding to Mudlet

Next step in the libmudlet split (#9011, step 2): `mudlet_core` has to survive without a view. `mpConsole` is a `QPointer`, so a view-less `Host` nulls it and every unguarded site is a segfault.

No user-visible change today - the desktop client always has a main console, bar one event-loop turn during profile teardown where scripts are already stopped.

#### Other info (issues closed, discussion etc)

A census of every affected entry point against a view-less profile, one fork per call: **48 SIGSEGV before, 0 after**. Five regression tests in `ConsoleModelExtractionTest`, each sabotage-verified red before green.

Based on #10185; retarget to development once that merges.
