### PR TITLE
Improve: Faster trigger dispatch on every incoming line

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2100,6 +2100,9 @@ void Host::runTriggers(int line)
     // cannot resize the one an outer pass is matching on.
     QString haystack = std::move(mTriggerHaystack);
     const auto haystackGuard = qScopeGuard([this, &haystack] {
+        if (haystack.capacity() > scmMaxRetainedHaystack) {
+            haystack = QString();
+        }
         mTriggerHaystack = std::move(haystack);
     });
     haystack.resize(0);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2092,9 +2092,20 @@ void Host::runTriggers(int line)
     consoleModel.mCurrentLine = consoleModel.buffer.line(line);
     getLuaInterpreter()->set_lua_string(TConsole::cmLuaLineVariable, consoleModel.mCurrentLine);
     // The matchers take the haystack by reference all the way down, so it must be
-    // a local: a nested pass reassigns mCurrentLine under them.
-    QString haystack = consoleModel.mCurrentLine;
-    haystack.append('\n');
+    // a local: a nested pass reassigns mCurrentLine under them. Its storage is
+    // borrowed from the Host, so the capacity outlives the line and only a line
+    // longer than any before it allocates. Moving the buffer out rather than
+    // writing into the member is what makes that safe under nesting: a pass a
+    // trigger script starts finds the member empty and grows its own, so it
+    // cannot resize the one an outer pass is matching on.
+    QString haystack = std::move(mTriggerHaystack);
+    const auto haystackGuard = qScopeGuard([this, &haystack] {
+        mTriggerHaystack = std::move(haystack);
+    });
+    haystack.resize(0);
+    haystack.reserve(consoleModel.mCurrentLine.size() + 1);
+    haystack.append(QStringView{consoleModel.mCurrentLine});
+    haystack.append(u'\n');
 
     if (TDebug::wants(TDebug::Category::GameLine)) {
         TDebug(Qt::darkGreen, Qt::black, TDebug::Category::GameLine) << "new line arrived:" >> this;

--- a/src/Host.h
+++ b/src/Host.h
@@ -1080,7 +1080,10 @@ private:
     QString mLine;
     // Storage runTriggers() lends out for the line it hands the trigger system,
     // kept between lines for its capacity alone - it holds nothing meaningful
-    // outside that call.
+    // outside that call. Past this length the capacity is dropped instead of
+    // kept, so one outsized line cannot hold its allocation for the rest of the
+    // session; no game line comes close to it.
+    static constexpr qsizetype scmMaxRetainedHaystack = 8192;
     QString mTriggerHaystack;
     QString mLogin;
     QString mPass;

--- a/src/Host.h
+++ b/src/Host.h
@@ -1078,6 +1078,10 @@ private:
     QString mDiscordGameName; // Discord self-reported game name
 
     QString mLine;
+    // Storage runTriggers() lends out for the line it hands the trigger system,
+    // kept between lines for its capacity alone - it holds nothing meaningful
+    // outside that call.
+    QString mTriggerHaystack;
     QString mLogin;
     QString mPass;
 

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -29,6 +29,7 @@
 #include "TTrigger.h"
 
 #include <QScopeGuard>
+#include <QStringConverter>
 
 #include <algorithm>
 #include <functional>
@@ -407,10 +408,33 @@ void TriggerUnit::processDataStream(const QString& data, int line)
         return;
     }
 
+    // Encoded into storage borrowed from the unit, so the capacity outlives the
+    // line and only a line longer than any before it allocates. Moving the buffer
+    // out rather than writing into the member is what makes that safe under
+    // nesting: a pass a trigger script starts finds the member empty and grows
+    // its own, so it cannot resize the one an outer pass is still matching.
+    QByteArray utf8Data = std::move(mUtf8Scratch);
+    const auto utf8Guard = qScopeGuard([this, &utf8Data] {
+        mUtf8Scratch = std::move(utf8Data);
+    });
+    // Stateless so that an unpaired surrogate at the end of the line is reported
+    // here rather than held back as state for a following call.
+    QStringEncoder toUtf8(QStringEncoder::Utf8, QStringConverter::Flag::Stateless);
+    utf8Data.resizeForOverwrite(toUtf8.requiredSpace(data.size()));
+    char* const encodedBegin = utf8Data.data();
+    const char* const encodedEnd = toUtf8.appendToBuffer(encodedBegin, data);
+    if (Q_UNLIKELY(toUtf8.hasError())) {
+        // The encoder writes a replacement character where an unpaired surrogate
+        // was, while toUtf8() drops it, and the difference would move every byte
+        // offset a capture is reported at. No decoder Mudlet has puts an unpaired
+        // surrogate on a line, so that path can afford the copy and stay exact.
+        utf8Data = data.toUtf8();
+    } else {
+        utf8Data.truncate(encodedEnd - encodedBegin);
+    }
     // subject points into utf8Data, so utf8Data has to outlive every match()
     // call below. Perl patterns see the line only as far as its first NUL
     // byte, so this is qstrnlen() rather than the byte count.
-    const QByteArray utf8Data = data.toUtf8();
     const char* subject = utf8Data.constData();
     const int subjectLength = static_cast<int>(qstrnlen(subject, utf8Data.size()));
 

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -137,7 +137,7 @@ void TriggerUnit::addTriggerRootNode(TTrigger* pT, int parentPosition, int child
     if (!pT->getID()) {
         pT->setID(getNewID());
     }
-    mpRootNodeSnapshot.reset();
+    mRootNodeSnapshotStale = true;
     if ((parentPosition == -1) || (childPosition >= static_cast<int>(mTriggerRootNodeList.size()))) {
         mTriggerRootNodeList.push_back(pT);
     } else {
@@ -171,7 +171,7 @@ void TriggerUnit::reParentTrigger(int childID, int oldParentID, int newParentID,
     if (pOldParent) {
         pOldParent->popChild(pChild);
     } else {
-        mpRootNodeSnapshot.reset();
+        mRootNodeSnapshotStale = true;
         mTriggerRootNodeList.remove(pChild);
     }
 
@@ -211,7 +211,7 @@ void TriggerUnit::removeTriggerRootNode(TTrigger* pT)
     // so a collision needs no coincidence)
     mLookupTable.remove(pT->getName(), pT);
     mTriggerMap.remove(pT->getID());
-    mpRootNodeSnapshot.reset();
+    mRootNodeSnapshotStale = true;
     mTriggerRootNodeList.remove(pT);
 }
 
@@ -327,7 +327,7 @@ void TriggerUnit::reorderTriggersAfterPackageImport()
             tempList.push_back(trigger);
         }
     }
-    mpRootNodeSnapshot.reset();
+    mRootNodeSnapshotStale = true;
     for (auto& trigger : tempList) {
         mTriggerRootNodeList.remove(trigger);
     }
@@ -415,6 +415,9 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     // its own, so it cannot resize the one an outer pass is still matching.
     QByteArray utf8Data = std::move(mUtf8Scratch);
     const auto utf8Guard = qScopeGuard([this, &utf8Data] {
+        if (utf8Data.capacity() > scmMaxRetainedUtf8Scratch) {
+            utf8Data = QByteArray();
+        }
         mUtf8Scratch = std::move(utf8Data);
     });
     // Stateless so that an unpaired surrogate at the end of the line is reported
@@ -465,8 +468,17 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     // same hazard for the same reason — see Mudlet issue #4297.
     // Pinned for the length of this pass rather than copied: a mutation
     // replaces the shared snapshot instead of editing the pinned one.
-    if (!mpRootNodeSnapshot) {
-        mpRootNodeSnapshot = std::make_shared<const std::vector<TTrigger*>>(mTriggerRootNodeList.cbegin(), mTriggerRootNodeList.cend());
+    if (mRootNodeSnapshotStale) {
+        // Refilling the vector an earlier pass built keeps a profile whose
+        // triggers churn - a one-shot tempTrigger() invalidates the snapshot
+        // every time it fires - down to no allocation per line as well. Only a
+        // snapshot an outer pass has pinned has to be left alone and replaced.
+        if (mpRootNodeSnapshot.use_count() == 1) {
+            mpRootNodeSnapshot->assign(mTriggerRootNodeList.cbegin(), mTriggerRootNodeList.cend());
+        } else {
+            mpRootNodeSnapshot = std::make_shared<std::vector<TTrigger*>>(mTriggerRootNodeList.cbegin(), mTriggerRootNodeList.cend());
+        }
+        mRootNodeSnapshotStale = false;
     }
     const auto pinnedNodeList = mpRootNodeSnapshot;
     // Triggers registered by a script during this pass (tempTrigger() & Co.)

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -136,6 +136,7 @@ void TriggerUnit::addTriggerRootNode(TTrigger* pT, int parentPosition, int child
     if (!pT->getID()) {
         pT->setID(getNewID());
     }
+    mpRootNodeSnapshot.reset();
     if ((parentPosition == -1) || (childPosition >= static_cast<int>(mTriggerRootNodeList.size()))) {
         mTriggerRootNodeList.push_back(pT);
     } else {
@@ -169,6 +170,7 @@ void TriggerUnit::reParentTrigger(int childID, int oldParentID, int newParentID,
     if (pOldParent) {
         pOldParent->popChild(pChild);
     } else {
+        mpRootNodeSnapshot.reset();
         mTriggerRootNodeList.remove(pChild);
     }
 
@@ -208,6 +210,7 @@ void TriggerUnit::removeTriggerRootNode(TTrigger* pT)
     // so a collision needs no coincidence)
     mLookupTable.remove(pT->getName(), pT);
     mTriggerMap.remove(pT->getID());
+    mpRootNodeSnapshot.reset();
     mTriggerRootNodeList.remove(pT);
 }
 
@@ -323,6 +326,7 @@ void TriggerUnit::reorderTriggersAfterPackageImport()
             tempList.push_back(trigger);
         }
     }
+    mpRootNodeSnapshot.reset();
     for (auto& trigger : tempList) {
         mTriggerRootNodeList.remove(trigger);
     }
@@ -435,7 +439,12 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     // mid-iteration (the underlying std::list::remove frees the iterator's
     // current node → use-after-free on the next ++). AliasUnit dodges the
     // same hazard for the same reason — see Mudlet issue #4297.
-    std::vector<TTrigger*> copyOfNodeList(mTriggerRootNodeList.cbegin(), mTriggerRootNodeList.cend());
+    // Pinned for the length of this pass rather than copied: a mutation
+    // replaces the shared snapshot instead of editing the pinned one.
+    if (!mpRootNodeSnapshot) {
+        mpRootNodeSnapshot = std::make_shared<const std::vector<TTrigger*>>(mTriggerRootNodeList.cbegin(), mTriggerRootNodeList.cend());
+    }
+    const auto pinnedNodeList = mpRootNodeSnapshot;
     // Triggers registered by a script during this pass (tempTrigger() & Co.)
     // are missing from the snapshot but must still match the current line:
     // before the snapshot the loop walked the live std::list, which a push_back
@@ -444,7 +453,7 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     // Entries below this index were added by outer (nested-feedTriggers) passes
     // and are already part of this pass's snapshot.
     const qsizetype firstNodeAddedThisPass = mRootNodesAddedWhileProcessing.size();
-    for (auto trigger : copyOfNodeList) {
+    for (auto trigger : *pinnedNodeList) {
         if (!trigger->isActive()) {
             continue;
         }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -35,6 +35,8 @@
 #include <QString>
 
 #include <list>
+#include <memory>
+#include <vector>
 
 class Host;
 class TTrigger;
@@ -135,6 +137,13 @@ private:
     QPointer<Host> mpHost;
     QMap<int, TTrigger*> mTriggerMap;
     std::list<TTrigger*> mTriggerRootNodeList;
+    // What processDataStream() iterates instead of mTriggerRootNodeList itself -
+    // see the note there. Shared rather than rebuilt per line: a pass pins the
+    // snapshot that was current when it started, so mutating the root list
+    // mid-pass leaves that one alone and only the next pass sees the rebuilt
+    // one. Every mutation of mTriggerRootNodeList must reset() this, or a pass
+    // would go on walking triggers that have since been freed.
+    std::shared_ptr<const std::vector<TTrigger*>> mpRootNodeSnapshot;
     int mMaxID;
     bool mModuleMember;
     int statsItemsTotal = 0;

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -138,7 +138,11 @@ private:
     QPointer<Host> mpHost;
     // Storage processDataStream() lends out for the UTF-8 form of the line it is
     // matching, kept between lines for its capacity alone - it holds nothing
-    // meaningful outside that call.
+    // meaningful outside that call. Past this size the capacity is dropped
+    // instead of kept, so one outsized line cannot hold its allocation for the
+    // rest of the session; the bound is three bytes per QChar of a line longer
+    // than any game sends.
+    static constexpr qsizetype scmMaxRetainedUtf8Scratch = 3 * 8192;
     QByteArray mUtf8Scratch;
     QMap<int, TTrigger*> mTriggerMap;
     std::list<TTrigger*> mTriggerRootNodeList;
@@ -146,9 +150,10 @@ private:
     // see the note there. Shared rather than rebuilt per line: a pass pins the
     // snapshot that was current when it started, so mutating the root list
     // mid-pass leaves that one alone and only the next pass sees the rebuilt
-    // one. Every mutation of mTriggerRootNodeList must reset() this, or a pass
-    // would go on walking triggers that have since been freed.
-    std::shared_ptr<const std::vector<TTrigger*>> mpRootNodeSnapshot;
+    // one. Every mutation of mTriggerRootNodeList must set the flag below, or a
+    // pass would go on walking triggers that have since been freed.
+    std::shared_ptr<std::vector<TTrigger*>> mpRootNodeSnapshot;
+    bool mRootNodeSnapshotStale = true;
     int mMaxID;
     bool mModuleMember;
     int statsItemsTotal = 0;

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -26,6 +26,7 @@
 
 #include "utils.h"
 
+#include <QByteArray>
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QHash>
@@ -135,6 +136,10 @@ private:
     void stopSameLineCreationLoop(const int chainId);
 
     QPointer<Host> mpHost;
+    // Storage processDataStream() lends out for the UTF-8 form of the line it is
+    // matching, kept between lines for its capacity alone - it holds nothing
+    // meaningful outside that call.
+    QByteArray mUtf8Scratch;
     QMap<int, TTrigger*> mTriggerMap;
     std::list<TTrigger*> mTriggerRootNodeList;
     // What processDataStream() iterates instead of mTriggerRootNodeList itself -


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `processDataStream()` copied the whole trigger root-node list into a fresh vector on every line, purely so a mid-pass mutation could not invalidate it (#4297). It now holds that snapshot in a `shared_ptr` and rebuilds it only when the root list actually changes; a pass pins whichever snapshot was current when it started, so the use-after-free guard is unchanged.
- `runTriggers()` copied the line to append a newline, and `processDataStream()` encoded that copy to UTF-8, so every arriving line allocated twice regardless of what the triggers did. Both now borrow a buffer kept on the object, moved out for the call so a nested pass started by a trigger script grows its own rather than resizing one still being matched against.
- 428k of 11.9M allocations over the benchmark run, both sites at zero afterwards. End to end that is a median 0.970 against base over six interleaved runs of the flood-throughput harness (2.30s -> 2.22s over 96,561 lines), two of the six showing no win.

#### Motivation for adding to Mudlet

This is per-line overhead paid before any trigger has been consulted, so it is charged even to profiles with no triggers at all.

#### Other info (issues closed, discussion etc)

The encoder falls back to `toUtf8()` when a line holds an unpaired surrogate: `QStringEncoder` emits U+FFFD there where `toUtf8()` drops it, and every capture offset would otherwise move.

**Test case:** Lua spec suite green (3,886 successes, no failures); the ingest benchmark produces a byte-identical 46-number match vector across arms, and peak RSS over the run is unchanged (483MB both ways).

Assisted-by: Claude:claude-opus-5