### PR TITLE
Fix: Typing on the connection window picks a game again, instead of renaming a profile

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -167,6 +167,10 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
     mpTabBar->setAccessibleDescription(tr("Switch between showing only your own games and all of the games Mudlet knows about."));
     verticalLayout_gamesList->insertWidget(0, mpTabBar);
     setTabOrder(mpTabBar, listWidget_profiles);
+    // that also takes the games list out of the head of the focus chain, so
+    // without this the profile name field opens focused - where typing a game's
+    // name renames a profile instead of picking that game
+    listWidget_profiles->setFocus();
 
     if (!mudlet::self()->mOnlyShownPredefinedProfiles.isEmpty()) {
         // dedicated single-game builds only ever show their own game(s), so
@@ -444,7 +448,8 @@ dlgConnectionProfiles::~dlgConnectionProfiles()
 
 // Restores the widgets that the first-launch tutorial invitation hides, so
 // every path out of the invitation (Skip button, New profile) leaves the
-// dialog in its regular state:
+// dialog in its regular state - bar the keyboard focus, which hiding those
+// widgets scatters and each caller has to claim for itself:
 void dlgConnectionProfiles::dismissTutorialInvitation()
 {
     mTutorialDismissed = true;
@@ -472,6 +477,9 @@ void dlgConnectionProfiles::slot_skipToGamesList()
     if (!items.isEmpty()) {
         listWidget_profiles->setCurrentItem(items.first());
     }
+    // dismissTutorialInvitation() hides whichever widget the invitation left
+    // holding the focus, which hands it on down the chain to the name field
+    listWidget_profiles->setFocus();
 }
 
 // the dialog can be accepted by pressing Enter on an qlineedit; this is a safeguard against it

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(WINDOW_GROUP_TEST_SOURCES
 set(PROFILE_GROUP_TEST_SOURCES
     ConfigDirOverrideTest.cpp
     ConnectionDialogCrashTest.cpp
+    ConnectionDialogFocusTest.cpp
     DefaultGameDeleteTest.cpp
     MissingDisplayFontTest.cpp
     ProfileDeletionSafetyTest.cpp
@@ -159,6 +160,7 @@ set(STARTERUI_GROUP_TEST_SOURCES
     StarterUiGaugePanelTest.cpp
     StarterUiSectionsTest.cpp
     StarterUiTriggerCostTest.cpp
+    TutorialInvitationFocusTest.cpp
     TutorialInvitationGateTest.cpp
     TutorialInvitationLayoutTest.cpp
 )

--- a/test/functional_tests/ConnectionDialogFocusTest.cpp
+++ b/test/functional_tests/ConnectionDialogFocusTest.cpp
@@ -99,8 +99,13 @@ private slots:
         QVERIFY2(dialog, "No connection dialog to test against");
         QVERIFY2(dialog->listWidget_profiles->isVisible(), "The games list is not on screen, so this is not the dialog the test is about");
 
-        // the focus is only handed out once the window manager activates the dialog
-        QVERIFY2(QTest::qWaitForWindowActive(dialog), "The connection dialog never became the active window");
+        // the focus is only handed out once the dialog is activated, so wait for
+        // it to arrive rather than reading it the moment the dialog is up
+        QTest::qWaitFor(
+                [dialog]() {
+                    return QApplication::focusWidget() == dialog->listWidget_profiles;
+                },
+                5000);
 
         QCOMPARE(QApplication::focusWidget(), static_cast<QWidget*>(dialog->listWidget_profiles));
     }

--- a/test/functional_tests/ConnectionDialogFocusTest.cpp
+++ b/test/functional_tests/ConnectionDialogFocusTest.cpp
@@ -1,0 +1,134 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Where the keyboard focus lands when the connection dialog opens. It has to be
+ * the games list: typing there picks a game, whereas the profile name field
+ * silently renames whichever profile is selected - see issue #10307.
+ *
+ * Run with: ctest -R ConnectionDialogFocusTest -V
+ */
+
+#include "PortableModeTestHelper.h"
+#include "MudletInstanceCoordinator.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include <QtTest/QtTest>
+
+#include <QLineEdit>
+#include <QListWidget>
+#include <QWindow>
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class ConnectionDialogFocusTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mXdgDir;
+    QByteArray mSavedXdg;
+
+    // two of them, so typing has somewhere to move the selection to
+    const QString mFirstProfile = qsl("Aardvark-ConnDialogFocus");
+    const QString mSecondProfile = qsl("Zebra-ConnDialogFocus");
+
+    // a saved profile keeps the first-launch tutorial invitation - which hides
+    // the games list altogether - out of the way
+    bool makeProfileFolder(const QString& name) const { return QDir().mkpath(qsl("%1/mudlet/profiles/%2").arg(mXdgDir.path(), name)); }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - cannot redirect the config dir for this test");
+        }
+
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(mXdgDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mXdgDir.path()))); // profiles/ = XDG opt-in
+        QVERIFY(makeProfileFolder(mFirstProfile));
+        QVERIFY(makeProfileFolder(mSecondProfile));
+        qputenv("XDG_CONFIG_HOME", mXdgDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QVERIFY(mudlet::getMudletPath(enums::profilesPath).startsWith(mXdgDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        mudlet::self()->startAutoLogin({});
+        // the dialog is only shown from a queued lambda, so the pointer turning
+        // up is not enough
+        QVERIFY(QTest::qWaitFor(
+                []() {
+                    return mudlet::self()->mpConnectionDialog && mudlet::self()->mpConnectionDialog->isVisible();
+                },
+                5000));
+    }
+
+    void cleanupTestCase()
+    {
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+        delete mudlet::self();
+    }
+
+    void test_gamesListHasTheOpeningFocus()
+    {
+        auto* dialog = mudlet::self()->mpConnectionDialog.data();
+        QVERIFY2(dialog, "No connection dialog to test against");
+        QVERIFY2(dialog->listWidget_profiles->isVisible(), "The games list is not on screen, so this is not the dialog the test is about");
+
+        // the focus is only handed out once the window manager activates the dialog
+        QVERIFY2(QTest::qWaitForWindowActive(dialog), "The connection dialog never became the active window");
+
+        QCOMPARE(QApplication::focusWidget(), static_cast<QWidget*>(dialog->listWidget_profiles));
+    }
+
+    void test_typingPicksAGameRatherThanRenamingAProfile()
+    {
+        auto* dialog = mudlet::self()->mpConnectionDialog.data();
+        QVERIFY2(dialog, "No connection dialog to test against");
+        auto* list = dialog->listWidget_profiles;
+
+        // select the first profile outright rather than relying on whatever the
+        // list starts on, so the only thing this measures is where the keystroke
+        // below lands
+        const auto items = dialog->findData(*list, mFirstProfile, dlgConnectionProfiles::csmNameRole);
+        QVERIFY2(!items.isEmpty(), "The first test profile is missing from the games list");
+        list->setCurrentItem(items.first());
+
+        // to the window rather than to the dialog, so the key is routed to
+        // whichever widget holds the focus - events sent to the dialog
+        // propagate up from it and never reach its focused child
+        QTest::keyClick(dialog->windowHandle(), static_cast<Qt::Key>(mSecondProfile.at(0).toUpper().unicode()));
+        QTest::qWait(100ms);
+
+        QVERIFY2(list->currentItem(), "Typing cleared the games list selection");
+        QCOMPARE(list->currentItem()->data(dlgConnectionProfiles::csmNameRole).toString(), mSecondProfile);
+        QCOMPARE(dialog->profile_name_entry->text(), mSecondProfile);
+    }
+};
+
+MUDLET_GROUPED_TEST_MAIN(ConnectionDialogFocusTest)
+#include "ConnectionDialogFocusTest.moc"

--- a/test/functional_tests/TutorialInvitationFocusTest.cpp
+++ b/test/functional_tests/TutorialInvitationFocusTest.cpp
@@ -1,0 +1,103 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Where the keyboard focus lands when the first-launch tutorial invitation is
+ * skipped. Restoring the games list hides the widgets the invitation put up,
+ * which scatters the focus on down the chain to the profile name field - where
+ * typing a game's name renames the selected profile. See issue #10307.
+ *
+ * Run with: ctest -R TutorialInvitationFocusTest -V
+ */
+
+#include "PortableModeTestHelper.h"
+#include "MudletInstanceCoordinator.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include <QtTest/QtTest>
+
+#include <QListWidget>
+#include <QPushButton>
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class TutorialInvitationFocusTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mXdgDir;
+    QByteArray mSavedXdg;
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - cannot redirect the config dir for this test");
+        }
+
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(mXdgDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mXdgDir.path()))); // profiles/ = XDG opt-in
+        qputenv("XDG_CONFIG_HOME", mXdgDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QVERIFY(mudlet::getMudletPath(enums::profilesPath).startsWith(mXdgDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        mudlet::self()->startAutoLogin({});
+        // the dialog is only shown from a queued lambda, so the pointer turning
+        // up is not enough
+        QVERIFY(QTest::qWaitFor(
+                []() {
+                    return mudlet::self()->mpConnectionDialog && mudlet::self()->mpConnectionDialog->isVisible();
+                },
+                5000));
+    }
+
+    void cleanupTestCase()
+    {
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+        delete mudlet::self();
+    }
+
+    void test_skippingTheInvitationFocusesTheGamesList()
+    {
+        auto* dialog = mudlet::self()->mpConnectionDialog.data();
+        QVERIFY2(dialog, "No connection dialog to test against");
+        QVERIFY2(QTest::qWaitForWindowActive(dialog), "The connection dialog never became the active window");
+
+        auto* skipButton = dialog->findChild<QPushButton*>(qsl("skipToGamesButton"));
+        QVERIFY2(skipButton, "The first-launch invitation has no skip button any more");
+        QVERIFY2(skipButton->isVisible(), "This is not a first-launch dialog - the skip button is not shown");
+        skipButton->click();
+        QTest::qWait(100ms);
+
+        QCOMPARE(QApplication::focusWidget(), static_cast<QWidget*>(dialog->listWidget_profiles));
+    }
+};
+
+MUDLET_GROUPED_TEST_MAIN(TutorialInvitationFocusTest)
+#include "TutorialInvitationFocusTest.moc"

--- a/test/functional_tests/TutorialInvitationFocusTest.cpp
+++ b/test/functional_tests/TutorialInvitationFocusTest.cpp
@@ -38,8 +38,6 @@
 
 #include "GroupedTest.h"
 
-using namespace std::chrono_literals;
-
 class TutorialInvitationFocusTest : public QObject
 {
     Q_OBJECT
@@ -87,13 +85,18 @@ private slots:
     {
         auto* dialog = mudlet::self()->mpConnectionDialog.data();
         QVERIFY2(dialog, "No connection dialog to test against");
-        QVERIFY2(QTest::qWaitForWindowActive(dialog), "The connection dialog never became the active window");
 
         auto* skipButton = dialog->findChild<QPushButton*>(qsl("skipToGamesButton"));
         QVERIFY2(skipButton, "The first-launch invitation has no skip button any more");
         QVERIFY2(skipButton->isVisible(), "This is not a first-launch dialog - the skip button is not shown");
         skipButton->click();
-        QTest::qWait(100ms);
+        // the focus only reaches the application once the dialog is activated,
+        // which can happen either side of the click
+        QTest::qWaitFor(
+                [dialog]() {
+                    return QApplication::focusWidget() == dialog->listWidget_profiles;
+                },
+                5000);
 
         QCOMPARE(QApplication::focusWidget(), static_cast<QWidget*>(dialog->listWidget_profiles));
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The Profile Connection window opens with the games list focused again, so typing the start of a game's name jumps to that game.
- Skipping the first-launch tutorial invitation now leaves the focus on the games list as well.

#### Motivation for adding to Mudlet

Since 5.0 the window opened on the "Profile name" field instead, so the long-standing habit of alt+c, type a name, Enter silently renamed the selected profile rather than connecting to that game - the reporter had renamed several profiles by accident before noticing.

#### Other info (issues closed, discussion etc)

Closes #10307.

The focus moved in #9452 (improve: split the games list into My games and All games tabs): `setTabOrder(mpTabBar, listWidget_profiles)` puts the new tab bar ahead of the list, which takes the list out of the head of the focus chain, so Qt hands the opening focus to the first line edit instead. Claiming the focus in the constructor rather than on show keeps a later `setFocus()` - `slot_addProfile()`'s, for one - winning as it did before.

Two functional tests cover it: `ConnectionDialogFocusTest` (opening focus, and that a keystroke moves the games list selection rather than the name field) and `TutorialInvitationFocusTest` (the skip path).

**Test case:** open the connection window and type the first letters of a game - the games list should jump to it, and the profile name should not change under you. On a fresh install, click "Skip to games list" first and check the same.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
