### PR TITLE
Fix: Placeholder text below WCAG AA in dark mode on older Qt

### DIFF
--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -42,6 +42,11 @@ void DarkTheme::polish(QPalette& palette)
     palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
     palette.setColor(QPalette::ToolTipText, Qt::white);
     palette.setColor(QPalette::Text, Qt::white);
+    // Qt derives this role from the light theme's text colour, which on a dark
+    // field draws the placeholder all but black, so derive it from ours instead
+    QColor placeholderText(palette.color(QPalette::Text));
+    placeholderText.setAlphaF(0.5f);
+    palette.setColor(QPalette::PlaceholderText, placeholderText);
     palette.setColor(QPalette::Dark, QColor(35, 35, 35));
     palette.setColor(QPalette::Light, QColor(75, 75, 75));
     palette.setColor(QPalette::Midlight, QColor(64, 64, 64));

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -42,8 +42,9 @@ void DarkTheme::polish(QPalette& palette)
     palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
     palette.setColor(QPalette::ToolTipText, Qt::white);
     palette.setColor(QPalette::Text, Qt::white);
-    // Qt derives this role from the light theme's text colour, which on a dark
-    // field draws the placeholder all but black, so derive it from ours instead
+    // Before Qt 6.10, Fusion hands polish() the light palette even in dark mode,
+    // leaving this role at #646464 - 2.9:1 against the Base set above, under the
+    // 4.5:1 AA floor. Newer Qt derives a dark value itself, so this is for 6.8/6.9
     QColor placeholderText(palette.color(QPalette::Text));
     placeholderText.setAlphaF(0.5f);
     palette.setColor(QPalette::PlaceholderText, placeholderText);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `DarkTheme::polish()` repaints 22 palette roles but never `QPalette::PlaceholderText`. On Qt before 6.10 that leaves the role at Fusion's light-theme `#646464`, which against the `#191919` field this same function installs measures **2.9:1** - under the 4.5:1 WCAG AA floor. It is now derived from the dark palette's own `Text` at 50% alpha, measuring **5.1:1** on rendered pixels.

#### Motivation for adding to Mudlet
Placeholder hints across the app - trigger and alias patterns, the package exporter's fields - sit below AA contrast in dark mode when Mudlet is built against Qt 6.8 or 6.9.

#### Other info (issues closed, discussion etc)
Measured rather than assumed. Four builds (patched and unpatched, against Qt 6.8.3 and 6.10.1) driven through the same UI path headlessly, sampling rendered pixels:

| field | Qt 6.8.3 before | Qt 6.8.3 after | Qt 6.10.1 before | Qt 6.10.1 after |
| --- | --- | --- | --- | --- |
| alias pattern hint | `#636363` 2.90:1 | `#888b81` 5.07:1 | `#81837a` 4.57:1 | `#888b81` 5.07:1 |
| trigger pattern hint | `#616362` 2.90:1 | `#878b88` 5.09:1 | - | - |
| package exporter name | `#636363` 2.93:1 | `#8b8a8a` 5.11:1 | - | - |

**Scope.** From Qt 6.10, `styleHints()->setColorScheme(Dark)` makes Fusion hand `polish()` a genuinely dark palette with `PlaceholderText` already at `#80f0f0f0`:

```
Qt 6.8.3   polish() got  PlaceholderText: #ff646464  Text: #ff000000  Base: #fffcfcfc
Qt 6.10.1  polish() got  PlaceholderText: #80f0f0f0  Text: #fff0f0f0  Base: #ff242424
```

So on the Qt 6.11.1 that CI ships this is a no-op - a max channel delta of 8/255, invisible. It earns its place for anyone building against the declared `find_package(Qt6 6.8.2)` floor, distro packagers mainly.

**Not covered.** Widgets under a Qt stylesheet resolve `PlaceholderText` from the stylesheet's own `color` rather than the application palette, so this does not reach the redesigned settings dialog (#10237) and that dialog keeps its local workaround.

**Test case:** build against Qt 6.8.x, switch to dark mode, open the script editor and add an alias - the `^myalias$ (example)` hint reads as a mid grey rather than a dim smudge. On Qt 6.10 or newer there is nothing to see; Qt already handles it.

Assisted-by: Claude:claude-fable-5
Assisted-by: Claude:claude-opus-5

https://claude.ai/code/session_014S43F8L5PnCUzLHzJJrNpD