### PR TITLE
Fix: undefined behaviour on every profile load, from resetting the telnet session too early

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -280,6 +280,11 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mPass(pass)
 , mPort(port)
 {
+    // cTelnet is declared ahead of the members reset() clears (mMxpProcessor,
+    // mMSSPTlsPort, mIsRemoteEchoingActive and friends), so it cannot do this from
+    // its own constructor - at that point those members do not exist yet.
+    mTelnet.reset();
+
     TDebug::addHost(this, mHostName);
     setDisplayFont(QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal));
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -156,9 +156,6 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
         mAcceptableEncodings << TBuffer::getEncodingNames();
     }
 
-    // initialize telnet session
-    reset();
-
     mpPostingTimer->setInterval(mTimeOut);
     connect(mpPostingTimer, &QTimer::timeout, this, &cTelnet::slot_timerPosting);
 
@@ -241,7 +238,7 @@ void cTelnet::reset()
     // Half of an ANSI sequence left over from the previous connection can only
     // ever be completed by bytes that will never arrive, so drop it instead of
     // letting it consume the new connection's output. There is nothing to drop
-    // when this runs from the constructor, before the profile has a console:
+    // when this runs from the Host constructor, before the profile has a console:
     if (mpHost->mpConsole) {
         mpHost->mpConsole->buffer.resetSequenceParserState();
     }
@@ -249,13 +246,7 @@ void cTelnet::reset()
     // A fresh connection: the player has not interacted yet, so an unsolicited Char.Login.URL must
     // not auto-open the browser until they do (see Host::userSentInputThisConnection()).
     mpHost->setUserSentInputThisConnection(false);
-}
 
-// The same forgetting, for the parts of a game's story about itself that are kept on the Host.
-// Kept out of reset() because the cTelnet constructor calls that, and cTelnet is declared ahead of
-// these members, so at that point they have not been constructed yet.
-void cTelnet::forgetGameSuppliedHostState()
-{
     // Every other place that turns enableMXP off does this too. Without it the processor is left
     // enabled holding a half-built tag from the last game, and TBuffer's tag watchdog answers to
     // the processor alone, so the next escape code spills that tag into the next game's output.
@@ -919,7 +910,6 @@ void cTelnet::slot_socketConnected()
 
     mpSocket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
     reset();
-    forgetGameSuppliedHostState();
     setKeepAlive(mpSocket->socketDescriptor());
 
 #if !defined(QT_NO_SSL)
@@ -1010,7 +1000,6 @@ void cTelnet::slot_socketDisconnected()
     }
     mNeedDecompression = false;
     reset();
-    forgetGameSuppliedHostState();
 
     if (!mpHost->isClosingDown()) {
 #if !defined(QT_NO_SSL)
@@ -4708,7 +4697,7 @@ void cTelnet::slot_tlsUpgradeResponse(const bool accepted)
 
     if (accepted) {
         // Read before disconnecting: a socket with nothing pending can emit disconnected() from
-        // inside disconnectFromHost(), and forgetGameSuppliedHostState() drops the advertised port.
+        // inside disconnectFromHost(), and reset() drops the advertised port.
         const int securePort = mpHost->mMSSPTlsPort;
         // The socket test above passes for a connection made *after* the one that advertised, so
         // it does not catch an answer that outlived its offer - but the port is forgotten with the

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -349,6 +349,11 @@ private:
     // without a real decompression bomb.
     friend class cTelnetBufferTest;
 
+    // Calls reset() from its constructor. It has to be the Host that does that,
+    // and not cTelnet itself, because reset() clears Host members declared after
+    // cTelnet, which do not exist yet while cTelnet is being constructed.
+    friend class Host;
+
 #if defined(QT_NO_SSL)
     void abortLosingSocket(QTcpSocket* losingSocket);
 #else
@@ -364,7 +369,6 @@ private:
     int decompressBuffer(char*& in_buffer, int& length, char* out_buffer);
     void reset();
     void handleFailedConnection();
-    void forgetGameSuppliedHostState();
     void sendLoginAndPass();
 
     QByteArray prepareNewEnvironData(const QString&);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`cTelnet mTelnet;` is Host's first member, so cTelnet's constructor runs before every Host member declared after it. That constructor called `reset()`, and `reset()` clears state that lives on the Host - `mIsRemoteEchoingActive`, `mUserSentInputThisConnection` - which at that point do not exist yet.

The Host constructor now makes that call, from its body, where all of its members are alive.

That also removes the only reason `forgetGameSuppliedHostState()` existed. It was split out of `reset()` purely because the cTelnet constructor could not safely touch those Host members, as its own comment said. Both of its call sites sat on the line immediately after a `reset()`, so it folds back in and disappears.

**This is behaviourally inert** - it exists to remove the undefined behaviour, so please don't spend time hunting for a behaviour change. Both members involved already default to `false`, and those initialisers ran after the old call and overwrote whatever it had written, so the values were the same either way. The work that is newly done at construction is a no-op three times over: the MXP processor is already off, and the MSSP port and hostname are already empty.

The two halves are not independent, which is worth knowing: `getForceMXPProcessorOn()` *reads* `mForceMXPProcessorOn`, also declared after `mTelnet`. Folding `forgetGameSuppliedHostState()` in without moving the call would have introduced a second report of exactly the same kind.

#### Motivation for adding to Mudlet

UBSan flags it on every profile load.

#### Other info (issues closed, discussion etc)

**Test case:** run the Lua specs against a `linux-debug-ubsan` build with `MALLOC_PERTURB_=1`, which makes fresh allocations a fixed non-zero pattern so the read is reported reliably rather than only when the leftover memory happens not to be 0 or 1:

```
MALLOC_PERTURB_=1 .claude/scripts/run-lua-tests.sh build-linux-debug-ubsan/src/mudlet
```

Before: `Host.cpp:5511:9: runtime error: load of value 254, which is not a valid value for type 'bool'`, under `cTelnet::reset()` <- `cTelnet::cTelnet` <- `Host::Host`. After: gone.

Specs 3756 / 0 failures and ctest 143/143 either way. The fold is already covered by `TelnetReconnectStateTest`, which asserts that a half-built MXP tag does not spill into the next game and that a secure port advertised by one game is not offered to the next.

No new test: both values end up identical from Lua's side, so there is nothing observable to assert, and CLAUDE.md says sanitiser coverage on its own is not a reason to add a functional test.


Part of a set of three clearing the UBSan reports from a fuzzing run: #10227, #10228 and this one. The one remaining report is #10223, which is a different bug.

Assisted-by: Claude:claude-opus-5
