### PR TITLE
Infra: Benchmark the console's cached-screen repaint path

### DIFF
--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -116,6 +116,7 @@ METRIC display_paints_per_sec ...
 METRIC display_paint_ms ...
 METRIC display_rows_per_paint ...
 METRIC display_cols_per_paint ...
+METRIC display_device_pixel_ratio ...
 METRIC display_lines_per_sec ...
 METRIC display_tail_small_paint_ms ...
 METRIC display_tail_large_paint_ms ...
@@ -221,15 +222,21 @@ than silently passing whenever it cannot trust the comparison:
 
 - an invariant (`text_corpus_lines`, `text_corpus_bytes`, `trigger_count`,
   `build_asan`, `corpus_version`, `display_rows_per_paint`,
-  `display_cols_per_paint`, `display_tail_small_cells`,
-  `display_tail_large_cells`, `display_overlay_small_cells`,
-  `display_overlay_large_cells`, `display_overlay_cache_reused`) is missing from
+  `display_cols_per_paint`, `display_device_pixel_ratio`,
+  `display_tail_small_cells`, `display_tail_large_cells`,
+  `display_overlay_small_cells`, `display_overlay_large_cells`,
+  `display_overlay_cache_reused`) is missing from
   either run, or differs between them - the two runs used different corpora,
-  trigger sets, screen geometry or build
+  trigger sets, screen geometry, display scaling or build
   flavours. `build_asan` specifically stops an ASan build being compared against
   a release build, `corpus_version` stops a comparison across a retuned corpus,
   and the `display_*` cell and geometry invariants stop one across a
-  differently-sized screen. `display_overlay_cache_reused` is the odd one out and
+  differently-sized screen. `display_device_pixel_ratio` stops one across a
+  different scale factor: the paint timings are paid per device pixel while every
+  other display invariant is logical, so without it a 1.0 run against a 2.0 run
+  agrees on every check and reports the ratio as a paint regression - measured
+  here as `display_paint_ms` +55% and `display_tail_large_paint_ms` +194% with no
+  code change at all. `display_overlay_cache_reused` is the odd one out and
   is explained under the display benchmark below.
   Because the invariants come from several slots, compare **full runs**: a
   single-slot run on both sides is refused for the missing ones.
@@ -317,6 +324,15 @@ speedup.
 It is checked against 1, not merely for agreement between the two runs: two
 builds that have both lost the path are equal, not comparable. The benchmark also
 warns on stderr naming the window that lost it, so a single run says so too.
+
+What it does **not** see is #10341 at the ratio the invocation above actually
+runs at. That truncation only loses the branch where the device pixel product
+comes out fractional, so the buggy build reads 1 at 1.0 - which is what
+`QT_QPA_PLATFORM=offscreen` gives - and 0 at 1.25 or 1.75. Reproducing that class
+of bug takes a fractional `QT_SCALE_FACTOR`, and since `REGISTER_PERF_BENCHMARK`
+is off by default, nothing runs this unattended to catch one either way. It costs
+the metric less than it sounds: any *other* way of losing the branch reads 0 at
+any ratio, which is most of what it guards.
 
 The `display_*` metrics are reported, not gated by default. They measure at
 least as tightly as the text metrics do on an unloaded machine, so gate on them

--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -117,6 +117,19 @@ METRIC display_paint_ms ...
 METRIC display_rows_per_paint ...
 METRIC display_cols_per_paint ...
 METRIC display_lines_per_sec ...
+METRIC display_tail_small_paint_ms ...
+METRIC display_tail_large_paint_ms ...
+METRIC display_tail_small_cells ...
+METRIC display_tail_large_cells ...
+METRIC display_tail_area_ratio ...
+METRIC display_tail_cost_ratio ...
+METRIC display_overlay_small_paint_ms ...
+METRIC display_overlay_large_paint_ms ...
+METRIC display_overlay_small_cells ...
+METRIC display_overlay_large_cells ...
+METRIC display_overlay_area_ratio ...
+METRIC display_overlay_cost_ratio ...
+METRIC display_overlay_cache_reused ...
 ```
 
 ### Two profile configurations, and why the split matters
@@ -208,11 +221,16 @@ than silently passing whenever it cannot trust the comparison:
 
 - an invariant (`text_corpus_lines`, `text_corpus_bytes`, `trigger_count`,
   `build_asan`, `corpus_version`, `display_rows_per_paint`,
-  `display_cols_per_paint`) is missing from either run, or differs between them -
-  the two runs used different corpora, trigger sets, screen geometry or build
+  `display_cols_per_paint`, `display_tail_small_cells`,
+  `display_tail_large_cells`, `display_overlay_small_cells`,
+  `display_overlay_large_cells`, `display_overlay_cache_reused`) is missing from
+  either run, or differs between them - the two runs used different corpora,
+  trigger sets, screen geometry or build
   flavours. `build_asan` specifically stops an ASan build being compared against
   a release build, `corpus_version` stops a comparison across a retuned corpus,
-  and the two `display_*` invariants stop one across a differently-sized screen.
+  and the `display_*` cell and geometry invariants stop one across a
+  differently-sized screen. `display_overlay_cache_reused` is the odd one out and
+  is explained under the display benchmark below.
   Because the invariants come from several slots, compare **full runs**: a
   single-slot run on both sides is refused for the missing ones.
 - a **gated** metric is missing from either run, or its "before" value is not
@@ -264,6 +282,40 @@ play for the text bench.
 The slot runs last so that its render target and the paint path's cached screen
 pixmap fall outside both `peak_rss_kb` and `defaults_peak_rss_kb`, whose
 difference is documented above as what the default packages cost.
+
+### The cached screen (`display_tail_*`, `display_overlay_*`)
+
+`benchDisplay` above measures the worst case, a full redraw every paint. The two
+benchmarks after it measure the two ways `drawForeground()` avoids one by reusing
+the screen it drew last time, because between them they are what a console
+actually spends its time doing:
+
+- **`display_tail_*`** - one line of new text per paint, a console following a
+  game. Served by the scroll shortcut.
+- **`display_overlay_*`** - a three-row band repainted with no new text and no
+  scroll, the damage a window edge or a Geyser label dragged across the console
+  leaves behind. Served by the cached-screen blit, which is a separate branch
+  with its own guard.
+
+Each runs the same workload in a 640x400 and a 1600x1000 window and reports
+`*_area_ratio` (how much bigger the screen got, ~4.9) against `*_cost_ratio` (how
+much dearer one paint got with it). A path really reusing the cache holds
+cost_ratio far below area_ratio.
+
+`display_overlay_cache_reused` is an **invariant, not a timing**: 1 only when
+both windows really took the cached-screen blit. It exists because the timings
+alone are actively misleading when that branch breaks. Issue #10341 - the guard
+rejecting the cache it had just allocated at fractional device pixel ratios - was
+measured here at `QT_SCALE_FACTOR=1.25` reporting **0.17ms against the fixed
+build's 0.37ms**: the broken build looks twice as fast because it never draws the
+band at all. A percentage would have reported that as a large speedup. Refusing
+the comparison says what actually happened.
+
+The reuse is detected by observation rather than by re-testing the guard, which
+would only keep agreeing with itself: the cache is marked above and inside the
+band, and only the wanted branch arrives with the first mark and without the
+second. The scroll shortcut blits the same pixmap, so blitting alone does not
+distinguish them.
 
 The `display_*` metrics are reported, not gated by default. They measure at
 least as tightly as the text metrics do on an unloaded machine, so gate on them

--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -279,9 +279,10 @@ workload, and comparing their throughput would report a geometry difference as a
 code change. That is the same role `text_corpus_lines` and `text_corpus_bytes`
 play for the text bench.
 
-The slot runs last so that its render target and the paint path's cached screen
-pixmap fall outside both `peak_rss_kb` and `defaults_peak_rss_kb`, whose
-difference is documented above as what the default packages cost.
+Every drawing slot runs after the memory ones so that their render targets and
+the paint path's cached screen pixmap fall outside both `peak_rss_kb` and
+`defaults_peak_rss_kb`, whose difference is documented above as what the default
+packages cost.
 
 ### The cached screen (`display_tail_*`, `display_overlay_*`)
 
@@ -299,23 +300,23 @@ actually spends its time doing:
 
 Each runs the same workload in a 640x400 and a 1600x1000 window and reports
 `*_area_ratio` (how much bigger the screen got, ~4.9) against `*_cost_ratio` (how
-much dearer one paint got with it). A path really reusing the cache holds
-cost_ratio far below area_ratio.
+much dearer one paint got with it, ~1.6). Read the pair as context for a change,
+not as proof the cache is working - the blit is itself proportional to the screen,
+so a broken path does not announce itself in the ratio. That is what the metric
+below is for.
 
 `display_overlay_cache_reused` is an **invariant, not a timing**: 1 only when
 both windows really took the cached-screen blit. It exists because the timings
-alone are actively misleading when that branch breaks. Issue #10341 - the guard
-rejecting the cache it had just allocated at fractional device pixel ratios - was
-measured here at `QT_SCALE_FACTOR=1.25` reporting **0.17ms against the fixed
-build's 0.37ms**: the broken build looks twice as fast because it never draws the
-band at all. A percentage would have reported that as a large speedup. Refusing
-the comparison says what actually happened.
+are not merely noisy when that branch breaks, they are inverted. A repaint whose
+cached-screen guard fails falls through to the scroll shortcut, which blits and
+then redraws nothing - so the damaged band is never drawn and the paint gets
+faster. Issue #10341 measured here at `QT_SCALE_FACTOR=1.25` reports **0.17ms
+against a fixed build's 0.37ms**. A percentage would call the regression a 2x
+speedup.
 
-The reuse is detected by observation rather than by re-testing the guard, which
-would only keep agreeing with itself: the cache is marked above and inside the
-band, and only the wanted branch arrives with the first mark and without the
-second. The scroll shortcut blits the same pixmap, so blitting alone does not
-distinguish them.
+It is checked against 1, not merely for agreement between the two runs: two
+builds that have both lost the path are equal, not comparable. The benchmark also
+warns on stderr naming the window that lost it, so a single run says so too.
 
 The `display_*` metrics are reported, not gated by default. They measure at
 least as tightly as the text metrics do on an unloaded machine, so gate on them

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -134,6 +134,7 @@ public:
     friend class FramePacingTest;
     friend class FrontendRefreshSeamTest;
     friend class TTextEditBlinkTest;
+    friend class PipelineBenchmark;
     static bool shouldRegisterBlinkClient(bool enableBlinkText, bool hasBlinkingContentInRedrawnRegion, bool isBlinkClientRegistered, bool reusedCachedScreenContent);
 
     QColor mFgColor;

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -61,6 +61,12 @@ HARNESSES = {
             "corpus_version",
             "display_rows_per_paint",
             "display_cols_per_paint",
+            # Every display timing is paid per device pixel while every other
+            # display invariant is logical, so two runs at different scale
+            # factors agree on the workload and disagree on every paint metric -
+            # the ratio reported as a code change. Formatted %.2f, so 1.00 and
+            # 1.25 stay distinct.
+            "display_device_pixel_ratio",
             "display_tail_small_cells",
             "display_tail_large_cells",
             "display_overlay_small_cells",
@@ -139,6 +145,18 @@ HARNESSES = {
 MODE_METRICS = ("bench_frame_hash_mode",)
 
 INVARIANTS = COMMON_INVARIANTS + MODE_METRICS + tuple(name for harness in HARNESSES.values() for name in harness["invariants"])
+
+# Why a differing invariant means the runs are not comparable, where the default
+# answer - the two builds are not the same harness, rebuild them - would send
+# someone rebuilding over something no build can change.
+INVARIANT_HINTS = {
+    "display_device_pixel_ratio": (
+        "the two runs drew at different display scaling, and every paint metric is paid per "
+        "device pixel while every other display invariant is logical - so the ratio would be "
+        "reported as a paint regression. Re-run both at the same QT_SCALE_FACTOR, or with none "
+        "set at all; rebuilding cannot change it."
+    ),
+}
 
 # Wall-clock ceiling for a single benchmark run under --run. The ASan/offscreen
 # functional-test build feeds a huge corpus several times, so this is generous.
@@ -263,11 +281,12 @@ def check_invariants(before, after):
                 f"the same {before_harness} harness/build and cannot be compared."
             )
         if before[name] != after[name]:
-            fail(
-                f"{name} differs ({before[name]:g} vs {after[name]:g}) - the two runs measured "
-                "different workloads or build configurations and cannot be compared. "
-                f"Rebuild both trees from the same {before_harness} harness, built the same way."
+            reason = INVARIANT_HINTS.get(
+                name,
+                "the two runs measured different workloads or build configurations and cannot be "
+                f"compared. Rebuild both trees from the same {before_harness} harness, built the same way.",
             )
+            fail(f"{name} differs ({before[name]:g} vs {after[name]:g}) - {reason}")
 
     for name in HARNESSES[before_harness].get("must_be_set", ()):
         for label in ("before", "after"):

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -72,6 +72,12 @@ HARNESSES = {
             # says so, where a percentage would bury it.
             "display_overlay_cache_reused",
         ),
+        # Invariants that also have to hold a particular value, not merely agree
+        # with each other. Two builds that have both lost the cached-screen path
+        # both emit 0, which equality is perfectly happy with - and the timings
+        # they carry then describe a full redraw on both sides rather than the
+        # repaint the metric names.
+        "must_be_set": ("display_overlay_cache_reused",),
         # Throughput for the text and trigger pipelines, plus the shipped default
         # packages on the same corpus - the pipeline metrics run on a bare
         # profile, so only defaults_text_lines_per_sec can see a package costing
@@ -262,6 +268,16 @@ def check_invariants(before, after):
                 "different workloads or build configurations and cannot be compared. "
                 f"Rebuild both trees from the same {before_harness} harness, built the same way."
             )
+
+    for name in HARNESSES[before_harness].get("must_be_set", ()):
+        for label in ("before", "after"):
+            run = before if label == "before" else after
+            if not run[name]:
+                fail(
+                    f"{name} is 0 in the {label} run - that run did not measure what the metric "
+                    "names, so comparing it says nothing. Both runs having lost it makes them "
+                    "equal, not comparable."
+                )
 
     for name in HARNESSES[before_harness].get("soft_invariants", ()):
         if name in before and name in after and before[name] != after[name]:

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -75,8 +75,8 @@ HARNESSES = {
         # Invariants that also have to hold a particular value, not merely agree
         # with each other. Two builds that have both lost the cached-screen path
         # both emit 0, which equality is perfectly happy with - and the timings
-        # they carry then describe a full redraw on both sides rather than the
-        # repaint the metric names.
+        # they carry then describe a repaint that skipped the damaged band on
+        # both sides, which is faster than the one the metric names.
         "must_be_set": ("display_overlay_cache_reused",),
         # Throughput for the text and trigger pipelines, plus the shipped default
         # packages on the same corpus - the pipeline metrics run on a bare

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -63,6 +63,14 @@ HARNESSES = {
             "display_cols_per_paint",
             "display_tail_small_cells",
             "display_tail_large_cells",
+            "display_overlay_small_cells",
+            "display_overlay_large_cells",
+            # 0 when the overlay bench's repaints stopped reusing the cached
+            # screen. An invariant rather than a gated metric because the timings
+            # of a build that lost that path are not slower versions of the same
+            # work, they are a different paint entirely - refusing to compare
+            # says so, where a percentage would bury it.
+            "display_overlay_cache_reused",
         ),
         # Throughput for the text and trigger pipelines, plus the shipped default
         # packages on the same corpus - the pipeline metrics run on a bare

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -64,8 +64,11 @@ HARNESSES = {
             # Every display timing is paid per device pixel while every other
             # display invariant is logical, so two runs at different scale
             # factors agree on the workload and disagree on every paint metric -
-            # the ratio reported as a code change. Formatted %.2f, so 1.00 and
-            # 1.25 stay distinct.
+            # the ratio reported as a code change. Invariants are compared by
+            # exact equality on the parsed value, so the %.2f the benchmark
+            # prints is what gives this one any tolerance: two runs whose real
+            # ratios differ below the second decimal both read 1.00 and compare
+            # equal, while a genuinely different scale factor still does not.
             "display_device_pixel_ratio",
             "display_tail_small_cells",
             "display_tail_large_cells",

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -41,6 +41,7 @@
  */
 
 #include <QFileInfo>
+#include <QPainter>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
@@ -141,6 +142,12 @@ private:
     static constexpr int kDisplayTailLargeWidth = 1600;
     static constexpr int kDisplayTailLargeHeight = 1000;
     static constexpr int kDisplayTailPaints = 400;
+
+    // The overlay pass repaints a band this many rows tall, the shape a window
+    // edge or a Geyser label dragged across the console damages: a few rows, no
+    // new text, and no scroll.
+    static constexpr int kDisplayOverlayBandRows = 3;
+    static constexpr int kDisplayOverlayPaints = 400;
 
     enum class LineShape {
         Prompt,
@@ -871,8 +878,124 @@ private slots:
         emitMetric("display_tail_cost_ratio", large.paintMs / small.paintMs);
     }
 
+    // The third way into drawForeground(), and the one nothing else here covers:
+    // a partial repaint with no new text and no scroll, which is what a window
+    // or a Geyser label dragged over the console leaves behind. It has its own
+    // guard on the cached screen, and when that guard rejects the cache every
+    // such repaint quietly becomes a full redraw. Issue #10341 was exactly that,
+    // and both benchmarks above stayed flat through it.
+    void benchDisplayOverlay()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        QVERIFY(noTriggersAreRunningYet(host));
+
+        host->mTelnet.loopbackTest(mCorpus);
+        const int bufferedLines = host->mpConsole->buffer.getLastLineNumber();
+        QVERIFY2(bufferedLines > 1000, qPrintable(qsl("console buffer only holds %1 lines - the pipeline did not process the corpus").arg(bufferedLines)));
+
+        TTextEdit* pane = host->mpConsole->mUpperPane;
+        QVERIFY(pane);
+
+        OverlayResult small;
+        measureOverlayPaints(pane, bufferedLines, kDisplayTailSmallWidth, kDisplayTailSmallHeight, small);
+        QVERIFY2(!QTest::currentTestFailed(), "the small-window pass did not produce a usable measurement");
+
+        OverlayResult large;
+        measureOverlayPaints(pane, bufferedLines, kDisplayTailLargeWidth, kDisplayTailLargeHeight, large);
+        QVERIFY2(!QTest::currentTestFailed(), "the large-window pass did not produce a usable measurement");
+
+        QVERIFY2(large.cells > small.cells * 2.0,
+                 qPrintable(qsl("the large pane draws %1 cells against the small pane's %2, which is too close to compare - the main window did not take one of the two sizes")
+                                    .arg(large.cells)
+                                    .arg(small.cells)));
+
+        emitMetric("display_overlay_small_paint_ms", small.paintMs);
+        emitMetric("display_overlay_large_paint_ms", large.paintMs);
+        emitMetric("display_overlay_small_cells", static_cast<qint64>(small.cells));
+        emitMetric("display_overlay_large_cells", static_cast<qint64>(large.cells));
+        // The blit is itself proportional to the screen, so cost_ratio does not
+        // flatten out entirely - what it does is stay well under area_ratio,
+        // which a full redraw of the band would not.
+        emitMetric("display_overlay_area_ratio", large.cells / small.cells);
+        emitMetric("display_overlay_cost_ratio", large.paintMs / small.paintMs);
+        // 1 only when both windows really took the cached-screen blit. Without
+        // this the timings alone are ambiguous: a build whose guard rejects the
+        // cache still reports a plausible number, and the comparison would read
+        // a silent full-redraw regression as a modest slowdown.
+        emitMetric("display_overlay_cache_reused", static_cast<qint64>((small.cacheReused && large.cacheReused) ? 1 : 0));
+    }
+
 private:
     enum class DefaultPackages { Skip, Install };
+
+    struct OverlayResult
+    {
+        double paintMs = 0.0;
+        double cells = 0.0;
+        int rows = 0;
+        bool cacheReused = false;
+    };
+
+    // Whether a partial repaint really took drawForeground()'s cached-screen
+    // blit, observed rather than recomputed: a copy of the guard would go on
+    // agreeing with itself long after the guard it was copied from started
+    // rejecting the cache.
+    //
+    // Blitting the cache is not on its own the answer, because the scroll
+    // shortcut below it blits the same pixmap and is what a build with a broken
+    // guard falls through to. The two are told apart by what they redraw: the
+    // cached-screen blit redraws the damaged band, the scroll shortcut redraws
+    // only the bottom row and leaves the band as it found it. So the cache is
+    // marked twice, once outside the band and once inside it, and only the
+    // wanted path arrives with the first mark and without the second.
+    bool overlayPaintReusedCache(TTextEdit* pane, QPixmap& target, const QRect& band)
+    {
+        const QColor outsideMark(0, 255, 0);
+        const QColor insideMark(0, 0, 255);
+        const int insideRow = band.top() / pane->mFontHeight;
+        markCacheRow(pane, 0, outsideMark);
+        markCacheRow(pane, insideRow, insideMark);
+        pane->render(&target, QPoint(), QRegion(band));
+
+        const QImage painted = pane->mRenderBuffer.toImage();
+        const int insideTop = qRound(insideRow * pane->mFontHeight * pane->devicePixelRatioF());
+        const double insideMarkLeft = markedFraction(painted, insideTop, insideMark);
+        const bool cacheWasBlitted = markedFraction(painted, 0, outsideMark) > 0.9;
+        const bool bandWasRedrawn = insideMarkLeft >= 0.0 && insideMarkLeft < 0.1;
+        return cacheWasBlitted && bandWasRedrawn;
+    }
+
+    static void markCacheRow(TTextEdit* pane, const int row, const QColor& colour)
+    {
+        QPainter mark(&pane->mScreenMap);
+        mark.setCompositionMode(QPainter::CompositionMode_Source);
+        mark.fillRect(QRect(0, row * pane->mFontHeight, pane->width(), pane->mFontHeight), colour);
+    }
+
+    // Share of a marked row still carrying its colour, or -1.0 if the row could
+    // not be read - which the caller has to treat as a failure, since "no mark
+    // found" is one of the two answers it is asking for. Sampled a few device
+    // rows below the top edge, which keeps the reading clear of the neighbouring
+    // row whatever the device pixel ratio rounded the boundary to.
+    static double markedFraction(const QImage& image, const int deviceTop, const QColor& colour)
+    {
+        if (image.isNull() || deviceTop < 0 || deviceTop + 6 >= image.height() || image.width() < 8) {
+            return -1.0;
+        }
+        const QRgb wanted = colour.rgb() | 0xff000000u;
+        int hits = 0;
+        int seen = 0;
+        for (int y = deviceTop + 2; y < deviceTop + 6; ++y) {
+            for (int x = 0; x < image.width(); x += 8) {
+                ++seen;
+                if ((image.pixel(x, y) | 0xff000000u) == wanted) {
+                    ++hits;
+                }
+            }
+        }
+        return seen ? static_cast<double>(hits) / seen : -1.0;
+    }
 
     struct TailResult
     {
@@ -943,6 +1066,51 @@ private:
             best = std::min(best, timer.nsecsElapsed() / 1.0e9);
         }
         result.paintMs = (best / kDisplayTailPaints) * 1000.0;
+    }
+
+    // A band of rows repainted with no new text and no scroll, which is the
+    // damage a window edge or a Geyser label dragged across the console leaves
+    // behind. Fills `result` for the reason measureTailPaints() gives.
+    void measureOverlayPaints(TTextEdit* pane, const int bufferedLines, const int windowWidth, const int windowHeight, OverlayResult& result)
+    {
+        mudlet::self()->resize(windowWidth, windowHeight);
+        qApp->processEvents();
+
+        result.rows = pane->getScreenHeight();
+        QVERIFY2(result.rows > kDisplayOverlayBandRows * 3,
+                 qPrintable(qsl("the display pane draws %1 rows, too few to hold a %2-row band with screen either side of it").arg(result.rows).arg(kDisplayOverlayBandRows)));
+        result.cells = static_cast<double>(result.rows) * pane->getColumnCount();
+
+        const int firstLine = result.rows + 16;
+        QVERIFY2(bufferedLines > firstLine + result.rows, qPrintable(qsl("%1 buffered lines cannot fill a %2-row screen that far into the buffer").arg(bufferedLines).arg(result.rows)));
+
+        QPixmap target(pane->size());
+        target.fill(Qt::magenta);
+
+        // A full paint first: it is what leaves a complete screen in the cache
+        // for the partial paints below to have something to reuse.
+        pane->scrollTo(firstLine);
+        pane->render(&target);
+        QVERIFY2(frameHasContent(target.toImage()), "the rendered frame is a single flat colour - nothing was drawn, so the timings below would describe an empty widget");
+        QVERIFY2(pane->imageTopLine() > 10, qPrintable(qsl("the top line is %1, close enough to the start of the buffer that drawForeground() forces full redraws").arg(pane->imageTopLine())));
+
+        const QRect band(0, (result.rows / 3) * pane->mFontHeight, pane->width(), kDisplayOverlayBandRows * pane->mFontHeight);
+        QVERIFY2(band.height() < pane->rect().height(), "the band covers the whole pane, so these would be full repaints rather than the partial ones this measures");
+        QVERIFY2(band.top() >= pane->mFontHeight, "the band starts at the top row, leaving no row above it for the probe below to mark");
+
+        double best = std::numeric_limits<double>::max();
+        for (int pass = 0; pass < kDisplayPasses; ++pass) {
+            QElapsedTimer timer;
+            timer.start();
+            for (int i = 0; i < kDisplayOverlayPaints; ++i) {
+                pane->render(&target, QPoint(), QRegion(band));
+            }
+            best = std::min(best, timer.nsecsElapsed() / 1.0e9);
+        }
+        result.paintMs = (best / kDisplayOverlayPaints) * 1000.0;
+
+        // Last, because it leaves marks in the cache: nothing is timed after it.
+        result.cacheReused = overlayPaintReusedCache(pane, target, band);
     }
 
     // Called before the benchmark installs any of its own, so anything running

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -821,6 +821,12 @@ private slots:
         // difference between two builds means they did not draw the same thing.
         emitMetric("display_rows_per_paint", static_cast<qint64>(rows));
         emitMetric("display_cols_per_paint", static_cast<qint64>(pane->getColumnCount()));
+        // Not the workload but the surface under it, and an invariant for the
+        // same reason: every display timing below is paid per device pixel,
+        // while every other invariant here is logical and so identical at any
+        // scale factor. Without this a run at 1.0 and a run at 2.0 agree on
+        // everything the script checks and disagree on every paint timing.
+        emitMetric("display_device_pixel_ratio", pane->devicePixelRatioF());
         // Lines/s the display can sustain, directly comparable to text_lines_per_sec.
         emitMetric("display_lines_per_sec", paintsPerSec * rows);
     }
@@ -882,8 +888,9 @@ private slots:
     // Its guard on the cached screen is separate from the scroll shortcut's, and
     // when it rejects the cache the repaint falls through to that shortcut, which
     // blits and then redraws nothing - so the damaged band is never drawn and the
-    // paint gets FASTER. Issue #10341 is that, unfixed on development as this
-    // lands, and both benchmarks above stay flat through it.
+    // paint gets FASTER. Issue #10341 was exactly that, and both benchmarks above
+    // stayed flat through it - which is why this one exists. Reproducing it now
+    // means reverting #10343 and running at a fractional QT_SCALE_FACTOR.
     void benchDisplayOverlay()
     {
         Host* host = startProfile();

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -143,9 +143,6 @@ private:
     static constexpr int kDisplayTailLargeHeight = 1000;
     static constexpr int kDisplayTailPaints = 400;
 
-    // The overlay pass repaints a band this many rows tall, the shape a window
-    // edge or a Geyser label dragged across the console damages: a few rows, no
-    // new text, and no scroll.
     static constexpr int kDisplayOverlayBandRows = 3;
     static constexpr int kDisplayOverlayPaints = 400;
 
@@ -880,10 +877,13 @@ private slots:
 
     // The third way into drawForeground(), and the one nothing else here covers:
     // a partial repaint with no new text and no scroll, which is what a window
-    // or a Geyser label dragged over the console leaves behind. It has its own
-    // guard on the cached screen, and when that guard rejects the cache every
-    // such repaint quietly becomes a full redraw. Issue #10341 was exactly that,
-    // and both benchmarks above stayed flat through it.
+    // or a Geyser label dragged over the console leaves behind.
+    //
+    // Its guard on the cached screen is separate from the scroll shortcut's, and
+    // when it rejects the cache the repaint falls through to that shortcut, which
+    // blits and then redraws nothing - so the damaged band is never drawn and the
+    // paint gets FASTER. Issue #10341 is that, unfixed on development as this
+    // lands, and both benchmarks above stay flat through it.
     void benchDisplayOverlay()
     {
         Host* host = startProfile();
@@ -914,15 +914,11 @@ private slots:
         emitMetric("display_overlay_large_paint_ms", large.paintMs);
         emitMetric("display_overlay_small_cells", static_cast<qint64>(small.cells));
         emitMetric("display_overlay_large_cells", static_cast<qint64>(large.cells));
-        // The blit is itself proportional to the screen, so cost_ratio does not
-        // flatten out entirely - what it does is stay well under area_ratio,
-        // which a full redraw of the band would not.
         emitMetric("display_overlay_area_ratio", large.cells / small.cells);
         emitMetric("display_overlay_cost_ratio", large.paintMs / small.paintMs);
-        // 1 only when both windows really took the cached-screen blit. Without
-        // this the timings alone are ambiguous: a build whose guard rejects the
-        // cache still reports a plausible number, and the comparison would read
-        // a silent full-redraw regression as a modest slowdown.
+        // 1 only when both windows really took the cached-screen blit, without
+        // which the timings above are not merely noisy but inverted: the build
+        // that lost the path is the faster-looking one.
         emitMetric("display_overlay_cache_reused", static_cast<qint64>((small.cacheReused && large.cacheReused) ? 1 : 0));
     }
 
@@ -945,8 +941,8 @@ private:
     // Blitting the cache is not on its own the answer, because the scroll
     // shortcut below it blits the same pixmap and is what a build with a broken
     // guard falls through to. The two are told apart by what they redraw: the
-    // cached-screen blit redraws the damaged band, the scroll shortcut redraws
-    // only the bottom row and leaves the band as it found it. So the cache is
+    // cached-screen blit redraws the damaged band, the scroll shortcut starts
+    // from the bottom row and leaves the band as it found it. So the cache is
     // marked twice, once outside the band and once inside it, and only the
     // wanted path arrives with the first mark and without the second.
     bool overlayPaintReusedCache(TTextEdit* pane, QPixmap& target, const QRect& band)
@@ -1068,9 +1064,7 @@ private:
         result.paintMs = (best / kDisplayTailPaints) * 1000.0;
     }
 
-    // A band of rows repainted with no new text and no scroll, which is the
-    // damage a window edge or a Geyser label dragged across the console leaves
-    // behind. Fills `result` for the reason measureTailPaints() gives.
+    // Fills `result` for the reason measureTailPaints() gives.
     void measureOverlayPaints(TTextEdit* pane, const int bufferedLines, const int windowWidth, const int windowHeight, OverlayResult& result)
     {
         mudlet::self()->resize(windowWidth, windowHeight);
@@ -1092,11 +1086,24 @@ private:
         pane->scrollTo(firstLine);
         pane->render(&target);
         QVERIFY2(frameHasContent(target.toImage()), "the rendered frame is a single flat colour - nothing was drawn, so the timings below would describe an empty widget");
-        QVERIFY2(pane->imageTopLine() > 10, qPrintable(qsl("the top line is %1, close enough to the start of the buffer that drawForeground() forces full redraws").arg(pane->imageTopLine())));
+        QVERIFY2(pane->imageTopLine() > 0, "the screen is at the very start of the buffer, where drawForeground() refuses the cached-screen blit outright");
 
         const QRect band(0, (result.rows / 3) * pane->mFontHeight, pane->width(), kDisplayOverlayBandRows * pane->mFontHeight);
         QVERIFY2(band.height() < pane->rect().height(), "the band covers the whole pane, so these would be full repaints rather than the partial ones this measures");
         QVERIFY2(band.top() >= pane->mFontHeight, "the band starts at the top row, leaving no row above it for the probe below to mark");
+        // Any of these makes drawForeground() write the repaint back to the
+        // cache, which swaps the two pixmaps and leaves the probe reading the
+        // pre-render cache rather than what was just painted - reporting 0 for a
+        // reason that has nothing to do with the paint path. The first two also
+        // widen the redraw to the whole screen below the band, so the timings
+        // would stop describing a band at all.
+        QVERIFY2(!pane->mMouseTracking && !pane->mForceUpdate && pane->mDirtyFirstLine < 0,
+                 "a drag, a forced redraw or a pending dirty line is in progress, so this would measure a wider repaint than the band and read the wrong pixmap back");
+        // The probe marks the cache and reads the band back out of the buffer, so
+        // a cache too small to carry the marks would report them missing - the
+        // same answer as a rejected cache, arrived at for an unrelated reason.
+        QVERIFY2(!pane->mScreenMap.isNull() && pane->mScreenMap.height() >= qRound(band.bottom() * pane->devicePixelRatioF()),
+                 "the cached screen is too small to mark, so the probe could not tell a rejected cache from an unreadable one");
 
         double best = std::numeric_limits<double>::max();
         for (int pass = 0; pass < kDisplayPasses; ++pass) {
@@ -1111,6 +1118,12 @@ private:
 
         // Last, because it leaves marks in the cache: nothing is timed after it.
         result.cacheReused = overlayPaintReusedCache(pane, target, band);
+        if (!result.cacheReused) {
+            qWarning("%s",
+                     qPrintable(qsl("the %1x%2 window's repaints did not reuse the cached screen, so the overlay timings from it describe a paint that skipped the band rather than one that drew it")
+                                        .arg(windowWidth)
+                                        .arg(windowHeight)));
+        }
     }
 
     // Called before the benchmark installs any of its own, so anything running


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Adds `benchDisplayOverlay()` to `PipelineBenchmark`: a 3-row band repainted with no new text and no scroll, at 640x400 and 1600x1000. That is `drawForeground()`'s cached-screen blit, which nothing here measured before.
- Adds `display_overlay_cache_reused`, a 0/1 invariant that is 1 only when both windows really took that branch, so `compare-perf-baseline.py` refuses the comparison instead of reporting a percentage when the branch breaks.
- Documents both, plus the previously undocumented `display_tail_*` metrics.

#### Motivation for adding to Mudlet

`benchDisplay` measures a full redraw and `benchDisplayTail` measures the scroll shortcut. The third path - a window or Geyser label dragged over the console - had no coverage, which is how #10341 went unnoticed by every benchmark we have.



#### Other info (issues closed, discussion etc)

Reuse is detected by observation, not by a copy of the guard, which would only keep agreeing with itself. The scroll shortcut blits the same pixmap, so blitting alone proves nothing; the cache is marked above and inside the band, and only the wanted branch arrives with the first mark and without the second.

Verified to fail without the fix: `display_overlay_cache_reused` reads 0 on development at dpr 1.25, and 1 once #10343's `qCeil` fix is applied. Clean at dpr 1.0/1.5/2.0 either way - truncation only loses something when the product is fractional.

**Test case:** `cmake --build <build> --target PipelineBenchmark`, then `HOME=$(mktemp -d) QT_QPA_PLATFORM=offscreen ./test/functional_tests/PipelineBenchmark`. Expect `METRIC display_overlay_cache_reused 1`. Re-run with `QT_SCALE_FACTOR=1.25` on a tree without #10343 to see it report 0.

Assisted-by: Claude:claude-opus-5

Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>