### PR TITLE
Infra: Spelling functions no longer crash without a main window

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -86,6 +86,13 @@ int luaopen_yajl(lua_State*);
 }
 
 
+// A Host outlives its main console: closing a profile's window destroys the view
+// while triggers, the buffer, logging and Lua all keep running. The live
+// Hunspell handles and the user dictionary's word set belong to that view, so
+// the spelling functions have to report this rather than dereference what is
+// gone.
+static const char* no_main_window_value = "the profile has no main window";
+
 // No documentation available in wiki - internal function
 static bool isMain(const QString& name)
 {
@@ -7147,6 +7154,9 @@ int TLuaInterpreter::addWordToDictionary(lua_State* L)
     }
 
     const QString text = getVerifiedString(L, __func__, 1, "word");
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     QPair<bool, QString> const result = host.mpConsole->addWordToSet(text);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
@@ -7167,6 +7177,9 @@ int TLuaInterpreter::removeWordFromDictionary(lua_State* L)
     }
 
     const QString text = getVerifiedString(L, __func__, 1, "word");
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     QPair<bool, QString> const result = host.mpConsole->removeWordFromSet(text);
     if (!result.first) {
         return warnArgumentValue(L, __func__, result.second.toUtf8().constData());
@@ -7196,6 +7209,9 @@ int TLuaInterpreter::spellCheckWord(lua_State* L)
     }
     const QString text{lua_tostring(L, 1)};
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     Hunhandle* handle = nullptr;
     QByteArray encodedText;
     if (useUserDictionary) {
@@ -7235,6 +7251,9 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
     }
     const QString text{lua_tostring(L, 1)};
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     char** wordList;
     size_t wordCount = 0;
     Hunhandle* handle = nullptr;
@@ -7279,6 +7298,9 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
         return warnArgumentValue(L, __func__, "no user dictionary enabled in the preferences for this profile");
     }
 
+    if (!host.mpConsole) {
+        return warnArgumentValue(L, __func__, no_main_window_value);
+    }
     // This may stall if this is accessing the shared user dictionary and that
     // is being updated by another profile, but it should eventually return...
     // We must keep a local reference/copy of the value returned because the

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -863,6 +863,52 @@ noViewReport = table.concat(noViewProblems, '; ')
         QCOMPARE(luaGlobalString(host, "noViewReport"), QString());
     }
 
+    // The Hunspell handles and the profile's word set are the view's, not the
+    // model's, so every spelling function reached through Host::mpConsole for
+    // them and took the client down with it once the window had been closed.
+    void test_spellingFunctionsReportWithNoView()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+        // Three of the five answer "no user dictionary enabled" before they ever
+        // reach the view, so without one they would report a refusal here
+        // whether the guard existed or not.
+        bool hasUserDictionary = false;
+        bool hasSharedDictionary = false;
+        host->getUserDictionaryOptions(hasUserDictionary, hasSharedDictionary);
+        QVERIFY2(hasUserDictionary, "The profile has no user dictionary, so the dictionary functions never reach the view.");
+        destroyTheView(host);
+
+        runLua(host, qsl(R"LUA(
+noViewSpellProblems = {}
+
+-- nil plus a reason naming the missing window, which is what these answer when
+-- the view holding the dictionaries has gone
+local function expectRefusal(name, ...)
+    local first, second = ...
+    if first ~= nil then
+        table.insert(noViewSpellProblems, name .. ' returned ' .. tostring(first))
+    elseif type(second) ~= 'string' or not second:find('main window', 1, true) then
+        table.insert(noViewSpellProblems, name .. ' gave the reason ' .. tostring(second))
+    end
+end
+
+expectRefusal('addWordToDictionary', addWordToDictionary('noviewword'))
+expectRefusal('removeWordFromDictionary', removeWordFromDictionary('noviewword'))
+expectRefusal('getDictionaryWordList', getDictionaryWordList())
+expectRefusal('spellCheckWord', spellCheckWord('noviewword'))
+expectRefusal('spellCheckWord user', spellCheckWord('noviewword', true))
+expectRefusal('spellSuggestWord', spellSuggestWord('noviewword'))
+expectRefusal('spellSuggestWord user', spellSuggestWord('noviewword', true))
+
+noViewSpellReport = table.concat(noViewSpellProblems, '; ')
+)LUA"));
+
+        QCOMPARE(luaGlobalString(host, "noViewSpellReport"), QString());
+    }
+
     // selectCaptureGroup() only reaches the view from inside a trigger that
     // captured something, and a selection needs a widget to live in - so with no
     // window it has to answer the -1 it already answers for a group that is not

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -872,7 +872,7 @@ noViewReport = table.concat(noViewProblems, '; ')
         auto host = mudlet::self()->getActiveHost();
         QVERIFY2(host, "No active host available for the test.");
         QVERIFY2(host->mpConsole, "The active host has no main console.");
-        // Three of the five answer "no user dictionary enabled" before they ever
+        // Five of the seven calls answer "no user dictionary enabled" before they ever
         // reach the view, so without one they would report a refusal here
         // whether the guard existed or not.
         bool hasUserDictionary = false;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- `addWordToDictionary`, `removeWordFromDictionary`, `spellCheckWord`, `spellSuggestWord` and `getDictionaryWordList` now return `nil` + "the profile has no main window" instead of segfaulting when the profile has no main console (all 7 call forms crashed before).
- New functional test drives all seven call forms in a view-less profile and pins both the `nil` and the reason string.

#### Motivation for adding to Mudlet
Part of the libmudlet split (#9011): a profile must work without a window, and these were the next unguarded console derefs of the same class #10154 removed from profile saving.

#### Other info (issues closed, discussion etc)
Same guard idiom and message as the existing view-less refusals in TLuaInterpreterUI.cpp. With a main window present the guards are no-ops; the existing specs covering all five functions stay green.

**Test case:** `ctest -R ConsoleModelExtraction` - `test_spellingFunctionsReportWithNoView` segfaults without the guards and passes with them. In a normal profile `spellCheckWord("hello")` etc. behave as before.

Assisted-by: Claude:claude-opus-5