### PR TITLE
Infra: stop CodeQL and a shared key evicting the build caches

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -333,11 +333,6 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ${{runner.workspace}}/ccache
-        # Two ubuntu-22.04 legs agree on every other part of this key and only
-        # one builds with -DUSE_SANITIZER=Address, so the asan/plain segment is
-        # what stops them sharing an entry and overwriting each other's objects.
-        # It repeats that flag's condition rather than reading enable_asan alone
-        # so that a tagged build, which drops the sanitizer, keys as plain.
         key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}-${{ github.sha }}
         restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}
 

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -333,8 +333,13 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ github.sha }}
-        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}
+        # Two ubuntu-22.04 legs agree on every other part of this key and only
+        # one builds with -DUSE_SANITIZER=Address, so the asan/plain segment is
+        # what stops them sharing an entry and overwriting each other's objects.
+        # It repeats that flag's condition rather than reading enable_asan alone
+        # so that a tagged build, which drops the sanitizer, keys as plain.
+        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}-${{ github.sha }}
+        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -323,11 +323,6 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ${{runner.workspace}}/ccache
-        # Two ubuntu-22.04 legs agree on every other part of this key and only
-        # one builds with -DUSE_SANITIZER=Address, so the asan/plain segment is
-        # what stops them sharing an entry and overwriting each other's objects.
-        # It repeats that flag's condition rather than reading enable_asan alone
-        # so that a tagged build, which drops the sanitizer, keys as plain.
         key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}-${{ github.ref_name }}
         restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}-development
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -323,8 +323,13 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ github.ref_name }}
-        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-development
+        # Two ubuntu-22.04 legs agree on every other part of this key and only
+        # one builds with -DUSE_SANITIZER=Address, so the asan/plain segment is
+        # what stops them sharing an entry and overwriting each other's objects.
+        # It repeats that flag's condition rather than reading enable_asan alone
+        # so that a tagged build, which drops the sanitizer, keys as plain.
+        key: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}-${{ github.ref_name }}
+        restore-keys: ccache-${{matrix.os}}-${{runner.arch}}-${{matrix.compiler}}${{matrix.gcc_compiler_version != '' && format('v{0}', matrix.gcc_compiler_version) || ''}}-${{matrix.qt}}-${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'asan' || 'plain' }}-development
 
     - name: (Linux) Set build info
       if: runner.os == 'Linux'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -100,10 +100,6 @@ jobs:
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
-        # 1.5GB per commit, and this runs on every push to development, so it
-        # held 59% of the repository's 10GB quota and evicted the branch ccache
-        # entries a cold build costs 20 minutes to rebuild. It only pays off
-        # when a run reuses an earlier commit's extraction, which these do not.
         trap-caching: false
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -100,6 +100,11 @@ jobs:
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
+        # 1.5GB per commit, and this runs on every push to development, so it
+        # held 59% of the repository's 10GB quota and evicted the branch ccache
+        # entries a cold build costs 20 minutes to rebuild. It only pays off
+        # when a run reuses an earlier commit's extraction, which these do not.
+        trap-caching: false
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `trap-caching: false` on CodeQL init - its TRAP cache held 3.16GB of the repo's 10GB Actions cache quota.
- An `asan`/`plain` segment in the ccache key - the two ubuntu-22.04 legs shared one key and overwrote each other every run.

#### Motivation for adding to Mudlet

The repo sits at 10.11GB, so LRU keeps evicting ccache entries that cost 20 minutes each to rebuild. PR hit rate medians had fallen to Windows 61.3% (was 98.8%) and Ubuntu 17.2% (was 82%), swinging 0-98% run to run.

#### Other info (issues closed, discussion etc)

Follows #9905 (infrastructure: stop the development ccache from going stale), which fixed branch saves but not this. codeql-action v4.37.8 recommends `trap-caching: false` itself.

First run after merge is a cold build everywhere. **Then ~5GB of dead cache needs deleting** - `trap-caching: false` also disables the action's own janitor, and `cleanup-caches.yml` only matches keys ending in a SHA. Swap `.id` for `.key` to list them first:

```bash
gh api "repos/Mudlet/Mudlet/actions/caches?per_page=100" --jq \
  '.actions_caches[] | select(.key | test("^codeql-trap-|-6\\.11\\.1-development$")) | .id' \
  | xargs -I{} gh api --method DELETE "repos/Mudlet/Mudlet/actions/caches/{}"
```

**Test case:** first push to development after merge saves 5 distinct ccache keys where there were 4 (the ubuntu legs now differing by `-asan-`/`-plain-`), and creates no `codeql-trap-*` entry.

Assisted-by: Claude:claude-opus-5
