### PR TITLE
fix: an embedded mapper keeps working after another map view closes

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3742,6 +3742,28 @@ QDockWidget* Host::mapWidget() const
     return mpConsole->mpDockableMapWidget;
 }
 
+// Hands TMap::mpMapper back to this profile's own mapper. The map dock and the
+// detached windows borrow it while they show a map of their own, and every one
+// of them gives it back through here. createMapper() records the embedded
+// mapper on the console and puts it in the main frame or a user window, so a
+// profile that has one is never the mpDockableMapWidget case below.
+void Host::restoreOwnMapper()
+{
+    if (!mpMap) {
+        return;
+    }
+
+    if (mpConsole && mpConsole->mpMapper) {
+        mpMap->mpMapper = mpConsole->mpMapper;
+    } else if (mpConsole && mpConsole->mpDockableMapWidget) {
+        auto hostMapWidget = mpConsole->mpDockableMapWidget->widget();
+
+        if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
+            mpMap->mpMapper = hostMapper;
+        }
+    }
+}
+
 std::pair<bool, QString> Host::setMapperTitle(const QString& title)
 {
     auto pM = mapWidget();

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3762,6 +3762,9 @@ void Host::restoreOwnMapper()
             mpMap->mpMapper = hostMapper;
         }
     }
+#if defined(DEBUG_WINDOW_HANDLING)
+    qDebug() << "Host::restoreOwnMapper:" << getName() << "- map is now drawn by" << mpMap->mpMapper.data();
+#endif
 }
 
 std::pair<bool, QString> Host::setMapperTitle(const QString& title)

--- a/src/Host.h
+++ b/src/Host.h
@@ -425,6 +425,8 @@ public:
     std::pair<bool, QString> setMapperTitle(const QString&);
     std::optional<QString> getMapperTitle() const;
     QDockWidget* mapWidget() const;
+    // Gives TMap::mpMapper back to this profile's own mapper - see the definition.
+    void restoreOwnMapper();
 
     // Multiple map views support
     std::pair<int, QString> createMapView(int areaId = 0);

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -1574,12 +1574,7 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                 // Restore main mapper for the other profile
                 if (auto pMudlet = mudlet::self()) {
                     if (auto pHost = pMudlet->getHostManager().getHost(dockProfileName)) {
-                        if (auto pMap = pHost->mpMap.data()) {
-                            pHost->restoreOwnMapper();
-#if defined(DEBUG_WINDOW_HANDLING)
-                            qDebug() << "TDetachedWindow: Restored main mapper for profile" << dockProfileName;
-#endif
-                        }
+                        pHost->restoreOwnMapper();
                     }
                 }
             }
@@ -2061,12 +2056,7 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             // Restore the main window's mapper before deleting our dock widget
             if (auto pMudlet = mudlet::self()) {
                 if (auto pHost = pMudlet->getHostManager().getHost(profileName)) {
-                    if (auto pMap = pHost->mpMap.data()) {
-                        pHost->restoreOwnMapper();
-#if defined(DEBUG_WINDOW_HANDLING)
-                        qDebug() << "TDetachedWindow::removeProfile: Restored main mapper for profile" << profileName;
-#endif
-                    }
+                    pHost->restoreOwnMapper();
                 }
             }
 

--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -131,16 +131,7 @@ TDetachedWindow::~TDetachedWindow()
                 QString profileName = key.mid(4); // Remove "map_" prefix
                 if (auto mudletInstance = mudlet::self()) {
                     if (auto pHost = mudletInstance->getHostManager().getHost(profileName)) {
-                        auto pMap = pHost->mpMap.data();
-
-                        if (pMap && pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                            // Find the main window's mapper
-                            auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                            if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                                pMap->mpMapper = mainMapper;
-                            }
-                        }
+                        pHost->restoreOwnMapper();
                     }
                 }
             }
@@ -156,16 +147,7 @@ TDetachedWindow::~TDetachedWindow()
         if (!mCurrentProfileName.isEmpty()) {
             if (auto mudletInstance = mudlet::self()) {
                 if (auto pHost = mudletInstance->getHostManager().getHost(mCurrentProfileName)) {
-                    auto pMap = pHost->mpMap.data();
-
-                    if (pMap && pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                        // Find the main window's mapper
-                        auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                        if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                            pMap->mpMapper = mainMapper;
-                        }
-                    }
+                    pHost->restoreOwnMapper();
                 }
             }
         }
@@ -1593,16 +1575,10 @@ void TDetachedWindow::updateDockWidgetVisibilityForProfile(const QString& profil
                 if (auto pMudlet = mudlet::self()) {
                     if (auto pHost = pMudlet->getHostManager().getHost(dockProfileName)) {
                         if (auto pMap = pHost->mpMap.data()) {
-                            if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                                auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                                    pMap->mpMapper = mainMapper;
+                            pHost->restoreOwnMapper();
 #if defined(DEBUG_WINDOW_HANDLING)
-                                    qDebug() << "TDetachedWindow: Restored main mapper for profile" << dockProfileName;
+                            qDebug() << "TDetachedWindow: Restored main mapper for profile" << dockProfileName;
 #endif
-                                }
-                            }
                         }
                     }
                 }
@@ -2086,16 +2062,10 @@ bool TDetachedWindow::removeProfile(const QString& profileName)
             if (auto pMudlet = mudlet::self()) {
                 if (auto pHost = pMudlet->getHostManager().getHost(profileName)) {
                     if (auto pMap = pHost->mpMap.data()) {
-                        if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                            auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                            if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                                pMap->mpMapper = mainMapper;
+                        pHost->restoreOwnMapper();
 #if defined(DEBUG_WINDOW_HANDLING)
-                                qDebug() << "TDetachedWindow::removeProfile: Restored main mapper for profile" << profileName;
+                        qDebug() << "TDetachedWindow::removeProfile: Restored main mapper for profile" << profileName;
 #endif
-                            }
-                        }
                     }
                 }
             }
@@ -2817,12 +2787,7 @@ void TDetachedWindow::slot_showMapperDialog()
             mpMapDockWidget = nullptr;
 
             // Restore the main window's mapper as the active one
-            if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                    pMap->mpMapper = mainMapper;
-                }
-            }
+            pHost->restoreOwnMapper();
         }
         return;
     }
@@ -2913,12 +2878,7 @@ void TDetachedWindow::slot_showMapperDialog()
             }
 
             // Restore the main window's mapper as the active one when hiding
-            if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                    pMap->mpMapper = mainMapper;
-                }
-            }
+            pHost->restoreOwnMapper();
         } else {
             // When showing, set this as the active mapper
             mpMapDockWidget = mapDockWidget;
@@ -3283,13 +3243,7 @@ void TDetachedWindow::addTransferredDockWidget(const QString& mapKey, QDockWidge
             }
 
             // Restore the main window's mapper as the active one when hiding
-            if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                auto mainMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                if (auto mainMapper = qobject_cast<dlgMapper*>(mainMapWidget)) {
-                    pMap->mpMapper = mainMapper;
-                }
-            }
+            pHost->restoreOwnMapper();
         } else {
             // When showing, set this as the active mapper
             mpMapDockWidget = mapDockWidget;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4348,13 +4348,7 @@ void mudlet::slot_showMapperDialog()
             mpCurrentMapDockWidget = nullptr;
 
             // Restore the host's default mapper if it exists
-            if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                auto hostMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
-                    pMap->mpMapper = hostMapper;
-                }
-            }
+            pHost->restoreOwnMapper();
         }
 
         return;
@@ -4453,13 +4447,7 @@ void mudlet::slot_showMapperDialog()
             }
 
             // Restore the host's default mapper when hiding
-            if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                auto hostMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
-                    pMap->mpMapper = hostMapper;
-                }
-            }
+            pHost->restoreOwnMapper();
         } else {
             // When showing, set this as the active mapper
             mpCurrentMapDockWidget = mapDockWidget;
@@ -8974,16 +8962,10 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
                 // Restore host's default mapper for the other profile
                 if (auto pHost = mHostManager.getHost(dockProfileName)) {
                     if (auto pMap = pHost->mpMap.data()) {
-                        if (pHost->mpConsole && pHost->mpConsole->mpDockableMapWidget) {
-                            auto hostMapWidget = pHost->mpConsole->mpDockableMapWidget->widget();
-
-                            if (auto hostMapper = qobject_cast<dlgMapper*>(hostMapWidget)) {
-                                pMap->mpMapper = hostMapper;
+                        pHost->restoreOwnMapper();
 #if defined(DEBUG_WINDOW_HANDLING)
-                                qDebug() << "mudlet: Restored host mapper for main window profile" << dockProfileName;
+                        qDebug() << "mudlet: Restored host mapper for main window profile" << dockProfileName;
 #endif
-                            }
-                        }
                     }
                 }
             }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -8961,12 +8961,7 @@ void mudlet::updateMainWindowDockWidgetVisibilityForProfile(const QString& profi
 
                 // Restore host's default mapper for the other profile
                 if (auto pHost = mHostManager.getHost(dockProfileName)) {
-                    if (auto pMap = pHost->mpMap.data()) {
-                        pHost->restoreOwnMapper();
-#if defined(DEBUG_WINDOW_HANDLING)
-                        qDebug() << "mudlet: Restored host mapper for main window profile" << dockProfileName;
-#endif
-                    }
+                    pHost->restoreOwnMapper();
                 }
             }
         }

--- a/test/functional_tests/EmbeddedMapperCreationTest.cpp
+++ b/test/functional_tests/EmbeddedMapperCreationTest.cpp
@@ -153,6 +153,35 @@ private slots:
         QVERIFY2(mapOpenEventCountIs(1), "a repeat createMapper() raised mapOpenEvent again");
     }
 
+    // An embedded mapper stops redrawing once the toolbar's own map dock has
+    // been opened and closed again. slot_showMapperDialog() repoints
+    // TMap::mpMapper at the mapper it puts in that dock, and on hide restores
+    // it only from mpConsole->mpDockableMapWidget - which is never where
+    // createMapper() put the embedded one, so the restore matches nothing and
+    // the QPointer is left null once the dock's own mapper dies with it. What
+    // the player sees is rooms being created and never drawn until the profile
+    // is reloaded.
+    void test_theEmbeddedMapperSurvivesTheToolbarMapDockClosing()
+    {
+        auto [created, message] = mpHost->mpConsole->createMapper(QString(), 0, 0, 300, 300);
+        QVERIFY2(created, qPrintable(message));
+        dlgMapper* pEmbedded = mpHost->mpConsole->mpMapper.data();
+        QVERIFY2(pEmbedded, "createMapper() left no embedded mapper to lose");
+        QCOMPARE(mpHost->mpMap->mpMapper.data(), pEmbedded);
+
+        mudlet::self()->slot_showMapperDialog();
+        const QString mapKey = qsl("map_%1").arg(mHostname);
+        QDockWidget* pDock = mudlet::self()->getMainWindowDockWidget(mapKey);
+        QVERIFY2(pDock, "the toolbar action created no map dock, so this case covers nothing");
+        QVERIFY2(mpHost->mpMap->mpMapper.data() != pEmbedded, "the dock did not take the map over, so restoring it below would prove nothing");
+
+        pDock->setVisible(false);
+        qApp->processEvents();
+
+        QVERIFY2(mpHost->mpMap->mpMapper, "closing the toolbar map dock left the map with no mapper at all, so nothing redraws it");
+        QCOMPARE(mpHost->mpMap->mpMapper.data(), pEmbedded);
+    }
+
     void test_createMapperWithNoMapToLoad()
     {
         QVERIFY2(mpHost->mpMap->mpRoomDB->isEmpty(), "a freshly created profile was expected to have no rooms");


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Add `Host::restoreOwnMapper()`, which hands `TMap::mpMapper` back to the profile's own mapper — preferring `mpConsole->mpMapper` (what `createMapper()` records) and keeping the existing `mpDockableMapWidget` lookup as a fallback.
- Route all **ten** places that give back a borrowed mapper through it, replacing ten copies of the same block (`+37 −77` in `src`).
- Regression test in `EmbeddedMapperCreationTest`.

#### Motivation for adding to Mudlet

A mapper created by `createMapper()` or `Geyser.Mapper` silently stops redrawing as soon as any other map view closes; only reloading the profile brings it back.

#### Other info (issues closed, discussion etc)

Fixes #10188.

The issue describes one site. The same defect is in ten — all of them restoring from `mpDockableMapWidget` alone, which is null for a profile whose mapper came from `createMapper()`. I instrumented every site and drove them from a functional test. Eight fire in practice, each reporting the profile's own mapper present and the old code restoring nothing:

| Site | How a user meets it |
|---|---|
| `mudlet.cpp:4450` | Closes the toolbar's map dock — the case in the issue. |
| `mudlet.cpp:8965` | Switches to another profile's tab, which hides the first profile's map dock. |
| `TDetachedWindow.cpp:134` | Closes a detached window, or quits, while it still holds map docks. |
| `TDetachedWindow.cpp:150` | Same, for the map that detached window is currently showing. |
| `TDetachedWindow.cpp:1578` | Switches tabs inside a detached window, hiding another profile's map there. |
| `TDetachedWindow.cpp:2065` | Drags a profile back to the main window, moves it to another detached window, or closes its tab. |
| `TDetachedWindow.cpp:2881` | Closes a map opened from a detached window's own toolbar. |
| `TDetachedWindow.cpp:3246` | Closes a map dock that followed a profile into a detached window. |

The other two, `mudlet.cpp:4351` and `TDetachedWindow.cpp:2790`, never fired in any scenario, and the reason is structural rather than a gap in the testing: `existingMapDock->setVisible(false)` emits `visibilityChanged` synchronously, that dock's own handler nulls `mpCurrentMapDockWidget`/`mpMapDockWidget`, so the `else if (… == existingMapDock)` immediately below is already false. They are converted anyway — same latent defect if anyone makes them reachable, and leaving two sites in the old shape would look arbitrary — but I am not claiming them as bugs fixed.

Two things worth a reviewer's eye:

- The `DEBUG_WINDOW_HANDLING` trace moved into `Host::restoreOwnMapper()`, where it reports which mapper the map ended up with instead of asserting a restore. It now fires at all ten sites rather than the previous three, so a developer building with that define sees more output than before.
- Only the `mudlet.cpp:4450` path has a shipped regression test. The other nine were confirmed with throwaway instrumentation that I removed, because reaching them from a test needs `TDetachedWindow`'s private slots exposed. Happy to add a friend declaration and a detached-window test if you would like those guarded too.

Worth noting for triage: this needs the main toolbar enabled (Settings → General → "Show main toolbar", which defaults to **Never**), because Toolbox → "Show map" goes to `Host::showHideOrCreateMapper()` and never repoints the mapper. That is likely why it went unreported so long.

**Test case:** With a throwaway profile loaded Offline, save a script containing:

```lua
local aid = addAreaName("probe") or getAreaTable()["probe"]
probeMap = probeMap or Geyser.Mapper:new({name = "probeMap", x = "60%", y = 0, width = "40%", height = "50%"})
probeLast = 1
addRoom(1, aid) setRoomCoordinates(1, 0, 0, 0) centerview(1)
tempAlias("^grow$", function()
  local nxt = probeLast + 1
  addRoom(nxt, aid) setRoomCoordinates(nxt, nxt - 1, 0, 0)
  setExit(probeLast, nxt, "east") probeLast = nxt centerview(nxt)
end)
```

Type `grow` a few times and watch the embedded mapper draw rooms. Turn on the main toolbar, click **Map**, close the dock that opens, then type `grow` again. Before this change the embedded mapper stops repainting; after it, it keeps up. `ctest` is 140/140.

*Written with AI assistance. Assisted-by: Claude:claude-opus-5*
