### PR TITLE
Infra: Remove the settings dialog's hidden Save button

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -324,7 +324,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
     connect(checkBox_showLineFeedsAndParagraphs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs);
-    connect(closeButton, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_saveAndClose);
     connect(pMudlet, &mudlet::signal_hostCreated, this, &dlgProfilePreferences::slot_handleHostAddition);
     connect(pMudlet, &mudlet::signal_hostDestroyed, this, &dlgProfilePreferences::slot_handleHostDeletion);
     // Because QComboBox::currentIndexChanged has multiple (overloaded) forms we
@@ -702,10 +701,6 @@ void dlgProfilePreferences::buildShell()
     }
     vBoxLayout_main->removeWidget(tabWidget);
     tabWidget->hide();
-    // Kept alive, parented to the dialog and out of every layout: the hidden
-    // Save button is still what MapSymbolFontTest clicks to apply and close:
-    vBoxLayout_main->removeWidget(widget_bottom);
-    widget_bottom->hide();
     vBoxLayout_main->setContentsMargins(0, 0, 0, 0);
     vBoxLayout_main->setSpacing(0);
 
@@ -6967,12 +6962,6 @@ void dlgProfilePreferences::slot_lineEditFinished()
         pLineEdit->setModified(false);
     }
     slot_scheduleApply();
-}
-
-// Instant apply has already written every change; closeEvent() does the rest
-void dlgProfilePreferences::slot_saveAndClose()
-{
-    close();
 }
 
 void dlgProfilePreferences::slot_chosenProfilesChanged(QAction* _action)

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -187,9 +187,6 @@ public slots:
     void slot_setMMCPChatName(const QString&);
     void slot_mmcpChatNameChanged();
 
-    // Save.
-    void slot_saveAndClose();
-
     void slot_hideActionLabel();
     void slot_setEncoding(const int);
 

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -5149,48 +5149,6 @@ you can use it but there could be issues with aligning columns of text</string>
      </widget>
     </widget>
    </item>
-   <item>
-    <widget class="QWidget" name="widget_bottom" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_widget_bottom">
-      <item>
-       <spacer name="horizontalSpacer_bottom">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>444</width>
-          <height>21</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="closeButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Save</string>
-        </property>
-        <property name="icon">
-         <iconset>
-          <normaloff>:/icons/icons/dialog-close.png</normaloff>:/icons/icons/dialog-close.png</iconset>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -5203,7 +5161,6 @@ you can use it but there could be issues with aligning columns of text</string>
  </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
-  <tabstop>closeButton</tabstop>
   <tabstop>MainIconSize</tabstop>
   <tabstop>comboBox_menuBarVisibility</tabstop>
   <tabstop>TEFolderIconSize</tabstop>

--- a/test/functional_tests/SettingsShellNavigationTest.cpp
+++ b/test/functional_tests/SettingsShellNavigationTest.cpp
@@ -301,13 +301,11 @@ private slots:
     // Every other case here rests on the tab strip being gone from the shell.
     // The tab widget itself survives, holding no pages, so what has to be
     // checked is that it is out of the layout rather than deleted.
-    void test_theTabWidgetAndTheSaveRowAreOutOfTheLayout()
+    void test_theTabWidgetIsOutOfTheLayout()
     {
         QCOMPARE(mpPreferences->vBoxLayout_main->indexOf(mpPreferences->tabWidget), -1);
-        QCOMPARE(mpPreferences->vBoxLayout_main->indexOf(mpPreferences->widget_bottom), -1);
         QCOMPARE(mpPreferences->tabWidget->count(), 0);
         QVERIFY2(mpPreferences->tabWidget->isHidden(), "the emptied tab widget is still on screen");
-        QVERIFY2(mpPreferences->widget_bottom->isHidden(), "the Save button row is still on screen");
 
         auto* pShell = mpPreferences->findChild<QWidget*>(qsl("settingsShell"));
         QVERIFY2(pShell, "the sidebar-and-cards shell was never built");


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Deletes `widget_bottom`/`closeButton` from `profile_preferences.ui` (43 lines, including the tabstop) and `slot_saveAndClose()` from the dialog - the button has been invisible since instant apply landed, kept only for tests that were migrated off it earlier in this chain.
- The close path is unchanged: the slot was a one-statement `close()`; applying, the profile save, and geometry all live in `closeEvent()`, and the window button and Esc still route there. The close/Esc/disk-save test cases prove it.

#### Motivation for adding to Mudlet
Last piece of the settings-redesign chain: dead UI scaffolding goes once nothing references it.

#### Other info (issues closed, discussion etc)
**Stacked PR**: base is `settings-cleanup` (#10244); the diff is this branch's single commit - the only `.ui` change in the whole chain. The "Save" source string simply drops out on the next Crowdin sync; no `.ts` file was touched. Note for reviewers running the full suite: `CrashTestHookTest` and `EmbeddedMapperCreationTest` fail environmentally on ASan runners (documented long before this chain) - not a regression. Remaining known .ui vestige, deliberately parked until a release ships the redesign: the emptied `tabWidget` pages, which stay so in-flight translations survive.

**Test case:** Open settings - no Save button anywhere; change a setting and close via Esc or the titlebar - it sticks and the profile is written.

Assisted-by: Claude:claude-fable-5

https://claude.ai/code/session_014S43F8L5PnCUzLHzJJrNpD