### PR TITLE
infra: skip the bundled-font tests when built without fonts

### DIFF
--- a/test/functional_tests/MissingDisplayFontTest.cpp
+++ b/test/functional_tests/MissingDisplayFontTest.cpp
@@ -289,6 +289,9 @@ private:
 private slots:
     void initTestCase()
     {
+#ifndef INCLUDE_FONTS
+        QSKIP("Built with WITH_FONTS=NO, so the bundled fonts this registers - the family it falls back to, and the one it renames for a package to supply - are not in the resources");
+#else
         QVERIFY(mConfigDir.isValid());
         QVERIFY(mSaveDir.isValid());
         QVERIFY(mArchiveDir.isValid());
@@ -312,6 +315,7 @@ private slots:
         QVERIFY(mpHost);
 
         QVERIFY2(!mudlet::self()->getAvailableFonts().contains(mMissingFamily, Qt::CaseInsensitive), "the stand-in for an uninstalled font turns out to be installed");
+#endif
     }
 
     // Registered per case rather than once for the class, because a couple of

--- a/test/functional_tests/PackageFontsOnRefusedArchiveTest.cpp
+++ b/test/functional_tests/PackageFontsOnRefusedArchiveTest.cpp
@@ -150,6 +150,9 @@ private:
 private slots:
     void initTestCase()
     {
+#ifndef INCLUDE_FONTS
+        QSKIP("Built with WITH_FONTS=NO, so there is no bundled font in the resources to build the test packages out of");
+#else
         if (portableMarkerPresent()) {
             QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
         }
@@ -180,6 +183,7 @@ private slots:
         if (QFontDatabase::families().contains(mFontFamily)) {
             QSKIP("the font this test installs is already registered on this machine, so a package bringing it cannot be told apart");
         }
+#endif
     }
 
     void cleanupTestCase()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`MissingDisplayFontTest` and `PackageFontsOnRefusedArchiveTest` both need `:/fonts/ttf-bitstream-vera-1.10/VeraMono.ttf`, which is only compiled into the resources when `USE_FONTS` is on. They now skip when `INCLUDE_FONTS` is undefined, exactly the way `GlyphOverflowTest` already does.

#### Motivation for adding to Mudlet

`development` is red. The `ubuntu / clang` CI job builds with `WITH_FONTS=no`, and it is the only Linux job that does not set `run_tests`, so it takes the `Run QTest` step and runs `ctest -L functional`. Since "Fix: Missing fonts fall back to the default instead of a random one" (#10134) merged, both of its new tests fail there:

```
76 - MissingDisplayFontTest (Failed)
129 - PackageFontsOnRefusedArchiveTest (Failed)
Errors while running CTest
```

Nothing is wrong with the tests themselves - they assert on fonts Mudlet ships, and that build deliberately ships none. #10134 was green on its own PR because the PR matrix does not build that configuration, and it should stay that way: the matrix is deliberately smaller to keep the CI backlog down. So the rule that has to hold instead is the one this PR follows - a functional test that needs an optional component must skip without it, rather than assume it is there.

#### Other info (issues closed, discussion etc)

Verified locally in both configurations, from the same worktree and the same sources:

- `WITH_FONTS=no` - both classes skip, suite green.
- `WITH_FONTS` on - both classes still run and pass, 18 and 5 cases respectively.
- `WITH_FONTS=no` with these two files reverted - both fail, so the guard is load-bearing rather than decorative.

One thing worth knowing when reading this, inherited from the `GlyphOverflowTest` idiom rather than introduced here: a class that skips in `initTestCase()` reports to ctest as **Passed**, not Skipped, because `QSKIP` exits 0 and no `SKIP_RETURN_CODE` is set on the functional tests. So the `ubuntu / clang` job's green does not cover these two classes. Putting a floor under that - the way `MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK` does for the media tests, so the fonts-on legs cannot skip them quietly either - is a worthwhile follow-up, but it changes behaviour on a runner I would want to observe first, so it is deliberately not in this PR.
