### PR TITLE
Infra: Add specs for the command line widget

### DIFF
--- a/src/mudlet-lua/tests/CommandLine_spec.lua
+++ b/src/mudlet-lua/tests/CommandLine_spec.lua
@@ -1,0 +1,111 @@
+-- The C++ TCommandLine widget, reached through the command line Lua API. The
+-- Geyser wrapper around a sub command line is covered in
+-- GeyserCommandLine_spec.lua.
+
+-- Password mode cannot be turned on from Lua: the game server takes the ECHO
+-- option, so the real telnet parser is what has to be fed to reach it. It can be
+-- turned off, by the profile's "disable password masking" preference, which the
+-- self-test profile leaves alone.
+local echoActive = false
+local function serverEcho(takesEcho)
+  local ok, msg = feedTelnet(takesEcho and "<T_IAC><T_WILL><O_ECHO>" or "<T_IAC><T_WONT><O_ECHO>")
+  assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
+  echoActive = takesEcho
+end
+
+-- These pin what becomes of the surrounding text at a password prompt. The
+-- masking itself is painted over the document by TCommandLine::paintEvent, so
+-- getCmdLine still reads the password back and no spec can see it happen.
+describe("Tests the functionality of the main command line at a server password prompt", function()
+  -- cTelnet stops answering ECHO once five negotiations arrive with less than
+  -- five seconds between consecutive ones, and it restarts that window on every
+  -- one, so spacing prompts out does not help. A prompt costs two negotiations,
+  -- so the tests below use four of the five: a third prompt needs a five second
+  -- wait in front of it, or the masking it asks for never happens.
+  -- https://github.com/Mudlet/Mudlet/issues/10367
+  after_each(function()
+    -- the suppression is process wide, so a prompt left open by a failed
+    -- assertion would follow every later spec file
+    if echoActive then
+      serverEcho(false)
+    end
+    clearCmdLine("main")
+  end)
+
+  it("puts the command aside while the server asks for a password, and gives it back", function()
+    -- what the profile does at a password prompt when auto-clear is off: the
+    -- command that was just sent is still there, selected. Only the text is
+    -- readable from Lua, so what the selection itself becomes goes unpinned
+    printCmdLine("main", "specCommandUnderPassword")
+    selectCmdLineText("main")
+    assert.are.equal("specCommandUnderPassword", getCmdLine("main"))
+
+    -- a sub command line is exempt from echo suppression, so the same prompt
+    -- doubles as its control
+    createCommandLine("specPasswordSubCmdLine", 0, 0, 200, 30)
+    finally(function() deleteCommandLine("specPasswordSubCmdLine") end)
+    printCmdLine("specPasswordSubCmdLine", "specSubCommandLineText")
+
+    serverEcho(true)
+    assert.are.equal("", getCmdLine("main"), "the typed command was left on screen for the password prompt")
+    assert.are.equal("specSubCommandLineText", getCmdLine("specPasswordSubCmdLine"),
+                     "the password prompt emptied a sub command line, which it has no business touching")
+
+    serverEcho(false)
+    assert.are.equal("specCommandUnderPassword", getCmdLine("main"), "the typed command was not put back when the password prompt ended")
+  end)
+
+  it("does not leave the password behind when the prompt ends", function()
+    clearCmdLine("main")
+    serverEcho(true)
+
+    printCmdLine("main", "specSecretPassword")
+    assert.are.equal("specSecretPassword", getCmdLine("main"))
+
+    serverEcho(false)
+    assert.are.equal("", getCmdLine("main"), "the password was still readable in the command line after the prompt ended")
+  end)
+end)
+
+-- Neither the suggestion list nor the tab completion blacklist can be read back
+-- from Lua, and only a Tab keypress consumes them, so what these pin is which
+-- argument the command line name is taken from: one argument is the word for
+-- the main command line, two make the first one a name.
+describe("Tests the functionality of addCmdLineSuggestion, removeCmdLineSuggestion, addCmdLineBlacklist and removeCmdLineBlacklist", function()
+  local missing = "mudlet-spec-no-such-command-line"
+  local functions = {"addCmdLineSuggestion", "removeCmdLineSuggestion", "addCmdLineBlacklist", "removeCmdLineBlacklist"}
+
+  teardown(function()
+    clearCmdLineSuggestions("main")
+    clearCmdLineBlacklist("main")
+  end)
+
+  for _, name in ipairs(functions) do
+    it(name .. " takes a lone argument as the word for the main command line", function()
+      assert.are.equal(0, select("#", _G[name](missing)))
+    end)
+
+    it(name .. " takes the first of two arguments as the command line name", function()
+      local ok, err = _G[name](missing, "specWord")
+      assert.is_nil(ok)
+      assert.are.equal('command line "' .. missing .. '" not found', err)
+    end)
+
+    it(name .. " raises a Lua error when the command line name is not a string", function()
+      local ok, err = pcall(_G[name], {}, "specWord")
+      assert.is_false(ok)
+      assert.is_truthy(tostring(err):find(name .. ": bad argument #1 type (command line name as string expected, got table)!", 1, true), tostring(err))
+    end)
+  end
+
+  -- clearCmdLineSuggestions and clearCmdLineBlacklist read their arguments the
+  -- other way round, so the lone-argument call that silently adds a word above
+  -- is a named lookup here
+  for _, name in ipairs({"clearCmdLineSuggestions", "clearCmdLineBlacklist"}) do
+    it(name .. " takes a lone argument as the command line name, unlike its add and remove siblings", function()
+      local ok, err = _G[name](missing)
+      assert.is_nil(ok)
+      assert.are.equal('command line "' .. missing .. '" not found', err)
+    end)
+  end
+end)

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -618,14 +618,16 @@ describe("Tests C++ functions in the Miscallaneous category", function()
       -- on the next launch.
       describe("Tests that an end of session save writes the command line histories", function()
         -- A save another spec started can still be running, and saveProfile()
-        -- answers nil - without emitting anything - until it finishes. Of the
-        -- refusals it can answer with that is the only one waiting clears, and
-        -- only test mode can pump the event loop to let it.
+        -- answers nil - without emitting anything - until it finishes.
         local function saveWaitingOutAnyOtherSave()
           local saved, message
           for _ = 1, 100 do
             saved, message = saveProfile()
-            if saved or not testMode then
+            -- Of the refusals saveProfile() can answer with, an already running
+            -- save is the only one waiting clears, and only test mode can pump
+            -- the event loop to let it. The rest are permanent, so they go back
+            -- as they are rather than costing five seconds of pumping first.
+            if saved or not testMode or not tostring(message):find("a save is already in progress", 1, true) then
               break
             end
             pumpEvents(50)

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -617,6 +617,22 @@ describe("Tests C++ functions in the Miscallaneous category", function()
       -- history is silently never written again, which the user only discovers
       -- on the next launch.
       describe("Tests that an end of session save writes the command line histories", function()
+        -- A save another spec started can still be running, and saveProfile()
+        -- answers nil - without emitting anything - until it finishes. Of the
+        -- refusals it can answer with that is the only one waiting clears, and
+        -- only test mode can pump the event loop to let it.
+        local function saveWaitingOutAnyOtherSave()
+          local saved, message
+          for _ = 1, 100 do
+            saved, message = saveProfile()
+            if saved or not testMode then
+              break
+            end
+            pumpEvents(50)
+          end
+          return saved, message
+        end
+
         it("writes the main command line's history file out again", function()
           -- slot_saveHistory() returns without writing anything unless both of
           -- these are on, so they are what makes a missing file mean the signal
@@ -636,18 +652,7 @@ describe("Tests C++ functions in the Miscallaneous category", function()
           os.remove(historyFile)
           assert.is_false(fileExists(historyFile), "the previous history file could not be cleared")
 
-          -- A save another spec started can still be running, and saveProfile()
-          -- answers nil - without emitting anything - until it finishes. Of the
-          -- refusals it can answer with that is the only one waiting clears,
-          -- and only test mode can pump the event loop to let it.
-          local saved, message
-          for _ = 1, 100 do
-            saved, message = saveProfile()
-            if saved or not testMode then
-              break
-            end
-            pumpEvents(50)
-          end
+          local saved, message = saveWaitingOutAnyOtherSave()
           if not saved and not testMode then
             pending("the profile save was refused and only test mode can wait one out: " .. tostring(message))
             return
@@ -657,6 +662,34 @@ describe("Tests C++ functions in the Miscallaneous category", function()
           -- slot_saveHistory() writes from inside the emit, so the file is
           -- there by the time saveProfile() has returned
           assert.is_true(fileExists(historyFile), "the end of session save never wrote the command line history out")
+        end)
+
+        it("writes nothing for a command line whose history saving is turned off", function()
+          local savedLines = getConfig("commandLineHistorySaveSize")
+          local savedSaving = getSaveCommandHistory("main")
+          finally(function()
+            setSaveCommandHistory("main", savedSaving)
+            setConfig("commandLineHistorySaveSize", savedLines)
+          end)
+
+          -- the profile-wide size stays on, so only the per-command-line
+          -- setting is left to answer for the file not coming back
+          setConfig("commandLineHistorySaveSize", 10)
+          assert.is_true(setSaveCommandHistory("main", false))
+          assert.is_false((getSaveCommandHistory("main")))
+
+          local historyFile = getMudletHomeDir() .. "/command_history_main"
+          os.remove(historyFile)
+          assert.is_false(fileExists(historyFile), "the previous history file could not be cleared")
+
+          local saved, message = saveWaitingOutAnyOtherSave()
+          if not saved and not testMode then
+            pending("the profile save was refused and only test mode can wait one out: " .. tostring(message))
+            return
+          end
+          assert.is_true(saved, tostring(message))
+
+          assert.is_false(fileExists(historyFile), "the history was written out despite saving being turned off for that command line")
         end)
       end)
     end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A new `CommandLine_spec.lua` covering `TCommandLine` through the Lua API: what becomes of the typed command around a server password prompt, and which argument the command line name is taken from across the suggestion and tab-completion blacklist functions.
- Pins the argument asymmetry in that family: `addCmdLineSuggestion` and its three siblings read a lone argument as the *word*, while `clearCmdLineSuggestions` and `clearCmdLineBlacklist` read it as the *command line name*.
- One spec in `Miscallaneous_spec.lua` for a command line whose history saving is turned off, plus a retry loop lifted into a named helper so both save tests share it.

#### Motivation for adding to Mudlet

`TCommandLine` had almost no coverage, and password prompt handling is the part of it that fails most quietly - it is driven by the game server taking the ECHO option, so nothing short of the real telnet parser reaches it.

#### Other info (issues closed, discussion etc)

Writing these turned up [#10367 - Password masking stops for the rest of the session once five ECHO negotiations arrive in quick succession](https://github.com/Mudlet/Mudlet/issues/10367), filed rather than fixed here. The comment above the password block explains the budget that bug imposes on this file, because a third password prompt added without a five second wait in front of it will silently stop masking.

Worth knowing for reviewers: the masking itself is painted over the document by `TCommandLine::paintEvent`, so `getCmdLine` still reads a password back and no spec can observe it. These specs pin the handling of the surrounding text, which is a different thing; the describe block is named accordingly.

Every test was checked by sabotage and goes red on its own line with its own message. The sub command line assertion doubles as the control for the main one, inside the same prompt, so it costs no extra ECHO negotiations.

**Test case:** run the Lua test suite. `CommandLine_spec.lua` reports `16 successes`, and the full suite is green at `3976 successes / 0 failures / 0 errors / 68 pending`.

Assisted-by: Claude:claude-opus-5