### PR TITLE
Fix: Undefined behavior on profile load, from a flag read before it exists

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -587,6 +587,14 @@ private:
     // through mainConsoleModel()/sharedMainConsoleModel().
     std::shared_ptr<TConsoleModel> mpMainConsoleModel;
 
+    // Read during the construction of the members below, so it has to be
+    // declared - and therefore initialised - ahead of them. cTelnet::postMessage()
+    // asks isClosingDown() to decide whether a message can be delivered or must be
+    // stacked up, and TLuaInterpreter's constructor posts the Lua module loading
+    // messages through it, so this is read while Host is still being built. The
+    // same shape as the reset() call #10229 moved out of cTelnet's constructor.
+    bool mIsClosingDown = false;
+
 public:
     // Make this the first public member instantiated so we can use ITS font
     // as the "reference" or "master" font for whole profile - and so we don't
@@ -1053,7 +1061,6 @@ private:
     int mHostID;
     QString mHostName;
     QString mDiscordGameName; // Discord self-reported game name
-    bool mIsClosingDown = false;
 
     QString mLine;
     QString mLogin;

--- a/src/Host.h
+++ b/src/Host.h
@@ -587,12 +587,16 @@ private:
     // through mainConsoleModel()/sharedMainConsoleModel().
     std::shared_ptr<TConsoleModel> mpMainConsoleModel;
 
-    // Read during the construction of the members below, so it has to be
-    // declared - and therefore initialised - ahead of them. cTelnet::postMessage()
-    // asks isClosingDown() to decide whether a message can be delivered or must be
-    // stacked up, and TLuaInterpreter's constructor posts the Lua module loading
-    // messages through it, so this is read while Host is still being built. The
-    // same shape as the reset() call #10229 moved out of cTelnet's constructor.
+    // Initialised ahead of mLuaInterpreter below, whose construction reads it:
+    // initLuaGlobals() posts a message for each Lua module that fails to load, and
+    // Host::postMessage() hands that to cTelnet::postMessage(), which asks
+    // isClosingDown() whether to flush what it has stacked up. Declaration order is
+    // what decides initialisation order, the access specifier between them is not.
+    //
+    // mpConsole's position carries the same weight: it is null for the whole of
+    // construction, so that guard returns before reaching the rest of the function,
+    // which reads members declared much later - mBgColor among them. Same class of
+    // bug as #10229, which had to move a call rather than a declaration.
     bool mIsClosingDown = false;
 
 public:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Host::mIsClosingDown` is read during the construction of `mLuaInterpreter`, which is declared above it, so it is moved ahead of it. `initLuaGlobals()` posts a message for each Lua module that fails to load, `Host::postMessage()` hands that to `cTelnet::postMessage()`, and that asks `isClosingDown()` whether to flush what it has stacked - while Host is still being built.
- Behaviorally inert, and checkable at the call site: the guard is `if (!mpHost || mpHost->isClosingDown() || !mpHost->mpConsole)`, and `mpConsole` is never assigned in `Host.cpp` at all - mudlet builds the console after the Host exists. So it is null for the whole of construction and that third term returns regardless of what the garbage bool held. Both branches reach the same `return` with the same `messageStack`. Inert as compiled, though - an indeterminate `bool` load is still UB, and the optimizer is entitled to anything downstream of it, which is the reason to fix it.

#### Motivation for adding to Mudlet

UBSan flags it on any profile load where a Lua module fails to load - a missing luarock is a normal, supported state, which Mudlet reports rather than treats as fatal:

```
Host.h:252: runtime error: load of value 170, which is not a valid value for type 'bool'
    #0 Host::isClosingDown()          Host.h:252
    #1 cTelnet::postMessage(QString)  ctelnet.cpp:4823
    #2 Host::postMessage(QString)     Host.h:371
    #3 TLuaInterpreter::initLuaGlobals()
    #4 TLuaInterpreter::TLuaInterpreter(Host*, ...)
    #6 Host::Host(...)                Host.cpp:247
```

#### Other info (issues closed, discussion etc)

Found while investigating @SlySven's UBSan report of `Host.cpp: load of value 32, which is not a valid value for type 'bool'`. That one was #10229, which landed the same morning and which his branch predates - rebuilding with UBSan after it shows his reported line clean, and this one still standing. Same class of bug, one member along; #10229 had to move a *call* out of a constructor, this moves a *declaration* ahead of one.

`mpConsole` being Host's first public member is what keeps the rest of `cTelnet::postMessage()` safe - it goes on to read `mBgColor`, declared 200 lines after `mLuaInterpreter`. That invariant was written down nowhere, so the comment now records it.

**No test, and none is possible.** Both branches of that guard reach the same `return` with the same state, so a test would pass with or without the fix - which is exactly what CLAUDE.md's "confirm a new test fails without the fix" rule exists to catch. `static_assert` with `offsetof` is not an alternative either: `offsetof` reports *layout* order while initialization follows *declaration* order, and those coincide only within one access-control block - these members straddle a `private:`/`public:` boundary, so such an assert could pass while the UB stands.

**So the honest regression guard is the comment on the declaration, plus a human running the UBSan preset.** CI builds with `-DUSE_SANITIZER=Address` only, and ASan does not implement `-fsanitize=bool`, so the green ASan ctest and spec runs are not evidence about this bug either way. A UBSan CI job would be the real answer; it cannot land with this PR because two unrelated reports would make it red on arrival - `Qt::Key` holding `0xFFFFFFFF` at `TKey.h:48` (via `TLuaInterpreter::startPermKey`) and `XMLexport.cpp:1373`. Both are left for their own change.

**Test case:** build with a `-ubsan` preset and load any profile with a Lua module missing. Malloc poisoning makes the read report reliably rather than only when the leftover byte happens not to be 0 or 1:

```
# macOS
MallocPreScribble=1 QT_QPA_PLATFORM=offscreen build-macos-debug-ubsan/src/mudlet.app/Contents/MacOS/mudlet --profile "<any>" --mirror --offline

# Linux, via the spec runner
MALLOC_PERTURB_=1 .claude/scripts/run-lua-tests.sh build-linux-debug-ubsan/src/mudlet
```

Before: the report above. After: gone. Whole spec suite under UBSan with poisoning is free of Host reports (3678 successes); ctest 147/147.