### PR TITLE
fix: an element removed from an adjustable container is no longer deleted with it

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -876,6 +876,14 @@ function Adjustable.Container:add(window, cons)
     end
 end
 
+function Adjustable.Container:remove(window)
+    if self.Inside and self.Inside.windowList[window.name] then
+        self.Inside:remove(window)
+    else
+        Geyser.remove(self, window)
+    end
+end
+
 -- overridden show function to prevent to show the right click menu on show
 function Adjustable.Container:show(auto)
     Geyser.Container.show(self, auto)

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -185,6 +185,22 @@ describe("Tests functionality of Adjustable.Container", function()
       assert.are.same({}, leftovers)
     end)
 
+    -- #9568: add() puts the child in the Inside container, but there was no
+    -- remove() override, so removal reached only the outer container's own
+    -- lists. The child stayed tracked by Inside, and a later delete() on the
+    -- container destroyed it along with the children it really did own.
+    it("stops tracking a child that was removed from it", function()
+      local child = Geyser.MiniConsole:new({name = "gasRemovedChild"}, container)
+      assert.is_truthy(container.Inside.windowList.gasRemovedChild, "setup: the child never reached the Inside container")
+
+      container:remove(child)
+
+      assert.is_nil(container.Inside.windowList.gasRemovedChild, "the Inside container still tracks a child that was removed")
+      assert.is_nil(container.windowList.gasRemovedChild)
+
+      child:delete()
+    end)
+
     it("puts its backdrop label over the container's geometry", function()
       assert.are.equal("label", windowType("gasContaineradjLabel"))
       assert.are.same({x = 20, y = 30, width = 200, height = 200}, geometry("gasContaineradjLabel"))


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Adjustable.Container` now overrides `remove()`, so an element taken out of one stops being tracked by it.
- Covered by a case in `GeyserAdjustableContainer_spec.lua`.

#### Motivation for adding to Mudlet

Removing an element from an adjustable container appeared to work, but the container still held it — so deleting the container destroyed an element the script had already taken out of it.

#### Other info (issues closed, discussion etc)

Fixes #9568, and the reporter's diagnosis was right.

`Adjustable.Container:add()` delegates to `self.Inside:add(...)`, so children are tracked by the inner container. There was no `remove()` override, so `container:remove(child)` reached the base `Geyser:remove()`, which clears the *outer* container's `windowList` and `windows`. Measured before the fix: after `remove()`, `Inside.windowList` still held the child while the outer list never had it, and `container:delete()` then destroyed it.

`HBox` and `VBox` are the only other classes that override `add()`, and both already override `remove()` too. This closes the last gap.

**Why it dispatches rather than always delegating to `Inside`:** `Inside` is itself constructed as a child of the container (`Geyser.Container:new({...}, self)`), and `Geyser.Container:delete()` finishes by calling `self.container:remove(self)`. So `Inside` asks the adjustable container to unregister *it* during teardown. An unconditional `self.Inside:remove(window)` would hand that to `Inside` itself and leave `Inside` stranded in the outer `windowList`. Testing which of the two is actually tracking the window handles that, the ordinary children, and `adjLabel` — which is parented the same way — without depending on `goInside`, which a script can change after a child has been added.

`add` and `add2` both funnel through `base_add`, which tracks in those same two structures, so no add2-specific removal path is needed.

**Test case:** `GeyserAdjustableContainer_spec.lua` — "stops tracking a child that was removed from it". A miniconsole is added to the container, removed, and neither the inner nor the outer list may still hold it. Full spec suite is 3509 passes / 4 failures with this change and 3508 / 5 without, the extra failure being this case reporting `the Inside container still tracks a child that was removed`; the four remaining failures are the pre-existing `DB_spec` and `UI_spec` ones present on `development` either way. Lua only, so no rebuild is needed to run it.

*Written with AI assistance. Assisted-by: Claude:claude-opus-5*
