### PR TITLE
Fix: Crash when using a scroll box or text box after its window was deleted

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -95,6 +95,10 @@ TLabel::~TLabel()
     // itself going, with nobody taking it out of the map first.
     if (mpHost) {
         mpHost->windowRegistry().deregisterLabel(mName, mpModel.get());
+        // The tracker holds the movie raw and reads every entry it has to report
+        if (mpMovie) {
+            mpHost->getGifTracker()->unregisterGif(mpMovie);
+        }
     }
 
     if (mpMovie) {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -440,6 +440,8 @@ void TMainConsole::registerScrollBox(const QString& name, TScrollBox* pScrollBox
 
 void TMainConsole::deregisterScrollBox(TScrollBox* pScrollBox)
 {
+    // This is the only destroyed() connection made from a scroll box to this
+    // console, so severing all of them is severing just that one.
     disconnect(pScrollBox, &QObject::destroyed, this, nullptr);
     // By value, not by name: a replacement may already hold the name
     mScrollBoxMap.removeIf([this, pScrollBox](const auto& it) {
@@ -468,6 +470,8 @@ void TMainConsole::registerTextBox(const QString& name, TTextBox* pTextBox)
 
 void TMainConsole::deregisterTextBox(TTextBox* pTextBox)
 {
+    // This is the only destroyed() connection made from a text edit to this
+    // console, so severing all of them is severing just that one.
     disconnect(pTextBox, &QObject::destroyed, this, nullptr);
     mTextBoxMap.removeIf([this, pTextBox](const auto& it) {
         if (it.value() != pTextBox) {
@@ -752,8 +756,6 @@ std::pair<bool, QString> TMainConsole::deleteTextBox(const QString& name)
 
     auto pTextBox = mTextBoxMap.value(name);
     if (pTextBox) {
-        // Not a bare take(): the widget outlives this call until its deferred
-        // delete lands, so its destroyed() handler must not stay armed
         deregisterTextBox(pTextBox);
         pTextBox->deleteLater();
 
@@ -777,8 +779,6 @@ std::pair<bool, QString> TMainConsole::deleteScrollBox(const QString& name)
 
     auto pScrollBox = mScrollBoxMap.value(name);
     if (pScrollBox) {
-        // Not a bare take(): the widget outlives this call until its deferred
-        // delete lands, so its destroyed() handler must not stay armed
         deregisterScrollBox(pScrollBox);
         // Using deleteLater() rather than delete as it seems a safer option
         // given that this item is likely to be linked to some events and

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -112,24 +112,29 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 
 TMainConsole::~TMainConsole()
 {
-    // There is one window in which a command line's destroyed() handler is unsafe:
-    // after this console's members - mSubCommandLineMap among them - have been
-    // destroyed, but before ~QObject severs incoming connections. The only command
-    // lines that can be destroyed inside it are the ones QWidget::~QWidget deletes,
-    // i.e. this console's own children, so sweeping those is enough. Command lines
-    // created into a user window belong to a TDockWidget reparented onto the main
-    // window instead, and can only die after ~QObject has already dropped the
-    // connection. Children rather than map entries, because deleteCommandLine() and
-    // resetMainConsole() drop the entry while the widget lives on until its
-    // deferred delete is delivered.
+    // There is one window in which these widgets' destroyed() handlers are unsafe:
+    // after this console's members - the maps they write to among them - have been
+    // destroyed, but before ~QObject severs incoming connections. The only ones that
+    // can be destroyed inside it are the ones QWidget::~QWidget deletes, i.e. this
+    // console's own children, so sweeping those is enough. One created into a user
+    // window belongs to a TDockWidget reparented onto the main window instead, and
+    // can only die after ~QObject has already dropped the connection. Children rather
+    // than map entries, because deleteCommandLine() and resetMainConsole() drop the
+    // entry while the widget lives on until its deferred delete is delivered.
     for (auto commandLine : findChildren<TCommandLine*>()) {
         disconnect(commandLine, &QObject::destroyed, this, nullptr);
     }
+    for (auto scrollBox : findChildren<TScrollBox*>()) {
+        disconnect(scrollBox, &QObject::destroyed, this, nullptr);
+    }
+    for (auto textBox : findChildren<TTextBox*>()) {
+        disconnect(textBox, &QObject::destroyed, this, nullptr);
+    }
 
     // A label and a sub-console take themselves out of the registry from their own
-    // destructor; none of the three kinds here does. A scroll box and a text box never
-    // deregister themselves, and for the command lines that are this console's own
-    // children the handler that would have done it was disconnected just above. A dock
+    // destructor; none of the three kinds here does. For the ones that are this
+    // console's own children the handler that would have done it was disconnected just
+    // above, and the rest die after ~QObject has dropped the connection. A dock
     // widget has no destructor either but needs no sweep: one only ever exists beside a
     // user window's sub-console, and closing the profile closes every sub-console before
     // the console goes, which takes the dock out through TConsole::closeEvent(). Quitting
@@ -425,24 +430,54 @@ void TMainConsole::registerScrollBox(const QString& name, TScrollBox* pScrollBox
 {
     mScrollBoxMap[name] = pScrollBox;
     mpHost->windowRegistry().registerScrollBox(name);
+
+    // A scroll box created into a user window dies as that window's child with
+    // deleteScrollBox() never called, and this map holds no QPointers
+    connect(pScrollBox, &QObject::destroyed, this, [this, pScrollBox]() {
+        deregisterScrollBox(pScrollBox);
+    });
 }
 
-TScrollBox* TMainConsole::deregisterScrollBox(const QString& name)
+void TMainConsole::deregisterScrollBox(TScrollBox* pScrollBox)
 {
-    mpHost->windowRegistry().deregisterScrollBox(name);
-    return mScrollBoxMap.take(name);
+    disconnect(pScrollBox, &QObject::destroyed, this, nullptr);
+    // By value, not by name: a replacement may already hold the name
+    mScrollBoxMap.removeIf([this, pScrollBox](const auto& it) {
+        if (it.value() != pScrollBox) {
+            return false;
+        }
+        // Quitting destroys every Host before the deferred deletes of the widgets
+        // a user window holds, leaving no registry to take the name out of
+        if (mpHost) {
+            mpHost->windowRegistry().deregisterScrollBox(it.key());
+        }
+        return true;
+    });
 }
 
 void TMainConsole::registerTextBox(const QString& name, TTextBox* pTextBox)
 {
     mTextBoxMap[name] = pTextBox;
     mpHost->windowRegistry().registerTextBox(name);
+
+    // As for a scroll box, and every by-name getter reads this map straight through
+    connect(pTextBox, &QObject::destroyed, this, [this, pTextBox]() {
+        deregisterTextBox(pTextBox);
+    });
 }
 
-TTextBox* TMainConsole::deregisterTextBox(const QString& name)
+void TMainConsole::deregisterTextBox(TTextBox* pTextBox)
 {
-    mpHost->windowRegistry().deregisterTextBox(name);
-    return mTextBoxMap.take(name);
+    disconnect(pTextBox, &QObject::destroyed, this, nullptr);
+    mTextBoxMap.removeIf([this, pTextBox](const auto& it) {
+        if (it.value() != pTextBox) {
+            return false;
+        }
+        if (mpHost) {
+            mpHost->windowRegistry().deregisterTextBox(it.key());
+        }
+        return true;
+    });
 }
 
 void TMainConsole::resetMainConsole()
@@ -483,18 +518,16 @@ void TMainConsole::resetMainConsole()
         label->deleteLater();
     }
 
-    const QStringList scrollBoxNames = mScrollBoxMap.keys();
-    for (const QString& scrollBoxName : scrollBoxNames) {
-        if (auto pScrollBox = deregisterScrollBox(scrollBoxName)) {
-            pScrollBox->deleteLater();
-        }
+    const QList<TScrollBox*> scrollBoxes = mScrollBoxMap.values();
+    for (auto scrollBox : scrollBoxes) {
+        deregisterScrollBox(scrollBox);
+        scrollBox->deleteLater();
     }
 
-    const QStringList textBoxNames = mTextBoxMap.keys();
-    for (const QString& textBoxName : textBoxNames) {
-        if (auto pTextBox = deregisterTextBox(textBoxName)) {
-            pTextBox->deleteLater();
-        }
+    const QList<TTextBox*> textBoxes = mTextBoxMap.values();
+    for (auto textBox : textBoxes) {
+        deregisterTextBox(textBox);
+        textBox->deleteLater();
     }
 }
 
@@ -717,8 +750,11 @@ std::pair<bool, QString> TMainConsole::deleteTextBox(const QString& name)
         return {false, QLatin1String("a text edit cannot have an empty string as its name")};
     }
 
-    auto pTextBox = deregisterTextBox(name);
+    auto pTextBox = mTextBoxMap.value(name);
     if (pTextBox) {
+        // Not a bare take(): the widget outlives this call until its deferred
+        // delete lands, so its destroyed() handler must not stay armed
+        deregisterTextBox(pTextBox);
         pTextBox->deleteLater();
 
         TEvent mudletEvent{};
@@ -739,8 +775,11 @@ std::pair<bool, QString> TMainConsole::deleteScrollBox(const QString& name)
         return {false, QLatin1String("a scrollbox cannot have an empty string as its name")};
     }
 
-    auto pScrollBox = deregisterScrollBox(name);
+    auto pScrollBox = mScrollBoxMap.value(name);
     if (pScrollBox) {
+        // Not a bare take(): the widget outlives this call until its deferred
+        // delete lands, so its destroyed() handler must not stay armed
+        deregisterScrollBox(pScrollBox);
         // Using deleteLater() rather than delete as it seems a safer option
         // given that this item is likely to be linked to some events and
         // suchlike:

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -265,9 +265,9 @@ private:
     // and removal from the three maps goes through these, so that the Host's
     // window registry cannot fall out of step with them.
     void registerScrollBox(const QString& name, TScrollBox* pScrollBox);
-    TScrollBox* deregisterScrollBox(const QString& name);
+    void deregisterScrollBox(TScrollBox* pScrollBox);
     void registerTextBox(const QString& name, TTextBox* pTextBox);
-    TTextBox* deregisterTextBox(const QString& name);
+    void deregisterTextBox(TTextBox* pTextBox);
 
     // The view's half of the named-window bookkeeping; the core's half is the
     // Host's window registry, which this class registers into and deregisters

--- a/src/TWindowRegistry.h
+++ b/src/TWindowRegistry.h
@@ -134,12 +134,11 @@ public:
     void registerCommandLine(const QString& name) { mCommandLines.insert(name); }
 
     // None of these three is identity-checked, unlike labels and sub-consoles:
-    // no widget of these kinds deregisters itself from its own destructor, so
-    // every removal is the view taking the name out of its map at the same
+    // every removal is the view taking a name out of its own map at the same
     // moment, and there is no window in which a stale deregistration could evict
-    // a replacement. A command line does get dropped from the view's map by its
-    // destroyed() handler, but that drops it by widget identity and so only ever
-    // names a name the dying command line still holds.
+    // a replacement. All three do get dropped from the view's map by a destroyed()
+    // handler, but that drops them by widget identity and so only ever names a
+    // name the dying widget still holds.
     void deregisterCommandLine(const QString& name) { mCommandLines.remove(name); }
     bool hasCommandLine(const QString& name) const { return mCommandLines.contains(name); }
 

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -19,6 +19,7 @@
 
 #include <QFile>
 #include <QImage>
+#include <QMovie>
 #include <QPointer>
 #include <QRegularExpression>
 #include <QTemporaryDir>
@@ -26,8 +27,10 @@
 
 #include <chrono>
 #include <memory>
+#include <tuple>
 
 #include "PortableModeTestHelper.h"
+#include "GifTracker.h"
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
 #include "TCommandLine.h"
@@ -37,6 +40,8 @@
 #include "TLabelModel.h"
 #include "TLuaInterpreter.h"
 #include "TMainConsole.h"
+#include "TScrollBox.h"
+#include "TTextBox.h"
 #include "TTrigger.h"
 #include "TWindowRegistry.h"
 #include "TelnetServerStub.h"
@@ -1203,6 +1208,67 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(!host->setClickthrough(labelName, true), "setClickthrough reached a label that had been destroyed with its scroll box.");
     }
 
+    // A label's movie is the profile's to count, and the tracker holds it as a raw
+    // pointer while Qt holds it as the label's child. Deleting the user window the
+    // label was created into destroys both without deleteLabel() ever running, so
+    // an entry left behind is read through by every later report - which is what
+    // getProfileStats() asks for.
+    void test_aLabelsMovieLeavesTheGifTrackerWithItsUserWindow()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString gifPath = writeTestGif();
+        QVERIFY2(!gifPath.isEmpty(), "Could not write a GIF that Qt reads back as a movie.");
+        const QString windowName = qsl("gifParentWindow");
+        const QString labelName = qsl("gifChildLabel");
+        runLua(host, qsl("openUserWindow('%1')\ncreateLabel('%1', '%2', 0, 0, 10, 10, 1)\nsetMovie('%2', '%3')\n").arg(windowName, labelName, gifPath));
+
+        TLabel* label = host->mpConsole->labelWidget(labelName);
+        QVERIFY2(label, "Creating a label into a user window left the console's own widget map empty.");
+        const QPointer<QMovie> movie = label->mpMovie;
+        QVERIFY2(movie, "setMovie gave the label no movie, so the checks below prove nothing.");
+        QCOMPARE(registeredGifs(host), 1);
+
+        runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
+        QTRY_VERIFY_WITH_TIMEOUT(movie.isNull(), 5000);
+
+        QCOMPARE(registeredGifs(host), 0);
+        QCOMPARE(luaGifTotal(host), 0);
+    }
+
+    // The other parent a label can be created into, torn down by a different call
+    // and so needing its own pass over the same ground.
+    void test_aLabelsMovieLeavesTheGifTrackerWithItsScrollBox()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString gifPath = writeTestGif();
+        QVERIFY2(!gifPath.isEmpty(), "Could not write a GIF that Qt reads back as a movie.");
+        const QString scrollBoxName = qsl("gifParentScrollBox");
+        const QString labelName = qsl("gifScrollBoxChildLabel");
+        runLua(host, qsl("createScrollBox('%1', 0, 0, 200, 200)\ncreateLabel('%1', '%2', 0, 0, 10, 10, 1)\nsetMovie('%2', '%3')\n").arg(scrollBoxName, labelName, gifPath));
+
+        TLabel* label = host->mpConsole->labelWidget(labelName);
+        QVERIFY2(label, "Creating a label into a scroll box left the console's own widget map empty.");
+        const QPointer<QMovie> movie = label->mpMovie;
+        QVERIFY2(movie, "setMovie gave the label no movie, so the checks below prove nothing.");
+        QCOMPARE(registeredGifs(host), 1);
+
+        runLua(host, qsl("deleteScrollBox('%1')\n").arg(scrollBoxName));
+        QTRY_VERIFY_WITH_TIMEOUT(movie.isNull(), 5000);
+
+        // Asked the script's way round first here, and the tracker's way round
+        // first in the test above, so neither reading shadows the other
+        QCOMPARE(luaGifTotal(host), 0);
+        QCOMPARE(registeredGifs(host), 0);
+    }
+
     // The console's own labels die after its members have, so their destroyed()
     // handlers would run against a map that has already gone. ~TMainConsole
     // severs them first, and the console's own destroyed() - emitted before Qt
@@ -2026,6 +2092,150 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(!host->windowType(textBoxName).has_value(), "Host still reports a window type for a text box destroyed with the console.");
     }
 
+    // A scroll box created into a user window is a Qt child of that window's dock,
+    // so deleting the window destroys it with deleteScrollBox() never called. The
+    // console's map holds no QPointers and Host answers "is this name taken" from
+    // the registry beside it, so an entry left behind sends the next
+    // createScrollBox() of that name into resizing a freed widget.
+    void test_deletingAUserWindowTakesItsScrollBoxesWithIt()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString windowName = qsl("registryScrollBoxParentWindow");
+        const QString scrollBoxName = qsl("registryOrphanedChildScrollBox");
+        runLua(host, qsl("openUserWindow('%1')\ncreateScrollBox('%1', '%2', 0, 0, 40, 40)\n").arg(windowName, scrollBoxName));
+        QVERIFY2(host->windowRegistry().hasScrollBox(scrollBoxName), "Creating a scroll box into a user window registered nothing in the profile's window registry.");
+        TDockWidget* dock = host->mpConsole->dockWidget(windowName);
+        QVERIFY2(dock, "Opening a user window left no dock in the console's own map.");
+        QPointer<TScrollBox> widget = dock->findChild<TScrollBox*>(scrollBoxName);
+        QVERIFY2(widget, "The scroll box was not created inside the user window's dock, so the checks below prove nothing.");
+
+        runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
+        QTRY_VERIFY_WITH_TIMEOUT(widget.isNull(), 5000);
+
+        QVERIFY2(!host->windowRegistry().hasScrollBox(scrollBoxName), "A scroll box destroyed with its user window stayed in the profile's window registry.");
+        QVERIFY2(!host->windowType(scrollBoxName).has_value(), "Host still reports a window type for a scroll box destroyed with its user window.");
+
+        // The crashing call: with the registry entry left behind this takes the
+        // "already exists" branch and resizes the freed widget, and with only the
+        // console's map entry left behind it refuses the name as still taken
+        runLua(host, qsl("recreated, recreateError = createScrollBox('%1', 0, 0, 40, 40)\nrecreated = tostring(recreated)\nrecreateError = tostring(recreateError)\n").arg(scrollBoxName));
+        QVERIFY2(luaGlobalString(host, "recreated") == qsl("true"),
+                 qPrintable(qsl("The name of a scroll box destroyed with its window could not be used again: %1").arg(luaGlobalString(host, "recreateError"))));
+    }
+
+    // The same for a text edit, which cannot be reached the same way -
+    // createTextEdit refuses a name it already holds rather than resizing it - but
+    // is read straight out of the console's map by every getter and setter.
+    void test_deletingAUserWindowTakesItsTextBoxesWithIt()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString windowName = qsl("registryTextBoxParentWindow");
+        const QString textBoxName = qsl("registryOrphanedChildTextBox");
+        runLua(host, qsl("openUserWindow('%1')\ncreateTextEdit('%1', '%2', 0, 0, 40, 40)\n").arg(windowName, textBoxName));
+        QVERIFY2(host->windowRegistry().hasTextBox(textBoxName), "Creating a text edit into a user window registered nothing in the profile's window registry.");
+        QPointer<TTextBox> widget = host->mpConsole->textBoxWidget(textBoxName);
+        QVERIFY2(widget, "Creating a text edit into a user window left the console's own widget map empty.");
+
+        runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
+        QTRY_VERIFY_WITH_TIMEOUT(widget.isNull(), 5000);
+
+        QVERIFY2(!host->windowRegistry().hasTextBox(textBoxName), "A text edit destroyed with its user window stayed in the profile's window registry.");
+        QVERIFY2(!host->windowType(textBoxName).has_value(), "Host still reports a window type for a text edit destroyed with its user window.");
+        QVERIFY2(!host->mpConsole->textBoxWidget(textBoxName), "A text edit destroyed with its user window left a dangling widget in the console's map.");
+
+        // The crashing call, which reads that map entry and dies in the freed widget
+        runLua(host, qsl("textEditText, textEditError = getTextEditText('%1')\ntextEditText = tostring(textEditText)\ntextEditError = tostring(textEditError)\n").arg(textBoxName));
+        QCOMPARE(luaGlobalString(host, "textEditText"), qsl("nil"));
+        QVERIFY2(luaGlobalString(host, "textEditError").contains(qsl("not found")),
+                 qPrintable(qsl("getTextEditText did not report the name as gone, it answered: %1").arg(luaGlobalString(host, "textEditError"))));
+
+        const auto [recreated, recreateMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 0, 40, 40);
+        QVERIFY2(recreated, qPrintable(qsl("The name of a text edit destroyed with its window could not be used again: %1").arg(recreateMessage)));
+    }
+
+    // The console's own scroll boxes and text edits die after its members have, so
+    // their destroyed() handlers would run against maps that have already gone.
+    // ~TMainConsole severs them first, and the console's own destroyed() - emitted
+    // before Qt deletes the children - is the one place that can still be asked.
+    void test_destroyingTheViewSeversItsPlainWindowDestroyedHandlers()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString scrollBoxName = qsl("registrySweptScrollBox");
+        const QString textBoxName = qsl("registrySweptTextBox");
+        runLua(host, qsl("createScrollBox('%1', 0, 0, 40, 40)\ncreateTextEdit('%2', 0, 50, 40, 40)\n").arg(scrollBoxName, textBoxName));
+        TScrollBox* scrollBox = host->mpConsole->findChild<TScrollBox*>(scrollBoxName);
+        QVERIFY2(scrollBox, "Creating a scroll box left no widget under the console.");
+        TTextBox* textBox = host->mpConsole->textBoxWidget(textBoxName);
+        QVERIFY2(textBox, "Creating a text edit left the console's own widget map empty.");
+
+        TMainConsole* console = host->mpConsole;
+        bool consoleWasDestroyed = false;
+        bool scrollBoxSevered = false;
+        bool textBoxSevered = false;
+        const auto probe = QObject::connect(console, &QObject::destroyed, [&consoleWasDestroyed, &scrollBoxSevered, &textBoxSevered, scrollBox, textBox, console]() {
+            consoleWasDestroyed = true;
+            scrollBoxSevered = !QObject::disconnect(scrollBox, &QObject::destroyed, console, nullptr);
+            textBoxSevered = !QObject::disconnect(textBox, &QObject::destroyed, console, nullptr);
+        });
+
+        destroyTheView(host);
+        // The lambda writes to this frame, so it must not outlive it
+        QObject::disconnect(probe);
+
+        QVERIFY2(consoleWasDestroyed, "The console never emitted destroyed(), so the checks below were never made.");
+        QVERIFY2(scrollBoxSevered, "A scroll box of the console still had its destroyed() handler attached when the console went, so it would have run against a destroyed map.");
+        QVERIFY2(textBoxSevered, "A text edit of the console still had its destroyed() handler attached when the console went, so it would have run against a destroyed map.");
+    }
+
+    // Deleting a scroll box only queues the widget for deletion, so a replacement
+    // takes the name while the old widget is still alive, and the old one's
+    // deferred delete lands afterwards. The registry and the console's map both
+    // have to come out of that holding the replacement.
+    void test_aReplacedScrollBoxKeepsTheReplacementRegistered()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString scrollBoxName = qsl("registryReplacedScrollBox");
+        runLua(host, qsl("createScrollBox('%1', 0, 0, 40, 40)\n").arg(scrollBoxName));
+        const QPointer<TScrollBox> original = host->mpConsole->findChild<TScrollBox*>(scrollBoxName);
+        QVERIFY2(original, "Creating a scroll box left no widget under the console.");
+
+        const auto [deleted, deleteMessage] = host->mpConsole->deleteScrollBox(scrollBoxName);
+        QVERIFY2(deleted, qPrintable(deleteMessage));
+        QVERIFY2(!host->windowRegistry().hasScrollBox(scrollBoxName), "Deleting a scroll box left it in the profile's window registry.");
+
+        runLua(host, qsl("createScrollBox('%1', 0, 0, 40, 40)\n").arg(scrollBoxName));
+        TScrollBox* replacement = nullptr;
+        for (auto candidate : host->mpConsole->findChildren<TScrollBox*>(scrollBoxName)) {
+            if (candidate != original) {
+                replacement = candidate;
+            }
+        }
+        QVERIFY2(replacement, "Creating a scroll box over a deleted name did not produce a new widget.");
+
+        QTRY_VERIFY_WITH_TIMEOUT(original.isNull(), 5000);
+
+        QVERIFY2(host->windowRegistry().hasScrollBox(scrollBoxName), "The old scroll box's deferred delete took its replacement's registry entry with it.");
+        QCOMPARE(host->windowType(scrollBoxName), std::optional<QString>(qsl("scrollbox")));
+        QVERIFY2(host->mpConsole->resizePlainWindow(scrollBoxName, 33, 44), "The old scroll box's deferred delete took its replacement out of the console's own map.");
+        QCOMPARE(replacement->size(), QSize(33, 44));
+    }
+
 private:
     // Utility function to manually start a profile like a user would do via the
     // GUI
@@ -2284,6 +2494,42 @@ private:
         const int value = lua_isnumber(L, -1) ? static_cast<int>(lua_tonumber(L, -1)) : -1;
         lua_pop(L, 1);
         return value;
+    }
+
+    // Writes the smallest GIF Qt reads back as a movie, since setLabelMovie()
+    // reads the file before it registers anything with the profile's tracker and
+    // Qt ships no GIF writer to make one with. An empty path back means Qt would
+    // not have taken it.
+    QString writeTestGif()
+    {
+        QByteArray gif("GIF89a");
+        gif.append(QByteArray::fromHex("01000100910000"));
+        gif.append(QByteArray::fromHex("ff000000ff000000ff000000"));
+        gif.append(QByteArray::fromHex("21f90400701700002c00000000010001000002024c0100"));
+        gif.append(QByteArray::fromHex("3b"));
+
+        const QString path = qsl("%1/label-movie.gif").arg(mConfigDir.path());
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly) || file.write(gif) != gif.size()) {
+            return QString();
+        }
+        file.close();
+        return QMovie(path).isValid() ? path : QString();
+    }
+
+    // Utility function: the count the profile's tracker reports is produced by
+    // reading state() off every movie it holds, so this is the call that walks a
+    // freed one rather than merely a tally beside it.
+    static int registeredGifs(Host* host) { return std::get<1>(host->getGifTracker()->assembleReport()); }
+
+    // Utility function asking the same question the way a script does. A -1 back
+    // means the snippet never ran, which no real count can be mistaken for.
+    int luaGifTotal(Host* host)
+    {
+        if (!host->getLuaInterpreter()->compileAndExecuteScript(qsl("gifTotal = getProfileStats().gifs.total\n"))) {
+            return -1;
+        }
+        return luaGlobalNumber(host, "gifTotal");
     }
 
     // Writes a real image out, so a background image that landed can be told from

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <tuple>
 
+#include "GifTestHelper.h"
 #include "PortableModeTestHelper.h"
 #include "GifTracker.h"
 #include "Host.h"
@@ -1235,7 +1236,6 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
         QTRY_VERIFY_WITH_TIMEOUT(movie.isNull(), 5000);
 
-        QCOMPARE(registeredGifs(host), 0);
         QCOMPARE(luaGifTotal(host), 0);
     }
 
@@ -1263,10 +1263,7 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         runLua(host, qsl("deleteScrollBox('%1')\n").arg(scrollBoxName));
         QTRY_VERIFY_WITH_TIMEOUT(movie.isNull(), 5000);
 
-        // Asked the script's way round first here, and the tracker's way round
-        // first in the test above, so neither reading shadows the other
         QCOMPARE(luaGifTotal(host), 0);
-        QCOMPARE(registeredGifs(host), 0);
     }
 
     // The console's own labels die after its members have, so their destroyed()
@@ -2047,6 +2044,12 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(deleted, qPrintable(deleteMessage));
         QVERIFY2(!host->windowRegistry().hasCommandLine(commandLineName), "Deleting a command line left it in the profile's window registry.");
 
+        // The replacement is told from the original by identity below, and a
+        // QPointer that has already gone null compares unequal to anything - so
+        // if the deferred delete has landed by here there is no replacement being
+        // tested at all, just a second create.
+        QVERIFY2(!original.isNull(), "The old command line was already destroyed before its replacement was made, so nothing below tests a replacement outliving a deferred delete.");
+
         const auto [recreated, recreateMessage] = host->mpConsole->createCommandLine(QString(), commandLineName, 0, 50, 40, 20);
         QVERIFY2(recreated, qPrintable(recreateMessage));
         TCommandLine* replacement = host->mpConsole->subCommandLineWidget(commandLineName);
@@ -2114,6 +2117,12 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(widget, "The scroll box was not created inside the user window's dock, so the checks below prove nothing.");
 
         runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
+
+        // Still registered at this point, because the dock is only queued for
+        // deletion. That is what makes the assertions after the wait a test of
+        // the destroyed() handler and of nothing else.
+        QVERIFY2(host->windowRegistry().hasScrollBox(scrollBoxName), "Deleting a user window deregistered the scroll box inside it before the widget was destroyed.");
+
         QTRY_VERIFY_WITH_TIMEOUT(widget.isNull(), 5000);
 
         QVERIFY2(!host->windowType(scrollBoxName).has_value(), "Host still reports a window type for a scroll box destroyed with its user window.");
@@ -2145,6 +2154,12 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(widget, "Creating a text edit into a user window left the console's own widget map empty.");
 
         runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
+
+        // Still registered at this point, because the dock is only queued for
+        // deletion. That is what makes the assertions after the wait a test of
+        // the destroyed() handler and of nothing else.
+        QVERIFY2(host->windowRegistry().hasTextBox(textBoxName), "Deleting a user window deregistered the text edit inside it before the widget was destroyed.");
+
         QTRY_VERIFY_WITH_TIMEOUT(widget.isNull(), 5000);
 
         QVERIFY2(!host->windowType(textBoxName).has_value(), "Host still reports a window type for a text edit destroyed with its user window.");
@@ -2159,6 +2174,74 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
 
         const auto [recreated, recreateMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 0, 40, 40);
         QVERIFY2(recreated, qPrintable(qsl("The name of a text edit destroyed with its window could not be used again: %1").arg(recreateMessage)));
+        // createTextBox() gates on the console's map alone, so on its own that
+        // only restates the check above it. Writing through the name and reading
+        // back out of it is what says the map now holds a live replacement.
+        runLua(host, qsl("setTextEditText('%1', 'the replacement is reachable')\nroundTrippedText = tostring(getTextEditText('%1'))\n").arg(textBoxName));
+        QCOMPARE(luaGlobalString(host, "roundTrippedText"), qsl("the replacement is reachable"));
+    }
+
+    // The other parent both kinds can be created into, and the other half of the
+    // fix: a scroll box inside a scroll box is one of this console's own
+    // recursive children, which ~TMainConsole's sweep finds and severs, where a
+    // user window's child hangs off a dock and never is. deleteScrollBox() severs
+    // only the outer box's own destroyed() connection, so the nested ones have to
+    // still be there to fire - a disconnect widened to a blanket form would leave
+    // the user window case green and break this one.
+    void test_deletingAScrollBoxTakesItsPlainWindowsWithIt()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString outerName = qsl("registryOuterScrollBox");
+        const QString innerName = qsl("registryNestedScrollBox");
+        const QString textBoxName = qsl("registryNestedTextBox");
+        runLua(host,
+               qsl("createScrollBox('%1', 0, 0, 200, 200)\n"
+                   "createScrollBox('%1', '%2', 0, 0, 100, 100)\n"
+                   "createTextEdit('%1', '%3', 0, 110, 100, 60)\n")
+                       .arg(outerName, innerName, textBoxName));
+        TScrollBox* outer = host->mpConsole->findChild<TScrollBox*>(outerName);
+        QVERIFY2(outer, "Creating the outer scroll box left no widget under the console.");
+        QPointer<TScrollBox> inner = outer->findChild<TScrollBox*>(innerName);
+        QVERIFY2(inner, "The inner scroll box was not created inside the outer one, so the checks below prove nothing.");
+        QPointer<TTextBox> textBox = host->mpConsole->textBoxWidget(textBoxName);
+        QVERIFY2(textBox, "Creating a text edit into a scroll box left the console's own widget map empty.");
+        // Not findChild() by name as for the scroll box: a text edit's object
+        // name is decorated with the profile's, so ask the parentage instead
+        QVERIFY2(outer->isAncestorOf(textBox), "The text edit was not created inside the outer scroll box, so the checks below prove nothing.");
+        QCOMPARE(host->windowType(innerName), std::optional<QString>(qsl("scrollbox")));
+        QCOMPARE(host->windowType(textBoxName), std::optional<QString>(qsl("textedit")));
+
+        const auto [deleted, deleteMessage] = host->mpConsole->deleteScrollBox(outerName);
+        QVERIFY2(deleted, qPrintable(deleteMessage));
+
+        // Still registered at this point, because the outer box is only queued
+        // for deletion. That is what makes the assertions after the wait a test
+        // of the nested widgets' destroyed() handlers and of nothing else.
+        QVERIFY2(host->windowRegistry().hasScrollBox(innerName), "Deleting a scroll box deregistered the scroll box inside it before the widget was destroyed.");
+        QVERIFY2(host->windowRegistry().hasTextBox(textBoxName), "Deleting a scroll box deregistered the text edit inside it before the widget was destroyed.");
+
+        QTRY_VERIFY_WITH_TIMEOUT(inner.isNull() && textBox.isNull(), 5000);
+
+        QVERIFY2(!host->windowRegistry().hasScrollBox(innerName), "A scroll box destroyed with the scroll box it was in stayed in the profile's window registry.");
+        QVERIFY2(!host->windowRegistry().hasTextBox(textBoxName), "A text edit destroyed with the scroll box it was in stayed in the profile's window registry.");
+        QVERIFY2(!host->windowType(innerName).has_value(), "Host still reports a window type for a scroll box destroyed with the scroll box it was in.");
+        QVERIFY2(!host->windowType(textBoxName).has_value(), "Host still reports a window type for a text edit destroyed with the scroll box it was in.");
+        QVERIFY2(!host->mpConsole->textBoxWidget(textBoxName), "A text edit destroyed with the scroll box it was in left a dangling widget in the console's map.");
+
+        // Both names have to be usable again. The scroll box one goes through
+        // Host, which reads the registry and would otherwise resize the freed
+        // widget; the text edit one is read straight out of the console's map, so
+        // it is written through and read back to show the map holds a live one.
+        const auto [recreatedScrollBox, scrollBoxMessage] = host->createScrollBox(QString(), innerName, 0, 0, 40, 40);
+        QVERIFY2(recreatedScrollBox, qPrintable(qsl("The name of a scroll box destroyed with its scroll box could not be used again: %1").arg(scrollBoxMessage)));
+        const auto [recreatedTextBox, textBoxMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 50, 40, 40);
+        QVERIFY2(recreatedTextBox, qPrintable(qsl("The name of a text edit destroyed with its scroll box could not be used again: %1").arg(textBoxMessage)));
+        runLua(host, qsl("setTextEditText('%1', 'the nested replacement is reachable')\nnestedRoundTrippedText = tostring(getTextEditText('%1'))\n").arg(textBoxName));
+        QCOMPARE(luaGlobalString(host, "nestedRoundTrippedText"), qsl("the nested replacement is reachable"));
     }
 
     // The console's own scroll boxes and text edits die after its members have, so
@@ -2219,6 +2302,12 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(deleted, qPrintable(deleteMessage));
         QVERIFY2(!host->windowRegistry().hasScrollBox(scrollBoxName), "Deleting a scroll box left it in the profile's window registry.");
 
+        // The replacement is told from the original by identity below, and a
+        // QPointer that has already gone null compares unequal to anything - so
+        // if the deferred delete has landed by here there is no replacement being
+        // tested at all, just a second create.
+        QVERIFY2(!original.isNull(), "The old scroll box was already destroyed before its replacement was made, so nothing below tests a replacement outliving a deferred delete.");
+
         runLua(host, qsl("createScrollBox('%1', 0, 0, 40, 40)\n").arg(scrollBoxName));
         TScrollBox* replacement = nullptr;
         for (auto candidate : host->mpConsole->findChildren<TScrollBox*>(scrollBoxName)) {
@@ -2234,6 +2323,47 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QCOMPARE(host->windowType(scrollBoxName), std::optional<QString>(qsl("scrollbox")));
         QVERIFY2(host->mpConsole->resizePlainWindow(scrollBoxName, 33, 44), "The old scroll box's deferred delete took its replacement out of the console's own map.");
         QCOMPARE(replacement->size(), QSize(33, 44));
+    }
+
+    // The same for a text edit, whose deregistration is a hand-copied twin of the
+    // scroll box's. A slip there takes a live text edit out of the console's map
+    // without a word - no crash, no error, just getTextEditText(),
+    // setTextEditText(), resizeWindow() and moveWindow() all ceasing to find it.
+    void test_aReplacedTextBoxKeepsTheReplacementRegistered()
+    {
+        startProfile();
+        auto host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        QVERIFY2(host->mpConsole, "The active host has no main console.");
+
+        const QString textBoxName = qsl("registryReplacedTextBox");
+        const auto [created, createMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 80, 40, 40);
+        QVERIFY2(created, qPrintable(createMessage));
+        const QPointer<TTextBox> original = host->mpConsole->textBoxWidget(textBoxName);
+        QVERIFY2(original, "Creating a text edit left no widget in the console's own map.");
+
+        const auto [deleted, deleteMessage] = host->mpConsole->deleteTextBox(textBoxName);
+        QVERIFY2(deleted, qPrintable(deleteMessage));
+        QVERIFY2(!host->windowRegistry().hasTextBox(textBoxName), "Deleting a text edit left it in the profile's window registry.");
+
+        // The replacement is told from the original by identity below, and a
+        // QPointer that has already gone null compares unequal to anything - so
+        // if the deferred delete has landed by here there is no replacement being
+        // tested at all, just a second create.
+        QVERIFY2(!original.isNull(), "The old text edit was already destroyed before its replacement was made, so nothing below tests a replacement outliving a deferred delete.");
+
+        const auto [recreated, recreateMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 80, 40, 40);
+        QVERIFY2(recreated, qPrintable(recreateMessage));
+        TTextBox* replacement = host->mpConsole->textBoxWidget(textBoxName);
+        QVERIFY2(replacement && replacement != original, "Creating a text edit over a deleted name did not produce a new widget.");
+
+        QTRY_VERIFY_WITH_TIMEOUT(original.isNull(), 5000);
+
+        QVERIFY2(host->windowRegistry().hasTextBox(textBoxName), "The old text edit's deferred delete took its replacement's registry entry with it.");
+        QCOMPARE(host->windowType(textBoxName), std::optional<QString>(qsl("textedit")));
+        QVERIFY2(host->mpConsole->textBoxWidget(textBoxName) == replacement, "The old text edit's deferred delete took its replacement out of the console's own map.");
+        runLua(host, qsl("setTextEditText('%1', 'the replacement is still reachable')\nreplacedRoundTrippedText = tostring(getTextEditText('%1'))\n").arg(textBoxName));
+        QCOMPARE(luaGlobalString(host, "replacedRoundTrippedText"), qsl("the replacement is still reachable"));
     }
 
 private:
@@ -2496,18 +2626,12 @@ private:
         return value;
     }
 
-    // Writes the smallest GIF Qt reads back as a movie, since setLabelMovie()
-    // reads the file before it registers anything with the profile's tracker and
-    // Qt ships no GIF writer to make one with. An empty path back means Qt would
-    // not have taken it.
+    // Writes a movie out, since setLabelMovie() reads the file before it
+    // registers anything with the profile's tracker. An empty path back means Qt
+    // would not have taken it.
     QString writeTestGif()
     {
-        QByteArray gif("GIF89a");
-        gif.append(QByteArray::fromHex("01000100910000"));
-        gif.append(QByteArray::fromHex("ff000000ff000000ff000000"));
-        gif.append(QByteArray::fromHex("21f90400701700002c00000000010001000002024c0100"));
-        gif.append(QByteArray::fromHex("3b"));
-
+        const QByteArray gif = threeFrameGif();
         const QString path = qsl("%1/label-movie.gif").arg(mConfigDir.path());
         QFile file(path);
         if (!file.open(QIODevice::WriteOnly) || file.write(gif) != gif.size()) {

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -2116,8 +2116,8 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
         QTRY_VERIFY_WITH_TIMEOUT(widget.isNull(), 5000);
 
-        QVERIFY2(!host->windowRegistry().hasScrollBox(scrollBoxName), "A scroll box destroyed with its user window stayed in the profile's window registry.");
         QVERIFY2(!host->windowType(scrollBoxName).has_value(), "Host still reports a window type for a scroll box destroyed with its user window.");
+        QVERIFY2(!host->windowRegistry().hasScrollBox(scrollBoxName), "A scroll box destroyed with its user window stayed in the profile's window registry.");
 
         // The crashing call: with the registry entry left behind this takes the
         // "already exists" branch and resizes the freed widget, and with only the
@@ -2147,8 +2147,8 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         runLua(host, qsl("deleteMiniConsole('%1')\n").arg(windowName));
         QTRY_VERIFY_WITH_TIMEOUT(widget.isNull(), 5000);
 
-        QVERIFY2(!host->windowRegistry().hasTextBox(textBoxName), "A text edit destroyed with its user window stayed in the profile's window registry.");
         QVERIFY2(!host->windowType(textBoxName).has_value(), "Host still reports a window type for a text edit destroyed with its user window.");
+        QVERIFY2(!host->windowRegistry().hasTextBox(textBoxName), "A text edit destroyed with its user window stayed in the profile's window registry.");
         QVERIFY2(!host->mpConsole->textBoxWidget(textBoxName), "A text edit destroyed with its user window left a dangling widget in the console's map.");
 
         // The crashing call, which reads that map entry and dies in the freed widget

--- a/test/functional_tests/ConsoleModelExtractionTest.cpp
+++ b/test/functional_tests/ConsoleModelExtractionTest.cpp
@@ -2044,10 +2044,8 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(deleted, qPrintable(deleteMessage));
         QVERIFY2(!host->windowRegistry().hasCommandLine(commandLineName), "Deleting a command line left it in the profile's window registry.");
 
-        // The replacement is told from the original by identity below, and a
-        // QPointer that has already gone null compares unequal to anything - so
-        // if the deferred delete has landed by here there is no replacement being
-        // tested at all, just a second create.
+        // A QPointer that has gone null compares unequal to anything, so the identity
+        // check below would take a plain second create for a replacement.
         QVERIFY2(!original.isNull(), "The old command line was already destroyed before its replacement was made, so nothing below tests a replacement outliving a deferred delete.");
 
         const auto [recreated, recreateMessage] = host->mpConsole->createCommandLine(QString(), commandLineName, 0, 50, 40, 20);
@@ -2181,13 +2179,12 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QCOMPARE(luaGlobalString(host, "roundTrippedText"), qsl("the replacement is reachable"));
     }
 
-    // The other parent both kinds can be created into, and the other half of the
-    // fix: a scroll box inside a scroll box is one of this console's own
-    // recursive children, which ~TMainConsole's sweep finds and severs, where a
-    // user window's child hangs off a dock and never is. deleteScrollBox() severs
-    // only the outer box's own destroyed() connection, so the nested ones have to
-    // still be there to fire - a disconnect widened to a blanket form would leave
-    // the user window case green and break this one.
+    // A scroll box inside a scroll box is one of this console's own recursive
+    // children, which ~TMainConsole's sweep finds and severs, where a user window's
+    // child hangs off a dock and never is. deleteScrollBox() severs only the outer
+    // box's own destroyed() connection, so the nested ones have to still be there
+    // to fire - a disconnect widened to a blanket form would leave the user window
+    // case green and break this one.
     void test_deletingAScrollBoxTakesItsPlainWindowsWithIt()
     {
         startProfile();
@@ -2232,10 +2229,9 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(!host->windowType(textBoxName).has_value(), "Host still reports a window type for a text edit destroyed with the scroll box it was in.");
         QVERIFY2(!host->mpConsole->textBoxWidget(textBoxName), "A text edit destroyed with the scroll box it was in left a dangling widget in the console's map.");
 
-        // Both names have to be usable again. The scroll box one goes through
-        // Host, which reads the registry and would otherwise resize the freed
-        // widget; the text edit one is read straight out of the console's map, so
-        // it is written through and read back to show the map holds a live one.
+        // The scroll box goes through Host, which reads the registry; the text edit
+        // is read straight out of the console's map, so it is written through and
+        // read back to show the map holds a live one.
         const auto [recreatedScrollBox, scrollBoxMessage] = host->createScrollBox(QString(), innerName, 0, 0, 40, 40);
         QVERIFY2(recreatedScrollBox, qPrintable(qsl("The name of a scroll box destroyed with its scroll box could not be used again: %1").arg(scrollBoxMessage)));
         const auto [recreatedTextBox, textBoxMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 50, 40, 40);
@@ -2302,10 +2298,8 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(deleted, qPrintable(deleteMessage));
         QVERIFY2(!host->windowRegistry().hasScrollBox(scrollBoxName), "Deleting a scroll box left it in the profile's window registry.");
 
-        // The replacement is told from the original by identity below, and a
-        // QPointer that has already gone null compares unequal to anything - so
-        // if the deferred delete has landed by here there is no replacement being
-        // tested at all, just a second create.
+        // A QPointer that has gone null compares unequal to anything, so the identity
+        // check below would take a plain second create for a replacement.
         QVERIFY2(!original.isNull(), "The old scroll box was already destroyed before its replacement was made, so nothing below tests a replacement outliving a deferred delete.");
 
         runLua(host, qsl("createScrollBox('%1', 0, 0, 40, 40)\n").arg(scrollBoxName));
@@ -2346,10 +2340,8 @@ noViewSpellReport = table.concat(noViewSpellProblems, '; ')
         QVERIFY2(deleted, qPrintable(deleteMessage));
         QVERIFY2(!host->windowRegistry().hasTextBox(textBoxName), "Deleting a text edit left it in the profile's window registry.");
 
-        // The replacement is told from the original by identity below, and a
-        // QPointer that has already gone null compares unequal to anything - so
-        // if the deferred delete has landed by here there is no replacement being
-        // tested at all, just a second create.
+        // A QPointer that has gone null compares unequal to anything, so the identity
+        // check below would take a plain second create for a replacement.
         QVERIFY2(!original.isNull(), "The old text edit was already destroyed before its replacement was made, so nothing below tests a replacement outliving a deferred delete.");
 
         const auto [recreated, recreateMessage] = host->mpConsole->createTextBox(QString(), textBoxName, 0, 80, 40, 40);

--- a/test/functional_tests/GifTestHelper.h
+++ b/test/functional_tests/GifTestHelper.h
@@ -1,0 +1,40 @@
+#ifndef MUDLET_GIFTESTHELPER_H
+#define MUDLET_GIFTESTHELPER_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QByteArray>
+
+// Qt ships no GIF writer, so a test that needs a movie on disk has to spell one
+// out. Three frames rather than one, so the frame count is a distinctive thing
+// to compare and QMovie::state() is meaningfully Running, and a 60 second frame
+// delay so the animation never advances between two reads.
+inline QByteArray threeFrameGif()
+{
+    QByteArray gif("GIF89a");
+    gif.append(QByteArray::fromHex("01000100910000"));
+    gif.append(QByteArray::fromHex("ff000000ff000000ff000000"));
+    const QByteArray frame = QByteArray::fromHex("21f90400701700002c00000000010001000002024c0100");
+    gif.append(frame).append(frame).append(frame);
+    gif.append(QByteArray::fromHex("3b"));
+    return gif;
+}
+
+#endif // MUDLET_GIFTESTHELPER_H

--- a/test/functional_tests/LabelMovieRefusalTest.cpp
+++ b/test/functional_tests/LabelMovieRefusalTest.cpp
@@ -31,6 +31,7 @@
 #include <QtTest/QtTest>
 #include <chrono>
 
+#include "GifTestHelper.h"
 #include "PortableModeTestHelper.h"
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
@@ -63,19 +64,6 @@ private:
     QByteArray mSavedXdgConfigHome;
     QString mGifPath;
     QString mNotAGifPath;
-
-    // three frames so the count is a distinctive thing to compare, and a 60
-    // second frame delay so the animation never advances between two reads
-    static QByteArray threeFrameGif()
-    {
-        QByteArray gif("GIF89a");
-        gif.append(QByteArray::fromHex("01000100910000"));
-        gif.append(QByteArray::fromHex("ff000000ff000000ff000000"));
-        const QByteArray frame = QByteArray::fromHex("21f90400701700002c00000000010001000002024c0100");
-        gif.append(frame).append(frame).append(frame);
-        gif.append(QByteArray::fromHex("3b"));
-        return gif;
-    }
 
     static bool writeFixture(const QString& path, const QByteArray& contents)
     {


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A scroll box or text edit inside a user window stayed in the console's by-name map after the window took it down, so the next Lua call that looked it up reached freed memory.
- A label's animated GIF stayed registered with the profile's tracker after the label died, so asking for profile stats walked a freed `QMovie`.
- Both now deregister on `destroyed()`, by widget identity rather than by name, and `~TMainConsole` severs the handlers it would otherwise outlive.

#### Motivation for adding to Mudlet

Both are crashes a script can reach through ordinary window management.

#### Other info (issues closed, discussion etc)

Closes #10319, closes #10344. Both pre-date the console-model work and reproduce on 5.0.1.

**Test case:** put a scroll box and a text box in a user window, delete the window, then call `getTextEditText` on the text box - previously a crash, now the name is simply free again. Suite: 171/171 ctest, 3959/0/0/68 specs.

Assisted-by: Claude:claude-opus-5