### PR TITLE
fix: copy2decho no longer copies the wrong line's text

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2460,7 +2460,7 @@ local function copy2color(name,win,str,inst)
     return ""
   end
   local start, len = selectString(win, str, inst), utf8.len(str)
-  if not start then
+  if start < 0 then
     error(name..": string not found",3)
   end
   local style, endspan, result, r, g, b, rb, gb, bb, cr, cg, cb, crb, cgb, cbb, char

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2461,7 +2461,8 @@ local function copy2color(name,win,str,inst)
   end
   local start, len = selectString(win, str, inst), utf8.len(str)
   if start < 0 then
-    error(name..": string not found",3)
+    -- happens when the text is not on the current line, which is all selectString() searches
+    return ""
   end
   local style, endspan, result, r, g, b, rb, gb, bb, cr, cg, cb, crb, cgb, cbb, char
   local selectSection, getFgColor, getBgColor = selectSection, getFgColor, getBgColor

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -66,6 +66,28 @@ describe("Tests UI functions", function()
       assert.are.equal(testdecho, copy2decho("testconsole"))
     end)
 
+    -- #4175: selectString() only searches the current line and answers -1 for
+    -- text that is not on it, which is truthy in Lua - so the "string not found"
+    -- error never fired and characters were taken from whichever line the cursor
+    -- was on. A multiline trigger reaches this whenever it copies an earlier
+    -- line's multimatches, since it fires with the cursor on the last one.
+    it("Should not copy the current line when asked for text that is not on it", function()
+      decho("testconsole", "<0,255,0>copy4175first<r>\n")
+      decho("testconsole", "<255,0,0>copy4175second and longer<r>\n")
+
+      assert.is_true(moveCursor("testconsole", 0, 1))
+      assert.are.equal(-1, selectString("testconsole", "copy4175first", 1))
+
+      assert.is_true(moveCursor("testconsole", 0, 1))
+      local ok, err = pcall(copy2decho, "testconsole", "copy4175first")
+      assert.is_false(ok, "copy2decho returned instead of reporting the text was not found")
+      assert.is_truthy(tostring(err):find("copy2decho: string not found", 1, true),
+        "unexpected error: " .. tostring(err))
+
+      -- the cursor outlives the test and the cases below read it
+      moveCursor("testconsole", 0, 0)
+    end)
+
     -- TODO: https://github.com/Mudlet/Mudlet/issues/5589
     -- it("Should copy2decho text with italics, bold, and underline", function()
     --   local testdecho = "separate: <i>italic</i>, <b>bold</b>, <u>underline</u>. all together: <i>italic<b>bold<u>underline<r>"

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -35,9 +35,12 @@ describe("Tests UI functions", function()
       setWindowWrap("testconsole", 100)
     end)
 
-    -- clear miniconsole before each test
+    -- clear miniconsole before each test. The user cursor outlives clearWindow(),
+    -- so put it back where output lands or a case that moved it changes what the
+    -- next one reads
     before_each(function()
       clearWindow("testconsole")
+      moveCursorEnd("testconsole")
     end)
 
     teardown(function()
@@ -79,13 +82,17 @@ describe("Tests UI functions", function()
       assert.are.equal(-1, selectString("testconsole", "copy4175first", 1))
 
       assert.is_true(moveCursor("testconsole", 0, 1))
-      local ok, err = pcall(copy2decho, "testconsole", "copy4175first")
-      assert.is_false(ok, "copy2decho returned instead of reporting the text was not found")
-      assert.is_truthy(tostring(err):find("copy2decho: string not found", 1, true),
-        "unexpected error: " .. tostring(err))
+      assert.are.equal("", copy2decho("testconsole", "copy4175first"))
+    end)
 
-      -- the cursor outlives the test and the cases below read it
-      moveCursor("testconsole", 0, 0)
+    -- a request longer than the line is also "not on this line", and used to be
+    -- answered with the whole line by an off-by-one that happened to come out
+    -- right - which is a different wrong answer from the fragment above
+    it("Should return nothing when asked for text longer than the current line", function()
+      decho("testconsole", "<0,255,0>dup dup<r>\n")
+
+      assert.are.equal(-1, selectString("testconsole", "dup dup dup dup", 1))
+      assert.are.equal("", copy2decho("testconsole", "dup dup dup dup"))
     end)
 
     -- TODO: https://github.com/Mudlet/Mudlet/issues/5589
@@ -106,9 +113,12 @@ describe("Tests UI functions", function()
       setWindowWrap("testconsole", 100)
     end)
 
-    -- clear miniconsole before each test
+    -- clear miniconsole before each test. The user cursor outlives clearWindow(),
+    -- so put it back where output lands or a case that moved it changes what the
+    -- next one reads
     before_each(function()
       clearWindow("testconsole")
+      moveCursorEnd("testconsole")
     end)
 
     it("Should copy colored English text", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `copy2color()` now tests `selectString()`'s documented `-1` return, so `copy2decho()`/`copy2html()` answer `""` for text that is not on the current line instead of copying characters from whichever line the cursor is on.
- Two cases in `UI_spec.lua`, covering both wrong answers the old code gave.

#### Motivation for adding to Mudlet

A multiline trigger copying an earlier line's `multimatches` silently produced a fragment of a different line, with no error to say anything had gone wrong.

#### Other info (issues closed, discussion etc)

Addresses #4175. Per @vadi2's review, #4175 itself is working-as-designed: `copy2color()` is handed only a string and cannot learn which line it came from, so returning the earlier line's text needs the trigger engine to tell Lua each multimatch's line number - new API rather than a bug fix. Not auto-closing it, hence "Addresses".

`selectString()` searches the current line only and answers `-1` there, which is truthy in Lua, so the `error()` this guarded has been unreachable since #3508 added these functions. With `start = -1` the copy loop runs from index 0, reading characters out of `getCurrentLine()`.

**Answering rather than raising**, per @vadi2's measurements: the guard has been dead, so no script has ever seen that error, and the path returns usable output today whenever the requested text is longer than the line - the off-by-one happens to come out right and yields the whole line, correctly coloured. Raising is uncaught and abandons the rest of the script, so #4175's own two-line trigger body would lose its second line's output too. `""` keeps `copy2decho(x) .. "\n"` working and still never emits another line's text.

The guard tests `start < 0`, not `<= 0`: a match at the first column answers `0` and is a success - every `copy2decho()` call without a `str` defaults to the whole line and matches at 0.

Two spec cases, because the old code gave two different wrong answers: a shorter absent string returned a fragment (`<0,255,0:0,0,0>du<r>` for `"zzz"` on `dup dup`), a longer one returned the whole line. Both `before_each` blocks now restore the user cursor, which outlives `clearWindow()` - with the guard regressed, the old spec leaked two `copy2html` failures on top of the real one. Measured on the PR-branch spec: 5 failures against the old library (3 pre-existing + both new cases, no collateral), 3 with the fix; 7 with neither cursor reset.

`copy2html()` takes the same contract, since both funnel through `copy2color()`. It is covered by the same branch rather than a case of its own.

**Test case:** `UI_spec.lua` - the two `copy2decho` cases above.

*Written with AI assistance. Assisted-by: Claude:claude-opus-5*
