### PR TITLE
Infra: Give the map-audit flag a home that does not need the main window

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -680,7 +680,7 @@ void TMap::audit()
                         // now:
                         const int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, false, 40.0, 50, std::nullopt, l.fgColor);
                         if (newID > -1) {
-                            if (mudlet::self()->showMapAuditErrors()) {
+                            if (smShowMapAuditErrors) {
                                 const QString msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
                                 postMessage(msg);
                             }
@@ -688,7 +688,7 @@ void TMap::audit()
                             pArea->mMapLabels[i] = pArea->mMapLabels.take(newID);
 
                         } else {
-                            if (mudlet::self()->showMapAuditErrors()) {
+                            if (smShowMapAuditErrors) {
                                 const QString msg = tr("[ WARN ] - CONVERTING: cannot convert old style label in area with id: %1,  label id is: %2.").arg(areaID).arg(i);
                                 postMessage(msg);
                             }
@@ -2001,7 +2001,7 @@ bool TMap::restore(QString location)
             const QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
                                                        "area) not found, adding reserved -1 id.");
             appendErrorMsgWithNoLf(defaultAreaInsertionMsg, false);
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (smShowMapAuditErrors) {
                 postMessage(defaultAreaInsertionMsg);
             }
         }
@@ -2155,7 +2155,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
 
     const QString infoMsg = tr(R"([ INFO ]  - Checking map file "%1", format version "%2".)").arg(file.fileName()).arg(otherProfileVersion);
     appendErrorMsg(infoMsg, false);
-    if (mudlet::self()->showMapAuditErrors()) {
+    if (smShowMapAuditErrors) {
         postMessage(infoMsg);
     }
 
@@ -2656,7 +2656,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
     mapAuditErrors.clear();
     mapAuditAreaErrors.clear();
     mapAuditRoomErrors.clear();
-    if (mIsFileViewingRecommended && (!mudlet::self()->showMapAuditErrors())) {
+    if (mIsFileViewingRecommended && (!smShowMapAuditErrors)) {
         postMessage(tr("[ ALERT ] - At least one thing was detected during that last map operation\n"
                        "that it is recommended that you review the most recent report in\n"
                        "the file:\n"
@@ -2664,7 +2664,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
                             .arg(mudlet::getMudletPath(enums::profileLogErrorsFilePath, mProfileName), title));
-    } else if (mIsFileViewingRecommended && mudlet::self()->showMapAuditErrors()) {
+    } else if (mIsFileViewingRecommended && smShowMapAuditErrors) {
         postMessage(tr("[ INFO ]  - The equivalent to the above information about that last map\n"
                        "operation has been saved for review as the most recent report in\n"
                        "the file:\n"

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -126,6 +126,9 @@ public:
     void updateArea(int areaId);
 
     void audit();
+    // One switch for every profile, not per map: the main window persists it
+    // and the preferences dialog toggles it for the whole application.
+    inline static bool smShowMapAuditErrors = false;
 
     QList<int> detectRoomCollisions(int id);
     void setRoom(int);

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -126,8 +126,7 @@ public:
     void updateArea(int areaId);
 
     void audit();
-    // One switch for every profile, not per map: the main window persists it
-    // and the preferences dialog toggles it for the whole application.
+    // One switch for the whole application, not one per map.
     inline static bool smShowMapAuditErrors = false;
 
     QList<int> detectRoomCollisions(int id);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -28,7 +28,6 @@
 #include "TArea.h"
 #include "TMap.h"
 #include "TRoomDB.h"
-#include "mudlet.h"
 
 #include <QJsonArray>
 #include <QJsonObject>
@@ -1313,7 +1312,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                 //: %1 is the room ID, %2 is the destination room ID
                 const QString warnMsg =
                         tr("[ WARN ]  - In room ID: %1 removing invalid (special) exit to %2 (with no name!)").arg(id, 6, 10, QLatin1Char('0')).arg(exitRoomId, 6, 10, QLatin1Char('0'));
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
                 mpRoomDB->mpMap->appendRoomErrorMsg(id, warnMsg);
@@ -1330,7 +1329,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                                                 .arg(exitName)
                                                 .arg(exitRoomId)
                                                 .arg(roomRemapping.value(exitRoomId));
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     mpRoomDB->mpMap->postMessage(infoMsg);
                 }
                 mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg);
@@ -1361,7 +1360,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                                     .arg(exitName)
                                     .arg(exitRoomId)
                                     .arg(auditKey);
-                    if (mudlet::self()->showMapAuditErrors()) {
+                    if (TMap::smShowMapAuditErrors) {
                         mpRoomDB->mpMap->postMessage(warnMsg);
                     }
                     mpRoomDB->mpMap->appendRoomErrorMsg(id, warnMsg, true);
@@ -1405,7 +1404,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                                 .arg(exitName)
                                 .arg(exitRoomId)
                                 .arg(auditKey);
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     mpRoomDB->mpMap->postMessage(infoMsg);
                 }
                 mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1454,7 +1453,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         }
         //: %1 is the room ID, %2 is a list of door items
         const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus door items that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
         mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1471,7 +1470,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         }
         //: %1 is the room ID, %2 is a list of weight items
         const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus weight items that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
         mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1488,7 +1487,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         }
         //: %1 is the room ID, %2 is a list of exit lock items
         const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus exit lock items that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
         mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1568,7 +1567,7 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
         if (!extras.isEmpty()) {
             //: %1 is the room ID, %2 is a list of custom line elements
             const QString infoMsg = tr("[ INFO ]  - In room with ID: %1 found one or more surplus custom line elements that were removed: %2.").arg(id).arg(extras.join(QLatin1String(", ")));
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (TMap::smShowMapAuditErrors) {
                 mpRoomDB->mpMap->postMessage(infoMsg);
             }
             mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1605,7 +1604,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
                                         .arg(displayName)
                                         .arg(exitRoomId)
                                         .arg(roomRemapping.value(exitRoomId));
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
         mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1624,7 +1623,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
                             .arg(displayName)
                             .arg(exitRoomId)
                             .arg(auditKey);
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (TMap::smShowMapAuditErrors) {
                 mpRoomDB->mpMap->postMessage(warnMsg);
             }
             mpRoomDB->mpMap->appendRoomErrorMsg(id, warnMsg, true);
@@ -1671,7 +1670,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
                                 .arg(id)
                                 .arg(displayName)
                                 .arg(exitRoomId);
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
                 mpRoomDB->mpMap->appendRoomErrorMsg(id, warnMsg, true);
@@ -1748,7 +1747,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             infoMsg.append(qsl("  %1").arg(tr(R"(It had a weight, this is recorded as user data with key: "%1".)").arg(auditKeyWeight)));
             exitWeights.remove(exitKey);
         }
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpRoomDB->mpMap->postMessage(infoMsg);
         }
         mpRoomDB->mpMap->appendRoomErrorMsg(id, infoMsg, true);
@@ -1756,7 +1755,7 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
 
         if (customLines.contains(exitKey)) {
             const QString warnMsg = tr("[ WARN ]  - There was a custom exit line associated with the invalid exit but it has not been possible to salvage this, it has been lost!");
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (TMap::smShowMapAuditErrors) {
                 mpRoomDB->mpMap->postMessage(warnMsg);
             }
             mpRoomDB->mpMap->appendRoomErrorMsg(id, warnMsg, true);

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -25,7 +25,7 @@
 #include "Host.h"
 #include "TArea.h"
 #include "T2DMap.h"
-#include "mudlet.h"
+#include "TMap.h"
 
 #include <QElapsedTimer>
 #include <QRegularExpression>
@@ -667,7 +667,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             itRoom.next();
             TRoom* pR = itRoom.value();
             if (!pR) {
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     const QString warnMsg = tr("[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
                                                "room's data has been lost so the id is now being deleted.  This\n"
                                                "suggests serious problems with the currently running version of\n"
@@ -724,7 +724,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         }
 
         if (!areas.contains(usedAreaId)) {
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (TMap::smShowMapAuditErrors) {
                 const QString warnMsg = tr("[ ALERT ] - Area with id: %1 expected but not found, will be created.").arg(usedAreaId);
                 mpMap->postMessage(warnMsg);
             }
@@ -756,7 +756,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // * WILL NOT be in TRoomDB::areas - as that is the source of the error this
     // bit of the task being addressed here is fixing
     if (!missingAreasNeeded.isEmpty()) {
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             const QString alertMsg = tr("[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
                                         "Look for further messages related to the rooms that are supposed\n"
                                         "to be in this/these area(s)...",
@@ -772,7 +772,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                       true);
 
         QString infoMsg;
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             infoMsg = tr("[ INFO ]  - The missing area(s) are now called:\n"
                          "(ID) ==> \"name\"",
                          "Making use of %n to allow quantity dependent message form 8-) !",
@@ -798,7 +798,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         // in the debugger a little clearer...
         missingAreasNeeded.clear();
 
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpMap->postMessage(infoMsg);
         }
         mpMap->appendErrorMsg(infoMsg, true);
@@ -807,7 +807,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     // START OF TASK 5.1
     // Now process problem areaIds
     if (!areaRemapping.isEmpty()) {
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             const QString alertMsg = tr("[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
                                         "in map, now working out what new id numbers to use...")
                                              .arg(areaRemapping.count());
@@ -819,7 +819,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                               true);
 
         QString infoMsg;
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             infoMsg = tr("[ INFO ]  - The renumbered area ids will be:\n"
                          "Old ==> New");
         }
@@ -834,7 +834,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             } while (areas.contains(++replacementAreaId));
             // Insert replacement value into hash
             itRemappedArea.setValue(replacementAreaId);
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (TMap::smShowMapAuditErrors) {
                 infoMsg.append(qsl("\n%1 ==> %2").arg(QString::number(faultyAreaId), QString::number(replacementAreaId)));
             }
 
@@ -871,11 +871,11 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             pA->mIsDirty = true;
         }
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpMap->postMessage(infoMsg);
         }
     } else {
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             const QString infoMsg = tr("[ INFO ]  - Area id numbering is satisfactory.");
             mpMap->postMessage(infoMsg);
         }
@@ -886,7 +886,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
     // Now complete TASK 1 - find the new room Ids to use
     if (!roomRemapping.isEmpty()) {
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             const QString alertMsg = tr("[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
                                         "out what new id numbers to use.")
                                              .arg(roomRemapping.count());
@@ -898,7 +898,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                               true);
 
         QString infoMsg;
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             infoMsg = qsl("%1\n").arg(tr("[ INFO ]  - The renumbered rooms will be:"));
         }
         QMutableHashIterator<int, int> itRenumberedRoomId(roomRemapping);
@@ -911,14 +911,14 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             itRenumberedRoomId.setValue(newRoomId); // Update the QHash
             validUsedRoomIds.insert(newRoomId);
-            if (mudlet::self()->showMapAuditErrors()) {
+            if (TMap::smShowMapAuditErrors) {
                 infoMsg.append(qsl("%1 ==> %2").arg(QString::number(itRenumberedRoomId.key()), QString::number(itRenumberedRoomId.value())));
             }
 
             mpMap->appendRoomErrorMsg(itRenumberedRoomId.key(), tr("[ INFO ]  - This room with the bad id was renumbered to: %1.").arg(itRenumberedRoomId.value()), true);
             mpMap->appendRoomErrorMsg(itRenumberedRoomId.value(), tr("[ INFO ]  - This room was renumbered from the bad id: %1.").arg(itRenumberedRoomId.key()), true);
         }
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             mpMap->postMessage(infoMsg);
         }
 
@@ -951,7 +951,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             rooms.insert(newRoomId, pR);
         }
     } else {
-        if (mudlet::self()->showMapAuditErrors()) {
+        if (TMap::smShowMapAuditErrors) {
             const QString infoMsg = tr("[ INFO ]  - Room id numbering is satisfactory.");
             mpMap->postMessage(infoMsg);
         }
@@ -974,7 +974,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // that is persistent:
             QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
             if (_set.count() < _listCount) {
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     const QString infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
                                                "anomaly but has been cleaned up easily.")
                                                     .arg(itRoom.key());
@@ -988,7 +988,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             _listCount = pR->exitLocks.count();
             _set = QSet<int>{pR->exitLocks.begin(), pR->exitLocks.end()};
             if (_set.count() < _listCount) {
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     const QString infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
                                                "anomaly but has been cleaned up easily.")
                                                     .arg(itRoom.key());
@@ -1072,7 +1072,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                                       .arg(itArea.key()),
                                               true);
                 }
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     const QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
                                                "should be recording as possessing, they were:\n%3\nthey have been added.")
                                                     .arg(itArea.key())
@@ -1107,7 +1107,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                                                       .arg(itArea.key()),
                                               true);
                 }
-                if (mudlet::self()->showMapAuditErrors()) {
+                if (TMap::smShowMapAuditErrors) {
                     const QString infoMsg = tr("[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
                                                "should be recording as possessing, they were:\n%3\nthey have been removed.")
                                                     .arg(itArea.key())

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3787,7 +3787,7 @@ void dlgProfilePreferences::populateApplicationSettings()
     checkBox_showSpacesAndTabs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowTabsAndSpaces);
     checkBox_showLineFeedsAndParagraphs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
 
-    checkBox_reportMapIssuesOnScreen->setChecked(pMudlet->showMapAuditErrors());
+    checkBox_reportMapIssuesOnScreen->setChecked(TMap::smShowMapAuditErrors);
     checkBox_showIconsOnMenus->setCheckState(pMudlet->mShowIconsOnMenuCheckedState);
 
     MainIconSize->setValue(pMudlet->mToolbarIconSize);
@@ -5938,7 +5938,7 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
 
     // Ensure the setting is already made as the TConsole::loadMap(...) uses
     // the set value:
-    const bool showAuditErrors = mudlet::self()->showMapAuditErrors();
+    const bool showAuditErrors = TMap::smShowMapAuditErrors;
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
     bool success = false;
@@ -6066,7 +6066,7 @@ void dlgProfilePreferences::slot_saveMap()
         // show up when saving big maps
 
         // Ensure the setting is already made as the saveMap(...) uses the set value
-        const bool showAuditErrors = mudlet::self()->showMapAuditErrors();
+        const bool showAuditErrors = TMap::smShowMapAuditErrors;
         mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
         bool success = false;
@@ -6179,7 +6179,7 @@ void dlgProfilePreferences::slot_copyMap()
 
     // Ensure the setting is already made as the value could be used in the
     // code following after
-    const bool savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->showMapAuditErrors();
+    const bool savedOldAuditErrorsToConsoleEnabledSetting = TMap::smShowMapAuditErrors;
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
 
     // We now KNOW there are places where the destination profiles will/have

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4068,7 +4068,7 @@ void mudlet::readLateSettings(const QSettings& settings)
 
     mEditorTextOptions = static_cast<QTextOption::Flags>(settings.value("editorTextOptions", QVariant(0)).toInt());
 
-    mShowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();
+    TMap::smShowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();
     mInvertMapZoom = settings.value("invertMapZoom", QVariant(false)).toBool(); // Default to false for modern (non-inverted) behavior
     mStorePasswordsSecurely = settings.value("storePasswordsSecurely", QVariant(true)).toBool();
     mShowTabConnectionIndicators = settings.value("showTabConnectionIndicators", QVariant(false)).toBool();
@@ -4280,7 +4280,7 @@ void mudlet::writeSettings()
     settings.setValue("maximized", static_cast<bool>(windowState() & Qt::WindowMaximized));
     settings.setValue("fullScreen", static_cast<bool>(windowState() & Qt::WindowFullScreen));
     settings.setValue("editorTextOptions", static_cast<int>(mEditorTextOptions));
-    settings.setValue("reportMapIssuesToConsole", mShowMapAuditErrors);
+    settings.setValue("reportMapIssuesToConsole", TMap::smShowMapAuditErrors);
     settings.setValue("invertMapZoom", mInvertMapZoom);
     settings.setValue("storePasswordsSecurely", mStorePasswordsSecurely);
     settings.setValue("showTabConnectionIndicators", mShowTabConnectionIndicators);
@@ -7502,8 +7502,8 @@ void mudlet::slot_passwordMigratedToSecureStorage(QKeychain::Job* job)
 
 void mudlet::setShowMapAuditErrors(const bool state)
 {
-    if (mShowMapAuditErrors != state) {
-        mShowMapAuditErrors = state;
+    if (TMap::smShowMapAuditErrors != state) {
+        TMap::smShowMapAuditErrors = state;
 
         emit signal_showMapAuditErrorsChanged(state);
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -308,7 +308,6 @@ public:
     void setToolBarVisibility(enums::controlsVisibility);
     void showChangelogIfUpdated();
     void slot_showConnectionDialog();
-    bool showMapAuditErrors() const { return mShowMapAuditErrors; }
     bool invertMapZoom() const { return mInvertMapZoom; }
     bool showTabConnectionIndicators() const { return mShowTabConnectionIndicators; }
     // Addon toolbar button management
@@ -783,7 +782,6 @@ private:
     QWidget* mpWidget_profileContainer = nullptr;
     // read-only value to see if the interface is light or dark. To set the value,
     // use setAppearance instead
-    bool mShowMapAuditErrors = false;
     bool mInvertMapZoom = false; // true = old behavior (inverted), false = modern behavior (non-inverted)
     QSplitter* mpSplitter_profileContainer = nullptr;
     bool mStorePasswordsSecurely = true;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The "report map issues on screen" switch moves from `mudlet::mShowMapAuditErrors` to `TMap::smShowMapAuditErrors`, an `inline static` on the map model. The 38 reads in `TRoomDB`, `TRoom` and `TMap` use it directly. `mudlet::setShowMapAuditErrors()` stays as the preferences dialog's entry point - it writes the flag and emits the same signal - and the getter goes.
- `TRoom.cpp` drops `#include "mudlet.h"`; `TRoomDB.cpp` swaps it for `TMap.h`. Neither names the main window any more.
- Still one flag for the whole application rather than one per map, and the settings key is untouched, so behaviour is unchanged.

#### Motivation for adding to Mudlet

`class mudlet` is a `QMainWindow`, so every `mudlet::` reference from core code pulls in all of Qt Widgets. This flag is map-model state, and it was the only reason the room and room-database classes reached for the main window at all.

#### Other info (issues closed, discussion etc)

Works towards #8681 (Plan to separate Mudlet backend (libmudlet) and Qt frontend using a C API) and #9011 (Split Mudlet up into `libmudlet` and a Qt front-end). Home chosen by subject, as #10284 (home the debug switch and timestamp formats in core classes) did.

The Qt Widgets audit count is unchanged at 150 before and after (the committed baseline is 149; #10374 removes the dead include behind the difference). The audit scores direct Widgets includes and symbols per file, and these two files were already on its clean list - the `mudlet.h` include was transitive exposure it never counted.

**Test case:** 172/172 ctest. Manually: in Preferences, tick "report map issues on screen", load a map that has audit issues and watch the messages appear in the console; untick and reload, they stop; restart Mudlet and the choice persists.

Assisted-by: Claude:claude-fable-5-1