### PR TITLE
Infra: Stop the editor position test flaking on macOS CI

### DIFF
--- a/test/functional_tests/ProfileTestHelper.h
+++ b/test/functional_tests/ProfileTestHelper.h
@@ -99,15 +99,12 @@ inline Host* create(const QString& profileName,
 
     // Until the zero-timer in slot_showConnectionDialog() has shown and activated
     // the dialog, the focus slot_addProfile() sets reaches only the window, never
-    // QApplication::focusWidget(), which is what the waits below read. So being
-    // visible is not enough to click into: activation is a queued window-system
-    // event, and any window still open from an earlier test can be the one that
-    // ends up with it. Ask again on every turn until the dialog holds it, rather
-    // than typing into a dialog that cannot report focus and blaming the field.
+    // QApplication::focusWidget(), which is what the waits below read. Activation
+    // is queued, so a window an earlier test left open can be holding it.
     if (!QTest::qWaitFor(
                 []() {
                     dlgConnectionProfiles* dialog = mudlet::self()->mpConnectionDialog;
-                    if (!dialog || !dialog->isVisible() || !dialog->new_profile_button || !dialog->profile_name_entry) {
+                    if (!dialog || !dialog->isVisible()) {
                         return false;
                     }
                     if (!dialog->isActiveWindow()) {
@@ -117,7 +114,9 @@ inline Host* create(const QString& profileName,
                     return true;
                 },
                 timeout)) {
-        qWarning() << "TestProfile::create() - the connection dialog was never shown and activated";
+        const dlgConnectionProfiles* dialog = mudlet::self()->mpConnectionDialog;
+        qWarning() << "TestProfile::create() - the connection dialog never became active. dialog:" << dialog << "visible:" << (dialog && dialog->isVisible())
+                   << "active:" << (dialog && dialog->isActiveWindow()) << "activation is held by:" << QApplication::focusWindow();
         return nullptr;
     }
 

--- a/test/functional_tests/ProfileTestHelper.h
+++ b/test/functional_tests/ProfileTestHelper.h
@@ -99,14 +99,25 @@ inline Host* create(const QString& profileName,
 
     // Until the zero-timer in slot_showConnectionDialog() has shown and activated
     // the dialog, the focus slot_addProfile() sets reaches only the window, never
-    // QApplication::focusWidget(), which is what the waits below read.
+    // QApplication::focusWidget(), which is what the waits below read. So being
+    // visible is not enough to click into: activation is a queued window-system
+    // event, and any window still open from an earlier test can be the one that
+    // ends up with it. Ask again on every turn until the dialog holds it, rather
+    // than typing into a dialog that cannot report focus and blaming the field.
     if (!QTest::qWaitFor(
                 []() {
                     dlgConnectionProfiles* dialog = mudlet::self()->mpConnectionDialog;
-                    return dialog != nullptr && dialog->isVisible() && dialog->new_profile_button != nullptr && dialog->profile_name_entry != nullptr;
+                    if (!dialog || !dialog->isVisible() || !dialog->new_profile_button || !dialog->profile_name_entry) {
+                        return false;
+                    }
+                    if (!dialog->isActiveWindow()) {
+                        dialog->activateWindow();
+                        return false;
+                    }
+                    return true;
                 },
                 timeout)) {
-        qWarning() << "TestProfile::create() - the connection dialog was never shown";
+        qWarning() << "TestProfile::create() - the connection dialog was never shown and activated";
         return nullptr;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `TestProfile::create()` now waits for the connection dialog to be the *active* window, not merely visible, and nudges it with `activateWindow()` on each turn.
- When that wait times out, the warning names the window actually holding activation instead of claiming the dialog "was never shown".

#### Motivation for adding to Mudlet

`EditorWindowPositionTest::testAnUnopenedEditorDoesNotOverwriteThePosition()` has been failing intermittently on the macOS CI job across unrelated PRs: `QWidget::setFocus()` only reaches `QApplication::focusWidget()` once the widget's window is active, activation on the offscreen QPA plugin is delivered as a queued window-system event, and a top-level left open by an earlier test case in the same binary can still be holding it when the dialog appears - so the subsequent focus waits time out even though the dialog is up and clickable.

#### Other info (issues closed, discussion etc)

The helper is shared by 95 functional tests; all 128 grouped ctest cases pass with the change. Verified by sabotage rather than by reading: stealing activation once makes the unfixed helper fail with "never took focus" and the fixed helper pass, and holding activation forever makes the fixed helper fail while naming `main_windowWindow` as the holder.

**Test case:** `ctest -R EditorWindowPositionTest --output-on-failure` - all 18 cases pass; no behavior change for a test whose dialog activates normally.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
