### PR TITLE
Infra: Stop the glibc resolver leak flaking the CI leak job

### DIFF
--- a/asan-suppressions.txt
+++ b/asan-suppressions.txt
@@ -148,3 +148,21 @@ leak:QTranslatorPrivate::do_load
 # ==============================================================================
 leak:OSSL_PROVIDER_try_load
 leak:OSSL_DECODER_do_all_provided
+
+# ==============================================================================
+# glibc DNS resolver leak
+# A lookup of a hostname - any test that points a profile at "localhost" rather
+# than 127.0.0.1 - runs getaddrinfo() on a Qt host-lookup worker thread, which
+# reaches nss_dns. LeakSanitizer's tracer sometimes finds that worker among
+# /proc/<pid>/task while it is not in the sanitizer's thread registry, says so
+# with "Thread N not found in registry", and then scans neither its stack nor
+# its TLS. The buffer glibc's resolver still owns from there loses its only
+# visible referrer and is reported as a 28-byte direct leak whose two frames
+# name no Mudlet code at all:
+#   malloc / __res_context_send (libc.so.6)
+# Which test it lands on is down to that race, not to anything the test does:
+# byte-identical reports failed MapDownloadTest in run 33002748956 and
+# StarterUiSectionsTest in run 32879955034. glibc owns and frees this buffer
+# itself, so no Mudlet allocation can hide behind the line below.
+# ==============================================================================
+leak:__res_context_send


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
LeakSanitizer's tracer sometimes finds the Qt host-lookup worker thread outside its registry, scans neither that thread's stack nor its TLS, and reports the 28 bytes glibc's resolver still owns there as a direct leak. Byte-identical reports failed MapDownloadTest in run 33002748956 and StarterUiSectionsTest in run 32879955034.
#### Motivation for adding to Mudlet
Fix flaky tests
#### Other info (issues closed, discussion etc)
Assisted-by: Claude:claude-opus-5