### PR TITLE
Fix: Profile tab bar clipping and theme switching glitches

### DIFF
--- a/src/TDetachedWindow.cpp
+++ b/src/TDetachedWindow.cpp
@@ -168,7 +168,6 @@ void TDetachedWindow::setupUI()
 
     // Create a tab bar to show the profile names and allow reattachment
     mpTabBar = new TTabBar(centralWidget);
-    mpTabBar->setMaximumHeight(30);
     mpTabBar->setTabsClosable(true);
     mpTabBar->setMovable(true);
 
@@ -3161,6 +3160,13 @@ void TDetachedWindow::refreshTabBar()
 
             mpTabBar->setTabText(i, displayText);
         }
+    }
+}
+
+void TDetachedWindow::refreshAfterApplicationStyleChange()
+{
+    if (mpTabBar) {
+        mpTabBar->refreshAfterApplicationStyleChange();
     }
 }
 

--- a/src/TDetachedWindow.h
+++ b/src/TDetachedWindow.h
@@ -62,6 +62,7 @@ public:
     void refreshTabBar();                             // Update tab text to account for CDC identifiers
     void updateWindowMenu();                          // Update the window menu with current window list
     void switchToProfile(const QString& profileName); // Switch to a specific profile tab
+    void refreshAfterApplicationStyleChange();
 
     // Dock widget management methods
     QDockWidget* getDockWidget(const QString& mapKey) const { return mDockWidgetMap.value(mapKey); }

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2698,6 +2698,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
     event.mArgumentList.append(host.getName());
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     qApp->setStyleSheet(styleSheet);
+    mudlet::self()->refreshTabBarsAfterStyleChange();
     mudlet::self()->getHostManager().postInterHostEvent(nullptr, event, true);
     lua_pushboolean(L, true);
     return 1;

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -29,6 +29,7 @@
 #include "utils.h"
 
 #include <QApplication>
+#include <QEvent>
 #include <QStyleOption>
 #include <QStyleOptionTab>
 #include <QPainter>
@@ -111,6 +112,24 @@ QRect TStyle::subElementRect(SubElement element, const QStyleOption* option, con
     }
 
     return rect;
+}
+
+// Tab geometry has to come from the same style that paints the tabs, which
+// drawControl() above delegates to the application style. Our proxy base is
+// null, so it resolves to a separate instance of the platform's native style;
+// letting the dark theme's Fusion style paint tabs sized by the macOS native
+// style clips the descenders off the tab text. styleHint() and
+// subElementRect() deliberately stay on the native base so the close button
+// keeps its platform-native side (the leading edge on macOS) - do not
+// delegate them to the application style as well.
+QSize TStyle::sizeFromContents(ContentsType type, const QStyleOption* option, const QSize& contentsSize, const QWidget* widget) const
+{
+    return qApp->style()->sizeFromContents(type, option, contentsSize, widget);
+}
+
+int TStyle::pixelMetric(PixelMetric metric, const QStyleOption* option, const QWidget* widget) const
+{
+    return qApp->style()->pixelMetric(metric, option, widget);
 }
 
 void TStyle::paintConnectionIndicator(QPainter* painter, const QStyleOptionTab* tabOption, TabConnectionIndicator state) const
@@ -306,6 +325,17 @@ QSize TTabBar::tabSizeHint(int index) const
     }
 
     return s;
+}
+
+// QApplication::setStyle() delivers StyleChange only to widgets without
+// WA_SetStyle, and installing our TStyle sets that attribute - so the bar
+// keeps tab sizes computed against the previous application style unless
+// we hand it the event it was skipped for.
+void TTabBar::refreshAfterApplicationStyleChange()
+{
+    QEvent event(QEvent::StyleChange);
+    QApplication::sendEvent(this, &event);
+    updateGeometry();
 }
 
 QString TTabBar::tabName(const int index) const

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -55,6 +55,8 @@ public:
 
     void drawControl(ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget = nullptr) const override;
     QRect subElementRect(SubElement element, const QStyleOption* option, const QWidget* widget = nullptr) const override;
+    QSize sizeFromContents(ContentsType type, const QStyleOption* option, const QSize& contentsSize, const QWidget* widget = nullptr) const override;
+    int pixelMetric(PixelMetric metric, const QStyleOption* option = nullptr, const QWidget* widget = nullptr) const override;
     void setTabBold(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mBoldTabsSet); }
     void setTabBold(const int index, const bool state) { setIndexedTabState(index, state, mBoldTabsSet); }
     void setTabItalic(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mItalicTabsSet); }
@@ -157,6 +159,7 @@ public:
     void removeTab(const QString& tabName);
     void removeTab(int);
     QStringList tabNames() const;
+    void refreshAfterApplicationStyleChange();
 
 signals:
     void tabDetachRequested(int index, const QPoint& globalPos);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7606,6 +7606,18 @@ void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
         qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
     }
 
+    refreshTabBarsAfterStyleChange();
+
+    getHostManager().changeAllHostColour(getActiveHost());
+    mAppearance = state;
+    emit signal_appearanceChanged(state);
+}
+
+// The application style object is replaced in two places - setAppearance()
+// and Lua's setAppStyleSheet() - and the tab bars miss the StyleChange
+// broadcast both times (see TTabBar::refreshAfterApplicationStyleChange()).
+void mudlet::refreshTabBarsAfterStyleChange()
+{
     if (mpTabBar) {
         mpTabBar->refreshAfterApplicationStyleChange();
     }
@@ -7620,10 +7632,6 @@ void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
     for (TDetachedWindow* pDetachedWindow : uniqueDetachedWindows) {
         pDetachedWindow->refreshAfterApplicationStyleChange();
     }
-
-    getHostManager().changeAllHostColour(getActiveHost());
-    mAppearance = state;
-    emit signal_appearanceChanged(state);
 }
 
 void mudlet::setInterfaceLanguage(const QString& languageCode)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1060,7 +1060,6 @@ void mudlet::init()
     auto frame = new QWidget(this);
     setCentralWidget(frame);
     mpTabBar = new TTabBar(frame);
-    mpTabBar->setMaximumHeight(30);
     mpTabBar->setFocusPolicy(Qt::NoFocus);
     mpTabBar->setTabsClosable(true);
     mpTabBar->setAutoHide(true);
@@ -1079,6 +1078,7 @@ void mudlet::init()
     connect(mpTabBar, &QWidget::customContextMenuRequested, this, &mudlet::slot_showTabContextMenu);
     auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);
+    layoutTopLevel->setSpacing(0);
     layoutTopLevel->addWidget(mpTabBar);
     mpWidget_profileContainer = new QWidget(frame);
     const QPalette mainPalette;
@@ -7573,11 +7573,6 @@ void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
         return;
     }
 
-    mDarkMode = false;
-    if (state == enums::Appearance::dark || (state == enums::Appearance::systemSetting && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)) {
-        mDarkMode = true;
-    }
-
     switch (state) {
     case enums::Appearance::dark:
         QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
@@ -7588,6 +7583,14 @@ void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
     case enums::Appearance::systemSetting:
         QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Unknown);
         break;
+    }
+
+    // Only read the scheme after the override above has been replaced -
+    // before that, colorScheme() still reports the previous explicit
+    // choice, so systemSetting would inherit it instead of the OS setting.
+    mDarkMode = false;
+    if (state == enums::Appearance::dark || (state == enums::Appearance::systemSetting && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)) {
+        mDarkMode = true;
     }
 
     if (needsCustomDarkTheme()) {
@@ -7601,6 +7604,21 @@ void mudlet::setAppearance(const enums::Appearance state, const bool& loading)
     } else {
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
         qApp->setStyle(new AltFocusMenuBarDisable(mDefaultStyle));
+    }
+
+    if (mpTabBar) {
+        mpTabBar->refreshAfterApplicationStyleChange();
+    }
+    // mDetachedWindows is keyed by profile name, so a window hosting several
+    // profiles appears once per profile - collect the unique windows first.
+    QSet<TDetachedWindow*> uniqueDetachedWindows;
+    for (const auto& pDetachedWindow : std::as_const(mDetachedWindows)) {
+        if (pDetachedWindow) {
+            uniqueDetachedWindows.insert(pDetachedWindow);
+        }
+    }
+    for (TDetachedWindow* pDetachedWindow : uniqueDetachedWindows) {
+        pDetachedWindow->refreshAfterApplicationStyleChange();
     }
 
     getHostManager().changeAllHostColour(getActiveHost());

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -286,6 +286,7 @@ public:
     QPair<bool, bool> removeWordFromSet(const QString&);
     QString readProfileData(const QString& profile, const QString& item);
     void refreshTabBar();
+    void refreshTabBarsAfterStyleChange();
     // Used by a profile to tell the mudlet class
     // to tell other profiles to reload the updated
     // maps (via signal_profileMapReloadRequested(...))


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Profile tab text no longer clips its descenders in dark mode on macOS: the tab bar's proxy style sized tabs with the native macOS style while the dark theme's Fusion style painted them; geometry queries (`sizeFromContents`/`pixelMetric`) now come from the same style that paints. `styleHint`/`subElementRect` deliberately stay native so close buttons keep their platform side.
- Removed the dead gray band between the tabs and the console (the top-level layout zeroed margins but not spacing) and the 2009-era 30px tab bar height caps (they trimmed Fusion's 32px tabs; `QTabBar`'s fixed vertical policy already bounds the bar).
- Switching appearance at runtime no longer leaves stale tab geometry: `QApplication::setStyle()` skips `StyleChange` delivery for widgets with their own style, so both places that swap the application style object - `mudlet::setAppearance()` and Lua's `setAppStyleSheet()` - now hand the tab bars the missed event (main window and detached windows) via `mudlet::refreshTabBarsAfterStyleChange()`.
- "System setting" appearance now reads the OS scheme instead of inheriting the previously chosen explicit light/dark override (`mDarkMode` was computed before the override was replaced).

#### Motivation for adding to Mudlet
Profile names with lower case letters would get cut off in dark mode on macOS, wasted vertical space sat under the tabs, and toggling appearance in the settings degraded the tab bar until restart.

#### Other info (issues closed, discussion etc)
Behavior notes for reviewers:
- On Windows dark mode, tab geometry now follows Fusion metrics (which paint the tabs) instead of the windows11 style's - intended, same mismatch class as the macOS bug.
- User stylesheets that request taller tabs (e.g. `QTabBar::tab { min-height: 60px; }`) are now honored instead of clamped to a clipped 30px bar, and take effect immediately when set from Lua. Deliberate, but it is a visible change for profiles shipping such stylesheets.
- Known follow-up, out of scope here: nothing listens to `QStyleHints::colorSchemeChanged`, so an OS theme flip while in "system setting" is not picked up until the appearance is changed manually.
- No tests added: this is QStyle metric plumbing with no Lua-reachable surface; a test would only re-assert Qt's own style arithmetic.

Before dark mode:
<img width="942" height="835" alt="Screenshot 2026-08-31 at 14 03 06" src="https://github.com/user-attachments/assets/789d6fdb-b403-48fc-a874-8a0e15fe3e86" />

Before light mode:
<img width="942" height="835" alt="Screenshot 2026-08-31 at 14 03 32" src="https://github.com/user-attachments/assets/1f06ee44-b50d-4edd-84fa-0df2b0ce91fe" />

Before setting "System mode" after light mode, if system mode is "Dark":
<img width="942" height="835" alt="Screenshot 2026-08-31 at 14 05 20" src="https://github.com/user-attachments/assets/60d4f626-592c-438b-8fee-60f061fae47b" />

---------------------------------------------------------------------------------------

After dark mode:
<img width="965" height="839" alt="Screenshot 2026-08-31 at 14 01 06" src="https://github.com/user-attachments/assets/f9a1c7ea-81ed-4d85-8fed-15cbffb5472f" />

After light mode:
<img width="965" height="839" alt="Screenshot 2026-08-31 at 14 02 10" src="https://github.com/user-attachments/assets/d57ba56f-d894-4490-940e-a104564ab0ca" />

**Test case:** on macOS with dark system theme, open two profiles with descender-heavy names (e.g. "Morquin", "gyq") - the full glyphs render and no gray band sits between tabs and console. In Settings > General, cycle Appearance dark -> light -> system setting in every order: the tab bar relayouts each time and "system setting" matches the OS theme even right after an explicit light/dark choice. Then run `lua setAppStyleSheet([[QTabBar::tab { padding: 12px; }]])` - the tabs grow immediately; `lua setAppStyleSheet("")` restores them.

Assisted-by: Claude:claude-fable-5