### PR TITLE
Improve: Color sequences reach the parser without allocating

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -87,6 +87,9 @@ bool endsStringSequence(const char byte)
 // hostile sequence that never sends a final byte (defense against a server
 // growing mIncompleteSequenceBytes without bound across packets)
 constexpr size_t MAX_CSI_SEQUENCE_LENGTH = 4096;
+// Enough inline room for any SGR parameter string a game actually sends,
+// so the common case is handed over without touching the heap:
+constexpr qsizetype SGR_INLINE_CHARS = 64;
 
 // Helper to interpret JSON values as boolean
 // Accepts both boolean true and numeric non-zero values (servers may send 1 instead of true)
@@ -1107,7 +1110,17 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
 #if defined(DEBUG_SGR_PROCESSING)
                     qDebug().nospace().noquote() << "    Consider the SGR sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
 #endif
-                    decodeSGR(QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str()));
+                    {
+                        // The scan above only let bytes from "0123456789;:<=>?"
+                        // through, so each one widens to a single UTF-16 code
+                        // unit and the sequence can be handed over without
+                        // building a QString for it:
+                        QVarLengthArray<char16_t, SGR_INLINE_CHARS> sgrChars(spanEnd - spanStart);
+                        for (size_t i = spanStart; i < spanEnd; ++i) {
+                            sgrChars[i - spanStart] = static_cast<unsigned char>(localBuffer[i]);
+                        }
+                        decodeSGR(QStringView(sgrChars.data(), sgrChars.size()));
+                    }
                     break;
 
                 case static_cast<quint8>('z'):
@@ -2543,7 +2556,7 @@ void TBuffer::decodeSGR48(const SgrParameters& parameters, bool isColonSeparated
     }
 }
 
-void TBuffer::decodeSGR(const QString& sequence)
+void TBuffer::decodeSGR(const QStringView sequence)
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -2554,7 +2567,7 @@ void TBuffer::decodeSGR(const QString& sequence)
     const bool haveColorSpaceId = pHost->getHaveColorSpaceId();
 
     SgrParameters parameterStrings;
-    for (const QStringView parameter : QStringView{sequence}.tokenize(u';')) {
+    for (const QStringView parameter : sequence.tokenize(u';')) {
         parameterStrings.append(parameter);
     }
     for (int paraIndex = 0, total = parameterStrings.count(); paraIndex < total; ++paraIndex) {

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1105,23 +1105,22 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                 // Zuggsoft's MXP protocol:
                 const quint8 modeChar = static_cast<unsigned char>(localBuffer[spanEnd]);
                 switch (modeChar) {
-                case static_cast<quint8>('m'):
+                case static_cast<quint8>('m'): {
                     // We have a complete SGR sequence:
 #if defined(DEBUG_SGR_PROCESSING)
                     qDebug().nospace().noquote() << "    Consider the SGR sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
 #endif
-                    {
-                        // The scan above only let bytes from "0123456789;:<=>?"
-                        // through, so each one widens to a single UTF-16 code
-                        // unit and the sequence can be handed over without
-                        // building a QString for it:
-                        QVarLengthArray<char16_t, SGR_INLINE_CHARS> sgrChars(spanEnd - spanStart);
-                        for (size_t i = spanStart; i < spanEnd; ++i) {
-                            sgrChars[i - spanStart] = static_cast<unsigned char>(localBuffer[i]);
-                        }
-                        decodeSGR(QStringView(sgrChars.data(), sgrChars.size()));
+                    // Only bytes from cParameter can be here - the four that
+                    // may open a private sequence were turned away above - so
+                    // each one widens to a single UTF-16 code unit and the
+                    // parameter string can be handed over without building a
+                    // QString for it:
+                    QVarLengthArray<char16_t, SGR_INLINE_CHARS> sgrChars(spanEnd - spanStart);
+                    for (size_t i = spanStart; i < spanEnd; ++i) {
+                        sgrChars[i - spanStart] = static_cast<unsigned char>(localBuffer[i]);
                     }
-                    break;
+                    decodeSGR(QStringView(sgrChars));
+                } break;
 
                 case static_cast<quint8>('z'):
                     // We have a control sequence for MXP

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1108,7 +1108,7 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
                 case static_cast<quint8>('m'): {
                     // We have a complete SGR sequence:
 #if defined(DEBUG_SGR_PROCESSING)
-                    qDebug().nospace().noquote() << "    Consider the SGR sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
+                    qDebug().nospace().noquote() << "    Consider the SGR sequence: \"" << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << "\"";
 #endif
                     // Only bytes from cParameter can be here - the four that
                     // may open a private sequence were turned away above - so

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -464,7 +464,7 @@ private:
     bool processEUC_KRSequence(const std::string&, bool, size_t, size_t&, bool&);
     // Views into the string decodeSGR() was handed, so none may outlive that call.
     using SgrParameters = QVarLengthArray<QStringView, 12>;
-    void decodeSGR(const QString&);
+    void decodeSGR(QStringView);
     void decodeSGR38(const SgrParameters&, bool isColonSeparated = true);
     void decodeSGR48(const SgrParameters&, bool isColonSeparated = true);
     void decodeOSC(const QString&);

--- a/src/mudlet-lua/tests/Telnet_spec.lua
+++ b/src/mudlet-lua/tests/Telnet_spec.lua
@@ -121,6 +121,17 @@ describe("Tests SGR default colour handling", function()
     assert.are.same({175, 255, 255}, getTextFormat("main").foreground)
   end)
 
+  -- the parameter string itself outgrows SGR_INLINE_CHARS in TBuffer.cpp, the
+  -- inline capacity of the buffer the CSI scanner widens those bytes into, so
+  -- this is the case that spills that buffer onto the heap
+  it("keeps a colour correct past the inline length of a parameter string", function()
+    local parameters = string.rep("0;", 31) .. "38;5;159"
+    assert.is_true(#parameters > 64, "the sequence stopped reaching the heap path")
+    feed("\27[0m\27[" .. parameters .. "mSgrLongL\r\n")
+    selectMarker("SgrLongL")
+    assert.are.same({175, 255, 255}, getTextFormat("main").foreground)
+  end)
+
   it("restores the default background and keeps it through a later bold", function()
     feed("\27[0m\27[41mSgrRedBgH \27[49mSgrPlainBgH \27[1mSgrBoldBgH\r\n")
     selectMarker("SgrPlainBgH")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The SGR call site made a `std::string` copy of the parameter bytes and then a `QString` from it, so a colour-heavy line allocated before parsing began: once for the `QString` on every non-empty sequence, and twice once the parameter string outgrows `std::string`'s inline buffer - 15 characters on libstdc++, 22 on libc++, which a truecolour foreground and background pair passes at 30.
- The preceding scan has already established every byte is one of `0123456789;:`, so they are widened into a stack buffer instead and `decodeSGR()` takes the `QStringView` it was already building internally.

- Ingest benchmark: median 0.980 over six interleaved A/B pairs, against the branch this stacks on.

#### Motivation for adding to Mudlet

Finishes the job #10267 (improve: parse SGR colour sequences without allocating) started: that removed the allocations inside the parser, this removes the ones the caller made handing the sequence to it.

#### Other info (issues closed, discussion etc)

Stacked on #10267 (improve: parse SGR colour sequences without allocating) - please merge that first; the diff shown here is this branch's own commits.

Mudlet squash-merges, so #10267's commit will not become an ancestor of this branch when it lands: GitHub's automatic retarget leaves the merge base before it and the diff carrying its changes as well. This branch needs a rebase onto `development` at that point, not just the retarget.

Touches `TBuffer.cpp` alongside #10293, so whichever lands last will want a rebase.

**Test case:** Lua spec suite green, `Telnet_spec.lua`'s SGR cases included (3,849 successes, no failures); a colour-heavy game session renders identically; peak RSS over the run is unchanged (483MB both ways).

`Telnet_spec.lua` gains a case for a parameter string longer than the stack buffer's inline capacity, which nothing in the suite reached before - the longest of the 272 sequences across the specs and the C++ tests is 30 characters. Truncating the copy at that capacity fails the new case and nothing else.

Assisted-by: Claude:claude-opus-5
