### PR TITLE
Fix: undefined behaviour when creating or deleting any trigger, alias, timer, key, script or button

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -47,7 +47,8 @@ ActionUnit::~ActionUnit()
     for (auto action : mActionRootNodeList) {
         action->mpHost = nullptr;
         std::function<void(TAction*)> nullifyChildren = [&nullifyChildren](TAction* a) {
-            for (auto child : *a->mpMyChildrenList) {
+            for (auto* childNode : *a->mpMyChildrenList) {
+                auto* child = static_cast<TAction*>(childNode);
                 child->mpHost = nullptr;
                 nullifyChildren(child);
             }
@@ -61,8 +62,9 @@ ActionUnit::~ActionUnit()
 
 void ActionUnit::_uninstall(TAction* pChild, const QString& packageName)
 {
-    std::list<TAction*>* childrenList = pChild->mpMyChildrenList;
-    for (auto action : *childrenList) {
+    std::list<Tree<TAction>*>* childrenList = pChild->mpMyChildrenList;
+    for (auto* actionNode : *childrenList) {
+        auto* action = static_cast<TAction*>(actionNode);
         _uninstall(action, packageName);
         uninstallList.append(action);
     }
@@ -375,7 +377,8 @@ void ActionUnit::regenerateToolBars()
             continue; // skip over any root action node that is NOT going to be a TToolBar.
         }
         if (!action->mPackageName.isEmpty()) {
-            for (auto& childAction : *action->mpMyChildrenList) {
+            for (auto* childActionNode : *action->mpMyChildrenList) {
+                auto* childAction = static_cast<TAction*>(childActionNode);
                 QPointer<TToolBar> pTB = nullptr;
                 for (auto& toolBar : mToolBarList) {
                     if (toolBar == childAction->mpToolBar) {
@@ -439,27 +442,28 @@ void ActionUnit::regenerateEasyButtonBars()
         if (!rootAction->mPackageName.isEmpty()) {
             // It has a package name so it is actually the parent
             // module/package item rather than the actual ToolBar
-            for (auto childActionIterator = rootAction->mpMyChildrenList->begin(); childActionIterator != rootAction->mpMyChildrenList->end(); childActionIterator++) {
+            for (auto* childActionNode : *rootAction->mpMyChildrenList) {
+                auto* childAction = static_cast<TAction*>(childActionNode);
                 TEasyButtonBar* pTB = nullptr;
                 for (auto& easyButtonBar : mEasyButtonBarList) {
-                    if (easyButtonBar == (*childActionIterator)->mpEasyButtonBar) {
+                    if (easyButtonBar == childAction->mpEasyButtonBar) {
                         pTB = easyButtonBar;
                         break;
                     }
                 }
                 if (!pTB) {
-                    pTB = new TEasyButtonBar(rootAction, (*childActionIterator)->getName(), mpHost->mpConsole->mpTopToolBar);
+                    pTB = new TEasyButtonBar(rootAction, childAction->getName(), mpHost->mpConsole->mpTopToolBar);
                     mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
                     mEasyButtonBarList.emplace_back(pTB);
-                    (*childActionIterator)->mpEasyButtonBar = pTB; // needed for drag&drop
+                    childAction->mpEasyButtonBar = pTB; // needed for drag&drop
                 }
-                if ((*childActionIterator)->mOrientation == 1) {
+                if (childAction->mOrientation == 1) {
                     pTB->setVerticalOrientation();
                 } else {
                     pTB->setHorizontalOrientation();
                 }
-                constructToolbar(*childActionIterator, pTB);
-                (*childActionIterator)->mpEasyButtonBar = pTB;
+                constructToolbar(childAction, pTB);
+                childAction->mpEasyButtonBar = pTB;
                 pTB->setStyleSheet(pTB->mpTAction->css);
             }
             continue; //rootAction package
@@ -511,7 +515,8 @@ TAction* ActionUnit::findEasyButtonBarAction(const QString& name)
             continue;
         }
         if (!rootAction->mPackageName.isEmpty()) {
-            for (auto& childAction : *rootAction->mpMyChildrenList) {
+            for (auto* childActionNode : *rootAction->mpMyChildrenList) {
+                auto* childAction = static_cast<TAction*>(childActionNode);
                 if (childAction->mLocation != 4 && childAction->getName() == name) {
                     return childAction;
                 }
@@ -536,7 +541,8 @@ bool ActionUnit::namesAFloatingToolBar(const QString& name)
         if (rootAction->mPackageName.isEmpty()) {
             continue;
         }
-        for (auto& childAction : *rootAction->mpMyChildrenList) {
+        for (auto* childActionNode : *rootAction->mpMyChildrenList) {
+            auto* childAction = static_cast<TAction*>(childActionNode);
             if (childAction->mLocation == 4 && childAction->getName() == name) {
                 return true;
             }
@@ -558,7 +564,8 @@ std::pair<bool, QString> ActionUnit::setToolBarActive(const QString& name, const
             if (rootAction->mLocation == 4 || rootAction->mPackageName.isEmpty() || rootAction->getName() != name) {
                 continue;
             }
-            for (auto& childAction : *rootAction->mpMyChildrenList) {
+            for (auto* childActionNode : *rootAction->mpMyChildrenList) {
+                auto* childAction = static_cast<TAction*>(childActionNode);
                 if (childAction->mLocation != 4) {
                     childAction->setIsActive(active);
                     found = true;

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -47,7 +47,8 @@ AliasUnit::~AliasUnit()
         alias->mpHost = nullptr;
         // Also set mpHost to null on all children recursively
         std::function<void(TAlias*)> nullifyChildren = [&nullifyChildren](TAlias* a) {
-            for (auto child : *a->mpMyChildrenList) {
+            for (auto* childNode : *a->mpMyChildrenList) {
+                auto* child = static_cast<TAlias*>(childNode);
                 child->mpHost = nullptr;
                 nullifyChildren(child);
             }
@@ -61,8 +62,9 @@ AliasUnit::~AliasUnit()
 
 void AliasUnit::_uninstall(TAlias* pChild, const QString& packageName)
 {
-    std::list<TAlias*>* childrenList = pChild->mpMyChildrenList;
-    for (auto alias : *childrenList) {
+    std::list<Tree<TAlias>*>* childrenList = pChild->mpMyChildrenList;
+    for (auto* aliasNode : *childrenList) {
+        auto* alias = static_cast<TAlias*>(aliasNode);
         _uninstall(alias, packageName);
         uninstallList.append(alias);
     }
@@ -419,8 +421,9 @@ bool AliasUnit::killAlias(const QString& name)
 
 void AliasUnit::assembleReport(TAlias* pItem)
 {
-    std::list<TAlias*>* childrenList = pItem->mpMyChildrenList;
-    for (auto pChild : *childrenList) {
+    std::list<Tree<TAlias>*>* childrenList = pItem->mpMyChildrenList;
+    for (auto* pChildNode : *childrenList) {
+        auto* pChild = static_cast<TAlias*>(pChildNode);
         ++statsItemsTotal;
         if (pChild->isActive()) {
             ++statsActiveItems;

--- a/src/EditorAddItemCommand.cpp
+++ b/src/EditorAddItemCommand.cpp
@@ -54,7 +54,7 @@ void EditorAddItemCommand::undo()
     case EditorViewType::cmTriggerView: {
         TTrigger* trigger = mpHost->getTriggerUnit()->getTrigger(mItemID);
         if (trigger) {
-            std::function<void(TTrigger*)> collectIDs = [&](TTrigger* t) {
+            std::function<void(Tree<TTrigger>*)> collectIDs = [&](Tree<TTrigger>* t) {
                 if (!t) {
                     return;
                 }
@@ -76,7 +76,7 @@ void EditorAddItemCommand::undo()
     case EditorViewType::cmAliasView: {
         TAlias* alias = mpHost->getAliasUnit()->getAlias(mItemID);
         if (alias) {
-            std::function<void(TAlias*)> collectIDs = [&](TAlias* a) {
+            std::function<void(Tree<TAlias>*)> collectIDs = [&](Tree<TAlias>* a) {
                 if (!a) {
                     return;
                 }
@@ -98,7 +98,7 @@ void EditorAddItemCommand::undo()
     case EditorViewType::cmTimerView: {
         TTimer* timer = mpHost->getTimerUnit()->getTimer(mItemID);
         if (timer) {
-            std::function<void(TTimer*)> collectIDs = [&](TTimer* t) {
+            std::function<void(Tree<TTimer>*)> collectIDs = [&](Tree<TTimer>* t) {
                 if (!t) {
                     return;
                 }
@@ -120,7 +120,7 @@ void EditorAddItemCommand::undo()
     case EditorViewType::cmScriptView: {
         TScript* script = mpHost->getScriptUnit()->getScript(mItemID);
         if (script) {
-            std::function<void(TScript*)> collectIDs = [&](TScript* s) {
+            std::function<void(Tree<TScript>*)> collectIDs = [&](Tree<TScript>* s) {
                 if (!s) {
                     return;
                 }
@@ -142,7 +142,7 @@ void EditorAddItemCommand::undo()
     case EditorViewType::cmKeysView: {
         TKey* key = mpHost->getKeyUnit()->getKey(mItemID);
         if (key) {
-            std::function<void(TKey*)> collectIDs = [&](TKey* k) {
+            std::function<void(Tree<TKey>*)> collectIDs = [&](Tree<TKey>* k) {
                 if (!k) {
                     return;
                 }
@@ -164,7 +164,7 @@ void EditorAddItemCommand::undo()
     case EditorViewType::cmActionView: {
         TAction* action = mpHost->getActionUnit()->getAction(mItemID);
         if (action) {
-            std::function<void(TAction*)> collectIDs = [&](TAction* a) {
+            std::function<void(Tree<TAction>*)> collectIDs = [&](Tree<TAction>* a) {
                 if (!a) {
                     return;
                 }
@@ -329,7 +329,7 @@ void EditorAddItemCommand::redo()
 
                 // Collect all new descendant IDs and map to old IDs
                 QList<int> newDescendantIDs;
-                std::function<void(TTrigger*)> collectIDs = [&](TTrigger* t) {
+                std::function<void(Tree<TTrigger>*)> collectIDs = [&](Tree<TTrigger>* t) {
                     if (!t)
                         return;
                     newDescendantIDs.append(t->getID());
@@ -367,7 +367,7 @@ void EditorAddItemCommand::redo()
 
                 // Collect all new descendant IDs and map to old IDs
                 QList<int> newDescendantIDs;
-                std::function<void(TAlias*)> collectIDs = [&](TAlias* a) {
+                std::function<void(Tree<TAlias>*)> collectIDs = [&](Tree<TAlias>* a) {
                     if (!a)
                         return;
                     newDescendantIDs.append(a->getID());
@@ -405,7 +405,7 @@ void EditorAddItemCommand::redo()
 
                 // Collect all new descendant IDs and map to old IDs
                 QList<int> newDescendantIDs;
-                std::function<void(TTimer*)> collectIDs = [&](TTimer* t) {
+                std::function<void(Tree<TTimer>*)> collectIDs = [&](Tree<TTimer>* t) {
                     if (!t)
                         return;
                     newDescendantIDs.append(t->getID());
@@ -443,7 +443,7 @@ void EditorAddItemCommand::redo()
 
                 // Collect all new descendant IDs after recreation
                 QList<int> newDescendantIDs;
-                std::function<void(TScript*)> collectIDs = [&](TScript* s) {
+                std::function<void(Tree<TScript>*)> collectIDs = [&](Tree<TScript>* s) {
                     if (!s)
                         return;
                     newDescendantIDs.append(s->getID());
@@ -496,7 +496,7 @@ void EditorAddItemCommand::redo()
 
                 // Collect all new descendant IDs and map to old IDs
                 QList<int> newDescendantIDs;
-                std::function<void(TKey*)> collectIDs = [&](TKey* k) {
+                std::function<void(Tree<TKey>*)> collectIDs = [&](Tree<TKey>* k) {
                     if (!k)
                         return;
                     newDescendantIDs.append(k->getID());
@@ -534,7 +534,7 @@ void EditorAddItemCommand::redo()
 
                 // Collect all new descendant IDs and map to old IDs
                 QList<int> newDescendantIDs;
-                std::function<void(TAction*)> collectIDs = [&](TAction* a) {
+                std::function<void(Tree<TAction>*)> collectIDs = [&](Tree<TAction>* a) {
                     if (!a)
                         return;
                     newDescendantIDs.append(a->getID());

--- a/src/EditorDeleteItemCommand.cpp
+++ b/src/EditorDeleteItemCommand.cpp
@@ -205,7 +205,8 @@ void EditorDeleteItemCommand::undo()
                     if (!pT || !pT->mpMyChildrenList) {
                         return;
                     }
-                    for (auto* pChild : *pT->mpMyChildrenList) {
+                    for (auto* pChildNode : *pT->mpMyChildrenList) {
+                        auto* pChild = static_cast<TTrigger*>(pChildNode);
                         // Find this child in mDeletedItems by name and parent ID
                         auto childIt = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [pChild, parentID](const DeletedItemInfo& item) {
                             return item.itemName == pChild->getName() && item.parentID == parentID;
@@ -276,7 +277,8 @@ void EditorDeleteItemCommand::undo()
                     if (!pA || !pA->mpMyChildrenList) {
                         return;
                     }
-                    for (auto* pChild : *pA->mpMyChildrenList) {
+                    for (auto* pChildNode : *pA->mpMyChildrenList) {
+                        auto* pChild = static_cast<TAlias*>(pChildNode);
                         auto childIt = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [pChild, parentID](const DeletedItemInfo& item) {
                             return item.itemName == pChild->getName() && item.parentID == parentID;
                         });
@@ -345,7 +347,8 @@ void EditorDeleteItemCommand::undo()
                     if (!pT || !pT->mpMyChildrenList) {
                         return;
                     }
-                    for (auto* pChild : *pT->mpMyChildrenList) {
+                    for (auto* pChildNode : *pT->mpMyChildrenList) {
+                        auto* pChild = static_cast<TTimer*>(pChildNode);
                         auto childIt = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [pChild, parentID](const DeletedItemInfo& item) {
                             return item.itemName == pChild->getName() && item.parentID == parentID;
                         });
@@ -414,7 +417,8 @@ void EditorDeleteItemCommand::undo()
                     if (!pS || !pS->mpMyChildrenList) {
                         return;
                     }
-                    for (auto* pChild : *pS->mpMyChildrenList) {
+                    for (auto* pChildNode : *pS->mpMyChildrenList) {
+                        auto* pChild = static_cast<TScript*>(pChildNode);
                         auto childIt = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [pChild, parentID](const DeletedItemInfo& item) {
                             return item.itemName == pChild->getName() && item.parentID == parentID;
                         });
@@ -483,7 +487,8 @@ void EditorDeleteItemCommand::undo()
                     if (!pK || !pK->mpMyChildrenList) {
                         return;
                     }
-                    for (auto* pChild : *pK->mpMyChildrenList) {
+                    for (auto* pChildNode : *pK->mpMyChildrenList) {
+                        auto* pChild = static_cast<TKey*>(pChildNode);
                         auto childIt = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [pChild, parentID](const DeletedItemInfo& item) {
                             return item.itemName == pChild->getName() && item.parentID == parentID;
                         });
@@ -552,7 +557,8 @@ void EditorDeleteItemCommand::undo()
                     if (!pA || !pA->mpMyChildrenList) {
                         return;
                     }
-                    for (auto* pChild : *pA->mpMyChildrenList) {
+                    for (auto* pChildNode : *pA->mpMyChildrenList) {
+                        auto* pChild = static_cast<TAction*>(pChildNode);
                         auto childIt = std::find_if(mDeletedItems.begin(), mDeletedItems.end(), [pChild, parentID](const DeletedItemInfo& item) {
                             return item.itemName == pChild->getName() && item.parentID == parentID;
                         });

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -49,7 +49,8 @@ KeyUnit::~KeyUnit()
         key->mpHost = nullptr;
         // Also set mpHost to null on all children recursively
         std::function<void(TKey*)> nullifyChildren = [&nullifyChildren](TKey* k) {
-            for (auto child : *k->mpMyChildrenList) {
+            for (auto* childNode : *k->mpMyChildrenList) {
+                auto* child = static_cast<TKey*>(childNode);
                 child->mpHost = nullptr;
                 nullifyChildren(child);
             }
@@ -70,8 +71,9 @@ void KeyUnit::resetStats()
 
 void KeyUnit::_uninstall(TKey* pChild, const QString& packageName)
 {
-    std::list<TKey*>* childrenList = pChild->mpMyChildrenList;
-    for (auto key : *childrenList) {
+    std::list<Tree<TKey>*>* childrenList = pChild->mpMyChildrenList;
+    for (auto* keyNode : *childrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         _uninstall(key, packageName);
         uninstallList.append(key);
     }
@@ -456,8 +458,9 @@ QString KeyUnit::getKeyName(const Qt::Key keyCode, const Qt::KeyboardModifiers m
 
 void KeyUnit::assembleReport(TKey* pItem)
 {
-    std::list<TKey*>* childrenList = pItem->mpMyChildrenList;
-    for (auto pChild : *childrenList) {
+    std::list<Tree<TKey>*>* childrenList = pItem->mpMyChildrenList;
+    for (auto* pChildNode : *childrenList) {
+        auto* pChild = static_cast<TKey*>(pChildNode);
         ++statsItemsTotal;
         if (pChild->isActive()) {
             ++statsActiveItems;

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -42,7 +42,8 @@ ScriptUnit::~ScriptUnit()
     for (auto script : mScriptRootNodeList) {
         script->mpHost = nullptr;
         std::function<void(TScript*)> nullifyChildren = [&nullifyChildren](TScript* s) {
-            for (auto child : *s->mpMyChildrenList) {
+            for (auto* childNode : *s->mpMyChildrenList) {
+                auto* child = static_cast<TScript*>(childNode);
                 child->mpHost = nullptr;
                 nullifyChildren(child);
             }
@@ -63,8 +64,9 @@ void ScriptUnit::resetStats()
 
 void ScriptUnit::_uninstall(TScript* pChild, const QString& packageName)
 {
-    std::list<TScript*>* childrenList = pChild->mpMyChildrenList;
-    for (auto script : *childrenList) {
+    std::list<Tree<TScript>*>* childrenList = pChild->mpMyChildrenList;
+    for (auto* scriptNode : *childrenList) {
+        auto* script = static_cast<TScript*>(scriptNode);
         _uninstall(script, packageName);
         uninstallList.append(script);
     }
@@ -316,8 +318,9 @@ std::vector<int> ScriptUnit::findItems(const QString& name, const bool exactMatc
 
 void ScriptUnit::assembleReport(TScript* pItem)
 {
-    std::list<TScript*>* childrenList = pItem->mpMyChildrenList;
-    for (auto pChild : *childrenList) {
+    std::list<Tree<TScript>*>* childrenList = pItem->mpMyChildrenList;
+    for (auto* pChildNode : *childrenList) {
+        auto* pChild = static_cast<TScript*>(pChildNode);
         ++statsItemsTotal;
         if (pChild->isActive()) {
             ++statsActiveItems;

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -89,7 +89,8 @@ void TAction::compileAll()
         }
         mOK_code = false;
     }
-    for (auto pTAction : *mpMyChildrenList) {
+    for (auto* pTActionNode : *mpMyChildrenList) {
+        auto* pTAction = static_cast<TAction*>(pTActionNode);
         pTAction->compileAll();
     }
 }
@@ -104,7 +105,8 @@ void TAction::compile()
             mOK_code = false;
         }
     }
-    for (auto pTAction : *mpMyChildrenList) {
+    for (auto* pTActionNode : *mpMyChildrenList) {
+        auto* pTAction = static_cast<TAction*>(pTActionNode);
         pTAction->compile();
     }
 }
@@ -184,7 +186,8 @@ void TAction::expandToolbar(TToolBar* pT)
 {
     // The -1 is needed to compensate for the initial pre-increment to TToolBar::mItemCount
     pT->resetItemCount(mButtonFillerOffset - 1);
-    for (auto pTAction : *mpMyChildrenList) {
+    for (auto* pTActionNode : *mpMyChildrenList) {
+        auto* pTAction = static_cast<TAction*>(pTActionNode);
         if (!pTAction->isActive()) {
             // This test and conditional loop abort was missing from this method
             // but is needed so that disabled buttons do not appear on
@@ -260,7 +263,8 @@ void TAction::insertActions(TToolBar* pT, QMenu* pMenu)
         pNewMenu->setStyleSheet(css);
         pEAction->setMenu(pNewMenu);
 
-        for (auto childAction : *mpMyChildrenList) {
+        for (auto* childActionNode : *mpMyChildrenList) {
+            auto* childAction = static_cast<TAction*>(childActionNode);
             childAction->insertActions(pT, pNewMenu);
         }
     }
@@ -271,7 +275,8 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
 {
     // The -1 is needed to compensate for the initial pre-increment to TEasyButtonBar::mItemCount
     pT->resetItemCount(mButtonFillerOffset - 1);
-    for (auto pTAction : *mpMyChildrenList) {
+    for (auto* pTActionNode : *mpMyChildrenList) {
+        auto* pTAction = static_cast<TAction*>(pTActionNode);
         if (!pTAction->isActive()) {
             continue;
         }
@@ -336,7 +341,8 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
 // the need for the split is not yet clear to me! - Slysven
 void TAction::fillMenu(TEasyButtonBar* pT, QMenu* pMenu)
 {
-    for (auto pTAction : *mpMyChildrenList) {
+    for (auto* pTActionNode : *mpMyChildrenList) {
+        auto* pTAction = static_cast<TAction*>(pTActionNode);
         if (!pTAction->isActive()) {
             continue;
         }

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -85,7 +85,8 @@ bool TAlias::match(const QString& haystack)
     if (!isActive()) {
         if (isFolder()) {
             if (shouldBeActive()) {
-                for (auto alias : *mpMyChildrenList) {
+                for (auto* aliasNode : *mpMyChildrenList) {
+                    auto* alias = static_cast<TAlias*>(aliasNode);
                     if (alias->match(haystack)) {
                         matchCondition = true;
                     }
@@ -245,7 +246,8 @@ END: {
 }
 
 MUD_ERROR:
-    for (auto childAlias : *mpMyChildrenList) {
+    for (auto* childAliasNode : *mpMyChildrenList) {
+        auto* childAlias = static_cast<TAlias*>(childAliasNode);
         if (childAlias->match(haystack)) {
             matchCondition = true;
         }
@@ -318,7 +320,8 @@ void TAlias::compileAll()
         mOK_code = false;
     }
     compileRegex(); // Effectively will repost the error if there was a problem in the regex
-    for (auto alias : *mpMyChildrenList) {
+    for (auto* aliasNode : *mpMyChildrenList) {
+        auto* alias = static_cast<TAlias*>(aliasNode);
         alias->compileAll();
     }
 }
@@ -333,7 +336,8 @@ void TAlias::compile()
             mOK_code = false;
         }
     }
-    for (auto alias : *mpMyChildrenList) {
+    for (auto* aliasNode : *mpMyChildrenList) {
+        auto* alias = static_cast<TAlias*>(aliasNode);
         alias->compile();
     }
 }

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -88,7 +88,8 @@ bool TKey::match(const Qt::Key key, const Qt::KeyboardModifiers modifier, const 
             }
         }
 
-        for (auto childKey : *mpMyChildrenList) {
+        for (auto* childKeyNode : *mpMyChildrenList) {
+            auto* childKey = static_cast<TKey*>(childKeyNode);
             if (childKey->match(key, modifier, isToMatchAll)) {
                 if (isToMatchAll) {
                     isAMatch = true;
@@ -114,7 +115,8 @@ bool TKey::wouldMatch(const Qt::Key key, const Qt::KeyboardModifiers modifier) c
         return true;
     }
 
-    for (auto childKey : *mpMyChildrenList) {
+    for (auto* childKeyNode : *mpMyChildrenList) {
+        auto* childKey = static_cast<TKey*>(childKeyNode);
         if (childKey->wouldMatch(key, modifier)) {
             return true;
         }
@@ -139,7 +141,8 @@ void TKey::enableKey(const QString& name)
     if (mName == name) {
         setIsActive(true);
     }
-    for (auto key : *mpMyChildrenList) {
+    for (auto* keyNode : *mpMyChildrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         key->enableKey(name);
     }
 }
@@ -149,7 +152,8 @@ void TKey::disableKey(const QString& name)
     if (mName == name) {
         setIsActive(false);
     }
-    for (auto key : *mpMyChildrenList) {
+    for (auto* keyNode : *mpMyChildrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         key->disableKey(name);
     }
 }
@@ -163,7 +167,8 @@ void TKey::compileAll()
         }
         mOK_code = false;
     }
-    for (auto key : *mpMyChildrenList) {
+    for (auto* keyNode : *mpMyChildrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         key->compileAll();
     }
 }
@@ -178,7 +183,8 @@ void TKey::compile()
             mOK_code = false;
         }
     }
-    for (auto key : *mpMyChildrenList) {
+    for (auto* keyNode : *mpMyChildrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         key->compile();
     }
 }

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -86,7 +86,8 @@ void TScript::compileAll(bool saveLoadingError)
         mNeedsToBeCompiled = true;
     }
     compile(saveLoadingError);
-    for (auto script : *mpMyChildrenList) {
+    for (auto* scriptNode : *mpMyChildrenList) {
+        auto* script = static_cast<TScript*>(scriptNode);
         script->compileAll(saveLoadingError);
     }
 }

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -144,7 +144,8 @@ void TTimer::compile()
             mOK_code = false;
         }
     }
-    for (auto timer : *mpMyChildrenList) {
+    for (auto* timerNode : *mpMyChildrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         timer->compile();
     }
 }
@@ -158,7 +159,8 @@ void TTimer::compileAll()
         }
         mOK_code = false;
     }
-    for (auto timer : *mpMyChildrenList) {
+    for (auto* timerNode : *mpMyChildrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         timer->compileAll();
     }
 }
@@ -253,7 +255,8 @@ void TTimer::execute()
     }
 
     if ((!isFolder() && hasChildren()) || (isOffsetTimer())) {
-        for (auto timer : *mpMyChildrenList) {
+        for (auto* timerNode : *mpMyChildrenList) {
+            auto* timer = static_cast<TTimer*>(timerNode);
             if (timer->isOffsetTimer()) {
                 timer->enableTimer(timer->getID());
             }
@@ -310,7 +313,8 @@ void TTimer::enableTimer(int id)
     }
 
     if (isFolder()) {
-        for (auto timer : *mpMyChildrenList) {
+        for (auto* timerNode : *mpMyChildrenList) {
+            auto* timer = static_cast<TTimer*>(timerNode);
             if (!timer->isOffsetTimer()) {
                 timer->enableTimer(timer->getID());
             }
@@ -325,7 +329,8 @@ void TTimer::disableTimer(int id)
         mpQTimer->stop();
     }
 
-    for (auto timer : *mpMyChildrenList) {
+    for (auto* timerNode : *mpMyChildrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         if (!timer->isOffsetTimer() && timer->shouldBeActive()) {
             timer->disableTimer(timer->getID());
         }
@@ -346,7 +351,8 @@ void TTimer::enableTimer()
         }
     }
     if (!isOffsetTimer()) {
-        for (auto timer : *mpMyChildrenList) {
+        for (auto* timerNode : *mpMyChildrenList) {
+            auto* timer = static_cast<TTimer*>(timerNode);
             if (!timer->isOffsetTimer()) {
                 timer->enableTimer();
             }
@@ -358,7 +364,8 @@ void TTimer::disableTimer()
 {
     deactivate();
     mpQTimer->stop();
-    for (auto timer : *mpMyChildrenList) {
+    for (auto* timerNode : *mpMyChildrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         timer->disableTimer();
     }
 }
@@ -378,7 +385,8 @@ void TTimer::enableTimer(const QString& name)
     }
 
     if (!isOffsetTimer()) {
-        for (auto timer : *mpMyChildrenList) {
+        for (auto* timerNode : *mpMyChildrenList) {
+            auto* timer = static_cast<TTimer*>(timerNode);
             timer->enableTimer(timer->getName());
         }
     }
@@ -391,7 +399,8 @@ void TTimer::disableTimer(const QString& name)
         mpQTimer->stop();
     }
 
-    for (auto timer : *mpMyChildrenList) {
+    for (auto* timerNode : *mpMyChildrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         timer->disableTimer(timer->getName());
     }
 }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -585,7 +585,8 @@ void TTrigger::filter(std::string& capture, int& posOffset, int lineNumber)
     // pcre2 takes an explicit subject length: cut it at the first NUL, so perl
     // patterns stop there while the QString-based ones still see the whole capture
     const int captureLength = static_cast<int>(qstrnlen(capture.data(), capture.size()));
-    for (auto& trigger : *mpMyChildrenList) {
+    for (auto* triggerNode : *mpMyChildrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         trigger->match(capture.data(), captureLength, text, lineNumber, posOffset);
     }
 }
@@ -1107,7 +1108,8 @@ bool TTrigger::match(const char* haystackC, const int haystackCLength, const QSt
         // if at least one regex is defined a folder is considered a trigger chain otherwise a structural element
         if (!mFilterTrigger) {
             if (conditionMet || (mPatterns.empty())) {
-                for (auto trigger : *mpMyChildrenList) {
+                for (auto* triggerNode : *mpMyChildrenList) {
+                    auto* trigger = static_cast<TTrigger*>(triggerNode);
                     ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset);
                     if (ret) {
                         conditionMet = true;
@@ -1121,7 +1123,8 @@ bool TTrigger::match(const char* haystackC, const int haystackCLength, const QSt
             if ((mKeepFiring == mStayOpen) || (mpMyChildrenList->empty())) {
                 execute();
             }
-            for (auto trigger : *mpMyChildrenList) {
+            for (auto* triggerNode : *mpMyChildrenList) {
+                auto* trigger = static_cast<TTrigger*>(triggerNode);
                 ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset);
                 if (ret) {
                     conditionMet = true;
@@ -1272,7 +1275,8 @@ void TTrigger::compileAll()
         mOK_code = false;
     }
     setRegexCodeList(mPatterns, mPatternKinds);
-    for (auto trigger : *mpMyChildrenList) {
+    for (auto* triggerNode : *mpMyChildrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         trigger->compileAll();
     }
 }
@@ -1288,7 +1292,8 @@ void TTrigger::compile()
             mOK_code = false;
         }
     }
-    for (auto trigger : *mpMyChildrenList) {
+    for (auto* triggerNode : *mpMyChildrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         trigger->compile();
     }
 }
@@ -1453,7 +1458,8 @@ void TTrigger::enableTrigger(const QString& name)
     if (mName == name) {
         setIsActive(true);
     }
-    for (auto trigger : *mpMyChildrenList) {
+    for (auto* triggerNode : *mpMyChildrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         trigger->enableTrigger(name);
     }
 }
@@ -1463,7 +1469,8 @@ void TTrigger::disableTrigger(const QString& name)
     if (mName == name) {
         setIsActive(false);
     }
-    for (auto trigger : *mpMyChildrenList) {
+    for (auto* triggerNode : *mpMyChildrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         trigger->disableTrigger(name);
     }
 }
@@ -1473,7 +1480,8 @@ TTrigger* TTrigger::killTrigger(const QString& name)
     if (mName == name) {
         setIsActive(false);
     }
-    for (auto trigger : *mpMyChildrenList) {
+    for (auto* triggerNode : *mpMyChildrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         trigger->killTrigger(name);
     }
     return nullptr;

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -46,7 +46,8 @@ TimerUnit::~TimerUnit()
         timer->mpHost = nullptr;
         // Also set mpHost to null on all children recursively
         std::function<void(TTimer*)> nullifyChildren = [&nullifyChildren](TTimer* t) {
-            for (auto child : *t->mpMyChildrenList) {
+            for (auto* childNode : *t->mpMyChildrenList) {
+                auto* child = static_cast<TTimer*>(childNode);
                 child->mpHost = nullptr;
                 nullifyChildren(child);
             }
@@ -68,8 +69,9 @@ void TimerUnit::resetStats()
 
 void TimerUnit::_uninstall(TTimer* pChild, const QString& packageName)
 {
-    std::list<TTimer*>* childrenList = pChild->mpMyChildrenList;
-    for (auto timer : *childrenList) {
+    std::list<Tree<TTimer>*>* childrenList = pChild->mpMyChildrenList;
+    for (auto* timerNode : *childrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         _uninstall(timer, packageName);
         uninstallList.append(timer);
     }
@@ -494,8 +496,9 @@ void TimerUnit::markCleanup(TTimer* pT)
 
 void TimerUnit::assembleReport(TTimer* pItem)
 {
-    std::list<TTimer*>* childrenList = pItem->mpMyChildrenList;
-    for (auto pChild : *childrenList) {
+    std::list<Tree<TTimer>*>* childrenList = pItem->mpMyChildrenList;
+    for (auto* pChildNode : *childrenList) {
+        auto* pChild = static_cast<TTimer*>(pChildNode);
         ++statsItemsTotal;
         if (pChild->isOffsetTimer() ? pChild->shouldBeActive() : pChild->isActive()) {
             ++statsActiveItems;

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -40,17 +40,17 @@ public:
     virtual ~Tree();
 
     T* getParent() const { return mpParent; }
-    std::list<T*>* getChildrenList() const;
+    std::list<Tree<T>*>* getChildrenList() const;
     std::list<T*> getAncestorList() const;
     bool hasChildren() const { return (!mpMyChildrenList->empty()); }
     int getChildCount() const { return mpMyChildrenList->size(); }
     int getID() const { return mID; }
     virtual void setID(const int id) { mID = id; }
     // Enum-based API for clear insertion mode specification
-    void addChild(T* newChild, TreeItemInsertMode mode, int position = 0);
+    void addChild(Tree<T>* newChild, TreeItemInsertMode mode, int position = 0);
     // Legacy integer-based position API - delegates to enum-based version
-    void addChild(T* newChild, int parentPostion = -1, int parentPosition = -1);
-    bool popChild(T* removeChild);
+    void addChild(Tree<T>* newChild, int parentPostion = -1, int parentPosition = -1);
+    bool popChild(Tree<T>* removeChild);
     void setParent(T* parent);
     void enableFamily();
     void disableFamily();
@@ -86,7 +86,10 @@ public:
     }
 
     T* mpParent;
-    std::list<T*>* mpMyChildrenList;
+    // Tree<T>* and not T*: a node adds itself to its parent's list from Tree's
+    // own constructor, where its T subobject does not exist yet, so casting
+    // down to T* there is undefined behaviour.
+    std::list<Tree<T>*>* mpMyChildrenList;
     int mID;
     QString mPackageName;
     // Not used:    QString mModuleName;
@@ -108,7 +111,7 @@ private:
 template <class T>
 Tree<T>::Tree()
 : mpParent(nullptr)
-, mpMyChildrenList(new std::list<T*>)
+, mpMyChildrenList(new std::list<Tree<T>*>)
 , mID(0)
 , mOK_init(true)
 , mOK_code(true)
@@ -122,7 +125,7 @@ Tree<T>::Tree()
 template <class T>
 Tree<T>::Tree(T* pParent)
 : mpParent(pParent)
-, mpMyChildrenList(new std::list<T*>)
+, mpMyChildrenList(new std::list<Tree<T>*>)
 , mID(0)
 , mOK_init(true)
 , mOK_code(true)
@@ -132,7 +135,7 @@ Tree<T>::Tree(T* pParent)
 , mFolder(false)
 {
     if (pParent) {
-        pParent->addChild(static_cast<T*>(this));
+        pParent->addChild(this);
     } else {
         mpParent = nullptr;
     }
@@ -143,13 +146,13 @@ Tree<T>::~Tree()
 {
     while (!mpMyChildrenList->empty()) {
         auto it = mpMyChildrenList->begin();
-        T* pChild = *it;
+        Tree<T>* pChild = *it;
         delete pChild;
     }
     delete mpMyChildrenList;
     mpMyChildrenList = nullptr;
     if (mpParent) {
-        mpParent->popChild(static_cast<T*>(this)); // tell parent about my death
+        mpParent->popChild(this); // tell parent about my death
         if (std::uncaught_exceptions()) {
             std::cout << "ERROR: Hook destructed during stack rewind because of an uncaught exception." << std::endl;
         }
@@ -263,7 +266,7 @@ void Tree<T>::disableFamily()
 
 // Enum-based addChild implementation
 template <class T>
-void Tree<T>::addChild(T* newChild, TreeItemInsertMode mode, int position)
+void Tree<T>::addChild(Tree<T>* newChild, TreeItemInsertMode mode, int position)
 {
     if (mode == TreeItemInsertMode::Append || position >= static_cast<int>(mpMyChildrenList->size())) {
         mpMyChildrenList->push_back(newChild);
@@ -282,7 +285,7 @@ void Tree<T>::addChild(T* newChild, TreeItemInsertMode mode, int position)
 
 // Legacy integer-based addChild - delegates to enum-based version
 template <class T>
-void Tree<T>::addChild(T* newChild, int parentPosition, int childPosition)
+void Tree<T>::addChild(Tree<T>* newChild, int parentPosition, int childPosition)
 {
     if (parentPosition == -1 || childPosition == -1) {
         addChild(newChild, TreeItemInsertMode::Append, 0);
@@ -298,7 +301,7 @@ void Tree<T>::setParent(T* pParent)
 }
 
 template <class T>
-bool Tree<T>::popChild(T* pChild)
+bool Tree<T>::popChild(Tree<T>* pChild)
 {
     for (auto it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++) {
         if (*it == pChild) {
@@ -310,7 +313,7 @@ bool Tree<T>::popChild(T* pChild)
 }
 
 template <class T>
-std::list<T*>* Tree<T>::getChildrenList() const
+std::list<Tree<T>*>* Tree<T>::getChildrenList() const
 {
     return mpMyChildrenList;
 }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -54,7 +54,8 @@ TriggerUnit::~TriggerUnit()
         trigger->mpHost = nullptr;
         // Also set mpHost to null on all children recursively
         std::function<void(TTrigger*)> nullifyChildren = [&nullifyChildren](TTrigger* t) {
-            for (auto child : *t->mpMyChildrenList) {
+            for (auto* childNode : *t->mpMyChildrenList) {
+                auto* child = static_cast<TTrigger*>(childNode);
                 child->mpHost = nullptr;
                 nullifyChildren(child);
             }
@@ -77,8 +78,9 @@ void TriggerUnit::resetStats()
 
 void TriggerUnit::_uninstall(TTrigger* pChild, const QString& packageName)
 {
-    std::list<TTrigger*>* childrenList = pChild->mpMyChildrenList;
-    for (auto trigger : *childrenList) {
+    std::list<Tree<TTrigger>*>* childrenList = pChild->mpMyChildrenList;
+    for (auto* triggerNode : *childrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         _uninstall(trigger, packageName);
         uninstallList.append(trigger);
     }
@@ -604,8 +606,9 @@ bool TriggerUnit::killTrigger(const QString& name)
 
 void TriggerUnit::assembleReport(TTrigger* pItem)
 {
-    std::list<TTrigger*>* childrenList = pItem->mpMyChildrenList;
-    for (auto pChild : *childrenList) {
+    std::list<Tree<TTrigger>*>* childrenList = pItem->mpMyChildrenList;
+    for (auto* pChildNode : *childrenList) {
+        auto* pChild = static_cast<TTrigger*>(pChildNode);
         ++statsItemsTotal;
         if (pChild->isActive()) {
             ++statsActiveItems;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -1086,8 +1086,8 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto& it : *pT->mpMyChildrenList) {
-        writeTrigger(it, xmlParent);
+    for (auto* child : *pT->mpMyChildrenList) {
+        writeTrigger(static_cast<TTrigger*>(child), xmlParent);
     }
 }
 
@@ -1139,8 +1139,8 @@ void XMLexport::writeAlias(TAlias* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto& it : *pT->mpMyChildrenList) {
-        writeAlias(it, xmlParent);
+    for (auto* child : *pT->mpMyChildrenList) {
+        writeAlias(static_cast<TAlias*>(child), xmlParent);
     }
 }
 
@@ -1210,8 +1210,8 @@ void XMLexport::writeAction(TAction* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto& it : *pT->mpMyChildrenList) {
-        writeAction(it, xmlParent);
+    for (auto* child : *pT->mpMyChildrenList) {
+        writeAction(static_cast<TAction*>(child), xmlParent);
     }
 }
 
@@ -1266,8 +1266,8 @@ void XMLexport::writeTimer(TTimer* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto& it : *pT->mpMyChildrenList) {
-        writeTimer(it, xmlParent);
+    for (auto* child : *pT->mpMyChildrenList) {
+        writeTimer(static_cast<TTimer*>(child), xmlParent);
     }
 }
 
@@ -1321,8 +1321,8 @@ void XMLexport::writeScript(TScript* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto& it : *pT->mpMyChildrenList) {
-        writeScript(it, xmlParent);
+    for (auto* child : *pT->mpMyChildrenList) {
+        writeScript(static_cast<TScript*>(child), xmlParent);
     }
 }
 
@@ -1375,8 +1375,8 @@ void XMLexport::writeKey(TKey* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto& it : *pT->mpMyChildrenList) {
-        writeKey(it, xmlParent);
+    for (auto* child : *pT->mpMyChildrenList) {
+        writeKey(static_cast<TKey*>(child), xmlParent);
     }
 }
 

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1683,13 +1683,13 @@ void dlgPackageExporter::checkChildren(QTreeWidgetItem* item) const
 
 void dlgPackageExporter::recurseTriggers(TTrigger* trig, QTreeWidgetItem* qTrig)
 {
-    std::list<TTrigger*>* childList = trig->getChildrenList();
+    std::list<Tree<TTrigger>*>* childList = trig->getChildrenList();
     if (childList->empty()) {
         return;
     }
-    std::list<TTrigger*>::iterator it;
+    std::list<Tree<TTrigger>*>::iterator it;
     for (it = childList->begin(); it != childList->end(); ++it) {
-        TTrigger* pChild = *it;
+        auto* pChild = static_cast<TTrigger*>(*it);
         if (pChild->isTemporary()) {
             continue;
         }
@@ -1731,13 +1731,13 @@ void dlgPackageExporter::listTriggers()
 
 void dlgPackageExporter::recurseAliases(TAlias* item, QTreeWidgetItem* qItem)
 {
-    std::list<TAlias*>* childList = item->getChildrenList();
+    std::list<Tree<TAlias>*>* childList = item->getChildrenList();
     if (childList->empty()) {
         return;
     }
-    std::list<TAlias*>::iterator it;
+    std::list<Tree<TAlias>*>::iterator it;
     for (it = childList->begin(); it != childList->end(); ++it) {
-        TAlias* pChild = *it;
+        auto* pChild = static_cast<TAlias*>(*it);
         if (pChild->isTemporary()) {
             continue;
         }
@@ -1779,13 +1779,13 @@ void dlgPackageExporter::listAliases()
 
 void dlgPackageExporter::recurseScripts(TScript* item, QTreeWidgetItem* qItem)
 {
-    std::list<TScript*>* childList = item->getChildrenList();
+    std::list<Tree<TScript>*>* childList = item->getChildrenList();
     if (childList->empty()) {
         return;
     }
-    std::list<TScript*>::iterator it;
+    std::list<Tree<TScript>*>::iterator it;
     for (it = childList->begin(); it != childList->end(); ++it) {
-        TScript* pChild = *it;
+        auto* pChild = static_cast<TScript*>(*it);
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
@@ -1821,13 +1821,13 @@ void dlgPackageExporter::listScripts()
 
 void dlgPackageExporter::recurseKeys(TKey* item, QTreeWidgetItem* qItem)
 {
-    std::list<TKey*>* childList = item->getChildrenList();
+    std::list<Tree<TKey>*>* childList = item->getChildrenList();
     if (childList->empty()) {
         return;
     }
-    std::list<TKey*>::iterator it;
+    std::list<Tree<TKey>*>::iterator it;
     for (it = childList->begin(); it != childList->end(); ++it) {
-        TKey* pChild = *it;
+        auto* pChild = static_cast<TKey*>(*it);
         if (pChild->isTemporary()) {
             continue;
         }
@@ -1869,13 +1869,13 @@ void dlgPackageExporter::listKeys()
 
 void dlgPackageExporter::recurseActions(TAction* item, QTreeWidgetItem* qItem)
 {
-    std::list<TAction*>* childList = item->getChildrenList();
+    std::list<Tree<TAction>*>* childList = item->getChildrenList();
     if (childList->empty()) {
         return;
     }
-    std::list<TAction*>::iterator it;
+    std::list<Tree<TAction>*>::iterator it;
     for (it = childList->begin(); it != childList->end(); ++it) {
-        TAction* pChild = *it;
+        auto* pChild = static_cast<TAction*>(*it);
         QStringList sl;
         sl << pChild->getName();
         auto pItem = new QTreeWidgetItem(sl);
@@ -1911,13 +1911,13 @@ void dlgPackageExporter::listActions()
 
 void dlgPackageExporter::recurseTimers(TTimer* item, QTreeWidgetItem* qItem)
 {
-    std::list<TTimer*>* childList = item->getChildrenList();
+    std::list<Tree<TTimer>*>* childList = item->getChildrenList();
     if (childList->empty()) {
         return;
     }
-    std::list<TTimer*>::iterator it;
+    std::list<Tree<TTimer>*>::iterator it;
     for (it = childList->begin(); it != childList->end(); ++it) {
-        TTimer* pChild = *it;
+        auto* pChild = static_cast<TTimer*>(*it);
         if (pChild->isTemporary()) {
             continue;
         }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3777,8 +3777,9 @@ void dlgProfilePreferences::populateScriptsList()
 // adds trigger name ID to the list of them for the theme preview combobox, recursing down all of them
 void dlgProfilePreferences::addTriggersToPreview(TTrigger* pTriggerParent, std::vector<std::tuple<QString, QString, int>>& items)
 {
-    std::list<TTrigger*>* childTriggers = pTriggerParent->getChildrenList();
-    for (auto trigger : *childTriggers) {
+    std::list<Tree<TTrigger>*>* childTriggers = pTriggerParent->getChildrenList();
+    for (auto* triggerNode : *childTriggers) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         if (!trigger->getScript().isEmpty()) {
             items.push_back({trigger->getName(), qsl("trigger"), trigger->getID()});
         }
@@ -3792,8 +3793,9 @@ void dlgProfilePreferences::addTriggersToPreview(TTrigger* pTriggerParent, std::
 // adds alias name ID to the list of them for the theme preview combobox, recursing down all of them
 void dlgProfilePreferences::addAliasesToPreview(TAlias* pAliasParent, std::vector<std::tuple<QString, QString, int>>& items)
 {
-    std::list<TAlias*>* childrenList = pAliasParent->getChildrenList();
-    for (auto alias : *childrenList) {
+    std::list<Tree<TAlias>*>* childrenList = pAliasParent->getChildrenList();
+    for (auto* aliasNode : *childrenList) {
+        auto* alias = static_cast<TAlias*>(aliasNode);
         if (!alias->getScript().isEmpty()) {
             items.push_back({alias->getName(), qsl("alias"), alias->getID()});
         }
@@ -3807,8 +3809,9 @@ void dlgProfilePreferences::addAliasesToPreview(TAlias* pAliasParent, std::vecto
 // adds timer name ID to the list of them for the theme preview combobox, recursing down all of them
 void dlgProfilePreferences::addTimersToPreview(TTimer* pTimerParent, std::vector<std::tuple<QString, QString, int>>& items)
 {
-    std::list<TTimer*>* childrenList = pTimerParent->getChildrenList();
-    for (auto timer : *childrenList) {
+    std::list<Tree<TTimer>*>* childrenList = pTimerParent->getChildrenList();
+    for (auto* timerNode : *childrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         if (!timer->getScript().isEmpty()) {
             items.push_back({timer->getName(), qsl("timer"), timer->getID()});
         }
@@ -3822,8 +3825,9 @@ void dlgProfilePreferences::addTimersToPreview(TTimer* pTimerParent, std::vector
 // adds key name ID to the list of them for the theme preview combobox, recursing down all of them
 void dlgProfilePreferences::addKeysToPreview(TKey* pKeyParent, std::vector<std::tuple<QString, QString, int>>& items)
 {
-    std::list<TKey*>* childrenList = pKeyParent->getChildrenList();
-    for (auto key : *childrenList) {
+    std::list<Tree<TKey>*>* childrenList = pKeyParent->getChildrenList();
+    for (auto* keyNode : *childrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         if (!key->getScript().isEmpty()) {
             items.push_back({key->getName(), qsl("key"), key->getID()});
         }
@@ -3837,8 +3841,9 @@ void dlgProfilePreferences::addKeysToPreview(TKey* pKeyParent, std::vector<std::
 // adds script name ID to the list of them for the theme preview combobox, recursing down all of them
 void dlgProfilePreferences::addScriptsToPreview(TScript* pScriptParent, std::vector<std::tuple<QString, QString, int>>& items)
 {
-    std::list<TScript*>* childrenList = pScriptParent->getChildrenList();
-    for (auto script : *childrenList) {
+    std::list<Tree<TScript>*>* childrenList = pScriptParent->getChildrenList();
+    for (auto* scriptNode : *childrenList) {
+        auto* script = static_cast<TScript*>(scriptNode);
         if (!script->getScript().isEmpty()) {
             items.push_back({script->getName(), qsl("script"), script->getID()});
         }
@@ -3852,8 +3857,9 @@ void dlgProfilePreferences::addScriptsToPreview(TScript* pScriptParent, std::vec
 // adds action name ID to the list of them for the theme preview combobox, recursing down all of them
 void dlgProfilePreferences::addActionsToPreview(TAction* pActionParent, std::vector<std::tuple<QString, QString, int>>& items)
 {
-    std::list<TAction*>* childrenList = pActionParent->getChildrenList();
-    for (auto action : *childrenList) {
+    std::list<Tree<TAction>*>* childrenList = pActionParent->getChildrenList();
+    for (auto* actionNode : *childrenList) {
+        auto* action = static_cast<TAction*>(actionNode);
         if (!action->getScript().isEmpty()) {
             items.push_back({action->getName(), qsl("button"), action->getID()});
         }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -2872,8 +2872,9 @@ void dlgTriggerEditor::searchTriggers(const QString& text)
 
 void dlgTriggerEditor::recursiveSearchTriggers(TTrigger* pTriggerParent, const QString& text)
 {
-    std::list<TTrigger*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto trigger : *childrenList) {
+    std::list<Tree<TTrigger>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* triggerNode : *childrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         searchSingleTrigger(trigger, text);
         if (trigger->hasChildren()) {
             recursiveSearchTriggers(trigger, text);
@@ -2883,8 +2884,9 @@ void dlgTriggerEditor::recursiveSearchTriggers(TTrigger* pTriggerParent, const Q
 
 void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QString& text)
 {
-    std::list<TAlias*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto alias : *childrenList) {
+    std::list<Tree<TAlias>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* aliasNode : *childrenList) {
+        auto* alias = static_cast<TAlias*>(aliasNode);
         searchSingleAlias(alias, text);
         if (alias->hasChildren()) {
             recursiveSearchAlias(alias, text);
@@ -2894,8 +2896,9 @@ void dlgTriggerEditor::recursiveSearchAlias(TAlias* pTriggerParent, const QStrin
 
 void dlgTriggerEditor::recursiveSearchScripts(TScript* pTriggerParent, const QString& text)
 {
-    std::list<TScript*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto script : *childrenList) {
+    std::list<Tree<TScript>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* scriptNode : *childrenList) {
+        auto* script = static_cast<TScript*>(scriptNode);
         searchSingleScript(script, text);
         if (script->hasChildren()) {
             recursiveSearchScripts(script, text);
@@ -2905,8 +2908,9 @@ void dlgTriggerEditor::recursiveSearchScripts(TScript* pTriggerParent, const QSt
 
 void dlgTriggerEditor::recursiveSearchActions(TAction* pTriggerParent, const QString& text)
 {
-    std::list<TAction*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto action : *childrenList) {
+    std::list<Tree<TAction>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* actionNode : *childrenList) {
+        auto* action = static_cast<TAction*>(actionNode);
         searchSingleAction(action, text);
         if (action->hasChildren()) {
             recursiveSearchActions(action, text);
@@ -2916,8 +2920,9 @@ void dlgTriggerEditor::recursiveSearchActions(TAction* pTriggerParent, const QSt
 
 void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QString& text)
 {
-    std::list<TTimer*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto timer : *childrenList) {
+    std::list<Tree<TTimer>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* timerNode : *childrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         searchSingleTimer(timer, text);
         if (timer->hasChildren()) {
             recursiveSearchTimers(timer, text);
@@ -2927,8 +2932,9 @@ void dlgTriggerEditor::recursiveSearchTimers(TTimer* pTriggerParent, const QStri
 
 void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& text)
 {
-    std::list<TKey*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto key : *childrenList) {
+    std::list<Tree<TKey>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* keyNode : *childrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         searchSingleKey(key, text);
         if (key->hasChildren()) {
             recursiveSearchKeys(key, text);
@@ -2987,7 +2993,7 @@ void dlgTriggerEditor::delete_alias()
         if (pT->mpMyChildrenList) {
             int i = 0;
             for (auto* pChild : *pT->mpMyChildrenList) {
-                captureAliasAndChildren(pChild, pT->getID(), i);
+                captureAliasAndChildren(static_cast<TAlias*>(pChild), pT->getID(), i);
                 ++i;
             }
         }
@@ -3172,7 +3178,7 @@ void dlgTriggerEditor::delete_action()
         if (pT->mpMyChildrenList) {
             int i = 0;
             for (auto* pChild : *pT->mpMyChildrenList) {
-                captureActionAndChildren(pChild, pT->getID(), i);
+                captureActionAndChildren(static_cast<TAction*>(pChild), pT->getID(), i);
                 ++i;
             }
         }
@@ -3408,7 +3414,7 @@ void dlgTriggerEditor::delete_script()
         if (pT->mpMyChildrenList) {
             int i = 0;
             for (auto* pChild : *pT->mpMyChildrenList) {
-                captureScriptAndChildren(pChild, pT->getID(), i);
+                captureScriptAndChildren(static_cast<TScript*>(pChild), pT->getID(), i);
                 ++i;
             }
         }
@@ -3550,7 +3556,7 @@ void dlgTriggerEditor::delete_key()
         if (pT->mpMyChildrenList) {
             int i = 0;
             for (auto* pChild : *pT->mpMyChildrenList) {
-                captureKeyAndChildren(pChild, pT->getID(), i);
+                captureKeyAndChildren(static_cast<TKey*>(pChild), pT->getID(), i);
                 ++i;
             }
         }
@@ -3692,7 +3698,7 @@ void dlgTriggerEditor::delete_trigger()
         if (pT->mpMyChildrenList) {
             int i = 0;
             for (auto* pChild : *pT->mpMyChildrenList) {
-                captureTriggerAndChildren(pChild, pT->getID(), i);
+                captureTriggerAndChildren(static_cast<TTrigger*>(pChild), pT->getID(), i);
                 ++i;
             }
         }
@@ -3839,7 +3845,7 @@ void dlgTriggerEditor::delete_timer()
         if (pT->mpMyChildrenList) {
             int i = 0;
             for (auto* pChild : *pT->mpMyChildrenList) {
-                captureTimerAndChildren(pChild, pT->getID(), i);
+                captureTimerAndChildren(static_cast<TTimer*>(pChild), pT->getID(), i);
                 ++i;
             }
         }
@@ -9291,8 +9297,9 @@ void dlgTriggerEditor::repopulateVars()
 
 void dlgTriggerEditor::expand_child_triggers(TTrigger* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)
 {
-    std::list<TTrigger*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto trigger : *childrenList) {
+    std::list<Tree<TTrigger>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* triggerNode : *childrenList) {
+        auto* trigger = static_cast<TTrigger*>(triggerNode);
         const QString s = trigger->getName();
         QStringList sList;
         sList << s;
@@ -9375,8 +9382,9 @@ void dlgTriggerEditor::expand_child_triggers(TTrigger* pTriggerParent, QTreeWidg
 
 void dlgTriggerEditor::expand_child_key(TKey* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)
 {
-    std::list<TKey*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto key : *childrenList) {
+    std::list<Tree<TKey>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* keyNode : *childrenList) {
+        auto* key = static_cast<TKey*>(keyNode);
         const QString s = key->getName();
         QStringList sList;
         sList << s;
@@ -9442,8 +9450,9 @@ void dlgTriggerEditor::expand_child_key(TKey* pTriggerParent, QTreeWidgetItem* p
 
 void dlgTriggerEditor::expand_child_scripts(TScript* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)
 {
-    std::list<TScript*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto script : *childrenList) {
+    std::list<Tree<TScript>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* scriptNode : *childrenList) {
+        auto* script = static_cast<TScript*>(scriptNode);
         const QString s = script->getName();
         QStringList sList;
         sList << s;
@@ -9500,8 +9509,9 @@ void dlgTriggerEditor::expand_child_scripts(TScript* pTriggerParent, QTreeWidget
 
 void dlgTriggerEditor::expand_child_alias(TAlias* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)
 {
-    std::list<TAlias*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto alias : *childrenList) {
+    std::list<Tree<TAlias>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* aliasNode : *childrenList) {
+        auto* alias = static_cast<TAlias*>(aliasNode);
         const QString s = alias->getName();
         QStringList sList;
         sList << s;
@@ -9566,8 +9576,9 @@ void dlgTriggerEditor::expand_child_alias(TAlias* pTriggerParent, QTreeWidgetIte
 
 void dlgTriggerEditor::expand_child_action(TAction* pTriggerParent, QTreeWidgetItem* pWidgetItemParent)
 {
-    std::list<TAction*>* childrenList = pTriggerParent->getChildrenList();
-    for (auto action : *childrenList) {
+    std::list<Tree<TAction>*>* childrenList = pTriggerParent->getChildrenList();
+    for (auto* actionNode : *childrenList) {
+        auto* action = static_cast<TAction*>(actionNode);
         const QString s = action->getName();
         QStringList sList;
         sList << s;
@@ -9626,8 +9637,9 @@ void dlgTriggerEditor::expand_child_action(TAction* pTriggerParent, QTreeWidgetI
 
 void dlgTriggerEditor::expand_child_timers(TTimer* pTimerParent, QTreeWidgetItem* pWidgetItemParent)
 {
-    std::list<TTimer*>* childrenList = pTimerParent->getChildrenList();
-    for (auto timer : *childrenList) {
+    std::list<Tree<TTimer>*>* childrenList = pTimerParent->getChildrenList();
+    for (auto* timerNode : *childrenList) {
+        auto* timer = static_cast<TTimer*>(timerNode);
         const QString s = timer->getName();
         QStringList sList;
         sList << s;

--- a/src/mudlet-lua/tests/TreeLinkage_spec.lua
+++ b/src/mudlet-lua/tests/TreeLinkage_spec.lua
@@ -1,0 +1,201 @@
+-- Triggers, aliases, timers, keys and scripts are all nodes in a tree: each one
+-- holds a list of its children and a pointer back to its parent. isActive(name,
+-- type, true) is the only Lua reading of the parent chain, and the timer block
+-- below is the only enable/disable that descends the children list - the other
+-- four types are switched through their unit's name lookup table - so between
+-- them both links are covered.
+--
+-- Each item type keeps its own copy of that walk, so every type is driven here
+-- rather than one standing in for the rest. Permanent items have no removal API,
+-- so every block switches its own items off again - left enabled they are saved
+-- with the profile and are live on the next run.
+
+describe("tree linkage", function()
+
+  local permanentItems
+
+  before_each(function()
+    permanentItems = {}
+  end)
+
+  after_each(function()
+    local stillEnabled = {}
+    for _, item in ipairs(permanentItems) do
+      if not item.disable(item.name) then
+        stillEnabled[#stillEnabled + 1] = item.name
+      end
+    end
+    permanentItems = {}
+    assert.are.equal("", table.concat(stillEnabled, ", "), "these items could not be switched off again")
+  end)
+
+  local function track(disable, name)
+    permanentItems[#permanentItems + 1] = {disable = disable, name = name}
+    return name
+  end
+
+  local function assertCreated(ids, itemType)
+    for _, key in ipairs({"top", "mid", "leaf", "sibling"}) do
+      assert.is_true((ids[key] or 0) > 0, "the " .. key .. " " .. itemType .. " should have been created")
+    end
+  end
+
+  -- The shape every block builds:
+  --
+  -- top
+  --  |- mid
+  --  |   `- leaf
+  --  `- sibling
+
+  -- Turning a group off silences what hangs below it without touching those
+  -- items' own switches, and reaches only its own branch.
+  local function silencesOnlyItsOwnBranch(itemType, names, enable, disable)
+    local function effective(name)
+      return isActive(name, itemType, true) == 1
+    end
+    local function switchedOn(name)
+      return isActive(name, itemType) == 1
+    end
+
+    enable(names.top)
+    enable(names.mid)
+    enable(names.leaf)
+    enable(names.sibling)
+    assert.is_true(effective(names.leaf), "the leaf should be effective with both groups above it on")
+    assert.is_true(effective(names.sibling), "the sibling should be effective with its group on")
+
+    disable(names.top)
+    assert.is_false(effective(names.leaf), "the leaf should be silenced by the group two levels above it")
+    assert.is_false(effective(names.sibling), "the sibling should be silenced by the group above it")
+    assert.is_true(switchedOn(names.leaf), "the leaf's own switch must survive an ancestor being turned off")
+    assert.is_true(switchedOn(names.sibling), "the sibling's own switch must survive an ancestor being turned off")
+
+    enable(names.top)
+    assert.is_true(effective(names.leaf), "the leaf should come back when the group above it does")
+    assert.is_true(effective(names.sibling), "the sibling should come back when its group does")
+
+    disable(names.mid)
+    assert.is_false(effective(names.leaf), "the leaf should be silenced by its immediate group")
+    assert.is_true(effective(names.sibling), "the sibling hangs off top, not mid, so it must be untouched")
+  end
+
+  it("links triggers to the groups above them", function()
+    local names = {
+      top = track(disableTrigger, "Spec Tree Trigger Top"),
+      mid = track(disableTrigger, "Spec Tree Trigger Mid"),
+      leaf = track(disableTrigger, "Spec Tree Trigger Leaf"),
+      sibling = track(disableTrigger, "Spec Tree Trigger Sibling"),
+    }
+    local ids = {
+      top = permSubstringTrigger(names.top, "", {}, ""),
+      mid = permSubstringTrigger(names.mid, names.top, {}, ""),
+      leaf = permSubstringTrigger(names.leaf, names.mid, {"spec_tree_trig_leaf"}, ""),
+      sibling = permSubstringTrigger(names.sibling, names.top, {"spec_tree_trig_sibling"}, ""),
+    }
+    assertCreated(ids, "trigger")
+
+    silencesOnlyItsOwnBranch("trigger", names, enableTrigger, disableTrigger)
+  end)
+
+  it("links aliases to the groups above them", function()
+    local names = {
+      top = track(disableAlias, "Spec Tree Alias Top"),
+      mid = track(disableAlias, "Spec Tree Alias Mid"),
+      leaf = track(disableAlias, "Spec Tree Alias Leaf"),
+      sibling = track(disableAlias, "Spec Tree Alias Sibling"),
+    }
+    local ids = {
+      top = permAlias(names.top, "", "", ""),
+      mid = permAlias(names.mid, names.top, "", ""),
+      leaf = permAlias(names.leaf, names.mid, "^spec_tree_alias_leaf$", ""),
+      sibling = permAlias(names.sibling, names.top, "^spec_tree_alias_sibling$", ""),
+    }
+    assertCreated(ids, "alias")
+
+    silencesOnlyItsOwnBranch("alias", names, enableAlias, disableAlias)
+  end)
+
+  it("links keys to the groups above them", function()
+    local names = {
+      top = track(disableKey, "Spec Tree Key Top"),
+      mid = track(disableKey, "Spec Tree Key Mid"),
+      leaf = track(disableKey, "Spec Tree Key Leaf"),
+      sibling = track(disableKey, "Spec Tree Key Sibling"),
+    }
+    local ids = {
+      top = permKey(names.top, "", -1, ""),
+      mid = permKey(names.mid, names.top, -1, ""),
+      leaf = permKey(names.leaf, names.mid, mudlet.key.F10, ""),
+      sibling = permKey(names.sibling, names.top, mudlet.key.F11, ""),
+    }
+    assertCreated(ids, "keybind")
+
+    silencesOnlyItsOwnBranch("keybind", names, enableKey, disableKey)
+  end)
+
+  it("links scripts to the groups above them", function()
+    local names = {
+      top = track(disableScript, "Spec Tree Script Top"),
+      mid = track(disableScript, "Spec Tree Script Mid"),
+      leaf = track(disableScript, "Spec Tree Script Leaf"),
+      sibling = track(disableScript, "Spec Tree Script Sibling"),
+    }
+    -- an empty body is what makes an item a script folder rather than a script,
+    -- which is exactly what the two groups have to be
+    local body = "-- deliberately does nothing"
+    local ids = {
+      top = permScript(names.top, "", ""),
+      mid = permScript(names.mid, names.top, ""),
+      leaf = permScript(names.leaf, names.mid, body),
+      sibling = permScript(names.sibling, names.top, body),
+    }
+    assertCreated(ids, "script")
+
+    silencesOnlyItsOwnBranch("script", names, enableScript, disableScript)
+  end)
+
+  -- Timers are the one type that cannot merely be masked by an ancestor: a timer
+  -- under a group that goes off has to have its real QTimer stopped, so
+  -- disabling a node walks the children list turning every descendant off
+  -- outright rather than leaving their own switches up. Enabling walks the same
+  -- list to start them again.
+  it("stops the timers below a group outright, and starts them again", function()
+    local names = {
+      top = track(disableTimer, "Spec Tree Timer Top"),
+      mid = track(disableTimer, "Spec Tree Timer Mid"),
+      leaf = track(disableTimer, "Spec Tree Timer Leaf"),
+      sibling = track(disableTimer, "Spec Tree Timer Sibling"),
+    }
+    local ids = {
+      top = permTimer(names.top, "", 0, ""),
+      mid = permTimer(names.mid, names.top, 0, ""),
+      leaf = permTimer(names.leaf, names.mid, 60, ""),
+      sibling = permTimer(names.sibling, names.top, 60, ""),
+    }
+    assertCreated(ids, "timer")
+
+    local function running(name)
+      return isActive(name, "timer", true) == 1
+    end
+    local function switchedOn(name)
+      return isActive(name, "timer") == 1
+    end
+
+    enableTimer(names.top)
+    enableTimer(names.mid)
+    enableTimer(names.leaf)
+    enableTimer(names.sibling)
+    assert.is_true(running(names.leaf), "the leaf timer should be running with both groups above it on")
+    assert.is_true(running(names.sibling), "the sibling timer should be running with its group on")
+
+    disableTimer(names.top)
+    assert.is_false(running(names.leaf), "the leaf timer should stop when a group above it is turned off")
+    assert.is_false(running(names.sibling), "the sibling timer should stop when its group is turned off")
+    assert.is_false(switchedOn(names.leaf), "the leaf timer's own switch goes down too - its QTimer really has to stop")
+    assert.is_false(switchedOn(names.sibling), "the sibling timer's own switch goes down too")
+
+    enableTimer(names.top)
+    assert.is_true(running(names.leaf), "the leaf timer should start again with the group above it")
+    assert.is_true(running(names.sibling), "the sibling timer should start again with its group")
+  end)
+end)

--- a/test/functional_tests/ProfileRoundTripTest.cpp
+++ b/test/functional_tests/ProfileRoundTripTest.cpp
@@ -282,7 +282,7 @@ private:
         auto itOriginal = original->mpMyChildrenList->begin();
         auto itImported = imported->mpMyChildrenList->begin();
         while (itOriginal != original->mpMyChildrenList->end()) {
-            compareTriggerNodes(*itOriginal, *itImported, path);
+            compareTriggerNodes(static_cast<TTrigger*>(*itOriginal), static_cast<TTrigger*>(*itImported), path);
             if (QTest::currentTestFailed()) {
                 return;
             }
@@ -307,7 +307,7 @@ private:
         auto itOriginal = original->mpMyChildrenList->begin();
         auto itImported = imported->mpMyChildrenList->begin();
         while (itOriginal != original->mpMyChildrenList->end()) {
-            compareAliasNodes(*itOriginal, *itImported, path);
+            compareAliasNodes(static_cast<TAlias*>(*itOriginal), static_cast<TAlias*>(*itImported), path);
             if (QTest::currentTestFailed()) {
                 return;
             }
@@ -337,7 +337,7 @@ private:
         auto itOriginal = original->mpMyChildrenList->begin();
         auto itImported = imported->mpMyChildrenList->begin();
         while (itOriginal != original->mpMyChildrenList->end()) {
-            compareTimerNodes(*itOriginal, *itImported, path);
+            compareTimerNodes(static_cast<TTimer*>(*itOriginal), static_cast<TTimer*>(*itImported), path);
             if (QTest::currentTestFailed()) {
                 return;
             }
@@ -363,7 +363,7 @@ private:
         auto itOriginal = original->mpMyChildrenList->begin();
         auto itImported = imported->mpMyChildrenList->begin();
         while (itOriginal != original->mpMyChildrenList->end()) {
-            compareKeyNodes(*itOriginal, *itImported, path);
+            compareKeyNodes(static_cast<TKey*>(*itOriginal), static_cast<TKey*>(*itImported), path);
             if (QTest::currentTestFailed()) {
                 return;
             }
@@ -387,7 +387,7 @@ private:
         auto itOriginal = original->mpMyChildrenList->begin();
         auto itImported = imported->mpMyChildrenList->begin();
         while (itOriginal != original->mpMyChildrenList->end()) {
-            compareScriptNodes(*itOriginal, *itImported, path);
+            compareScriptNodes(static_cast<TScript*>(*itOriginal), static_cast<TScript*>(*itImported), path);
             if (QTest::currentTestFailed()) {
                 return;
             }
@@ -415,7 +415,7 @@ private:
     static int countNodes(const QList<T*>& rootNodes)
     {
         int total = 0;
-        std::function<void(T*)> walk = [&](T* node) {
+        std::function<void(Tree<T>*)> walk = [&](Tree<T>* node) {
             ++total;
             for (auto* child : *node->mpMyChildrenList) {
                 walk(child);

--- a/test/functional_tests/StarterUiTriggerCostTest.cpp
+++ b/test/functional_tests/StarterUiTriggerCostTest.cpp
@@ -320,7 +320,8 @@ private slots:
 
         int gatePatterns = 0;
         QStringList shapes;
-        for (auto gate : *tree->getChildrenList()) {
+        for (auto* gateNode : *tree->getChildrenList()) {
+            auto* gate = static_cast<TTrigger*>(gateNode);
             const QList<int> kinds = gate->getRegexCodePropertyList();
             QVERIFY2(!kinds.isEmpty(), qPrintable(qsl("gate \"%1\" has no patterns, so it passes every line straight to its regexes").arg(gate->getName())));
             for (const int kind : kinds) {
@@ -328,7 +329,8 @@ private slots:
                          qPrintable(qsl("gate \"%1\" has a pattern of kind %2 - a gate must be substring matching only, or every line pays for a regex").arg(gate->getName(), QString::number(kind))));
             }
             gatePatterns += static_cast<int>(kinds.size());
-            for (auto shape : *gate->getChildrenList()) {
+            for (auto* shapeNode : *gate->getChildrenList()) {
+                auto* shape = static_cast<TTrigger*>(shapeNode);
                 shapes << shape->getPatternsList();
             }
         }
@@ -584,7 +586,8 @@ private:
         if (trigger->getName() == name) {
             found << trigger;
         }
-        for (auto child : *trigger->getChildrenList()) {
+        for (auto* childNode : *trigger->getChildrenList()) {
+            auto* child = static_cast<TTrigger*>(childNode);
             collectByNameIn(child, name, found);
         }
     }
@@ -604,7 +607,8 @@ private:
         if (trigger->getName() == name) {
             return trigger;
         }
-        for (auto child : *trigger->getChildrenList()) {
+        for (auto* childNode : *trigger->getChildrenList()) {
+            auto* child = static_cast<TTrigger*>(childNode);
             if (TTrigger* found = findTriggerIn(child, name)) {
                 return found;
             }
@@ -616,7 +620,8 @@ private:
     {
         TTrigger* tree = findTrigger(host, qsl("Mudlet base UI chat capture"));
         QVERIFY(tree);
-        for (auto gate : *tree->getChildrenList()) {
+        for (auto* gateNode : *tree->getChildrenList()) {
+            auto* gate = static_cast<TTrigger*>(gateNode);
             const QStringList patterns = gate->getPatternsList();
             const QList<int> kinds = gate->getRegexCodePropertyList();
             for (int i = 0; i < patterns.size() && i < kinds.size(); ++i) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`Tree<T>` registered a node with its parent from its own constructor and destructor, downcasting `this` to `T*` at a point where the `T` subobject does not exist yet (ctor) or no longer does (dtor). That is undefined behaviour, and UBSan flags both sites on every trigger, alias, timer, key, script and button that is created or destroyed.

The children list now stores `Tree<T>*`, so no cast happens where the derived object is not alive; the cast moves to the point of use, where it is valid and free. Changing the stored type turned every reader into a compile error, so the compiler found all 20 other files rather than me having to.

#### Motivation for adding to Mudlet

This fires on every item construction and destruction - it is UB that happens to work today, and it makes UBSan output noisy enough to hide real findings.

#### Other info (issues closed, discussion etc)

**Test case:** new `TreeLinkage_spec.lua` drives all five item types through a `top -> mid -> leaf` + `sibling` tree, checking that a group silences only its own branch. Specs go 3756 -> 3761 successes. Sabotage-verified: cutting the children walk reddens only the timer block, cutting the parent chain reddens the other four. Both `Tree.h` UBSan reports are gone.

Found alongside, filed separately, not fixed here: #10223 (key groups store -1 in a `Qt::Key`).

Assisted-by: Claude:claude-opus-5
