### PR TITLE
infra: build clang on PRs too

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -54,9 +54,9 @@ jobs:
           # Note: using / in the "buildname" has significance - replacing the
           # ',' in some of the following with a '/' seemed to cause extra
           # spurious steps in the build and broke things! - SlySven
-          # Smaller than build-mudlet.yml's on purpose - only builds that produce
-          # an artifact. 'ubuntu (x86_64)' and 'ubuntu / clang' still run there on
-          # every push to development and nightly.
+          # Smaller than build-mudlet.yml's on purpose: it leaves out
+          # 'ubuntu (x86_64)', which is the same OS, compiler and Qt as the gcc
+          # build below. That one still runs on every push to development.
           # oldest OS supported for maximum compatibility of built AppImage
           - os: ubuntu-22.04
             buildname: 'ubuntu / gcc / lua tests + leak detection'
@@ -68,6 +68,14 @@ jobs:
             # Enable AddressSanitizer for PTB and testing builds, but not release
             # builds (tagged Mudlet-*) - ASAN adds significant runtime overhead
             enable_asan: 'true'
+          # produces no artifact, but is the only configuration built without the
+          # updater, the 3D mapper and the bundled fonts, so it is the only one
+          # that can catch code depending on them before it is merged
+          - os: ubuntu-latest
+            buildname: 'ubuntu / clang'
+            compiler: clang_64
+            gcc_compiler_version: 10
+            qt: '6.11.1'
           - os: macos-15-intel
             buildname: 'macos (x86_64) / c++, lua tests'
             compiler: clang_64


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds the `ubuntu / clang` job to the pull request build matrix. The entry is byte-identical to the one in `build-mudlet.yml`, and every step that job would otherwise reach is already gated on `deploy` or `run_tests`, so no other change to the workflow is needed.

#### Motivation for adding to Mudlet

`ubuntu / clang` is the only configuration built without the updater, the 3D mapper and the bundled fonts. It ran on pushes to `development` and nightly, but not on PRs - so code that quietly depended on an optional component went red *after* merging rather than before.

That is exactly what just happened: "Fix: Missing fonts fall back to the default instead of a random one" (#10134) was green on its own PR, then turned `development` red on merge because its two new tests need fonts that this configuration does not build. Its fix is #10254, which this one is stacked on.

Enabling it also activates the `Run QTest` step, which today is dead in this workflow - it is conditioned on `run_tests != 'true'` and all three existing entries set `run_tests: 'true'`.

#### Other info (issues closed, discussion etc)

Stacked on #10254, and pointed at its branch rather than `development`, because merging this one alone would turn every open PR red until that fix lands. Please merge them in order.

Cost is one more Linux job per PR. It warms from the `development` ccache - the PR restore-key prefix `ccache-ubuntu-latest-…-6.11.1` prefix-matches the key that workflow already writes - so it should not be a cold build. `cleanup-caches.yml`'s comment already budgets for four build jobs, which this makes accurate rather than optimistic.

I checked the rest of the suite before enabling the job: the other functional tests that touch fonts do not assert that a bundled family registered (`CommandLineScrollRangeTest` asserts scroll range, which holds under Qt's substitution; `MapSymbolFontTest` takes whatever `getAvailableFonts()` returns), so this should not surface anything beyond what the stacked fix already handles.
