### PR TITLE
Fix: only the Next button advances the interface tour

### DIFF
--- a/src/TUiTour.cpp
+++ b/src/TUiTour.cpp
@@ -31,7 +31,6 @@
 #include <QLabel>
 #include <QMenu>
 #include <QMenuBar>
-#include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPushButton>
@@ -56,6 +55,9 @@ TUiTour::TUiTour(mudlet* pMainWindow, const bool skipIntroStep)
 {
     setObjectName(qsl("uiTour"));
     setAttribute(Qt::WA_DeleteOnClose);
+    // The overlay spans the whole window: without this, clicks and drags on it
+    // propagate to the main window underneath and still resize docks
+    setAttribute(Qt::WA_NoMousePropagation);
     setFocusPolicy(Qt::StrongFocus);
     //: Name of the interface tour overlay, announced by screen readers
     setAccessibleName(tr("Mudlet interface tour"));
@@ -183,9 +185,9 @@ void TUiTour::buildSteps()
         mSteps.push_back({nullptr,
                           //: Title of the first step of the interface tour
                           tr("Welcome to Mudlet!"),
-                          //: Body of the first step of the interface tour
+                          //: Body of the first step of the interface tour. "Next" is the button label, keep the two the same
                           tr("New here? This quick tour points out the most important parts of Mudlet - it takes less than a minute. "
-                             "Click anywhere or use the arrow keys to move through it.")});
+                             "Use Next or the arrow keys to move through it.")});
     }
 
     mSteps.push_back({[activeConsole, widgetRect]() -> QRect {
@@ -381,13 +383,6 @@ void TUiTour::keyPressEvent(QKeyEvent* event)
     } else {
         QWidget::keyPressEvent(event);
     }
-}
-
-void TUiTour::mouseReleaseEvent(QMouseEvent* event)
-{
-    // the overlay spans the whole window, so a click anywhere on it would otherwise
-    // advance the tour - swallow it and leave that to the Next button
-    event->accept();
 }
 
 bool TUiTour::eventFilter(QObject* watched, QEvent* event)

--- a/src/TUiTour.cpp
+++ b/src/TUiTour.cpp
@@ -385,8 +385,9 @@ void TUiTour::keyPressEvent(QKeyEvent* event)
 
 void TUiTour::mouseReleaseEvent(QMouseEvent* event)
 {
+    // the overlay spans the whole window, so a click anywhere on it would otherwise
+    // advance the tour - swallow it and leave that to the Next button
     event->accept();
-    slot_next();
 }
 
 bool TUiTour::eventFilter(QObject* watched, QEvent* event)

--- a/src/TUiTour.h
+++ b/src/TUiTour.h
@@ -28,7 +28,6 @@
 class QFrame;
 class QKeyEvent;
 class QLabel;
-class QMouseEvent;
 class QPaintEvent;
 class QPushButton;
 
@@ -56,7 +55,6 @@ signals:
 protected:
     void paintEvent(QPaintEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
-    void mouseReleaseEvent(QMouseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private slots:


### PR DESCRIPTION
Clicking anywhere on the first-launch interface tour advanced it, so a stray click skipped a step. Only the Next button (and the existing keyboard shortcuts) advances it now, and the intro text no longer says "Click anywhere".

While in there: the overlay only accepted the mouse release, so presses, drags and double clicks still reached the main window - a drag on the overlay could resize a dock behind it. `WA_NoMousePropagation` covers all of those.

Tested by walking the tour on a fresh profile: two clicks on empty overlay area leave it on "1 of 5", Next moves it to "2 of 5", keyboard navigation and Skip/Esc unchanged.

Same reasoning as #10163 does for the Mudlet Tutorial's own panels.