### PR TITLE
Improve: Substring triggers skip lines they cannot match

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -261,6 +261,23 @@ static void pcre2_code_deleter(pcre2_code* pointer)
     pcre2_code_free(pointer);
 }
 
+// A pattern of fewer than two characters sets no bits, so it is never filtered
+// out.
+TBigramFilter::Bits TBigramFilter::bitsFor(const QString& text)
+{
+    static_assert(Bits::scmWords * 64 == 256, "the hash below yields a bit number of 0-255, which has to be exactly the number of bits Bits holds");
+    Bits bits;
+    const QChar* data = text.constData();
+    for (qsizetype i = 1, size = text.size(); i < size; ++i) {
+        const quint32 pair = (static_cast<quint32>(data[i - 1].unicode()) << 16) | data[i].unicode();
+        // Knuth's multiplicative hash: only the top bits of the product depend
+        // on every bit of the pair
+        const quint32 bit = (pair * 2654435761u) >> 24;
+        bits.words[bit / 64] |= (quint64(1) << (bit % 64));
+    }
+    return bits;
+}
+
 static void pcre2_match_data_deleter(pcre2_match_data* pointer)
 {
     pcre2_match_data_free(pointer);
@@ -271,7 +288,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
 {
     patterns.replaceInStrings("\n", "");
     mPatterns.clear();
-    mSubstringMatchers.clear();
+    mSubstringPatterns.clear();
     mRegexes.clear();
     mMatchData.clear();
     mRegexJitCompiled.clear();
@@ -326,9 +343,9 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
             mRegexJitCompiled.push_back(false);
 
             if (patternKinds.at(i) == REGEX_SUBSTRING) {
-                mSubstringMatchers.emplace_back(std::make_unique<QStringMatcher>(patterns.at(i)));
+                mSubstringPatterns.emplace_back(TSubstringPattern{std::make_unique<QStringMatcher>(patterns.at(i)), TBigramFilter::bitsFor(patterns.at(i))});
             } else {
-                mSubstringMatchers.emplace_back(nullptr);
+                mSubstringPatterns.emplace_back();
             }
 
             if (patternKinds.at(i) == REGEX_PERL) {
@@ -780,7 +797,8 @@ void TTrigger::filter(std::string& capture, int& posOffset, int lineNumber)
     const int captureLength = static_cast<int>(qstrnlen(capture.data(), capture.size()));
     for (auto* triggerNode : *mpMyChildrenList) {
         auto* trigger = static_cast<TTrigger*>(triggerNode);
-        trigger->match(capture.data(), captureLength, text, lineNumber, posOffset);
+        // no line filter: a capture is not the line those bits were built from
+        trigger->match(capture.data(), captureLength, text, lineNumber, posOffset, nullptr);
     }
 }
 
@@ -794,9 +812,13 @@ void TTrigger::setExpiryCount(int expiryCount)
     mExpiryCount = expiryCount;
 }
 
-bool TTrigger::match_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber)
+bool TTrigger::match_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber, const TBigramFilter* pLineBigrams)
 {
-    const int where = mSubstringMatchers[patternNumber]->indexIn(haystack);
+    const TSubstringPattern& pattern = mSubstringPatterns[patternNumber];
+    if (pLineBigrams && !pLineBigrams->couldContain(haystack, pattern.bigrams)) {
+        return false;
+    }
+    const int where = pattern.matcher->indexIn(haystack);
     if (where != -1) {
         processSubstringMatch(haystack, needle, patternNumber, posOffset, where, lineNumber);
         return true;
@@ -1148,7 +1170,7 @@ void TTrigger::processExactMatch(int patternNumber, int posOffset, int lineNumbe
 // haystack: string to match as a QString
 // line: line number in the buffer
 // posOffset: position in the line to start matching from; used by child triggers
-bool TTrigger::match(const char* haystackC, const int haystackCLength, const QString& haystack, int line, int posOffset)
+bool TTrigger::match(const char* haystackC, const int haystackCLength, const QString& haystack, int line, int posOffset, const TBigramFilter* pLineBigrams)
 {
     // Guard against re-entrancy: cleanup may have deleted this trigger while
     // match() was still on the call stack
@@ -1196,7 +1218,7 @@ bool TTrigger::match(const char* haystackC, const int haystackCLength, const QSt
             ret = false;
             switch (mPatternKinds.at(patternNumber)) {
             case REGEX_SUBSTRING:
-                ret = match_substring(haystack, mPatterns.at(patternNumber), patternNumber, posOffset, line);
+                ret = match_substring(haystack, mPatterns.at(patternNumber), patternNumber, posOffset, line, pLineBigrams);
                 break;
 
             case REGEX_PERL:
@@ -1311,7 +1333,7 @@ bool TTrigger::match(const char* haystackC, const int haystackCLength, const QSt
             if (conditionMet || (mPatterns.empty())) {
                 for (auto* triggerNode : *mpMyChildrenList) {
                     auto* trigger = static_cast<TTrigger*>(triggerNode);
-                    ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset);
+                    ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset, pLineBigrams);
                     if (ret) {
                         conditionMet = true;
                     }
@@ -1326,7 +1348,7 @@ bool TTrigger::match(const char* haystackC, const int haystackCLength, const QSt
             }
             for (auto* triggerNode : *mpMyChildrenList) {
                 auto* trigger = static_cast<TTrigger*>(triggerNode);
-                ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset);
+                ret = trigger->match(haystackC, haystackCLength, haystack, line, posOffset, pLineBigrams);
                 if (ret) {
                     conditionMet = true;
                 }
@@ -1453,7 +1475,7 @@ bool TTrigger::setupTmpColorTrigger(int ansiFg, int ansiBg)
     // Everything setRegexCodeList() fills is indexed by pattern number, so a
     // pattern added here has to extend all of it - even though a colour
     // pattern is matched out of mColorPatternList and compiles no regex.
-    mSubstringMatchers.emplace_back(nullptr);
+    mSubstringPatterns.emplace_back();
     mPatternsUtf8.emplace_back(patternText.toUtf8().constData());
     mRegexes.emplace_back();
     mMatchData.emplace_back();

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -343,7 +343,9 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds, b
             mRegexJitCompiled.push_back(false);
 
             if (patternKinds.at(i) == REGEX_SUBSTRING) {
-                mSubstringPatterns.emplace_back(TSubstringPattern{std::make_unique<QStringMatcher>(patterns.at(i)), TBigramFilter::bitsFor(patterns.at(i))});
+                // Qt::CaseSensitive is the default, spelt out because bitsFor() summarises
+                // this same string case-sensitively: change one and the other has to follow
+                mSubstringPatterns.emplace_back(TSubstringPattern{std::make_unique<QStringMatcher>(patterns.at(i), Qt::CaseSensitive), TBigramFilter::bitsFor(patterns.at(i))});
             } else {
                 mSubstringPatterns.emplace_back();
             }
@@ -816,6 +818,10 @@ bool TTrigger::match_substring(const QString& haystack, const QString& needle, i
 {
     const TSubstringPattern& pattern = mSubstringPatterns[patternNumber];
     if (pLineBigrams && !pLineBigrams->couldContain(haystack, pattern.bigrams)) {
+        // A pattern that occurs in the line contributes only pairs the line already has, so
+        // it can never be dismissed - unless the filter and the matcher have stopped
+        // comparing the same way, which nothing else would notice
+        Q_ASSERT_X(pattern.matcher->indexIn(haystack) == -1, "TTrigger::match_substring", "the bigram filter dismissed a pattern the matcher does find in the line");
         return false;
     }
     const int where = pattern.matcher->indexIn(haystack);

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -72,6 +72,70 @@ struct TColorTable
     QColor mBgColor;
 };
 
+// A 256-bit Bloom filter over the adjacent character pairs of one line: a
+// substring pattern whose own pairs are not all present cannot occur in that
+// line, so it can be dismissed without searching for it. That holds only while
+// the search it stands in for compares exactly the same way bitsFor() does -
+// a case-insensitive matcher would need a case-insensitive summary too.
+class TBigramFilter
+{
+public:
+    struct Bits
+    {
+        static constexpr int scmWords = 4;
+        quint64 words[scmWords]{};
+    };
+
+    static Bits bitsFor(const QString& text);
+
+    // Summarising a line costs about as much as searching it three or four
+    // times over, so a profile with only a couple of substring patterns pays
+    // more for the summary than the searches it saves. How many patterns asked
+    // about the previous line stands in for how many will ask about this one,
+    // a profile's trigger set hardly ever changing between two lines:
+    static constexpr int scmQuestionsWorthSummarising = 5;
+
+    TBigramFilter(const QString& line, const int questionsOnThePreviousLine)
+    : mLine(line)
+    , mSummarise(questionsOnThePreviousLine >= scmQuestionsWorthSummarising)
+    {
+    }
+    TBigramFilter(QString&&, int) = delete;
+    Q_DISABLE_COPY_MOVE(TBigramFilter)
+
+    // Takes the haystack it is standing in for only to check it really is the
+    // line these bits describe: answering about any other string - a capture,
+    // or a slice of the line - would silently stop triggers firing.
+    bool couldContain(const QString& haystack, const Bits& pattern) const
+    {
+        Q_ASSERT(haystack.constData() == mLine.constData());
+        Q_UNUSED(haystack)
+        ++mQuestionsAsked;
+        if (!mSummarise) {
+            return true;
+        }
+        if (!mBuilt) {
+            mLineBits = bitsFor(mLine);
+            mBuilt = true;
+        }
+        for (int i = 0; i < Bits::scmWords; ++i) {
+            if (pattern.words[i] & ~mLineBits.words[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    int questionsAsked() const { return mQuestionsAsked; }
+
+private:
+    const QString& mLine;
+    const bool mSummarise;
+    mutable Bits mLineBits;
+    mutable bool mBuilt = false;
+    mutable int mQuestionsAsked = 0;
+};
+
 class TTrigger : public Tree<TTrigger>
 {
     Q_DECLARE_TR_FUNCTIONS(TTrigger) // Needed so we can use tr() even though TTrigger is NOT derived from QObject
@@ -117,7 +181,7 @@ public:
     QString getScript() const { return mScript; }
     bool setScript(const QString& script);
     bool compileScript();
-    bool match(const char* haystackC, int haystackCLength, const QString&, int line, int posOffset = 0);
+    bool match(const char* haystackC, int haystackCLength, const QString&, int line, int posOffset = 0, const TBigramFilter* pLineBigrams = nullptr);
     bool checkIfNew();
     void unmarkAsNew();
 
@@ -132,7 +196,7 @@ public:
     void enableTrigger(const QString&);
     void disableTrigger(const QString&);
     TTrigger* killTrigger(const QString&);
-    bool match_substring(const QString&, const QString&, int, int posOffset, int lineNumber);
+    bool match_substring(const QString&, const QString&, int, int posOffset, int lineNumber, const TBigramFilter* pLineBigrams);
     bool match_perl(const char* haystackC, int haystackCLength, const QString&, int, int posOffset, int lineNumber);
     bool match_exact_match(const QString&, const QString&, int, int posOffset, int lineNumber);
     bool match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset, int lineNumber);
@@ -220,10 +284,17 @@ private:
 
 
     QList<int> mPatternKinds;
+    // The matcher is null for every pattern kind that is not a substring one;
+    // it lives beside its own filter bits so the two cannot fall out of step
+    struct TSubstringPattern
+    {
+        std::unique_ptr<QStringMatcher> matcher;
+        TBigramFilter::Bits bigrams;
+    };
     // Indexed by pattern number rather than keyed by it: every line reaches
     // these for every pattern of every trigger, which is no place for a tree
     // lookup and a reference count
-    std::vector<std::unique_ptr<QStringMatcher>> mSubstringMatchers;
+    std::vector<TSubstringPattern> mSubstringPatterns;
     std::vector<QSharedPointer<pcre2_code>> mRegexes;
     std::vector<QSharedPointer<pcre2_match_data>> mMatchData;
     // char rather than bool: keeps the plain element access the bit-packed

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -488,11 +488,12 @@ void TriggerUnit::processDataStream(const QString& data, int line)
     // Entries below this index were added by outer (nested-feedTriggers) passes
     // and are already part of this pass's snapshot.
     const qsizetype firstNodeAddedThisPass = mRootNodesAddedWhileProcessing.size();
+    const TBigramFilter lineBigrams(data, mSubstringQuestionsOnTheLastLine);
     for (auto trigger : *pinnedNodeList) {
         if (!trigger->isActive()) {
             continue;
         }
-        trigger->match(subject, subjectLength, data, line);
+        trigger->match(subject, subjectLength, data, line, 0, &lineBigrams);
     }
     // A match here can register more triggers, which also get a shot at the
     // current line - so the list grows in front of the loop, and a trigger that
@@ -517,8 +518,9 @@ void TriggerUnit::processDataStream(const QString& data, int line)
             stopSameLineCreationLoop(trigger->sameLineChainId());
             continue;
         }
-        trigger->match(subject, subjectLength, data, line);
+        trigger->match(subject, subjectLength, data, line, 0, &lineBigrams);
     }
+    mSubstringQuestionsOnTheLastLine = lineBigrams.questionsAsked();
 }
 
 void TriggerUnit::compileAll()

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -164,6 +164,9 @@ private:
     int statsPatternsActive = 0;
     // Counter for nested processing; cleanup deferred until 0
     int mProcessingDepth = 0;
+    // How many substring patterns asked about the previous line, which decides
+    // whether summarising this one is worth it - see TBigramFilter
+    int mSubstringQuestionsOnTheLastLine = 0;
     const QString* mpCurrentExecutingTriggerName = nullptr;
     // Root triggers registered while processDataStream() is running, so each
     // pass can match the ones created during it against the line being

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -655,6 +655,96 @@ describe("Trigger processing", function()
 
     end)
 
+    describe("substring pattern matching", function()
+
+        local line = "ab café the quick brown fox jumps over the lazy dog. 🐉"
+
+        -- Mudlet only summarises a line's character pairs once a profile has
+        -- enough substring patterns for the summary to pay for itself. These
+        -- match nothing and exist only to carry a profile well past that
+        -- threshold, so that raising it later cannot quietly move these specs
+        -- off the summarised path they are written to cover.
+        local function installBallast()
+            local ids = {}
+            for i = 1, 20 do
+                ids[i] = tempTrigger("SpecBigramBallast" .. i, function() end)
+            end
+            return ids
+        end
+
+        local function killAll(ids)
+            for _, id in ipairs(ids) do
+                disableTrigger(id)
+                killTrigger(id)
+            end
+        end
+
+        -- Whether to summarise a line is judged from the line before it, so the
+        -- line is fed twice and only the second pass counted.
+        local function hitsFor(needles)
+            local hits = {}
+            local ids = installBallast()
+            for _, needle in ipairs(needles) do
+                hits[needle] = 0
+                ids[#ids + 1] = tempTrigger(needle, function()
+                    hits[needle] = hits[needle] + 1
+                end)
+            end
+
+            feedTriggers("\n" .. line .. "\n")
+            for _, needle in ipairs(needles) do
+                hits[needle] = 0
+            end
+            feedTriggers("\n" .. line .. "\n")
+
+            killAll(ids)
+            return hits
+        end
+
+        it("matches substrings of every shape that occur in the line", function()
+            local needles = {"a", "ab", "café", "é the", "🐉", "the quick", "brown fox", "over the lazy", "dog."}
+            local hits = hitsFor(needles)
+            for _, needle in ipairs(needles) do
+                assert.are.equal(1, hits[needle], "'" .. needle .. "' occurs in the line and should have matched")
+            end
+        end)
+
+        it("does not match text the line only appears to contain", function()
+            -- each of these is built from characters, and "quick the" from
+            -- character pairs, that the line itself does have
+            local needles = {"ZZ", "Fox", "cafe", "quick the", "abé", "dog.."}
+            local hits = hitsFor(needles)
+            for _, needle in ipairs(needles) do
+                assert.are.equal(0, hits[needle], "'" .. needle .. "' does not occur in the line and should not have matched")
+            end
+        end)
+
+        it("matches a capture the filtering parent carried over from an earlier line", function()
+            _G.TrigBigramCarried = 0
+            local code = [==[ ]==]
+            -- enough plain substring triggers that the profile summarises its
+            -- lines at all, which is the condition this spec is about
+            local ballast = installBallast()
+            feedTriggers("warming the line summary\n")
+
+            tempComplexRegexTrigger("SpecBigramParent", [[^first (\w+)$]], code, 1, 0, 0, 1, 0, 0, 0, 0, 0, 3)
+            tempComplexRegexTrigger("SpecBigramParent", [[^second (\w+)$]], code, 1, 0, 0, 1, 0, 0, 0, 0, 0, 3)
+            permSubstringTrigger("SpecBigramChild", "SpecBigramParent", {"zebra"},
+                                 [==[_G.TrigBigramCarried = _G.TrigBigramCarried + 1]==])
+
+            feedTriggers("first zebra\n")
+            feedTriggers("second wombat\n")
+
+            local fires = _G.TrigBigramCarried
+            killTrigger("SpecBigramChild")
+            killTrigger("SpecBigramParent")
+            killAll(ballast)
+            _G.TrigBigramCarried = nil
+            assert.are.equal(1, fires, "the child searches its parent's capture, which need not come from the line that completed the match")
+        end)
+
+    end)
+
     describe("temporary trigger argument validation", function()
 
         it("tempTrigger rejects a non-string, non-function body", function()

--- a/test/functional_tests/BigramFilterTest.cpp
+++ b/test/functional_tests/BigramFilterTest.cpp
@@ -1,0 +1,111 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * TBigramFilter lets a substring trigger dismiss a line without searching it.
+ * A wrong "yes" only costs the search that would have happened anyway, but a
+ * wrong "no" silently stops a trigger firing, so the property worth pinning is
+ * that there is never one: whatever the line is made of, every substring of it
+ * has to survive the filter.
+ *
+ * A Lua spec cannot see the filter's verdict, only the match it leads to, so it
+ * can only cover the character shapes someone thought to write a trigger for.
+ * This covers every substring of each shape instead.
+ *
+ * Run with: ctest -R BigramFilterTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "TTrigger.h"
+
+#include "GroupedTest.h"
+
+class BigramFilterTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Built rather than written out, so that no source file encoding can turn
+    // the astral character into something that is not a surrogate pair.
+    static QStringList interestingLines()
+    {
+        const QString dragon = QString(QChar(0xD83D)) + QChar(0xDC09); // U+1F409, a surrogate pair
+        const QString acute = QChar(0x0301);                           // a combining mark
+        return QStringList{QString(),
+                           qsl("x"),
+                           qsl("the quick brown fox jumps over the lazy dog"),
+                           qsl("caf") + QChar(0x00E9) + qsl(" touch") + QChar(0x00E9),
+                           qsl("a dragon ") + dragon + qsl(" appears"),
+                           dragon + dragon,
+                           qsl("aaaaaaaa"),
+                           QString(QChar(0)) + qsl("a null leads this line"),
+                           qsl("e") + acute + qsl(" is two characters")};
+    }
+
+private slots:
+    void noSubstringOfALineIsEverDismissed()
+    {
+        for (const QString& line : interestingLines()) {
+            const TBigramFilter filter(line, TBigramFilter::scmQuestionsWorthSummarising);
+            for (qsizetype start = 0; start <= line.size(); ++start) {
+                for (qsizetype length = 0; start + length <= line.size(); ++length) {
+                    const QString substring = line.mid(start, length);
+                    QVERIFY2(filter.couldContain(line, TBigramFilter::bitsFor(substring)),
+                             qPrintable(qsl("'%1' occurs in '%2' at %3 but the filter dismissed it").arg(substring, line, QString::number(start))));
+                }
+            }
+        }
+    }
+
+    void dismissesTextTheLineCannotContain()
+    {
+        const QString line = qsl("the quick brown fox");
+        const TBigramFilter filter(line, TBigramFilter::scmQuestionsWorthSummarising);
+        // every character of "xorb" is in the line, so only the pairs can tell
+        QVERIFY2(!filter.couldContain(line, TBigramFilter::bitsFor(qsl("xorb"))), "a filter that dismisses nothing would save no searches at all");
+    }
+
+    void summarisesOnlyOnceEnoughPatternsAsk()
+    {
+        const QString line = qsl("the quick brown fox");
+        const TBigramFilter::Bits absent = TBigramFilter::bitsFor(qsl("xorb"));
+
+        const TBigramFilter tooFewAsked(line, TBigramFilter::scmQuestionsWorthSummarising - 1);
+        QVERIFY2(tooFewAsked.couldContain(line, absent), "below the threshold the line is not summarised, so nothing can be dismissed");
+
+        const TBigramFilter enoughAsked(line, TBigramFilter::scmQuestionsWorthSummarising);
+        QVERIFY(!enoughAsked.couldContain(line, absent));
+    }
+
+    void countsQuestionsEvenWhenNotSummarising()
+    {
+        // the count is what turns summarising on for the next line, so a line
+        // that is not summarised itself still has to do the counting
+        const QString line = qsl("the quick brown fox");
+        const TBigramFilter filter(line, 0);
+        QCOMPARE(filter.questionsAsked(), 0);
+        filter.couldContain(line, TBigramFilter::bitsFor(qsl("xorb")));
+        filter.couldContain(line, TBigramFilter::bitsFor(qsl("quick")));
+        QCOMPARE(filter.questionsAsked(), 2);
+    }
+};
+
+#include "BigramFilterTest.moc"
+MUDLET_GROUPED_TEST_MAIN(BigramFilterTest)

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -109,6 +109,7 @@ set(TELNET_GROUP_TEST_SOURCES
 
 # Triggers and the other scriptable units, and what a running script does to them
 set(TRIGGER_GROUP_TEST_SOURCES
+    BigramFilterTest.cpp
     CorruptTriggerPatternsTest.cpp
     MultilineTriggerReentrancyTest.cpp
     SetScriptCallbackTest.cpp

--- a/test/functional_tests/CorruptTriggerPatternsTest.cpp
+++ b/test/functional_tests/CorruptTriggerPatternsTest.cpp
@@ -360,7 +360,7 @@ private:
         return pTrigger->match(utf8.constData(), utf8.size(), line, -1);
     }
 
-    // match_substring() indexes mSubstringMatchers by pattern number and
+    // match_substring() indexes mSubstringPatterns by pattern number and
     // dereferences the entry without a bounds or null check, so it relies on one
     // entry per pattern, holding a matcher for exactly the substring kinds.
     // Answers rather than asserting: a QVERIFY here would return from this
@@ -369,13 +369,13 @@ private:
     {
         const QStringList patterns = pTrigger->getPatternsList();
         const QList<int> kinds = pTrigger->getRegexCodePropertyList();
-        if (static_cast<int>(pTrigger->mSubstringMatchers.size()) != patterns.size()) {
+        if (static_cast<int>(pTrigger->mSubstringPatterns.size()) != patterns.size()) {
             return qsl("trigger '%1' holds %2 pattern(s) but %3 matcher slot(s)")
-                    .arg(pTrigger->getName(), QString::number(patterns.size()), QString::number(pTrigger->mSubstringMatchers.size()));
+                    .arg(pTrigger->getName(), QString::number(patterns.size()), QString::number(pTrigger->mSubstringPatterns.size()));
         }
         for (int i = 0; i < patterns.size(); ++i) {
             const bool wantMatcher = kinds.at(i) == REGEX_SUBSTRING;
-            const bool haveMatcher = pTrigger->mSubstringMatchers[i] != nullptr;
+            const bool haveMatcher = pTrigger->mSubstringPatterns[i].matcher != nullptr;
             if (haveMatcher != wantMatcher) {
                 return qsl("trigger '%1' pattern %2 is kind %3 but %4 a matcher")
                         .arg(pTrigger->getName(), QString::number(i), QString::number(kinds.at(i)), haveMatcher ? qsl("has") : qsl("lacks"));


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Each incoming line gets a 256-bit summary of the character pairs it contains, built the first time a substring trigger asks about that line.
- A substring pattern whose own character pairs are not all in that summary cannot occur in the line, so it is dismissed without searching for it.
- Building that summary costs about as much as searching the line three or four times over, so it is only built for a profile carrying enough substring patterns to earn it back - judged from how many asked about the previous line, since a profile's trigger set hardly ever changes between two lines.
- A pattern that survives the check is still searched for exactly as before, so the summary can never invent a match.

#### Motivation for adding to Mudlet

Most substring triggers do not match most lines, and every one of them currently scans the whole line to find that out; a profile with many substring triggers pays that scan over and over for every line the game sends.

#### Other info (issues closed, discussion etc)

Against a 96,561-line real game log, the check rejects 95.0% of substring searches, and the true match rate is 3.4% - so it is close to the best a filter of this kind can do.

Measured by replaying that log through a 46-trigger profile (12 of them substring triggers), 10 repeats per arm, arms interleaved, both arms built in the same tree:

| | time |
| --- | --- |
| before | 1.110 s |
| after | 1.048 s |

5.5% faster over ten independent interleaved pairs. Trigger output is unchanged: 496,010 trigger invocations and a hash of every capture come out identical on all twenty runs. Peak RSS is unchanged (471.6 MB against 473.9 MB).

The size of the win depends on how many substring patterns share the summary, so the same log was also replayed through profiles carrying nothing but substring triggers:

| substring triggers | vs before |
| --- | --- |
| 1 | 1.00x |
| 12 | 0.92x |

A single substring trigger never reaches the point where a summary pays for itself, so none is built and the only thing that profile does extra is count how many patterns asked. Without that cut-off it measured about 11% slower, which is what the cut-off exists to prevent.

Three new specs in `Trigger_spec.lua` cover it: patterns that do occur in a line all match; patterns that do not all fail to - including one built entirely from character pairs the line does contain, which passes the filter and must still be rejected by the real search; and a filter trigger's child, which searches its parent's capture rather than the line, and so must not be offered the line's summary at all. Each was confirmed to fail against a deliberately broken version of the filter.

A new `BigramFilterTest` pins the one property a spec cannot see directly, since a spec only ever observes the match the filter leads to. For nine lines of awkward shapes - an empty line, a single character, a surrogate pair, a combining mark, a leading null byte - every substring of every one of them has to survive the filter. A wrong "no", which would silently stop a trigger firing, is caught there whatever the text is made of.

**Test case:** create a few substring triggers, some matching the incoming text and some not, and confirm exactly the matching ones fire - e.g. on the line `the quick brown fox`, triggers for `brown fox` and `the quick` fire while `quick the` and `Fox` do not.

Assisted-by: Claude:claude-opus-5
