### PR TITLE
Fix: trigger pattern highlighter read an uninitialised flag on every pattern row

### DIFF
--- a/src/TriggerHighlighter.h
+++ b/src/TriggerHighlighter.h
@@ -51,7 +51,7 @@ private:
     QTextCharFormat groupFormat;
     QTextCharFormat quantifierFormat;
 
-    bool highlightingEnabled;
+    bool highlightingEnabled = false;
     void applyFormatting(QTextCharFormat& format, edbee::TextThemeRule* rule);
 };
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`TriggerHighlighter::highlightingEnabled` was the one member of the class with no initialiser, and the constructor reads it: `setTheme()` calls `rehighlight()`, which calls `highlightBlock()`, which tests the flag. So every trigger pattern edit box read uninitialised memory as a `bool`.

Gives it an initialiser.

#### Motivation for adding to Mudlet

UBSan flags it on every `TriggerHighlighter` constructed, which is one per pattern row in the trigger editor.

#### Other info (issues closed, discussion etc)

**Test case:** run the Lua specs against a `linux-debug-ubsan` build with `MALLOC_PERTURB_=1`, which makes fresh allocations a fixed non-zero pattern so the read is reported reliably rather than only when the leftover memory happens not to be 0 or 1:

```
MALLOC_PERTURB_=1 .claude/scripts/run-lua-tests.sh build-linux-debug-ubsan/src/mudlet
```

Before: `TriggerHighlighter.cpp:41:10: runtime error: load of value 254, which is not a valid value for type 'bool'`. After: gone. Specs 3756 successes / 0 failures either way - nothing observable changes, because the only construction site enables highlighting on the next line.

Assisted-by: Claude:claude-opus-5
