### PR TITLE
Improve: Label the trigger editor's advanced options toggle

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7536,8 +7536,8 @@ void dlgTriggerEditor::updatePatternTabOrder()
         previous = next;
     };
 
-    addToChain(mpTriggersMainArea->toolButton_toggleExtraControls);
     addToChain(mpTriggersMainArea->lineEdit_trigger_command);
+    addToChain(mpTriggersMainArea->toolButton_toggleExtraControls);
 
     for (int i = 0; i < mVisiblePatternCount && i < mTriggerPatternEdit.size(); ++i) {
         auto* item = mTriggerPatternEdit.value(i, nullptr);
@@ -13588,7 +13588,7 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
     /*
      * With all widgets shown:              With some hidden:
      *  +--------------------------------+   +--------------------------------+
-     *  | name / control toggle /command |   | name / control toggle /command |
+     *  | name / command / toggle / id   |   | name / command / toggle / id   |
      *--+----------------------+---------+ --+----------------------+---------+
      *  |+--------------------+|         |   |+------------------------------+|
      *w_||                    ||         |   ||                              ||

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -110,6 +110,7 @@ class dlgTriggerEditor : public QMainWindow, private Ui::trigger_editor
     friend class dlgTriggerEditorUndoRedoTest;
     friend class EditorBannerViewSwitchTest;
     friend class ScriptEventHandlerLifetimeTest;
+    friend class TriggerEditorDisclosureTest;
     friend class VariableEditorWriteBackTest;
 
     enum SearchDataRole {

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -43,7 +43,7 @@
      <property name="autoFillBackground">
       <bool>true</bool>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_widget_top" stretch="0,1,0,0,1,0">
+     <layout class="QHBoxLayout" name="horizontalLayout_widget_top" stretch="0,1,0,1,0,0">
       <property name="leftMargin">
        <number>6</number>
       </property>
@@ -80,32 +80,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QToolButton" name="toolButton_toggleExtraControls">
-        <property name="toolTip">
-         <string>&lt;p&gt;Use this control to show or hide the extra controls for the trigger; this can be used to allow more space to show the trigger &lt;i&gt;items&lt;/i&gt; on smaller screen.&lt;/p&gt;</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset resource="../mudlet.qrc">
-          <normaloff>:/icons/arrow-right_grey-16x.png</normaloff>
-          <normalon>:/icons/arrow-down_grey-16x.png</normalon>
-          <activeoff>:/icons/arrow-right-16x.png</activeoff>
-          <activeon>:/icons/arrow-down-16x.png</activeon>:/icons/arrow-right_grey-16x.png</iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QLabel" name="label_trigger_command">
         <property name="text">
          <string>Command:</string>
@@ -125,6 +99,32 @@
         </property>
         <property name="placeholderText">
          <string>Text to send to the game (optional)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="toolButton_toggleExtraControls">
+        <property name="toolTip">
+         <string>&lt;p&gt;Show or hide the advanced options for this trigger; hiding them leaves more room for the trigger &lt;i&gt;items&lt;/i&gt; on a smaller screen.&lt;/p&gt;</string>
+        </property>
+        <property name="text">
+         <string extracomment="Label of the disclosure button that shows or hides the trigger's less commonly used settings - the stay open, sound, multi-line, filter and colourise options. Keep it short, it shares one row with the Name and Command fields.">Advanced options</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../mudlet.qrc">
+          <normaloff>:/icons/arrow-right_grey-16x.png</normaloff>
+          <normalon>:/icons/arrow-down_grey-16x.png</normalon>
+          <activeoff>:/icons/arrow-right-16x.png</activeoff>
+          <activeon>:/icons/arrow-down-16x.png</activeon>:/icons/arrow-right_grey-16x.png</iconset>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextBesideIcon</enum>
         </property>
        </widget>
       </item>

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -124,6 +124,7 @@ set(EDITOR_GROUP_TEST_SOURCES
     EditorBannerViewSwitchTest.cpp
     EditorWindowPositionTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
+    TriggerEditorDisclosureTest.cpp
     TriggerEditorTest.cpp
     VariableEditorWriteBackTest.cpp
 )

--- a/test/functional_tests/TriggerEditorDisclosureTest.cpp
+++ b/test/functional_tests/TriggerEditorDisclosureTest.cpp
@@ -1,0 +1,216 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The trigger editor's advanced options disclosure control.
+ *
+ * Mudlet 5.0 shipped this as a bare ">" glyph with no label and no frame, and
+ * users read it as decoration rather than a control. These tests pin the
+ * properties that make it read as a button: a text label, and a frame that is
+ * there without having to hover first.
+ *
+ * Run with: ctest -R TriggerEditorDisclosureTest -V
+ */
+
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include <QLineEdit>
+#include <QScopeGuard>
+#include <QToolButton>
+
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "TelnetServerStub.h"
+#include "dlgConnectionProfiles.h"
+#include "dlgTriggerEditor.h"
+#include "dlgTriggersMainArea.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class TriggerEditorDisclosureTest : public QObject {
+  Q_OBJECT
+
+private:
+  QTemporaryDir mConfigDir;
+  QByteArray mSavedXdg;
+  TelnetServerStub *mpServer = nullptr;
+  dlgTriggerEditor *mpEditor = nullptr;
+  Host *mpHost = nullptr;
+  const QString mHostname = qsl("TriggerEditorDisclosure-Test");
+  QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+  const QString mLocalhost = qsl("localhost");
+
+  void deleteProfileDirectory(const QString &profileName) {
+    QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+    if (dir.exists()) {
+      dir.removeRecursively();
+    }
+  }
+
+  // setTabOrder threads focus through widgets that never take tab focus
+  // themselves (containers, scroll-area viewports), so "the next widget in
+  // the chain" is not the next tab stop
+  QWidget *nextTabStop(QWidget *from) const {
+    for (QWidget *w = from->nextInFocusChain(); w && w != from;
+         w = w->nextInFocusChain()) {
+      if ((w->focusPolicy() & Qt::TabFocus) && w->isVisibleTo(mpEditor)) {
+        return w;
+      }
+    }
+    return nullptr;
+  }
+
+  QToolButton *toggle() const {
+    return mpEditor->mpTriggersMainArea->toolButton_toggleExtraControls;
+  }
+
+private slots:
+  void initTestCase() {
+    if (portableMarkerPresent()) {
+      QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, "
+            "so the config dir cannot be redirected");
+    }
+
+    // A config root of this process's own. Sharing the developer's
+    // ~/.config/mudlet means sharing a profile list, so a second copy of this
+    // test running at the same time is told the name it types is already in
+    // use and never gets an enabled Connect button. Since #9712 the opt-in
+    // that makes setupConfig() adopt a directory is
+    // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+    QVERIFY(mConfigDir.isValid());
+    QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+    mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+    qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+    mpServer = new TelnetServerStub(qApp);
+    mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids
+                                    // collisions across concurrent test runs
+    QVERIFY2(mpServer->isListening(),
+             qPrintable(qsl("TelnetServerStub failed to start: %1")
+                            .arg(mpServer->errorString())));
+    mPort = QString::number(mpServer->serverPort());
+    mudlet::start();
+    mudlet::self()->setupConfig();
+    mudlet::self()->takeOwnershipOfInstanceCoordinator(
+        std::make_unique<MudletInstanceCoordinator>(
+            "MudletInstanceCoordinator"));
+    mudlet::self()->init();
+    mudlet::self()->setStorePasswordsSecurely(false);
+    deleteProfileDirectory(mHostname);
+
+    mpHost = TestProfile::create(mHostname, mLocalhost, mPort);
+    QVERIFY2(mpHost, "No active host after profile creation");
+    QSignalSpy connected(&(mpHost->mTelnet), &cTelnet::signal_connected);
+    QVERIFY2(connected.wait(1000), "Could not connect with the host.");
+
+    mudlet::self()->slot_showScriptDialog();
+    mpEditor = mpHost->mpEditorDialog;
+    QVERIFY2(mpEditor, "Editor dialog should be created");
+    // wide enough that the main area lays out at its natural size rather than
+    // squeezed, which is what the geometry assertions below measure
+    mpEditor->resize(1200, 800);
+    QVERIFY(QTest::qWaitForWindowExposed(mpEditor));
+
+    mpEditor->slot_showTriggers();
+    mpEditor->addTrigger(false);
+    QCoreApplication::processEvents();
+    QVERIFY2(mpEditor->mpTriggersMainArea->isVisible(),
+             "the triggers main area should be showing after adding a trigger");
+  }
+
+  void cleanupTestCase() {
+    mpEditor = nullptr;
+    mpHost = nullptr;
+    delete mpServer;
+    mpServer = nullptr;
+    // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+    // getMudletPath() dereferences the instance rather than checking it
+    if (mudlet::self()) {
+      deleteProfileDirectory(mHostname);
+      delete mudlet::self();
+    }
+    mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME")
+                       : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+  }
+
+  void test_toggleReadsAsAButton() {
+    QVERIFY2(!toggle()->text().isEmpty(),
+             "the disclosure control needs a text label - an unlabelled arrow "
+             "reads as an ornament, which is the bug this replaced");
+    QCOMPARE(toggle()->toolButtonStyle(), Qt::ToolButtonTextBesideIcon);
+    QVERIFY2(!toggle()->icon().isNull(),
+             "the label should be paired with a disclosure arrow");
+    QVERIFY2(toggle()->isCheckable(),
+             "the arrow direction tracks the checked state");
+    QVERIFY2(!toggle()->autoRaise(),
+             "the frame has to be there at rest - an affordance that only "
+             "appears on hover is one nobody discovers");
+  }
+
+  // It shares the Command row rather than taking a row of its own, and the ID
+  // number keeps the far right of that row
+  void test_toggleSitsBetweenTheCommandFieldAndTheId() {
+    auto *area = mpEditor->mpTriggersMainArea;
+    auto *command = area->lineEdit_trigger_command;
+
+    // the ID is opt-in, and it is only in the layout while it is shown
+    const bool idWasShown = mpHost->showIdsInEditor();
+    auto restoreId = qScopeGuard(
+        [this, idWasShown]() { mpHost->setShowIdsInEditor(idWasShown); });
+    mpHost->setShowIdsInEditor(true);
+    QCoreApplication::processEvents();
+
+    const QRect toggleRect(toggle()->mapTo(area, QPoint(0, 0)),
+                           toggle()->size());
+    const QRect commandRect(command->mapTo(area, QPoint(0, 0)),
+                            command->size());
+    const QRect idRect(area->frameId->mapTo(area, QPoint(0, 0)),
+                       area->frameId->size());
+
+    const QRect commandBand(0, commandRect.top(), area->width(),
+                            commandRect.height());
+    QVERIFY2(toggleRect.intersects(commandBand),
+             qPrintable(qsl("the toggle should share the command row, but it "
+                            "spans y %1..%2 and the command field spans %3..%4")
+                            .arg(toggleRect.top())
+                            .arg(toggleRect.bottom())
+                            .arg(commandRect.top())
+                            .arg(commandRect.bottom())));
+    QVERIFY2(toggleRect.left() >= commandRect.right(),
+             "the toggle follows the command field, so the command label and "
+             "field stay adjacent");
+    QVERIFY2(toggleRect.right() <= idRect.left(),
+             "the ID number keeps the far right of the row");
+  }
+
+  void test_tabFromCommandFieldReachesTheToggle() {
+    auto *command = mpEditor->mpTriggersMainArea->lineEdit_trigger_command;
+    QCOMPARE(nextTabStop(command), static_cast<QWidget *>(toggle()));
+  }
+};
+
+#include "TriggerEditorDisclosureTest.moc"
+MUDLET_GROUPED_TEST_MAIN(TriggerEditorDisclosureTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The `>` glyph that reveals a trigger's advanced options gains the label **Advanced options** and a frame that is there at rest instead of only on hover. The disclosure arrow stays, pointing right when collapsed and down when expanded.
- It moves to the right of the Command field, just before the ID number, so the Name and Command label/field pairs are no longer split apart by it. It stays on the Command row, so it costs no vertical space.
- Tab order and the layout comment follow it; nothing else changes.

Unchanged: the advanced options stay hidden by default, the expanded state is still sticky and still persists across restarts (`showAllTriggerControls` in QSettings - that already worked), the object ID keeps its space at the far right of the row, and the dark-mode icon selection from #9412 is untouched. Triggers are the only item type with this control.

#### Motivation for adding to Mudlet

In the first week after 5.0 shipped, at least six separate people in the Mudlet Discord read the glyph as decoration rather than a control - "I never realized that was a button", "it looks like a play button", "it looks like some graphical ornament".

#### Other info (issues closed, discussion etc)

Interim discoverability fix, deliberately scoped small: it uses the standard platform disclosure pattern and invents no new visual language, so it does not preempt the broader design-language pass anchored on the new settings window.

`TriggerEditorDisclosureTest` joins the existing editor test group, so it costs a compile rather than a link. It pins what makes this read as a control: a text label beside the arrow, a frame at rest (`autoRaise` off), a position between the Command field and the ID, and a tab stop following the Command field. Every one of those assertions fails against the pre-change build and passes after. Full functional suite: 131/131.

Verified on Linux in light and dark themes. **Not verified on Windows or macOS** - the change is layout-only within an existing `.ui`, but a look on both would be welcome before merge.

**Test case:** open the trigger editor, select a trigger, and look at the Command row - the toggle reads "Advanced options" with a framed button. Click it to reveal the stay open / sound / multi-line / filter / colourise options, close and reopen Mudlet, and confirm it comes back expanded. Turn on Settings -> Editor -> "Show Items' ID number" and confirm the ID still sits at the far right of that row.

Assisted-by: Claude:claude-opus-5