### PR TITLE
Improve: Color triggers check single-colored lines faster

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1952,9 +1952,11 @@ void TBuffer::commitLineData(QString line, std::vector<TChar> chars, const char 
         std::vector<TChar> savedPassLine;
         savedPassLine.swap(mPreTriggerPassLine);
         const int savedPassLineNumber = mPreTriggerPassLineNumber;
+        const PassLineUniformity savedPassLineUniformity = mPreTriggerPassLineUniformity;
         mPreTriggerPassLine.swap(mSpareTriggerPassLine);
         mPreTriggerPassLine.assign(buffer.back().cbegin(), buffer.back().cend());
         mPreTriggerPassLineNumber = lineIndex;
+        mPreTriggerPassLineUniformity = PassLineUniformity::Unknown;
         mpHost->runTriggers(lineIndex);
         mSpareTriggerPassLine.swap(mPreTriggerPassLine);
         if (mSpareTriggerPassLine.capacity() > csmMaxRetainedLineCapacity) {
@@ -1962,6 +1964,7 @@ void TBuffer::commitLineData(QString line, std::vector<TChar> chars, const char 
         }
         mPreTriggerPassLine.swap(savedPassLine);
         mPreTriggerPassLineNumber = savedPassLineNumber;
+        mPreTriggerPassLineUniformity = savedPassLineUniformity;
     }
 
     // Only use of TBuffer::wrap(), breaks up new text
@@ -2257,7 +2260,28 @@ void TBuffer::syncPreTriggerPassLine(int y)
 {
     if (y >= 0 && y == mPreTriggerPassLineNumber && y < static_cast<int>(buffer.size())) {
         mPreTriggerPassLine = buffer[y];
+        mPreTriggerPassLineUniformity = PassLineUniformity::Unknown;
     }
+}
+
+const TChar* TBuffer::preTriggerPassLineUniformColors(int lineNumber)
+{
+    if (lineNumber < 0 || lineNumber != mPreTriggerPassLineNumber || mPreTriggerPassLine.empty()) {
+        return nullptr;
+    }
+    const TChar& first = mPreTriggerPassLine.front();
+    if (mPreTriggerPassLineUniformity == PassLineUniformity::Unknown) {
+        // The first character only stands in for the rest of them while this
+        // compares colors the same way the trigger it answers for does
+        const bool uniform = std::all_of(mPreTriggerPassLine.cbegin() + 1, mPreTriggerPassLine.cend(), [&first](const TChar& character) {
+            return sameColor(first.foreground(), character.foreground()) && sameColor(first.background(), character.background());
+        });
+        mPreTriggerPassLineUniformity = uniform ? PassLineUniformity::Uniform : PassLineUniformity::Mixed;
+    }
+    if (mPreTriggerPassLineUniformity == PassLineUniformity::Uniform) {
+        return &first;
+    }
+    return nullptr;
 }
 
 void TBuffer::processMxpWatchdogCallback()

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -43,6 +43,7 @@
 #include <QVarLengthArray>
 #include <QVector>
 
+#include <cstring>
 #include <deque>
 #include <memory>
 #include <string>
@@ -74,6 +75,22 @@ public:
     {
     }
 };
+
+// Only two RGB colors compare as a plain comparison of the front of the object,
+// which can be inlined here rather than made as a call into Qt. HSV, HSL and
+// ExtendedRgb all compare approximately - HSV counts hue 0 and hue 36000 as the
+// same red - so those are left to QColor::operator==(). Every color a trigger
+// actually sees is RGB, which makes the fast path the predicted one.
+constexpr size_t COLOR_COMPARED_BYTES = sizeof(QColor::Spec) + 5 * sizeof(ushort);
+static_assert(sizeof(QColor) == 16 && COLOR_COMPARED_BYTES == 14, "QColor is no longer a spec word followed by five component words - use QColor::operator==() instead of sameColor()");
+
+inline bool sameColor(const QColor& left, const QColor& right)
+{
+    if (Q_LIKELY(left.spec() == QColor::Rgb && right.spec() == QColor::Rgb)) {
+        return std::memcmp(&left, &right, COLOR_COMPARED_BYTES) == 0;
+    }
+    return left == right;
+}
 
 class TChar
 {
@@ -351,6 +368,9 @@ public:
     // Colors of the current trigger-pass line as committed, before any
     // trigger ran; nullptr when lineNumber is not the line being processed:
     const std::vector<TChar>* preTriggerPassLine(int lineNumber) const;
+    // The one color pair shared by every character of that same line, or
+    // nullptr when its colors vary or there is no snapshot for it:
+    const TChar* preTriggerPassLineUniformColors(int lineNumber);
     int find(int line, const QString& what, int pos);
     QStringList split(int line, const QString& splitter);
     QStringList split(int line, const QRegularExpression& splitter);
@@ -585,6 +605,9 @@ private:
     // allocation instead of making a fresh one for each committed line:
     std::vector<TChar> mSpareTriggerPassLine;
     int mPreTriggerPassLineNumber = -1;
+    enum class PassLineUniformity { Unknown, Uniform, Mixed };
+    // Worked out on demand, so a profile with no color triggers never pays for it:
+    PassLineUniformity mPreTriggerPassLineUniformity = PassLineUniformity::Unknown;
     // A line that ended at the game's own wrap column (Host::mUndoServerWrap)
     // is held here instead of being committed, so its continuation can be
     // joined back on and triggers run once over the whole logical line:

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -109,24 +109,6 @@ int indexOfNeedle(const QString& haystack, const QString& needle, const int from
     return -1;
 }
 
-// QColor::operator==() is an exported, out-of-line comparison of a colour spec
-// and five component words, and a colour trigger makes one of those per
-// character of every line it is offered. For two RGB colours that is exactly a
-// comparison of the front of the object, so do it here where it can be
-// inlined. HSL and HSV both compare approximately - HSV counts hue 0 and hue
-// 36000 as the same red - so they are left to Qt. Every colour a trigger
-// actually sees is RGB, which makes the fast path the predicted one.
-constexpr size_t COLOR_COMPARED_BYTES = sizeof(QColor::Spec) + 5 * sizeof(ushort);
-static_assert(sizeof(QColor) == 16 && COLOR_COMPARED_BYTES == 14, "QColor is no longer a spec word followed by five component words - use QColor::operator==() instead of sameColor()");
-
-inline bool sameColor(const QColor& left, const QColor& right)
-{
-    if (Q_LIKELY(left.spec() == QColor::Rgb && right.spec() == QColor::Rgb)) {
-        return std::memcmp(&left, &right, COLOR_COMPARED_BYTES) == 0;
-    }
-    return left == right;
-}
-
 // Holds the capture list and position list of one fire, taking their nodes
 // from TCaptureNodePool and handing them back when the fire is over.
 //
@@ -914,15 +896,30 @@ bool TTrigger::match_color_pattern(int line, int patternNumber, int posOffset, i
     const QColor& defaultBg = consoleModel.mBgColor;
     const int passLineSize = pPassLine ? static_cast<int>(pPassLine->size()) : 0;
 
+    // This allows matching against the current default colours (-2) and
+    // allows ONE of the foreground or background to NOT be considered (-1)
+    // Ideally we should base the matching on only the ANSI code but not
+    // all parts of the text come from the Server and can be determined to
+    // have come from a decoded ANSI code number:
+    const auto colorsMatch = [&](const TChar& character) {
+        return ((ansiFg == scmIgnored) || ((ansiFg == scmDefault) && sameColor(defaultFg, character.foreground())) || sameColor(patternFg, character.foreground()))
+               && ((ansiBg == scmIgnored) || ((ansiBg == scmDefault) && sameColor(defaultBg, character.background())) || sameColor(patternBg, character.background()));
+    };
+
+    if (end > start && passLineSize >= end) {
+        if (const TChar* pUniformColors = consoleModel.buffer.preTriggerPassLineUniformColors(line)) {
+            if (!colorsMatch(*pUniformColors)) {
+                return false;
+            }
+            lists.add(QStringView(lineBuffer).mid(start, end - start), start);
+            processColorPattern(patternNumber, lists.mCaptures, lists.mPositions, line);
+            return true;
+        }
+    }
+
     for (auto it = bufferLine.begin() + start; pos < end; ++it, ++pos) {
         const TChar& character = (pos < passLineSize) ? (*pPassLine)[pos] : *it;
-        // This now allows matching against the current default colours (-2) and
-        // allows ONE of the foreground or background to NOT be considered (-1)
-        // Ideally we should base the matching on only the ANSI code but not
-        // all parts of the text come from the Server and can be determined to
-        // have come from a decoded ANSI code number:
-        if (((ansiFg == scmIgnored) || ((ansiFg == scmDefault) && sameColor(defaultFg, character.foreground())) || sameColor(patternFg, character.foreground()))
-            && ((ansiBg == scmIgnored) || ((ansiBg == scmDefault) && sameColor(defaultBg, character.background())) || sameColor(patternBg, character.background()))) {
+        if (colorsMatch(character)) {
             if (matchBegin == -1) {
                 matchBegin = pos;
             }

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -211,6 +211,108 @@ describe("Trigger processing", function()
             assert.is_true(highlighted, "Highlighting trigger should have run")
         end)
 
+        it("should capture the whole line when every character shares one color", function()
+            _G.uniformColorMatches = {}
+            -- ANSI 2 = green foreground, -1 = any background
+            local colorTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.uniformColorMatches, matches[1])]])
+
+            feedTriggers("\n\27[32mevery character here is green\27[0m\n")
+
+            killTrigger(colorTrigger)
+            local captured = _G.uniformColorMatches
+            _G.uniformColorMatches = nil
+
+            assert.are.equal(1, #captured, "A single-colored line should produce one match")
+            assert.are.equal("every character here is green", captured[1])
+        end)
+
+        it("should capture only the colored run on a line of mixed colors", function()
+            _G.mixedColorMatches = {}
+            local colorTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.mixedColorMatches, matches[1])]])
+
+            feedTriggers("\nplain \27[32mgreen\27[0m plain\n")
+
+            killTrigger(colorTrigger)
+            local captured = _G.mixedColorMatches
+            _G.mixedColorMatches = nil
+
+            assert.are.equal(1, #captured, "Only the green run should have matched")
+            assert.are.equal("green", captured[1])
+        end)
+
+        it("should not match a line that is uniformly a different color", function()
+            _G.otherColorMatches = {}
+            local colorTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.otherColorMatches, matches[1])]])
+
+            feedTriggers("\n\27[31mevery character here is red\27[0m\n")
+
+            killTrigger(colorTrigger)
+            local captured = _G.otherColorMatches
+            _G.otherColorMatches = nil
+
+            assert.are.equal(0, #captured, "A red line should not match a green color trigger")
+        end)
+
+        it("re-reads a line's colors after a trigger inserts text into it", function()
+            _G.uniformInsertMatches = {}
+            local inserted = false
+
+            -- reads the line while it is still all green, so the answer is
+            -- already worked out by the time the insert changes it
+            local beforeTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.uniformInsertMatches, matches[1])]])
+            local insertTrigger = tempRegexTrigger("^greengreen$", function()
+                moveCursor(5, getLineNumber())
+                cinsertText("<red>PLAIN")
+                resetFormat()
+                inserted = true
+            end)
+            local afterTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.uniformInsertMatches, matches[1])]])
+
+            feedTriggers("\n\27[32mgreengreen\27[0m\n")
+
+            killTrigger(beforeTrigger)
+            killTrigger(insertTrigger)
+            killTrigger(afterTrigger)
+            local captured = _G.uniformInsertMatches
+            _G.uniformInsertMatches = nil
+
+            assert.is_true(inserted, "the inserting trigger should have run")
+            assert.are.equal(2, #captured, "got: [" .. table.concat(captured, "][") .. "]")
+            assert.are.equal("greengreen", captured[1], "before the insert every character of the line is green")
+            assert.are.equal("green", captured[2], "the inserted text is not green, so it must not be swept into the capture")
+        end)
+
+        it("judges a line's colors from the snapshot, not from a recolored buffer", function()
+            _G.uniformRecolorMatches = {}
+            local recolored = false
+
+            local recolorTrigger = tempRegexTrigger("^plain green$", function()
+                if selectString("plain green", 1) > -1 then
+                    setFgColor(255, 0, 0)
+                    recolored = true
+                end
+                resetFormat()
+            end)
+            local colorTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.uniformRecolorMatches, matches[1])]])
+
+            feedTriggers("\nplain \27[32mgreen\27[0m\n")
+
+            killTrigger(recolorTrigger)
+            killTrigger(colorTrigger)
+            local captured = _G.uniformRecolorMatches
+            _G.uniformRecolorMatches = nil
+
+            assert.is_true(recolored, "the recoloring trigger should have run")
+            assert.are.equal(1, #captured, "recoloring the whole line red must not make it match green")
+            assert.are.equal("green", captured[1])
+        end)
+
         it("should keep the outer line's original colors across a nested feedTriggers", function()
             _G.innerSnapshotMatches = {}
             _G.outerSnapshotMatches = {}
@@ -240,6 +342,69 @@ describe("Trigger processing", function()
 
             assert.is_true(innerMatched, "Inner pass should match the inner line's original colors")
             assert.is_true(outerMatched, "Outer pass should still match its original colors after the nested pass")
+        end)
+
+        it("judges a nested line's colors on its own, not on the outer line's", function()
+            _G.nestedOwnColorMatches = {}
+
+            -- runs before the feeder, so the outer line is read - and found to
+            -- be all one color - before the nested line is ever processed
+            local colorTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.nestedOwnColorMatches, matches[1])]])
+            local feeder = tempRegexTrigger("^OUTERALLGREEN$", function()
+                feedTriggers("\n\27[32mINNERGREEN\27[0m plaintail\n")
+            end)
+
+            feedTriggers("\n\27[32mOUTERALLGREEN\27[0m\n")
+
+            killTrigger(colorTrigger)
+            killTrigger(feeder)
+            local captured = _G.nestedOwnColorMatches
+            _G.nestedOwnColorMatches = nil
+
+            assert.are.equal(2, #captured, "got: [" .. table.concat(captured, "][") .. "]")
+            assert.are.equal("OUTERALLGREEN", captured[1])
+            assert.are.equal("INNERGREEN", captured[2], "the nested line is only green up to its tail, whatever the outer line was")
+        end)
+
+        it("judges the outer line's colors on its own after a nested feedTriggers", function()
+            _G.nestedOuterColorMatches = {}
+
+            local feeder = tempRegexTrigger("^GREENSTART plaintail$", function()
+                feedTriggers("\n\27[32mINNERALLGREEN\27[0m\n")
+            end)
+            -- runs after the feeder, so it reads the outer line only once the
+            -- nested pass has been and gone
+            local colorTrigger = tempAnsiColorTrigger(2, -1,
+                [[table.insert(_G.nestedOuterColorMatches, matches[1])]])
+
+            feedTriggers("\n\27[32mGREENSTART\27[0m plaintail\n")
+
+            killTrigger(feeder)
+            killTrigger(colorTrigger)
+            local captured = _G.nestedOuterColorMatches
+            _G.nestedOuterColorMatches = nil
+
+            assert.are.equal(2, #captured, "got: [" .. table.concat(captured, "][") .. "]")
+            assert.are.equal("INNERALLGREEN", captured[1])
+            assert.are.equal("GREENSTART", captured[2], "the outer line is only green up to its tail, whatever the nested line was")
+        end)
+
+        it("should capture only the colored run when a line varies by background alone", function()
+            _G.backgroundRunMatches = {}
+            -- ANSI 44 = blue background; the foreground is never set, so it is
+            -- the same on every character and only the background varies
+            local colorTrigger = tempAnsiColorTrigger(-1, 4,
+                [[table.insert(_G.backgroundRunMatches, matches[1])]])
+
+            feedTriggers("\n\27[44mBLUEBG\27[0m plain\n")
+
+            killTrigger(colorTrigger)
+            local captured = _G.backgroundRunMatches
+            _G.backgroundRunMatches = nil
+
+            assert.are.equal(1, #captured, "got: [" .. table.concat(captured, "][") .. "]")
+            assert.are.equal("BLUEBG", captured[1])
         end)
 
         -- A trigger script that calls feedTriggers() re-enters trigger processing.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A color trigger offered a line whose characters all carry the same foreground and background now decides the whole line from one color comparison, instead of repeating that comparison for every character.
- The "is this line all one color" answer is worked out the first time a color trigger asks for it and cached for the rest of that line's trigger pass, so a profile with no color triggers never computes it at all.
- `sameColor()` moves from `TTrigger.cpp` into `TBuffer.h` so both files share one definition.

#### Motivation for adding to Mudlet

Most lines a game sends are a single color, so the per-character color comparisons a profile's color triggers make almost always have the same answer for every character of the line - asking once is enough.

#### Other info (issues closed, discussion etc)

Measured by replaying a 96,561-line real game log through a 46-trigger profile (4 of them color triggers), 10 repeats per arm, arms interleaved, both arms built in the same tree:

| | time |
| --- | --- |
| before | 1.099 s |
| after | 1.028 s |

6.5% faster over ten independent interleaved pairs. Trigger output is unchanged: 496,010 trigger invocations and a hash of every capture come out identical on all twenty runs. Peak RSS is unchanged (406.9 MB before against 407.5 MB after).

Eight new specs in `Trigger_spec.lua` cover the new path: a uniformly colored line, a line of mixed colors, a uniformly colored line of the wrong color, a line that varies by background alone, two that make sure the cached answer is thrown away when a trigger changes the line under it (one inserting differently colored text, one recoloring part of it), and two around a nested `feedTriggers()` - that the nested line is judged on its own colors, and that the outer line still is once the nested pass has been and gone. Each was confirmed to fail against a deliberately broken version of the fast path.

**Test case:** make a color trigger for green foreground / any background, then `feedTriggers("\n\27[32mall green\27[0m\n")` - it should fire with `matches[1] == "all green"`. Then `feedTriggers("\nplain \27[32mgreen\27[0m plain\n")` - it should fire once with `matches[1] == "green"`.

Assisted-by: Claude:claude-opus-5
