### PR TITLE
Infra: Fix a settings test that flaked on macOS

### DIFF
--- a/test/functional_tests/SettingsInstantApplyTest.cpp
+++ b/test/functional_tests/SettingsInstantApplyTest.cpp
@@ -149,8 +149,6 @@ private slots:
     {
         delete mpPreferences;
         mpPreferences = nullptr;
-        // A case that closed the dialog leaves a profile save running - mFORCE_SAVE_ON_EXIT
-        // defaults to on - and that write lands off the main thread, in some later case.
         mpHost->waitForProfileSave();
     }
 
@@ -321,8 +319,6 @@ private slots:
         openPreferences();
         mpPreferences->checkBox_enableTextAnalyzer->click();
         mpPreferences->close();
-        // ...by this close, not by one left over from an earlier case: saveProfile()
-        // registers its writer before returning, and refuses to start a second save
         QVERIFY2(mpHost->currentlySavingProfile(), "closing the settings did not start a profile save");
 
         // the write itself runs off the main thread

--- a/test/functional_tests/SettingsInstantApplyTest.cpp
+++ b/test/functional_tests/SettingsInstantApplyTest.cpp
@@ -149,6 +149,9 @@ private slots:
     {
         delete mpPreferences;
         mpPreferences = nullptr;
+        // A case that closed the dialog leaves a profile save running - mFORCE_SAVE_ON_EXIT
+        // defaults to on - and that write lands off the main thread, in some later case.
+        mpHost->waitForProfileSave();
     }
 
     // Nothing is pressed: the user stops editing and the setting is written
@@ -318,6 +321,9 @@ private slots:
         openPreferences();
         mpPreferences->checkBox_enableTextAnalyzer->click();
         mpPreferences->close();
+        // ...by this close, not by one left over from an earlier case: saveProfile()
+        // registers its writer before returning, and refuses to start a second save
+        QVERIFY2(mpHost->currentlySavingProfile(), "closing the settings did not start a profile save");
 
         // the write itself runs off the main thread
         QVERIFY2(QTest::qWaitFor(


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `SettingsInstantApplyTest` now drains any in-flight profile save in `cleanup()`, so one case's asynchronous write can no longer land in a later case.
- `test_closingWritesTheProfileToDisk` asserts that its own close started the save, rather than accepting any XML that happens to appear.

#### Motivation for adding to Mudlet

`test_closingWritesTheProfileToDisk` failed on macOS arm64 about 1 run in 8 (most recently [run 33517415946](https://github.com/Mudlet/Mudlet/actions/runs/33517415946)): `mFORCE_SAVE_ON_EXIT` defaults to on, so every dialog close starts an asynchronous profile save, and two earlier cases left one running - which then refilled the save directory the case had just emptied. The same leak could also let the case pass on an earlier case's file, since `saveProfile()` refuses to start a second save.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest -R SettingsInstantApplyTest`. The CI failure reproduces deterministically by stalling the `QtConcurrent` write behind an env var - red without the fix with CI's exact message, green with it at stalls of 0/300/1000/2500ms. The new assertion is sabotage-verified (red with `mFORCE_SAVE_ON_EXIT` forced off). All 9 `Settings*` tests pass.

Assisted-by: Claude:claude-opus-5