### PR TITLE
Fix: Lua's unzip() works again on official builds

### DIFF
--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -38,10 +38,51 @@ function unzip( what, dest )
     return
   end
 
+  -- Two different libraries answer to the global `zip`: Mudlet loads lua-zip
+  -- (brimworks) first and only falls back to luazip (Kepler) on builds where
+  -- brimworks is missing (see TLuaInterpreter.cpp). They enumerate an archive
+  -- differently - brimworks counts entries with get_num_files() and describes
+  -- each one with stat(i), indexed from 1, while Kepler hands back an iterator
+  -- from files() - so walk whichever one actually loaded. Both yield the same
+  -- {filename, uncompressed_size} shape the rest of this function expects.
+  local function entries()
+    if type( z.get_num_files ) == "function" then
+      local index, count = 0, z:get_num_files()
+      return function()
+        index = index + 1
+        if index > count then
+          return nil
+        end
+        local info = z:stat( index )
+        return { filename = info.name, uncompressed_size = info.size }
+      end
+    end
+    return z:files()
+  end
+
+  -- brimworks' entry:read() wants a byte count and rejects io.read's "*a" with
+  -- "number expected, got string"; reading in fixed chunks until one comes back
+  -- empty is understood by both libraries.
+  local function readEntry( filename )
+    local _f = z:open( filename )
+    if not _f then
+      return ""
+    end
+    local chunks = {}
+    while true do
+      local chunk = _f:read( 1024 * 1024 )
+      if not chunk or chunk == "" then
+        break
+      end
+      chunks[#chunks + 1] = chunk
+    end
+    _f:close()
+    return table.concat( chunks )
+  end
+
   local createdDirs = {}
-  for file in z:files() do
-    local _f, err = z:open( file.filename )
-    local _data = _f:read("*a")
+  for file in entries() do
+    local _data = readEntry( file.filename )
     local _path = dest .. file.filename
     local _dir = string.split( file.filename, '/' )
     local created = dest;
@@ -61,7 +102,6 @@ function unzip( what, dest )
         end
       end
     end
-    local _path = dest .. file.filename
     if file.uncompressed_size > 0 then
       local out = io.open( _path, "wb" )
       if out then
@@ -72,7 +112,6 @@ function unzip( what, dest )
         cecho("<red>ERROR: can't write file:" .. _path .. "\n")
       end
     end
-    _f:close();
   end
   z:close()
 end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -66,7 +66,7 @@ function unzip( what, dest )
   local function readEntry( filename )
     local _f = z:open( filename )
     if not _f then
-      return ""
+      return nil
     end
     local chunks = {}
     while true do
@@ -103,13 +103,17 @@ function unzip( what, dest )
       end
     end
     if file.uncompressed_size > 0 then
-      local out = io.open( _path, "wb" )
-      if out then
-        -- cecho("<green>unpacking file:".._path.."\n")
-        out:write( _data )
-        out:close()
+      if not _data then
+        cecho("<red>ERROR: can't read archived file:" .. file.filename .. "\n")
       else
-        cecho("<red>ERROR: can't write file:" .. _path .. "\n")
+        local out = io.open( _path, "wb" )
+        if out then
+          -- cecho("<green>unpacking file:".._path.."\n")
+          out:write( _data )
+          out:close()
+        else
+          cecho("<red>ERROR: can't write file:" .. _path .. "\n")
+        end
       end
     end
   end

--- a/src/mudlet-lua/tests/LuaGlobal_spec.lua
+++ b/src/mudlet-lua/tests/LuaGlobal_spec.lua
@@ -1,0 +1,114 @@
+-- Specs for the globals defined in lua/LuaGlobal.lua.
+
+local specDirectory = debug.getinfo(1, "S").source:match("^@(.*)[/\\]")
+assert(specDirectory, "LuaGlobal_spec.lua has to be run from a file so that it can find its fixtures")
+local fixtureDirectory = specDirectory .. "/fixtures/packages"
+
+-- lfs.rmdir only removes empty folders, so take the tree unzip() wrote apart
+-- from the leaves up. Names are gathered before anything is removed so the
+-- directory is not mutated while lfs.dir is still walking it.
+local function removeTree(path)
+  local mode = lfs.attributes(path, "mode")
+  if not mode then
+    return
+  end
+  if mode == "directory" then
+    local names = {}
+    for entry in lfs.dir(path) do
+      if entry ~= "." and entry ~= ".." then
+        names[#names + 1] = entry
+      end
+    end
+    for _, name in ipairs(names) do
+      removeTree(path .. "/" .. name)
+    end
+    lfs.rmdir(path)
+  else
+    os.remove(path)
+  end
+end
+
+local function fileContents(path)
+  local handle = io.open(path, "rb")
+  if not handle then
+    return nil
+  end
+  local contents = handle:read("*a")
+  handle:close()
+  return contents
+end
+
+describe("Tests the functionality of unzip", function()
+  -- unzip() drives whichever zip library Mudlet preloaded as the global `zip`:
+  -- lua-zip (brimworks) on every official build, luazip (Kepler) on the dev
+  -- builds that fall back to it (see TLuaInterpreter.cpp). Both have to unpack
+  -- the same tree, so this runs against the real module rather than a mock. The
+  -- resources fixture is used because it carries a nested folder as well as
+  -- top-level files, so one extraction exercises both the directory and the
+  -- file paths through the function.
+  local archivePath = fixtureDirectory .. "/mudlet-spec-resources.mpackage"
+  -- unzip() joins dest and each entry name as-is, so dest ends in a separator -
+  -- the documented "/tmp/out/" calling shape. The folder is not named
+  -- mudlet-spec-* so it does not trip Package_spec's leftover-folder guard if a
+  -- teardown ever fails to run.
+  local destinationRoot = getMudletHomeDir() .. "/busted-unzip-spec"
+  local destination = destinationRoot .. "/"
+
+  setup(function()
+    -- a nil zip module is a broken environment, not a reason the assertions
+    -- below should quietly pass; lua-zip is a required rock on every platform
+    -- the suite runs on
+    assert.is_table(zip, "the zip module is missing, so unzip() cannot run")
+    removeTree(destinationRoot)
+    -- unzip() writes into dest but does not create dest itself
+    lfs.mkdir(destinationRoot)
+    -- With the pre-fix body this raises under brimworks ("attempt to call
+    -- method 'files'"), failing every spec in the block; the point of the fix is
+    -- that it now returns having written the tree out.
+    unzip(archivePath, destination)
+  end)
+
+  teardown(function()
+    removeTree(destinationRoot)
+  end)
+
+  it("extracts the archive's top-level files", function()
+    assert.is_not_nil(lfs.attributes(destination .. "config.lua", "mode"), "config.lua was not extracted")
+    assert.is_not_nil(lfs.attributes(destination .. "mudlet-spec-resources.xml", "mode"), "the package XML was not extracted")
+  end)
+
+  it("recreates the archive's nested folders and their files", function()
+    assert.equals("directory", lfs.attributes(destination .. "resources", "mode"))
+    assert.equals("directory", lfs.attributes(destination .. "resources/nested", "mode"))
+    assert.is_not_nil(lfs.attributes(destination .. "resources/spec-note.txt", "mode"), "resources/spec-note.txt was not extracted")
+    assert.is_not_nil(lfs.attributes(destination .. "resources/nested/spec-nested.txt", "mode"), "the nested file was not extracted")
+  end)
+
+  it("writes each entry's contents out", function()
+    local note = fileContents(destination .. "resources/spec-note.txt")
+    assert.is_string(note)
+    assert.is_not_nil(note:find("mudlet-spec-resources fixture resource", 1, true), tostring(note))
+    local nested = fileContents(destination .. "resources/nested/spec-nested.txt")
+    assert.is_string(nested)
+    assert.is_not_nil(nested:find("in a nested folder", 1, true), tostring(nested))
+  end)
+end)
+
+describe("Tests unzip on an archive that cannot be opened", function()
+  local destinationRoot = getMudletHomeDir() .. "/busted-unzip-missing"
+  local destination = destinationRoot .. "/"
+
+  teardown(function()
+    removeTree(destinationRoot)
+  end)
+
+  it("returns without raising when the archive is not there", function()
+    -- zip.open() answers nil + message for a missing file, so unzip() prints the
+    -- error and returns early. This is the path that hid the brimworks breakage
+    -- for years: a missing archive never reaches the files()/read("*a") idioms
+    -- that only Kepler understands, so the function looked like it merely failed
+    -- quietly rather than raising on every real archive.
+    local ok = pcall(unzip, fixtureDirectory .. "/mudlet-spec-there-is-no-such-archive.mpackage", destination)
+    assert.is_true(ok, "unzip() raised on a missing archive instead of returning quietly")
+  end)
+end)


### PR DESCRIPTION

#### Brief overview of PR changes/additions
- Port the Lua `unzip()` loop to the brimworks lua-zip API that official builds load, while keeping the Kepler luazip path working (TLuaInterpreter tries brimworks first and falls back to luazip).
- Add `LuaGlobal_spec.lua` covering `unzip()` against the committed fixture archives.

#### Motivation for adding to Mudlet
Technical: `unzip()` errors on every official build since 4.8.0 with `attempt to call method 'files' (a nil value)`. Personal: Small thank you for the platform.

#### Other info (issues closed, discussion etc)
Closes #10184

Test case: Reproduced the failure on an official 4.22.0 install (`unzip()` → `attempt to call method 'files' (a nil value)` at LuaGlobal line 42); with this patch the same command extracts a 2-entry zip including a nested folder, contents byte-identical to the archive. The new `LuaGlobal_spec.lua` runs in CI, which installs lua-zip.

Assisted-by: Claude:claude-opus-5
