### PR TITLE
Fix: macOS Lua tests job crashes because deferred package installs re-enter themselves

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -93,6 +93,15 @@
 #error Mudlet requires a version of libzip of at least 1.0
 #endif
 
+// How the handlers that put an operation off until the profile has finished
+// saving are hooked up. Both of them start a save of their own, and a save
+// that finishes announces itself synchronously, so a directly connected
+// handler is re-entered from inside its own body - once per operation that was
+// waiting, and a poll that asks during a save leaves one waiting per ask.
+// Queued keeps every one of them at the bottom of the stack; single-shot stops
+// a second announcement running an operation that has already been carried out.
+static constexpr auto deferredSaveHandlerConnection = static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::SingleShotConnection);
+
 using namespace std::chrono;
 
 stopWatch::stopWatch()
@@ -869,10 +878,15 @@ void Host::reloadModule(const QString& syncModuleName, const QString& syncingFro
     if (syncingFromHost.isEmpty() && currentlySavingProfile()) {
         //create a dummy object to singleshot connect (disconnect/delete after execution)
         QObject* obj = new QObject(this);
-        connect(this, &Host::profileSaveFinished, obj, [=, this]() {
-            reloadModule(syncModuleName);
-            obj->deleteLater();
-        });
+        connect(
+                this,
+                &Host::profileSaveFinished,
+                obj,
+                [=, this]() {
+                    reloadModule(syncModuleName);
+                    obj->deleteLater();
+                },
+                deferredSaveHandlerConnection);
         return;
     }
     QMap<QString, QStringList> installedModules = mInstalledModules;
@@ -2335,21 +2349,26 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, enums::Pa
     if (currentlySavingProfile()) {
         // Auto-retry installation after save completes
         QObject* obj = new QObject(this);
-        connect(this, &Host::profileSaveFinished, obj, [=, this]() {
-            auto [ok, msg] = installPackage(fileName, thing, quiet);
-            if (!ok) {
-                qWarning() << "Host::installPackage() deferred install of" << fileName << "failed:" << msg;
-                // A non-quiet install has already been reported by fail() inside the
-                // call above. A quiet one has not, and cannot be: quiet's bargain is
-                // that the caller gets the reason as a return value instead of a
-                // console line, and this caller was handed {true, ""} long before the
-                // failure happened. Nobody else can say it, so say it here.
-                if (quiet) {
-                    postMessage(tr("[ ERROR ] - Package install failed for \"%1\": %2").arg(fileName, msg));
-                }
-            }
-            obj->deleteLater();
-        });
+        connect(
+                this,
+                &Host::profileSaveFinished,
+                obj,
+                [=, this]() {
+                    auto [ok, msg] = installPackage(fileName, thing, quiet);
+                    if (!ok) {
+                        qWarning() << "Host::installPackage() deferred install of" << fileName << "failed:" << msg;
+                        // A non-quiet install has already been reported by fail() inside the
+                        // call above. A quiet one has not, and cannot be: quiet's bargain is
+                        // that the caller gets the reason as a return value instead of a
+                        // console line, and this caller was handed {true, ""} long before the
+                        // failure happened. Nobody else can say it, so say it here.
+                        if (quiet) {
+                            postMessage(tr("[ ERROR ] - Package install failed for \"%1\": %2").arg(fileName, msg));
+                        }
+                    }
+                    obj->deleteLater();
+                },
+                deferredSaveHandlerConnection);
         return {true, QString()};
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -93,13 +93,12 @@
 #error Mudlet requires a version of libzip of at least 1.0
 #endif
 
-// How the handlers that put an operation off until the profile has finished
-// saving are hooked up. Both of them start a save of their own, and a save
-// that finishes announces itself synchronously, so a directly connected
-// handler is re-entered from inside its own body - once per operation that was
-// waiting, and a poll that asks during a save leaves one waiting per ask.
-// Queued keeps every one of them at the bottom of the stack; single-shot stops
-// a second announcement running an operation that has already been carried out.
+// Both handlers that defer an operation until the profile has finished saving
+// start a save of their own, and profileSaveFinished is emitted synchronously,
+// so a directly connected one is re-entered from inside its own body - once per
+// operation still waiting, and a caller that polls during a save leaves one
+// waiting per poll. Queued keeps each at the bottom of the stack; single-shot
+// stops a second announcement re-running an operation already carried out.
 static constexpr auto deferredSaveHandlerConnection = static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::SingleShotConnection);
 
 using namespace std::chrono;

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -465,14 +465,15 @@ void dlgPackageManager::slot_installPackageFromRepository()
                     const QString& filePath = it.value();
 
                     if (mpHost) {
+                        // Ahead of both calls below, because the previous pass's install
+                        // leaves a save in flight: during a save an uninstall is refused
+                        // outright, and an install is put off until the save finishes - long
+                        // after the archive is deleted below.
+                        mpHost->waitForProfileSave();
                         // Uninstall existing package first if this is an update
                         if (mpHost->mInstalledPackages.contains(packageName)) {
                             mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package);
                         }
-                        // Before the install, not after it: the previous pass's install
-                        // leaves a save in flight, and an install begun during a save is put
-                        // off until it finishes - long after the archive is deleted below.
-                        mpHost->waitForProfileSave();
                         if (!mpHost->installPackage(filePath, enums::PackageModuleType::Package).first) {
                             failedPackages << packageName;
                             qWarning() << "dlgPackageManager::slot_installPackageFromRepository() ERROR - failed to install" << packageName;

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -469,10 +469,11 @@ void dlgPackageManager::slot_installPackageFromRepository()
                         if (mpHost->mInstalledPackages.contains(packageName)) {
                             mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package);
                         }
-                        if (mpHost->installPackage(filePath, enums::PackageModuleType::Package).first) {
-                            // the next install would be postponed behind this save, and the loop deletes the file it needs
-                            mpHost->waitForProfileSave();
-                        } else {
+                        // Before the install, not after it: an install begun while a save is
+                        // in flight - the uninstall above starts one - is put off until that
+                        // save finishes, long after the archive is deleted below.
+                        mpHost->waitForProfileSave();
+                        if (!mpHost->installPackage(filePath, enums::PackageModuleType::Package).first) {
                             failedPackages << packageName;
                             qWarning() << "dlgPackageManager::slot_installPackageFromRepository() ERROR - failed to install" << packageName;
                         }

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -469,9 +469,9 @@ void dlgPackageManager::slot_installPackageFromRepository()
                         if (mpHost->mInstalledPackages.contains(packageName)) {
                             mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package);
                         }
-                        // Before the install, not after it: an install begun while a save is
-                        // in flight - the uninstall above starts one - is put off until that
-                        // save finishes, long after the archive is deleted below.
+                        // Before the install, not after it: the previous pass's install
+                        // leaves a save in flight, and an install begun during a save is put
+                        // off until it finishes - long after the archive is deleted below.
                         mpHost->waitForProfileSave();
                         if (!mpHost->installPackage(filePath, enums::PackageModuleType::Package).first) {
                             failedPackages << packageName;

--- a/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
+++ b/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
@@ -146,6 +146,19 @@ private:
     // ...specifically one whose config.lua renames the package to declaredName.
     static bool writeConfigOnlyArchive(const QString& path, const QString& declaredName) { return writeArchive(path, qsl("config.lua"), qsl("mpackage = \"%1\"\n").arg(declaredName).toUtf8()); }
 
+    // ...and one that installs rather than being refused: an archive is only a
+    // package if it holds a Mudlet package XML, empty though this one's units are.
+    static bool writeInstallableArchive(const QString& path, const QString& packageName)
+    {
+        static const char packageXml[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                         "<!DOCTYPE MudletPackage>\n"
+                                         "<MudletPackage version=\"1.001\">\n"
+                                         "<TriggerPackage /><TimerPackage /><AliasPackage /><ActionPackage />\n"
+                                         "<ScriptPackage /><KeyPackage /><VariablePackage><HiddenVariables /></VariablePackage>\n"
+                                         "</MudletPackage>\n";
+        return writeArchive(path, qsl("%1.xml").arg(packageName), QByteArray(packageXml, sizeof(packageXml) - 1));
+    }
+
     QString profileFilePath(const QString& relativePath) const { return qsl("%1/%2").arg(mudlet::getMudletPath(enums::profileHomePath, mProfileName), relativePath); }
 
 private slots:
@@ -277,6 +290,92 @@ private slots:
         auto [fileNameOk, fileNameMessage] = mpHost->installPackage(viaFileName, enums::PackageModuleType::Package, true);
         QVERIFY2(!fileNameOk, "An archive holding no package was installed");
         QVERIFY2(QFile::exists(mapFile), "Refusing the archive took the profile's map folder with it");
+    }
+
+    // The Package Manager's repository install deletes each archive as soon as
+    // installPackage() returns (dlgPackageManager::slot_installPackageFromRepository),
+    // so no install in that loop may be put off: the first one starts a save, and the
+    // second would otherwise be left waiting on a file the loop has already deleted.
+    // This replays the loop's order for two packages.
+    void test_aSecondRepositoryInstallIsNotLeftWaitingOnItsDeletedArchive()
+    {
+        QTemporaryDir archiveDir;
+        QVERIFY2(archiveDir.isValid(), "Could not create a temporary directory for the test archives");
+        const QString firstName = qsl("uninstall-save-repository-first");
+        const QString secondName = qsl("uninstall-save-repository-second");
+        const QString firstPath = archiveDir.filePath(qsl("%1.mpackage").arg(firstName));
+        const QString secondPath = archiveDir.filePath(qsl("%1.mpackage").arg(secondName));
+        QVERIFY2(writeInstallableArchive(firstPath, firstName), "Could not write the first test archive");
+        QVERIFY2(writeInstallableArchive(secondPath, secondName), "Could not write the second test archive");
+
+        // The loop's first package, handled the way the dialog handles it.
+        mpHost->waitForProfileSave();
+        auto [first, firstMessage] = mpHost->installPackage(firstPath, enums::PackageModuleType::Package, true);
+        QVERIFY2(first, qPrintable(firstMessage));
+        QVERIFY2(QFile::remove(firstPath), "Could not delete the first archive the way the loop does");
+        QVERIFY2(mpHost->currentlySavingProfile(), "SETUP: the first install left no save for the second to be put off behind");
+
+        // ...and its second, which is the one at risk.
+        mpHost->waitForProfileSave();
+        auto [second, secondMessage] = mpHost->installPackage(secondPath, enums::PackageModuleType::Package, true);
+        QVERIFY2(second, qPrintable(secondMessage));
+        QVERIFY2(QFile::remove(secondPath), "Could not delete the second archive the way the loop does");
+
+        // Long enough that an install merely waiting its turn would have had it.
+        QTest::qWait(1000);
+        QVERIFY2(mpHost->mInstalledPackages.contains(secondName), "The second install was left waiting on an archive the repository loop had already deleted");
+
+        mpHost->waitForProfileSave();
+        QVERIFY2(mpHost->uninstallPackage(firstName, enums::PackageModuleType::Package), "the first package could not be uninstalled");
+        mpHost->waitForProfileSave();
+        QVERIFY2(mpHost->uninstallPackage(secondName, enums::PackageModuleType::Package), "the second package could not be uninstalled");
+        mpHost->waitForProfileSave();
+    }
+
+    // An install put off until a save finishes must run at the bottom of the event
+    // loop, not from inside the profileSaveFinished emission that releases it. That
+    // install starts a save of its own, and a directly connected handler is
+    // therefore re-entered from its own body once per operation still waiting -
+    // deep enough on macOS to exhaust the stack (#10320).
+    void test_anInstallDeferredByASaveRunsOutsideTheAnnouncement()
+    {
+        QTemporaryDir archiveDir;
+        QVERIFY2(archiveDir.isValid(), "Could not create a temporary directory for the test archive");
+        const QString packageName = qsl("uninstall-save-deferred-install");
+        const QString archivePath = archiveDir.filePath(qsl("%1.mpackage").arg(packageName));
+        QVERIFY2(writeInstallableArchive(archivePath, packageName), "Could not write the test archive");
+
+        mpHost->waitForProfileSave();
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "SETUP: the package this installs is already installed");
+
+        mpHost->saveProfile();
+        QVERIFY2(mpHost->currentlySavingProfile(), "SETUP: saveProfile() left no save for the install to be put off behind");
+
+        auto [ok, message] = mpHost->installPackage(archivePath, enums::PackageModuleType::Package, true);
+        QVERIFY2(ok, qPrintable(message));
+        QVERIFY2(!mpHost->mInstalledPackages.contains(packageName), "SETUP: the install was not put off, so there is nothing here to observe");
+
+        // Connected after the Host's own handler, so Qt runs it second and it sees
+        // whatever that handler has done by the time the announcement returns. Only
+        // the first announcement can tell the two connection types apart: the install
+        // starts a save of its own, and by the time that second one is announced the
+        // package is installed either way.
+        QObject observerContext;
+        int announcements = 0;
+        bool installedFromInsideTheAnnouncement = false;
+        connect(mpHost, &Host::profileSaveFinished, &observerContext, [&]() {
+            if (++announcements == 1) {
+                installedFromInsideTheAnnouncement = mpHost->mInstalledPackages.contains(packageName);
+            }
+        });
+
+        QTRY_VERIFY_WITH_TIMEOUT(mpHost->mInstalledPackages.contains(packageName), 10000);
+        QVERIFY2(announcements > 0, "SETUP: no save was announced, so the observer never ran");
+        QVERIFY2(!installedFromInsideTheAnnouncement, "The put-off install ran from inside the profileSaveFinished emission that released it");
+
+        mpHost->waitForProfileSave();
+        QVERIFY2(mpHost->uninstallPackage(packageName, enums::PackageModuleType::Package), "the package could not be uninstalled");
+        mpHost->waitForProfileSave();
     }
 
     // The refusal is about archives nothing could be read out of, not about

--- a/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
+++ b/test/functional_tests/PackageRemovalSaveTeardownTest.cpp
@@ -293,10 +293,11 @@ private slots:
     }
 
     // The Package Manager's repository install deletes each archive as soon as
-    // installPackage() returns (dlgPackageManager::slot_installPackageFromRepository),
-    // so no install in that loop may be put off: the first one starts a save, and the
-    // second would otherwise be left waiting on a file the loop has already deleted.
-    // This replays the loop's order for two packages.
+    // installPackage() returns (dlgPackageManager::slot_installPackageFromRepository), and
+    // its first pass leaves a save in flight. During a save an uninstall is refused
+    // outright and an install is put off, so a second pass that updates an existing
+    // package would keep the old copy and then wait on a file already deleted. This
+    // replays the loop's order for two packages, the second of them an update.
     void test_aSecondRepositoryInstallIsNotLeftWaitingOnItsDeletedArchive()
     {
         QTemporaryDir archiveDir;
@@ -308,22 +309,30 @@ private slots:
         QVERIFY2(writeInstallableArchive(firstPath, firstName), "Could not write the first test archive");
         QVERIFY2(writeInstallableArchive(secondPath, secondName), "Could not write the second test archive");
 
-        // The loop's first package, handled the way the dialog handles it.
+        // The older copy the loop's second pass is going to update.
+        mpHost->waitForProfileSave();
+        auto [older, olderMessage] = mpHost->installPackage(secondPath, enums::PackageModuleType::Package, true);
+        QVERIFY2(older, qPrintable(olderMessage));
+        mpHost->waitForProfileSave();
+        QVERIFY2(mpHost->mInstalledPackages.contains(secondName), "SETUP: there is no older copy for the second pass to update");
+
+        // The loop's first pass, handled the way the dialog handles it.
         mpHost->waitForProfileSave();
         auto [first, firstMessage] = mpHost->installPackage(firstPath, enums::PackageModuleType::Package, true);
         QVERIFY2(first, qPrintable(firstMessage));
         QVERIFY2(QFile::remove(firstPath), "Could not delete the first archive the way the loop does");
-        QVERIFY2(mpHost->currentlySavingProfile(), "SETUP: the first install left no save for the second to be put off behind");
+        QVERIFY2(mpHost->currentlySavingProfile(), "SETUP: the first pass left no save for the second to run into");
 
-        // ...and its second, which is the one at risk.
+        // ...and its second pass, which is the one at risk.
         mpHost->waitForProfileSave();
+        QVERIFY2(mpHost->uninstallPackage(secondName, enums::PackageModuleType::Package), "The update's removal was refused, so the older copy would have been kept");
         auto [second, secondMessage] = mpHost->installPackage(secondPath, enums::PackageModuleType::Package, true);
         QVERIFY2(second, qPrintable(secondMessage));
         QVERIFY2(QFile::remove(secondPath), "Could not delete the second archive the way the loop does");
 
         // Long enough that an install merely waiting its turn would have had it.
         QTest::qWait(1000);
-        QVERIFY2(mpHost->mInstalledPackages.contains(secondName), "The second install was left waiting on an archive the repository loop had already deleted");
+        QVERIFY2(mpHost->mInstalledPackages.contains(secondName), "The update was left waiting on an archive the repository loop had already deleted");
 
         mpHost->waitForProfileSave();
         QVERIFY2(mpHost->uninstallPackage(firstName, enums::PackageModuleType::Package), "the first package could not be uninstalled");


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`Host::installPackage()` and `Host::reloadModule()` defer work onto `profileSaveFinished` using the default connection type, which on one thread is a direct one - so the handler runs inside the emission, starts a save of its own, and is re-entered from its own body, once per operation still waiting. Both now use `Qt::QueuedConnection | Qt::SingleShotConnection`.

That means `waitForProfileSave()` no longer covers a deferred install, and the Package Manager's repository loop relied on it doing so: that loop deletes each archive as soon as `installPackage()` returns. Its wait now sits ahead of the uninstall and the install rather than after them.

#### Motivation for adding to Mudlet

The macOS "Run Lua tests" job segfaults about 1 run in 30, on a stack exhausted by that recursion. macOS only because `QCocoaEventDispatcher`'s `processEvents()` costs far more stack per nesting level than glib's.

This is a re-land: the identical `Host.cpp` change was reviewed and merged as part of #10203, but that PR merged into a stacking base branch rather than into development, so it never arrived.

**Test case:** two tests added to the existing grouped `PackageRemovalSaveTeardownTest`, so neither costs a link. Both sabotage-verified - red without the fix, green with it. Locally 164/164 functional tests and 3906 specs / 0 failures. The recursion itself does not reproduce on demand on Linux, so the tests pin the ordering rather than a crash.

#### Other info (issues closed, discussion etc)

Closes #10320.

Assisted-by: Claude:claude-opus-5
