### PR TITLE
Fix: undefined behaviour when the script editor's undo stack is destroyed

### DIFF
--- a/src/EditorUndoStack.cpp
+++ b/src/EditorUndoStack.cpp
@@ -60,6 +60,14 @@ EditorUndoStack::EditorUndoStack(QObject* parent)
     });
 }
 
+EditorUndoStack::~EditorUndoStack()
+{
+    // ~QUndoStack runs before ~QObject severs the connection, and it calls
+    // clear(), which emits indexChanged(). By then this object is only a
+    // QUndoStack, so the lambda above must not be allowed to touch our members.
+    disconnect(this, &QUndoStack::indexChanged, this, nullptr);
+}
+
 void EditorUndoStack::emitChangesForCommand(const QUndoCommand* cmd)
 {
     if (!cmd) {

--- a/src/EditorUndoStack.h
+++ b/src/EditorUndoStack.h
@@ -36,6 +36,7 @@ class EditorUndoStack : public QUndoStack
 
 public:
     explicit EditorUndoStack(QObject* parent = nullptr);
+    ~EditorUndoStack() override;
 
     // Updates all commands on the stack when an item gets a new ID after undo/redo
     void remapItemIDs(int oldID, int newID);

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -108,11 +108,13 @@ void TelnetServerStub::onNewConnection()
         }
     });
 
-    connect(client, &QTcpSocket::disconnected, [safeClient]() {
-        if (!safeClient) {
+    // ~QTcpSocket emits disconnected() from ~QAbstractSocket, by which point the
+    // socket is no longer a QTcpSocket - so hold it as the base type here.
+    connect(client, &QTcpSocket::disconnected, [safeSocket = QPointer<QAbstractSocket>(client)]() {
+        if (!safeSocket) {
             return;
         }
-        qInfo().noquote() << qsl("Client disconnected: %1").arg(safeClient->peerAddress().toString());
-        safeClient->deleteLater();
+        qInfo().noquote() << qsl("Client disconnected: %1").arg(safeSocket->peerAddress().toString());
+        safeSocket->deleteLater();
     });
 }


### PR DESCRIPTION
Closes #10231

`~QUndoStack` calls `clear()`, which emits `indexChanged()` while the constructor's `this`-capturing lambda is still connected - `~QObject` severs connections only afterwards. So closing the script editor ran that lambda on an object that was by then only a `QUndoStack`, reading `mInPushOperation`, `mInMacroPush` and `mPreviousIndex` and writing the last one. Six accesses, all reported by UBSan. The destructor now severs that one self-connection.

The functional-test telnet stub had the same shape: a `QPointer<QTcpSocket>` dereferenced from a `disconnected()` handler that `~QAbstractSocket` emits, so the downcast in `QPointer::data()` was undefined. Holding the base type instead makes it well-defined and calls identical code.

Both are sanitizer-only diagnostics with no observable behavioural change, so there is no test that can go red without the fix and green with it - `clear()` empties the stack before it emits, so the lambda's `affectedCommandIndex < count()` guard never passes and `itemsChanged` is never emitted during teardown. `DialogTeardownTest::test_triggerEditorDestroyedWithFocusedNameField` already walks the path and is what reported the errors; it would become a real regression test if CI ever built with `-DUSE_SANITIZER=Undefined -fno-sanitize-recover=all`, which it currently does not.

Found by an UndefinedBehaviorSanitizer sweep for the bug class in #10228.

### Verification
- `DialogTeardownTest`: the 6 `EditorUndoStack` UBSan errors are gone, same 6 passed / 3 failed (those 3 fail on `development` too).
- `dlgTriggerEditorUndoRedoTest`: 80 passed, 0 failed.
- `TriggerEditorTest` 3/3, `EditorBannerViewSwitchTest` 9/9.
