### PR TITLE
Infra: Clear out the CodeQL code scanning alerts

### DIFF
--- a/src/SpeechAudioCapture.cpp
+++ b/src/SpeechAudioCapture.cpp
@@ -271,7 +271,7 @@ void SpeechAudioCapture::convertAndEmit(const QByteArray& audioData)
     // read.
     const int consumedFrames = qMin(static_cast<int>(phase), availableFrames);
     if (consumedFrames > 0) {
-        mCarryBuffer.remove(0, consumedFrames * frameBytes);
+        mCarryBuffer.remove(0, static_cast<qsizetype>(consumedFrames) * frameBytes);
     }
     mResamplePhase = phase - consumedFrames;
 

--- a/src/SpeechRecognizerFactory.cpp
+++ b/src/SpeechRecognizerFactory.cpp
@@ -43,7 +43,7 @@ SpeechRecognizer* SpeechRecognizerFactory::create(Backend backend, QObject* pare
         return new VoskRecognizer(parent);
 
     case Backend::Whisper:
-        // Future: return new WhisperRecognizer(parent);
+        // The Whisper backend has no implementation yet
         return nullptr;
 
     case Backend::Platform:
@@ -88,7 +88,7 @@ QString SpeechRecognizerFactory::defaultModelPath(Backend backend)
         return VoskRecognizer::defaultModelPath();
 
     case Backend::Whisper:
-        // Future: return WhisperRecognizer::defaultModelPath();
+        // The Whisper backend has no implementation yet
         return QString();
 
     case Backend::Platform:

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1240,7 +1240,7 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
             } else {
                 qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - detected an invalid CSI sequence beginning with \"CSI"
                                              << localBuffer.substr(spanStart, spanEnd - spanStart).c_str() << " which Mudlet will ignore.";
-            } // End of (isAValidFinalByte) {}
+            } // End of the isAValidFinalByte test
 
             mGotCSI = false;
             // Step over the parameter string and the byte that ended it, unless


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Widen the speech capture resampler's frame-byte multiplication to `qsizetype` before it reaches `QByteArray::remove()`, so the product cannot overflow `int` on the way (CodeQL's only high-severity finding).
- Replace two `// Future: return ...` placeholders in `SpeechRecognizerFactory` with prose saying the Whisper backend is not implemented yet.
- Reword a block-end marker in `TBuffer` that CodeQL read as commented-out code, keeping the file's existing `// End of ...` convention.

#### Motivation for adding to Mudlet

These were the four code scanning alerts worth acting on; the other 41 open ones have been dismissed on GitHub as false positives or won't-fix, so the queue is now empty either way.

#### Other info (issues closed, discussion etc)

The dismissals are mostly `cpp/inconsistent-null-check` on `mudlet::self()` (32 of them) - it returns the singleton set in `mudlet::start()` and cleared only in `~mudlet`, and every flagged site already requires a live instance. The rest are a Qt parent-owned `QListWidgetItem` read as a leak, the MSDP parser's long switch case, three deliberate loop-counter advances that consume two-character tokens, and three FIXME comments.

Worth noting: the `cpp/inconsistent-null-check` family regenerates for any *new* `mudlet::self()` call site, since dismissals only cover the alerts that exist. If that becomes annoying, the rule id could join `cpp/poorly-documented-function` in the `query-filters` block of `.github/codeql/codeql-config.yml` - not done here, as that is a CI policy call rather than an alert triage one.

**Test case:** nothing user-visible changes. Build and confirm speech recognition still transcribes normally, and that ANSI/CSI handling in the console is unaffected.

Assisted-by: Claude:claude-opus-5