### PR TITLE
Infra: Fix a settings test that broke on an optimized icon

### DIFF
--- a/test/functional_tests/SettingsSearchTest.cpp
+++ b/test/functional_tests/SettingsSearchTest.cpp
@@ -34,6 +34,7 @@
 #include <QtTest/QtTest>
 
 #include <QBoxLayout>
+#include <QColorSpace>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -404,7 +405,14 @@ private slots:
         // survives out of the file and into the header
         const QImage expected(qsl(":/icons/settings-display.png"));
         QCOMPARE(carried.size(), expected.size());
-        QCOMPARE(carried.convertToFormat(QImage::Format_Alpha8), expected.convertToFormat(QImage::Format_Alpha8));
+        QImage carriedShape = carried.convertToFormat(QImage::Format_Alpha8);
+        QImage expectedShape = expected.convertToFormat(QImage::Format_Alpha8);
+        // QImage::operator== compares the colour space, which a gAMA chunk in the
+        // icon gives one side and painting the tint strips from the other - an
+        // image optimiser re-encoding the icon would otherwise fail this
+        carriedShape.setColorSpace(QColorSpace());
+        expectedShape.setColorSpace(QColorSpace());
+        QCOMPARE(carriedShape, expectedShape);
     }
 
     // What someone types is often not a word the settings use - an acronym, or


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `SettingsSearchTest` compared the sidebar glyph against the icon resource with `QImage::operator==`, which compares `QImage::colorSpace()` alongside the pixels
- It now clears the color space on both sides first, so it still pins the icon's shape but ignores the embedded color profile

#### Motivation for adding to Mudlet

ImgBot's re-encode of `src/icons/settings-display.png` in #10318 leaves every alpha byte identical but adds `gAMA` and `cHRM` chunks, and that failed this test on all four CI platforms.

#### Other info (issues closed, discussion etc)

The two sides pick a color profile up differently: the resource is loaded straight into a `QImage` and keeps it, while the header glyph is painted through `tintedGlyph()`, and painting into a `QPixmap` strips it. `convertToFormat(Format_Alpha8)` carries it through rather than dropping it, so it reached the comparison.

The committed icon has no `gAMA` chunk today, so this is green either way on `development` - it unblocks #10318, which goes green once this lands and it is re-run. It is on its own branch because ImgBot force-updates its own.

**Test case:** copy ImgBot's re-encoded `settings-display.png` over `src/icons/settings-display.png` and run `ctest -R SettingsSearchTest` - red before this change, green after. Pointing `expected` at a different icon (`settings-mapper.png`) still fails, so the assertion still discriminates.

Assisted-by: Claude:claude-opus-5