### PR TITLE
Fix: Code formatter no longer fails on Windows

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6404,11 +6404,11 @@ void TLuaInterpreter::initIndenterGlobals()
     if (!qsl(LUA_DEFAULT_PATH).isEmpty()) {
         additionalLuaPaths << qsl(LUA_DEFAULT_PATH "/?.lua");
     }
-    // 2 AppImage (directory of executable) - not needed for Wndows:
+    // 2 AppImage and the Windows package (directory of executable):
     //     "<applicationDirectory>/?.lua"
-#if !defined(Q_OS_WINDOWS)
+    // Windows needs this spelled out: the lua51.dll we bundle has no
+    // executable-directory entry in its built-in path, only the working directory
     additionalLuaPaths << qsl("%1/?.lua").arg(appPath);
-#endif
     // 3 QMake shadow builds without CONFIG containing "debug_and_release" but
     //    with "debug_and_release_target" (default on most OS but NOT Windows):
     //     "<applicationDirectory>/../3rdparty/?.lua"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Always add the executable's directory to the code formatter's `package.path`, instead of skipping it on Windows.

#### Motivation for adding to Mudlet

On Windows, right-click -> Format All fails with `attempt to call global 'get_ast' (a nil value)` unless Mudlet happens to have been started from its own app folder. `initIndenterGlobals()` skipped that path entry on Windows because Lua's compiled-in default used to cover it - the `lua51.dll` we bundle today has no executable-directory entry any more, leaving only the working directory to find `lcf` with.

#### Other info (issues closed, discussion etc)

Closes #10311.

**Test case:** on Windows, start Mudlet with a working directory other than its app folder (`Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine="<appdir>\mudlet.exe"; CurrentDirectory="C:\"}`), open the script editor, add some Lua, and right-click -> Format All. Before: nothing happens and the error above is shown. After: the code is formatted. Verified on installed 5.0.0 by supplying the equivalent path via `LUA_PATH`.

Assisted-by: Claude:claude-opus-5