### PR TITLE
Improve: Open settings dialog reflects changes made elsewhere

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -50,6 +50,7 @@
 #include "utils.h"
 
 #include <chrono>
+#include <vector>
 #include <QtConcurrentRun>
 #include <QAbstractScrollArea>
 #include <QAbstractSpinBox>
@@ -88,6 +89,7 @@
 #include <QScrollArea>
 #include <QScrollBar>
 #include <QShortcut>
+#include <QSignalBlocker>
 #include <QStackedWidget>
 #include <QStyle>
 #include <QStyledItemDelegate>
@@ -191,42 +193,8 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     // multiple profiles each with a separate instance of this form open we also
     // have to respond to changes in the settings when *another* profile saves
     // them.
-    checkBox_showSpacesAndTabs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowTabsAndSpaces);
-    checkBox_showLineFeedsAndParagraphs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
+    populateApplicationSettings();
 
-    checkBox_reportMapIssuesOnScreen->setChecked(pMudlet->showMapAuditErrors());
-    checkBox_showIconsOnMenus->setCheckState(pMudlet->mShowIconsOnMenuCheckedState);
-
-    MainIconSize->setValue(pMudlet->mToolbarIconSize);
-    TEFolderIconSize->setValue(pMudlet->mEditorTreeWidgetIconSize);
-
-    switch (pMudlet->menuBarVisibility()) {
-    case enums::visibleNever:
-        comboBox_menuBarVisibility->setCurrentIndex(0);
-        break;
-    case enums::visibleOnlyWithoutLoadedProfile:
-        comboBox_menuBarVisibility->setCurrentIndex(1);
-        break;
-    default:
-        comboBox_menuBarVisibility->setCurrentIndex(2);
-    }
-
-    switch (pMudlet->toolBarVisibility()) {
-    case enums::visibleNever:
-        comboBox_toolBarVisibility->setCurrentIndex(0);
-        break;
-    case enums::visibleOnlyWithoutLoadedProfile:
-        comboBox_toolBarVisibility->setCurrentIndex(1);
-        break;
-    default:
-        comboBox_toolBarVisibility->setCurrentIndex(2);
-    }
-
-    // Sync "Never" item deactivation so the dialog opens with consistent state
-    // if either visibility was already "Never" on previous save (issue #7079).
-    slot_syncMenuToolBarNeverItem();
-
-    checkBox_showTabConnectionIndicators->setChecked(pMudlet->mShowTabConnectionIndicators);
     connect(checkBox_showTabConnectionIndicators, &QCheckBox::toggled, this, [=](bool checked) {
         mudlet::self()->setShowTabConnectionIndicators(checked);
     });
@@ -335,8 +303,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     connect(comboBox_menuBarVisibility, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeShowMenuBar);
     connect(comboBox_toolBarVisibility, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeShowToolBar);
 
-    comboBox_appearance->setCurrentIndex(pMudlet->mAppearance);
-
     // This group of signal/slot connections handles updating *this* instance of
     // the "Profile preferences" form/dialog when a *different* profile saves
     // new settings from this one - there is a further connect(...) above which
@@ -425,13 +391,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         }
     }
 
-    QSettings settings("Mudlet", "CrashReporter");
-    QVariant storedOption = settings.value("autoSendCrashReports", QVariant());
-    int option = 2;
-    if (storedOption.isValid()) {
-        option = storedOption.toInt() - 1;
-    }
-    comboBox_crashReportPolicy->setCurrentIndex(option);
     connect(comboBox_crashReportPolicy, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_crashReportPolicyChanged);
 
     setupPasswordsMigration();
@@ -2272,6 +2231,18 @@ void dlgProfilePreferences::resizeEvent(QResizeEvent* pEvent)
     updateSidebarMode();
 }
 
+// Coming back to the window is the moment the settings can be re-read without
+// interrupting anything - see refreshFromSettings(), which decides whether this
+// particular return is such a moment.
+bool dlgProfilePreferences::event(QEvent* pEvent)
+{
+    const bool handled = QDialog::event(pEvent);
+    if (pEvent->type() == QEvent::WindowActivate) {
+        refreshFromSettings();
+    }
+    return handled;
+}
+
 bool dlgProfilePreferences::eventFilter(QObject* pObject, QEvent* pEvent)
 {
     // A checkbox whose label had to be wrapped into a QLabel beside it keeps
@@ -3296,6 +3267,106 @@ bool dlgProfilePreferences::anyDirty(const QList<const QObject*>& controls) cons
     return false;
 }
 
+bool dlgProfilePreferences::pendingEdits() const
+{
+    // An apply is already on its way. Whatever the settings say, what the
+    // controls hold is the user's until that has run - and the refresh at the
+    // end of it will pick the settings up a moment later anyway.
+    if (mpTimer_apply && mpTimer_apply->isActive()) {
+        return true;
+    }
+    for (const auto* pWidget : findChildren<QWidget*>()) {
+        if (pWidget == mpLineEdit_search || !controlValue(pWidget).isValid()) {
+            continue;
+        }
+        // dirty() answers false for a field being typed into, so that a shared
+        // debounce cannot commit half a word - but half a word is exactly the
+        // edit that must not be written over here, so it is asked separately:
+        if (beingTypedInto(pWidget) || dirty(pWidget)) {
+            return true;
+        }
+    }
+    if (currentShortcuts != mShortcutsSnapshot) {
+        return true;
+    }
+    // A shortcut editor holds a capture until editingFinished, so one showing
+    // anything other than what it last committed is an edit in progress:
+    for (auto it = mShortcutEditors.cbegin(), end = mShortcutEditors.cend(); it != end; ++it) {
+        if (it.value() && it.value()->keySequence() != currentShortcuts.value(it.key())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Two-way binding, at the one moment it can be had for nothing: the dialog
+// stays open for hours while scripts and other dialogs move the settings on
+// underneath it, so coming back to its window is when it re-reads them. It only
+// ever does that over a dialog showing nothing of the user's own - re-reading
+// is indistinguishable from discarding whatever was in the way of it - so an
+// edit anywhere in the dialog means this run is skipped and the next activation
+// after that edit has been applied does the work instead.
+void dlgProfilePreferences::refreshFromSettings()
+{
+    // Activation arrives repeatedly - a dialog opened over this one and closed
+    // again is two of them - and the population below is what raises
+    // mPopulating, so re-entering it is impossible rather than merely unlikely:
+    if (mPopulating || mClosing || !mShellReady) {
+        return;
+    }
+    if (mSearchActive) {
+        // Repopulating replaces the text the search index was built from, and
+        // the only honest way to fix that up is to clear the query - which is
+        // the user's. The activation after they leave the results refreshes.
+        return;
+    }
+    if (pendingEdits()) {
+        return;
+    }
+
+    // Nothing is borrowed with no query standing, so this only throws the index
+    // away for the next query to rebuild from whatever the cards now say
+    invalidateSearch();
+
+    // On the two paths that build the dialog, population happens before the
+    // write-through connections are made. Here they are already there, so every
+    // control that carries a value is written silently - otherwise a setting
+    // that has moved would travel straight back out of the control that has
+    // just been told about it, and one whose control cannot hold it exactly
+    // (the room size is a 1-11 scale over a qreal) would come back rounded.
+    std::vector<QSignalBlocker> blockers;
+    const auto controls = findChildren<QWidget*>();
+    blockers.reserve(controls.size());
+    for (auto* pControl : controls) {
+        if (controlValue(pControl).isValid()) {
+            blockers.emplace_back(pControl);
+        }
+    }
+
+    mPopulating = true;
+    populateApplicationSettings();
+    if (Host* pHost = mpHost; pHost) {
+        initWithHost(pHost);
+    }
+    mPopulating = false;
+    // Released before the re-measuring below, which moves checkboxes between
+    // parents rather than merely writing them
+    blockers.clear();
+
+    // The pairing every population in this dialog ends with, for the same
+    // reason: what the controls hold now is what the settings say, so only what
+    // changes after this is the user's next edit
+    connectApplyTriggers();
+    snapshotValues();
+    // Nothing new was built - initWithHost() builds once - so applyShellStyle()
+    // has no unstyled control to catch up on, but the caps have work: a label
+    // can have been replaced by a longer or shorter one, and a checkbox that
+    // needed wrapping may no longer. Caps after whatever wrote the controls,
+    // tab order after the caps, because a wrapped checkbox sits a widget deeper.
+    updateColumnWidthCaps();
+    rebuildTabOrder();
+}
+
 void dlgProfilePreferences::setupPasswordsMigration()
 {
     hidePasswordMigrationLabelTimer = std::make_unique<QTimer>(this);
@@ -3587,6 +3658,79 @@ void dlgProfilePreferences::enableHostDetails()
     doubleSpinBox_networkPacketTimeout->setEnabled(true);
 }
 
+// The settings that belong to Mudlet rather than to any one profile, read from
+// where they actually live. Every write here is blocked from signalling,
+// because this is the dialog reading a setting - a control that answered by
+// writing the same value straight back would, on a language or appearance
+// setting, be a control that undoes what another dialog just did.
+void dlgProfilePreferences::populateApplicationSettings()
+{
+    mudlet* pMudlet = mudlet::self();
+
+    // As we demonstrate the options that these next two checkboxes control in
+    // the editor "preview" widget (on another tab) we will need to track
+    // changes and update the edbee widget straight away. As we can have
+    // multiple profiles each with a separate instance of this form open we also
+    // have to respond to changes in the settings when *another* profile saves
+    // them.
+    checkBox_showSpacesAndTabs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowTabsAndSpaces);
+    checkBox_showLineFeedsAndParagraphs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
+
+    checkBox_reportMapIssuesOnScreen->setChecked(pMudlet->showMapAuditErrors());
+    checkBox_showIconsOnMenus->setCheckState(pMudlet->mShowIconsOnMenuCheckedState);
+
+    MainIconSize->setValue(pMudlet->mToolbarIconSize);
+    TEFolderIconSize->setValue(pMudlet->mEditorTreeWidgetIconSize);
+
+    {
+        const QSignalBlocker menuBarBlocker(comboBox_menuBarVisibility);
+        switch (pMudlet->menuBarVisibility()) {
+        case enums::visibleNever:
+            comboBox_menuBarVisibility->setCurrentIndex(0);
+            break;
+        case enums::visibleOnlyWithoutLoadedProfile:
+            comboBox_menuBarVisibility->setCurrentIndex(1);
+            break;
+        default:
+            comboBox_menuBarVisibility->setCurrentIndex(2);
+        }
+
+        const QSignalBlocker toolBarBlocker(comboBox_toolBarVisibility);
+        switch (pMudlet->toolBarVisibility()) {
+        case enums::visibleNever:
+            comboBox_toolBarVisibility->setCurrentIndex(0);
+            break;
+        case enums::visibleOnlyWithoutLoadedProfile:
+            comboBox_toolBarVisibility->setCurrentIndex(1);
+            break;
+        default:
+            comboBox_toolBarVisibility->setCurrentIndex(2);
+        }
+    }
+
+    // Sync "Never" item deactivation so the dialog opens with consistent state
+    // if either visibility was already "Never" on previous save (issue #7079).
+    slot_syncMenuToolBarNeverItem();
+
+    {
+        const QSignalBlocker blocker(checkBox_showTabConnectionIndicators);
+        checkBox_showTabConnectionIndicators->setChecked(pMudlet->mShowTabConnectionIndicators);
+    }
+    {
+        const QSignalBlocker blocker(comboBox_appearance);
+        comboBox_appearance->setCurrentIndex(pMudlet->mAppearance);
+    }
+    {
+        // The one setting on this page that lives in its own QSettings group
+        // rather than in the mudlet instance, so the only one with nothing to
+        // announce a change made from somewhere else
+        const QSignalBlocker blocker(comboBox_crashReportPolicy);
+        const QSettings settings("Mudlet", "CrashReporter");
+        const QVariant storedOption = settings.value("autoSendCrashReports", QVariant());
+        comboBox_crashReportPolicy->setCurrentIndex(storedOption.isValid() ? storedOption.toInt() - 1 : 2);
+    }
+}
+
 void dlgProfilePreferences::initWithHost(Host* pHost)
 {
     loadEditorTab();
@@ -3598,16 +3742,21 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     spinBox_displayFontSize->setValue(std::max(1, pHost->getDisplayFont().pointSize()));
     checkBox_antiAlias->setChecked(!pHost->mNoAntiAlias);
 
-    connect(fontComboBox_displayFont, &QFontComboBox::currentFontChanged, this, &dlgProfilePreferences::slot_displayFontChanged);
-    connect(spinBox_displayFontSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_displayFontSizeChanged);
-    connect(checkBox_antiAlias, &QCheckBox::clicked, this, &dlgProfilePreferences::slot_displayFontAliasingChanged);
+    connect(fontComboBox_displayFont, &QFontComboBox::currentFontChanged, this, &dlgProfilePreferences::slot_displayFontChanged, Qt::UniqueConnection);
+    connect(spinBox_displayFontSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_displayFontSizeChanged, Qt::UniqueConnection);
+    connect(checkBox_antiAlias, &QCheckBox::clicked, this, &dlgProfilePreferences::slot_displayFontAliasingChanged, Qt::UniqueConnection);
 
-    // search engine load
-    search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
+    // search engine load - emptied first so that a second run of this function
+    // replaces the list rather than appending a second copy of it
+    {
+        const QSignalBlocker blocker(search_engine_combobox);
+        search_engine_combobox->clear();
+        search_engine_combobox->addItems(QStringList(pHost->mSearchEngineData.keys()));
 
-    // set to saved value or default to Google
-    const int savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
-    search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
+        // set to saved value or default to Google
+        const int savedText = search_engine_combobox->findText(pHost->getSearchEngine().first);
+        search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
+    }
 
     checkBox_mVersionInTTYPE->setChecked(pHost->mVersionInTTYPE);
     checkBox_mForceMXPProcessorOn->setChecked(pHost->getForceMXPProcessorOn());
@@ -3714,7 +3863,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     if (!pHost->getMmpMapLocation().isEmpty()) {
         groupBox_downloadMapOptions->setVisible(true);
-        connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_downloadMap);
+        connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_downloadMap, Qt::UniqueConnection);
     } else {
         groupBox_downloadMapOptions->setVisible(false);
     }
@@ -3729,19 +3878,19 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     checkBox_announceIncomingText->setChecked(pHost->mAnnounceIncomingText);
     checkBox_advertiseScreenReader->setChecked(pHost->mAdvertiseScreenReader);
-    connect(checkBox_advertiseScreenReader, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleAdvertiseScreenReader);
+    connect(checkBox_advertiseScreenReader, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleAdvertiseScreenReader, Qt::UniqueConnection);
     checkBox_enableOSC8Hyperlinks->setChecked(pHost->mEnableOSC8Hyperlinks);
-    connect(checkBox_enableOSC8Hyperlinks, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleEnableOSC8Hyperlinks);
+    connect(checkBox_enableOSC8Hyperlinks, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleEnableOSC8Hyperlinks, Qt::UniqueConnection);
 
     checkBox_enableClosedCaption->setChecked(pHost->mEnableClosedCaption);
-    connect(checkBox_enableClosedCaption, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleEnableClosedCaption);
+    connect(checkBox_enableClosedCaption, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleEnableClosedCaption, Qt::UniqueConnection);
 
     // Block signals before setting initial state to prevent toggled signal
     checkBox_f3SearchEnabled->blockSignals(true);
     checkBox_f3SearchEnabled->setChecked(pHost->getF3SearchEnabled());
     checkBox_f3SearchEnabled->blockSignals(false);
     // Now connect the signal
-    connect(checkBox_f3SearchEnabled, &QCheckBox::toggled, pHost, &Host::setF3SearchEnabled);
+    connect(checkBox_f3SearchEnabled, &QCheckBox::toggled, pHost, &Host::setF3SearchEnabled, Qt::UniqueConnection);
 
     checkBox_enableBlinkText->setChecked(pHost->getEnableBlinkText());
 
@@ -3754,10 +3903,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_undoServerWrap->setChecked(pHost->mUndoServerWrap);
     undo_server_wrap_width_spinBox->setValue(pHost->mUndoServerWrapWidth);
     undo_server_wrap_width_spinBox->setEnabled(pHost->mUndoServerWrap);
-    connect(checkBox_undoServerWrap, &QCheckBox::toggled, undo_server_wrap_width_spinBox, &QWidget::setEnabled);
+    connect(checkBox_undoServerWrap, &QCheckBox::toggled, undo_server_wrap_width_spinBox, &QWidget::setEnabled, Qt::UniqueConnection);
     // The note is only worth its space to someone actually running the option:
     label_undo_server_wrap_experimental->setVisible(pHost->mUndoServerWrap);
-    connect(checkBox_undoServerWrap, &QCheckBox::toggled, label_undo_server_wrap_experimental, &QWidget::setVisible);
+    connect(checkBox_undoServerWrap, &QCheckBox::toggled, label_undo_server_wrap_experimental, &QWidget::setVisible, Qt::UniqueConnection);
 
     console_buffer_size_spinBox->setValue(pHost->getConsoleBufferSize());
     checkBox_useMaxBufferSize->setChecked(pHost->getUseMaxConsoleBufferSize());
@@ -3772,6 +3921,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         if (pHost->getUseMaxConsoleBufferSize()) {
             console_buffer_size_spinBox->setValue(maxBufferSize);
             console_buffer_size_spinBox->setEnabled(false);
+        } else {
+            // ...and back on again for a profile that has stopped using it,
+            // which the checkbox's own slot would otherwise be the only way to
+            // hear about
+            console_buffer_size_spinBox->setEnabled(true);
         }
     }
 
@@ -3885,16 +4039,23 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     label_logFileName->setVisible(isLogFileNameEntryShown);
     label_logFileNameExtension->setText(logExtension);
 
-    // This is the previous standard:
-    comboBox_logFileNameFormat->addItem(tr("yyyy-MM-dd#HH-mm-ss (e.g., 1970-01-01#00-00-00%1)").arg(logExtension), qsl("yyyy-MM-dd#HH-mm-ss"));
-    // The ISO standard for this uses T as the date/time separator
-    comboBox_logFileNameFormat->addItem(tr("yyyy-MM-ddTHH-mm-ss (e.g., 1970-01-01T00-00-00%1)").arg(logExtension), qsl("yyyy-MM-ddTHH-mm-ss"));
-    comboBox_logFileNameFormat->addItem(tr("yyyy-MM-dd (concatenate daily logs in, e.g. 1970-01-01%1)").arg(logExtension), qsl("yyyy-MM-dd"));
-    // It might be possible to use QDateTime::weekNumber but that number is not
-    // available from the QDateTime::toString(...) method
-    comboBox_logFileNameFormat->addItem(tr("yyyy-MM (concatenate month logs in, e.g. 1970-01%1)").arg(logExtension), qsl("yyyy-MM"));
-    comboBox_logFileNameFormat->addItem(tr("Named file (concatenate logs in one file)"), QString());
-    comboBox_logFileNameFormat->setCurrentIndex(comboBox_logFileNameFormat->findData(pHost->mLogFileNameFormat));
+    {
+        // Rebuilt rather than added to, for the same reason as the search
+        // engines - and silently, since the momentary empty list in the middle
+        // of it is not a log format anyone chose
+        const QSignalBlocker blocker(comboBox_logFileNameFormat);
+        comboBox_logFileNameFormat->clear();
+        // This is the previous standard:
+        comboBox_logFileNameFormat->addItem(tr("yyyy-MM-dd#HH-mm-ss (e.g., 1970-01-01#00-00-00%1)").arg(logExtension), qsl("yyyy-MM-dd#HH-mm-ss"));
+        // The ISO standard for this uses T as the date/time separator
+        comboBox_logFileNameFormat->addItem(tr("yyyy-MM-ddTHH-mm-ss (e.g., 1970-01-01T00-00-00%1)").arg(logExtension), qsl("yyyy-MM-ddTHH-mm-ss"));
+        comboBox_logFileNameFormat->addItem(tr("yyyy-MM-dd (concatenate daily logs in, e.g. 1970-01-01%1)").arg(logExtension), qsl("yyyy-MM-dd"));
+        // It might be possible to use QDateTime::weekNumber but that number is
+        // not available from the QDateTime::toString(...) method
+        comboBox_logFileNameFormat->addItem(tr("yyyy-MM (concatenate month logs in, e.g. 1970-01%1)").arg(logExtension), qsl("yyyy-MM"));
+        comboBox_logFileNameFormat->addItem(tr("Named file (concatenate logs in one file)"), QString());
+        comboBox_logFileNameFormat->setCurrentIndex(comboBox_logFileNameFormat->findData(pHost->mLogFileNameFormat));
+    }
 
     lineEdit_logFileName->setText(pHost->mLogFileName);
 
@@ -3931,7 +4092,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     updateProtocolSummary();
 
     groupBox_purgeMediaCache->setVisible(true);
-    connect(buttonPurgeMediaCache, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_purgeMediaCache);
+    connect(buttonPurgeMediaCache, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_purgeMediaCache, Qt::UniqueConnection);
 
     // load profiles into mappers "copy map to profile" combobox
     // this feature should work seamlessly both for online and offline profiles
@@ -4003,33 +4164,39 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             }
         }
 
-        QLabel* pLabel_mapSymbolFontFudge = new QLabel(tr("2D Map Room Symbol scaling factor:"), groupBox_mapSymbols);
-        mpDoubleSpinBox_mapSymbolFontFudge = new QDoubleSpinBox(groupBox_mapSymbols);
-        mpDoubleSpinBox_mapSymbolFontFudge->setPrefix(qsl("×"));
-        mpDoubleSpinBox_mapSymbolFontFudge->setRange(TMap::scmMinimumSymbolFontFudgeFactor, TMap::scmMaximumSymbolFontFudgeFactor);
-        mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
-        // Qt's default of two decimals would show a factor set from Lua as
-        // something it is not - the API takes any value in the range. Both this
-        // and the range have to be in place before the value, which a spin-box
-        // rounds and clamps as it is given:
-        mpDoubleSpinBox_mapSymbolFontFudge->setDecimals(3);
-        mpDoubleSpinBox_mapSymbolFontFudge->setValue(pHost->mpMap->getSymbolFontFudgeFactor());
-        auto* pSymbolsLayout = qobject_cast<QGridLayout*>(groupBox_mapSymbols->layout());
-        if (pSymbolsLayout) {
-            const int existingRows = pSymbolsLayout->rowCount();
-            pSymbolsLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
-            pSymbolsLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
-        } else {
-            qWarning() << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapSymbols layout to expected QGridLayout - someone has messed with the profile_preferences.ui "
-                          "file and the contents of the groupBox can not be shown...!";
-        }
-        connect(mpDoubleSpinBox_mapSymbolFontFudge, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this](double value) {
-            Host* pHost = mpHost;
-            if (!pHost || !pHost->mpMap) {
-                return;
+        // The one control on this page the .ui file does not carry, so the one
+        // that has to be built rather than filled - and built once, however
+        // many profiles this dialog outlives:
+        if (!mpDoubleSpinBox_mapSymbolFontFudge) {
+            QLabel* pLabel_mapSymbolFontFudge = new QLabel(tr("2D Map Room Symbol scaling factor:"), groupBox_mapSymbols);
+            mpDoubleSpinBox_mapSymbolFontFudge = new QDoubleSpinBox(groupBox_mapSymbols);
+            mpDoubleSpinBox_mapSymbolFontFudge->setPrefix(qsl("×"));
+            mpDoubleSpinBox_mapSymbolFontFudge->setRange(TMap::scmMinimumSymbolFontFudgeFactor, TMap::scmMaximumSymbolFontFudgeFactor);
+            mpDoubleSpinBox_mapSymbolFontFudge->setSingleStep(0.01);
+            // Qt's default of two decimals would show a factor set from Lua as
+            // something it is not - the API takes any value in the range. Both
+            // this and the range have to be in place before the value, which a
+            // spin-box rounds and clamps as it is given:
+            mpDoubleSpinBox_mapSymbolFontFudge->setDecimals(3);
+            auto* pSymbolsLayout = qobject_cast<QGridLayout*>(groupBox_mapSymbols->layout());
+            if (pSymbolsLayout) {
+                const int existingRows = pSymbolsLayout->rowCount();
+                pSymbolsLayout->addWidget(pLabel_mapSymbolFontFudge, existingRows, 0);
+                pSymbolsLayout->addWidget(mpDoubleSpinBox_mapSymbolFontFudge, existingRows, 1);
+            } else {
+                qWarning()
+                        << "dlgProfilePreferences::initWithHost(...) WARNING - Unable to cast groupBox_mapSymbols layout to expected QGridLayout - someone has messed with the profile_preferences.ui "
+                           "file and the contents of the groupBox can not be shown...!";
             }
-            pHost->mpMap->setSymbolFontFudgeFactor(value);
-        });
+        }
+        {
+            // Whether it was just built or a previous profile left it here, what
+            // it shows is this profile's factor - and writing it is this dialog
+            // reading the map, not the user turning the dial:
+            const QSignalBlocker blocker(mpDoubleSpinBox_mapSymbolFontFudge);
+            mpDoubleSpinBox_mapSymbolFontFudge->setValue(pHost->mpMap->getSymbolFontFudgeFactor());
+        }
+        connect(mpDoubleSpinBox_mapSymbolFontFudge, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_mapSymbolFontFudgeChanged, Qt::UniqueConnection);
 
         label_mapSymbolsFont->setEnabled(true);
         fontComboBox_mapSymbols->setEnabled(true);
@@ -4059,12 +4226,12 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         setButtonColor(pushButton_playerRoomPrimaryColor, pHost->mpMap->mPlayerRoomOuterColor, true);
         setButtonColor(pushButton_playerRoomSecondaryColor, pHost->mpMap->mPlayerRoomInnerColor, true);
 
-        connect(pushButton_deleteMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_deleteMap);
-        connect(comboBox_playerRoomStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changePlayerRoomStyle);
-        connect(pushButton_playerRoomPrimaryColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setPlayerRoomPrimaryColor);
-        connect(pushButton_playerRoomSecondaryColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setPlayerRoomSecondaryColor);
-        connect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPlayerRoomOuterDiameter);
-        connect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPlayerRoomInnerDiameter);
+        connect(pushButton_deleteMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_deleteMap, Qt::UniqueConnection);
+        connect(comboBox_playerRoomStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changePlayerRoomStyle, Qt::UniqueConnection);
+        connect(pushButton_playerRoomPrimaryColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setPlayerRoomPrimaryColor, Qt::UniqueConnection);
+        connect(pushButton_playerRoomSecondaryColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setPlayerRoomSecondaryColor, Qt::UniqueConnection);
+        connect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPlayerRoomOuterDiameter, Qt::UniqueConnection);
+        connect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPlayerRoomInnerDiameter, Qt::UniqueConnection);
 
         // Initialize room, exit, and border size controls
         spinBox_roomSize->setValue(pHost->mRoomSize * 10);
@@ -4074,38 +4241,13 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         spinBox_exitSize->setValue(qBound(1, qRound(50.0 / pHost->mLineSize), 11));
         spinBox_borderSize->setValue(qBound(1, qRound(50.0 / pHost->mRoomBorderSize), 11));
         doubleSpinBox_gridSize->setValue(pHost->mMapGridLineSize);
-        connect(spinBox_roomSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_roomSizeChanged);
-        connect(spinBox_exitSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_exitSizeChanged);
-        connect(spinBox_borderSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_borderSizeChanged);
-        connect(doubleSpinBox_gridSize, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_gridSizeChanged);
-        connect(checkbox_mMapperShowRoomBorders, &QCheckBox::toggled, this, [this](bool checked) {
-            Host* pHost = mpHost;
-            if (!pHost) {
-                return;
-            }
-            pHost->mMapperShowRoomBorders = checked;
-            if (pHost->mpMap && pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap) {
-                pHost->mpMap->mpMapper->mp2dMap->update();
-            }
-        });
-        connect(checkBox_drawUpperLowerLevels, &QCheckBox::toggled, this, [this](bool checked) {
-            mudlet::self()->mDrawUpperLowerLevels = checked;
-            Host* pHost = mpHost;
-            if (pHost && pHost->mpMap && pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap) {
-                pHost->mpMap->mpMapper->mp2dMap->update();
-            }
-        });
-        connect(mMapperUseAntiAlias, &QCheckBox::toggled, this, [this](bool checked) {
-            Host* pHost = mpHost;
-            if (!pHost) {
-                return;
-            }
-            pHost->mMapperUseAntiAlias = checked;
-            if (pHost->mpMap && pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap) {
-                pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = checked;
-                pHost->mpMap->mpMapper->mp2dMap->update();
-            }
-        });
+        connect(spinBox_roomSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_roomSizeChanged, Qt::UniqueConnection);
+        connect(spinBox_exitSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_exitSizeChanged, Qt::UniqueConnection);
+        connect(spinBox_borderSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_borderSizeChanged, Qt::UniqueConnection);
+        connect(doubleSpinBox_gridSize, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_gridSizeChanged, Qt::UniqueConnection);
+        connect(checkbox_mMapperShowRoomBorders, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeMapperShowRoomBorders, Qt::UniqueConnection);
+        connect(checkBox_drawUpperLowerLevels, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeDrawUpperLowerLevels, Qt::UniqueConnection);
+        connect(mMapperUseAntiAlias, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeMapperUseAntiAlias, Qt::UniqueConnection);
     } else {
         label_mapSymbolsFont->setEnabled(false);
         fontComboBox_mapSymbols->setEnabled(false);
@@ -4116,28 +4258,34 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         groupBox_playerRoomStyle->setEnabled(false);
     }
 
-    comboBox_encoding->addItem(mudlet::self()->getEncodingNamesMap().value(QByteArray("ASCII")), QByteArray("ASCII"));
-    for (const auto& encoding : pHost->mTelnet.getEncodingsList()) {
-        auto encodingTitle =
-                mudlet::self()->getEncodingNamesMap().value(encoding,
-                                                            tr("%1 (*Error, report to Mudlet Makers*)",
-                                                               // Intentional comment to separate arguments
-                                                               "The encoder code name is not in the mudlet class mEncodingNamesMap when it should be and the Mudlet Makers need to fix it!")
-                                                                    .arg(QLatin1String(encoding)));
-        comboBox_encoding->addItem(encodingTitle, encoding);
-    }
-    if (pHost->mTelnet.getEncoding().isEmpty()) {
-        // cTelnet::mEncoding is (or should be) empty for the default 7-bit
-        // ASCII case, so need to set the control specially to its (the
-        // first) value
-        comboBox_encoding->setCurrentIndex(0);
-    } else {
-        const int currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
-        if (currentIndex >= 0) {
-            comboBox_encoding->setCurrentIndex(currentIndex);
-        } else {
-            // invalid or not found - so reset to ASCII:
+    {
+        // Which encodings there are is the profile's connection talking, so the
+        // list is rebuilt from scratch each time this runs
+        const QSignalBlocker blocker(comboBox_encoding);
+        comboBox_encoding->clear();
+        comboBox_encoding->addItem(mudlet::self()->getEncodingNamesMap().value(QByteArray("ASCII")), QByteArray("ASCII"));
+        for (const auto& encoding : pHost->mTelnet.getEncodingsList()) {
+            auto encodingTitle =
+                    mudlet::self()->getEncodingNamesMap().value(encoding,
+                                                                tr("%1 (*Error, report to Mudlet Makers*)",
+                                                                   // Intentional comment to separate arguments
+                                                                   "The encoder code name is not in the mudlet class mEncodingNamesMap when it should be and the Mudlet Makers need to fix it!")
+                                                                        .arg(QLatin1String(encoding)));
+            comboBox_encoding->addItem(encodingTitle, encoding);
+        }
+        if (pHost->mTelnet.getEncoding().isEmpty()) {
+            // cTelnet::mEncoding is (or should be) empty for the default 7-bit
+            // ASCII case, so need to set the control specially to its (the
+            // first) value
             comboBox_encoding->setCurrentIndex(0);
+        } else {
+            const int currentIndex = comboBox_encoding->findData(pHost->mTelnet.getEncoding());
+            if (currentIndex >= 0) {
+                comboBox_encoding->setCurrentIndex(currentIndex);
+            } else {
+                // invalid or not found - so reset to ASCII:
+                comboBox_encoding->setCurrentIndex(0);
+            }
         }
     }
 
@@ -4146,7 +4294,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     comboBox_controlCharacterHandling->setItemData(2, QVariant::fromValue(ControlCharacterMode::OEM));
     auto cch_index = comboBox_controlCharacterHandling->findData(static_cast<int>(pHost->getControlCharacterMode()));
     comboBox_controlCharacterHandling->setCurrentIndex((cch_index > 0) ? cch_index : 0);
-    connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling);
+    connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling, Qt::UniqueConnection);
 
     timeEdit_timerDebugOutputMinimumInterval->setTime(pHost->mTimerDebugOutputSuppressionInterval);
     frame_notificationArea->hide();
@@ -4218,7 +4366,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
                         break;
                     default: {
                     } // There are a significant number of other errors
-                        // that are not handled here!
+                    // that are not handled here!
                     }
                 }
             }
@@ -4251,18 +4399,25 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     // credentialExists() collapses a read failure (locked/denied/timed-out keychain) to "no token", so
     // the button deliberately stays hidden on any read failure - the only cost is not offering to forget
     // a token that could not be read, and clicking would just yield a graceful "could not remove" warning.
-    pushButton_forgetSavedSignIn->setVisible(false);
     pushButton_forgetSavedSignIn->setEnabled(mEnableGMCP->isChecked());
-    QPointer<dlgProfilePreferences> safeDialog = this;
-    QPointer<CredentialManager> credentialManager = new CredentialManager();
-    credentialManager->credentialExists(pHost->getName(), qsl("reconnect"), [safeDialog, credentialManager](bool exists) {
-        if (credentialManager) {
-            credentialManager->deleteLater();
-        }
-        if (safeDialog && exists) {
-            safeDialog->pushButton_forgetSavedSignIn->setVisible(true);
-        }
-    });
+    // Asked once per profile rather than once per run of this function: reading
+    // the keychain can cost the user a prompt on some platforms, and re-reading
+    // it every time the dialog re-reads the settings would spend that prompt
+    // over and over for an answer that hardly ever changes.
+    if (mSignInTokenCheckedFor != pHost->getName()) {
+        mSignInTokenCheckedFor = pHost->getName();
+        pushButton_forgetSavedSignIn->setVisible(false);
+        QPointer<dlgProfilePreferences> safeDialog = this;
+        QPointer<CredentialManager> credentialManager = new CredentialManager();
+        credentialManager->credentialExists(pHost->getName(), qsl("reconnect"), [safeDialog, credentialManager](bool exists) {
+            if (credentialManager) {
+                credentialManager->deleteLater();
+            }
+            if (safeDialog && exists) {
+                safeDialog->pushButton_forgetSavedSignIn->setVisible(true);
+            }
+        });
+    }
 
     groupBox_proxy->setEnabled(true);
     groupBox_proxy->setChecked(pHost->mUseProxy);
@@ -4303,60 +4458,60 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // CHECKME: Have moved ALL the connects, where possible, to the end so that
     // none are triggered by the setup operations...
-    connect(pushButton_command_line_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandLineFgColor);
-    connect(pushButton_command_line_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandLineBgColor);
+    connect(pushButton_command_line_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandLineFgColor, Qt::UniqueConnection);
+    connect(pushButton_command_line_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandLineBgColor, Qt::UniqueConnection);
 
-    connect(pushButton_black, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorBlack);
-    connect(pushButton_lBlack, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightBlack);
-    connect(pushButton_red, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorRed);
-    connect(pushButton_lRed, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightRed);
-    connect(pushButton_green, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorGreen);
-    connect(pushButton_lGreen, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightGreen);
-    connect(pushButton_yellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorYellow);
-    connect(pushButton_lYellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightYellow);
-    connect(pushButton_blue, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorBlue);
-    connect(pushButton_lBlue, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightBlue);
-    connect(pushButton_magenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorMagenta);
-    connect(pushButton_lMagenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightMagenta);
-    connect(pushButton_cyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorCyan);
-    connect(pushButton_lCyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightCyan);
-    connect(pushButton_white, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorWhite);
-    connect(pushButton_lWhite, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightWhite);
+    connect(pushButton_black, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorBlack, Qt::UniqueConnection);
+    connect(pushButton_lBlack, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightBlack, Qt::UniqueConnection);
+    connect(pushButton_red, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorRed, Qt::UniqueConnection);
+    connect(pushButton_lRed, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightRed, Qt::UniqueConnection);
+    connect(pushButton_green, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorGreen, Qt::UniqueConnection);
+    connect(pushButton_lGreen, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightGreen, Qt::UniqueConnection);
+    connect(pushButton_yellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorYellow, Qt::UniqueConnection);
+    connect(pushButton_lYellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightYellow, Qt::UniqueConnection);
+    connect(pushButton_blue, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorBlue, Qt::UniqueConnection);
+    connect(pushButton_lBlue, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightBlue, Qt::UniqueConnection);
+    connect(pushButton_magenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorMagenta, Qt::UniqueConnection);
+    connect(pushButton_lMagenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightMagenta, Qt::UniqueConnection);
+    connect(pushButton_cyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorCyan, Qt::UniqueConnection);
+    connect(pushButton_lCyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightCyan, Qt::UniqueConnection);
+    connect(pushButton_white, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorWhite, Qt::UniqueConnection);
+    connect(pushButton_lWhite, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightWhite, Qt::UniqueConnection);
 
-    connect(pushButton_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setFgColor);
-    connect(pushButton_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setBgColor);
-    connect(pushButton_command_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandFgColor);
-    connect(pushButton_command_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandBgColor);
+    connect(pushButton_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setFgColor, Qt::UniqueConnection);
+    connect(pushButton_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setBgColor, Qt::UniqueConnection);
+    connect(pushButton_command_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandFgColor, Qt::UniqueConnection);
+    connect(pushButton_command_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandBgColor, Qt::UniqueConnection);
 
-    connect(pushButton_resetColors, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetColors);
-    connect(reset_colors_button_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetMapColors);
-    connect(pushButton_black_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorBlack);
-    connect(pushButton_Lblack_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightBlack);
-    connect(pushButton_green_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorGreen);
-    connect(pushButton_Lgreen_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightGreen);
-    connect(pushButton_red_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorRed);
-    connect(pushButton_Lred_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightRed);
-    connect(pushButton_blue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorBlue);
-    connect(pushButton_Lblue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightBlue);
-    connect(pushButton_yellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorYellow);
-    connect(pushButton_Lyellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightYellow);
-    connect(pushButton_cyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorCyan);
-    connect(pushButton_Lcyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightCyan);
-    connect(pushButton_magenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorMagenta);
-    connect(pushButton_Lmagenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightMagenta);
-    connect(pushButton_white_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorWhite);
-    connect(pushButton_Lwhite_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightWhite);
+    connect(pushButton_resetColors, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetColors, Qt::UniqueConnection);
+    connect(reset_colors_button_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetMapColors, Qt::UniqueConnection);
+    connect(pushButton_black_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorBlack, Qt::UniqueConnection);
+    connect(pushButton_Lblack_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightBlack, Qt::UniqueConnection);
+    connect(pushButton_green_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorGreen, Qt::UniqueConnection);
+    connect(pushButton_Lgreen_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightGreen, Qt::UniqueConnection);
+    connect(pushButton_red_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorRed, Qt::UniqueConnection);
+    connect(pushButton_Lred_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightRed, Qt::UniqueConnection);
+    connect(pushButton_blue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorBlue, Qt::UniqueConnection);
+    connect(pushButton_Lblue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightBlue, Qt::UniqueConnection);
+    connect(pushButton_yellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorYellow, Qt::UniqueConnection);
+    connect(pushButton_Lyellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightYellow, Qt::UniqueConnection);
+    connect(pushButton_cyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorCyan, Qt::UniqueConnection);
+    connect(pushButton_Lcyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightCyan, Qt::UniqueConnection);
+    connect(pushButton_magenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorMagenta, Qt::UniqueConnection);
+    connect(pushButton_Lmagenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightMagenta, Qt::UniqueConnection);
+    connect(pushButton_white_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorWhite, Qt::UniqueConnection);
+    connect(pushButton_Lwhite_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightWhite, Qt::UniqueConnection);
 
-    connect(pushButton_foreground_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapExitsColor);
-    connect(pushButton_background_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapBgColor);
-    connect(pushButton_lowerLevelColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setLowerLevelColor);
-    connect(pushButton_upperLevelColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setUpperLevelColor);
-    connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomBorderColor);
-    connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapInfoBgColor);
-    connect(pushButton_roomCollisionBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomCollisionBorderColor);
-    connect(pushButton_mapGridColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapGridColor);
+    connect(pushButton_foreground_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapExitsColor, Qt::UniqueConnection);
+    connect(pushButton_background_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapBgColor, Qt::UniqueConnection);
+    connect(pushButton_lowerLevelColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setLowerLevelColor, Qt::UniqueConnection);
+    connect(pushButton_upperLevelColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setUpperLevelColor, Qt::UniqueConnection);
+    connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomBorderColor, Qt::UniqueConnection);
+    connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapInfoBgColor, Qt::UniqueConnection);
+    connect(pushButton_roomCollisionBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomCollisionBorderColor, Qt::UniqueConnection);
+    connect(pushButton_mapGridColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapGridColor, Qt::UniqueConnection);
 
-    connect(pushButton_forgetSavedSignIn, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_forgetSavedSignIn);
+    connect(pushButton_forgetSavedSignIn, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_forgetSavedSignIn, Qt::UniqueConnection);
 
     // The security hero says what this profile's connection actually is at this
     // moment, so it has to hear about the connection coming and going
@@ -4364,55 +4519,27 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(&pHost->mTelnet, &cTelnet::signal_connected, this, &dlgProfilePreferences::updateSecurityStatus, Qt::UniqueConnection);
     connect(&pHost->mTelnet, &cTelnet::signal_disconnected, this, &dlgProfilePreferences::updateSecurityStatus, Qt::UniqueConnection);
 
-    connect(mFORCE_MCCP_OFF, &QAbstractButton::clicked, need_reconnect_for_specialoption, &QWidget::show);
-    connect(mFORCE_GA_OFF, &QAbstractButton::clicked, need_reconnect_for_specialoption, &QWidget::show);
-    connect(mpMenu.data(), &QMenu::triggered, this, &dlgProfilePreferences::slot_chosenProfilesChanged);
+    connect(mFORCE_MCCP_OFF, &QAbstractButton::clicked, need_reconnect_for_specialoption, &QWidget::show, Qt::UniqueConnection);
+    connect(mFORCE_GA_OFF, &QAbstractButton::clicked, need_reconnect_for_specialoption, &QWidget::show, Qt::UniqueConnection);
+    connect(mpMenu.data(), &QMenu::triggered, this, &dlgProfilePreferences::slot_chosenProfilesChanged, Qt::UniqueConnection);
 
-    connect(pushButton_copyMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_copyMap);
-    connect(pushButton_loadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_loadMap);
-    connect(pushButton_saveMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_saveMap);
-    connect(comboBox_encoding, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_setEncoding);
+    connect(pushButton_copyMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_copyMap, Qt::UniqueConnection);
+    connect(pushButton_loadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_loadMap, Qt::UniqueConnection);
+    connect(pushButton_saveMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_saveMap, Qt::UniqueConnection);
+    connect(comboBox_encoding, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_setEncoding, Qt::UniqueConnection);
 
-    // Progressive disclosure for screen-reader users: surface the hyperlink
-    // navigation/activation/menu shortcuts at the moment the user picks a
-    // pane-switching key, so they don't have to consult the wiki to discover
-    // them. Picking Tab additionally warns about the shared binding.
-    connect(comboBox_caretModeKey, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
-        if (index < 0) {
-            return;
-        }
-        if (!QAccessible::isActive()) {
-            return;
-        }
-        auto* app = mudlet::self();
-        if (!app) {
-            return;
-        }
-        QString announcement;
-        const auto choice = static_cast<Host::CaretShortcut>(index);
-        if (choice == Host::CaretShortcut::Tab) {
-            //: Screen-reader hint when the user picks Tab as the caret-mode pane-switching key, warning Tab is shared with hyperlink navigation and explaining how to activate links, open their menu, and jump to latest content. Do not translate the key names "Tab", "Ctrl+]", "Ctrl+[", "Enter", "Space", "Menu", "Shift+F10", "Ctrl+End" or "Ctrl+Home".
-            announcement = tr("Tab will switch between the input line and main window, and also step through hyperlinks while in caret mode. Ctrl+] and Ctrl+[ navigate links without conflicting with "
-                              "pane-switching. Press Enter or Space to activate the focused link, and the Menu key or Shift+F10 to open its context menu. Press Ctrl+End to jump to the latest "
-                              "content or Ctrl+Home to jump to the start of the buffer.");
-        } else {
-            //: Screen-reader hint when the user picks any caret-mode pane-switching key other than Tab, explaining how to navigate, activate and open menus on hyperlinks, and jump to latest content. Do not translate the key names "Ctrl+]", "Ctrl+[", "Enter", "Space", "Menu", "Shift+F10", "Ctrl+End" or "Ctrl+Home".
-            announcement = tr("In caret mode, use Ctrl+] for the next hyperlink and Ctrl+[ for the previous hyperlink. Press Enter or Space to activate the focused link, and the Menu key or "
-                              "Shift+F10 to open its context menu. Press Ctrl+End to jump to the latest content or Ctrl+Home to jump to the start of the buffer.");
-        }
-        app->announce(announcement, QString(), true);
-    });
+    connect(comboBox_caretModeKey, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_caretModeKeyChanged, Qt::UniqueConnection);
 
-    connect(pushButton_whereToLog, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setLogDir);
-    connect(pushButton_resetLogDir, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetLogDir);
-    connect(comboBox_logFileNameFormat, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_logFileNameFormatChange);
-    connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
-    connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
-    connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
-    connect(checkBox_invertMapZoom, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeInvertMapZoom);
+    connect(pushButton_whereToLog, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setLogDir, Qt::UniqueConnection);
+    connect(pushButton_resetLogDir, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetLogDir, Qt::UniqueConnection);
+    connect(comboBox_logFileNameFormat, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_logFileNameFormatChange, Qt::UniqueConnection);
+    connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml, Qt::UniqueConnection);
+    connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout, Qt::UniqueConnection);
+    connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows, Qt::UniqueConnection);
+    connect(checkBox_invertMapZoom, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeInvertMapZoom, Qt::UniqueConnection);
 
     // Console buffer settings
-    connect(checkBox_useMaxBufferSize, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleUseMaxBufferSize);
+    connect(checkBox_useMaxBufferSize, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_toggleUseMaxBufferSize, Qt::UniqueConnection);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
@@ -4422,6 +4549,17 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         auto shortcutIt = pHost->profileShortcuts.find(key);
         QKeySequence currentSequence = (shortcutIt != pHost->profileShortcuts.end()) ? QKeySequence(*shortcutIt->second) : QKeySequence();
         currentShortcuts.insert(key, currentSequence);
+        // The editors outlive the profile that first filled them, so a second
+        // profile re-reads the ones already in this grid. Building them again
+        // would leave the first set below the second, still wired to write
+        // through to whatever profile is current (#10165's snapshot would then
+        // be taken of two editors per shortcut, one of them stale).
+        if (auto* pExistingEdit = mShortcutEditors.value(key).data(); pExistingEdit) {
+            const QSignalBlocker blocker(pExistingEdit);
+            pExistingEdit->setKeySequence(currentSequence);
+            shortcutsRow++;
+            continue;
+        }
         const QString labelText = mudlet::self()->mpShortcutsManager->getLabel(key);
         auto sequenceEdit = new TKeySequenceEdit(currentSequence, labelText);
         auto label = new QLabel(labelText);
@@ -4436,6 +4574,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
         gridLayout_groupBox_shortcuts->addWidget(label, floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 1);
         gridLayout_groupBox_shortcuts->addWidget(sequenceEdit, floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 2);
+        mShortcutEditors.insert(key, sequenceEdit);
         shortcutsRow++;
         connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=]() {
             QKeySequence newSequence;
@@ -4747,6 +4886,8 @@ void dlgProfilePreferences::clearHostDetails()
     checkBox_askTlsAvailable->setChecked(false);
     pushButton_forgetSavedSignIn->setEnabled(false);
     pushButton_forgetSavedSignIn->setVisible(false);
+    // ...so the next profile to arrive asks the keychain again
+    mSignInTokenCheckedFor.clear();
     groupBox_proxy->setDisabled(true);
     // With no profile there is no connection for the hero to report on
     updateSecurityStatus();
@@ -4811,10 +4952,10 @@ void dlgProfilePreferences::loadEditorTab()
     checkBox_showIdNumbers->setChecked(pHost->showIdsInEditor());
 
     // changes the theme being previewed
-    connect(code_editor_theme_selection_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_themeSelected);
+    connect(code_editor_theme_selection_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_themeSelected, Qt::UniqueConnection);
 
     // allows people to select a script of theirs to preview
-    connect(script_preview_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_scriptSelected);
+    connect(script_preview_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_scriptSelected, Qt::UniqueConnection);
 
     // A deep link can put the dialog on the Editor page before there was a Host
     // to build this from, in which case that first visit has already happened:
@@ -5604,6 +5745,16 @@ void dlgProfilePreferences::fillOutMapHistory()
         return;
     }
 
+    // What map files are on disk changes while the dialog is open, so this is a
+    // rebuild rather than an accumulation - and the enabled state goes back to
+    // where the empty list leaves it, since a profile can have no saved maps
+    {
+        const QSignalBlocker blocker(comboBox_mapHistory);
+        comboBox_mapHistory->clear();
+    }
+    comboBox_mapHistory->setEnabled(false);
+    pushButton_loadHistoricMap->setEnabled(false);
+
     const QString profile_name = pHost->getName();
     auto const locale = mudlet::self()->getUserLocale();
     int longestMapHistoryLength = 0;
@@ -5683,7 +5834,7 @@ void dlgProfilePreferences::fillOutMapHistory()
     if (comboBox_mapHistory->count()) {
         comboBox_mapHistory->setEnabled(true);
         pushButton_loadHistoricMap->setEnabled(true);
-        connect(pushButton_loadHistoricMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_loadHistoryMap);
+        connect(pushButton_loadHistoricMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_loadHistoryMap, Qt::UniqueConnection);
     }
 }
 
@@ -6726,6 +6877,12 @@ void dlgProfilePreferences::applyAll()
     // What the controls hold now is what the settings say, so only what changes
     // after this point is the user's next edit:
     snapshotValues();
+
+    // ...and with nothing of the user's left outstanding, this is the other
+    // moment the dialog can re-read the settings: a write can be refused (a
+    // font with no metrics, a value the Host clamps) or answered by a script,
+    // so what the settings hold after an apply is not always what was sent.
+    refreshFromSettings();
 }
 
 void dlgProfilePreferences::slot_scheduleApply()
@@ -8376,6 +8533,81 @@ void dlgProfilePreferences::slot_changeInvertMapZoom(const bool state)
     mudlet::self()->setInvertMapZoom(state);
 }
 
+void dlgProfilePreferences::slot_mapSymbolFontFudgeChanged(const double factor)
+{
+    Host* pHost = mpHost;
+    if (!pHost || !pHost->mpMap) {
+        return;
+    }
+
+    pHost->mpMap->setSymbolFontFudgeFactor(factor);
+}
+
+void dlgProfilePreferences::slot_changeMapperShowRoomBorders(const bool state)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+
+    pHost->mMapperShowRoomBorders = state;
+    if (pHost->mpMap && pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap) {
+        pHost->mpMap->mpMapper->mp2dMap->update();
+    }
+}
+
+void dlgProfilePreferences::slot_changeDrawUpperLowerLevels(const bool state)
+{
+    mudlet::self()->mDrawUpperLowerLevels = state;
+    Host* pHost = mpHost;
+    if (pHost && pHost->mpMap && pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap) {
+        pHost->mpMap->mpMapper->mp2dMap->update();
+    }
+}
+
+void dlgProfilePreferences::slot_changeMapperUseAntiAlias(const bool state)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+
+    pHost->mMapperUseAntiAlias = state;
+    if (pHost->mpMap && pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap) {
+        pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = state;
+        pHost->mpMap->mpMapper->mp2dMap->update();
+    }
+}
+
+// Progressive disclosure for screen-reader users: surface the hyperlink
+// navigation/activation/menu shortcuts at the moment the user picks a
+// pane-switching key, so they don't have to consult the wiki to discover them.
+// Picking Tab additionally warns about the shared binding.
+void dlgProfilePreferences::slot_caretModeKeyChanged(const int index)
+{
+    if (index < 0 || !QAccessible::isActive()) {
+        return;
+    }
+    auto* app = mudlet::self();
+    if (!app) {
+        return;
+    }
+
+    QString announcement;
+    const auto choice = static_cast<Host::CaretShortcut>(index);
+    if (choice == Host::CaretShortcut::Tab) {
+        //: Screen-reader hint when the user picks Tab as the caret-mode pane-switching key, warning Tab is shared with hyperlink navigation and explaining how to activate links, open their menu, and jump to latest content. Do not translate the key names "Tab", "Ctrl+]", "Ctrl+[", "Enter", "Space", "Menu", "Shift+F10", "Ctrl+End" or "Ctrl+Home".
+        announcement = tr("Tab will switch between the input line and main window, and also step through hyperlinks while in caret mode. Ctrl+] and Ctrl+[ navigate links without conflicting with "
+                          "pane-switching. Press Enter or Space to activate the focused link, and the Menu key or Shift+F10 to open its context menu. Press Ctrl+End to jump to the latest "
+                          "content or Ctrl+Home to jump to the start of the buffer.");
+    } else {
+        //: Screen-reader hint when the user picks any caret-mode pane-switching key other than Tab, explaining how to navigate, activate and open menus on hyperlinks, and jump to latest content. Do not translate the key names "Ctrl+]", "Ctrl+[", "Enter", "Space", "Menu", "Shift+F10", "Ctrl+End" or "Ctrl+Home".
+        announcement = tr("In caret mode, use Ctrl+] for the next hyperlink and Ctrl+[ for the previous hyperlink. Press Enter or Space to activate the focused link, and the Menu key or "
+                          "Shift+F10 to open its context menu. Press Ctrl+End to jump to the latest content or Ctrl+Home to jump to the start of the buffer.");
+    }
+    app->announce(announcement, QString(), true);
+}
+
 bool dlgProfilePreferences::updateDisplayFont()
 {
     if (mpHost.isNull() || (mpHost.data()->mpConsole.isNull())) {
@@ -8539,6 +8771,10 @@ void dlgProfilePreferences::reject()
 
 void dlgProfilePreferences::closeEvent(QCloseEvent* event)
 {
+    // Raised here rather than beside QDialog::closeEvent() so that it covers
+    // the whole close: the apply below ends by re-reading the settings, and a
+    // dialog on its way out has no use for a freshly populated page.
+    mClosing = true;
     cancelShortcutCaptures();
 
     if (mpDialogMapGlyphUsage) {
@@ -8565,7 +8801,6 @@ void dlgProfilePreferences::closeEvent(QCloseEvent* event)
     if (mpHost) {
         emit preferencesClosing(mpHost->getName());
     }
-    mClosing = true;
     QDialog::closeEvent(event);
     mClosing = false;
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -36,6 +36,7 @@
 class Host;
 class QCloseEvent;
 class QDoubleSpinBox;
+class QEvent;
 class QFrame;
 class QListWidget;
 class QListWidgetItem;
@@ -205,6 +206,14 @@ private slots:
     void slot_displayFontAliasingChanged();
     void slot_changeShowTabConnectionIndicators(bool state);
     void slot_crashReportPolicyChanged(int index);
+    // Named rather than lambdas so that initWithHost() can make every one of
+    // its connections with Qt::UniqueConnection - see the comment on that
+    // function for why running it twice has to be harmless
+    void slot_mapSymbolFontFudgeChanged(const double factor);
+    void slot_changeMapperShowRoomBorders(const bool state);
+    void slot_changeDrawUpperLowerLevels(const bool state);
+    void slot_changeMapperUseAntiAlias(const bool state);
+    void slot_caretModeKeyChanged(const int index);
 
 
 signals:
@@ -215,6 +224,7 @@ signals:
 
 protected:
     void closeEvent(QCloseEvent* event) override;
+    bool event(QEvent* pEvent) override;
     bool eventFilter(QObject* pObject, QEvent* pEvent) override;
     void resizeEvent(QResizeEvent* pEvent) override;
 
@@ -233,7 +243,25 @@ private:
     void addActionsToPreview(TAction* pActionParent, std::vector<std::tuple<QString, QString, int>>& items);
     void addScriptsToPreview(TScript* pScriptParent, std::vector<std::tuple<QString, QString, int>>& items);
     void addKeysToPreview(TKey* pKeyParent, std::vector<std::tuple<QString, QString, int>>& items);
+    // Writes every control a profile decides the value of. Safe to run again on
+    // a dialog that is already showing a profile: everything it builds is built
+    // once and re-read afterwards, every list it fills is emptied first, and
+    // every connection it makes is either Qt::UniqueConnection or inside one of
+    // those build-once blocks. refreshFromSettings() depends on all three.
     void initWithHost(Host*);
+    // ...and its counterpart for the settings that belong to the application
+    // rather than to any profile
+    void populateApplicationSettings();
+    // Re-reads the settings into a dialog that has been left open, so that a
+    // change made from Lua or from another dialog is what the user comes back
+    // to. Refuses whenever the dialog is holding an edit of its own, because
+    // re-reading would throw that edit away - see pendingEdits().
+    void refreshFromSettings();
+    // Anything the user has changed that the settings do not know about yet: a
+    // control differing from its snapshot, a shortcut editor holding a sequence
+    // that has not been committed, a line edit part-way through a word, or an
+    // apply still waiting out its debounce
+    bool pendingEdits() const;
     QString certificateWarningCheckBoxStyle() const;
     QString certificateWarningLabelStyle() const;
     void restyleCertificateWarnings();
@@ -363,6 +391,9 @@ private:
     QPointer<QDoubleSpinBox> mpDoubleSpinBox_mapSymbolFontFudge;
     std::unique_ptr<QTimer> hidePasswordMigrationLabelTimer;
     QMap<QString, QKeySequence> currentShortcuts;
+    // The editor showing each of those, so that a second profile re-reads the
+    // editors the first one left behind rather than adding a second row of them
+    QMap<QString, QPointer<TKeySequenceEdit>> mShortcutEditors;
     // The ten telnet protocols, on the Connection page's protocols subpage
     QPointer<QCheckBox> mEnableGMCP;
     QPointer<QCheckBox> mEnableMSDP;
@@ -464,14 +495,19 @@ private:
     // fitCheckBoxesToColumn()
     bool mShellReady = false;
     // Suppresses the instant apply while initWithHost()/clearHostDetails() are
-    // writing the controls rather than the user
+    // writing the controls rather than the user - and, since it is raised for
+    // the whole of a repopulation, what makes re-entering one impossible
     bool mPopulating = false;
-    // QDialog::closeEvent() calls reject(), which is where the close this is
-    // already inside of would otherwise start again
+    // Raised for the whole of closeEvent(): QDialog::closeEvent() calls
+    // reject(), which is where the close this is already inside of would
+    // otherwise start again, and nothing on the way out is worth repopulating
     bool mClosing = false;
     bool mEditorThemesChecked = false;
 
     QString mLogDirPath;
+    // Which profile the keychain has already been asked about for the "forget
+    // saved sign-in" button, so that re-reading the settings does not ask again
+    QString mSignInTokenCheckedFor;
     // Needed to remember the state on construction so that we can sent the same
     // flag back for Host::mUseSharedDictionary even if we turn-off
     // Host::mEnableUserDictionary: - although, following review THAT has been

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SETTINGS_GROUP_TEST_SOURCES
     SettingsDirtyApplyTest.cpp
     SettingsHostLifecycleTest.cpp
     SettingsInstantApplyTest.cpp
+    SettingsLiveSyncTest.cpp
     SettingsSearchTest.cpp
     SettingsShellNavigationTest.cpp
 )
@@ -438,6 +439,7 @@ set_tests_properties(SettingsBannerTest
                      SettingsDirtyApplyTest
                      SettingsHostLifecycleTest
                      SettingsInstantApplyTest
+                     SettingsLiveSyncTest
                      SettingsSearchTest
                      SettingsShellNavigationTest
                      PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/SettingsHostLifecycleTest.cpp
+++ b/test/functional_tests/SettingsHostLifecycleTest.cpp
@@ -40,7 +40,9 @@
 #include <QBoxLayout>
 #include <QComboBox>
 #include <QDoubleSpinBox>
+#include <QGridLayout>
 #include <QGroupBox>
+#include <QKeySequenceEdit>
 #include <QLineEdit>
 #include <QScrollArea>
 #include <QSignalSpy>
@@ -119,6 +121,24 @@ private:
             }
         }
         return placements;
+    }
+
+    // Everything a profile brings with it or fills up, counted in one string so
+    // that a failure names which of them doubled rather than only that one did
+    QString controlInventory() const
+    {
+        return qsl("%1 map symbol scaling spin box(es), %2 shortcut editor(s), %3 item(s) in the shortcuts grid, "
+                   "%4 search engine(s), %5 log name format(s), %6 encoding(s), %7 dictionary/-ies, "
+                   "%8 map save format(s), %9 map history entry/-ies")
+                .arg(QString::number(mpPreferences->groupBox_mapSymbols->findChildren<QDoubleSpinBox*>().size()),
+                     QString::number(mpPreferences->groupBox_main_window_shortcuts->findChildren<QKeySequenceEdit*>().size()),
+                     QString::number(mpPreferences->gridLayout_groupBox_shortcuts->count()),
+                     QString::number(mpPreferences->search_engine_combobox->count()),
+                     QString::number(mpPreferences->comboBox_logFileNameFormat->count()),
+                     QString::number(mpPreferences->comboBox_encoding->count()),
+                     QString::number(mpPreferences->comboBox_dictionary->count()),
+                     QString::number(mpPreferences->comboBox_mapFileSaveFormatVersion->count()),
+                     QString::number(mpPreferences->comboBox_mapHistory->count()));
     }
 
     // What disableHostDetails() greys out, and what it deliberately leaves
@@ -274,6 +294,26 @@ private slots:
         const QPalette shellStyled = mpPreferences->topBorderHeight->palette();
         QCOMPARE(fudgeBoxes.constFirst()->palette().color(QPalette::PlaceholderText), shellStyled.color(QPalette::PlaceholderText));
         QCOMPARE(fudgeBoxes.constFirst()->palette().color(QPalette::Window), shellStyled.color(QPalette::Window));
+    }
+
+    // The dialog outlives profiles, so everything it builds for one - the map
+    // symbol scaling spin box, the shortcut editors - and every list it fills
+    // from one has to be built and filled once however many profiles come and
+    // go. Without that the second profile leaves a second set below the first,
+    // laid out and visible and still wired to write through, and every list on
+    // the page holds two of everything.
+    void test_aProfileArrivingASecondTimeDoesNotDoubleTheDialogsControls()
+    {
+        openPreferences(mpPreferences, nullptr);
+        mpPreferences->slot_handleHostAddition(mpHost, 1);
+        const QString afterFirstProfile = controlInventory();
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        mpPreferences->slot_handleHostDeletion(mpHost);
+        mpPreferences->slot_handleHostAddition(mpHost, 1);
+
+        QCOMPARE(controlInventory(), afterFirstProfile);
+        QVERIFY2(!applySpy.wait(scmQuietWindow), "walking a profile out and back in again applied the settings");
     }
 
     // A profile can arrive while the search results are showing, and those

--- a/test/functional_tests/SettingsLiveSyncTest.cpp
+++ b/test/functional_tests/SettingsLiveSyncTest.cpp
@@ -1,0 +1,422 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers - mudlet@mudlet.org           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The settings dialog stays open for as long as the user leaves it open, while
+ * scripts and the game itself move the settings on underneath it. Coming back
+ * to its window is when it re-reads them, so that what it shows is what the
+ * settings say rather than what they said when it opened.
+ *
+ * Re-reading is indistinguishable from discarding whatever it writes over, so
+ * every case here is really about the same question: whose value is on the
+ * control. The dialog's own, and the settings win; the user's, and they do -
+ * a control changed but not yet applied, a word half typed, a query standing
+ * in the search field. And re-reading must never turn into writing: a spin box
+ * shown a value it cannot hold exactly must not answer with the rounded one.
+ *
+ * Run with: ctest -R SettingsLiveSyncTest -V
+ */
+
+#include <memory>
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <QCheckBox>
+#include <QFrame>
+#include <QLineEdit>
+#include <QScrollArea>
+#include <QSignalSpy>
+#include <QSpinBox>
+#include <QStackedWidget>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "dlgProfilePreferences.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class SettingsLiveSyncTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    QByteArray mSavedNoThemeDownload;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgProfilePreferences* mpPreferences = nullptr;
+    const QString mProfileName = qsl("SettingsLiveSync-Test");
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    const QString mLocalhost = qsl("localhost");
+
+    // Comfortably past the 400ms debounce even on a loaded sanitiser build
+    static constexpr int scmQuietWindow = 1500;
+    static constexpr int scmApplyTimeout = 10000;
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    static bool waitForApply(QSignalSpy& spy) { return !spy.isEmpty() || spy.wait(scmApplyTimeout); }
+
+    void openPreferences()
+    {
+        mpPreferences = new dlgProfilePreferences(mudlet::self(), mpHost);
+        mpPreferences->resize(1060, 760);
+        mpPreferences->show();
+        QVERIFY(QTest::qWaitForWindowExposed(mpPreferences));
+    }
+
+    // Every list on the page that a profile fills, counted in one string so
+    // that a failure names which of them grew rather than only that one did
+    QString listLengths() const
+    {
+        return qsl("%1 search engine(s), %2 log name format(s), %3 encoding(s), %4 dictionary/-ies, "
+                   "%5 map save format(s), %6 map history entry/-ies, %7 editor theme(s), %8 previewable script(s)")
+                .arg(QString::number(mpPreferences->search_engine_combobox->count()),
+                     QString::number(mpPreferences->comboBox_logFileNameFormat->count()),
+                     QString::number(mpPreferences->comboBox_encoding->count()),
+                     QString::number(mpPreferences->comboBox_dictionary->count()),
+                     QString::number(mpPreferences->comboBox_mapFileSaveFormatVersion->count()),
+                     QString::number(mpPreferences->comboBox_mapHistory->count()),
+                     QString::number(mpPreferences->code_editor_theme_selection_combobox->count()),
+                     QString::number(mpPreferences->script_preview_combobox->count()));
+    }
+
+    // The user coming back to the window. Sent rather than driven through the
+    // window manager so that every case says the same thing on every platform;
+    // test_theRealWindowActivationIsWhatCarriesIt drives the real one once, to
+    // prove the handler is on the event a window manager actually delivers.
+    void returnToTheDialog()
+    {
+        QEvent activation(QEvent::WindowActivate);
+        QCoreApplication::sendEvent(mpPreferences, &activation);
+        QCoreApplication::processEvents();
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own - see the same block in
+        // DialogTeardownTest for why sharing the developer's one does not work
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+        // Re-reading the settings takes the dialog through the Editor page's
+        // theme list every time, and that is the one population step that can
+        // reach the network
+        mSavedNoThemeDownload = qgetenv("MUDLET_TEST_NO_THEME_DOWNLOAD");
+        qputenv("MUDLET_TEST_NO_THEME_DOWNLOAD", "1");
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, mPort);
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+        mSavedNoThemeDownload.isNull() ? qunsetenv("MUDLET_TEST_NO_THEME_DOWNLOAD") : qputenv("MUDLET_TEST_NO_THEME_DOWNLOAD", mSavedNoThemeDownload);
+    }
+
+    void cleanup()
+    {
+        delete mpPreferences;
+        mpPreferences = nullptr;
+    }
+
+    // The dialog was populated when it opened; a script has moved two settings
+    // on since. Coming back to the window is what it takes to see them.
+    void test_aSettingChangedElsewhereShowsWhenTheUserComesBackToTheDialog()
+    {
+        openPreferences();
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), mpHost->mWrapAt);
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        const int wrapFromAScript = mpHost->mWrapAt + 23;
+        mpHost->mWrapAt = wrapFromAScript;
+        mpHost->mCommandSeparator = qsl("!!");
+        QVERIFY2(mpPreferences->wrap_at_spinBox->value() != wrapFromAScript, "the dialog showed the new value before it was told to look again");
+
+        returnToTheDialog();
+
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), wrapFromAScript);
+        QCOMPARE(mpPreferences->command_separator_lineedit->text(), qsl("!!"));
+        QVERIFY2(!applySpy.wait(scmQuietWindow), "re-reading the settings applied them");
+    }
+
+    // ...and it is the activation a window manager delivers that does it, not
+    // only the event this file synthesises for the cases above
+    void test_theRealWindowActivationIsWhatCarriesIt()
+    {
+        openPreferences();
+        // Something else has to hold the activation first, or activating the
+        // dialog it already has changes nothing and delivers no event
+        auto pOther = std::make_unique<QWidget>();
+        pOther->resize(200, 200);
+        pOther->show();
+        QVERIFY(QTest::qWaitForWindowExposed(pOther.get()));
+        pOther->activateWindow();
+        if (!QTest::qWaitForWindowActive(pOther.get())) {
+            QSKIP("this platform does not hand window activation around, so the real path cannot be driven here");
+        }
+
+        const int wrapFromAScript = mpHost->mWrapAt + 17;
+        mpHost->mWrapAt = wrapFromAScript;
+
+        mpPreferences->activateWindow();
+        QVERIFY(QTest::qWaitForWindowActive(mpPreferences));
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), wrapFromAScript);
+    }
+
+    // The user changed a control and walked away inside the 400ms debounce.
+    // What they left on the control is theirs until it has been written, so
+    // coming back must not replace it with the value it is about to overwrite.
+    void test_anEditWaitingToBeAppliedIsNotOverwritten()
+    {
+        openPreferences();
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        const int wrapTheUserTyped = mpHost->mWrapAt + 5;
+        mpPreferences->wrap_at_spinBox->setValue(wrapTheUserTyped);
+        mpHost->mWrapAt = wrapTheUserTyped + 40;
+
+        returnToTheDialog();
+
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), wrapTheUserTyped);
+        QVERIFY2(waitForApply(applySpy), "the debounce never wrote the settings back");
+        QCOMPARE(mpHost->mWrapAt, wrapTheUserTyped);
+    }
+
+    // The same thing one keystroke at a time: a field being typed into is not
+    // "dirty" as far as the apply is concerned - that is what stops a shared
+    // debounce committing half a word - so it has to be asked about separately
+    void test_aWordHalfTypedSurvivesTheUserComingBack()
+    {
+        openPreferences();
+
+        QLineEdit* pSeparator = mpPreferences->command_separator_lineedit;
+        pSeparator->setFocus();
+        QVERIFY2(pSeparator->hasFocus(), "the command separator field could not be given the focus, so nothing here is mid-edit");
+        QTest::keyClicks(pSeparator, qsl("::"));
+        QVERIFY(pSeparator->isModified());
+        const QString halfTyped = pSeparator->text();
+        mpHost->mCommandSeparator = qsl("&&");
+        QVERIFY(halfTyped != mpHost->mCommandSeparator);
+
+        returnToTheDialog();
+
+        QCOMPARE(pSeparator->text(), halfTyped);
+    }
+
+    // Re-reading a setting must not be a way of writing it. The room size is a
+    // qreal shown on a 1-11 integer scale, so a value a script set between two
+    // of those steps is exactly what a control answering its own population
+    // would round away.
+    void test_readingASettingBackDoesNotWriteTheRoundedValueOut()
+    {
+        mpHost->mRoomSize = 0.5;
+        openPreferences();
+        QCOMPARE(mpPreferences->spinBox_roomSize->value(), 5);
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        // Between the 7 and the 8 the scale offers, so the step the box moves
+        // to is not the value it was moved there by
+        const double sizeFromAScript = 0.75;
+        mpHost->mRoomSize = sizeFromAScript;
+
+        returnToTheDialog();
+
+        QCOMPARE(mpPreferences->spinBox_roomSize->value(), 7);
+        QCOMPARE(mpHost->mRoomSize, sizeFromAScript);
+        QVERIFY2(!applySpy.wait(scmQuietWindow), "re-reading the settings applied them");
+    }
+
+    // An apply is the other moment nothing of the user's is outstanding, so the
+    // settings are re-read once it has finished - here, a change made from a
+    // script while the debounce for an unrelated edit was running
+    void test_theSettingsAreRereadOnceAnApplyHasFinished()
+    {
+        openPreferences();
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        mpPreferences->checkBox_echoLuaErrors->click();
+        const int wrapFromAScript = mpHost->mWrapAt + 31;
+        mpHost->mWrapAt = wrapFromAScript;
+
+        QVERIFY2(waitForApply(applySpy), "the debounce never wrote the settings back");
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), wrapFromAScript);
+        // ...and the edit that started the apply still reached the profile
+        QCOMPARE(mpHost->mEchoLuaErrors, mpPreferences->checkBox_echoLuaErrors->isChecked());
+    }
+
+    // Re-reading the settings walks the same population that fills the lists a
+    // profile decides the contents of. Nothing clears them in between - the
+    // host-swap path has clearHostDetails() for that and this one has nothing -
+    // so each of those lists has to be rebuilt rather than added to.
+    void test_readingTheSettingsBackDoesNotGrowTheDialogsLists()
+    {
+        openPreferences();
+        const QString whenOpened = listLengths();
+
+        returnToTheDialog();
+        returnToTheDialog();
+
+        QCOMPARE(listLengths(), whenOpened);
+    }
+
+    // A subpage is a page like any other as far as the stack is concerned, but
+    // it is the one the sidebar cannot get back to, so a repopulation that
+    // navigated anywhere would strand the user on the parent category
+    void test_aSubpageIsStillShowingAfterTheSettingsAreReread()
+    {
+        openPreferences();
+        mpPreferences->setTab(qsl("connection/protocols"));
+        QCoreApplication::processEvents();
+        auto* pStack = mpPreferences->findChild<QStackedWidget*>(qsl("settingsStack"));
+        QVERIFY(pStack);
+        QCOMPARE(pStack->currentWidget()->objectName(), qsl("settingsPage_connection_protocols"));
+
+        const bool msspFromAScript = !mpHost->mEnableMSSP;
+        mpHost->mEnableMSSP = msspFromAScript;
+        returnToTheDialog();
+
+        QCOMPARE(pStack->currentWidget()->objectName(), qsl("settingsPage_connection_protocols"));
+        auto* pMssp = mpPreferences->findChild<QCheckBox*>(qsl("checkBox_enableMSSP"));
+        QVERIFY2(pMssp, "the MSSP checkbox is not on the protocols subpage");
+        QCOMPARE(pMssp->isChecked(), msspFromAScript);
+    }
+
+    // The banner belongs to no category: it is lent to the top of whichever
+    // page is showing. Re-reading the settings must neither take it off that
+    // page nor leave a second one behind it.
+    void test_theMigrationBannerStaysWhereItWasAfterTheSettingsAreReread()
+    {
+        openPreferences();
+        QFrame* pBanner = mpPreferences->findChild<QFrame*>(qsl("settingsMigrationBanner"));
+        QVERIFY2(pBanner, "the migration banner was not built, so this case is watching nothing");
+        auto* pStack = mpPreferences->findChild<QStackedWidget*>(qsl("settingsStack"));
+        QWidget* pColumn = qobject_cast<QScrollArea*>(pStack->currentWidget())->widget();
+        QCOMPARE(pColumn->layout()->indexOf(pBanner), 0);
+
+        const int wrapFromAScript = mpHost->mWrapAt + 11;
+        mpHost->mWrapAt = wrapFromAScript;
+        returnToTheDialog();
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), wrapFromAScript); // ...so the refresh this is watching did happen
+
+        QCOMPARE(mpPreferences->findChildren<QFrame*>(qsl("settingsMigrationBanner")).size(), 1);
+        QVERIFY2(pBanner->isVisible(), "re-reading the settings hid the migration banner");
+        QCOMPARE(pColumn->layout()->indexOf(pBanner), 0);
+    }
+
+    // A deep link outlines the card it meant for a second or two. The pulse is
+    // an overlay parented to the column the re-read then re-measures, so this
+    // is the one moment where re-reading meets something animating over it.
+    void test_aSpotlightPulseSurvivesTheSettingsBeingReread()
+    {
+        openPreferences();
+        mpPreferences->setTab(qsl("mapper/groupBox_playerRoomStyle"));
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return mpPreferences->findChild<QWidget*>(qsl("settingsSpotlight")) != nullptr;
+                         },
+                         2000),
+                 "the deep link never spotlighted anything, so this case is watching nothing");
+
+        const int wrapFromAScript = mpHost->mWrapAt + 13;
+        mpHost->mWrapAt = wrapFromAScript;
+        returnToTheDialog();
+
+        QCOMPARE(mpPreferences->wrap_at_spinBox->value(), wrapFromAScript);
+        QVERIFY2(mpPreferences->findChild<QWidget*>(qsl("settingsSpotlight")), "re-reading the settings took the spotlight off the card mid-pulse");
+        // ...and it still ends by itself rather than being left on the page
+        QVERIFY2(QTest::qWaitFor(
+                         [this]() {
+                             return mpPreferences->findChild<QWidget*>(qsl("settingsSpotlight")) == nullptr;
+                         },
+                         5000),
+                 "the spotlight outlived its pulse once the settings had been re-read");
+    }
+
+    // A query is an interaction in progress like any other. Re-reading the
+    // settings replaces the text the search index was built from, and the only
+    // honest way to fix that up is to clear the query - which is the user's.
+    void test_aQueryStandingInTheSearchFieldSurvivesTheUserComingBack()
+    {
+        openPreferences();
+        QLineEdit* pSearch = mpPreferences->findChild<QLineEdit*>(qsl("settingsSearchField"));
+        QVERIFY2(pSearch, "the settings shell has no search field");
+        auto* pStack = mpPreferences->findChild<QStackedWidget*>(qsl("settingsStack"));
+        QVERIFY(pStack);
+
+        pSearch->setFocus();
+        pSearch->setText(qsl("color"));
+        QCoreApplication::processEvents();
+        const int resultsPage = pStack->currentIndex();
+        QCOMPARE(pStack->widget(resultsPage)->objectName(), qsl("settingsPage_searchResults"));
+
+        mpHost->mWrapAt = mpHost->mWrapAt + 7;
+        returnToTheDialog();
+
+        QCOMPARE(pSearch->text(), qsl("color"));
+        QCOMPARE(pStack->currentIndex(), resultsPage);
+    }
+};
+
+#include "SettingsLiveSyncTest.moc"
+MUDLET_GROUPED_TEST_MAIN(SettingsLiveSyncTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The settings dialog now re-reads every setting when its window is activated and after each apply - so changes made from Lua, another dialog, or the game show up in an open dialog instead of going stale. Strictly clean-only: any pending edit (dirty control, armed debounce, half-typed field, uncommitted shortcut capture) skips the refresh, so the user is never clobbered - the #10165 dirty-apply tests are untouched and green.
- The prerequisite fix: `initWithHost()` could previously run twice (profile opened > closed > reopened under one dialog), duplicating 28 shortcut editors and the map-symbol spin box per cycle, doubling signal connections, and appending combo entries (a pre-existing, unnoticed bug). It is now safe to run repeatedly: create-once guards, rebuilt lists, `Qt::UniqueConnection` on 94 connects.
- Population no longer writes itself back: a refresh holds a signal blocker over every tracked control (before this, a Lua-set room size of 0.75 would round-trip through the integer spin box into 0.699...).

#### Motivation for adding to Mudlet
The redesign's dirty-aware apply stopped external changes being *reverted*; this makes the open dialog *show* them - the other half of issue #10165's story.

#### Other info (issues closed, discussion etc)
**Stacked PR**: base is `settings-responsive` (#10242); the diff is this branch's single commit. New `SettingsLiveSyncTest` covers the refresh, the skip conditions, and its interaction with search, subpages, the banner, and the spotlight - nine assertions red-proven, including an exact reproduction of the 28-to-56 widget duplication. Full suite 149/151 with only the two long-documented environmental failures.

**Test case:** Open settings, alt-tab away, change a setting from Lua (e.g. `setBorderTop(50)`), return to the dialog - it shows the new value. Start editing a field, repeat - your half-finished edit survives.

Assisted-by: Claude:claude-fable-5

https://claude.ai/code/session_014S43F8L5PnCUzLHzJJrNpD