### PR TITLE
Fix: MSDP scripts that subscribe on connect work again

### DIFF
--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -123,8 +123,8 @@ FIXTURE_PIDS+=($!)
 for _ in $(seq 1 50); do [ -s "$peer_dir/port" ] && break; sleep 0.1; done
 [ -s "$peer_dir/port" ] || { echo "mmcp fixture failed"; cat "$TMP/mmcp.log"; exit 1; }
 
-# 4. silent recording game server. Never negotiates, so the specs that connect to
-# it see the connected-but-unnegotiated state a package's connect handler runs in.
+# 4. silent recording game server (ephemeral port); never negotiates, so specs
+# see the connected-but-unnegotiated state.
 telnet_dir="$TMP/telnet-server"
 mkdir -p "$telnet_dir"
 MUDLET_TEST_TELNET_DIR="$telnet_dir" nohup python3 "$WS/CI/telnet-fixture-server.py" > "$TMP/telnet.log" 2>&1 &

--- a/.claude/scripts/run-lua-tests.sh
+++ b/.claude/scripts/run-lua-tests.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Runs the busted Lua specs the way CI's "(Linux) Run Lua tests" step does:
-# starts the HTTP, Discord IPC and MMCP peer fixtures, then drives the built
-# Mudlet through the "Mudlet self-test" profile under xvfb. --offline stops the
-# profile connecting to its game server, which is also what leaves the telnet
-# socket in the state feedTelnet() needs.
+# starts the HTTP, Discord IPC, MMCP peer and telnet fixtures, then drives the
+# built Mudlet through the "Mudlet self-test" profile under xvfb. --offline stops
+# the profile connecting to its game server, which is also what leaves the telnet
+# socket in the state feedTelnet() needs; the specs that do need a connection open
+# one to the telnet fixture themselves.
 #
 # Usage: .claude/scripts/run-lua-tests.sh [path-to-mudlet-binary]
 # Defaults to the linux-debug-nosan build. A binary built in another worktree
@@ -122,6 +123,15 @@ FIXTURE_PIDS+=($!)
 for _ in $(seq 1 50); do [ -s "$peer_dir/port" ] && break; sleep 0.1; done
 [ -s "$peer_dir/port" ] || { echo "mmcp fixture failed"; cat "$TMP/mmcp.log"; exit 1; }
 
+# 4. silent recording game server. Never negotiates, so the specs that connect to
+# it see the connected-but-unnegotiated state a package's connect handler runs in.
+telnet_dir="$TMP/telnet-server"
+mkdir -p "$telnet_dir"
+MUDLET_TEST_TELNET_DIR="$telnet_dir" nohup python3 "$WS/CI/telnet-fixture-server.py" > "$TMP/telnet.log" 2>&1 &
+FIXTURE_PIDS+=($!)
+for _ in $(seq 1 50); do [ -s "$telnet_dir/port" ] && break; sleep 0.1; done
+[ -s "$telnet_dir/port" ] || { echo "telnet fixture failed"; cat "$TMP/telnet.log"; exit 1; }
+
 # absolute rock paths, resolved against the real HOME before it is replaced
 eval "$(luarocks path --local --lua-version 5.1)"
 export LUA_PATH LUA_CPATH
@@ -137,10 +147,12 @@ export MUDLET_TEST_MODE=1
 export MUDLET_TEST_REQUIRE_TTS_MOCK=1
 export MUDLET_TEST_REQUIRE_HTTP_FIXTURE=1
 export MUDLET_TEST_REQUIRE_MMCP_PEER=1
+export MUDLET_TEST_REQUIRE_TELNET_FIXTURE=1
 export MUDLET_TEST_REQUIRE_MEDIA=1
 export MUDLET_TEST_REQUIRE_DISCORD=1
 export MUDLET_TEST_HTTP_PORT="$HTTP_PORT"
 export MUDLET_TEST_MMCP_DIR="$peer_dir"
+export MUDLET_TEST_TELNET_DIR="$telnet_dir"
 export XDG_RUNTIME_DIR="${MUDLET_TEST_DISCORD_RUNTIME_DIR:-$runtime_dir}"
 export LD_LIBRARY_PATH="$WS/3rdparty/discord/rpc/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export DBUS_SESSION_BUS_ADDRESS='disabled:'

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -602,7 +602,6 @@ jobs:
           exit 1
         fi
         echo "MUDLET_TEST_TELNET_DIR=${telnet_dir}" >> "${GITHUB_ENV}"
-        echo "MUDLET_TEST_REQUIRE_TELNET_FIXTURE=1" >> "${GITHUB_ENV}"
         echo "telnet fixture ready on port $(cat "${telnet_dir}/port")"
 
     - name: (Linux/macOS) Start MMCP peer fixture for Lua tests
@@ -644,6 +643,7 @@ jobs:
         MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         MUDLET_TEST_REQUIRE_HTTP_FIXTURE: 1
         MUDLET_TEST_REQUIRE_MMCP_PEER: 1
+        MUDLET_TEST_REQUIRE_TELNET_FIXTURE: 1
         # Qt Multimedia runs a player here even without an audio device, so a
         # media effect spec that cannot play is a regression rather than an
         # environment quirk. macOS runners start no player at all, so the gate
@@ -692,6 +692,7 @@ jobs:
         MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         MUDLET_TEST_REQUIRE_HTTP_FIXTURE: 1
         MUDLET_TEST_REQUIRE_MMCP_PEER: 1
+        MUDLET_TEST_REQUIRE_TELNET_FIXTURE: 1
         # No MUDLET_TEST_REQUIRE_MEDIA: Qt Multimedia starts no player on the
         # macOS runners, so the media effect specs pend here by design.
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
@@ -706,6 +707,15 @@ jobs:
         cat "${{runner.temp}}/discord-ipc-fixture.log" 2>/dev/null || true
         echo "--- frames it captured ---"
         cat "${{runner.temp}}/mudlet-discord-frames.jsonl" 2>/dev/null || true
+
+    - name: (Linux/macOS) Show the telnet fixture log on failure
+      if: failure() && matrix.run_tests == 'true'
+      shell: bash
+      run: |
+        echo "--- telnet fixture log ---"
+        cat "${{runner.temp}}/telnet-fixture.log" 2>/dev/null || true
+        echo "--- what it captured ---"
+        cat "${{runner.temp}}/mudlet-telnet-fixture/capture.json" 2>/dev/null || true
 
     - name: Passed Lua tests
       if: matrix.run_tests == 'true'

--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -584,6 +584,27 @@ jobs:
         echo "MUDLET_TEST_DISCORD_LIB_PATH=${{github.workspace}}/3rdparty/discord/rpc/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
         echo "fake Discord IPC server ready in ${runtime_dir}"
 
+    - name: (Linux/macOS) Start telnet fixture for Lua tests
+      if: matrix.run_tests == 'true'
+      shell: bash
+      run: |
+        telnet_dir="${{runner.temp}}/mudlet-telnet-fixture"
+        rm -rf "${telnet_dir}"
+        mkdir -p "${telnet_dir}"
+        MUDLET_TEST_TELNET_DIR="${telnet_dir}" nohup python3 "${{github.workspace}}/CI/telnet-fixture-server.py" > "${{runner.temp}}/telnet-fixture.log" 2>&1 &
+        for _ in $(seq 1 50); do
+          [ -s "${telnet_dir}/port" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${telnet_dir}/port" ]; then
+          echo "telnet fixture failed to start" >&2
+          cat "${{runner.temp}}/telnet-fixture.log" 2>/dev/null || true
+          exit 1
+        fi
+        echo "MUDLET_TEST_TELNET_DIR=${telnet_dir}" >> "${GITHUB_ENV}"
+        echo "MUDLET_TEST_REQUIRE_TELNET_FIXTURE=1" >> "${GITHUB_ENV}"
+        echo "telnet fixture ready on port $(cat "${telnet_dir}/port")"
+
     - name: (Linux/macOS) Start MMCP peer fixture for Lua tests
       if: matrix.run_tests == 'true'
       shell: bash

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -654,7 +654,6 @@ jobs:
           exit 1
         fi
         echo "MUDLET_TEST_TELNET_DIR=${telnet_dir}" >> "${GITHUB_ENV}"
-        echo "MUDLET_TEST_REQUIRE_TELNET_FIXTURE=1" >> "${GITHUB_ENV}"
         echo "telnet fixture ready on port $(cat "${telnet_dir}/port")"
 
     - name: (Linux/macOS) Start MMCP peer fixture for Lua tests
@@ -696,6 +695,7 @@ jobs:
         MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         MUDLET_TEST_REQUIRE_HTTP_FIXTURE: 1
         MUDLET_TEST_REQUIRE_MMCP_PEER: 1
+        MUDLET_TEST_REQUIRE_TELNET_FIXTURE: 1
         # Qt Multimedia runs a player here even without an audio device, so a
         # media effect spec that cannot play is a regression rather than an
         # environment quirk. macOS runners start no player at all, so the gate
@@ -744,6 +744,7 @@ jobs:
         MUDLET_TEST_REQUIRE_TTS_MOCK: 1
         MUDLET_TEST_REQUIRE_HTTP_FIXTURE: 1
         MUDLET_TEST_REQUIRE_MMCP_PEER: 1
+        MUDLET_TEST_REQUIRE_TELNET_FIXTURE: 1
         # No MUDLET_TEST_REQUIRE_MEDIA: Qt Multimedia starts no player on the
         # macOS runners, so the media effect specs pend here by design.
         TESTS_DIRECTORY: ${{github.workspace}}/src/mudlet-lua/tests
@@ -758,6 +759,15 @@ jobs:
         cat "${{runner.temp}}/discord-ipc-fixture.log" 2>/dev/null || true
         echo "--- frames it captured ---"
         cat "${{runner.temp}}/mudlet-discord-frames.jsonl" 2>/dev/null || true
+
+    - name: (Linux/macOS) Show the telnet fixture log on failure
+      if: failure() && matrix.run_tests == 'true'
+      shell: bash
+      run: |
+        echo "--- telnet fixture log ---"
+        cat "${{runner.temp}}/telnet-fixture.log" 2>/dev/null || true
+        echo "--- what it captured ---"
+        cat "${{runner.temp}}/mudlet-telnet-fixture/capture.json" 2>/dev/null || true
 
     - name: Passed Lua tests
       if: matrix.run_tests == 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -636,6 +636,27 @@ jobs:
         echo "MUDLET_TEST_DISCORD_LIB_PATH=${{github.workspace}}/3rdparty/discord/rpc/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> "${GITHUB_ENV}"
         echo "fake Discord IPC server ready in ${runtime_dir}"
 
+    - name: (Linux/macOS) Start telnet fixture for Lua tests
+      if: matrix.run_tests == 'true'
+      shell: bash
+      run: |
+        telnet_dir="${{runner.temp}}/mudlet-telnet-fixture"
+        rm -rf "${telnet_dir}"
+        mkdir -p "${telnet_dir}"
+        MUDLET_TEST_TELNET_DIR="${telnet_dir}" nohup python3 "${{github.workspace}}/CI/telnet-fixture-server.py" > "${{runner.temp}}/telnet-fixture.log" 2>&1 &
+        for _ in $(seq 1 50); do
+          [ -s "${telnet_dir}/port" ] && break
+          sleep 0.1
+        done
+        if [ ! -s "${telnet_dir}/port" ]; then
+          echo "telnet fixture failed to start" >&2
+          cat "${{runner.temp}}/telnet-fixture.log" 2>/dev/null || true
+          exit 1
+        fi
+        echo "MUDLET_TEST_TELNET_DIR=${telnet_dir}" >> "${GITHUB_ENV}"
+        echo "MUDLET_TEST_REQUIRE_TELNET_FIXTURE=1" >> "${GITHUB_ENV}"
+        echo "telnet fixture ready on port $(cat "${telnet_dir}/port")"
+
     - name: (Linux/macOS) Start MMCP peer fixture for Lua tests
       if: matrix.run_tests == 'true'
       shell: bash

--- a/CI/telnet-fixture-server.py
+++ b/CI/telnet-fixture-server.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Silent, recording game server for Mudlet's busted networking specs.
+
+Mudlet only reaches its "connected" state by way of a real socket, and several
+guards in the Lua API distinguish connected from disconnected. Specs run with
+--offline, so without a server on the other end that branch is unreachable and
+those guards can only ever be checked in their disconnected form. This fixture
+is the other end.
+
+Two properties make it useful, and both are deliberate:
+
+  It never negotiates. It accepts the connection and then says nothing at all,
+  so every telnet option Mudlet offers goes unanswered. MSDP, GMCP and the rest
+  therefore stay disabled for as long as the connection lives. That is not a
+  limitation to work around - it is the state under test. sysConnectionEvent is
+  raised on TCP connect, before any negotiation has happened, so it is exactly
+  what a package's connect handler sees, and a guard that demands a negotiated
+  protocol there rejects work a real server would have accepted.
+
+  It records. Everything Mudlet writes is kept as hex, so a spec can assert on
+  the actual bytes rather than on a return value that merely claims they were
+  sent.
+
+Channels, all inside the directory named by ``MUDLET_TEST_TELNET_DIR`` (one
+environment variable, read by both this process and the specs):
+
+  port          the OS-assigned listening port, written once the socket is
+                accepting. Ephemeral rather than a fixed one: CI jobs and
+                parallel local worktrees would collide.
+  capture.json  what this server has seen, rewritten atomically after every
+                change so a reader never gets a torn file.
+
+A spec reads ``received`` (hex, oldest first) and looks for its own bytes in the
+tail past whatever length it noted beforehand. Connections are served one at a
+time; a new one replaces the old and clears the buffer, with ``connections``
+counting them so a spec can tell a reconnect from a stall.
+"""
+
+import json
+import os
+import selectors
+import socket
+import sys
+
+# Enough for the negotiation Mudlet opens with plus anything a spec sends, while
+# still bounding the capture file over a whole suite run.
+MAX_CAPTURE_BYTES = 65536
+POLL_SECONDS = 0.01
+
+
+class TelnetServer:
+    def __init__(self, directory):
+        self.directory = directory
+        self.capture_path = os.path.join(directory, "capture.json")
+        self.port_path = os.path.join(directory, "port")
+
+        self.received = bytearray()
+        self.connections = 0
+        self.peer = None
+
+        self.selector = selectors.DefaultSelector()
+        self.connection = None
+
+        self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.listener.bind(("127.0.0.1", 0))
+        self.listener.listen(4)
+        self.listener.setblocking(False)
+        self.port = self.listener.getsockname()[1]
+
+    # -- capture ------------------------------------------------------------
+
+    def write_capture(self):
+        payload = {
+            "port": self.port,
+            "connections": self.connections,
+            "connected": self.connection is not None,
+            "peer": self.peer,
+            # Hex rather than raw text: this is a binary protocol, and JSON has
+            # no way to carry bytes that are not valid UTF-8.
+            "received": self.received.hex(),
+            "bytes": len(self.received),
+        }
+        tmp_path = self.capture_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        os.replace(tmp_path, self.capture_path)
+
+    # -- connection ---------------------------------------------------------
+
+    def accept(self):
+        connection, address = self.listener.accept()
+        connection.setblocking(False)
+        connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        if self.connection is not None:
+            # One connection at a time: an earlier one that never went away
+            # would keep appending to the same buffer a later spec is reading.
+            self.close_connection()
+        self.connection = connection
+        self.selector.register(connection, selectors.EVENT_READ)
+        self.received.clear()
+        self.connections += 1
+        self.peer = "%s:%d" % address
+        self.write_capture()
+
+    def close_connection(self):
+        if self.connection is None:
+            return
+        try:
+            self.selector.unregister(self.connection)
+        except (KeyError, ValueError):
+            pass
+        try:
+            self.connection.close()
+        except OSError:
+            pass
+        self.connection = None
+        self.write_capture()
+
+    def read(self):
+        try:
+            chunk = self.connection.recv(4096)
+        except BlockingIOError:
+            # BlockingIOError is an OSError, so it has to be let through before
+            # the catch-all below turns a spurious wakeup into a disconnect.
+            return
+        except OSError:
+            chunk = b""
+        if not chunk:
+            self.close_connection()
+            return
+        self.received.extend(chunk)
+        del self.received[:-MAX_CAPTURE_BYTES]
+        self.write_capture()
+
+    # -- main loop ----------------------------------------------------------
+
+    def run(self):
+        self.selector.register(self.listener, selectors.EVENT_READ)
+        self.write_capture()
+        self.write_port()
+        print("telnet fixture listening on 127.0.0.1:%d" % self.port, flush=True)
+        while True:
+            for key, _ in self.selector.select(POLL_SECONDS):
+                if key.fileobj is self.listener:
+                    self.accept()
+                elif key.fileobj is self.connection:
+                    self.read()
+
+    def write_port(self):
+        # Written last, and atomically, so its presence means the server is
+        # already accepting connections.
+        tmp_path = self.port_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            handle.write(str(self.port))
+        os.replace(tmp_path, self.port_path)
+
+    def forget_port(self):
+        # The specs read the port file to decide whether there is a server worth
+        # connecting to, so one that is going away has to take it with it.
+        try:
+            os.remove(self.port_path)
+        except OSError:
+            pass
+
+
+def main():
+    directory = os.environ.get("MUDLET_TEST_TELNET_DIR")
+    if not directory:
+        print("MUDLET_TEST_TELNET_DIR is not set", file=sys.stderr)
+        return 1
+    os.makedirs(directory, exist_ok=True)
+    server = TelnetServer(directory)
+    try:
+        server.run()
+    finally:
+        server.forget_port()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CI/telnet-fixture-server.py
+++ b/CI/telnet-fixture-server.py
@@ -1,51 +1,35 @@
 #!/usr/bin/env python3
 """Silent, recording game server for Mudlet's busted networking specs.
 
-Mudlet only reaches its "connected" state by way of a real socket, and several
-guards in the Lua API distinguish connected from disconnected. Specs run with
---offline, so without a server on the other end that branch is unreachable and
-those guards can only ever be checked in their disconnected form. This fixture
-is the other end.
+Specs run with --offline, so the connected branch of the Lua API's send guards
+is otherwise unreachable. This fixture is the other end of a real socket.
 
-Two properties make it useful, and both are deliberate:
+It never negotiates: it accepts and then says nothing, so every telnet option
+Mudlet offers goes unanswered and MSDP, GMCP and the rest stay disabled for the
+life of the connection. That is the state under test - sysConnectionEvent is
+raised on TCP connect, which is what a package's connect handler sees.
 
-  It never negotiates. It accepts the connection and then says nothing at all,
-  so every telnet option Mudlet offers goes unanswered. MSDP, GMCP and the rest
-  therefore stay disabled for as long as the connection lives. That is not a
-  limitation to work around - it is the state under test. sysConnectionEvent is
-  raised on TCP connect, before any negotiation has happened, so it is exactly
-  what a package's connect handler sees, and a guard that demands a negotiated
-  protocol there rejects work a real server would have accepted.
+Channels, inside the directory named by ``MUDLET_TEST_TELNET_DIR``:
 
-  It records. Everything Mudlet writes is kept as hex, so a spec can assert on
-  the actual bytes rather than on a return value that merely claims they were
-  sent.
+  port          the listening port, written once the socket is accepting.
+                Ephemeral: CI jobs and parallel worktrees would collide.
+  capture.json  ``received`` is hex, cleared on each new connection; rewritten
+                atomically so a reader never gets a torn file.
 
-Channels, all inside the directory named by ``MUDLET_TEST_TELNET_DIR`` (one
-environment variable, read by both this process and the specs):
-
-  port          the OS-assigned listening port, written once the socket is
-                accepting. Ephemeral rather than a fixed one: CI jobs and
-                parallel local worktrees would collide.
-  capture.json  what this server has seen, rewritten atomically after every
-                change so a reader never gets a torn file.
-
-A spec reads ``received`` (hex, oldest first) and looks for its own bytes in the
-tail past whatever length it noted beforehand. Connections are served one at a
-time; a new one replaces the old and clears the buffer, with ``connections``
-counting them so a spec can tell a reconnect from a stall.
+The kernel completes the handshake from the listen backlog before accept() runs,
+so a connected client can be writing while ``received`` still holds the previous
+connection's bytes. accept() clears it and bumps ``connections`` in the same
+write, so a spec that notes the count before connecting can tell the two apart.
 """
 
 import json
 import os
 import selectors
+import signal
 import socket
 import sys
 
-# Enough for the negotiation Mudlet opens with plus anything a spec sends, while
-# still bounding the capture file over a whole suite run.
 MAX_CAPTURE_BYTES = 65536
-POLL_SECONDS = 0.01
 
 
 class TelnetServer:
@@ -93,8 +77,8 @@ class TelnetServer:
         connection.setblocking(False)
         connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         if self.connection is not None:
-            # One connection at a time: an earlier one that never went away
-            # would keep appending to the same buffer a later spec is reading.
+            # One at a time: a stale connection would keep appending to the
+            # buffer a later spec is reading.
             self.close_connection()
         self.connection = connection
         self.selector.register(connection, selectors.EVENT_READ)
@@ -141,7 +125,7 @@ class TelnetServer:
         self.write_port()
         print("telnet fixture listening on 127.0.0.1:%d" % self.port, flush=True)
         while True:
-            for key, _ in self.selector.select(POLL_SECONDS):
+            for key, _ in self.selector.select():
                 if key.fileobj is self.listener:
                     self.accept()
                 elif key.fileobj is self.connection:
@@ -156,8 +140,8 @@ class TelnetServer:
         os.replace(tmp_path, self.port_path)
 
     def forget_port(self):
-        # The specs read the port file to decide whether there is a server worth
-        # connecting to, so one that is going away has to take it with it.
+        # A port file outliving the server sends the specs at a dead socket, so
+        # they fail with "never connected" instead of "no fixture running".
         try:
             os.remove(self.port_path)
         except OSError:
@@ -170,6 +154,9 @@ def main():
         print("MUDLET_TEST_TELNET_DIR is not set", file=sys.stderr)
         return 1
     os.makedirs(directory, exist_ok=True)
+    # Both consumers stop the fixture with SIGTERM, whose default handler would
+    # skip the cleanup below.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
     server = TelnetServer(directory)
     try:
         server.run()

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -334,7 +334,6 @@ int TLuaInterpreter::sendATCP(lua_State* L)
     output += TN_IAC;
     output += TN_SE;
 
-    // Check connection status first (most common issue)
     if (host.mTelnet.getConnectionState() != QAbstractSocket::ConnectedState) {
         return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending ATCP"));
     }
@@ -385,7 +384,6 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
     output += TN_IAC;
     output += TN_SE;
 
-    // Check connection status first (most common issue)
     if (host.mTelnet.getConnectionState() != QAbstractSocket::ConnectedState) {
         return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending GMCP"));
     }
@@ -492,8 +490,8 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending MSDP"));
     }
 
-    // Deliberately no isMSDPEnabled() check: sysConnectionEvent fires before telnet
-    // negotiation, so requiring it here silently drops packages' variable subscriptions.
+    // No isMSDPEnabled() check, unlike sendGMCP/sendATCP: sysConnectionEvent fires
+    // before negotiation, so one here silently drops packages' subscriptions.
 
     // output is in Mud Server Encoding form here:
     if (!host.mTelnet.socketOutRaw(output)) {

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -488,14 +488,12 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
     output += TN_IAC;
     output += TN_SE;
 
-    // Check connection status first (most common issue)
     if (host.mTelnet.getConnectionState() != QAbstractSocket::ConnectedState) {
         return warnArgumentValue(L, __func__, qsl("not connected to game server - connect first before sending MSDP"));
     }
 
-    if (!host.mTelnet.isMSDPEnabled()) {
-        return warnArgumentValue(L, __func__, qsl("MSDP is not currently enabled"));
-    }
+    // Deliberately no isMSDPEnabled() check: sysConnectionEvent fires before telnet
+    // negotiation, so requiring it here silently drops packages' variable subscriptions.
 
     // output is in Mud Server Encoding form here:
     if (!host.mTelnet.socketOutRaw(output)) {

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -8,13 +8,14 @@
 -- function returns when its precondition (a connection, a peer, an enabled
 -- protocol, an available API) is not met.
 --
--- The download, HTTP and MMCP families are the exception: their infrastructure
--- can be stood up locally, so their real effects are checked against the
--- fixture server in CI/http-fixture-server.py (ephemeral port in
--- MUDLET_TEST_HTTP_PORT) and the scripted chat peer in CI/mmcp-peer.py
--- (handover directory in MUDLET_TEST_MMCP_DIR). Both skip cleanly when absent
--- so the suite still passes without them. Nothing here mocks a real API
--- function.
+-- The download, HTTP, MMCP and MSDP families are the exception: their
+-- infrastructure can be stood up locally, so their real effects are checked
+-- against the fixture server in CI/http-fixture-server.py (ephemeral port in
+-- MUDLET_TEST_HTTP_PORT), the scripted chat peer in CI/mmcp-peer.py (handover
+-- directory in MUDLET_TEST_MMCP_DIR) and the silent game server in
+-- CI/telnet-fixture-server.py (handover directory in MUDLET_TEST_TELNET_DIR).
+-- All skip cleanly when absent so the suite still passes without them. Nothing
+-- here mocks a real API function.
 
 local function contains(haystack, needle)
   return type(haystack) == "string" and haystack:find(needle, 1, true) ~= nil
@@ -2049,9 +2050,8 @@ end)
 -- The connected-but-unnegotiated state, which nothing else in the suite can
 -- reach: it runs with --offline, so every other send guard is only ever checked
 -- in its disconnected form. CI/telnet-fixture-server.py accepts the connection
--- and then stays silent, so no telnet option is ever negotiated and MSDP stays
--- disabled for as long as the connection lives.
-describe("sendMSDP against a game server that has not negotiated MSDP", function()
+-- and then stays silent, so no telnet option is ever negotiated.
+describe("sending protocol data to a game server that has not negotiated", function()
   local telnetDir = os.getenv("MUDLET_TEST_TELNET_DIR")
   local fixtureRequired = os.getenv("MUDLET_TEST_REQUIRE_TELNET_FIXTURE")
 
@@ -2069,8 +2069,8 @@ describe("sendMSDP against a game server that has not negotiated MSDP", function
     return contents
   end
 
-  -- The fixture writes its port only once it is accepting, so a readable port
-  -- file means it is up.
+  -- The fixture writes its port only once it is accepting, and removes it on the
+  -- way out, so a readable port file means it is up.
   local function serverPort()
     if not telnetDir then
       return nil
@@ -2095,7 +2095,7 @@ describe("sendMSDP against a game server that has not negotiated MSDP", function
     return true
   end
 
-  local function wireHex()
+  local function capture()
     local raw = readFile(telnetDir .. "/capture.json")
     if not raw or raw == "" then
       return nil
@@ -2104,7 +2104,17 @@ describe("sendMSDP against a game server that has not negotiated MSDP", function
     if not ok or type(decoded) ~= "table" then
       return nil
     end
-    return decoded.received
+    return decoded
+  end
+
+  local function connectionCount()
+    local seen = capture()
+    return seen and seen.connections or 0
+  end
+
+  local function wireHex()
+    local seen = capture()
+    return seen and seen.received
   end
 
   local function waitUntil(predicate, timeoutMs)
@@ -2123,41 +2133,57 @@ describe("sendMSDP against a game server that has not negotiated MSDP", function
     return isConnected
   end
 
-  local function sawSubnegotiation()
-    local hex = wireHex()
-    return hex ~= nil and hex:find(SUBNEGOTIATION, 1, true) ~= nil
+  -- The kernel completes the handshake from the listen backlog before the
+  -- fixture calls accept(), so Mudlet can be connected and writing while the
+  -- capture still holds the previous connection's bytes. accept() clears them
+  -- and bumps the counter in one write, so a count past the one noted before
+  -- connecting is what makes these bytes this connection's.
+  local function sawSubnegotiation(before)
+    local seen = capture()
+    return seen ~= nil and seen.connections > before and contains(seen.received, SUBNEGOTIATION)
   end
+
+  local msdpNegotiated, protocolHandler
 
   before_each(function()
     disconnect()
+    waitUntil(function() return not connected() end, 2000)
+    msdpNegotiated = false
+    protocolHandler = registerAnonymousEventHandler("sysProtocolEnabled", function(_, protocol)
+      if protocol == "MSDP" then
+        msdpNegotiated = true
+      end
+    end)
   end)
 
   -- Leaving the socket open would hand the next spec file a connected profile,
   -- which several of them assume they do not have.
   after_each(function()
+    killAnonymousEventHandler(protocolHandler)
     disconnect()
-    waitUntil(function() return not connected() end, 2000)
+    assert.is_true(waitUntil(function() return not connected() end, 2000),
+                   "the telnet fixture connection outlived the spec")
   end)
 
   it("puts the subnegotiation on the wire while MSDP is still unnegotiated", function()
     if serverUnavailable() then return end
+    local before = connectionCount()
     connectToServer("127.0.0.1", serverPort())
     assert.is_true(waitUntil(connected, 5000), "never connected to the telnet fixture")
 
     local ok, err = sendMSDP("REPORT", "HEALTH")
     assert.is_true(ok, "sendMSDP refused a connected socket: " .. tostring(err))
-    assert.is_true(waitUntil(sawSubnegotiation, 2000),
+    assert.is_true(waitUntil(function() return sawSubnegotiation(before) end, 2000),
                    "the MSDP subnegotiation never reached the wire, saw: " .. tostring(wireHex()))
+    assert.is_false(msdpNegotiated, "the fixture negotiated MSDP, so this no longer covers the unnegotiated state")
   end)
 
   it("is usable from a sysConnectionEvent handler, which runs before negotiation", function()
     if serverUnavailable() then return end
 
     -- What a package's connect handler does: subscribe to the variables it
-    -- wants as soon as the connection comes up. sysConnectionEvent is raised on
-    -- TCP connect, before the server has had any chance to offer MSDP, so a
-    -- guard that demanded a negotiated protocol here rejected every one of
-    -- those subscriptions - silently, since nothing reads sendMSDP's return.
+    -- wants. sysConnectionEvent is raised on TCP connect, before the server can
+    -- offer MSDP.
     local ran, result, failure = false, nil, nil
     local handler = registerAnonymousEventHandler("sysConnectionEvent", function()
       result, failure = sendMSDP("REPORT", "HEALTH")
@@ -2165,10 +2191,28 @@ describe("sendMSDP against a game server that has not negotiated MSDP", function
     end)
     finally(function() killAnonymousEventHandler(handler) end)
 
+    local before = connectionCount()
     connectToServer("127.0.0.1", serverPort())
     assert.is_true(waitUntil(function() return ran end, 5000), "the sysConnectionEvent handler never ran")
     assert.is_true(result, "sendMSDP refused inside sysConnectionEvent: " .. tostring(failure))
-    assert.is_true(waitUntil(sawSubnegotiation, 2000),
+    assert.is_true(waitUntil(function() return sawSubnegotiation(before) end, 2000),
                    "the MSDP subnegotiation never reached the wire, saw: " .. tostring(wireHex()))
+    assert.is_false(msdpNegotiated, "the fixture negotiated MSDP, so this no longer covers the unnegotiated state")
+  end)
+
+  -- sendGMCP and sendATCP keep the check sendMSDP does without: theirs has been
+  -- there since 2018 and packages are written around it.
+  it("still refuses sendGMCP and sendATCP, whose enabled-checks are wanted", function()
+    if serverUnavailable() then return end
+    connectToServer("127.0.0.1", serverPort())
+    assert.is_true(waitUntil(connected, 5000), "never connected to the telnet fixture")
+
+    local gmcp, gmcpErr = sendGMCP("Core.Hello")
+    assert.is_nil(gmcp)
+    assert.is_true(contains(gmcpErr, "GMCP is not currently enabled"), tostring(gmcpErr))
+
+    local atcp, atcpErr = sendATCP("Core.Hello")
+    assert.is_nil(atcp)
+    assert.is_true(contains(atcpErr, "ATCP is not currently enabled"), tostring(atcpErr))
   end)
 end)

--- a/src/mudlet-lua/tests/Networking_spec.lua
+++ b/src/mudlet-lua/tests/Networking_spec.lua
@@ -2045,3 +2045,130 @@ describe("getNetworkLatency", function()
     assert.equals(0, latency)
   end)
 end)
+
+-- The connected-but-unnegotiated state, which nothing else in the suite can
+-- reach: it runs with --offline, so every other send guard is only ever checked
+-- in its disconnected form. CI/telnet-fixture-server.py accepts the connection
+-- and then stays silent, so no telnet option is ever negotiated and MSDP stays
+-- disabled for as long as the connection lives.
+describe("sendMSDP against a game server that has not negotiated MSDP", function()
+  local telnetDir = os.getenv("MUDLET_TEST_TELNET_DIR")
+  local fixtureRequired = os.getenv("MUDLET_TEST_REQUIRE_TELNET_FIXTURE")
+
+  -- IAC SB MSDP MSDP_VAR "REPORT" MSDP_VAL "HEALTH" IAC SE, which is what
+  -- sendMSDP("REPORT", "HEALTH") is defined to put on the wire.
+  local SUBNEGOTIATION = "fffa45015245504f5254024845414c5448fff0"
+
+  local function readFile(path)
+    local handle = io.open(path, "r")
+    if not handle then
+      return nil
+    end
+    local contents = handle:read("*a")
+    handle:close()
+    return contents
+  end
+
+  -- The fixture writes its port only once it is accepting, so a readable port
+  -- file means it is up.
+  local function serverPort()
+    if not telnetDir then
+      return nil
+    end
+    local raw = readFile(telnetDir .. "/port")
+    return raw and tonumber(raw:match("%d+"))
+  end
+
+  local function serverUnavailable()
+    local reason
+    if not serverPort() then
+      reason = "telnet fixture not running (run CI/telnet-fixture-server.py with MUDLET_TEST_TELNET_DIR set)"
+    elseif type(yajl) ~= "table" then
+      reason = "the yajl Lua module is unavailable, so the fixture's capture file cannot be read"
+    else
+      return false
+    end
+    if fixtureRequired then
+      assert.is_true(false, "MUDLET_TEST_REQUIRE_TELNET_FIXTURE is set but " .. reason .. " (MUDLET_TEST_TELNET_DIR=" .. tostring(telnetDir) .. ")")
+    end
+    pending(reason)
+    return true
+  end
+
+  local function wireHex()
+    local raw = readFile(telnetDir .. "/capture.json")
+    if not raw or raw == "" then
+      return nil
+    end
+    local ok, decoded = pcall(yajl.to_value, raw)
+    if not ok or type(decoded) ~= "table" then
+      return nil
+    end
+    return decoded.received
+  end
+
+  local function waitUntil(predicate, timeoutMs)
+    local step = 20
+    for _ = 1, math.ceil((timeoutMs or 5000) / step) do
+      if predicate() then
+        return true
+      end
+      pumpEvents(step)
+    end
+    return predicate()
+  end
+
+  local function connected()
+    local _, _, isConnected = getConnectionInfo()
+    return isConnected
+  end
+
+  local function sawSubnegotiation()
+    local hex = wireHex()
+    return hex ~= nil and hex:find(SUBNEGOTIATION, 1, true) ~= nil
+  end
+
+  before_each(function()
+    disconnect()
+  end)
+
+  -- Leaving the socket open would hand the next spec file a connected profile,
+  -- which several of them assume they do not have.
+  after_each(function()
+    disconnect()
+    waitUntil(function() return not connected() end, 2000)
+  end)
+
+  it("puts the subnegotiation on the wire while MSDP is still unnegotiated", function()
+    if serverUnavailable() then return end
+    connectToServer("127.0.0.1", serverPort())
+    assert.is_true(waitUntil(connected, 5000), "never connected to the telnet fixture")
+
+    local ok, err = sendMSDP("REPORT", "HEALTH")
+    assert.is_true(ok, "sendMSDP refused a connected socket: " .. tostring(err))
+    assert.is_true(waitUntil(sawSubnegotiation, 2000),
+                   "the MSDP subnegotiation never reached the wire, saw: " .. tostring(wireHex()))
+  end)
+
+  it("is usable from a sysConnectionEvent handler, which runs before negotiation", function()
+    if serverUnavailable() then return end
+
+    -- What a package's connect handler does: subscribe to the variables it
+    -- wants as soon as the connection comes up. sysConnectionEvent is raised on
+    -- TCP connect, before the server has had any chance to offer MSDP, so a
+    -- guard that demanded a negotiated protocol here rejected every one of
+    -- those subscriptions - silently, since nothing reads sendMSDP's return.
+    local ran, result, failure = false, nil, nil
+    local handler = registerAnonymousEventHandler("sysConnectionEvent", function()
+      result, failure = sendMSDP("REPORT", "HEALTH")
+      ran = true
+    end)
+    finally(function() killAnonymousEventHandler(handler) end)
+
+    connectToServer("127.0.0.1", serverPort())
+    assert.is_true(waitUntil(function() return ran end, 5000), "the sysConnectionEvent handler never ran")
+    assert.is_true(result, "sendMSDP refused inside sysConnectionEvent: " .. tostring(failure))
+    assert.is_true(waitUntil(sawSubnegotiation, 2000),
+                   "the MSDP subnegotiation never reached the wire, saw: " .. tostring(wireHex()))
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `sendMSDP()` no longer refuses to send before MSDP has been negotiated, so a package that subscribes to variables from `sysConnectionEvent` reaches the game again.
- `sendGMCP()` and `sendATCP()` keep their equivalent checks - those have been in place since 2018 and packages are written around them.
- Adds a silent telnet fixture server plus three specs covering the connected-but-not-yet-negotiated state, so this cannot regress unnoticed.

#### Motivation for adding to Mudlet

`sysConnectionEvent` is raised the moment the socket connects, before any telnet option negotiation happens, so the check added in 5.0 made every `sendMSDP()` call from that event fail - and because `warnArgumentValue()` only prints with debug mode on, affected packages simply stopped receiving data with no visible error.

#### Other info (issues closed, discussion etc)

Came out of Discord reports of MSDP packages going quiet after upgrading to 5.0; reproduced with the `CK` package on 4.22.0 vs 5.0.0. The check came in with #9478 (Fix: guard sendMSDP against disconnected/unnegotiated state); the disconnected half of that guard stays.

The wiki now documents the right pattern too - subscribe from `sysProtocolEnabled` rather than `sysConnectionEvent` - on [Manual:Event Engine](https://wiki.mudlet.org/w/Manual:Event_Engine#sysConnectionEvent), [Manual:Networking Functions](https://wiki.mudlet.org/w/Manual:Networking_Functions#sendMSDP) and [Manual:Best Practices](https://wiki.mudlet.org/w/Manual:Best_Practices).

**Test case:** connect to an MSDP game with a script that calls `sendMSDP("REPORT", "HEALTH")` from `sysConnectionEvent` - the variable is reported again, where before the call silently did nothing.

Assisted-by: Claude:claude-opus-5
