### PR TITLE
Fix: Selecting a capture group no longer breaks the next selection

### DIFF
--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -2536,26 +2536,10 @@ int TLuaInterpreter::selectCaptureGroup(lua_State* L)
         }
         // We want capture groups to start with 1 instead of 0 so predecrement
         // luaNumOfMatch :
-        if (--captureGroup < static_cast<int>(host.getLuaInterpreter()->mCaptureGroupList.size())) {
-            auto iti = pL->mCaptureGroupPosList.begin();
-            auto its = pL->mCaptureGroupList.begin();
-            begin = *iti;
-            std::string& s = *its;
-
-            for (int i = 0; iti != pL->mCaptureGroupPosList.end(); ++iti, ++i) {
-                begin = *iti;
-                if (i >= captureGroup) {
-                    break;
-                }
-            }
-            for (int i = 0; its != pL->mCaptureGroupList.end(); ++its, ++i) {
-                s = *its;
-                if (i >= captureGroup) {
-                    break;
-                }
-            }
-
-            length = QString::fromStdString(s).size();
+        if (--captureGroup < static_cast<int>(pL->mCaptureGroupList.size()) && captureGroup < static_cast<int>(pL->mCaptureGroupPosList.size())) {
+            const auto offset = static_cast<std::list<std::string>::difference_type>(captureGroup);
+            begin = *std::next(pL->mCaptureGroupPosList.cbegin(), offset);
+            length = QString::fromStdString(*std::next(pL->mCaptureGroupList.cbegin(), offset)).size();
             if (TDebug::wants(TDebug::Category::Selection)) {
                 TDebug(Qt::white, Qt::red, TDebug::Category::Selection) << "selectCaptureGroup(" << begin << ", " << length << ")\n" >> &host;
             }

--- a/src/TLuaInterpreterUI.cpp
+++ b/src/TLuaInterpreterUI.cpp
@@ -32,6 +32,8 @@
 #include <QClipboard>
 #include <QGuiApplication>
 
+#include <iterator>
+
 #include "EAction.h"
 #include "Host.h"
 #include "TArea.h"
@@ -2536,7 +2538,7 @@ int TLuaInterpreter::selectCaptureGroup(lua_State* L)
         }
         // We want capture groups to start with 1 instead of 0 so predecrement
         // luaNumOfMatch :
-        if (--captureGroup < static_cast<int>(pL->mCaptureGroupList.size()) && captureGroup < static_cast<int>(pL->mCaptureGroupPosList.size())) {
+        if (--captureGroup < static_cast<int>(pL->mCaptureGroupList.size())) {
             const auto offset = static_cast<std::list<std::string>::difference_type>(captureGroup);
             begin = *std::next(pL->mCaptureGroupPosList.cbegin(), offset);
             length = QString::fromStdString(*std::next(pL->mCaptureGroupList.cbegin(), offset)).size();

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -360,10 +360,7 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
-    -- Selecting a numbered group used to hold a reference to capture 1 and
-    -- assign every capture it walked past through that reference, so picking
-    -- any later group overwrote the stored full match. The next selection in
-    -- the same script then took its length from the wrong text.
+    -- selecting a later group must leave the stored full match untouched
     it("selectCaptureGroup by number leaves the other captures alone", function()
         local later, full
         local id = tempRegexTrigger("^(\\w+) (\\w+)$", function()
@@ -379,6 +376,24 @@ describe("PCRE regex cases with tempRegexTrigger", function()
 
         assert.are.equal("World", later)
         assert.are.equal("Hello World", full)
+        killTrigger(id)
+    end)
+
+    it("a group number past the last capture returns -1 and keeps the selection", function()
+        local past, zero, still
+        local id = tempRegexTrigger("^(\\w+) (\\w+)$", function()
+            selectCaptureGroup(2)
+            past = selectCaptureGroup(4)
+            zero = selectCaptureGroup(0)
+            still = getSelection()
+            deselect()
+        end, 1)
+
+        feedTriggers("\nHello World\n")
+
+        assert.are.equal(-1, past)
+        assert.are.equal(-1, zero)
+        assert.are.equal("Hello", still)
         killTrigger(id)
     end)
 

--- a/src/mudlet-lua/tests/Regex_spec.lua
+++ b/src/mudlet-lua/tests/Regex_spec.lua
@@ -360,6 +360,28 @@ describe("PCRE regex cases with tempRegexTrigger", function()
         killTrigger(id)
     end)
 
+    -- Selecting a numbered group used to hold a reference to capture 1 and
+    -- assign every capture it walked past through that reference, so picking
+    -- any later group overwrote the stored full match. The next selection in
+    -- the same script then took its length from the wrong text.
+    it("selectCaptureGroup by number leaves the other captures alone", function()
+        local later, full
+        local id = tempRegexTrigger("^(\\w+) (\\w+)$", function()
+            selectCaptureGroup(3)
+            later = getSelection()
+            deselect()
+            selectCaptureGroup(1)
+            full = getSelection()
+            deselect()
+        end, 1)
+
+        feedTriggers("\nHello World\n")
+
+        assert.are.equal("World", later)
+        assert.are.equal("Hello World", full)
+        killTrigger(id)
+    end)
+
     -- selectCaptureGroup returns -1 for non-existent named group
     it("selectCaptureGroup returns -1 for non-existent named group", function()
         local result


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `selectCaptureGroup(n)` kept a reference to capture 1 and assigned every capture it walked past through that reference, so selecting any group but the first overwrote the stored full match.
- A later `selectCaptureGroup(1)` in the same script then took its length from the wrong text and selected too few characters.
- Indexing both lists directly removes the two walk loops and the aliasing with them.

```lua
selectCaptureGroup(3)   -- "World"       - correct
deselect()
selectCaptureGroup(1)   -- "Hello"       - should be "Hello World"
```

#### Motivation for adding to Mudlet

Scripts that select more than one capture group from the same line silently highlight and recolour the wrong text, and there is no way to work around it from Lua.

#### Other info (issues closed, discussion etc)

Closes #10300.

**Test case:** `Regex_spec.lua` gains a case that selects group 3 and then group 1 on the same line - it fails on a binary without the fix (`'Hello'` where `'Hello World'` was expected) and passes with it - plus one pinning that an out-of-range group number returns -1 and leaves the existing selection alone. Full suite green.

Assisted-by: Claude:claude-opus-5