### PR TITLE
Infra: Warn when the wiki manual documents a function twice

### DIFF
--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * fri'
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   update-autocompletion:
     runs-on: ubuntu-latest
@@ -24,7 +28,28 @@ jobs:
         luarocks install lunajson
 
     - name: update autocompletion data
-      run: lua CI/update-autocompletion.lua src/lua-function-list.json
+      id: update
+      run: |
+        set -o pipefail
+        lua CI/update-autocompletion.lua src/lua-function-list.json | tee update.log
+
+        duplicates=$(sed -n 's/^::warning:://p' update.log)
+        if [ -n "$duplicates" ]; then
+          {
+            echo "### :warning: Duplicate function headings in the wiki manual"
+            echo ""
+            echo "$duplicates" | sed 's/^/- /'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "duplicates<<PRBODY"
+            echo "#### :warning: Duplicate function headings in the wiki manual"
+            echo "$duplicates" | sed 's/^/- /'
+            echo "PRBODY"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "duplicate_count=$(echo "$duplicates" | wc --lines)" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: sort autocompletion data
       run: |
@@ -46,7 +71,7 @@ jobs:
       run: |
         lines_changed=$(git diff --patch --unified=0 src/lua-function-list.json | wc --lines)
         echo "$lines_changed lines changed."
-        echo ::set-output name=lines_changed::$lines_changed
+        echo "lines_changed=$lines_changed" >> "$GITHUB_OUTPUT"
 
     - name: send in a pull request
       uses: peter-evans/create-pull-request@v8
@@ -62,4 +87,28 @@ jobs:
           :crown: An automated PR to update autocompletion data in Mudlet from ${{ github.ref }} (${{ github.sha }}).
           #### Motivation for adding to Mudlet
           So autocompletion works as expected.
+          ${{ steps.update.outputs.duplicates }}
         author: mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>
+
+    # GitHub Actions cannot conclude a run as anything but success or failure, so raise the
+    # duplicates as a separate check run - 'neutral' is what shows up as a yellow warning
+    - name: flag duplicate functions in the manual
+      if: steps.update.outputs.duplicates != ''
+      uses: actions/github-script@v9
+      env:
+        DUPLICATE_COUNT: ${{ steps.update.outputs.duplicate_count }}
+        DUPLICATES: ${{ steps.update.outputs.duplicates }}
+      with:
+        script: |
+          await github.rest.checks.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: 'wiki manual duplicates',
+            head_sha: context.sha,
+            status: 'completed',
+            conclusion: 'neutral',
+            output: {
+              title: `${process.env.DUPLICATE_COUNT} duplicate function heading(s) in the wiki manual`,
+              summary: process.env.DUPLICATES,
+            },
+          });

--- a/CI/update-autocompletion.lua
+++ b/CI/update-autocompletion.lua
@@ -28,6 +28,9 @@ local function scrapeLuaFunctions(htmlbody)
       -- of a repeated heading with _2, _3 ... which is not part of the function name
       name = string.match(line, '<h2><span class="mw%-headline" id=".-">(.-)</span></h2>')
       if name then
+        -- MediaWiki strips tags when it builds the anchor id but not from the heading
+        -- text, so a heading wrapped in a link would otherwise carry raw HTML into the name
+        name = name:gsub("<[^>]*>", "")
         state = 1
       end
     elseif state == 1 then

--- a/CI/update-autocompletion.lua
+++ b/CI/update-autocompletion.lua
@@ -10,27 +10,30 @@ local function magiclines(s)
   return s:gmatch("(.-)\n")
 end
 
+-- ::warning:: turns this into an annotation on the GitHub Actions run
+local function warn(message)
+  print("::warning::" .. message)
+end
+
 local function scrapeLuaFunctions(htmlbody)
   local funcs = {}
   local funcsHash = {}
   local count = 0
+  local duplicates = 0
   local state = 0
-  local line = nil
-  local match = nil
-  local name, usage, definition
+  local name, usage
   for line in magiclines(htmlbody) do
     if state == 0 then
-      --print("testing match on " .. line)
-      name = string.match(line, '<h2><span class="mw%-headline" id="(.-)">.-</span></h2>')
+      -- take the heading text rather than the anchor id: MediaWiki suffixes the id
+      -- of a repeated heading with _2, _3 ... which is not part of the function name
+      name = string.match(line, '<h2><span class="mw%-headline" id=".-">(.-)</span></h2>')
       if name then
         state = 1
-        --print("Name: " .. name)
       end
     elseif state == 1 then
       usage = string.match(line, '<dl><dt>(.-)</dt>')
       if usage then
         state = 0
-        --print("Usage: " .. usage)
         local func = {}
         func.name = trim(name)
         func.usage = trim(usage)
@@ -39,18 +42,24 @@ local function scrapeLuaFunctions(htmlbody)
     end
   end
 
-  funcsHash = {}
-  local count = 0
   for i, v in ipairs(funcs) do
     count = count + 1
-    --print(v.name .. " - " .. v.usage)
     if not string.match(v.name, "[%:%.]") then
-      funcsHash[v.name] = v.usage
+      if funcsHash[v.name] then
+        duplicates = duplicates + 1
+        warn(string.format("%s is documented more than once in the manual - keeping '%s' and dropping '%s'. Merge the duplicate headings on the wiki.",
+                           v.name, funcsHash[v.name], v.usage))
+      else
+        funcsHash[v.name] = v.usage
+      end
     end
   end
 
   local jsonText = lunajson.encode(funcsHash)
   print(count .. " functions in the API.")
+  if duplicates > 0 then
+    print(duplicates .. " duplicate function heading(s) in the manual.")
+  end
 
   return jsonText
 end


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `CI/update-autocompletion.lua` now takes the function name from the wiki heading *text* rather than its anchor id. MediaWiki suffixes a repeated heading's id with `_2`, `_3` …, which is how `createMapLabel_2` and `saveProfile_2` ended up in `src/lua-function-list.json` as autocompletable names that do not exist.
- Duplicates are no longer silent: each one is reported as a GitHub Actions `::warning::` annotation, listed in the job summary, and appended to the body of the automated "Update autocompletion data" PR, naming the signature kept and the one dropped.
- Because Actions cannot conclude a run as anything but success or failure, the workflow also creates a separate `wiki manual duplicates` check run with `conclusion: neutral` — the yellow ⚠ next to the commit. `neutral` counts as passing, so it flags without blocking and the weekly update still goes through.
- Drive-by: the deprecated `::set-output` is replaced with `$GITHUB_OUTPUT`; its own deprecation annotation would otherwise sit in the same yellow block as the new warnings.

#### Motivation for adding to Mudlet

Duplicated wiki headings quietly become bogus `_2` entries in Mudlet's editor autocompletion, and nothing told us they were there.

#### Other info (issues closed, discussion etc)

Two duplicates exist on the wiki right now, and this is what the workflow will report until they are merged:

- `createMapLabel` is documented twice on `Manual:Mapper_Functions`, the second time with the `outlineRed/Green/Blue` parameters.
- `saveProfile` is documented on both `Manual:File_System_Functions` and `Manual:Miscellaneous_Functions`.

The wiki edits are a separate, manual job. Once the next run happens, `createMapLabel_2` and `saveProfile_2` drop out of `src/lua-function-list.json` on their own — that file is autogenerated, so it is deliberately untouched here.

**Test case:** run the workflow on this branch with `gh workflow run update-autocompletion.yml --ref autocompletion-duplicate-warning`. The run stays green, the summary page shows two warning annotations plus a "Duplicate function headings in the wiki manual" section, and a yellow `wiki manual duplicates` check appears on the commit. The regenerated `src/lua-function-list.json` differs from the committed one by exactly the two `_2` keys and nothing else.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Piotr Wilczynski <delwing@gmail.com>

https://claude.ai/code/session_01TZcGgVqhqFGZhvihSdin9H