### PR TITLE
Add: Czech (Čeština) translation

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1493,6 +1493,8 @@ void mudlet::scanForMudletTranslations(const QString& path)
                 currentTranslation.mNativeName = qsl("한국어");
             } else if (!languageCode.compare(QLatin1String("he_IL"), Qt::CaseInsensitive)) {
                 currentTranslation.mNativeName = qsl("עִברִית");
+            } else if (!languageCode.compare(QLatin1String("cs_CZ"), Qt::CaseInsensitive)) {
+                currentTranslation.mNativeName = qsl("Čeština");
             } else {
                 currentTranslation.mNativeName = languageCode;
             }

--- a/translations/translated/qm.qrc
+++ b/translations/translated/qm.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/lang">
         <file>mudlet_ar_SA.qm</file>
+        <file>mudlet_cs_CZ.qm</file>
         <file>mudlet_de_DE.qm</file>
         <file>mudlet_el_GR.qm</file>
         <file>mudlet_en_GB.qm</file>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds Czech as a new Mudlet language.

* `translations/translated/mudlet_cs_CZ.ts` — **3415 / 3415 messages translated (100 %)**, 99 contexts, all 30 `numerus` messages carry the **three** forms Czech needs (singular / paucal 2–4 / plural).
* `translations/lua/translated/mudlet-lua_cs_CZ.json` — **25 / 25** Lua strings.
* `translations/translated/qm.qrc` — `mudlet_cs_CZ.qm` entry, so the `.qm` gets compiled into `:/lang`.
* `src/mudlet.cpp` — native name `Čeština` in the locale-to-native-name chain in `scanForMudletTranslations()`, appended at the end like the other recent additions.

Nothing else is touched, and no existing language is affected.

#### Motivation for adding to Mudlet

Czech is not among the ~20 languages Mudlet currently ships, and there is a Czech-speaking MUD community that would use it.

The translation is finished rather than started, so this is not a stub that decays — it is a complete language ready for the next release.

**Verified with a real build**, not just by eyeballing the XML. Built locally on Windows (MSYS2 CLANG64, Qt 6) via the project's own `CI/` scripts:

* `lrelease` reports `Generated 3415 translation(s) (3415 finished and 0 unfinished)` — no dropped or unfinished entries.
* the generated `translation-stats.json` reports `{"translated_percent": 100, "total": 3415, "translated": 3415, "untranslated": 0}` for `cs_CZ`.
* the running binary lists **Čeština** in Settings and switches the whole UI over.

Quality notes, in case they help review:

* A checker was run over the whole file on every pass: placeholders (`%1`, `%n`), counts of real HTML tags, `&` mnemonics, leading/trailing whitespace, plural-form counts, and strings left accidentally untranslated. It currently reports **0 findings**. During the work it caught six genuine mistakes, including a lost `<strong>` pair and three swallowed trailing spaces.
* Terminology follows a written glossary. MUD jargon that Czech players use in English — **trigger**, **timer**, **alias** — is deliberately left untranslated; translating it would make the manual and community help unusable.
* The existing `it_IT`, `de_DE` and `pl_PL` translations were used as cross-checks. That comparison surfaced traps worth knowing about: `Key` rendered as *legend* in one and *door key* in another, `Delete` and `Remove` collapsed into one word, and `Cancel` and `Undo` likewise. Czech keeps them distinct.

#### Other info (issues closed, discussion etc)

**On Crowdin:** I understand `.crowdin.yml` makes Crowdin the source of truth for `translations/`, so a hand-added translated file is unusual. The reason it is here is the bootstrap problem — `cs` does not exist in the Crowdin project yet, so there was nowhere to put it. **If you would rather have this go through Crowdin, say the word:** enable Czech there and I will upload this file as a pre-translation instead, and reduce this PR to just the `qm.qrc` and `mudlet.cpp` lines. Happy either way — I just did not want to ask for a language to be enabled without first showing the finished work.

Also note that `qm.qrc` and `mudlet.cpp` are needed regardless of which route the files take; without them a `cs_CZ` translation on Crowdin would never reach users.

Translated by Pavel Třešňák with Claude Opus 5.
