### PR TITLE
Infra: Route MXP frame redirects through a write-only print sink

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -435,6 +435,7 @@ set(mudlet_HDRS
     TMxpTagProcessor.h
     TMxpVarTagHandler.h
     TMxpVersionTagHandler.h
+    TPrintSink.h
     TrailingWhitespaceMarker.h
     Tree.h
     TriggerHighlighter.h

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -32,6 +32,7 @@
 #include "THyperlinkCompactManager.h"
 #include "THyperlinkVisibilityManager.h"
 #include "THyperlinkSelectionManager.h"
+#include "TPrintSink.h"
 #include "TStringUtils.h"
 #include "TTextEdit.h"
 #include "UntrustedText.h"
@@ -1674,10 +1675,8 @@ void TBuffer::flushPendingDestinationContent()
     }
 
     if (mpHost->mMxpFrameManager.hasActiveDestination()) {
-        TConsole* destConsole = mpHost->mMxpFrameManager.getCurrentDestinationConsole();
-
-        if (destConsole && destConsole != mpHost->mpConsole) {
-            destConsole->printFormatted(mMudLine, mMudBuffer, mLinkStore);
+        if (TPrintSink* destSink = mpHost->mMxpFrameManager.currentDestinationSink()) {
+            destSink->printFormatted(mMudLine, mMudBuffer, mLinkStore);
             mMudLine.clear();
             mMudBuffer.clear();
         }
@@ -1727,11 +1726,10 @@ bool TBuffer::commitLine(char ch, size_t& localBufferPosition, const bool isFrom
 
     // Check if there's an active MXP DEST - route to destination frame
     if (mpHost->mMxpFrameManager.hasActiveDestination()) {
-        TConsole* destConsole = mpHost->mMxpFrameManager.getCurrentDestinationConsole();
-        if (destConsole && destConsole != mpHost->mpConsole) {
+        if (TPrintSink* destSink = mpHost->mMxpFrameManager.currentDestinationSink()) {
             flushPendingServerWrapJoin();
             if (!mMudLine.isEmpty()) {
-                destConsole->printFormatted(mMudLine, mMudBuffer, mLinkStore);
+                destSink->printFormatted(mMudLine, mMudBuffer, mLinkStore);
             }
             mMudLine.clear();
             mMudBuffer.clear();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2238,6 +2238,16 @@ void TConsole::printFormatted(const QString& text, const std::vector<TChar>& for
     }
 }
 
+void TConsole::clearSink()
+{
+    buffer.clear();
+}
+
+void TConsole::clearSinkLastLine()
+{
+    buffer.clearLastLine();
+}
+
 void TConsole::printSystemMessage(const QString& msg)
 {
     const QString txt = tr("System Message: %1").arg(msg);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2238,12 +2238,15 @@ void TConsole::printFormatted(const QString& text, const std::vector<TChar>& for
     }
 }
 
-void TConsole::clearSink()
+// Deliberately the bare buffer clear the DEST redirect has always done, not
+// TConsole::clear() - that would also reset the scrollbar, drop the selection,
+// and repaint, which the redirect never did.
+void TConsole::discardAll()
 {
     buffer.clear();
 }
 
-void TConsole::clearSinkLastLine()
+void TConsole::discardLastLine()
 {
     buffer.clearLastLine();
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -29,6 +29,7 @@
 
 #include "TBuffer.h"
 #include "TConsoleModel.h"
+#include "TPrintSink.h"
 
 #include <QDataStream>
 #include <QElapsedTimer>
@@ -159,7 +160,9 @@ class TSplitter;
 class dlgNotepad;
 
 
-class TConsole : public QWidget
+// TPrintSink is the write-only face core code redirects output to; QWidget
+// stays first so moc sees the QObject base it needs.
+class TConsole : public QWidget, public TPrintSink
 {
     Q_OBJECT
 
@@ -276,7 +279,9 @@ public:
     // The Central Debug Console keeps its find bar hidden until Ctrl+F, or
     // until its right-click menu asks for it:
     void showSearchBar();
-    void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore);
+    void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore) override;
+    void clearSink() override;
+    void clearSinkLastLine() override;
     void printSystemMessage(const QString& msg);
     void printCommand(QString&);
     bool hasSelection();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -280,8 +280,8 @@ public:
     // until its right-click menu asks for it:
     void showSearchBar();
     void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore) override;
-    void clearSink() override;
-    void clearSinkLastLine() override;
+    void discardAll() override;
+    void discardLastLine() override;
     void printSystemMessage(const QString& msg);
     void printCommand(QString&);
     bool hasSelection();

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -304,13 +304,13 @@ void TMxpFrameManager::setDestination(const QString& frameName, bool eol, bool e
 
     mCurrentDestination = frameName;
 
-    auto* console = getCurrentDestinationConsole();
+    auto* sink = currentDestinationSink();
 
-    if (console) {
+    if (sink) {
         if (eof) {
-            console->buffer.clear();
+            sink->clearSink();
         } else if (eol) {
-            console->buffer.clearLastLine();
+            sink->clearSinkLastLine();
         }
     }
 }
@@ -330,14 +330,23 @@ QWidget* TMxpFrameManager::getCurrentDestinationWidget() const
     return frame ? frame->widget.data() : nullptr;
 }
 
-TConsole* TMxpFrameManager::getCurrentDestinationConsole() const
+TPrintSink* TMxpFrameManager::currentDestinationSink() const
 {
     if (mCurrentDestination.isEmpty()) {
-        return qobject_cast<TConsole*>(mpHost->mpConsole);
+        return nullptr;
     }
 
     const auto* frame = getFrame(mCurrentDestination);
-    return frame ? frame->console.data() : nullptr;
+    if (!frame) {
+        return nullptr;
+    }
+
+    TConsole* console = frame->console.data();
+    if (!console || console == mpHost->mpConsole) {
+        return nullptr;
+    }
+
+    return console;
 }
 
 TMxpFrame* TMxpFrameManager::getFrame(const QString& name)

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -308,9 +308,9 @@ void TMxpFrameManager::setDestination(const QString& frameName, bool eol, bool e
 
     if (sink) {
         if (eof) {
-            sink->clearSink();
+            sink->discardAll();
         } else if (eol) {
-            sink->clearSinkLastLine();
+            sink->discardLastLine();
         }
     }
 }

--- a/src/TMxpFrameManager.h
+++ b/src/TMxpFrameManager.h
@@ -38,6 +38,7 @@
 class Host;
 class TConsole;
 class TDockWidget;
+class TPrintSink;
 
 /**
  * @brief Represents a single MXP frame for multi-window layouts.
@@ -103,7 +104,12 @@ public:
     void clearDestination();
     QString getCurrentDestination() const { return mCurrentDestination; }
     QWidget* getCurrentDestinationWidget() const;
-    TConsole* getCurrentDestinationConsole() const;
+    // Where <DEST> is redirecting output to, as a write-only sink so that the
+    // buffer translation never gets a view pointer back. Null unless a
+    // redirect is really in force: no destination set, a frame that has since
+    // gone, or a destination that resolves back to the main console - which
+    // would recurse into the very buffer being translated.
+    TPrintSink* currentDestinationSink() const;
     bool hasActiveDestination() const { return !mCurrentDestination.isEmpty(); }
     
     // Frame queries

--- a/src/TPrintSink.h
+++ b/src/TPrintSink.h
@@ -1,0 +1,55 @@
+#ifndef MUDLET_TPRINTSINK_H
+#define MUDLET_TPRINTSINK_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QString>
+
+#include <vector>
+
+class TChar;
+class TLinkStore;
+
+// A write-only text destination that core code can be handed instead of a view
+// pointer. The MXP DEST redirect resolves the frame it is writing into to one
+// of these, so the translation loop in TBuffer never holds a TConsole (#8681).
+//
+// Write-only is the whole point: nothing here reads state back, so a sink can
+// be satisfied by a TConsole widget today and by a view-less TConsoleModel
+// later without the callers changing. Keep it that way - a getter added here
+// is a coupling that the model-backed implementation would have to invent an
+// answer for.
+class TPrintSink
+{
+public:
+    virtual ~TPrintSink() = default;
+
+    // Appends text carrying its own per-character formatting. sourceLinkStore
+    // holds the links that formatting's link indices refer to; the sink remaps
+    // them into its own store, so the two must be passed together.
+    virtual void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore) = 0;
+
+    // <DEST ... EOF> empties the destination, <DEST ... EOL> discards the
+    // part-written line it would otherwise have continued.
+    virtual void clearSink() = 0;
+    virtual void clearSinkLastLine() = 0;
+};
+
+#endif // MUDLET_TPRINTSINK_H

--- a/src/TPrintSink.h
+++ b/src/TPrintSink.h
@@ -39,17 +39,32 @@ class TLinkStore;
 class TPrintSink
 {
 public:
-    virtual ~TPrintSink() = default;
-
     // Appends text carrying its own per-character formatting. sourceLinkStore
     // holds the links that formatting's link indices refer to; the sink remaps
     // them into its own store, so the two must be passed together.
+    //
+    // The line semantics every implementation must reproduce (today they live
+    // in TBuffer::appendFormatted, which the TConsole implementation defers
+    // to): the first segment continues a part-written trailing line if the
+    // sink holds one, an embedded QChar::LineFeed starts a new line, and every
+    // call with non-empty text finishes on a committed line boundary - the
+    // next call never continues this call's text. Empty text is a no-op, with
+    // no boundary committed. formatting must be the same length as text; a
+    // mismatch is tolerated (missing entries print unformatted, extras are
+    // ignored) but warns, so callers must not lean on it.
     virtual void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore) = 0;
 
-    // <DEST ... EOF> empties the destination, <DEST ... EOL> discards the
-    // part-written line it would otherwise have continued.
-    virtual void clearSink() = 0;
-    virtual void clearSinkLastLine() = 0;
+    // Empties the sink of everything it holds (<DEST ... EOF>).
+    virtual void discardAll() = 0;
+
+    // Blanks the part-written trailing line that the next printFormatted
+    // would otherwise continue (<DEST ... EOL>).
+    virtual void discardLastLine() = 0;
+
+protected:
+    // Nothing owns a sink through this interface - consoles belong to their
+    // widget parents - so deleting through it is a compile error.
+    ~TPrintSink() = default;
 };
 
 #endif // MUDLET_TPRINTSINK_H

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -244,5 +244,48 @@ describe("Tests MXP handling", function()
       assert.is_true(holds(frameLines(), "MXPDEST4 red in the frame"))
       assert.are.same(plainColour, mainColourOf("MXPDEST4 back in main"))
     end)
+
+    -- EOF on the opening tag empties the frame before the redirected text
+    -- lands, so the frame ends up holding only what this redirect wrote
+    it("empties the frame when the redirect carries EOF", function()
+      assert.is_true(feedTriggers(('<DEST %s>MXPDEST5 stale</DEST>'):format(frame) .. "\n"))
+      -- the state EOF is meant to undo, so a frame that was empty anyway
+      -- cannot pass this by accident
+      assert.is_true(holds(frameLines(), "MXPDEST5 stale"))
+
+      assert.is_true(feedTriggers(('<DEST %s EOF>MXPDEST6 fresh</DEST>'):format(frame) .. "\n"))
+      local shown = table.concat(frameLines(), "|")
+      assert.is_false(holds(frameLines(), "MXPDEST5 stale"), shown)
+      assert.is_true(holds(frameLines(), "MXPDEST6 fresh"), shown)
+    end)
+
+    -- EOL discards the part-written line the frame was left sitting on rather
+    -- than continuing it. A redirect closes its own last line, so the open
+    -- line has to come from elsewhere - an echo into the frame leaves one the
+    -- way a game writing a partial line into the frame would.
+    it("drops the frame's unfinished line when the redirect carries EOL", function()
+      echo(frame, "MXPDEST7 unfinished")
+      assert.is_true(holds(frameLines(), "MXPDEST7 unfinished"))
+
+      assert.is_true(feedTriggers(('<DEST %s EOL>MXPDEST8 after</DEST>'):format(frame) .. "\n"))
+      local shown = table.concat(frameLines(), "|")
+      -- without the clear the redirect continues that line instead, so the
+      -- needle survives as the head of a joined-up line
+      assert.is_false(holds(frameLines(), "MXPDEST7 unfinished"), shown)
+      assert.is_true(holds(frameLines(), "MXPDEST8 after"), shown)
+    end)
+
+    -- EOL is the narrower of the two: it must leave the finished lines above
+    -- the open one where they are, which is what tells it apart from EOF
+    it("keeps the frame's finished lines when the redirect carries EOL", function()
+      assert.is_true(feedTriggers(('<DEST %s>MXPDEST9 kept</DEST>'):format(frame) .. "\n"))
+      echo(frame, "MXPDEST10 unfinished")
+      assert.is_true(holds(frameLines(), "MXPDEST9 kept"))
+
+      assert.is_true(feedTriggers(('<DEST %s EOL>MXPDEST11 after</DEST>'):format(frame) .. "\n"))
+      local shown = table.concat(frameLines(), "|")
+      assert.is_true(holds(frameLines(), "MXPDEST9 kept"), shown)
+      assert.is_false(holds(frameLines(), "MXPDEST10 unfinished"), shown)
+    end)
   end)
 end)

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -252,11 +252,14 @@ describe("Tests MXP handling", function()
       -- the state EOF is meant to undo, so a frame that was empty anyway
       -- cannot pass this by accident
       assert.is_true(holds(frameLines(), "MXPDEST5 stale"))
+      assert.is_true(feedTriggers("MXPDEST12 anchored in main\n"))
 
       assert.is_true(feedTriggers(('<DEST %s EOF>MXPDEST6 fresh</DEST>'):format(frame) .. "\n"))
       local shown = table.concat(frameLines(), "|")
       assert.is_false(holds(frameLines(), "MXPDEST5 stale"), shown)
       assert.is_true(holds(frameLines(), "MXPDEST6 fresh"), shown)
+      -- an EOF clear that overreached past the frame would take main with it
+      assert.is_true(mainRecentlyHolds("MXPDEST12 anchored in main"))
     end)
 
     -- EOL discards the part-written line the frame was left sitting on rather
@@ -266,6 +269,7 @@ describe("Tests MXP handling", function()
     it("drops the frame's unfinished line when the redirect carries EOL", function()
       echo(frame, "MXPDEST7 unfinished")
       assert.is_true(holds(frameLines(), "MXPDEST7 unfinished"))
+      assert.is_true(feedTriggers("MXPDEST13 anchored in main\n"))
 
       assert.is_true(feedTriggers(('<DEST %s EOL>MXPDEST8 after</DEST>'):format(frame) .. "\n"))
       local shown = table.concat(frameLines(), "|")
@@ -273,6 +277,7 @@ describe("Tests MXP handling", function()
       -- needle survives as the head of a joined-up line
       assert.is_false(holds(frameLines(), "MXPDEST7 unfinished"), shown)
       assert.is_true(holds(frameLines(), "MXPDEST8 after"), shown)
+      assert.is_true(mainRecentlyHolds("MXPDEST13 anchored in main"))
     end)
 
     -- EOL is the narrower of the two: it must leave the finished lines above
@@ -280,6 +285,7 @@ describe("Tests MXP handling", function()
     it("keeps the frame's finished lines when the redirect carries EOL", function()
       assert.is_true(feedTriggers(('<DEST %s>MXPDEST9 kept</DEST>'):format(frame) .. "\n"))
       echo(frame, "MXPDEST10 unfinished")
+      assert.is_true(holds(frameLines(), "MXPDEST10 unfinished"))
       assert.is_true(holds(frameLines(), "MXPDEST9 kept"))
 
       assert.is_true(feedTriggers(('<DEST %s EOL>MXPDEST11 after</DEST>'):format(frame) .. "\n"))


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- New `TPrintSink` interface (`printFormatted` / `discardAll` / `discardLastLine`); `TConsole` implements it
- The MXP `<DEST>` redirect in `TBuffer` and `TMxpFrameManager` now resolves a sink instead of a raw `TConsole*`; `getCurrentDestinationConsole()` is deleted
- Three new specs pin the previously untested `<DEST EOF>` / `<DEST EOL>` frame clears, including that a clear leaves the main window alone

#### Motivation for adding to Mudlet
Part of #8681: core text translation must not name the view, so a view-less console model can satisfy the same seam later.

#### Other info (issues closed, discussion etc)
- Behavior-preserving: every null-sink path maps 1:1 to the old `destConsole && destConsole != mpConsole` guard. The two semantic deltas (an empty frame name resolves to null instead of the main console; the EOF/EOL clear now also excludes a frame aliasing the main console) are unreachable from every caller.
- Every new spec proven red first: 8 production-wire cuts, each reddening a named spec, plus two overreaching-clear sabotages caught only by the new main-window assertions.
- 3816/0 busted specs, 148/148 ctest, widgets-audit count unchanged.

**Test case:** run the MXP specs, or feed `<DEST frame EOF>text</DEST>` / `<DEST frame EOL>text</DEST>` from a game: the frame empties (EOF) or drops only its unfinished line (EOL) exactly as before, and the main window is untouched.

Assisted-by: Claude:claude-opus-5