### PR TITLE
Infra: Give the Discord integration a home that does not need the main window

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -25,6 +25,7 @@
 
 #include "Host.h"
 
+#include "discord.h"
 #include "dlgIRC.h"
 #include "dlgMapper.h"
 #include "dlgModuleManager.h"
@@ -3677,15 +3678,15 @@ void Host::processGMCPDiscordInfo(const QJsonObject& discordInfo)
     if (appID != QJsonValue::Undefined) {
         hasApplicationId = true;
         if (appID.toString() == Discord::mMudletApplicationId) {
-            pMudlet->mDiscord.setApplicationID(this, QString());
+            Discord::self()->setApplicationID(this, QString());
         } else {
             hasCustomAppID = true;
-            pMudlet->mDiscord.setApplicationID(this, appID.toString());
-            auto image = pMudlet->mDiscord.getLargeImage(this);
+            Discord::self()->setApplicationID(this, appID.toString());
+            auto image = Discord::self()->getLargeImage(this);
 
             if (image.isEmpty() || image == QLatin1String("mudlet")) {
-                pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIcon);
-                pMudlet->mDiscord.setLargeImage(this, qsl("server-icon"));
+                Discord::self()->setServerOrigin(this, DiscordSetLargeIcon);
+                Discord::self()->setLargeImage(this, qsl("server-icon"));
             }
         }
     }
@@ -3718,92 +3719,92 @@ void Host::processGMCPDiscordStatus(const QJsonObject& discordInfo)
     if (gameName != QJsonValue::Undefined) {
         setDiscordGameName(gameName.toString());
         pMudlet->updateDiscordNamedIcon();
-        QPair<bool, QString> const richPresenceSupported = pMudlet->mDiscord.gameIntegrationSupported(getUrl());
-        if (richPresenceSupported.first && pMudlet->mDiscord.usingMudletsDiscordID(this)) {
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetDetail);
-            pMudlet->mDiscord.setDetailText(this, tr("Playing %1").arg(richPresenceSupported.second));
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIcon);
-            pMudlet->mDiscord.setLargeImage(this, richPresenceSupported.second);
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIconText);
+        QPair<bool, QString> const richPresenceSupported = Discord::self()->gameIntegrationSupported(getUrl());
+        if (richPresenceSupported.first && Discord::self()->usingMudletsDiscordID(this)) {
+            Discord::self()->setServerOrigin(this, DiscordSetDetail);
+            Discord::self()->setDetailText(this, tr("Playing %1").arg(richPresenceSupported.second));
+            Discord::self()->setServerOrigin(this, DiscordSetLargeIcon);
+            Discord::self()->setLargeImage(this, richPresenceSupported.second);
+            Discord::self()->setServerOrigin(this, DiscordSetLargeIconText);
             //: %1 is the game name and %2:%3 is game server address like: mudlet.org:23
-            pMudlet->mDiscord.setLargeImageText(this, tr("%1 at %2:%3").arg(gameName.toString(), getUrl(), QString::number(getPort())));
+            Discord::self()->setLargeImageText(this, tr("%1 at %2:%3").arg(gameName.toString(), getUrl(), QString::number(getPort())));
         } else {
             // We are using a custom application id, so the top line is
             // likely to be saying "Playing MudName"
             if (richPresenceSupported.first) {
-                pMudlet->mDiscord.setServerOrigin(this, DiscordSetDetail);
-                pMudlet->mDiscord.setDetailText(this, QString());
-                pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIconText);
+                Discord::self()->setServerOrigin(this, DiscordSetDetail);
+                Discord::self()->setDetailText(this, QString());
+                Discord::self()->setServerOrigin(this, DiscordSetLargeIconText);
                 //: %1 is the game name and %2:%3 is game server address like: mudlet.org:23
-                pMudlet->mDiscord.setLargeImageText(this, tr("%1 at %2:%3").arg(gameName.toString(), getUrl(), QString::number(getPort())));
-                pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIcon);
-                pMudlet->mDiscord.setLargeImage(this, qsl("server-icon"));
+                Discord::self()->setLargeImageText(this, tr("%1 at %2:%3").arg(gameName.toString(), getUrl(), QString::number(getPort())));
+                Discord::self()->setServerOrigin(this, DiscordSetLargeIcon);
+                Discord::self()->setLargeImage(this, qsl("server-icon"));
             }
         }
     }
 
     auto details = discordInfo.value(qsl("details"));
     if (details != QJsonValue::Undefined) {
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetDetail);
-        pMudlet->mDiscord.setDetailText(this, details.toString());
+        Discord::self()->setServerOrigin(this, DiscordSetDetail);
+        Discord::self()->setDetailText(this, details.toString());
     }
 
     auto state = discordInfo.value(qsl("state"));
     if (state != QJsonValue::Undefined) {
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetState);
-        pMudlet->mDiscord.setStateText(this, state.toString());
+        Discord::self()->setServerOrigin(this, DiscordSetState);
+        Discord::self()->setStateText(this, state.toString());
     }
 
     auto largeImages = discordInfo.value(qsl("largeimage"));
     if (largeImages != QJsonValue::Undefined) {
         auto largeImage = largeImages.toArray().first();
         if (largeImage != QJsonValue::Undefined) {
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIcon);
-            pMudlet->mDiscord.setLargeImage(this, largeImage.toString());
+            Discord::self()->setServerOrigin(this, DiscordSetLargeIcon);
+            Discord::self()->setLargeImage(this, largeImage.toString());
         }
     }
 
     auto largeImageText = discordInfo.value(qsl("largeimagetext"));
     if (largeImageText != QJsonValue::Undefined) {
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetLargeIconText);
-        pMudlet->mDiscord.setLargeImageText(this, largeImageText.toString());
+        Discord::self()->setServerOrigin(this, DiscordSetLargeIconText);
+        Discord::self()->setLargeImageText(this, largeImageText.toString());
     }
 
     auto smallImages = discordInfo.value(qsl("smallimage"));
     if (smallImages != QJsonValue::Undefined) {
         auto smallImage = smallImages.toArray().first();
         if (smallImage != QJsonValue::Undefined) {
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetSmallIcon);
-            pMudlet->mDiscord.setSmallImage(this, smallImage.toString());
+            Discord::self()->setServerOrigin(this, DiscordSetSmallIcon);
+            Discord::self()->setSmallImage(this, smallImage.toString());
         }
     }
 
     auto smallImageText = discordInfo.value(qsl("smallimagetext"));
     if ((smallImageText != QJsonValue::Undefined)) {
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetSmallIconText);
-        pMudlet->mDiscord.setSmallImageText(this, smallImageText.toString());
+        Discord::self()->setServerOrigin(this, DiscordSetSmallIconText);
+        Discord::self()->setSmallImageText(this, smallImageText.toString());
     }
 
     int64_t timeStamp = -1;
     auto endTimeStamp = discordInfo.value(qsl("endtime"));
     if (endTimeStamp.isDouble()) {
         timeStamp = static_cast<int64_t>(endTimeStamp.toDouble());
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetTimeInfo);
-        pMudlet->mDiscord.setEndTimeStamp(this, timeStamp);
+        Discord::self()->setServerOrigin(this, DiscordSetTimeInfo);
+        Discord::self()->setEndTimeStamp(this, timeStamp);
     } else if (endTimeStamp.isString()) {
         timeStamp = endTimeStamp.toString().toLongLong();
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetTimeInfo);
-        pMudlet->mDiscord.setEndTimeStamp(this, timeStamp);
+        Discord::self()->setServerOrigin(this, DiscordSetTimeInfo);
+        Discord::self()->setEndTimeStamp(this, timeStamp);
     } else {
         auto startTimeStamp = discordInfo.value(qsl("starttime"));
         if (startTimeStamp.isDouble()) {
             timeStamp = static_cast<int64_t>(startTimeStamp.toDouble());
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetTimeInfo);
-            pMudlet->mDiscord.setStartTimeStamp(this, timeStamp);
+            Discord::self()->setServerOrigin(this, DiscordSetTimeInfo);
+            Discord::self()->setStartTimeStamp(this, timeStamp);
         } else if (startTimeStamp.isString()) {
             timeStamp = startTimeStamp.toString().toLongLong();
-            pMudlet->mDiscord.setServerOrigin(this, DiscordSetTimeInfo);
-            pMudlet->mDiscord.setStartTimeStamp(this, timeStamp);
+            Discord::self()->setServerOrigin(this, DiscordSetTimeInfo);
+            Discord::self()->setStartTimeStamp(this, timeStamp);
         }
     }
 
@@ -3812,37 +3813,36 @@ void Host::processGMCPDiscordStatus(const QJsonObject& discordInfo)
     auto partyMax = discordInfo.value(qsl("partymax"));
     auto partySize = discordInfo.value(qsl("partysize"));
     if (partyMax != QJsonValue::Undefined || partySize != QJsonValue::Undefined) {
-        pMudlet->mDiscord.setServerOrigin(this, DiscordSetPartyInfo);
+        Discord::self()->setServerOrigin(this, DiscordSetPartyInfo);
     }
     if (partyMax.isDouble()) {
         partyMaxValue = static_cast<int>(partyMax.toDouble());
         if (partyMaxValue > 0 && partySize.isDouble()) {
             partySizeValue = static_cast<int>(partySize.toDouble());
-            pMudlet->mDiscord.setParty(this, partySizeValue, partyMaxValue);
+            Discord::self()->setParty(this, partySizeValue, partyMaxValue);
         } else {
-            pMudlet->mDiscord.setParty(this, 0, 0);
+            Discord::self()->setParty(this, 0, 0);
         }
     } else {
         if (partySize.isDouble()) {
             partySizeValue = static_cast<int>(partySize.toDouble());
-            pMudlet->mDiscord.setParty(this, partySizeValue);
+            Discord::self()->setParty(this, partySizeValue);
         } else {
-            pMudlet->mDiscord.setParty(this, 0, 0);
+            Discord::self()->setParty(this, 0, 0);
         }
     }
 }
 
 void Host::clearDiscordData()
 {
-    mudlet* pMudlet = mudlet::self();
-    pMudlet->mDiscord.setDetailText(this, QString());
-    pMudlet->mDiscord.setStateText(this, QString());
-    pMudlet->mDiscord.setLargeImage(this, QString());
-    pMudlet->mDiscord.setLargeImageText(this, QString());
-    pMudlet->mDiscord.setSmallImage(this, QString());
-    pMudlet->mDiscord.setSmallImageText(this, QString());
-    pMudlet->mDiscord.setStartTimeStamp(this, 0);
-    pMudlet->mDiscord.setParty(this, 0, 0);
+    Discord::self()->setDetailText(this, QString());
+    Discord::self()->setStateText(this, QString());
+    Discord::self()->setLargeImage(this, QString());
+    Discord::self()->setLargeImageText(this, QString());
+    Discord::self()->setSmallImage(this, QString());
+    Discord::self()->setSmallImageText(this, QString());
+    Discord::self()->setStartTimeStamp(this, 0);
+    Discord::self()->setParty(this, 0, 0);
 }
 
 void Host::setDiscordMode(DiscordMode mode)
@@ -3851,8 +3851,6 @@ void Host::setDiscordMode(DiscordMode mode)
     mDiscordMode = mode;
 
     writeProfileData(qsl("discordmode"), QString::number(static_cast<int>(mode)));
-
-    auto pMudlet = mudlet::self();
 
     if (mode == DiscordShowGameDetails && oldMode != DiscordShowGameDetails) {
         // Switching to full integration - advertise Discord support to server.
@@ -3869,11 +3867,11 @@ void Host::setDiscordMode(DiscordMode mode)
         if (mTelnet.isGMCPEnabled()) {
             mTelnet.sendGMCPSupportsRemove(qsl("External.Discord 1"));
         }
-        pMudlet->mDiscord.resetData(this);
+        Discord::self()->resetData(this);
         return;
     }
 
-    pMudlet->mDiscord.UpdatePresence();
+    Discord::self()->UpdatePresence();
 }
 
 
@@ -3901,9 +3899,9 @@ void Host::processDiscordMSDP(const QString& variable, QString value)
     //    }
 
     //    if (variable == QLatin1String("SERVER_ID")) {
-    //        mudlet::self()->mDiscord.setGame(this, value);
+    //        Discord::self()->setGame(this, value);
     //    } else if (variable == QLatin1String("AREA_NAME")) {
-    //        mudlet::self()->mDiscord.setArea(this, value);
+    //        Discord::self()->setArea(this, value);
     //    }
 }
 

--- a/src/TLuaInterpreterDiscord.cpp
+++ b/src/TLuaInterpreterDiscord.cpp
@@ -47,6 +47,7 @@
 #include "TTabBar.h"
 #include "TTextEdit.h"
 #include "TTimer.h"
+#include "discord.h"
 #include "dlgComposer.h"
 #include "dlgIRC.h"
 #include "dlgMapper.h"
@@ -74,9 +75,7 @@
 // No documentation available in wiki - internal function
 std::pair<bool, QString> TLuaInterpreter::discordApiEnabled(lua_State* L, bool writeAccess)
 {
-    mudlet* pMudlet = mudlet::self();
-
-    if (!pMudlet->mDiscord.libraryLoaded()) {
+    if (!Discord::self()->libraryLoaded()) {
         return {false, qsl("Discord API is not available")};
     }
 
@@ -85,7 +84,7 @@ std::pair<bool, QString> TLuaInterpreter::discordApiEnabled(lua_State* L, bool w
         return {false, qsl("Discord is disabled in settings")};
     }
 
-    if (writeAccess && !pMudlet->mDiscord.discordUserIdMatch(&host)) {
+    if (writeAccess && !Discord::self()->discordUserIdMatch(&host)) {
         return {false, qsl("Discord API is read-only as you're logged in with a different account in Discord compared to the one you entered for this profile")};
     }
 
@@ -95,7 +94,6 @@ std::pair<bool, QString> TLuaInterpreter::discordApiEnabled(lua_State* L, bool w
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#usingMudletsDiscordID
 int TLuaInterpreter::usingMudletsDiscordID(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -103,14 +101,13 @@ int TLuaInterpreter::usingMudletsDiscordID(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    lua_pushboolean(L, pMudlet->mDiscord.usingMudletsDiscordID(&host));
+    lua_pushboolean(L, Discord::self()->usingMudletsDiscordID(&host));
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordDetail
 int TLuaInterpreter::getDiscordDetail(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -121,14 +118,13 @@ int TLuaInterpreter::getDiscordDetail(lua_State* L)
     // Pushed as data, never as a format string: presence text can come from the
     // game server, and a '%' in it would otherwise be taken as a printf
     // specifier. The same holds for the five other Discord text getters below.
-    lua_pushstring(L, pMudlet->mDiscord.getDetailText(&host).toUtf8().constData());
+    lua_pushstring(L, Discord::self()->getDetailText(&host).toUtf8().constData());
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordLargeIcon
 int TLuaInterpreter::getDiscordLargeIcon(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -136,14 +132,13 @@ int TLuaInterpreter::getDiscordLargeIcon(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    lua_pushstring(L, pMudlet->mDiscord.getLargeImage(&host).toUtf8().constData());
+    lua_pushstring(L, Discord::self()->getLargeImage(&host).toUtf8().constData());
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordLargeIconText
 int TLuaInterpreter::getDiscordLargeIconText(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -151,14 +146,13 @@ int TLuaInterpreter::getDiscordLargeIconText(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    lua_pushstring(L, pMudlet->mDiscord.getLargeImageText(&host).toUtf8().constData());
+    lua_pushstring(L, Discord::self()->getLargeImageText(&host).toUtf8().constData());
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordParty
 int TLuaInterpreter::getDiscordParty(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -166,7 +160,7 @@ int TLuaInterpreter::getDiscordParty(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    QPair<int, int> const partyValues = pMudlet->mDiscord.getParty(&host);
+    QPair<int, int> const partyValues = Discord::self()->getParty(&host);
     lua_pushnumber(L, partyValues.first);
     lua_pushnumber(L, partyValues.second);
     return 2;
@@ -175,7 +169,6 @@ int TLuaInterpreter::getDiscordParty(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordSmallIcon
 int TLuaInterpreter::getDiscordSmallIcon(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -183,14 +176,13 @@ int TLuaInterpreter::getDiscordSmallIcon(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    lua_pushstring(L, pMudlet->mDiscord.getSmallImage(&host).toUtf8().constData());
+    lua_pushstring(L, Discord::self()->getSmallImage(&host).toUtf8().constData());
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordSmallIconText
 int TLuaInterpreter::getDiscordSmallIconText(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -198,14 +190,13 @@ int TLuaInterpreter::getDiscordSmallIconText(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    lua_pushstring(L, pMudlet->mDiscord.getSmallImageText(&host).toUtf8().constData());
+    lua_pushstring(L, Discord::self()->getSmallImageText(&host).toUtf8().constData());
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getDiscordState
 int TLuaInterpreter::getDiscordState(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L);
@@ -213,7 +204,7 @@ int TLuaInterpreter::getDiscordState(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    lua_pushstring(L, pMudlet->mDiscord.getStateText(&host).toUtf8().constData());
+    lua_pushstring(L, Discord::self()->getStateText(&host).toUtf8().constData());
     return 1;
 }
 
@@ -227,7 +218,7 @@ int TLuaInterpreter::getDiscordTimeStamps(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    QPair<int64_t, int64_t> const timeStamps = mudlet::self()->mDiscord.getTimeStamps(&host);
+    QPair<int64_t, int64_t> const timeStamps = Discord::self()->getTimeStamps(&host);
     lua_pushnumber(L, timeStamps.first);
     lua_pushnumber(L, timeStamps.second);
     return 2;
@@ -236,7 +227,6 @@ int TLuaInterpreter::getDiscordTimeStamps(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetDiscordData
 int TLuaInterpreter::resetDiscordData(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -244,7 +234,7 @@ int TLuaInterpreter::resetDiscordData(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    pMudlet->mDiscord.resetData(&host);
+    Discord::self()->resetData(&host);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -252,7 +242,6 @@ int TLuaInterpreter::resetDiscordData(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordApplicationID
 int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -261,7 +250,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
     }
 
     if (!lua_gettop(L)) {
-        pMudlet->mDiscord.setApplicationID(&host, QString());
+        Discord::self()->setApplicationID(&host, QString());
         lua_pushboolean(L, true);
         return 1;
     }
@@ -272,7 +261,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
     if (inputText.isEmpty()) {
         // Empty string input - to reset to default the same as the no
         // argument case:
-        pMudlet->mDiscord.setApplicationID(&host, QString());
+        Discord::self()->setApplicationID(&host, QString());
         // This must always succeed
         lua_pushboolean(L, true);
         return 1;
@@ -281,7 +270,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
     quint64 const numericEquivalent = inputText.toULongLong(&isOk);
     if (numericEquivalent && isOk) {
         const QString appID = QString::number(numericEquivalent);
-        if (pMudlet->mDiscord.setApplicationID(&host, appID)) {
+        if (Discord::self()->setApplicationID(&host, appID)) {
             lua_pushboolean(L, true);
             return 1;
         }
@@ -293,7 +282,6 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordDetail
 int TLuaInterpreter::setDiscordDetail(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -306,8 +294,8 @@ int TLuaInterpreter::setDiscordDetail(lua_State* L)
         return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
-    pMudlet->mDiscord.setDetailText(&host, discordText);
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetDetail);
+    Discord::self()->setDetailText(&host, discordText);
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetDetail);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -315,7 +303,6 @@ int TLuaInterpreter::setDiscordDetail(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordElapsedStartTime
 int TLuaInterpreter::setDiscordElapsedStartTime(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -327,8 +314,8 @@ int TLuaInterpreter::setDiscordElapsedStartTime(lua_State* L)
     if (timeStamp < 0) {
         return warnArgumentValue(L, __func__, "the timestamp must be zero to clear the 'elapsed:' time or an epoch time value from the recent past");
     }
-    pMudlet->mDiscord.setStartTimeStamp(&host, static_cast<int64_t>(timeStamp));
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetTimeInfo);
+    Discord::self()->setStartTimeStamp(&host, static_cast<int64_t>(timeStamp));
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetTimeInfo);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -336,7 +323,6 @@ int TLuaInterpreter::setDiscordElapsedStartTime(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordGame
 int TLuaInterpreter::setDiscordGame(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -345,10 +331,10 @@ int TLuaInterpreter::setDiscordGame(lua_State* L)
     }
 
     const QString gamename = getVerifiedString(L, __func__, 1, "game name");
-    pMudlet->mDiscord.setDetailText(&host, tr("Playing %1").arg(gamename));
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetDetail);
-    pMudlet->mDiscord.setLargeImage(&host, gamename.toLower());
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetLargeIcon);
+    Discord::self()->setDetailText(&host, tr("Playing %1").arg(gamename));
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetDetail);
+    Discord::self()->setLargeImage(&host, gamename.toLower());
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetLargeIcon);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -397,7 +383,6 @@ int TLuaInterpreter::setDiscordGameUrl(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordLargeIcon
 int TLuaInterpreter::setDiscordLargeIcon(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -405,8 +390,8 @@ int TLuaInterpreter::setDiscordLargeIcon(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    pMudlet->mDiscord.setLargeImage(&host, getVerifiedString(L, __func__, 1, "key").toLower());
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetLargeIcon);
+    Discord::self()->setLargeImage(&host, getVerifiedString(L, __func__, 1, "key").toLower());
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetLargeIcon);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -414,7 +399,6 @@ int TLuaInterpreter::setDiscordLargeIcon(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordLargeIconText
 int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -427,8 +411,8 @@ int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
         return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
-    pMudlet->mDiscord.setLargeImageText(&host, discordText);
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetLargeIconText);
+    Discord::self()->setLargeImageText(&host, discordText);
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetLargeIconText);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -436,7 +420,6 @@ int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordParty
 int TLuaInterpreter::setDiscordParty(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -456,12 +439,12 @@ int TLuaInterpreter::setDiscordParty(lua_State* L)
             return warnArgumentValue(L, __func__, "the optional party maximum size must be zero (to remove the party details) or more (to set the maximum)");
         }
 
-        pMudlet->mDiscord.setParty(&host, partySize, partyMax);
+        Discord::self()->setParty(&host, partySize, partyMax);
     } else {
         // Only got the partySize now
-        pMudlet->mDiscord.setParty(&host, partySize);
+        Discord::self()->setParty(&host, partySize);
     }
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetPartyInfo);
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetPartyInfo);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -469,7 +452,6 @@ int TLuaInterpreter::setDiscordParty(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordRemainingEndTime
 int TLuaInterpreter::setDiscordRemainingEndTime(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -482,8 +464,8 @@ int TLuaInterpreter::setDiscordRemainingEndTime(lua_State* L)
     if (timeStamp < 0) {
         return warnArgumentValue(L, __func__, "the timestamp must be zero to clear the 'remaining:' time or an epoch time value in the recent future");
     }
-    pMudlet->mDiscord.setEndTimeStamp(&host, static_cast<int64_t>(timeStamp));
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetTimeInfo);
+    Discord::self()->setEndTimeStamp(&host, static_cast<int64_t>(timeStamp));
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetTimeInfo);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -491,7 +473,6 @@ int TLuaInterpreter::setDiscordRemainingEndTime(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordSmallIcon
 int TLuaInterpreter::setDiscordSmallIcon(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -499,8 +480,8 @@ int TLuaInterpreter::setDiscordSmallIcon(lua_State* L)
         return warnArgumentValue(L, __func__, result.second);
     }
 
-    pMudlet->mDiscord.setSmallImage(&host, getVerifiedString(L, __func__, 1, "key").toLower());
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetSmallIcon);
+    Discord::self()->setSmallImage(&host, getVerifiedString(L, __func__, 1, "key").toLower());
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetSmallIcon);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -508,7 +489,6 @@ int TLuaInterpreter::setDiscordSmallIcon(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDiscordSmallIconText
 int TLuaInterpreter::setDiscordSmallIconText(lua_State* L)
 {
-    mudlet* pMudlet = mudlet::self();
     auto& host = getHostFromLua(L);
 
     auto result = discordApiEnabled(L, true);
@@ -521,8 +501,8 @@ int TLuaInterpreter::setDiscordSmallIconText(lua_State* L)
         return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
-    pMudlet->mDiscord.setSmallImageText(&host, discordText);
-    pMudlet->mDiscord.clearServerOrigin(&host, Host::DiscordSetSmallIconText);
+    Discord::self()->setSmallImageText(&host, discordText);
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetSmallIconText);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -542,8 +522,8 @@ int TLuaInterpreter::setDiscordState(lua_State* L)
         return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
-    mudlet::self()->mDiscord.setStateText(&host, discordText);
-    mudlet::self()->mDiscord.clearServerOrigin(&host, Host::DiscordSetState);
+    Discord::self()->setStateText(&host, discordText);
+    Discord::self()->clearServerOrigin(&host, Host::DiscordSetState);
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -45,6 +45,7 @@
 #include "TEncodingHelper.h"
 #include "utils.h"
 #include "TTextEdit.h"
+#include "discord.h"
 #include "dlgComposer.h"
 #include "dlgMapper.h"
 #include "mudlet.h"
@@ -3184,7 +3185,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += OPT_GMCP;
             {
                 std::string supportsList = R"(Core.Supports.Set [ "Char 1", "Char.Skills 1", "Char.Items 1", "Room 1", "IRE.Rift 1", "IRE.Composer 1")";
-                if (mpHost->mDiscordMode == Host::DiscordShowGameDetails && mudlet::self()->mDiscord.libraryLoaded()) {
+                if (mpHost->mDiscordMode == Host::DiscordShowGameDetails && Discord::self()->libraryLoaded()) {
                     supportsList += R"(, "External.Discord 1")";
                 }
                 supportsList += R"(, "Client.Media 1", "Char.Login 2"])";
@@ -3194,7 +3195,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += TN_SE;
             socketOutRaw(output);
 
-            if (mpHost->mDiscordMode == Host::DiscordShowGameDetails && mudlet::self()->mDiscord.libraryLoaded()) {
+            if (mpHost->mDiscordMode == Host::DiscordShowGameDetails && Discord::self()->libraryLoaded()) {
                 sendDiscordHello();
                 sendDiscordGet();
             }

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -62,6 +62,10 @@ Discord::Discord(QObject* parent)
           {"asteria", {"asteriamud.com"}},
   }
 {
+    // Before the library probe below, which returns early when the Discord RPC
+    // library is absent - self() must still answer in that case.
+    smpSelf = this;
+
 #if defined(Q_OS_WIN64)
     // Only defined on 64 bit Windows
     mpLibrary.reset(new QLibrary(qsl("discord-rpc64")));
@@ -153,6 +157,8 @@ Discord::~Discord()
 
     // Clear out the localDiscordPresence collection:
     mPresencePtrs.clear();
+
+    smpSelf = nullptr;
 }
 
 // For all the setters below the caller is supposed to check that they have the
@@ -296,7 +302,7 @@ void Discord::handleDiscordReady(const DiscordUser* request)
     // Don't call UpdatePresence directly from here - re-entering the Discord
     // library from a callback freezes Mudlet. Instead, signal the timer to
     // pick it up on the next tick.
-    mudlet::self()->mDiscord.mPendingPresenceUpdate = true;
+    self()->mPendingPresenceUpdate = true;
 }
 
 void Discord::handleDiscordDisconnected(int errorCode, const char* message)

--- a/src/discord.h
+++ b/src/discord.h
@@ -181,6 +181,8 @@ public:
     explicit Discord(QObject *parent = nullptr);
     ~Discord() override;
 
+    static Discord* self() { return smpSelf; }
+
     bool libraryLoaded();
     bool usingMudletsDiscordID(Host*) const;
     static QString getLoggedInUserName() { return smUserName; }
@@ -303,6 +305,8 @@ private:
     static QString smUserName;
     static QString smUserId;
     static QString smAvatar;
+
+    inline static Discord* smpSelf = nullptr;
 };
 
 #endif // DISCORD_H

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -31,6 +31,7 @@
 #include "LuaInterface.h"
 #include "TGameDetails.h"
 #include "XMLimport.h"
+#include "discord.h"
 #include "mudlet.h"
 #include "CredentialManager.h"
 #include "SecureStringUtils.h"
@@ -2347,7 +2348,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         pHost->setAutoReconnect(auto_reconnect->isChecked());
 
         // This also writes the value out to the profile's base directory:
-        mudlet::self()->mDiscord.setApplicationID(pHost, mDiscordApplicationId);
+        Discord::self()->setApplicationID(pHost, mDiscordApplicationId);
     }
 
     emit signal_load_profile(profile_name, alsoConnect);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -42,6 +42,7 @@
 #include "TTimer.h"
 #include "TTrigger.h"
 #include "ctelnet.h"
+#include "discord.h"
 #include "dlgIRC.h"
 #include "dlgMapper.h"
 #include "dlgTriggerEditor.h"
@@ -4061,7 +4062,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         break;
     }
 
-    if (mudlet::self()->mDiscord.libraryLoaded()) {
+    if (Discord::self()->libraryLoaded()) {
         Host::DiscordOptionFlags const discordFlags = pHost->mDiscordAccessFlags;
         groupBox_discordPrivacy->show();
         mpCard_discord->show();
@@ -6795,7 +6796,7 @@ void dlgProfilePreferences::applyAll()
             const QString newDiscordUserName = lineEdit_discordUserName->text().trimmed().toLower();
             if (pHost->mRequiredDiscordUserName != newDiscordUserName) {
                 pHost->mRequiredDiscordUserName = newDiscordUserName;
-                pMudlet->mDiscord.UpdatePresence();
+                Discord::self()->UpdatePresence();
             }
         }
 
@@ -6933,7 +6934,7 @@ void dlgProfilePreferences::applyAll()
         pMudlet->setAppearance(static_cast<enums::Appearance>(comboBox_appearance->currentIndex()));
     }
 
-    pMudlet->mDiscord.UpdatePresence();
+    Discord::self()->UpdatePresence();
 
     emit signal_preferencesSaved();
 
@@ -7724,14 +7725,12 @@ void dlgProfilePreferences::generateDiscordTooltips()
         return;
     }
 
-    auto* mudlet = mudlet::self();
-
-    auto detail = mudlet->mDiscord.getDetailText(mpHost);
+    auto detail = Discord::self()->getDetailText(mpHost);
     if (!detail.isEmpty()) {
         detail = qsl("<br/>(\"%1\")").arg(detail);
     }
 
-    auto state = mudlet->mDiscord.getStateText(mpHost);
+    auto state = Discord::self()->getStateText(mpHost);
     if (!state.isEmpty()) {
         state = qsl("<br/>(\"%1\")").arg(state);
     }

--- a/test/functional_tests/TDiscordModeTest.cpp
+++ b/test/functional_tests/TDiscordModeTest.cpp
@@ -144,7 +144,7 @@ private:
     // runners.
     bool establishDiscordLogin()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (discord.mRpcActive && Discord::getLoggedInUserName() == mDiscordStubUserName) {
             return true;
         }
@@ -217,7 +217,7 @@ private slots:
         // handshake resets the library's internal reconnect backoff (capped at
         // 60s), which the per-test init/shutdown churn below can otherwise
         // inflate. The end-to-end tests reuse this connection where they can.
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (discord.libraryLoaded() && mpDiscordIpcStub->listening()) {
             mpHost->mDiscordMode = Host::DiscordShowGameDetails;
             mpHost->mRequiredDiscordUserName.clear();
@@ -228,7 +228,7 @@ private slots:
     void init()
     {
         QVERIFY(mpHost);
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         // Restore the default gating state BEFORE resetData(): resetData() calls
         // UpdatePresence() internally, and a Disabled mode or username mismatch
         // left over from the previous test would make that call tear the shared
@@ -248,7 +248,7 @@ private slots:
     void testGMCPIgnoredInDisabledMode()
     {
         mpHost->mDiscordMode = Host::DiscordDisabled;
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Exploring the forest","state":"Level 50 Mage"})"));
 
@@ -259,7 +259,7 @@ private slots:
     void testGMCPIgnoredInMudletOnlyMode()
     {
         mpHost->mDiscordMode = Host::DiscordShowMudletOnly;
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Exploring the forest","state":"Level 50 Mage"})"));
 
@@ -270,7 +270,7 @@ private slots:
     void testGMCPProcessedInGameDetailsMode()
     {
         mpHost->mDiscordMode = Host::DiscordShowGameDetails;
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Exploring the forest","state":"Level 50 Mage"})"));
 
@@ -281,7 +281,7 @@ private slots:
     void testGMCPInfoIgnoredOutsideGameDetailsMode()
     {
         mpHost->mDiscordMode = Host::DiscordShowMudletOnly;
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         mpHost->processDiscordGMCP(qsl("External.Discord.Info"), qsl(R"({"applicationid":"123456789"})"));
 
@@ -294,7 +294,7 @@ private slots:
     void testGMCPSetsServerOrigin()
     {
         mpHost->mDiscordMode = Host::DiscordShowGameDetails;
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         QVERIFY2(!discord.isServerOrigin(mpHost, Host::DiscordSetDetail), "Detail should not be server-origin before GMCP");
         QVERIFY2(!discord.isServerOrigin(mpHost, Host::DiscordSetState), "State should not be server-origin before GMCP");
@@ -307,7 +307,7 @@ private slots:
 
     void testLuaSetterClearsServerOrigin()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         // First, have the server set it
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Server set this"})"));
@@ -323,7 +323,7 @@ private slots:
 
     void testServerOriginNotSetForUnsentFields()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         // Send GMCP with only detail, not state
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Only details"})"));
@@ -336,7 +336,7 @@ private slots:
 
     void testPrivacyFlagBlocksServerField()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         // Server sets detail
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Secret details","state":"Visible state"})"));
@@ -357,7 +357,7 @@ private slots:
 
     void testGMCPStatusSetsAllFields()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"),
                                    qsl(R"({"details":"Hunting","state":"Level 50","smallimagetext":"Warrior","largeimagetext":"Achaea","starttime":1234567890,"partysize":3,"partymax":6})"));
@@ -381,7 +381,7 @@ private slots:
 
     void testResetDataClearsEverything()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
 
         // Set some data via GMCP
         mpHost->processDiscordGMCP(qsl("External.Discord.Status"), qsl(R"({"details":"Test","state":"Test"})"));
@@ -403,7 +403,7 @@ private slots:
 
     void testLuaSetterDeniedWhenDisabled()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         discord.setDetailText(mpHost, qsl("original"));
         mpHost->mDiscordMode = Host::DiscordDisabled;
 
@@ -415,7 +415,7 @@ private slots:
 
     void testLuaResetDeniedWhenDisabled()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         discord.setDetailText(mpHost, qsl("keep me"));
         mpHost->mDiscordMode = Host::DiscordDisabled;
 
@@ -427,7 +427,7 @@ private slots:
 
     void testLuaSetterAndResetDeniedWhenReadOnly()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (!discord.libraryLoaded()) {
             QSKIP("Discord RPC library not available - cannot test the read-only gate");
         }
@@ -451,7 +451,7 @@ private slots:
 
     void testLuaGettersAllowedWhenReadOnly()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (!discord.libraryLoaded()) {
             QSKIP("Discord RPC library not available - cannot test the read-only gate");
         }
@@ -472,7 +472,7 @@ private slots:
 
     void testLuaSetterAndResetAllowedWithWriteAccess()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (!discord.libraryLoaded()) {
             QSKIP("Discord RPC library not available - cannot test the write-access path");
         }
@@ -496,7 +496,7 @@ private slots:
 
     void testIpcHandshakeMakesApiReadOnlyEndToEnd()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (!discord.libraryLoaded()) {
             QSKIP("Discord RPC library not available - cannot test the IPC handshake");
         }
@@ -531,7 +531,7 @@ private slots:
 
     void testSetActivityReachesDiscordEndToEnd()
     {
-        auto& discord = mudlet::self()->mDiscord;
+        auto& discord = *Discord::self();
         if (!discord.libraryLoaded()) {
             QSKIP("Discord RPC library not available - cannot test presence delivery");
         }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Discord` gains its own `Discord::self()` accessor, so code reaches the integration directly instead of through `mudlet::self()->mDiscord`. `mudlet` keeps ownership; only the route changed.
- Repoints every call site in `Host.cpp`, `ctelnet.cpp`, `TLuaInterpreterDiscord.cpp`, both dialogs and `TDiscordModeTest`, and drops 23 locals that existed only to reach it. Every `libraryLoaded()` and `discordApiEnabled()` guard is preserved verbatim.
- `smpSelf` is assigned at the top of the constructor, ahead of the RPC library probe that returns early when the library is absent - `self()` has to answer on those machines too.

#### Motivation for adding to Mudlet

`class mudlet` is a `QMainWindow`, so every `mudlet::` reference from core code pulls in all of Qt Widgets. Removing this one lets the Discord-related core files stop depending on the main window.

#### Other info (issues closed, discussion etc)

Works towards #8681 (Plan to separate Mudlet backend (libmudlet) and Qt frontend using a C API) and #9011 (Split Mudlet up into `libmudlet` and a Qt front-end). No behaviour change, so the Qt Widgets count is unchanged.

`discord.cpp` still includes `mudlet.h` for `signal_tabChanged` and `getActiveHost()`; that is left for a later slice.

**Test case:** 171/171 ctest. `TDiscordModeTest` was run both ways - with the RPC library present (19 passed, end-to-end IPC included) and with it hidden (14 passed, 5 skipped), the second exercising the early-return path that the accessor's placement exists for.

Assisted-by: Claude:claude-opus-5