### PR TITLE
Infra: Stop two functional tests failing CI runs at random

### DIFF
--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -131,6 +131,7 @@ public:
     int mOldCaretColumn = 0;
 
     friend class CopyAsImageTest;
+    friend class FramePacingTest;
     friend class FrontendRefreshSeamTest;
     friend class TTextEditBlinkTest;
     static bool shouldRegisterBlinkClient(bool enableBlinkText, bool hasBlinkingContentInRedrawnRegion, bool isBlinkClientRegistered, bool reusedCachedScreenContent);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -340,10 +340,10 @@ set_tests_properties(MultilineTriggerReentrancyTest PROPERTIES TIMEOUT 300)
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
-# DebugConsoleFilterTest boots a fresh profile for each of its 24 methods, which used to measure
-# ~47s on the slowest runner - too little headroom against the default 60s. Dropping the fixed
-# sleeps out of its profile-start helper cut that threefold, so this is now headroom rather than
-# a necessity, and it is what the other per-method-profile tests here already use.
+# DebugConsoleFilterTest boots a fresh profile for each of its 24 methods, and timed out against
+# the default 60s on the macOS x86_64 runner, where it measured 46.95s when it passed. Waiting on
+# the connection dialog instead of sleeping through it took the Linux run from 30s to 9s, so this
+# is headroom rather than a necessity now, and it is what the other per-method-profile tests use.
 set_tests_properties(DebugConsoleFilterTest PROPERTIES TIMEOUT 300)
 
 # TelnetReconnectStateTest creates a fresh profile per test method and reconnects it several

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -340,8 +340,9 @@ set_tests_properties(MultilineTriggerReentrancyTest PROPERTIES TIMEOUT 300)
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
-# DebugConsoleFilterTest creates a fresh profile per test method, so it needs a longer timeout -
-# it timed out against the default 60s on the macOS x86_64 runner
+# DebugConsoleFilterTest boots a fresh profile for each of its 24 methods, measuring ~47s on the
+# slowest runner measured - too little headroom against the default 60s to survive the contention
+# of an ordinary parallel run. 300 is what the other per-method-profile tests here already use.
 set_tests_properties(DebugConsoleFilterTest PROPERTIES TIMEOUT 300)
 
 # TelnetReconnectStateTest creates a fresh profile per test method and reconnects it several

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -340,9 +340,10 @@ set_tests_properties(MultilineTriggerReentrancyTest PROPERTIES TIMEOUT 300)
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
-# DebugConsoleFilterTest boots a fresh profile for each of its 24 methods, measuring ~47s on the
-# slowest runner measured - too little headroom against the default 60s to survive the contention
-# of an ordinary parallel run. 300 is what the other per-method-profile tests here already use.
+# DebugConsoleFilterTest boots a fresh profile for each of its 24 methods, which used to measure
+# ~47s on the slowest runner - too little headroom against the default 60s. Dropping the fixed
+# sleeps out of its profile-start helper cut that threefold, so this is now headroom rather than
+# a necessity, and it is what the other per-method-profile tests here already use.
 set_tests_properties(DebugConsoleFilterTest PROPERTIES TIMEOUT 300)
 
 # TelnetReconnectStateTest creates a fresh profile per test method and reconnects it several

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -340,6 +340,10 @@ set_tests_properties(MultilineTriggerReentrancyTest PROPERTIES TIMEOUT 300)
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
+# DebugConsoleFilterTest creates a fresh profile per test method, so it needs a longer timeout -
+# it timed out against the default 60s on the macOS x86_64 runner
+set_tests_properties(DebugConsoleFilterTest PROPERTIES TIMEOUT 300)
+
 # TelnetReconnectStateTest creates a fresh profile per test method and reconnects it several
 # times per method, so it needs a longer timeout
 set_tests_properties(TelnetReconnectStateTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/DebugConsoleFilterTest.cpp
+++ b/test/functional_tests/DebugConsoleFilterTest.cpp
@@ -573,58 +573,64 @@ private:
         dir.removeRecursively();
     }
 
-    // Starts a profile the way a user would via the GUI (mirrors the helper in
-    // ClearWindowLogTest).
+    // Starts a profile by driving the connection dialog, as a user would.
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
         QTimer::singleShot(0, qApp, [hostname, address, port]() {
-            // Each step waits for the state the next one needs instead of a flat
-            // 100ms. Under the offscreen platform every one of them is already
-            // true - startAutoLogin() shows the dialog before it returns, and
-            // QTest sends its mouse and key events rather than posting them - so
-            // the whole sequence costs nothing, where the sleeps cost 700ms of
-            // every profile start. Waiting on the state rather than on the clock
-            // is also what keeps that safe on a runner slow enough to need it.
-            const auto waitForFocusToLeave = [](QWidget* previous) {
-                // Bounded by what the sleep it replaces allowed, so a platform
-                // that moves focus asynchronously is no worse off than before.
-                QTest::qWaitFor(
-                        [previous]() {
-                            return QApplication::focusWidget() && QApplication::focusWidget() != previous;
-                        },
-                        100);
+            const auto dialog = []() {
+                return mudlet::self()->mpConnectionDialog.data();
             };
 
             mudlet::self()->startAutoLogin({});
-            // The dialog hides the whole panel this button lives on while no
-            // profile exists, so its visibility is not what to wait for - it is
-            // clicked directly either way. The dialog owning it is.
-            QTest::qWaitFor(
-                    []() {
-                        return !mudlet::self()->mpConnectionDialog.isNull();
-                    },
-                    5000);
-            if (mudlet::self()->mpConnectionDialog.isNull()) {
-                // Leaves the profile unloaded, which the caller's spy reports.
+
+            // slot_showConnectionDialog() defers the dialog's show() to a zero
+            // timer, and a field cannot take focus before its window is up, so
+            // this wait has to spin the event loop to get there. A predicate
+            // already true on entry - the dialog merely existing, say - would
+            // not: qWaitFor returns without processing anything in that case.
+            if (!QTest::qWaitFor(
+                        [&dialog]() {
+                            return dialog() && dialog()->isVisible();
+                        },
+                        5000)) {
+                qWarning() << "the connection dialog never appeared";
                 return;
             }
 
-            QWidget* beforeClick = QApplication::focusWidget();
-            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            waitForFocusToLeave(beforeClick);
+            // Focus is what each step hands to the next, so the field about to
+            // be typed into is the real precondition. Naming it also keeps a
+            // missed handoff a legible warning, rather than the null-widget
+            // assert QTest::keyClicks() aborts the whole process with.
+            const auto waitForFocus = [](QWidget* field, const char* name) {
+                if (QTest::qWaitFor(
+                            [field]() {
+                                return QApplication::focusWidget() == field;
+                            },
+                            5000)) {
+                    return true;
+                }
+                qWarning() << "focus never reached the" << name << "field";
+                return false;
+            };
 
-            QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QWidget* nameField = QApplication::focusWidget();
-            QTest::keyClick(nameField, Qt::Key_Tab);
-            waitForFocusToLeave(nameField);
+            QTest::mouseClick(dialog()->new_profile_button, Qt::LeftButton);
+            if (!waitForFocus(dialog()->profile_name_entry, "profile name")) {
+                return;
+            }
+            QTest::keyClicks(dialog()->profile_name_entry, hostname);
+            QTest::keyClick(dialog()->profile_name_entry, Qt::Key_Tab);
 
-            QTest::keyClicks(QApplication::focusWidget(), address);
-            QWidget* addressField = QApplication::focusWidget();
-            QTest::keyClick(addressField, Qt::Key_Tab);
-            waitForFocusToLeave(addressField);
+            if (!waitForFocus(dialog()->host_name_entry, "server address")) {
+                return;
+            }
+            QTest::keyClicks(dialog()->host_name_entry, address);
+            QTest::keyClick(dialog()->host_name_entry, Qt::Key_Tab);
 
-            QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+            if (!waitForFocus(dialog()->port_entry, "port")) {
+                return;
+            }
+            QTest::keyClicks(dialog()->port_entry, port);
+            QTest::keyClick(dialog()->port_entry, Qt::Key_Return);
         });
 
         QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);

--- a/test/functional_tests/DebugConsoleFilterTest.cpp
+++ b/test/functional_tests/DebugConsoleFilterTest.cpp
@@ -578,20 +578,52 @@ private:
     void startProfile(const QString& hostname, const QString& address, const QString& port)
     {
         QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            // Each step waits for the state the next one needs instead of a flat
+            // 100ms. Under the offscreen platform every one of them is already
+            // true - startAutoLogin() shows the dialog before it returns, and
+            // QTest sends its mouse and key events rather than posting them - so
+            // the whole sequence costs nothing, where the sleeps cost 700ms of
+            // every profile start. Waiting on the state rather than on the clock
+            // is also what keeps that safe on a runner slow enough to need it.
+            const auto waitForFocusToLeave = [](QWidget* previous) {
+                // Bounded by what the sleep it replaces allowed, so a platform
+                // that moves focus asynchronously is no worse off than before.
+                QTest::qWaitFor(
+                        [previous]() {
+                            return QApplication::focusWidget() && QApplication::focusWidget() != previous;
+                        },
+                        100);
+            };
+
             mudlet::self()->startAutoLogin({});
-            QTest::qWait(100);
+            // The dialog hides the whole panel this button lives on while no
+            // profile exists, so its visibility is not what to wait for - it is
+            // clicked directly either way. The dialog owning it is.
+            QTest::qWaitFor(
+                    []() {
+                        return !mudlet::self()->mpConnectionDialog.isNull();
+                    },
+                    5000);
+            if (mudlet::self()->mpConnectionDialog.isNull()) {
+                // Leaves the profile unloaded, which the caller's spy reports.
+                return;
+            }
+
+            QWidget* beforeClick = QApplication::focusWidget();
             QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
-            QTest::qWait(100);
+            waitForFocusToLeave(beforeClick);
+
             QTest::keyClicks(QApplication::focusWidget(), hostname);
-            QTest::qWait(100);
-            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QWidget* nameField = QApplication::focusWidget();
+            QTest::keyClick(nameField, Qt::Key_Tab);
+            waitForFocusToLeave(nameField);
+
             QTest::keyClicks(QApplication::focusWidget(), address);
-            QTest::qWait(100);
-            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
-            QTest::qWait(100);
+            QWidget* addressField = QApplication::focusWidget();
+            QTest::keyClick(addressField, Qt::Key_Tab);
+            waitForFocusToLeave(addressField);
+
             QTest::keyClicks(QApplication::focusWidget(), port);
-            QTest::qWait(100);
             QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
         });
 

--- a/test/functional_tests/FramePacingTest.cpp
+++ b/test/functional_tests/FramePacingTest.cpp
@@ -64,12 +64,10 @@ private:
     static constexpr int csmBatchCount = 20;
     static constexpr int csmBatchGapMs = 2;
 
-    // Mirrors TTextEdit::csmPaintPaceMs, which is private. The cap this test holds
-    // the pane to, and the unit the flood's frame budget is counted in.
-    static constexpr int csmPaintPaceMs = 16;
-
-    // Absorbs a frame that straddles the end of the flood plus one repaint the pane
-    // owes to something other than the flood, such as the cursor blinking.
+    // Both ends of the flood are already paid for by the +1 on the window count, so
+    // this covers what that count cannot see: elapsed() truncates to whole
+    // milliseconds, leaving the span up to a window short, and an expose or resize
+    // repaint can land in the middle without the pacer gating it.
     static constexpr int csmPaintSlack = 2;
 
 protected:
@@ -150,34 +148,45 @@ private slots:
         // over a window per packet, and a pane pacing perfectly draws a frame per packet
         // with nothing wrong with it. An unpaced pane is still caught, because it paints
         // per packet however few windows the flood spanned.
-        const int windowsSpanned = static_cast<int>(floodMs / csmPaintPaceMs) + 1;
-        if (windowsSpanned + csmPaintSlack >= csmBatchCount) {
-            qWarning() << "flood of" << csmBatchCount << "packets took" << floodMs << "ms, a pacing window per packet - pacing not asserted this run";
-        } else {
-            QVERIFY2(paintsDuringFlood <= windowsSpanned + csmPaintSlack,
-                     qPrintable(qsl("%1 packets over %2ms spanned %3 pacing windows but drew %4 frames - the pane is painting per packet rather than per pacing window")
-                                        .arg(csmBatchCount)
-                                        .arg(floodMs)
-                                        .arg(windowsSpanned)
-                                        .arg(paintsDuringFlood)));
-        }
+        const int windowsSpanned = static_cast<int>(floodMs / TTextEdit::csmPaintPaceMs) + 1;
 
-        // Whatever arrives while a frame is still being held back has to be
-        // painted when that frame lands. Landing a paint first is what puts the
-        // second print inside the pacing window, which is the case that defers.
+        // A pane that paints per packet still breaks this bound whenever the flood
+        // spanned fewer windows than it sent packets, so the bound is worth asserting
+        // even then - it just stops being able to tell the two apart once the runner
+        // is slow enough to hand a packet its own window.
+        if (windowsSpanned + csmPaintSlack >= csmBatchCount) {
+            qWarning() << "flood of" << csmBatchCount << "packets took" << floodMs << "ms, about a pacing window each - pacing is not being told apart from scheduler jitter this run";
+        }
+        QVERIFY2(paintsDuringFlood <= windowsSpanned + csmPaintSlack,
+                 qPrintable(qsl("%1 packets over %2ms spanned %3 pacing windows but drew %4 frames - the pane is painting per packet rather than per pacing window")
+                                    .arg(csmBatchCount)
+                                    .arg(floodMs)
+                                    .arg(windowsSpanned)
+                                    .arg(paintsDuringFlood)));
+
+        // Whatever arrives while a frame is still being held back has to be painted
+        // when that frame lands. Reaching that case means printing inside the window
+        // a paint just opened, so repaint() lands one synchronously and the print
+        // follows without returning to the event loop - waiting for a paint instead
+        // lets the window lapse, and the print then takes the immediate path and
+        // never exercises deferral at all.
+        pane->repaint();
         mPaintCount = 0;
-        console->print(qsl("paced probe\n"));
+        console->print(qsl("trailing line\n"));
+
+        // The timer being armed is what proves the frame was held back; the wait
+        // below only proves the pane was not left blank. It cannot attribute the
+        // paint to the pacer, because an unrelated repaint lands about 130ms later
+        // anyway, and telling the two apart would need a deadline tight enough to
+        // start failing on a loaded runner - the very thing that made this test
+        // flaky in the first place.
+        QVERIFY2(pane->mpPaintPacer->isActive(), "the print did not hold a frame back, so the pane was not inside a pacing window and this is not exercising deferral at all");
         QVERIFY2(QTest::qWaitFor(
                          [this]() {
                              return mPaintCount > 0;
                          },
                          2000),
-                 "output never repainted the pane, so a deferred frame cannot be told apart from a lost one");
-        const int paintsBeforeTheDeferredLine = mPaintCount;
-
-        console->print(qsl("trailing line\n"));
-        QTest::qWait(200ms);
-        QVERIFY2(mPaintCount > paintsBeforeTheDeferredLine, "the line printed just after a paint was never drawn - pacing dropped the trailing frame instead of holding it for one window");
+                 "the line printed just after a paint was never drawn - pacing dropped the held-back frame instead of landing it one window later");
     }
 
 private:

--- a/test/functional_tests/FramePacingTest.cpp
+++ b/test/functional_tests/FramePacingTest.cpp
@@ -64,6 +64,14 @@ private:
     static constexpr int csmBatchCount = 20;
     static constexpr int csmBatchGapMs = 2;
 
+    // Mirrors TTextEdit::csmPaintPaceMs, which is private. The cap this test holds
+    // the pane to, and the unit the flood's frame budget is counted in.
+    static constexpr int csmPaintPaceMs = 16;
+
+    // Absorbs a frame that straddles the end of the flood plus one repaint the pane
+    // owes to something other than the flood, such as the cursor blinking.
+    static constexpr int csmPaintSlack = 2;
+
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override
     {
@@ -122,17 +130,37 @@ private slots:
         pane->installEventFilter(this);
 
         mPaintCount = 0;
+        QElapsedTimer floodTimer;
+        floodTimer.start();
         for (int i = 0; i < csmBatchCount; ++i) {
             mpServer->sendRaw(qsl("line %1\r\n").arg(i).toUtf8());
             QTest::qWait(csmBatchGapMs);
         }
         const int paintsDuringFlood = mPaintCount;
+        const qint64 floodMs = floodTimer.elapsed();
 
         QTest::qWait(200ms);
         QVERIFY2(waitForTextInBuffer(qsl("line %1").arg(csmBatchCount - 1)), "the flood never reached the buffer, so nothing was being paced");
         QVERIFY2(paintsDuringFlood > 0, "the pane painted nothing at all during the flood, so this test cannot tell pacing from a dead harness");
-        QVERIFY2(paintsDuringFlood < csmBatchCount / 2,
-                 qPrintable(qsl("%1 packets drew %2 frames - the pane is still painting per packet rather than per pacing window").arg(csmBatchCount).arg(paintsDuringFlood)));
+
+        // What a paced pane owes is one frame per window it spent, so that is what the
+        // count has to be measured against. Measuring it against a share of the packet
+        // count instead holds only while qWait() sleeps for about the gap it is asked
+        // for: on a loaded runner it sleeps several times that, the same flood stretches
+        // over a window per packet, and a pane pacing perfectly draws a frame per packet
+        // with nothing wrong with it. An unpaced pane is still caught, because it paints
+        // per packet however few windows the flood spanned.
+        const int windowsSpanned = static_cast<int>(floodMs / csmPaintPaceMs) + 1;
+        if (windowsSpanned + csmPaintSlack >= csmBatchCount) {
+            qWarning() << "flood of" << csmBatchCount << "packets took" << floodMs << "ms, a pacing window per packet - pacing not asserted this run";
+        } else {
+            QVERIFY2(paintsDuringFlood <= windowsSpanned + csmPaintSlack,
+                     qPrintable(qsl("%1 packets over %2ms spanned %3 pacing windows but drew %4 frames - the pane is painting per packet rather than per pacing window")
+                                        .arg(csmBatchCount)
+                                        .arg(floodMs)
+                                        .arg(windowsSpanned)
+                                        .arg(paintsDuringFlood)));
+        }
 
         // Whatever arrives while a frame is still being held back has to be
         // painted when that frame lands. Landing a paint first is what puts the

--- a/test/functional_tests/FramePacingTest.cpp
+++ b/test/functional_tests/FramePacingTest.cpp
@@ -17,6 +17,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QElapsedTimer>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 #include <chrono>
@@ -60,14 +61,17 @@ private:
     int mPaintCount = 0;
 
     // One line per packet, small enough that the cost is the paint and not the
-    // text, and spaced far enough apart that an unpaced pane paints per packet.
+    // text. The gap has to stay well under csmPaintPaceMs: at a whole window per
+    // packet a perfect pacer and a broken one both draw one frame per packet, and
+    // the assertion below degrades to the warning it prints for that case.
     static constexpr int csmBatchCount = 20;
     static constexpr int csmBatchGapMs = 2;
 
-    // Both ends of the flood are already paid for by the +1 on the window count, so
-    // this covers what that count cannot see: elapsed() truncates to whole
-    // milliseconds, leaving the span up to a window short, and an expose or resize
-    // repaint can land in the middle without the pacer gating it.
+    // A window is measured from the last paint rather than off a fixed grid -
+    // paintEvent() restarts the pacer's clock - so paced paints are always at least
+    // csmPaintPaceMs apart and the +1 on the window count is exact whatever the
+    // phase. This covers what that count cannot see: an expose or resize repaint
+    // lands without the pacer gating it. Two rather than one is plain margin.
     static constexpr int csmPaintSlack = 2;
 
 protected:
@@ -144,16 +148,17 @@ private slots:
         // What a paced pane owes is one frame per window it spent, so that is what the
         // count has to be measured against. Measuring it against a share of the packet
         // count instead holds only while qWait() sleeps for about the gap it is asked
-        // for: on a loaded runner it sleeps several times that, the same flood stretches
-        // over a window per packet, and a pane pacing perfectly draws a frame per packet
-        // with nothing wrong with it. An unpaced pane is still caught, because it paints
-        // per packet however few windows the flood spanned.
+        // for: on a loaded runner it sleeps several times that, and the flood that spans
+        // 3 windows here stretched to 10 on CI, where a perfectly paced pane drew the 10
+        // frames it owed and was failed for it. An unpaced pane is still caught while the
+        // flood stays inside far fewer windows than it sent packets, which is what the
+        // warning below checks.
         const int windowsSpanned = static_cast<int>(floodMs / TTextEdit::csmPaintPaceMs) + 1;
 
-        // A pane that paints per packet still breaks this bound whenever the flood
-        // spanned fewer windows than it sent packets, so the bound is worth asserting
-        // even then - it just stops being able to tell the two apart once the runner
-        // is slow enough to hand a packet its own window.
+        // The bound is worth asserting even in that case, so it stays outside the
+        // branch - it just stops telling a paced pane from an unpaced one once the
+        // runner is slow enough that windowsSpanned + csmPaintSlack reaches the
+        // packet count.
         if (windowsSpanned + csmPaintSlack >= csmBatchCount) {
             qWarning() << "flood of" << csmBatchCount << "packets took" << floodMs << "ms, about a pacing window each - pacing is not being told apart from scheduler jitter this run";
         }
@@ -165,28 +170,51 @@ private slots:
                                     .arg(paintsDuringFlood)));
 
         // Whatever arrives while a frame is still being held back has to be painted
-        // when that frame lands. Reaching that case means printing inside the window
-        // a paint just opened, so repaint() lands one synchronously and the print
+        // when that frame lands. Reaching that case means printing inside the 16ms
+        // cooldown a paint just started, so repaint() lands one synchronously and the print
         // follows without returning to the event loop - waiting for a paint instead
         // lets the window lapse, and the print then takes the immediate path and
         // never exercises deferral at all.
+        mPaintCount = 0;
         pane->repaint();
+        QVERIFY2(mPaintCount > 0, "repaint() delivered no paint event, so the pacer's cooldown never started and nothing below is inside a pacing window");
+
+        QSignalSpy pacerFired(pane->mpPaintPacer, &QTimer::timeout);
+        QElapsedTimer sinceRepaint;
+        sinceRepaint.start();
         mPaintCount = 0;
         console->print(qsl("trailing line\n"));
 
-        // The timer being armed is what proves the frame was held back; the wait
-        // below only proves the pane was not left blank. It cannot attribute the
-        // paint to the pacer, because an unrelated repaint lands about 130ms later
-        // anyway, and telling the two apart would need a deadline tight enough to
-        // start failing on a loaded runner - the very thing that made this test
-        // flaky in the first place.
-        QVERIFY2(pane->mpPaintPacer->isActive(), "the print did not hold a frame back, so the pane was not inside a pacing window and this is not exercising deferral at all");
+        // Read after the print, so this is an upper bound on how late scheduleUpdate()
+        // ran inside it. Under the bound the print was certainly inside the cooldown
+        // and the frame owed deferral; over it the pane was entitled to paint at once,
+        // and asserting deferral anyway would be the same wall-clock trap the flood
+        // half above was just fixed for - one preemption longer than a window and a
+        // healthy pane fails.
+        const qint64 sinceRepaintMs = sinceRepaint.elapsed();
+        const bool printLandedInsideTheCooldown = sinceRepaintMs < TTextEdit::csmPaintPaceMs;
+        if (printLandedInsideTheCooldown) {
+            QVERIFY2(pane->mpPaintPacer->isActive(), "the print inside the cooldown did not hold a frame back, so frames are not being deferred at all");
+        } else {
+            qWarning() << "the print landed" << sinceRepaintMs << "ms after the paint, past the" << TTextEdit::csmPaintPaceMs << "ms cooldown - deferral not exercised this run";
+        }
+
         QVERIFY2(QTest::qWaitFor(
                          [this]() {
                              return mPaintCount > 0;
                          },
                          2000),
-                 "the line printed just after a paint was never drawn - pacing dropped the held-back frame instead of landing it one window later");
+                 "the pane never repainted at all in the 2s after the print, so the harness is dead rather than the pacer being at fault");
+
+        // The wait above cannot say which repaint satisfied it - an unrelated one
+        // arrives about 130ms after the print regardless - so the timer having fired
+        // is what ties a frame to the pacer, and it needs no deadline to do it. It
+        // still cannot see a timeout handler that fires and paints nothing; telling
+        // that apart would need a deadline between the two repaints, which is the
+        // wall-clock trap this test was flaky for in the first place.
+        if (printLandedInsideTheCooldown) {
+            QVERIFY2(pacerFired.count() == 1, "the pacer armed a frame and then never fired, so the held-back line waits on an unrelated repaint to appear");
+        }
     }
 
 private:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Two functional tests were reddening CI runs without anything being wrong with the code they guard:

- **`FramePacingTest`** bounded a flood's paint count by a share of the packet count (`< 20/2`). A paced pane paints once per 16ms window, so that count is really the flood's wall duration - `qWait(2)` oversleeps to ~8ms on a loaded runner, stretching a 44ms flood to 168ms, and a perfectly paced pane draws 10 frames and fails as "painting per packet". It is now bounded by the pacing windows the flood actually spanned.
- **`DebugConsoleFilterTest`** timed out against ctest's default 60s. Its profile-start helper spent 700ms of every one of its 24 profile starts in seven `QTest::qWait(100)` calls; those now wait for the dialog and the field they need, which takes the test from 30s to 9s. It also gets the `TIMEOUT 300` the other per-method-profile tests here use, as headroom rather than a fix.

While verifying the first fix, that test's second half turned out to have no teeth at all: with the deferred-frame path deleted outright it still passed, because an unrelated repaint lands ~130ms later and satisfies the paint-count wait anyway. It now checks the pacer's timer directly, so it needs no deadline to attribute a frame.

#### Motivation for adding to Mudlet

`FramePacingTest` failed 6 of 61 job runs (9.8%) since it landed - 22.7% on macOS arm64 - and `DebugConsoleFilterTest` timed out on development, so both were costing re-runs on unrelated PRs.

#### Other info (issues closed, discussion etc)

The pacing bound is now scale-free, so a slower runner cannot fail it, while sabotaging the pacer still does at both speeds:

| pacer sabotage | before | after |
| --- | --- | --- |
| none, 2ms gap (idle machine) | pass, 3 paints | pass |
| none, 8ms gap (loaded CI) | **fail** | pass |
| pacing removed, always paints at once | fail | fail, `spanned 4 windows but drew 20 frames` |
| frame never held back | **pass** | fail, `the print inside the cooldown did not hold a frame back` |
| frame held back, timer never fires | **pass** | fail, `the pacer armed a frame and then never fired` |

Every one of the 6 CI failures reported exactly 10 frames - never 9, never 11, never 20 - i.e. all six sat on the boundary, which is the signature of a threshold measuring the scheduler rather than the pacer.

On the second test, the sleeps were waiting for state that is reached synchronously: `QTest` sends its mouse and key events rather than posting them, so each field has focus before the next line runs. The one thing that genuinely needs the event loop is the connection dialog, whose `show()` is deferred to a zero timer - so that is what the first wait now waits for. All 24 methods pass, 8 runs out of 8, in 8.8-9.9s against 29.9s before; under a 12-way CPU load they take 12-15s where the sleeping version still needed 28-33s.

The same seven-sleep helper is copy-pasted into six other test files, worth roughly another 40s per platform; that is left for a follow-up.

**Test case:** `ctest --preset linux-debug-nosan -R "FramePacingTest|DebugConsoleFilterTest"`. Both pass; `FramePacingTest` passed 12/12 consecutive runs with the final assertions and 35/35 earlier on the flood bound, including 15 on a machine at load 89.

Assisted-by: Claude:claude-opus-5
