### PR TITLE
Infra: Add runnable QA skills for test coverage, fuzzing and performance

### DIFF
--- a/.agents/skills/fuzz-apis/SKILL.md
+++ b/.agents/skills/fuzz-apis/SKILL.md
@@ -1,21 +1,16 @@
 ---
 name: fuzz-apis
 description: >-
-  Fuzz Mudlet's parsers and scripting API to find crashes and undefined behaviour. Runnable
-  as a task on its own: build a sanitizer binary, run the seeded in-process fuzzers with
-  fresh seeds, extend them to new surfaces, and triage what falls out. Also read before
-  triaging any sanitizer report.
+  Fuzz Mudlet's parsers and scripting API for crashes and undefined behaviour: build a
+  sanitizer binary, run the seeded in-process fuzzers with fresh seeds, extend them to new
+  surfaces, triage what falls out. Read before triaging any sanitizer report.
 license: GPL-2.0-or-later
 user-invocable: true
 argument-hint: Optional surface to fuzz (e.g. "GMCP handlers", "the buffer API")
 ---
 
-## When to use
-
-Invoke as a task ("fuzz Mudlet", "/fuzz-apis the buffer API"), or read before fuzzing any
-surface or triaging a sanitizer report a fuzz run produced. It runs out of the box: on
-Claude Code for the web the repository's SessionStart hook provisions the whole toolchain;
-on a local machine read the `build-mudlet` skill first.
+Runs out of the box on Claude Code for the web (the SessionStart hook provisions the
+toolchain); elsewhere read the `build-mudlet` skill first.
 
 ## Procedure
 

--- a/.agents/skills/fuzz-apis/SKILL.md
+++ b/.agents/skills/fuzz-apis/SKILL.md
@@ -20,8 +20,9 @@ on a local machine read the `build-mudlet` skill first.
 ## Procedure
 
 1. **Build a sanitizer binary**: `cmake --preset linux-debug` for AddressSanitizer;
-   `linux-debug-ubsan` for a second pass that catches what ASan cannot (uninitialised
-   reads, invalid bools, misaligned access). macOS variants exist - see `cmake
+   `linux-debug-ubsan` for a second pass that catches what ASan cannot (loads of invalid
+   bool and enum values - including from uninitialised memory, see the gotchas below -
+   misaligned access, integer overflow). macOS variants exist - see `cmake
    --list-presets`.
 2. **Run the existing fuzzers with a handful of fresh seeds** (invocation below). Vary the
    seed, not just the iteration count - each seed explores a different path prefix.

--- a/.agents/skills/fuzz-apis/SKILL.md
+++ b/.agents/skills/fuzz-apis/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: fuzz-apis
+description: >-
+  Fuzz Mudlet's parsers and scripting API to find crashes and undefined behaviour. Runnable
+  as a task on its own: build a sanitizer binary, run the seeded in-process fuzzers with
+  fresh seeds, extend them to new surfaces, and triage what falls out. Also read before
+  triaging any sanitizer report.
+license: GPL-2.0-or-later
+user-invocable: true
+argument-hint: Optional surface to fuzz (e.g. "GMCP handlers", "the buffer API")
+---
+
+## When to use
+
+Invoke as a task ("fuzz Mudlet", "/fuzz-apis the buffer API"), or read before fuzzing any
+surface or triaging a sanitizer report a fuzz run produced. It runs out of the box: on
+Claude Code for the web the repository's SessionStart hook provisions the whole toolchain;
+on a local machine read the `build-mudlet` skill first.
+
+## Procedure
+
+1. **Build a sanitizer binary**: `cmake --preset linux-debug` for AddressSanitizer;
+   `linux-debug-ubsan` for a second pass that catches what ASan cannot (uninitialised
+   reads, invalid bools, misaligned access). macOS variants exist - see `cmake
+   --list-presets`.
+2. **Run the existing fuzzers with a handful of fresh seeds** (invocation below). Vary the
+   seed, not just the iteration count - each seed explores a different path prefix.
+3. **On an abort, triage it** (rules below): replay the seed, reduce the recorded input,
+   search the issue tracker - some seeds reach bugs that are still open by design, so an
+   abort is a finding to check, not a broken harness. A new find is the deliverable: file
+   it with the minimal repro, or fix it and open a PR (via the `open-pr` skill) carrying a
+   regression spec.
+4. **All clean? That is a result too**, and the explored space is finite - extending beats
+   re-rolling seeds forever. Extend a generator (new option sequences, new API calls) or
+   aim at a fresh surface, with the user picking where; candidates that have never been
+   fuzzed: deeper GMCP/MSDP dispatch, the map file loaders on corrupt input, package
+   installation on malformed archives, OSC 8 hyperlink parsing. Write it with the pattern
+   below.
+5. **Report what ran either way**: sanitizer, seeds, iteration counts, and what fell out -
+   a clean run over a stated space is information the next run builds on.
+
+## The approach
+
+Mudlet needs no libFuzzer or AFL harness: the busted self-test profile runs the whole real
+application headless, so a spec can feed the real parsers directly. A fuzzer here is an
+ordinary spec with three properties:
+
+- every random choice derives from a seeded PRNG, so any run replays byte-for-byte;
+- it records each input before feeding it, so after an abort the tail of the dump IS the
+  crashing input;
+- it runs against a sanitizer build, which turns silent corruption into an abort at the
+  faulting line.
+
+## The existing fuzzers
+
+`src/mudlet-lua/tests/TelnetTriggerFuzz_spec.lua` (telnet parser + trigger engine) and
+`BufferManipFuzz_spec.lua` (console text and selection API, deliberately out-of-range
+indices). They arrive with PR #10221, together with a "Running the fuzzers" section in
+`src/mudlet-lua/tests/README.md` - if neither is in your tree yet, fetch them from that
+PR. Both bail out unless `MUDLET_FUZZ=1` is set, so normal runs and CI skip them. Seed,
+iteration counts and dump path are environment variables listed in each spec's header
+comment.
+
+```bash
+# point at the binary the preset actually built: build/src/mudlet for
+# linux-debug, build-linux-debug-ubsan/src/mudlet for the ubsan preset
+MUDLET_FUZZ=1 MUDLET_FUZZ_SEED=7 .claude/scripts/run-lua-tests.sh build/src/mudlet
+```
+
+Calibration: by 2026-08 the telnet generator had run ~48k feeds and ~19k compiled patterns
+across 6 seeds clean under ASan - that surface is well explored at default settings.
+
+## Sanitizer gotchas
+
+- UBSan's "load of value N, which is not a valid value for type 'bool'" fires only when the
+  leftover memory happens to be non-boolean: it is nondeterministic run to run, and a
+  report VANISHING is not proof of a fix - unrelated changes shift heap layout and silence
+  it by luck. `MALLOC_PERTURB_=1` fills fresh allocations with 0xfe and makes it fire every
+  run. That works because plain UBSan keeps glibc's malloc; ASan replaces it, so use the
+  ubsan preset for this.
+- Verify a fix by grepping the run for the SYMBOL under test, not the file:line - the fix
+  itself shifts line numbers.
+- Under ASan, a run where every spec printed green but the runner still exited non-zero is
+  usually a LeakSanitizer report at process exit, not a fuzz abort - check the output tail
+  for `LeakSanitizer` before hunting a lost crash dump.
+
+## Writing a new fuzzer
+
+- PRNG: Lua 5.1 has no integer or bit operations; MINSTD (`s = (16807 * s) % 2147483647`)
+  stays exact in a double. Take the seed from an environment variable and print it.
+- `feedTelnet()` C-string-truncates on a raw NUL and decodes `<...>` escapes: build input
+  with `string.char`, escaping only NUL as `<00>`, `<` as `<<` and `>` as `>>`.
+- Gate the spec behind `MUDLET_FUZZ` like the existing ones. Fuzz specs mutate persistent
+  state (telnet negotiation, encodings), so they must not join the always-on suite.
+- Aim at state, not just parsing. The telnet byte parser itself came back clean; the real
+  findings clustered in surrounding state machinery: writing to a console emptied by
+  `deleteLine()` crashed three separate paths (#10207), `Tree<T>` construction invoked UB
+  on every trigger/alias/timer ever created (#10227), a pattern-row flag was read
+  uninitialised (#10228), and profile load reset the telnet session before Host's members
+  existed (#10229).
+
+## Triage
+
+- Reduce before reporting: replay the seed, shrink the recorded input, and confirm the
+  minimal case aborts on a fresh run.
+- Measure "unbounded" claims before filing them. Cautionary example: `TTrigger::match`
+  passes a null match context to `pcre2_match`, which reads like unbounded ReDoS
+  backtracking - empirically PCRE2 applies its default MATCH_LIMIT (10 million steps) even
+  with a null context, and `(a+)+$` on adversarial input plateaus at ~9-15ms. The
+  code-reading conclusion was wrong; the measurement settled it.
+- File with an empirical repro, never from code reading, and search the issue tracker
+  first - several crashes a fuzzer can reach are already known.

--- a/.agents/skills/fuzz-apis/SKILL.md
+++ b/.agents/skills/fuzz-apis/SKILL.md
@@ -9,16 +9,21 @@ user-invocable: true
 argument-hint: Optional surface to fuzz (e.g. "GMCP handlers", "the buffer API")
 ---
 
-Runs out of the box on Claude Code for the web (the SessionStart hook provisions the
-toolchain); elsewhere read the `build-mudlet` skill first.
+Runs out of the box on Claude Code for the web, whose containers are Linux (the
+SessionStart hook provisions the toolchain); elsewhere read the `build-mudlet` skill
+first. Commands below default to Linux; where macOS or Windows differs it is called out
+inline.
 
 ## Procedure
 
 1. **Build a sanitizer binary**: `cmake --preset linux-debug` for AddressSanitizer;
    `linux-debug-ubsan` for a second pass that catches what ASan cannot (loads of invalid
    bool and enum values - including from uninitialised memory, see the gotchas below -
-   misaligned access, integer overflow). macOS variants exist - see `cmake
-   --list-presets`.
+   misaligned access, integer overflow). `macos-debug` and `macos-debug-ubsan` are the
+   same pair on macOS. **Windows cannot fuzz**: `src/CMakeLists.txt` skips
+   `EnableSanitizers.cmake` under `WIN32` ("Sanitizers disabled on Windows" in the
+   configure output), so a Windows build reports nothing however hard you fuzz it - do
+   this work on Linux or macOS, and confirm a Windows-specific suspicion by other means.
 2. **Run the existing fuzzers with a handful of fresh seeds** (invocation below). Vary the
    seed, not just the iteration count - each seed explores a different path prefix.
 3. **On an abort, triage it** (rules below): replay the seed, reduce the recorded input,
@@ -63,6 +68,12 @@ comment.
 MUDLET_FUZZ=1 MUDLET_FUZZ_SEED=7 .claude/scripts/run-lua-tests.sh build/src/mudlet
 ```
 
+That runner is Linux-only (`xvfb-run`, GNU `timeout`). On macOS set the same environment
+by hand and launch the bundle's binary
+(`build-macos-debug-ubsan/src/mudlet.app/Contents/MacOS/mudlet`) windowed or with
+`-platform offscreen`; `src/mudlet-lua/tests/README.md` carries the per-platform busted
+setup and the isolated-config-root invocation.
+
 Calibration: by 2026-08 the telnet generator had run ~48k feeds and ~19k compiled patterns
 across 6 seeds clean under ASan - that surface is well explored at default settings.
 
@@ -73,7 +84,9 @@ across 6 seeds clean under ASan - that surface is well explored at default setti
   report VANISHING is not proof of a fix - unrelated changes shift heap layout and silence
   it by luck. `MALLOC_PERTURB_=1` fills fresh allocations with 0xfe and makes it fire every
   run. That works because plain UBSan keeps glibc's malloc; ASan replaces it, so use the
-  ubsan preset for this.
+  ubsan preset for this. `MALLOC_PERTURB_` is a glibc feature and does nothing on macOS;
+  libmalloc's equivalents are `MallocPreScribble=1` (0xaa into fresh allocations) and
+  `MallocScribble=1` (0x55 into freed ones), likewise ignored under ASan.
 - Verify a fix by grepping the run for the SYMBOL under test, not the file:line - the fix
   itself shifts line numbers.
 - Under ASan, a run where every spec printed green but the runner still exited non-zero is

--- a/.agents/skills/improve-performance/SKILL.md
+++ b/.agents/skills/improve-performance/SKILL.md
@@ -52,13 +52,18 @@ inline.
 
 - **Benchmark on a quiet machine, and prove it was quiet.** A concurrent build roughly
   doubles every timing, and load that comes and goes mid-run leaves a plausible-looking
-  number rather than an obviously broken one. Before starting, shut down what you can:
-  other builds and test suites, a second agent's Mudlet, browsers and VMs, and the
-  platform's own background work - Spotlight (`mds`) indexing a fresh build tree and Time
-  Machine on macOS, Windows Defender scanning one and Windows Search indexing it, a
-  `updatedb`/backup cron on Linux. On a laptop, run on mains power: both macOS and Windows
-  down-clock aggressively on battery, and a thermally throttled machine produces a smooth
-  downward drift that looks exactly like a regression.
+  number rather than an obviously broken one. So look, before you start, at what else is
+  running: other builds and test suites, a second agent's Mudlet, browsers, VMs and
+  containers, and the platform's own background work - Spotlight (`mds`) indexing a fresh
+  build tree or Time Machine on macOS, Defender scanning one or Windows Search indexing
+  it, an `updatedb` or backup job on Linux. On a laptop, mains power rather than battery:
+  both macOS and Windows down-clock aggressively on battery, and a thermally throttled
+  machine produces a smooth downward drift that looks exactly like a regression.
+- **Never close, kill or suspend any of it yourself.** Those are the user's processes and
+  quite possibly their work in progress - a VM mid-session, a build someone is waiting on.
+  Report what you found and ask them to quiet the machine, or wait for it to finish, or
+  benchmark anyway and say in the write-up what was running. Only work this session
+  started itself is yours to stop.
 - Record the top CPU consumers into the log itself immediately before AND after each run,
   so a contaminated run is identifiable afterwards rather than merely suspected:
 
@@ -95,7 +100,9 @@ inline.
   side against one that has already run ten times. If cold start is itself the subject,
   drop the caches deliberately between runs instead of hoping - Linux
   `sync; echo 3 | sudo tee /proc/sys/vm/drop_caches`, macOS `sudo purge`, Windows
-  Sysinternals `RAMMap -Ew` - and say in the write-up which of the two you measured.
+  Sysinternals `RAMMap -Ew` - and say in the write-up which of the two you measured. All
+  three need elevation and empty the cache for everything on the machine, not just your
+  run, so ask the user before running one.
 - Alternate A and B runs rather than all of one then all of the other, and give each run
   its own config root so profile state cannot differ between sides - a profile with
   packages installed runs their triggers against every benchmark line. Mudlet keeps that

--- a/.agents/skills/improve-performance/SKILL.md
+++ b/.agents/skills/improve-performance/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: improve-performance
+description: >-
+  Make Mudlet faster. Runnable as a task on its own: pick a subsystem with the user - telnet
+  and text pipeline, trigger engine, 2D mapper, pathfinding - then measure, find the real
+  cost, fix it and prove the win. Also read before benchmarking anything or evaluating any
+  performance claim.
+license: GPL-2.0-or-later
+user-invocable: true
+argument-hint: Optional subsystem to speed up (e.g. "the 2D mapper", "triggers")
+---
+
+## When to use
+
+Invoke as a task ("make Mudlet faster", "/improve-performance triggers"), or read before any
+benchmarking or optimisation work. It runs out of the box: on Claude Code for the web the
+repository's SessionStart hook provisions the whole toolchain; on a local machine read the
+`build-mudlet` skill first.
+
+## Procedure
+
+1. **Pick the battlefield with the user.** If they named a subsystem, that is the target. If
+   not, ask them to pick rather than choosing silently - it is their client.
+   Proven-fertile ground: telnet + text pipeline throughput, the trigger
+   engine, 2D mapper rendering, map pathfinding, profile load and startup time. "You pick"
+   is also an answer: profile a busy session and take the top entry.
+2. **Build a benchmark-safe tree**: the `linux-debug-nosan` preset. Never benchmark a
+   sanitizer build - ASan (the default `linux-debug` preset) roughly halves text throughput.
+3. **Establish a baseline.** Use an in-tree benchmark where one covers the area (see below);
+   otherwise write a small harness following the patterns below. Record the exact
+   invocation - the after-number is worthless if it cannot be reproduced.
+4. **Find where the time goes** using the rules below: detect by shape, identify by ablation
+   or profiler, never by code reading.
+5. **Fix and re-measure A/B** under the measurement discipline below. Keep the fix only if
+   the end-to-end number moves, not just the microbenchmark.
+6. **Prove no behaviour change** - run the busted specs (`.claude/scripts/run-lua-tests.sh`)
+   and `ctest` - then open a pull request with the `open-pr` skill, quoting the before and
+   after numbers and the exact harness invocation so a reviewer can reproduce them.
+
+## Keep the numbers honest
+
+- Attribute every live compiler on the machine immediately before AND after each run, into
+  the log itself (Linux; on macOS substitute `lsof -p <pid> | grep cwd` for the `/proc`
+  read):
+
+  ```bash
+  for pid in $(pgrep -x 'cc1plus|cc1|ld|mold|ninja|cmake|make'); do readlink /proc/$pid/cwd; done
+  ```
+
+  Never gate on loadavg: it is exponentially weighted with a ~60s lag, so it reads quiet in
+  the trough between build steps and busy for a minute after the machine actually went
+  idle. A concurrent build roughly doubles every timing, and one that comes and goes
+  mid-run leaves a plausible-looking number rather than an obviously broken one. Discard a
+  contaminated run; do not salvage it.
+- Alternate A and B runs rather than all of one then all of the other, and give each run a
+  private `HOME` so profile state cannot differ between sides. A profile with packages
+  installed runs their triggers against every benchmark line.
+- An A/B ratio survives a measurement defect both sides share; absolute figures do not.
+  Before quoting an absolute number, validate the harness itself. A cloud or CI container
+  is noisier still and may be CPU-throttled: quote only ratios from one, never absolutes.
+
+## Find where the time goes
+
+- Fixed-cost detector: a timing flat across a large range of input sizes is setup cost, not
+  the algorithm. Two measurements at different sizes find it, no profiler needed.
+- That detects; it does not diagnose. Identify by ablation - patch out the suspect,
+  rebuild, remeasure - or by a profiler, never by code reading. A written, specific,
+  plausible explanation for one 80ms mapper cost was simply wrong; a ten-minute ablation
+  found the real one. The test of a code-reading diagnosis is whether the figure was
+  predicted before it was measured, not fitted afterwards.
+- Removing hot-loop lookups buys nothing when they hit a cache line the previous iteration
+  pulled in; the wins come from cold, scattered dereferences and allocation churn. "N
+  redundant lookups per frame" is not, by itself, a cost model.
+- After removing one fixed cost, a still-flat timing usually means a second fixed cost was
+  hiding behind the first - not that the fix failed.
+- Measure end to end before investing in an isolated win: SIMD gave 9.6x on the telnet byte
+  loop in isolation and ~1% on real traffic.
+- Calibration from past wins: a 56ms flat pathfinding setup cost became 0.14ms; a mapper
+  view-fit went 150ms to 55ms; per-line allocations dropped 38.6% from one deque-to-vector
+  swap. All were fixed costs or churn; none were hot-loop micro-optimisation.
+
+## In-tree benchmarks
+
+Four live in `test/functional_tests/`, built alongside the functional tests into
+`<build>/test/functional_tests/`. How to run each is not obvious, so:
+
+- `PipelineBenchmark` (text pipeline, latin-1 decode, trigger engine, peak memory,
+  default-package cost, display) is report-only: ctest runs it only when the tree was
+  configured with `-DREGISTER_PERF_BENCHMARK=ON`, so plain `ctest` never will. For a
+  before/after comparison run it through
+  `test/compare-perf-baseline.py --run <before-binary> <after-binary>`, which reads the
+  `METRIC` lines and gates on regressions.
+- `MapRenderBenchmark` (2D mapper paint path) and `PathfindBenchmark` (A* speedwalk search
+  plus the graph rebuild that feeds it) are never ctest-registered: each needs a real
+  saved map, handed to it in `MUDLET_BENCH_MAP`, and skips without one:
+
+  ```bash
+  MUDLET_BENCH_MAP=/path/to/map.dat QT_QPA_PLATFORM=offscreen ./MapRenderBenchmark
+  ```
+
+  `compare-perf-baseline.py` understands MapRenderBenchmark's output too.
+- `TelnetBenchmark` (small, medium and large payloads) is an ordinary grouped ctest case:
+  `ctest -R TelnetBenchmark`.
+
+When extending them:
+
+- PipelineBenchmark's slots `QVERIFY(noTriggersAreRunningYet(host))` so a polluted profile
+  fails loudly instead of silently benchmarking default-package triggers
+  (`benchDefaultPackages` is the deliberate exception - default-package cost is its
+  point). Keep that guard in new slots - the one slot that historically lacked it reported
+  a +133% improvement that was really +46%. TelnetBenchmark has no such guard.
+- Display measurement: `TTextEdit` takes its row count from its visible region, so resize
+  the main window and read `getScreenHeight()` - resizing a pane alone leaves it clipped by
+  its parents, and `getRowCount()` is a font-metric estimate, not the paint path. Scroll
+  strides must exceed one screenful, or `drawForeground()` serves frames from its cached
+  pixmap and inflates throughput several-fold.
+- Vary the text every iteration when echoing in a loop: several Qt paths
+  (`QLabel::setText` among them) short-circuit on identical input, and the benchmark then
+  measures nothing at all.
+
+## A/B against released versions
+
+Every release back to at least 4.14 is still downloadable from
+`https://www.mudlet.org/wp-content/files/` as `Mudlet-<version>-linux-x64.AppImage.tar`
+(the GitHub tags carry no release assets). One harness drives them all: hand-build a
+profile directory, drop a `<MudletPackage>` XML containing a ScriptPackage into
+`<profile>/current/` - its script body runs at profile load - and launch with
+`--profile <name>`. Write results with `io.open` so nothing is parsed from stdout; a
+`tempTimer(0, ...)` chain re-arming itself is a version-agnostic event-loop pump, and its
+tick count over a fixed wall-clock window includes painting. Traps:
+
+- Seed identical window geometry through `Mudlet.ini` (`[General]` `pos`, `size`,
+  `maximized` - unchanged since 4.17.2); each version otherwise picks its own default size
+  and paint numbers are not comparable.
+- In a container without FUSE (the web sessions included) an AppImage will not launch
+  directly: run it once with `--appimage-extract` and use the extracted `AppRun`.
+- Seeding any `Mudlet.ini` key also suppresses the 5.0 starter UI. That is what you want
+  against versions that never had it, but the starter UI's trigger package is real
+  per-line cost for a default new profile - decide explicitly which configuration is being
+  compared.
+
+## Lua-only changes need no rebuild
+
+`src/mudlet-lua` is read from disk at startup on Linux, so competing Lua-side variants can
+be A/B'd against ONE binary: write a spec per competing behaviour first, swap each
+candidate file over the product file, run `.claude/scripts/run-lua-tests.sh`, restore, and
+record the pass/fail matrix. That turns "which fix is right?" into a measurement.

--- a/.agents/skills/improve-performance/SKILL.md
+++ b/.agents/skills/improve-performance/SKILL.md
@@ -1,41 +1,37 @@
 ---
 name: improve-performance
 description: >-
-  Make Mudlet faster. Runnable as a task on its own: pick a subsystem with the user - telnet
-  and text pipeline, trigger engine, 2D mapper, pathfinding - then measure, find the real
-  cost, fix it and prove the win. Also read before benchmarking anything or evaluating any
-  performance claim.
+  Make Mudlet faster: pick a subsystem with the user, measure, find the real cost, fix it
+  and prove the win. Read before benchmarking anything or evaluating a performance claim.
 license: GPL-2.0-or-later
 user-invocable: true
 argument-hint: Optional subsystem to speed up (e.g. "the 2D mapper", "triggers")
 ---
 
-## When to use
-
-Invoke as a task ("make Mudlet faster", "/improve-performance triggers"), or read before any
-benchmarking or optimisation work. It runs out of the box: on Claude Code for the web the
-repository's SessionStart hook provisions the whole toolchain; on a local machine read the
-`build-mudlet` skill first.
+Runs out of the box on Claude Code for the web (the SessionStart hook provisions the
+toolchain); elsewhere read the `build-mudlet` skill first.
 
 ## Procedure
 
-1. **Pick the battlefield with the user.** If they named a subsystem, that is the target. If
-   not, ask them to pick rather than choosing silently - it is their client.
-   Proven-fertile ground: telnet + text pipeline throughput, the trigger
-   engine, 2D mapper rendering, map pathfinding, profile load and startup time. "You pick"
-   is also an answer: profile a busy session and take the top entry.
+1. **Pick the battlefield with the user.** If they named a subsystem, that is the target;
+   otherwise ask them to pick rather than choosing silently. Proven-fertile ground: telnet
+   + text pipeline throughput, the trigger engine, 2D mapper rendering, map pathfinding,
+   profile load and startup time. "You pick" is also an answer: profile a busy session and
+   take the top entry.
 2. **Build a benchmark-safe tree**: the `linux-debug-nosan` preset. Never benchmark a
-   sanitizer build - ASan (the default `linux-debug` preset) roughly halves text throughput.
-3. **Establish a baseline.** Use an in-tree benchmark where one covers the area (see below);
-   otherwise write a small harness following the patterns below. Record the exact
-   invocation - the after-number is worthless if it cannot be reproduced.
-4. **Find where the time goes** using the rules below: detect by shape, identify by ablation
-   or profiler, never by code reading.
-5. **Fix and re-measure A/B** under the measurement discipline below. Keep the fix only if
-   the end-to-end number moves, not just the microbenchmark.
-6. **Prove no behaviour change** - run the busted specs (`.claude/scripts/run-lua-tests.sh`)
-   and `ctest` - then open a pull request with the `open-pr` skill, quoting the before and
-   after numbers and the exact harness invocation so a reviewer can reproduce them.
+   sanitizer build - ASan (the default `linux-debug` preset) roughly halves text
+   throughput.
+3. **Establish a baseline** with an in-tree benchmark (below), or a small harness
+   following the patterns below. Record the exact invocation - an unreproducible number is
+   worthless.
+4. **Find where the time goes**: detect by shape, identify by ablation or profiler, never
+   by code reading (rules below).
+5. **Fix and re-measure A/B.** Keep the fix only if the end-to-end number moves, not just
+   the microbenchmark.
+6. **Prove no behaviour change** - run the busted specs
+   (`.claude/scripts/run-lua-tests.sh`) and `ctest` - then open a pull request with the
+   `open-pr` skill, quoting before/after numbers and the exact invocation so a reviewer
+   can reproduce them.
 
 ## Keep the numbers honest
 
@@ -47,34 +43,33 @@ repository's SessionStart hook provisions the whole toolchain; on a local machin
   for pid in $(pgrep -x 'cc1plus|cc1|ld|mold|ninja|cmake|make'); do readlink /proc/$pid/cwd; done
   ```
 
-  Never gate on loadavg: it is exponentially weighted with a ~60s lag, so it reads quiet in
-  the trough between build steps and busy for a minute after the machine actually went
-  idle. A concurrent build roughly doubles every timing, and one that comes and goes
-  mid-run leaves a plausible-looking number rather than an obviously broken one. Discard a
-  contaminated run; do not salvage it.
+  Never gate on loadavg: it lags ~60s both ways, reading quiet in the trough between build
+  steps and busy after the machine went idle. A concurrent build roughly doubles every
+  timing, and one that comes and goes mid-run leaves a plausible-looking number rather
+  than an obviously broken one. Discard a contaminated run; do not salvage it.
 - Alternate A and B runs rather than all of one then all of the other, and give each run a
-  private `HOME` so profile state cannot differ between sides. A profile with packages
+  private `HOME` so profile state cannot differ between sides - a profile with packages
   installed runs their triggers against every benchmark line.
 - An A/B ratio survives a measurement defect both sides share; absolute figures do not.
-  Before quoting an absolute number, validate the harness itself. A cloud or CI container
-  is noisier still and may be CPU-throttled: quote only ratios from one, never absolutes.
+  Validate the harness before quoting an absolute number. A cloud or CI container is
+  noisier still and may be CPU-throttled: quote only ratios from one.
 
 ## Find where the time goes
 
-- Fixed-cost detector: a timing flat across a large range of input sizes is setup cost, not
-  the algorithm. Two measurements at different sizes find it, no profiler needed.
+- Fixed-cost detector: a timing flat across a large range of input sizes is setup cost,
+  not the algorithm. Two measurements at different sizes find it, no profiler needed.
 - That detects; it does not diagnose. Identify by ablation - patch out the suspect,
-  rebuild, remeasure - or by a profiler, never by code reading. A written, specific,
-  plausible explanation for one 80ms mapper cost was simply wrong; a ten-minute ablation
-  found the real one. The test of a code-reading diagnosis is whether the figure was
-  predicted before it was measured, not fitted afterwards.
+  rebuild, remeasure - or by a profiler, never by code reading: a written, plausible
+  explanation for one 80ms mapper cost was simply wrong; a ten-minute ablation found the
+  real one. The test of a diagnosis is whether the figure was predicted before it was
+  measured, not fitted afterwards.
 - Removing hot-loop lookups buys nothing when they hit a cache line the previous iteration
-  pulled in; the wins come from cold, scattered dereferences and allocation churn. "N
+  pulled in; wins come from cold, scattered dereferences and allocation churn. "N
   redundant lookups per frame" is not, by itself, a cost model.
 - After removing one fixed cost, a still-flat timing usually means a second fixed cost was
   hiding behind the first - not that the fix failed.
-- Measure end to end before investing in an isolated win: SIMD gave 9.6x on the telnet byte
-  loop in isolation and ~1% on real traffic.
+- Measure end to end before investing in an isolated win: SIMD gave 9.6x on the telnet
+  byte loop in isolation and ~1% on real traffic.
 - Calibration from past wins: a 56ms flat pathfinding setup cost became 0.14ms; a mapper
   view-fit went 150ms to 55ms; per-line allocations dropped 38.6% from one deque-to-vector
   swap. All were fixed costs or churn; none were hot-loop micro-optimisation.
@@ -82,7 +77,7 @@ repository's SessionStart hook provisions the whole toolchain; on a local machin
 ## In-tree benchmarks
 
 Four live in `test/functional_tests/`, built alongside the functional tests into
-`<build>/test/functional_tests/`. How to run each is not obvious, so:
+`<build>/test/functional_tests/`:
 
 - `PipelineBenchmark` (text pipeline, latin-1 decode, trigger engine, peak memory,
   default-package cost, display) is report-only: ctest runs it only when the tree was
@@ -110,10 +105,10 @@ When extending them:
   point). Keep that guard in new slots - the one slot that historically lacked it reported
   a +133% improvement that was really +46%. TelnetBenchmark has no such guard.
 - Display measurement: `TTextEdit` takes its row count from its visible region, so resize
-  the main window and read `getScreenHeight()` - resizing a pane alone leaves it clipped by
-  its parents, and `getRowCount()` is a font-metric estimate, not the paint path. Scroll
-  strides must exceed one screenful, or `drawForeground()` serves frames from its cached
-  pixmap and inflates throughput several-fold.
+  the main window and read `getScreenHeight()` - resizing a pane alone leaves it clipped
+  by its parents, and `getRowCount()` is a font-metric estimate, not the paint path.
+  Scroll strides must exceed one screenful, or `drawForeground()` serves frames from its
+  cached pixmap and inflates throughput several-fold.
 - Vary the text every iteration when echoing in a loop: several Qt paths
   (`QLabel::setText` among them) short-circuit on identical input, and the benchmark then
   measures nothing at all.

--- a/.agents/skills/improve-performance/SKILL.md
+++ b/.agents/skills/improve-performance/SKILL.md
@@ -8,8 +8,10 @@ user-invocable: true
 argument-hint: Optional subsystem to speed up (e.g. "the 2D mapper", "triggers")
 ---
 
-Runs out of the box on Claude Code for the web (the SessionStart hook provisions the
-toolchain); elsewhere read the `build-mudlet` skill first.
+Runs out of the box on Claude Code for the web, whose containers are Linux (the
+SessionStart hook provisions the toolchain); elsewhere read the `build-mudlet` skill
+first. Commands below default to Linux; where macOS or Windows differs it is called out
+inline.
 
 ## Procedure
 
@@ -18,9 +20,21 @@ toolchain); elsewhere read the `build-mudlet` skill first.
    + text pipeline throughput, the trigger engine, 2D mapper rendering, map pathfinding,
    profile load and startup time. "You pick" is also an answer: profile a busy session and
    take the top entry.
-2. **Build a benchmark-safe tree**: the `linux-debug-nosan` preset. Never benchmark a
-   sanitizer build - ASan (the default `linux-debug` preset) roughly halves text
-   throughput.
+2. **Build a benchmark-safe tree.** Never benchmark a sanitizer build - ASan roughly
+   halves text throughput - and the default is to have one, because
+   `src/cmake/EnableSanitizers.cmake` defaults `USE_SANITIZER` to `address`.
+   - Linux: `linux-debug-nosan` (plain `linux-debug` IS an ASan build).
+   - macOS: `macos-debug-nosan`, same trap with the same preset naming.
+   - Windows: `windows-debug` is already safe - `src/CMakeLists.txt` skips
+     `EnableSanitizers.cmake` entirely under `WIN32`, so no Windows build has one.
+
+   Variant presets build into `build-<preset-name>/`, so the binary is
+   `build-linux-debug-nosan/src/mudlet`,
+   `build-macos-debug-nosan/src/mudlet.app/Contents/MacOS/mudlet` or
+   `build/src/mudlet.exe`. Confirm rather than assume before quoting any number -
+   `grep USE_SANITIZER <build>/CMakeCache.txt` must print an empty value on Linux and
+   macOS and nothing at all on Windows. A whole A/B campaign has been published off two
+   ASan binaries because nobody checked.
 3. **Establish a baseline** with an in-tree benchmark (below), or a small harness
    following the patterns below. Record the exact invocation - an unreproducible number is
    worthless.
@@ -29,27 +43,66 @@ toolchain); elsewhere read the `build-mudlet` skill first.
 5. **Fix and re-measure A/B.** Keep the fix only if the end-to-end number moves, not just
    the microbenchmark.
 6. **Prove no behaviour change** - run the busted specs
-   (`.claude/scripts/run-lua-tests.sh`) and `ctest` - then open a pull request with the
+   (`.claude/scripts/run-lua-tests.sh` on Linux, see below for elsewhere) and `ctest` -
+   then open a pull request with the
    `open-pr` skill, quoting before/after numbers and the exact invocation so a reviewer
    can reproduce them.
 
 ## Keep the numbers honest
 
-- Attribute every live compiler on the machine immediately before AND after each run, into
-  the log itself (Linux; on macOS substitute `lsof -p <pid> | grep cwd` for the `/proc`
-  read):
+- **Benchmark on a quiet machine, and prove it was quiet.** A concurrent build roughly
+  doubles every timing, and load that comes and goes mid-run leaves a plausible-looking
+  number rather than an obviously broken one. Before starting, shut down what you can:
+  other builds and test suites, a second agent's Mudlet, browsers and VMs, and the
+  platform's own background work - Spotlight (`mds`) indexing a fresh build tree and Time
+  Machine on macOS, Windows Defender scanning one and Windows Search indexing it, a
+  `updatedb`/backup cron on Linux. On a laptop, run on mains power: both macOS and Windows
+  down-clock aggressively on battery, and a thermally throttled machine produces a smooth
+  downward drift that looks exactly like a regression.
+- Record the top CPU consumers into the log itself immediately before AND after each run,
+  so a contaminated run is identifiable afterwards rather than merely suspected:
 
   ```bash
+  # Linux and macOS
+  ps -Ao pid,pcpu,comm | sort -k2 -rn | head -15
+  ```
+  ```powershell
+  # Windows
+  Get-Process | Sort-Object CPU -Descending | Select-Object -First 15 Name, CPU
+  ```
+
+  Attributing a live compiler to a checkout tells you whether it is your own build:
+
+  ```bash
+  # Linux
   for pid in $(pgrep -x 'cc1plus|cc1|ld|mold|ninja|cmake|make'); do readlink /proc/$pid/cwd; done
+  # macOS - no /proc, so ask lsof for the cwd descriptor
+  for pid in $(pgrep -x 'clang|clang++|ld|ninja|cmake|make'); do
+    lsof -a -p "$pid" -d cwd -Fn | sed -n 's/^n//p'
+  done
   ```
 
   Never gate on loadavg: it lags ~60s both ways, reading quiet in the trough between build
-  steps and busy after the machine went idle. A concurrent build roughly doubles every
-  timing, and one that comes and goes mid-run leaves a plausible-looking number rather
-  than an obviously broken one. Discard a contaminated run; do not salvage it.
-- Alternate A and B runs rather than all of one then all of the other, and give each run a
-  private `HOME` so profile state cannot differ between sides - a profile with packages
-  installed runs their triggers against every benchmark line.
+  steps and busy after the machine went idle. Windows has no loadavg at all. Discard a
+  contaminated run; do not salvage it.
+- **Cold and warm caches will fool you.** The first run after a build reads the binary,
+  the Qt libraries, the fonts and the profile tree off disk; every run after that gets
+  them from the OS page cache. Startup and profile-load timings routinely differ
+  several-fold between the two for reasons that have nothing to do with the change, and
+  Mudlet warms its own caches as well - font metrics, `drawForeground()`'s cached pixmap,
+  the map render cache. So: discard the first run of each side as a warm-up, alternate
+  afterwards so both sides see the same cache state, and never compare a freshly built
+  side against one that has already run ten times. If cold start is itself the subject,
+  drop the caches deliberately between runs instead of hoping - Linux
+  `sync; echo 3 | sudo tee /proc/sys/vm/drop_caches`, macOS `sudo purge`, Windows
+  Sysinternals `RAMMap -Ew` - and say in the write-up which of the two you measured.
+- Alternate A and B runs rather than all of one then all of the other, and give each run
+  its own config root so profile state cannot differ between sides - a profile with
+  packages installed runs their triggers against every benchmark line. Mudlet keeps that
+  root at `~/.config/mudlet` on every platform (`mudlet::setupConfig`), so a private
+  `HOME` isolates a run on Linux and macOS; `XDG_CONFIG_HOME` pointed at a directory with
+  `mudlet/profiles` pre-created is what the test harness uses, and dropping a
+  `portable.txt` beside the executable is the one that works everywhere, Windows included.
 - An A/B ratio survives a measurement defect both sides share; absolute figures do not.
   Validate the harness before quoting an absolute number. A cloud or CI container is
   noisier still and may be CPU-throttled: quote only ratios from one.
@@ -63,16 +116,54 @@ toolchain); elsewhere read the `build-mudlet` skill first.
   explanation for one 80ms mapper cost was simply wrong; a ten-minute ablation found the
   real one. The test of a diagnosis is whether the figure was predicted before it was
   measured, not fitted afterwards.
-- Removing hot-loop lookups buys nothing when they hit a cache line the previous iteration
-  pulled in; wins come from cold, scattered dereferences and allocation churn. "N
-  redundant lookups per frame" is not, by itself, a cost model.
 - After removing one fixed cost, a still-flat timing usually means a second fixed cost was
   hiding behind the first - not that the fix failed.
-- Measure end to end before investing in an isolated win: SIMD gave 9.6x on the telnet
-  byte loop in isolation and ~1% on real traffic.
-- Calibration from past wins: a 56ms flat pathfinding setup cost became 0.14ms; a mapper
-  view-fit went 150ms to 55ms; per-line allocations dropped 38.6% from one deque-to-vector
-  swap. All were fixed costs or churn; none were hot-loop micro-optimisation.
+- Measure end to end before investing in an isolated win, and once you know where the time
+  goes, see the next section for what to do about it.
+
+## Where the wins actually come from
+
+Ranked by what has paid in this codebase. Mudlet is single-threaded by design - every
+profile, every trigger and the Lua engine share the main thread, and only Qt's networking
+runs off it - so "move it to a worker thread" is almost never available. The work has to
+get smaller, not relocated.
+
+1. **Delete a fixed cost.** Every large win so far was setup work repeated per operation,
+   not a slow inner loop: A* rebuilt its whole graph on each call (56ms for a one-step
+   walk, now 0.003-0.141ms) and a mapper view-fit recomputed what it could hoist (150ms to
+   55ms). The fixed-cost detector above finds these in two measurements.
+2. **Stop allocating.** Per-line churn dominates the text pipeline: one `std::deque` to
+   `std::vector` swap cut allocations 38.6%. Look for containers rebuilt per line instead
+   of `reserve()`d and reused, `QString`/`QList` copies that could be a `const&` or a
+   `std::move`, implicit detaches from calling a non-const method on a shared container,
+   and runtime-built literals that `qsl()` would fold into the binary.
+3. **Index instead of scan.** A linear walk over every trigger, alias or room becomes a
+   `QHash` lookup. Check the container's semantics while you are there: `QMultiMap::find`
+   returns only the most recently inserted match, which is how duplicate names silently
+   lost entries here - `equal_range` is the fix.
+4. **Cache what is invariant, and name the event that clears it.** Font metrics, computed
+   layout and rendered pixmaps all repay caching; a stale cache is a correctness bug, so
+   pair every cache with the exact invalidation point rather than hoping. Caches also lie
+   to benchmarks - see the cold/warm bullet above.
+5. **Do less on the per-line path.** The line is the unit of work that scales with the
+   game, so anything unconditional there is multiplied by traffic: 77 always-on starter-UI
+   triggers made new-user throughput 2x-7.4x worse, and a single chat window made every
+   captured line expensive. Making a per-line cost conditional, or moving it to the point
+   of use, beats speeding it up. This is also why validation belongs in a comment, a test
+   or a debug-only assert rather than a runtime check that every line pays for.
+6. **Coalesce, but do not defer blindly.** Batching many small updates into one is fine.
+   Postponing a single one usually is not: Qt already coalesces paints, and adding a
+   deferral to Geyser updates bought nothing while breaking same-tick readback for
+   scripts.
+
+Not worth reaching for, on the evidence here:
+
+- SIMD and hand-vectorised byte loops - 9.6x on the telnet decode loop in isolation, ~1%
+  end to end.
+- Removing "redundant" lookups from a hot loop when they hit a cache line the previous
+  iteration already pulled in. Wins come from cold, scattered dereferences and allocation
+  churn; "N redundant lookups per frame" is not, by itself, a cost model.
+- Anything justified only by reading the code, however plausible it reads.
 
 ## In-tree benchmarks
 
@@ -92,6 +183,10 @@ Four live in `test/functional_tests/`, built alongside the functional tests into
   ```bash
   MUDLET_BENCH_MAP=/path/to/map.dat QT_QPA_PLATFORM=offscreen ./MapRenderBenchmark
   ```
+
+  The binaries land in `<build>/test/functional_tests/` on every platform (`.exe` on
+  Windows); the `VAR=value cmd` prefix form needs a shell that supports it, so on Windows
+  run them from the MSYS2 shell rather than cmd or PowerShell.
 
   `compare-perf-baseline.py` understands MapRenderBenchmark's output too.
 - `TelnetBenchmark` (small, medium and large payloads) is an ordinary grouped ctest case:
@@ -116,19 +211,38 @@ When extending them:
 ## A/B against released versions
 
 Every release back to at least 4.14 is still downloadable from
-`https://www.mudlet.org/wp-content/files/` as `Mudlet-<version>-linux-x64.AppImage.tar`
-(the GitHub tags carry no release assets). One harness drives them all: hand-build a
-profile directory, drop a `<MudletPackage>` XML containing a ScriptPackage into
-`<profile>/current/` - its script body runs at profile load - and launch with
-`--profile <name>`. Write results with `io.open` so nothing is parsed from stdout; a
-`tempTimer(0, ...)` chain re-arming itself is a version-agnostic event-loop pump, and its
-tick count over a fixed wall-clock window includes painting. Traps:
+`https://www.mudlet.org/wp-content/files/` (the GitHub tags carry no release assets); that
+directory is browsable, so check the exact name rather than guessing it, because the
+naming changed over time:
+
+- Linux: `Mudlet-<ver>-linux-x64.AppImage.tar` throughout, joined by
+  `-linux-x64-portable.tar.gz` from 4.21.0.
+- macOS: `Mudlet-<ver>.dmg` up to 4.18.x, then per-architecture `-x86_64.dmg` and
+  `-arm64.dmg`.
+- Windows: `-windows-installer.exe` up to 4.17.2, then `-windows-32-installer.exe` and
+  `-windows-64-installer.exe`, joined by `-windows-64-portable.zip` from 4.21.0.
+
+One harness drives them all: hand-build a profile directory, drop a `<MudletPackage>` XML
+containing a ScriptPackage into `<profile>/current/` - its script body runs at profile
+load - and launch with `--profile <name>`. Write results with `io.open` so nothing is
+parsed from stdout; a `tempTimer(0, ...)` chain re-arming itself is a version-agnostic
+event-loop pump, and its tick count over a fixed wall-clock window includes painting.
+Traps:
 
 - Seed identical window geometry through `Mudlet.ini` (`[General]` `pos`, `size`,
   `maximized` - unchanged since 4.17.2); each version otherwise picks its own default size
   and paint numbers are not comparable.
-- In a container without FUSE (the web sessions included) an AppImage will not launch
-  directly: run it once with `--appimage-extract` and use the extracted `AppRun`.
+- Get at the binary without installing anything, so the two versions stay side by side and
+  neither disturbs an installed Mudlet: on Linux, in a container without FUSE (the web
+  sessions included) an AppImage will not launch directly - run it once with
+  `--appimage-extract` and use the extracted `AppRun`. On macOS, `hdiutil attach` the dmg
+  and copy `Mudlet.app` out, then `hdiutil detach`. On Windows, prefer the portable zip
+  where the version has one; older releases ship only an installer, so those have to be
+  installed into separate directories.
+- Isolate each version's data: a `portable.txt` next to the executable (or beside
+  `Mudlet.app`'s binary) pointing at a per-version directory is the cross-platform way,
+  and it also keeps an older version from migrating or rewriting the real
+  `~/.config/mudlet`.
 - Seeding any `Mudlet.ini` key also suppresses the 5.0 starter UI. That is what you want
   against versions that never had it, but the starter UI's trigger package is real
   per-line cost for a default new profile - decide explicitly which configuration is being
@@ -136,7 +250,19 @@ tick count over a fixed wall-clock window includes painting. Traps:
 
 ## Lua-only changes need no rebuild
 
-`src/mudlet-lua` is read from disk at startup on Linux, so competing Lua-side variants can
-be A/B'd against ONE binary: write a spec per competing behaviour first, swap each
-candidate file over the product file, run `.claude/scripts/run-lua-tests.sh`, restore, and
-record the pass/fail matrix. That turns "which fix is right?" into a measurement.
+`src/mudlet-lua` is read from disk at startup, so competing Lua-side variants can be A/B'd
+against ONE binary: write a spec per competing behaviour first, swap each candidate file
+over the product file, run the specs, restore, and record the pass/fail matrix. That turns
+"which fix is right?" into a measurement.
+
+Two platform catches:
+
+- On Linux and Windows the source tree wins, so the swap takes effect immediately. On
+  macOS it does not: `loadGlobal()` tries `<exe>/../Resources/mudlet-lua/...` first, and
+  the build copies `mudlet-lua` into the `.app` bundle, so the bundled copy shadows your
+  edit. Re-run `cmake --build` after each swap - it is only a file copy, seconds, not a
+  rebuild - or edit the copy inside the bundle directly.
+- `.claude/scripts/run-lua-tests.sh` is Linux-only: it drives the run under `xvfb-run` and
+  leans on GNU `timeout`. Elsewhere set the same environment by hand and launch the binary
+  windowed or with `-platform offscreen`; `src/mudlet-lua/tests/README.md` has the
+  per-platform busted setup and the isolated-config-root invocation.

--- a/.agents/skills/improve-test-coverage/SKILL.md
+++ b/.agents/skills/improve-test-coverage/SKILL.md
@@ -9,9 +9,10 @@ user-invocable: true
 argument-hint: Optional subsystem or file to cover (e.g. "ctelnet", "the mapper")
 ---
 
-Runs out of the box on Claude Code for the web (the SessionStart hook provisions the
-toolchain); elsewhere read the `build-mudlet` skill first. For busted mechanics, see
-`src/mudlet-lua/tests/README.md`.
+Runs out of the box on Claude Code for the web, whose containers are Linux (the
+SessionStart hook provisions the toolchain); elsewhere read the `build-mudlet` skill
+first. Commands below default to Linux; where macOS or Windows differs it is called out
+inline. For busted mechanics, see `src/mudlet-lua/tests/README.md`.
 
 ## Procedure
 
@@ -37,8 +38,18 @@ toolchain); elsewhere read the `build-mudlet` skill first. For busted mechanics,
 
 ## Measuring
 
-Needs `gcovr` and `jq` (apt on Linux; the web containers get them from the SessionStart
-hook).
+Needs `gcovr` and `jq` (apt on Linux, `brew` on macOS; the web containers get them from
+the SessionStart hook).
+
+**Measure on Linux.** The recipe below is gcc + gcov, and the ranking it produces is
+platform-independent - the code Mudlet compiles is very nearly the same everywhere, so
+there is nothing to gain from a second platform's numbers and quite a lot of yak-shaving
+to lose. If you are on macOS anyway, the same recipe works with `macos-debug-nosan`
+provided gcovr is told to use clang's gcov shim
+(`gcovr --gcov-executable "llvm-cov gcov" ...`); mixing its output with a gcc run's is
+meaningless, so pick one and stay there. Windows is unexplored: MSYS2 has both compilers,
+so `--coverage` may well work, but nobody has run it - do not present a Windows number as
+a baseline without first proving the `.gcda` files appear.
 
 ```bash
 # gcov instrumentation wants gcc, the Linux default. See build-mudlet for parallelism limits.
@@ -47,6 +58,8 @@ cmake --preset linux-debug-nosan -B build-coverage \
   -DCMAKE_EXE_LINKER_FLAGS=--coverage
 cmake --build build-coverage
 
+# run-lua-tests.sh is Linux-only (xvfb-run, GNU timeout); see
+# src/mudlet-lua/tests/README.md for the per-platform equivalent.
 .claude/scripts/run-lua-tests.sh build-coverage/src/mudlet
 (cd build-coverage && ctest --output-on-failure)
 

--- a/.agents/skills/improve-test-coverage/SKILL.md
+++ b/.agents/skills/improve-test-coverage/SKILL.md
@@ -70,9 +70,10 @@ Reading the numbers:
 - Check that `.gcda` files exist under `build-coverage/test/` before trusting numbers for
   code only the standalone test binaries exercise; runs have been observed where they
   deposited none, leaving such code looking exercised only as far as specs reached it.
-- Rank files by uncovered-line mass, not percentage: `lua rollup.lua coverage.csv` (both in
-  this skill's directory) writes `rollup.md` with a per-subsystem rollup and a per-file
-  table sorted by uncovered mass. `./check-lines.sh coverage.json src/Foo.cpp 100 200`
+- Rank files by uncovered-line mass, not percentage:
+  `lua .agents/skills/improve-test-coverage/rollup.lua coverage.csv` writes `rollup.md`
+  with a per-subsystem rollup and a per-file table sorted by uncovered mass.
+  `.agents/skills/improve-test-coverage/check-lines.sh coverage.json src/Foo.cpp 100 200`
   answers "is this specific path covered" from the JSON export.
 
 ## Know when to stop

--- a/.agents/skills/improve-test-coverage/SKILL.md
+++ b/.agents/skills/improve-test-coverage/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: improve-test-coverage
+description: >-
+  Raise Mudlet's test coverage to a reasonable level. Runnable as a task on its own: measure
+  C++ line coverage, pick the targets that pay with the user, write specs that reach C++,
+  and prove each new test actually tests something. Also read before writing tests for any
+  subsystem.
+license: GPL-2.0-or-later
+user-invocable: true
+argument-hint: Optional subsystem or file to cover (e.g. "ctelnet", "the mapper")
+---
+
+## When to use
+
+Invoke as a task ("improve test coverage", "/improve-test-coverage ctelnet"), or read before
+writing tests for a subsystem you did not just change. It runs out of the box: on Claude
+Code for the web the repository's SessionStart hook provisions the whole toolchain; on a
+local machine read the `build-mudlet` skill first. For busted mechanics, see
+`src/mudlet-lua/tests/README.md`.
+
+## Procedure
+
+1. **Measure before writing.** Do not work from folklore about what is untested: when the
+   first real baseline was taken (2026-08), two of three "known gaps" turned out to be
+   already covered. Build one instrumented tree, run BOTH harnesses on it, then rank (recipe
+   below).
+2. **Pick a target that pays.** If the user named a subsystem, cover that. Otherwise show
+   them the top of the uncovered-mass ranking and let them pick. Skip what does not pay
+   (list below).
+3. **Write specs first.** A busted spec is the default; a C++ functional test needs one of
+   the specific justifications in `CLAUDE.md`'s Tests section. The "Reaching C++ from a
+   spec" section below shows how far specs actually reach.
+4. **Prove every test red before trusting it green** (see "Prove the test tests
+   something"). Both harnesses fail silently when set up wrong - a misconfigured run is
+   green.
+5. **Stop at reasonable** (see "Know when to stop"). Re-run gcovr and record before/after
+   for the files touched.
+6. **Deliver**: open a pull request with the `open-pr` skill, quoting the coverage
+   before/after. Bugs found along the way are filed separately, each with an empirical
+   repro - a probe that fails on one side of the change and passes on the other - never
+   from code reading alone: a second code path routinely compensates for the defect a
+   reading predicts.
+
+## Measuring
+
+Needs `gcovr` and `jq` (apt on Linux; the web containers get them from the SessionStart
+hook).
+
+```bash
+# gcov instrumentation wants gcc, the Linux default. See build-mudlet for parallelism limits.
+cmake --preset linux-debug-nosan -B build-coverage \
+  -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage \
+  -DCMAKE_EXE_LINKER_FLAGS=--coverage
+cmake --build build-coverage
+
+.claude/scripts/run-lua-tests.sh build-coverage/src/mudlet
+(cd build-coverage && ctest --output-on-failure)
+
+# Restrict the search paths as below: pointed at the whole build tree, gcovr
+# trips over oniguruma's gperf-generated sources and aborts.
+gcovr -r . build-coverage/src/CMakeFiles/mudlet_core.dir \
+           build-coverage/src/CMakeFiles/mudlet_executable.dir \
+      --csv coverage.csv --json coverage.json
+```
+
+Reading the numbers:
+
+- gcov "lines" are instrumented lines, roughly half the physical line count, and the branch
+  percentage is dragged down by compiler-generated branches. Use both only relatively.
+- Check that `.gcda` files exist under `build-coverage/test/` before trusting numbers for
+  code only the standalone test binaries exercise; runs have been observed where they
+  deposited none, leaving such code looking exercised only as far as specs reached it.
+- Rank files by uncovered-line mass, not percentage: `lua rollup.lua coverage.csv` (both in
+  this skill's directory) writes `rollup.md` with a per-subsystem rollup and a per-file
+  table sorted by uncovered mass. `./check-lines.sh coverage.json src/Foo.cpp 100 200`
+  answers "is this specific path covered" from the JSON export.
+
+## Know when to stop
+
+Complete coverage is not the goal - a reasonable level is. Chasing the last percent
+produces brittle tests that mirror the implementation line by line, and those cost more in
+maintenance than they catch.
+
+- A test must pin behaviour someone could plausibly break. If the strongest assertion you
+  can write restates the code, do not write it.
+- Poor value per uncovered line, skip: the 3D mapper and `T2DMap` paint paths, the
+  zero-coverage `dlg*` dialogs, `CustomLine` mouse handlers - all driven by GUI events that
+  tests cannot cheaply synthesise.
+- Prefer breadth across load-bearing subsystems over depth in one file.
+- Calibration, from the 2026-08 baseline: `src/` was 52.6% lines overall - specs alone gave
+  36.1%, functional tests another 16.5 points. The weakest heavily-used file was
+  `ctelnet.cpp` at 44%; one wave of specs plus a functional-test group took it to 67.5%,
+  and that was a good place to stop.
+
+## Reaching C++ from a spec
+
+The self-test profile runs the real application, so specs reach much further than they look:
+
+- `feedTelnet()` drives the real telnet parser (`cTelnet::processSocketData`): IAC
+  negotiation, subnegotiation (GMCP/MSDP/MSSP/CHARSET), ANSI/CSI/OSC, encodings. It needs
+  the profile loaded with `--offline`, which `run-lua-tests.sh` already passes.
+- `feedTriggers()` exercises the trigger engine end to end. It is a local feed
+  (`isFromServer` false), so server-only paths such as incomplete-sequence carry-over need
+  `feedTelnet()` instead.
+- `pumpEvents(ms)` makes deferred slots and timer work observable within one spec.
+
+Still unreachable even offline: bytes Mudlet SENDS (there is no socket to observe), and
+`connectIt()`'s Host-to-cTelnet config sync - a spec that toggles such config must verify
+the toggle actually bites.
+
+Sandbox gotcha: busted sandboxes each file, so a counter shared across callbacks must be
+`_G.`-qualified or it silently reads zero and the assertion goes vacuously green.
+
+## Functional tests, when a spec cannot reach
+
+- Join a `*_GROUP_TEST_SOURCES` group in `test/functional_tests/CMakeLists.txt` (the lists
+  there document how); a standalone binary costs ~250MB in every build tree.
+- Insert the new filename at a random position in the source list, not at the bottom -
+  parallel branches appending to the same last line all merge-conflict.
+- Bind `TelnetServerStub` to port 0 and read `serverPort()` back; hardcoded ports collide
+  when suites run in parallel.
+- Register the bundled fonts from Qt resources in `initTestCase()` and assert
+  `QFontInfo(font).family()` equals what was requested. `QTEST_MAIN` never runs `main()`,
+  so the fonts it would install are absent and Qt substitutes per-platform - metrically
+  identical on Linux, proportional on macOS and Windows, so a metrics test passes on one
+  platform and fails on the rest.
+- Take verdicts from ctest's own Passed/Failed summary: QTest can print every case as PASS
+  and the process still exit non-zero (a LeakSanitizer report, for one).
+- moc trap: a raw string literal containing `"` or `]]` can make moc emit an empty `.moc`,
+  surfacing at link time as `undefined symbol: vtable for <TestClass>`. Use escaped string
+  literals in files moc parses.
+
+## Prove the test tests something
+
+- Fail-without-fix, always: sabotage the code the test claims to cover and watch it go red.
+  Cut EVERY mechanism that could produce the behaviour, not just the obvious one - a second
+  path can keep the behaviour correct and make the test look wrong instead.
+- Pin preconditions: assert the state is NOT already the target before acting, then act,
+  then assert. A field with a plausible default satisfies the final assertion without the
+  code under test ever running.
+- After a C++ sabotage leg, rebuild once the source is restored - restoring the source does
+  not restore the binary, and a stale tree then fails exactly the new tests, which reads
+  like a real regression.

--- a/.agents/skills/improve-test-coverage/SKILL.md
+++ b/.agents/skills/improve-test-coverage/SKILL.md
@@ -1,41 +1,35 @@
 ---
 name: improve-test-coverage
 description: >-
-  Raise Mudlet's test coverage to a reasonable level. Runnable as a task on its own: measure
-  C++ line coverage, pick the targets that pay with the user, write specs that reach C++,
-  and prove each new test actually tests something. Also read before writing tests for any
-  subsystem.
+  Raise Mudlet's C++ test coverage to a reasonable level: measure line coverage, pick
+  targets that pay with the user, write specs that reach C++, prove each new test bites.
+  Read before writing tests for any subsystem.
 license: GPL-2.0-or-later
 user-invocable: true
 argument-hint: Optional subsystem or file to cover (e.g. "ctelnet", "the mapper")
 ---
 
-## When to use
-
-Invoke as a task ("improve test coverage", "/improve-test-coverage ctelnet"), or read before
-writing tests for a subsystem you did not just change. It runs out of the box: on Claude
-Code for the web the repository's SessionStart hook provisions the whole toolchain; on a
-local machine read the `build-mudlet` skill first. For busted mechanics, see
+Runs out of the box on Claude Code for the web (the SessionStart hook provisions the
+toolchain); elsewhere read the `build-mudlet` skill first. For busted mechanics, see
 `src/mudlet-lua/tests/README.md`.
 
 ## Procedure
 
-1. **Measure before writing.** Do not work from folklore about what is untested: when the
-   first real baseline was taken (2026-08), two of three "known gaps" turned out to be
-   already covered. Build one instrumented tree, run BOTH harnesses on it, then rank (recipe
-   below).
+1. **Measure before writing.** Folklore about what is untested goes stale: at the first
+   real baseline (2026-08), two of three "known gaps" were already covered. Build one
+   instrumented tree, run BOTH harnesses on it, then rank (recipe below).
 2. **Pick a target that pays.** If the user named a subsystem, cover that. Otherwise show
    them the top of the uncovered-mass ranking and let them pick. Skip what does not pay
    (list below).
 3. **Write specs first.** A busted spec is the default; a C++ functional test needs one of
-   the specific justifications in `CLAUDE.md`'s Tests section. The "Reaching C++ from a
-   spec" section below shows how far specs actually reach.
+   the specific justifications in `CLAUDE.md`'s Tests section. Specs reach further than
+   they look (below).
 4. **Prove every test red before trusting it green** (see "Prove the test tests
    something"). Both harnesses fail silently when set up wrong - a misconfigured run is
    green.
 5. **Stop at reasonable** (see "Know when to stop"). Re-run gcovr and record before/after
    for the files touched.
-6. **Deliver**: open a pull request with the `open-pr` skill, quoting the coverage
+6. **Deliver**: a pull request via the `open-pr` skill, quoting the coverage
    before/after. Bugs found along the way are filed separately, each with an empirical
    repro - a probe that fails on one side of the change and passes on the other - never
    from code reading alone: a second code path routinely compensates for the defect a
@@ -65,8 +59,9 @@ gcovr -r . build-coverage/src/CMakeFiles/mudlet_core.dir \
 
 Reading the numbers:
 
-- gcov "lines" are instrumented lines, roughly half the physical line count, and the branch
-  percentage is dragged down by compiler-generated branches. Use both only relatively.
+- gcov "lines" are instrumented lines, roughly half the physical line count, and the
+  branch percentage is dragged down by compiler-generated branches. Use both only
+  relatively.
 - Check that `.gcda` files exist under `build-coverage/test/` before trusting numbers for
   code only the standalone test binaries exercise; runs have been observed where they
   deposited none, leaving such code looking exercised only as far as specs reached it.
@@ -79,23 +74,24 @@ Reading the numbers:
 ## Know when to stop
 
 Complete coverage is not the goal - a reasonable level is. Chasing the last percent
-produces brittle tests that mirror the implementation line by line, and those cost more in
-maintenance than they catch.
+produces brittle tests that mirror the implementation, costing more in maintenance than
+they catch.
 
 - A test must pin behaviour someone could plausibly break. If the strongest assertion you
   can write restates the code, do not write it.
 - Poor value per uncovered line, skip: the 3D mapper and `T2DMap` paint paths, the
-  zero-coverage `dlg*` dialogs, `CustomLine` mouse handlers - all driven by GUI events that
-  tests cannot cheaply synthesise.
+  zero-coverage `dlg*` dialogs, `CustomLine` mouse handlers - all driven by GUI events
+  that tests cannot cheaply synthesise.
 - Prefer breadth across load-bearing subsystems over depth in one file.
-- Calibration, from the 2026-08 baseline: `src/` was 52.6% lines overall - specs alone gave
-  36.1%, functional tests another 16.5 points. The weakest heavily-used file was
+- Calibration, from the 2026-08 baseline: `src/` was 52.6% lines overall - specs alone
+  gave 36.1%, functional tests another 16.5 points. The weakest heavily-used file was
   `ctelnet.cpp` at 44%; one wave of specs plus a functional-test group took it to 67.5%,
   and that was a good place to stop.
 
 ## Reaching C++ from a spec
 
-The self-test profile runs the real application, so specs reach much further than they look:
+The self-test profile runs the real application, so specs reach much further than they
+look:
 
 - `feedTelnet()` drives the real telnet parser (`cTelnet::processSocketData`): IAC
   negotiation, subnegotiation (GMCP/MSDP/MSSP/CHARSET), ANSI/CSI/OSC, encodings. It needs
@@ -133,12 +129,12 @@ Sandbox gotcha: busted sandboxes each file, so a counter shared across callbacks
 
 ## Prove the test tests something
 
-- Fail-without-fix, always: sabotage the code the test claims to cover and watch it go red.
-  Cut EVERY mechanism that could produce the behaviour, not just the obvious one - a second
-  path can keep the behaviour correct and make the test look wrong instead.
+- Fail-without-fix, always: sabotage the code the test claims to cover and watch it go
+  red. Cut EVERY mechanism that could produce the behaviour, not just the obvious one - a
+  second path can keep the behaviour correct and make the test look wrong instead.
 - Pin preconditions: assert the state is NOT already the target before acting, then act,
   then assert. A field with a plausible default satisfies the final assertion without the
   code under test ever running.
-- After a C++ sabotage leg, rebuild once the source is restored - restoring the source does
-  not restore the binary, and a stale tree then fails exactly the new tests, which reads
-  like a real regression.
+- After a C++ sabotage leg, rebuild once the source is restored - restoring the source
+  does not restore the binary, and a stale tree then fails exactly the new tests, which
+  reads like a real regression.

--- a/.agents/skills/improve-test-coverage/check-lines.sh
+++ b/.agents/skills/improve-test-coverage/check-lines.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Prints the per-line hit counts gcovr recorded for a file's line range, so a
+# specific code path can be checked rather than a whole-file percentage.
+#
+# Usage: check-lines.sh <coverage.json> <src/File.cpp> <firstLine> <lastLine>
+set -euo pipefail
+
+json="$1"
+file="$2"
+first="$3"
+last="$4"
+
+jq -r --arg f "$file" --argjson a "$first" --argjson b "$last" '
+  .files[] | select(.file == $f) | .lines[]
+  | select(.line_number >= $a and .line_number <= $b)
+  | "\(.line_number)\t\(.count)"
+' "$json"

--- a/.agents/skills/improve-test-coverage/rollup.lua
+++ b/.agents/skills/improve-test-coverage/rollup.lua
@@ -1,0 +1,186 @@
+#!/usr/bin/env lua
+-- Turns gcovr's CSV export into the two tables the coverage baseline needs:
+-- a per-file listing sorted by uncovered-line MASS (not percentage) and a
+-- subsystem rollup. Reads coverage.csv from the directory it is given.
+--
+-- Usage: lua rollup.lua <coverage.csv> [outdir]
+
+local csvPath = arg[1] or "coverage.csv"
+local outDir = arg[2] or "."
+
+-- gcovr's CSV has no embedded commas in our paths, so a plain split is enough.
+local function splitCsv(line)
+  local fields = {}
+  for field in (line .. ","):gmatch("([^,]*),") do
+    fields[#fields + 1] = field
+  end
+  return fields
+end
+
+-- First match wins, so order matters: the mapper dialogs have to be claimed by
+-- the map bucket before the generic dlg* pattern sees them.
+local subsystems = {
+  {name = "Map + mapper widgets", patterns = {
+    "^TMap", "^TRoom", "^TArea", "^T2DMap", "^dlgMapper", "^dlgMapLabel", "^dlgRoomExits",
+    "^dlgRoomProperties", "^mapInfoContributorManager", "^glwidget", "^modern_glwidget",
+    "^CameraController", "^ShaderManager", "^RenderCommand", "^LabelTextureCache",
+    "^exitstreewidget", "^CustomLine", "^RoomContextMenuHandler", "^RoomMove",
+    "^PanInteractionHandler", "^MiddleMousePanHandler", "^SelectionRectangleHandler",
+    "^LabelInteractionHandler", "^TAstar",
+  }},
+  {name = "Telnet + MXP + MMCP + GMCP", patterns = {
+    "^ctelnet", "^MMCP", "^TMxp", "^MxpTag", "^GMCPAuthenticator", "^TEntity",
+    "^TTextCodec", "^TEncoding",
+  }},
+  {name = "Text pipeline (TBuffer/TConsole/TTextEdit)", patterns = {
+    "^TBuffer", "^TConsole", "^TMainConsole", "^TTextEdit", "^TCommandLine", "^TLinkStore",
+    "^TDebug", "^TTextBox", "^TStringUtils", "^THyperlink", "^TAccessible", "^TScrollBox",
+    "^TSplitter", "^UntrustedText", "^widechar_width", "^TTextProperties",
+  }},
+  {name = "Lua API (TLuaInterpreter*)", patterns = {
+    "^TLuaInterpreter", "^LuaInterface", "^LuaLiteral",
+  }},
+  {name = "Scripting engine (triggers/aliases/timers/keys/scripts/vars)", patterns = {
+    "^TTrigger", "^TAlias", "^TTimer", "^TKey%.", "^TKeySequenceEdit", "^TScript", "^TAction",
+    "^TVar", "Unit%.", "^TMatchState", "^Tree%.h", "^TEvent%.h", "^EAction",
+  }},
+  {name = "Editor + edbee glue", patterns = {
+    "^dlgSourceEditor", "^dlgTriggerEditor", "^dlgTriggerPatternEdit", "^TriggerHighlighter",
+    "^TrailingWhitespaceMarker", "^Editor", "^dlgColorTrigger", "^dlgComposer", "^dlgNotepad",
+    "^dlg.*MainArea", "^dlgSystemMessageArea", "^SingleLineTextEdit",
+  }},
+  {name = "Dialogs (dlg*)", patterns = {"^dlg"}},
+  {name = "Updater + dblsqd", patterns = {"^updater", "^src/updater/", "^Feed%.", "^Release%.", "^SemVer%.", "^UpdateDialog", "^sparkleupdater"}},
+  {name = "Media (TMedia)", patterns = {"^TMedia"}},
+  {name = "Discord", patterns = {"^discord"}},
+  {name = "IRC client", patterns = {"^dlgIRC", "^ircmessageformatter"}},
+  {name = "Persistence (XML import/export)", patterns = {"^XMLexport", "^XMLimport"}},
+  {name = "Host + mudlet core", patterns = {
+    "^Host", "^mudlet%.", "^main%.", "^MudletInstanceCoordinator", "^EventLoopPump",
+    "^FontManager", "^GeometryManager", "^ShortcutsManager", "^ResourceManager",
+    "^CredentialManager", "^SecureStringUtils", "^OAuthClientFlow", "^SentryWrapper",
+    "^FileOpenHandler", "^DarkTheme", "^AltFocusMenuBarDisable", "^TForkedProcess",
+    "^TUiTour", "^TFeatureCallout", "^TTabBar", "^TToolBar", "^TDockWidget",
+    "^TDetachedWindow", "^TEasyButtonBar", "^TFlipButton", "^TLabel", "^TTreeWidget",
+    "^WideComboBox", "^PackageItemDelegate", "^GifTracker", "^LsanHooks", "^emptyFile",
+    "^enums%.h", "^utils%.h", "^TGameDetails", "^TMapView",
+  }},
+}
+
+local function bucketFor(path)
+  -- Match on the path relative to src/ so nested directories keep their prefix.
+  local rel = path:gsub("^src/", "")
+  for _, subsystem in ipairs(subsystems) do
+    for _, pattern in ipairs(subsystem.patterns) do
+      if rel:match(pattern) or path:match(pattern) then
+        return subsystem.name
+      end
+    end
+  end
+  return "Other"
+end
+
+local rows = {}
+local header
+for line in io.lines(csvPath) do
+  if not header then
+    header = splitCsv(line)
+    -- Columns are read by position below; a gcovr that reorders them would
+    -- otherwise produce a silently zeroed report (tonumber(...) or 0).
+    local expected = { "filename", "line_total", "line_covered", nil, "branch_total", "branch_covered" }
+    for i, name in pairs(expected) do
+      if header[i] ~= name then
+        error(("unexpected gcovr CSV header: column %d is %q, expected %q"):format(i, tostring(header[i]), name))
+      end
+    end
+  else
+    local f = splitCsv(line)
+    local path = f[1]
+    if path and path ~= "" then
+      local lineTotal = tonumber(f[2]) or 0
+      local lineCovered = tonumber(f[3]) or 0
+      local branchTotal = tonumber(f[5]) or 0
+      local branchCovered = tonumber(f[6]) or 0
+      rows[#rows + 1] = {
+        path = path,
+        lineTotal = lineTotal,
+        lineCovered = lineCovered,
+        uncovered = lineTotal - lineCovered,
+        branchTotal = branchTotal,
+        branchCovered = branchCovered,
+        bucket = bucketFor(path),
+      }
+    end
+  end
+end
+
+local function pct(covered, total)
+  if total == 0 then
+    return "n/a"
+  end
+  return string.format("%.1f%%", 100 * covered / total)
+end
+
+-- Overall
+local all = {lineTotal = 0, lineCovered = 0, branchTotal = 0, branchCovered = 0}
+for _, r in ipairs(rows) do
+  all.lineTotal = all.lineTotal + r.lineTotal
+  all.lineCovered = all.lineCovered + r.lineCovered
+  all.branchTotal = all.branchTotal + r.branchTotal
+  all.branchCovered = all.branchCovered + r.branchCovered
+end
+
+local out = io.open(outDir .. "/rollup.md", "w")
+out:write("# Mudlet C++ coverage baseline\n\n")
+out:write(string.format("Files measured: %d\n\n", #rows))
+out:write(string.format("Overall src/ lines: %d covered / %d instrumented = %s\n",
+  all.lineCovered, all.lineTotal, pct(all.lineCovered, all.lineTotal)))
+out:write(string.format("Overall src/ branches: %d covered / %d = %s\n\n",
+  all.branchCovered, all.branchTotal, pct(all.branchCovered, all.branchTotal)))
+
+-- Subsystem rollup
+local buckets = {}
+local order = {}
+for _, r in ipairs(rows) do
+  local b = buckets[r.bucket]
+  if not b then
+    b = {name = r.bucket, lineTotal = 0, lineCovered = 0, branchTotal = 0, branchCovered = 0, files = 0}
+    buckets[r.bucket] = b
+    order[#order + 1] = b
+  end
+  b.lineTotal = b.lineTotal + r.lineTotal
+  b.lineCovered = b.lineCovered + r.lineCovered
+  b.branchTotal = b.branchTotal + r.branchTotal
+  b.branchCovered = b.branchCovered + r.branchCovered
+  b.files = b.files + 1
+end
+table.sort(order, function(a, b) return (a.lineTotal - a.lineCovered) > (b.lineTotal - b.lineCovered) end)
+
+out:write("## Subsystem rollup (sorted by uncovered lines)\n\n")
+out:write("| Subsystem | Files | Lines | Covered | Uncovered | Line % | Branch % |\n")
+out:write("| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+for _, b in ipairs(order) do
+  out:write(string.format("| %s | %d | %d | %d | %d | %s | %s |\n",
+    b.name, b.files, b.lineTotal, b.lineCovered, b.lineTotal - b.lineCovered,
+    pct(b.lineCovered, b.lineTotal), pct(b.branchCovered, b.branchTotal)))
+end
+
+-- Per-file, by uncovered mass
+table.sort(rows, function(a, b)
+  if a.uncovered ~= b.uncovered then return a.uncovered > b.uncovered end
+  return a.path < b.path
+end)
+
+out:write("\n## Per-file, sorted by uncovered-line mass\n\n")
+out:write("| # | File | Lines | Covered | Uncovered | Line % | Subsystem |\n")
+out:write("| ---: | --- | ---: | ---: | ---: | ---: | --- |\n")
+for i, r in ipairs(rows) do
+  out:write(string.format("| %d | %s | %d | %d | %d | %s | %s |\n",
+    i, r.path, r.lineTotal, r.lineCovered, r.uncovered, pct(r.lineCovered, r.lineTotal), r.bucket))
+end
+out:close()
+
+print(string.format("overall: %d/%d lines = %s ; %d/%d branches = %s ; %d files",
+  all.lineCovered, all.lineTotal, pct(all.lineCovered, all.lineTotal),
+  all.branchCovered, all.branchTotal, pct(all.branchCovered, all.branchTotal), #rows))
+print("wrote " .. outDir .. "/rollup.md")

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -95,6 +95,17 @@ if ! dpkg -s libxcb-shape0 >/dev/null 2>&1; then
     ffmpeg
 fi
 
+# Coverage tooling for the improve-test-coverage skill (gcovr for the report,
+# jq for its check-lines.sh helper). Separate guard: containers cached before
+# this block existed still pick it up.
+if ! command -v gcovr >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+  echo "Installing coverage tooling..."
+  ${SUDO} apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive ${SUDO} apt-get install -y --no-install-recommends \
+    gcovr \
+    jq
+fi
+
 # Lua rocks that LuaGlobal.lua and the test harnesses load, mirroring the CI
 # list in .github/workflows/build-mudlet.yml. The egress proxy blocks GitHub
 # codeload tarballs (403) while git clones are allowed, so rocks whose

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Check https://www.linguistic-antipatterns.com when naming anything to help ensur
 
 ## AI Coding Assistants
 
+To put an AI agent to work on Mudlet quality - test coverage, fuzzing, performance - see [Improving Mudlet with AI agents](https://wiki.mudlet.org/w/Improving_Mudlet_with_AI_agents) and the ready-made skills in [.agents/skills](https://github.com/Mudlet/Mudlet/tree/development/.agents/skills).
+
 ### Licensing and Legal Requirements
 
 All code must be compatible with Mudlet's license.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -9,6 +9,9 @@ Mudlet is a cross-platform MUD client built with Qt6 and C++20, providing script
 Task-specific instructions live in `.agents/skills/<name>/SKILL.md`, in the [Agent Skills](https://agentskills.io) format. Claude Code, GitHub Copilot and Cursor all read this directory (Claude Code via the `.claude/skills` symlink). Read the relevant one before starting that kind of task rather than working from memory:
 
 - `build-mudlet` - building, rebuilding or running Mudlet on any platform
+- `fuzz-apis` - fuzzing the parsers and scripting API under sanitizer builds
+- `improve-performance` - benchmarking, measurement discipline and finding where time goes
+- `improve-test-coverage` - measuring C++ line coverage and growing the test suite
 - `open-pr` - publishing a branch and opening a pull request upstream
 
 ## Coding standards

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -6,7 +6,7 @@ Mudlet is a cross-platform MUD client built with Qt6 and C++20, providing script
 
 ## Skills
 
-Task-specific instructions live in `.agents/skills/<name>/SKILL.md`, in the [Agent Skills](https://agentskills.io) format. Claude Code, GitHub Copilot and Cursor all read this directory (Claude Code via the `.claude/skills` symlink). Read the relevant one before starting that kind of task rather than working from memory:
+Task-specific instructions live in `.agents/skills/<name>/SKILL.md`, in the [Agent Skills](https://agentskills.io) format. Claude Code, GitHub Copilot, Cursor and OpenAI Codex all read this directory (Claude Code via the `.claude/skills` symlink). Read the relevant one before starting that kind of task rather than working from memory:
 
 - `build-mudlet` - building, rebuilding or running Mudlet on any platform
 - `fuzz-apis` - fuzzing the parsers and scripting API under sanitizer builds


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Three user-invocable Agent Skills in `.agents/skills/`: `improve-test-coverage`, `fuzz-apis` and `improve-performance`. Each is a step-by-step procedure an agent can run to a deliverable (a PR or a filed issue), backed by the measurement and test-validity gotchas learned doing this work by hand.
- The coverage skill ships its ranking helpers (`rollup.lua`, `check-lines.sh`), and the web session-start hook now installs `gcovr` and `jq`, so all three run out of the box on Claude Code web as well as locally.

#### Motivation for adding to Mudlet
Anyone with an AI agent (Claude Code, Copilot, Cursor) can point it at Mudlet and productively raise test coverage, fuzz for crashes, or speed up a subsystem of their choice - without rediscovering the pitfalls.

#### Other info (issues closed, discussion etc)
- The fuzz specs the fuzz-apis skill runs arrive with #10221; the skill flags that until it merges.
- Every path, preset and command in the skills was fact-checked against the tree, and the helpers were verified against the 2026-08 coverage baseline.

**Test case:** ask an agent to "improve test coverage" (or run `/improve-test-coverage`) in a fresh checkout and check it follows the measure-first procedure; `lua .agents/skills/improve-test-coverage/rollup.lua <gcovr csv> <outdir>` prints a ranked report.

Assisted-by: Claude:claude-fable-5

https://claude.ai/code/session_0161cS5rT4ReUeQe3RiRj68X