### PR TITLE
Fix: stray 'm' characters in game text on games using reserved ANSI parameter bytes

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2238,17 +2238,19 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
         if (parameters.count() > 2) {
             bool isOk = false;
             tag = parameters.at(2).toInt(&isOk);
-#if defined(DEBUG_SGR_PROCESSING)
             if (!isOk) {
+#if defined(DEBUG_SGR_PROCESSING)
                 if (isColonSeparated) {
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) ERROR - failed to parse color index parameter element (the third part) in a SGR...;38:5:" << parameters.at(2)
-                                                 << ":...;...m sequence treating it as a zero!";
+                                                 << ":...;...m sequence, leaving the colour as it was!";
                 } else {
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) ERROR - failed to parse color index parameter string (the third part) in a SGR...;38;5;" << parameters.at(2)
-                                                 << ";...m sequence treating it as a zero!";
+                                                 << ";...m sequence, leaving the colour as it was!";
                 }
-            }
 #endif
+                // An index we cannot read is not a request for colour zero:
+                return;
+            }
         } else {
             // Missing last parameter - so it is treated as a zero
 #if defined(DEBUG_SGR_PROCESSING)
@@ -2396,17 +2398,19 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
         if (parameters.count() > 2) {
             bool isOk = false;
             tag = parameters.at(2).toInt(&isOk);
-#if defined(DEBUG_SGR_PROCESSING)
             if (!isOk) {
+#if defined(DEBUG_SGR_PROCESSING)
                 if (isColonSeparated) {
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) ERROR - failed to parse color index parameter element (the third part) in a SGR...;48:5:" << parameters.at(2)
-                                                 << ":...;...m sequence treating it as a zero!";
+                                                 << ":...;...m sequence, leaving the colour as it was!";
                 } else {
                     qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) ERROR - failed to parse color index parameter string (the third part) in a SGR...;48;5;" << parameters.at(2)
-                                                 << ";...m sequence treating it as a zero!";
+                                                 << ";...m sequence, leaving the colour as it was!";
                 }
-            }
 #endif
+                // An index we cannot read is not a request for colour zero:
+                return;
+            }
         } else {
             // Missing last parameter - so it is treated as a zero
 #if defined(DEBUG_SGR_PROCESSING)

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1192,7 +1192,11 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
             } // End of (isAValidFinalByte) {}
 
             mGotCSI = false;
-            localBufferPosition += 1 + spanEnd - spanStart;
+            // Step over the parameter string and the byte that ended it, unless
+            // that byte is a control one - a sequence with no final byte at all
+            // never owned the newline or escape that stopped the scan, and
+            // eating it would join two lines or drop the sequence after it:
+            localBufferPosition += spanEnd - spanStart + (static_cast<unsigned char>(localBuffer[spanEnd]) < ' ' ? 0 : 1);
             // Go around while loop again:
             continue;
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -820,11 +820,14 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 
 void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFromServer)
 {
-    // What can appear in a CSI Parameter String (Ps) byte or at least for it
-    // to be something we can handle:
-    const QByteArray cParameter = QByteArrayLiteral("0123456789;:");
-    // What can appear in the initial position of a CSI Parameter String (Ps) byte:
-    const QByteArray cParameterInitial = QByteArrayLiteral("0123456789;:<=>?");
+    // What can appear anywhere in a CSI Parameter String (Ps): ECMA-48 5.4
+    // puts every byte of one in the range 0x30 to 0x3F, so '<', '=', '>' and
+    // '?' do not end the parameter string when they turn up after the first
+    // byte - games do emit them there and every other terminal consumes them:
+    const QByteArray cParameter = QByteArrayLiteral("0123456789;:<=>?");
+    // Which of those, in the FIRST position only, marks the whole sequence as
+    // private/reserved and so not something Mudlet can interpret:
+    const QByteArray cParameterPrivateIntroducer = QByteArrayLiteral("<=>?");
     // What can appear in a CSI Intermediate byte (includes a quote character in
     // the middle of the text here which has to be escaped with a backslash):
     const QByteArray cIntermediate = QByteArrayLiteral(" !\"#$%&'()*+,-./");
@@ -1012,18 +1015,14 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
         }
 
         if (mGotCSI) {
-            // Lookahead and try and see what we are processing
-            // At the start of a CSI sequence the only valid character is one of:
-            // "0-9:;<=>?" if it is one of "0-9:;" then it is a
-            // "parameter-string" ELSE if it is one of '<', '=', '>' or '?' it
-            // IS a private/experimental and not covered by the ECMA-48
-            // specifications..
-            // After the first character the remaining characters of the
-            // parameter string will be in the range "0-9:;" only
+            // Lookahead and try and see what we are processing. The parameter
+            // string runs over "0-9:;<=>?" - if its FIRST byte is one of '<',
+            // '=', '>' or '?' the whole sequence is private/experimental and
+            // not covered by the ECMA-48 specifications, but those same bytes
+            // later on are just parameter bytes to be consumed.
             size_t const spanStart = localBufferPosition;
             size_t spanEnd = spanStart;
-            // Only the first byte may be one of the private/reserved introducers:
-            while (spanEnd < localBufferLength && (spanEnd == spanStart ? cParameterInitial : cParameter).indexOf(localBuffer[spanEnd]) >= 0) {
+            while (spanEnd < localBufferLength && cParameter.indexOf(localBuffer[spanEnd]) >= 0) {
                 ++spanEnd;
             }
 
@@ -1053,7 +1052,7 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
             // first byte is within the usable subset of the allowed value - or
             // not. Doing this any earlier would consume a sequence split across
             // packets without leaving the trailing bytes for the next one.
-            if (cParameter.indexOf(localBuffer[spanStart]) == -1 && cParameterInitial.indexOf(localBuffer[spanStart]) >= 0) {
+            if (cParameterPrivateIntroducer.indexOf(localBuffer[spanStart]) >= 0) {
                 // Oh dear, the CSI parameter string sequence begins with one of
                 // the reserved characters ('<', '=', '>' or '?') which we
                 // can/do not handle

--- a/src/mudlet-lua/tests/TBufferOSC_spec.lua
+++ b/src/mudlet-lua/tests/TBufferOSC_spec.lua
@@ -275,10 +275,10 @@ describe("Tests TBuffer OSC sequence handling", function()
 
   end)
 
-  -- A CSI parameter string may only carry one of '<', '=', '>' or '?' in its
-  -- FIRST byte, where it marks a private/reserved sequence that Mudlet does not
-  -- interpret; after that only "0-9:;" are allowed. Getting those two sets the
-  -- wrong way round leaves the tail of such a sequence on screen as game text.
+  -- Every byte of a CSI parameter string is in "0-9:;<=>?"; one of '<', '=',
+  -- '>' or '?' in the FIRST byte marks the sequence as private/reserved, which
+  -- Mudlet does not interpret. Consuming a narrower set anywhere leaves the
+  -- tail of such a sequence on screen as game text.
   describe("Tests private/reserved CSI sequences", function()
 
     it("should consume a private DEC sequence that hides the cursor", function()
@@ -318,6 +318,31 @@ describe("Tests TBuffer OSC sequence handling", function()
     it("should still consume an SGR sequence with no parameters", function()
       assert.is_true(feedTriggers("CSISGR2(\027[mplain)CSISGR2\n"))
       assert.equals("CSISGR2(plain)CSISGR2", findRecentLine("CSISGR2"))
+    end)
+
+    -- SlothMUD ends every coloured span with this: a background parameter whose
+    -- value ran past 9 so the game emitted "4" plus the digit's code point.
+    -- '>' is a parameter byte, not a terminator, so the "m" is the final byte
+    -- and nothing may reach the screen.
+    it("should consume a reserved byte that appears after the first parameter", function()
+      assert.is_true(feedTriggers("CSIMID1(\027[0;37;4>mtext)CSIMID1\n"))
+      assert.equals("CSIMID1(text)CSIMID1", findRecentLine("CSIMID1"))
+    end)
+
+    it("should consume a reserved byte in the middle of a parameter", function()
+      assert.is_true(feedTriggers("CSIMID2(\027[0;3>7mtext)CSIMID2\n"))
+      assert.equals("CSIMID2(text)CSIMID2", findRecentLine("CSIMID2"))
+    end)
+
+    it("should consume every reserved byte appearing after the first parameter", function()
+      assert.is_true(feedTriggers("CSIMID3(\027[0;37;4<m\027[0;37;4=m\027[0;37;4?m)CSIMID3\n"))
+      assert.equals("CSIMID3()CSIMID3", findRecentLine("CSIMID3"))
+    end)
+
+    -- The parameters either side of the unusable one still have to be applied.
+    it("should still apply the usable parameters around a reserved byte", function()
+      assert.is_true(feedTriggers("CSIMID4(\027[0;32mgreen\027[0;37;4>mwhite)CSIMID4\n"))
+      assert.equals("CSIMID4(greenwhite)CSIMID4", findRecentLine("CSIMID4"))
     end)
 
   end)

--- a/src/mudlet-lua/tests/TBufferOSC_spec.lua
+++ b/src/mudlet-lua/tests/TBufferOSC_spec.lua
@@ -17,6 +17,24 @@ describe("Tests TBuffer OSC sequence handling", function()
     return nil
   end
 
+  -- the colour a word on that line ended up with, for the cases where the text
+  -- coming out right is not enough and the formatting has to be checked too
+  local function foregroundOf(needle, word)
+    local lastLine = getLastLineNumber("main")
+    local first = math.max(0, lastLine - 15)
+    local lines = getLines("main", first, lastLine + 1)
+    for i = #lines, 1, -1 do
+      if lines[i]:find(needle, 1, true) then
+        moveCursor("main", 0, first + i - 1)
+        assert.are_not.equal(-1, selectString("main", word, 1))
+        local foreground = getTextFormat("main").foreground
+        moveCursorEnd("main")
+        return foreground
+      end
+    end
+    return nil
+  end
+
   describe("Tests the protection against buffer underflow in OSC sequences", function()
     
     it("should handle OSC sequences at buffer start without crashing", function()
@@ -320,10 +338,9 @@ describe("Tests TBuffer OSC sequence handling", function()
       assert.equals("CSISGR2(plain)CSISGR2", findRecentLine("CSISGR2"))
     end)
 
-    -- SlothMUD ends every coloured span with this: a background parameter whose
-    -- value ran past 9 so the game emitted "4" plus the digit's code point.
-    -- '>' is a parameter byte, not a terminator, so the "m" is the final byte
-    -- and nothing may reach the screen.
+    -- SlothMUD ends every coloured span with this. '>' is a parameter byte, not
+    -- a terminator, so the "m" is the final byte and nothing may reach the
+    -- screen.
     it("should consume a reserved byte that appears after the first parameter", function()
       assert.is_true(feedTriggers("CSIMID1(\027[0;37;4>mtext)CSIMID1\n"))
       assert.equals("CSIMID1(text)CSIMID1", findRecentLine("CSIMID1"))
@@ -339,10 +356,30 @@ describe("Tests TBuffer OSC sequence handling", function()
       assert.equals("CSIMID3()CSIMID3", findRecentLine("CSIMID3"))
     end)
 
-    -- The parameters either side of the unusable one still have to be applied.
+    -- The parameters either side of the unusable one still have to be applied,
+    -- so both runs have to come out the colour a sequence without it gives.
     it("should still apply the usable parameters around a reserved byte", function()
       assert.is_true(feedTriggers("CSIMID4(\027[0;32mgreen\027[0;37;4>mwhite)CSIMID4\n"))
       assert.equals("CSIMID4(greenwhite)CSIMID4", findRecentLine("CSIMID4"))
+      local green = foregroundOf("CSIMID4", "green")
+      local white = foregroundOf("CSIMID4", "white")
+      assert.are_not.same(green, white)
+
+      assert.is_true(feedTriggers("CSIREF4(\027[0;32mgreen\027[0;37mwhite)CSIREF4\n"))
+      assert.are.same(foregroundOf("CSIREF4", "green"), green)
+      assert.are.same(foregroundOf("CSIREF4", "white"), white)
+    end)
+
+    -- A CSI that never gets a final byte is unusable, but the byte that ends
+    -- the scan is not part of it and has to be left alone.
+    it("should not swallow the escape that ends a sequence with no final byte", function()
+      assert.is_true(feedTriggers("CSINOFIN1(\027[0;4>\027[0mtext)CSINOFIN1\n"))
+      assert.equals("CSINOFIN1(text)CSINOFIN1", findRecentLine("CSINOFIN1"))
+    end)
+
+    it("should not swallow the newline that ends a sequence with no final byte", function()
+      assert.is_true(feedTriggers("CSINOFIN2(\027[0;4>\nCSINOFIN3)\n"))
+      assert.equals("CSINOFIN3)", findRecentLine("CSINOFIN3"))
     end)
 
   end)

--- a/src/mudlet-lua/tests/TBufferOSC_spec.lua
+++ b/src/mudlet-lua/tests/TBufferOSC_spec.lua
@@ -382,6 +382,21 @@ describe("Tests TBuffer OSC sequence handling", function()
       assert.equals("CSINOFIN3)", findRecentLine("CSINOFIN3"))
     end)
 
+    -- Consuming a reserved byte puts it in front of the SGR decoder, so a
+    -- parameter it has made unreadable must change nothing rather than be
+    -- read as far as it parses or fall back to colour zero.
+    it("should apply nothing from a parameter a reserved byte has broken", function()
+      assert.is_true(feedTriggers("CSIBAD1(\027[0;37mplain\027[1<2mafter)CSIBAD1\n"))
+      assert.equals("CSIBAD1(plainafter)CSIBAD1", findRecentLine("CSIBAD1"))
+      assert.are.same(foregroundOf("CSIBAD1", "plain"), foregroundOf("CSIBAD1", "after"))
+    end)
+
+    it("should apply nothing from a colour index a reserved byte has broken", function()
+      assert.is_true(feedTriggers("CSIBAD2(\027[0;37mplain\027[38;5;1<2mafter)CSIBAD2\n"))
+      assert.equals("CSIBAD2(plainafter)CSIBAD2", findRecentLine("CSIBAD2"))
+      assert.are.same(foregroundOf("CSIBAD2", "plain"), foregroundOf("CSIBAD2", "after"))
+    end)
+
   end)
 
   -- A line written through TBuffer::appendLine() that holds the documentation


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Every byte of a CSI parameter string is in 0x30-0x3F (ECMA-48 5.4); only a *leading* `<`, `=`, `>` or `?` makes the sequence private. Mudlet rejected those four at every position, so the scan stopped short of the final byte and the final byte reached the screen as game text.
- SlothMUD ends every coloured span with `ESC[0;37;4>m`, so on 5.0.0 every line came back with a stray `m`: `Room m8057m: mThe Innmm`.
- Two follow-ups on paths the first commit opens up: a CSI that never gets a final byte no longer swallows the newline or escape that stopped the scan, and a 256-colour index that fails to parse leaves the colour alone rather than selecting black.

#### Motivation for adding to Mudlet

Regression in 5.0.0 from fe2556247 (#9901, "fix: hidden control codes no longer leave stray characters in the game's text"), which fixed `ESC[?25l` but narrowed the later parameter positions. Player triggers stop firing because the game text no longer matches.

#### Other info (issues closed, discussion etc)

**Test case:** connect to `slothmud.org:6101` and log in - before, every line ends with a stray `m`; after, clean. Lua specs 3894 successes / 0 failures, with 8 new specs in `TBufferOSC_spec.lua` each confirmed to fail when its line of the fix is reverted. Also A/B'd against 4.22.0 and 5.0.0 AppImages replaying the reported bytes.

Fixes #10287

Assisted-by: Claude:claude-opus-5