### PR TITLE
Infra: Stop FramePacingTest failing CI at random

### DIFF
--- a/test/functional_tests/FramePacingTest.cpp
+++ b/test/functional_tests/FramePacingTest.cpp
@@ -180,23 +180,24 @@ private slots:
         QVERIFY2(mPaintCount > 0, "repaint() delivered no paint event, so the pacer's cooldown never started and nothing below is inside a pacing window");
 
         QSignalSpy pacerFired(pane->mpPaintPacer, &QTimer::timeout);
-        QElapsedTimer sinceRepaint;
-        sinceRepaint.start();
         mPaintCount = 0;
         console->print(qsl("trailing line\n"));
 
-        // Read after the print, so this is an upper bound on how late scheduleUpdate()
-        // ran inside it. Under the bound the print was certainly inside the cooldown
-        // and the frame owed deferral; over it the pane was entitled to paint at once,
-        // and asserting deferral anyway would be the same wall-clock trap the flood
-        // half above was just fixed for - one preemption longer than a window and a
-        // healthy pane fails.
-        const qint64 sinceRepaintMs = sinceRepaint.elapsed();
-        const bool printLandedInsideTheCooldown = sinceRepaintMs < TTextEdit::csmPaintPaceMs;
+        // The clock scheduleUpdate() itself consults, read just after the print: it
+        // overshoots what that call saw by the print's tail alone, well under a
+        // millisecond, and leaves the paint's own duration out of the reckoning
+        // entirely. Under the bound the print certainly landed inside the cooldown
+        // and the frame owed deferral; over it the pane may already have been
+        // entitled to paint at once, and asserting deferral anyway would be the
+        // wall-clock trap the flood half above guards against. Sound only while
+        // nothing inside print() paints synchronously, which is what the isActive()
+        // check below already rests on.
+        const qint64 paneCooldownMs = pane->mSincePaint.elapsed();
+        const bool printLandedInsideTheCooldown = paneCooldownMs < TTextEdit::csmPaintPaceMs;
         if (printLandedInsideTheCooldown) {
             QVERIFY2(pane->mpPaintPacer->isActive(), "the print inside the cooldown did not hold a frame back, so frames are not being deferred at all");
         } else {
-            qWarning() << "the print landed" << sinceRepaintMs << "ms after the paint, past the" << TTextEdit::csmPaintPaceMs << "ms cooldown - deferral not exercised this run";
+            qWarning() << "the print landed" << paneCooldownMs << "ms after the paint began, past the" << TTextEdit::csmPaintPaceMs << "ms cooldown - deferral not exercised this run";
         }
 
         QVERIFY2(QTest::qWaitFor(

--- a/test/functional_tests/FramePacingTest.cpp
+++ b/test/functional_tests/FramePacingTest.cpp
@@ -17,7 +17,6 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <QElapsedTimer>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 #include <chrono>
@@ -40,11 +39,25 @@ using namespace std::chrono_literals;
 // the receive loop, so a flood of small packets - a GMCP speedwalk sends one
 // room description per packet - spent a whole frame between every two packets
 // it could have spent reading. TTextEdit::scheduleUpdate() caps the paints at
-// one per 16ms instead, so several packets share a frame.
+// one per csmPaintPaceMs instead, so several packets share a frame.
 //
-// Both halves of that have to hold. Batching without a trailing frame would
-// leave the last packet of a burst unpainted until something else happened to
-// repaint the pane, which is far worse than the cost it saves.
+// What this covers is the seam that does the capping: output arriving inside the
+// cooldown has to arm the pacer rather than paint at once, and the frame it held
+// back has to arrive on its own afterwards. Batching without that trailing frame
+// would leave the last packet of a burst unpainted until something else happened
+// to repaint the pane, which is far worse than the cost it saves.
+//
+// Counting frames across a packet flood and dividing by the pacing window was
+// tried here and removed, so it is worth saying why rather than leaving the next
+// reader to reinvent it. A paced pane owes one frame per window it spends, so the
+// bound can only be the window count - and that count grows with runner load
+// until it reaches the packet count, past which a pane painting once per packet
+// clears the bound too. The flood spanned 3 windows unloaded and was seen at 10
+// on CI against the 17 that makes the bound vacuous, so it was well on its way to
+// asserting nothing on precisely the machines it ran on. It is not a loss: print()
+// reaches the pane through showNewLines() exactly as socket data does, so a pane
+// that paints per packet never arms the pacer and fails the check below - which
+// needs no wall clock to decide whether it holds.
 class FramePacingTest : public QObject
 {
     Q_OBJECT
@@ -59,20 +72,6 @@ private:
 
     QObject* mpWatchedPane = nullptr;
     int mPaintCount = 0;
-
-    // One line per packet, small enough that the cost is the paint and not the
-    // text. The gap has to stay well under csmPaintPaceMs: at a whole window per
-    // packet a perfect pacer and a broken one both draw one frame per packet, and
-    // the assertion below degrades to the warning it prints for that case.
-    static constexpr int csmBatchCount = 20;
-    static constexpr int csmBatchGapMs = 2;
-
-    // A window is measured from the last paint rather than off a fixed grid -
-    // paintEvent() restarts the pacer's clock - so paced paints are always at least
-    // csmPaintPaceMs apart and the +1 on the window count is exact whatever the
-    // phase. This covers what that count cannot see: an expose or resize repaint
-    // lands without the pacer gating it. Two rather than one is plain margin.
-    static constexpr int csmPaintSlack = 2;
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override
@@ -112,7 +111,7 @@ private slots:
         deleteProfileDirectory(mpHostname);
     }
 
-    void test_aFloodOfPacketsSharesFramesAndStillPaintsTheLastOne()
+    void test_aPrintInsideTheCooldownHoldsAFrameBackAndStillGetsPainted()
     {
         mpServer->setWelcomeMessage(qsl("hello\r\n"));
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -131,74 +130,44 @@ private slots:
         mpWatchedPane = pane;
         pane->installEventFilter(this);
 
-        mPaintCount = 0;
-        QElapsedTimer floodTimer;
-        floodTimer.start();
-        for (int i = 0; i < csmBatchCount; ++i) {
-            mpServer->sendRaw(qsl("line %1\r\n").arg(i).toUtf8());
-            QTest::qWait(csmBatchGapMs);
-        }
-        const int paintsDuringFlood = mPaintCount;
-        const qint64 floodMs = floodTimer.elapsed();
-
-        QTest::qWait(200ms);
-        QVERIFY2(waitForTextInBuffer(qsl("line %1").arg(csmBatchCount - 1)), "the flood never reached the buffer, so nothing was being paced");
-        QVERIFY2(paintsDuringFlood > 0, "the pane painted nothing at all during the flood, so this test cannot tell pacing from a dead harness");
-
-        // What a paced pane owes is one frame per window it spent, so that is what the
-        // count has to be measured against. Measuring it against a share of the packet
-        // count instead holds only while qWait() sleeps for about the gap it is asked
-        // for: on a loaded runner it sleeps several times that, and the flood that spans
-        // 3 windows here stretched to 10 on CI, where a perfectly paced pane drew the 10
-        // frames it owed and was failed for it. An unpaced pane is still caught while the
-        // flood stays inside far fewer windows than it sent packets, which is what the
-        // warning below checks.
-        const int windowsSpanned = static_cast<int>(floodMs / TTextEdit::csmPaintPaceMs) + 1;
-
-        // The bound is worth asserting even in that case, so it stays outside the
-        // branch - it just stops telling a paced pane from an unpaced one once the
-        // runner is slow enough that windowsSpanned + csmPaintSlack reaches the
-        // packet count.
-        if (windowsSpanned + csmPaintSlack >= csmBatchCount) {
-            qWarning() << "flood of" << csmBatchCount << "packets took" << floodMs << "ms, about a pacing window each - pacing is not being told apart from scheduler jitter this run";
-        }
-        QVERIFY2(paintsDuringFlood <= windowsSpanned + csmPaintSlack,
-                 qPrintable(qsl("%1 packets over %2ms spanned %3 pacing windows but drew %4 frames - the pane is painting per packet rather than per pacing window")
-                                    .arg(csmBatchCount)
-                                    .arg(floodMs)
-                                    .arg(windowsSpanned)
-                                    .arg(paintsDuringFlood)));
-
         // Whatever arrives while a frame is still being held back has to be painted
-        // when that frame lands. Reaching that case means printing inside the 16ms
-        // cooldown a paint just started, so repaint() lands one synchronously and the print
-        // follows without returning to the event loop - waiting for a paint instead
-        // lets the window lapse, and the print then takes the immediate path and
-        // never exercises deferral at all.
+        // when that frame lands. Reaching that case means printing inside the
+        // cooldown a paint just started, so repaint() lands one synchronously and the
+        // print follows without returning to the event loop - waiting for a paint
+        // instead lets the window lapse, and the print then takes the immediate path
+        // and never exercises deferral at all. The paint also leaves the pane clean
+        // for what follows: it covers the whole widget, so paintEvent() empties any
+        // pending region and stops a pacer that was already armed.
         mPaintCount = 0;
         pane->repaint();
         QVERIFY2(mPaintCount > 0, "repaint() delivered no paint event, so the pacer's cooldown never started and nothing below is inside a pacing window");
 
         QSignalSpy pacerFired(pane->mpPaintPacer, &QTimer::timeout);
         mPaintCount = 0;
+
+        // The pane's clock starts at paintEvent() entry, so the paint's own duration
+        // is already spent by the time repaint() returns - a full-pane paint of this
+        // console on a loaded runner can eat the whole window on its own and leave the
+        // print outside the very cooldown it is here to test. Restarting the clock
+        // immediately before the print opens the window by construction, so deferral
+        // is exercised every run rather than whenever the runner happened to be quick.
+        pane->mSincePaint.restart();
         console->print(qsl("trailing line\n"));
 
-        // The clock scheduleUpdate() itself consults, read just after the print: it
-        // overshoots what that call saw by the print's tail alone, well under a
-        // millisecond, and leaves the paint's own duration out of the reckoning
-        // entirely. Under the bound the print certainly landed inside the cooldown
-        // and the frame owed deferral; over it the pane may already have been
-        // entitled to paint at once, and asserting deferral anyway would be the
-        // wall-clock trap the flood half above guards against. Sound only while
-        // nothing inside print() paints synchronously, which is what the isActive()
-        // check below already rests on.
+        // The same clock scheduleUpdate() just consulted, so it cannot disagree with
+        // what that call saw by more than the print's own tail. print() appends one
+        // line and paints nothing synchronously - which is what the isActive() check
+        // below already rests on - so the window closing inside it means the process
+        // lost the CPU for a whole frame mid-print, and nothing below would be
+        // measuring the pacer any more.
         const qint64 paneCooldownMs = pane->mSincePaint.elapsed();
-        const bool printLandedInsideTheCooldown = paneCooldownMs < TTextEdit::csmPaintPaceMs;
-        if (printLandedInsideTheCooldown) {
-            QVERIFY2(pane->mpPaintPacer->isActive(), "the print inside the cooldown did not hold a frame back, so frames are not being deferred at all");
-        } else {
-            qWarning() << "the print landed" << paneCooldownMs << "ms after the paint began, past the" << TTextEdit::csmPaintPaceMs << "ms cooldown - deferral not exercised this run";
+        if (paneCooldownMs >= TTextEdit::csmPaintPaceMs) {
+            QSKIP(qPrintable(qsl("the print itself took %1ms, past the %2ms cooldown it had to land inside - the runner stalled mid-print, so deferral was not exercised")
+                                     .arg(paneCooldownMs)
+                                     .arg(TTextEdit::csmPaintPaceMs)));
         }
+
+        QVERIFY2(pane->mpPaintPacer->isActive(), "the print inside the cooldown did not hold a frame back, so frames are not being deferred at all");
 
         QVERIFY2(QTest::qWaitFor(
                          [this]() {
@@ -213,9 +182,7 @@ private slots:
         // still cannot see a timeout handler that fires and paints nothing; telling
         // that apart would need a deadline between the two repaints, which is the
         // wall-clock trap this test was flaky for in the first place.
-        if (printLandedInsideTheCooldown) {
-            QVERIFY2(pacerFired.count() == 1, "the pacer armed a frame and then never fired, so the held-back line waits on an unrelated repaint to appear");
-        }
+        QVERIFY2(pacerFired.count() == 1, "the pacer armed a frame and then never fired, so the held-back line waits on an unrelated repaint to appear");
     }
 
 private:


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- FramePacingTest's deferral guard now reads the pane's own cooldown clock (through the existing test friendship) instead of a wall-clock timer started around `repaint()`. The old timer started after `repaint()` returned, so it missed the paint's own duration and could read a print as "inside the cooldown" that `scheduleUpdate()` had already seen as outside it - failing the assert on a slow paint.
- It also restarts that clock immediately before the print, so the cooldown window is open by construction. `mSincePaint` starts at `paintEvent` entry, so a full-pane paint of this console can spend the whole window before `print()` is even reached, and the run then stood both asserts down. Only the print's own duration is slop now.
- The packet-flood half is removed. Its bound was frames-drawn <= windows-spanned, and the window count climbs with runner load until it reaches the packet count - past which a pane painting once per packet clears the bound too. Unloaded the flood spans 3 windows; CI was already seen at 10, against the 17 that makes the assert vacuous.
- The one remaining escape hatch is a `QSKIP` rather than a `qWarning`, so a run that measured nothing no longer reads as a pass that checked something.

#### Motivation for adding to Mudlet

The pacing assertion (added in #10247's deflake of #10195's test) still failed CI intermittently on loaded macOS runners.

Looking at why, the bigger problem was the other direction: both halves were written to stand down rather than fail when the runner was slow, and they did so silently. `ctest` runs with `--output-on-failure`, so those "not exercised this run" warnings never appear on a passing run - there was no way to tell a green FramePacingTest that checked the pacer from one that checked nothing.

Removing the flood half rather than retuning it is not a loss of coverage: `print()` reaches the pane through `showNewLines()` exactly as socket data does, so a pane that paints per packet never arms the pacer and fails the deferral check - which needs no wall clock to decide whether it holds.

#### Other info (issues closed, discussion etc)

Originally seen failing on an unrelated PR's macOS x86_64 job (run 33276508251).

**Test case:** `ctest -R FramePacingTest` in a build tree. Verified on `linux-debug-nosan`, with a 20ms sleep injected at `paintEvent` entry to stand in for a loaded runner:

- *Before* (this branch's previous commit), under the slow paint: `Totals: 3 passed, 0 failed, 0 skipped` - fully green while both halves stood down, logging `flood of 20 packets took 461 ms, about a pacing window each` and `the print landed 24 ms after the paint began, past the 16 ms cooldown - deferral not exercised this run`. Neither assert ran.
- *After*, under the same slow paint: `Totals: 3 passed, 0 failed, 0 skipped`, with the deferral assert actually executing.
- Forcing `scheduleUpdate()` down its immediate path (an unpaced pane) turns the trimmed test red on the intended assertion: `'pane->mpPaintPacer->isActive()' returned FALSE (the print inside the cooldown did not hold a frame back...)`.
- 5/5 consecutive clean runs, and all 31 tests in the shared `functional_window_tests` group still pass. Runtime drops from ~1.6s to ~0.77s.

Assisted-by: Claude:claude-opus-5