### PR TITLE
Infra: Add release build presets for all three platforms

### DIFF
--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -81,8 +81,8 @@ performance work, benchmarking, or reproducing something a player reports that a
 not show. It sets `CMAKE_BUILD_TYPE=Release` and clears `USE_SANITIZER`, which is what
 `.github/workflows/build-mudlet.yml` passes on a `Mudlet-*` tag.
 `CI/build-mudlet-for-windows.sh` builds Release on every Windows run and has no sanitizer to
-clear. A Debug build is unoptimised and roughly six times the size - 263MB against 43MB on
-Linux - so timings taken on one say little about the shipped client.
+clear. A `linux-debug` binary is unoptimised and close to seven times the size - 297MB against
+43MB - so timings taken on one say little about the shipped client.
 
 It is not a substitute for the CI release job. The preset stops at compiler flags: it leaves out
 the packaging, signing, Sentry DSN and `MUDLET_VERSION_BUILD` wiring, so the binary still reports

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -78,11 +78,11 @@ without forcing each other to rebuild. The `/build*` entry in `.gitignore` cover
 
 Reach for `<platform>-release` when the *speed and size* of the binary are what is being measured:
 performance work, benchmarking, or reproducing something a player reports that a Debug build may
-not show. It sets `CMAKE_BUILD_TYPE=Release` and clears `USE_SANITIZER`, which is what CI passes
-on a `Mudlet-*` tag - `.github/workflows/build-mudlet.yml`, and `CI/build-mudlet-for-windows.sh`
-on Windows, where there is no sanitizer to clear. A Debug build is several times
-the size - 251MB against 43MB on Linux - and materially slower to run, so timings taken on one say
-little about the shipped client.
+not show. It sets `CMAKE_BUILD_TYPE=Release` and clears `USE_SANITIZER`, which is what
+`.github/workflows/build-mudlet.yml` passes on a `Mudlet-*` tag.
+`CI/build-mudlet-for-windows.sh` builds Release on every Windows run and has no sanitizer to
+clear. A Debug build is unoptimised and roughly six times the size - 263MB against 43MB on
+Linux - so timings taken on one say little about the shipped client.
 
 It is not a substitute for the CI release job. The preset stops at compiler flags: it leaves out
 the packaging, signing, Sentry DSN and `MUDLET_VERSION_BUILD` wiring, so the binary still reports

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -64,6 +64,7 @@ ctest --preset macos-debug            # run the test suite
 | `<platform>-debug-ubsan` | macOS / Linux | UndefinedBehaviorSanitizer |
 | `<platform>-static-analysis` | macOS / Linux | Runs clang-tidy and cppcheck during compilation |
 | `linux-lowspec` | Linux | No sanitizers, no updater, no 3D mapper, 2 jobs — Raspberry Pi and similar |
+| `<platform>-release` | macOS / Linux / Windows | Release build, no sanitizers - the flags CI ships to players |
 
 Every configure preset has a matching build and test preset of the same name, and all three are
 conditioned on the host system — so `cmake --list-presets` on macOS will not offer `linux-debug`,
@@ -72,6 +73,21 @@ and `ctest --preset X` always runs against the tree that `cmake --build --preset
 The plain `<platform>-debug` presets build into `build/`. Every variant builds into
 `build-<preset-name>/` instead, so an AddressSanitizer tree and a sanitizer-free tree can coexist
 without forcing each other to rebuild. The `/build*` entry in `.gitignore` covers all of them.
+
+### When to use a release preset
+
+Reach for `<platform>-release` when the *speed and size* of the binary are what is being measured:
+performance work, benchmarking, or reproducing something a player reports that a Debug build may
+not show. It sets `CMAKE_BUILD_TYPE=Release` and clears `USE_SANITIZER`, which is what CI passes
+on a `Mudlet-*` tag - `.github/workflows/build-mudlet.yml`, and `CI/build-mudlet-for-windows.sh`
+on Windows, where there is no sanitizer to clear. A Debug build is several times
+the size - 251MB against 43MB on Linux - and materially slower to run, so timings taken on one say
+little about the shipped client.
+
+It is not a substitute for the CI release job. The preset stops at compiler flags: it leaves out
+the packaging, signing, Sentry DSN and `MUDLET_VERSION_BUILD` wiring, so the binary still reports
+itself as a `-dev-<sha>` build. Debug builds remain the right default for development: assertions
+and sanitizers catch what a release build quietly tolerates.
 
 ### Qt discovery
 
@@ -179,7 +195,8 @@ near-full rebuild. Run `ccache -s`; if `Cache size` has reached `Max cache size`
 
 **Sanitizers are on by default** on every non-Windows build, regardless of build type
 (`src/cmake/EnableSanitizers.cmake` defaults `USE_SANITIZER` to `address`). They cost both compile
-time and runtime speed. Use a `-nosan` preset when not chasing a memory bug.
+time and runtime speed. Use a `-nosan` or `-release` preset when not chasing a memory bug; both
+clear `USE_SANITIZER` explicitly, because a Release build type alone does not.
 
 For a combination the presets do not cover, pass a **CMake list — semicolon-separated, not
 comma-separated**: `-DUSE_SANITIZER="Address;Undefined"`. A comma-separated value is treated as one

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,6 +65,15 @@
       }
     },
     {
+      "name": "macos-release",
+      "displayName": "macOS Release, no sanitizers (what CI ships to players)",
+      "inherits": ["variant", "macos-debug"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "USE_SANITIZER": ""
+      }
+    },
+    {
       "name": "linux-debug",
       "displayName": "Linux Debug (Ninja, AddressSanitizer)",
       "inherits": "base",
@@ -117,6 +126,15 @@
       }
     },
     {
+      "name": "linux-release",
+      "displayName": "Linux Release, no sanitizers (what CI ships to players)",
+      "inherits": ["variant", "linux-debug"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "USE_SANITIZER": ""
+      }
+    },
+    {
       "name": "windows-debug",
       "displayName": "Windows Debug (MSYS2, Ninja)",
       "inherits": "base",
@@ -127,6 +145,14 @@
       },
       "cacheVariables": {
         "CMAKE_PREFIX_PATH": "$env{MSYSTEM_PREFIX}"
+      }
+    },
+    {
+      "name": "windows-release",
+      "displayName": "Windows Release (MSYS2, Ninja) - what CI ships to players",
+      "inherits": ["variant", "windows-debug"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
       }
     }
   ],
@@ -154,6 +180,7 @@
     { "name": "macos-debug-tsan", "inherits": "on-macos", "configurePreset": "macos-debug-tsan" },
     { "name": "macos-debug-ubsan", "inherits": "on-macos", "configurePreset": "macos-debug-ubsan" },
     { "name": "macos-static-analysis", "inherits": "on-macos", "configurePreset": "macos-static-analysis" },
+    { "name": "macos-release", "inherits": "on-macos", "configurePreset": "macos-release" },
     { "name": "linux-debug", "inherits": "on-linux", "configurePreset": "linux-debug" },
     { "name": "linux-debug-nosan", "inherits": "on-linux", "configurePreset": "linux-debug-nosan" },
     { "name": "linux-debug-tsan", "inherits": "on-linux", "configurePreset": "linux-debug-tsan" },
@@ -165,9 +192,19 @@
       "configurePreset": "linux-lowspec",
       "jobs": 2
     },
+    { "name": "linux-release", "inherits": "on-linux", "configurePreset": "linux-release" },
     {
       "name": "windows-debug",
       "configurePreset": "windows-debug",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-release",
+      "configurePreset": "windows-release",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -208,16 +245,28 @@
     { "name": "macos-debug-tsan", "inherits": "on-macos", "configurePreset": "macos-debug-tsan" },
     { "name": "macos-debug-ubsan", "inherits": "on-macos", "configurePreset": "macos-debug-ubsan" },
     { "name": "macos-static-analysis", "inherits": "on-macos", "configurePreset": "macos-static-analysis" },
+    { "name": "macos-release", "inherits": "on-macos", "configurePreset": "macos-release" },
     { "name": "linux-debug", "inherits": "on-linux", "configurePreset": "linux-debug" },
     { "name": "linux-debug-nosan", "inherits": "on-linux", "configurePreset": "linux-debug-nosan" },
     { "name": "linux-debug-tsan", "inherits": "on-linux", "configurePreset": "linux-debug-tsan" },
     { "name": "linux-debug-ubsan", "inherits": "on-linux", "configurePreset": "linux-debug-ubsan" },
     { "name": "linux-static-analysis", "inherits": "on-linux", "configurePreset": "linux-static-analysis" },
     { "name": "linux-lowspec", "inherits": "on-linux", "configurePreset": "linux-lowspec" },
+    { "name": "linux-release", "inherits": "on-linux", "configurePreset": "linux-release" },
     {
       "name": "windows-debug",
       "inherits": "test-defaults",
       "configurePreset": "windows-debug",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-release",
+      "inherits": "test-defaults",
+      "configurePreset": "windows-release",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -149,7 +149,7 @@
     },
     {
       "name": "windows-release",
-      "displayName": "Windows Release (MSYS2, Ninja) - what CI ships to players",
+      "displayName": "Windows Release (MSYS2, Ninja, what CI ships to players)",
       "inherits": ["variant", "windows-debug"],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"

--- a/docs/platform-builds.md
+++ b/docs/platform-builds.md
@@ -54,17 +54,18 @@ cmake --build --preset windows-debug
 ```
 
 Sanitizers are not enabled on Windows (`src/CMakeLists.txt` guards them with `if(NOT WIN32)`),
-so there is no `-nosan` variant. `windows-release` reads `MSYSTEM_PREFIX` the same way and only
-adds `CMAKE_BUILD_TYPE=Release`, matching `CI/build-mudlet-for-windows.sh`.
+so there is no `-nosan` variant. `windows-release` reads `MSYSTEM_PREFIX` the same way, adds
+`CMAKE_BUILD_TYPE=Release` to match `CI/build-mudlet-for-windows.sh` - which builds Release on
+every Windows run - and builds into `build-windows-release/`.
 
 ## Sanitizers and static analysis
 
 Sanitizers are enabled on every non-Windows build; `USE_SANITIZER` defaults to `address`, and a
 Release build type does not turn them off on its own - `<platform>-release` clears the variable
 explicitly. Use the `-tsan` / `-ubsan` / `-nosan` presets to change the choice, or pass a CMake
-list — semicolon-separated, not comma-separated — such as `-DUSE_SANITIZER="Address;Undefined"`. A comma-separated value is
-read as a single name, which silently skips the per-sanitizer options such as
-`-fno-omit-frame-pointer`.
+list — semicolon-separated, not comma-separated — such as `-DUSE_SANITIZER="Address;Undefined"`.
+A comma-separated value is read as a single name, which silently skips the per-sanitizer options
+such as `-fno-omit-frame-pointer`.
 
 Usable names are `Address`, `Thread` and `Undefined` on macOS, plus `Memory` and `Leak` on Linux.
 `MemoryWithOrigins` appears in the `USE_SANITIZER` cache docstring but has no mapping declared in

--- a/docs/platform-builds.md
+++ b/docs/platform-builds.md
@@ -17,9 +17,10 @@ cmake --build --preset macos-debug
 ```
 
 Run `cmake --list-presets` to see the presets available on your machine; alongside `macos-debug`
-there are `-nosan`, `-tsan` and `-ubsan` variants and a `macos-static-analysis` preset. Variants
-build into `build-<preset-name>/` rather than `build/`, so several configurations can coexist
-without invalidating each other.
+there are `-nosan`, `-tsan` and `-ubsan` variants, a `macos-static-analysis` preset and a
+`macos-release` one carrying the flags CI ships to players. Variants build into
+`build-<preset-name>/` rather than `build/`, so several configurations can coexist without
+invalidating each other.
 
 The presets do not pin a Qt location, relying on CMake's default search path. If Qt is not found,
 pass it explicitly: `cmake --preset macos-debug -DCMAKE_PREFIX_PATH="$(brew --prefix qt6)"`.
@@ -53,13 +54,15 @@ cmake --build --preset windows-debug
 ```
 
 Sanitizers are not enabled on Windows (`src/CMakeLists.txt` guards them with `if(NOT WIN32)`),
-so there is no `-nosan` variant.
+so there is no `-nosan` variant. `windows-release` reads `MSYSTEM_PREFIX` the same way and only
+adds `CMAKE_BUILD_TYPE=Release`, matching `CI/build-mudlet-for-windows.sh`.
 
 ## Sanitizers and static analysis
 
-Sanitizers are enabled on every non-Windows build; `USE_SANITIZER` defaults to `address`. Use the
-`-tsan` / `-ubsan` / `-nosan` presets to change that, or pass a CMake list — semicolon-separated,
-not comma-separated — such as `-DUSE_SANITIZER="Address;Undefined"`. A comma-separated value is
+Sanitizers are enabled on every non-Windows build; `USE_SANITIZER` defaults to `address`, and a
+Release build type does not turn them off on its own - `<platform>-release` clears the variable
+explicitly. Use the `-tsan` / `-ubsan` / `-nosan` presets to change the choice, or pass a CMake
+list — semicolon-separated, not comma-separated — such as `-DUSE_SANITIZER="Address;Undefined"`. A comma-separated value is
 read as a single name, which silently skips the per-sanitizer options such as
 `-fno-omit-frame-pointer`.
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Adds `linux-release`, `macos-release` and `windows-release` - a configure, build and test preset
  of each name, host-conditioned and building into `build-<preset-name>/` like every other variant.
- They set `CMAKE_BUILD_TYPE=Release` and clear `USE_SANITIZER`, which is what CI passes on a
  `Mudlet-*` tag. `windows-release` only sets the build type, since `src/CMakeLists.txt` guards
  sanitizers with `if(NOT WIN32)`, and it inherits `windows-debug`'s `CMAKE_PREFIX_PATH=$env{MSYSTEM_PREFIX}`.
- Documents them in the `build-mudlet` skill and `docs/platform-builds.md`, including when to reach
  for one.

#### Motivation for adding to Mudlet

Every preset was a Debug flavour, so anyone wanting to benchmark Mudlet, measure a performance
change, or reproduce something a player reports had to assemble the flags by hand. Clearing the
sanitizer is the part that is easy to miss: `src/cmake/EnableSanitizers.cmake` defaults
`USE_SANITIZER` to `address` regardless of build type, so `-DCMAKE_BUILD_TYPE=Release` on its own
still yields an AddressSanitizer binary and useless timings.

#### Other info (issues closed, discussion etc)

The flags come from `.github/workflows/build-mudlet.yml` (lines 372/374) and
`CI/build-mudlet-for-windows.sh`. What CI also passes but is deliberately **not** in the presets,
because it is release engineering rather than what makes the artefact a release build:

- `CMAKE_PREFIX_PATH` and `USE_ALTERNATE_LINKER=mold` - machine-specific; the existing presets
  deliberately do not pin Qt either.
- macOS `LUA_INCLUDE_DIR` / `LUA_LIBRARY` - paths to the `gh-actions-lua` install on the runner.
- `WITH_SENTRY`, `SENTRY_DSN`, `SENTRY_SEND_DEBUG` - crash telemetry needing a repo secret to do
  anything, plus a long sentry-native build.
- `MUDLET_VERSION_BUILD` - left unset on purpose, so a preset build still reports itself as
  `-dev-<sha>` and cannot be mistaken for an official release.
- Windows `CMAKE_RUNTIME_OUTPUT_DIRECTORY` and the explicit ccache launcher - packaging paths, and
  `CMakeLists.txt` already wires ccache up when it is installed.

`.github/workflows/performance-analysis.yml`, Mudlet's own benchmark job, builds with the same two
flags. It additionally sets `WITH_UPDATER=NO WITH_3DMAPPER=NO`, which the presets leave on, so a
`linux-release` binary is not byte-for-byte that job's binary.

**Verified by execution, on Linux only:** `cmake --list-presets` offers `linux-release` and neither
of the others; `cmake --preset macos-release` and `windows-release` are rejected as disabled rather
than malformed, so the inherited conditions resolve. A full build produced a fresh 43MB binary in
3m0s, compiling with `-O3 -DNDEBUG -DQT_NO_DEBUG` and no `-fsanitize`; `ldd` and `nm -D` find no
AddressSanitizer in it, while the `linux-debug` tree's binary links `libasan.so.8` and is 297MB.
`ctest --preset linux-release` ran 148/148 green.

**The macOS and Windows presets are unverified by execution** - no such machine here. They are
checked by reading against the presets they inherit from and against the CI invocations above.

**Test case:** `cmake --preset linux-release && cmake --build --preset linux-release`, then
`ldd build-linux-release/src/mudlet | grep -i asan` finds nothing, and
`grep CMAKE_BUILD_TYPE build-linux-release/CMakeCache.txt` reads `Release`.

Assisted-by: Claude:claude-opus-5
