### PR TITLE
Infra: Add specs for the Lua API's argument checking

### DIFF
--- a/src/mudlet-lua/tests/LuaApiContracts_spec.lua
+++ b/src/mudlet-lua/tests/LuaApiContracts_spec.lua
@@ -1,0 +1,363 @@
+-- Contract tests for the parts of the Lua API where the refusal *is* the
+-- behaviour: which message comes back, whether it arrives as nil plus a reason
+-- or as a raised error, and what the profile looks like afterwards. Scripts
+-- branch on those answers, so changing one is a breaking change even though
+-- nothing about the successful path moved.
+
+local function contains(haystack, needle)
+  return type(haystack) == "string" and haystack:find(needle, 1, true) ~= nil
+end
+
+-- Matching a message substring rather than merely "did it error?" is what
+-- proves the call reached its own argument validation: a function that had
+-- been renamed away would raise "attempt to call a nil value" and satisfy a
+-- bare has_error just as well.
+local function assertArgError(fn, needle)
+  local ok, err = pcall(fn)
+  assert.is_false(ok, "the call was accepted instead of raising")
+  assert.is_true(contains(err, needle), tostring(err))
+end
+
+local function assertRefused(needle, ok, err)
+  assert.is_nil(ok, "the call was accepted instead of refused")
+  assert.is_true(contains(err, needle), tostring(err))
+end
+
+-- Mudlet's own colour numbering predates the ANSI one and interleaves it: 1 is
+-- light black, 2 is black, 3 is light red, 4 is red, and so on up to 16, white.
+-- isAnsiFgColor, isAnsiBgColor and tempColorTrigger all speak it, and the saved
+-- profile format stores it, so renumbering silently changes what every colour
+-- trigger a player already has matches.
+local sgrForIndex = {
+  fg = {90, 30, 91, 31, 92, 32, 93, 33, 94, 34, 95, 35, 96, 36, 97, 37},
+  bg = {100, 40, 101, 41, 102, 42, 103, 43, 104, 44, 105, 45, 106, 46, 107, 47},
+}
+
+describe("Tests the legacy ANSI colour numbering", function()
+
+  local mark
+
+  local function feed(data)
+    local ok, msg = feedTelnet(data)
+    assert.is_true(ok, "start the suite with --offline, see the tests README - feedTelnet said: " .. tostring(msg))
+  end
+
+  -- the buffer line the marker landed on, looked for from where this test's own
+  -- output starts so that an earlier test's identical text cannot answer
+  local function lineNumberOf(marker)
+    local last = getLastLineNumber("main")
+    local lines = getLines("main", mark, last + 1)
+    for i = #lines, 1, -1 do
+      if lines[i]:find(marker, 1, true) then
+        return mark + i - 1
+      end
+    end
+    return nil
+  end
+
+  -- isAnsiFgColor and isAnsiBgColor read the first character of the selection
+  local function selectMarker(marker)
+    local line = lineNumberOf(marker)
+    assert.is_truthy(line, "no line carrying '" .. marker .. "' reached the buffer")
+    assert.is_true(moveCursor("main", 0, line))
+    assert.is_true(selectString(marker, 1) >= 0, "'" .. marker .. "' was not selectable on the line it landed on")
+  end
+
+  -- Index 0 is the profile's default colour, and the defaults are white on
+  -- black, so 0 legitimately answers true alongside 16 for a foreground and
+  -- alongside 2 for a background. It is left out of the sweep for that reason.
+  local function assertOnlyColour(reader, index, marker)
+    assert.is_true(reader(index), marker .. " did not answer to colour " .. index)
+    for other = 1, 16 do
+      if other ~= index then
+        assert.is_false(reader(other), marker .. " also answered to colour " .. other)
+      end
+    end
+  end
+
+  local function paintAndSelect(kind, index)
+    local marker = ("AnsiNum%s%d"):format(kind, index)
+    mark = getLastLineNumber("main")
+    feed(("\27[0m\27[%dm%s\r\n"):format(sgrForIndex[kind][index], marker))
+    selectMarker(marker)
+    return marker
+  end
+
+  after_each(function()
+    deselect()
+    -- selecting a marker parks the user cursor partway up the buffer, and every
+    -- spec after this one reads the buffer from wherever it was left
+    moveCursorEnd()
+  end)
+
+  it("gives isAnsiFgColor a distinct number for each foreground colour", function()
+    for index = 1, 16 do
+      local marker = paintAndSelect("fg", index)
+      assertOnlyColour(isAnsiFgColor, index, marker)
+      deselect()
+    end
+  end)
+
+  it("gives isAnsiBgColor a distinct number for each background colour", function()
+    for index = 1, 16 do
+      local marker = paintAndSelect("bg", index)
+      assertOnlyColour(isAnsiBgColor, index, marker)
+      deselect()
+    end
+  end)
+
+  -- the out of range refusals are already pinned, message and all, by
+  -- UI_spec.lua's "isAnsiFgColor/isAnsiBgColor error handling"
+
+  it("raises rather than guessing when the colour number is not a number", function()
+    paintAndSelect("fg", 4)
+    assertArgError(function() return isAnsiFgColor("red") end, "bad argument #1 type")
+    assertArgError(function() return isAnsiBgColor() end, "got no value")
+  end)
+end)
+
+describe("Tests the functionality of tempColorTrigger", function()
+
+  local created
+
+  before_each(function()
+    created = {}
+  end)
+
+  after_each(function()
+    for _, id in ipairs(created) do
+      killTrigger(id)
+    end
+  end)
+
+  local function track(id)
+    created[#created + 1] = id
+    return id
+  end
+
+  it("matches the colour its number names and no other", function()
+    local fired = {}
+    for index = 1, 16 do
+      track(tempColorTrigger(index, -1, function() fired[index] = true end))
+    end
+
+    for index = 1, 16 do
+      for key in pairs(fired) do
+        fired[key] = nil
+      end
+      feedTriggers(("\27[0m\27[%dmColourTriggerNumbering\n"):format(sgrForIndex.fg[index]))
+
+      local hits = {}
+      for key in pairs(fired) do
+        hits[#hits + 1] = key
+      end
+      table.sort(hits)
+      assert.are.same({index}, hits, ("SGR %d should have fired only the colour %d trigger"):format(sgrForIndex.fg[index], index))
+    end
+  end)
+
+  it("refuses to ignore both colours at once, since that would match everything", function()
+    assertRefused("only one of foreground and background colors can be -1", tempColorTrigger(-1, -1, "noop"))
+  end)
+
+  it("refuses an expiry count that would expire the trigger before it ever fires", function()
+    assertRefused("must be greater than zero, got 0", tempColorTrigger(4, -1, "noop", 0))
+    assertRefused("must be greater than zero, got -3", tempColorTrigger(4, -1, "noop", -3))
+  end)
+
+  it("raises on arguments it cannot make sense of, naming the one at fault", function()
+    assertArgError(function() return tempColorTrigger("red", -1, "noop") end, "bad argument #1 type")
+    assertArgError(function() return tempColorTrigger(4, "red", "noop") end, "bad argument #2 type")
+    assertArgError(function() return tempColorTrigger(4, -1, {}) end, "bad argument #3 type")
+    assertArgError(function() return tempColorTrigger(4, -1, "noop", "soon") end, "bad argument #4 value")
+  end)
+
+  -- Trigger IDs come off a counter that only a created trigger advances, so a
+  -- gap in them is the visible trace of a refusal that built something first
+  -- and then walked away from it
+  it("builds nothing when it refuses", function()
+    local first = track(tempColorTrigger(4, -1, "noop"))
+
+    tempColorTrigger(-1, -1, "noop")
+    tempColorTrigger(4, -1, "noop", 0)
+    pcall(function() return tempColorTrigger(4, -1, {}) end)
+    pcall(function() return tempColorTrigger("red", -1, "noop") end)
+
+    assert.are.equal(first + 1, track(tempColorTrigger(4, -1, "noop")), "a refused tempColorTrigger consumed a trigger ID")
+  end)
+end)
+
+describe("Tests the functionality of tempAnsiColorTrigger", function()
+
+  local created
+
+  before_each(function()
+    created = {}
+  end)
+
+  after_each(function()
+    for _, id in ipairs(created) do
+      killTrigger(id)
+    end
+  end)
+
+  -- -1 ignores a colour and -2 matches whatever the profile's default is; the
+  -- messages have to keep saying which is which, because they are the only
+  -- place a script author is told
+  it("names both sentinel colours when refusing one outside the range", function()
+    assertRefused("only -1 (ignore foreground color)", tempAnsiColorTrigger(999, 0, "noop"))
+    assertRefused("only -1 (ignore background color)", tempAnsiColorTrigger(0, 999, "noop"))
+    assertRefused("invalid ANSI color number -3", tempAnsiColorTrigger(-3, 0, "noop"))
+  end)
+
+  it("tells the two ways of ignoring everything apart", function()
+    -- with a background given but also ignored
+    assertRefused("you cannot ignore both foreground and background color", tempAnsiColorTrigger(-1, -1, "noop"))
+    -- with the background left out entirely, which is a different mistake
+    assertRefused("(omitted)", tempAnsiColorTrigger(-1, "noop"))
+    assertRefused("if the background color is omitted", tempAnsiColorTrigger(-1))
+  end)
+
+  it("refuses an expiry count that would expire the trigger before it ever fires", function()
+    assertRefused("must be nil or greater than zero, got 0", tempAnsiColorTrigger(0, 1, "noop", 0))
+  end)
+
+  it("raises on arguments it cannot make sense of, naming the one at fault", function()
+    assertArgError(function() return tempAnsiColorTrigger("red", 0, "noop") end, "bad argument #1 type")
+    -- the background is optional, so it is only read as one when the argument
+    -- count says it must be - hence the expiry count here
+    assertArgError(function() return tempAnsiColorTrigger(0, "red", "noop", 1) end, "bad argument #2 type")
+    assertArgError(function() return tempAnsiColorTrigger(0, 1, {}) end, "bad argument #3 type")
+    assertArgError(function() return tempAnsiColorTrigger(0, 1, "noop", "soon") end, "bad argument #4 value")
+  end)
+
+  it("builds nothing when it refuses", function()
+    local first = tempAnsiColorTrigger(0, 1, "noop")
+    created[#created + 1] = first
+
+    tempAnsiColorTrigger(999, 0, "noop")
+    tempAnsiColorTrigger(-1, -1, "noop")
+    tempAnsiColorTrigger(0, 1, "noop", 0)
+    pcall(function() return tempAnsiColorTrigger(0, 1, {}) end)
+    pcall(function() return tempAnsiColorTrigger("red", 0, "noop") end)
+
+    local second = tempAnsiColorTrigger(0, 1, "noop")
+    created[#created + 1] = second
+    assert.are.equal(first + 1, second, "a refused tempAnsiColorTrigger consumed a trigger ID")
+  end)
+
+  it("accepts a background-only match, which is the one -1 that is allowed", function()
+    local fired = false
+    local id = tempAnsiColorTrigger(-1, 1, function() fired = true end)
+    assert.is_number(id)
+    created[#created + 1] = id
+
+    feedTriggers("\27[0m\27[41mAnsiColourBackgroundOnly\n")
+    assert.is_true(fired, "a background-only trigger did not match a line painted in that background")
+  end)
+end)
+
+describe("Tests what feedTriggers will and will not carry", function()
+
+  local original
+
+  before_each(function()
+    original = getServerEncoding()
+  end)
+
+  after_each(function()
+    setServerEncoding(original)
+  end)
+
+  local function textFrom(mark)
+    return table.concat(getLines("main", mark, getLastLineNumber("main") + 1), "")
+  end
+
+  it("refuses text the game's encoding cannot carry instead of mangling it", function()
+    assert.is_true(setServerEncoding("ASCII"))
+    local mark = getLastLineNumber("main")
+
+    local ok, err = feedTriggers("FeedEncRejected \195\169\n")
+    assert.is_nil(ok, "text outside the game encoding should be refused")
+    assert.is_true(contains(err, "cannot be conveyed in the current game server encoding of 'ASCII'"), tostring(err))
+    assert.is_false(contains(textFrom(mark), "FeedEncRejected"), "the refused text was put on screen regardless")
+  end)
+
+  it("transcodes into the game's encoding when it can", function()
+    assert.is_true(setServerEncoding("ISO 8859-1"))
+    local mark = getLastLineNumber("main")
+
+    assert.is_true(feedTriggers("FeedEncLatin \195\169\n"))
+    assert.is_true(contains(textFrom(mark), "FeedEncLatin \195\169"), "the accented character did not survive the round trip")
+  end)
+
+  -- The second argument false is the older form: the caller has already encoded
+  -- the bytes themselves, so Mudlet must pass them through untouched rather
+  -- than reading them as UTF-8 and rejecting or double-encoding them
+  it("takes bytes already in the game's encoding when told they are not UTF-8", function()
+    assert.is_true(setServerEncoding("ISO 8859-1"))
+    local mark = getLastLineNumber("main")
+
+    assert.is_true(feedTriggers("FeedEncRaw \233\n", false))
+    assert.is_true(contains(textFrom(mark), "FeedEncRaw \195\169"), "the pre-encoded byte did not arrive as the character it stands for")
+  end)
+
+  it("raises on arguments it cannot make sense of", function()
+    assertArgError(function() return feedTriggers({}) end, "bad argument #1 type")
+    assertArgError(function() return feedTriggers("FeedEncNever\n", "yes") end, "bad argument #2 type")
+  end)
+end)
+
+describe("Tests announce and showNotification", function()
+
+  local processingKinds = {"importantall", "importantmostrecent", "all", "mostrecent", "currentthenmostrecent"}
+
+  -- The message is the only place a script author is told which processing
+  -- styles a screen reader will take, so dropping the list from it removes the
+  -- documentation along with the names
+  it("names every processing style announce accepts when refusing one", function()
+    local ok, err = pcall(announce, "spec announcement", "sideways")
+    assert.is_false(ok, "an unknown processing style should be refused, not passed on")
+    for _, kind in ipairs(processingKinds) do
+      assert.is_true(contains(err, kind), kind .. " was left out of the refusal: " .. tostring(err))
+    end
+  end)
+
+  it("accepts every processing style it lists", function()
+    for _, kind in ipairs(processingKinds) do
+      assert.is_true(pcall(announce, "spec announcement", kind), kind .. " is offered in the refusal but refused when used")
+    end
+    assert.is_true(pcall(announce, "spec announcement"), "the processing style is meant to be optional")
+  end)
+
+  it("raises when there is nothing to announce", function()
+    assertArgError(function() return announce() end, "text to announce as string expected")
+  end)
+
+  -- showNotification's refusals are pinned in Miscallaneous_spec.lua, among the
+  -- other functions whose effect needs a desktop; only the accepted argument
+  -- counts are left to cover
+  it("takes a title on its own, a message with it, and an expiry with both", function()
+    assert.is_true(showNotification("Mudlet spec notification"))
+    assert.is_true(showNotification("Mudlet spec notification", "with a body"))
+    assert.is_true(showNotification("Mudlet spec notification", "with a body", 1))
+  end)
+end)
+
+describe("Tests the functionality of alert", function()
+
+  -- zero is a duration, so the boundary is where the refusal starts rather
+  -- than "anything falsy is rejected"
+  it("takes a duration of zero but refuses one below it", function()
+    assert.is_true(pcall(alert, 0), "zero seconds is a duration, not a mistake")
+    assertArgError(function() return alert(-0.001) end, "is optional but if given must be zero or greater")
+  end)
+
+  it("takes no duration at all", function()
+    assert.is_true(pcall(alert))
+  end)
+
+  it("raises when the duration is not a number", function()
+    assertArgError(function() return alert("soon") end, "alert duration in seconds as number expected")
+  end)
+end)

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -1698,8 +1698,16 @@ describe("Tests C++ functions in the Miscallaneous category", function()
       local function nested(itemType)
         if not nestedItems[itemType] then
           local groupName = "mudletSpecAncestorGroup" .. itemType
-          assert.is_true(permGroup(groupName, groupType[itemType]), "could not create the " .. itemType .. " group")
-          local id = createChild[itemType]("mudletSpecAncestorChild" .. itemType, groupName)
+          local childName = "mudletSpecAncestorChild" .. itemType
+          -- The profile these run in is saved on exit and reused by the next
+          -- run, so a second run finds the first run's items still there. They
+          -- cannot be deleted from Lua, and creating them again just stacks up
+          -- another copy under the same name, so reuse what is already there.
+          local id = findItems(childName, itemType)[1]
+          if not id then
+            assert.is_true(permGroup(groupName, groupType[itemType]), "could not create the " .. itemType .. " group")
+            id = createChild[itemType](childName, groupName)
+          end
           assert.is_true(type(id) == "number" and id > 0, "could not nest a " .. itemType .. " in " .. groupName)
           nestedItems[itemType] = {id = id, group = groupName}
         end
@@ -1815,7 +1823,10 @@ describe("Tests C++ functions in the Miscallaneous category", function()
         if exists(toolbar, "button") == 0 then
           assert.is_true(tempButtonToolbar(toolbar, 0, 0) > 0)
         end
-        local buttonId = tempButton(toolbar, "mudletSpecAncestorButton", 0)
+        -- the toolbar and its button are saved with the profile, so a reused
+        -- profile already has both and tempButton() refuses the duplicate name
+        local buttonId = findItems("mudletSpecAncestorButton", "button")[1]
+            or tempButton(toolbar, "mudletSpecAncestorButton", 0)
         assert.is_true(type(buttonId) == "number" and buttonId > 0, "could not put a button on " .. toolbar)
 
         assertNamesTheGroup(ancestors(buttonId, "button"), toolbar)

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -1680,6 +1680,156 @@ describe("Tests C++ functions in the Miscallaneous category", function()
       end)
     end)
 
+    describe("Tests the functionality of ancestors", function()
+      -- Nesting needs permanent items, which Lua cannot delete again, so each
+      -- item type gets one group and one child, built on first use and shared
+      -- by the specs below.
+      local nestedItems = {}
+
+      local createChild = {
+        timer = function(name, parent) return permTimer(name, parent, 0, "") end,
+        alias = function(name, parent) return permAlias(name, parent, "^mudletSpecAncestorNeverTyped$", "") end,
+        keybind = function(name, parent) return permKey(name, parent, mudlet.key.F12, "") end,
+        script = function(name, parent) return permScript(name, parent, "") end,
+      }
+      -- permGroup spells the key type "key" where ancestors() spells it "keybind"
+      local groupType = {timer = "timer", alias = "alias", keybind = "key", script = "script"}
+
+      local function nested(itemType)
+        if not nestedItems[itemType] then
+          local groupName = "mudletSpecAncestorGroup" .. itemType
+          assert.is_true(permGroup(groupName, groupType[itemType]), "could not create the " .. itemType .. " group")
+          local id = createChild[itemType]("mudletSpecAncestorChild" .. itemType, groupName)
+          assert.is_true(type(id) == "number" and id > 0, "could not nest a " .. itemType .. " in " .. groupName)
+          nestedItems[itemType] = {id = id, group = groupName}
+        end
+        return nestedItems[itemType].id, nestedItems[itemType].group
+      end
+
+      local function assertNamesTheGroup(list, groupName)
+        assert.is_table(list)
+        assert.equals(1, #list, "expected exactly the one group the item was created in")
+        assert.equals(groupName, list[1].name)
+        assert.equals("group", list[1].node)
+        assert.is_number(list[1].id)
+        assert.is_boolean(list[1].isActive)
+      end
+
+      it("raises a Lua error when called with no arguments", function()
+        assertArgError(function() ancestors() end, "ancestors: bad argument #1 type")
+      end)
+
+      it("raises a Lua error when given no item type", function()
+        assertArgError(function() ancestors(1) end, "ancestors: bad argument #2 type")
+      end)
+
+      it("returns nil+msg for a negative item ID", function()
+        local ok, err = ancestors(-1, "alias")
+        assert.is_nil(ok)
+        assert.is_true(contains(err, "does not seem to be parseable as a positive integer"), tostring(err))
+      end)
+
+      it("returns nil+msg for an item that does not exist", function()
+        local ok, err = ancestors(9999999, "trigger")
+        assert.is_nil(ok)
+        assert.is_true(contains(err, "does not exist"), tostring(err))
+      end)
+
+      it("returns nil+msg for an item type it does not know", function()
+        local ok, err = ancestors(1, "sandwich")
+        assert.is_nil(ok)
+        assert.is_true(contains(err, "invalid item type 'sandwich' given"), tostring(err))
+      end)
+
+      it("returns an empty list for a temporary item, which has no ancestors", function()
+        local triggerId = tempTrigger("mudletSpecAncestorsTrigger", function() end)
+        local timerId = tempTimer(60, function() end)
+        finally(function()
+          killTrigger(tostring(triggerId))
+          killTimer(timerId)
+        end)
+
+        assert.same({}, ancestors(triggerId, "trigger"))
+        assert.same({}, ancestors(timerId, "timer"))
+      end)
+
+      it("names every group between a nested trigger and the top, innermost first", function()
+        -- the run-tests package (the one running these specs) is the only
+        -- hierarchy a spec can count on being there
+        local nestedTriggers = findItems("Trigger", "trigger")
+        assert.equals(1, #nestedTriggers, "expected exactly the run-tests package's nested 'Trigger'")
+        local list = ancestors(nestedTriggers[1], "trigger")
+
+        assert.is_true(#list >= 3, "expected at least the three groups the trigger is nested in, got " .. #list)
+        assert.equals("Not Filter", list[1].name)
+        assert.equals("Filter", list[2].name)
+        assert.equals("Test selectCaptureGroup with nested hierarchy", list[3].name)
+        for index, ancestor in ipairs(list) do
+          assert.is_number(ancestor.id)
+          assert.is_true(ancestor.node == "group" or ancestor.node == "package",
+            "ancestor " .. index .. " of a trigger should be a group or a package, got " .. tostring(ancestor.node))
+        end
+      end)
+
+      it("reports each ancestor's own active state, not the item's", function()
+        local nestedTriggers = findItems("Trigger", "trigger")
+        assert.equals(1, #nestedTriggers, "expected exactly the run-tests package's nested 'Trigger'")
+        local childId = nestedTriggers[1]
+        finally(function() enableTrigger("Not Filter") end)
+
+        assert.is_true(ancestors(childId, "trigger")[1].isActive)
+
+        assert.is_true(disableTrigger("Not Filter"))
+        local list = ancestors(childId, "trigger")
+        assert.is_false(list[1].isActive, "the disabled group still reported itself as active")
+        assert.is_true(list[2].isActive, "disabling one group should not touch the group above it")
+      end)
+
+      it("names the group a permanent timer sits in", function()
+        local id, groupName = nested("timer")
+        assertNamesTheGroup(ancestors(id, "timer"), groupName)
+      end)
+
+      it("names the group a permanent alias sits in", function()
+        local id, groupName = nested("alias")
+        assertNamesTheGroup(ancestors(id, "alias"), groupName)
+      end)
+
+      it("names the group a permanent keybind sits in", function()
+        local id, groupName = nested("keybind")
+        assertNamesTheGroup(ancestors(id, "keybind"), groupName)
+      end)
+
+      it("names the group a permanent script sits in", function()
+        local id, groupName = nested("script")
+        assertNamesTheGroup(ancestors(id, "script"), groupName)
+      end)
+
+      it("names the toolbar a button sits on", function()
+        local toolbar = "mudletSpecAncestorToolbar"
+        -- Lua cannot delete a toolbar again, and one left docked keeps its
+        -- share of the main window's height for the rest of the run - which is
+        -- enough to stop the window resize specs elsewhere from having room to
+        -- measure. Hiding it hands that height back.
+        finally(function() hideToolBar(toolbar) end)
+        if exists(toolbar, "button") == 0 then
+          assert.is_true(tempButtonToolbar(toolbar, 0, 0) > 0)
+        end
+        local buttonId = tempButton(toolbar, "mudletSpecAncestorButton", 0)
+        assert.is_true(type(buttonId) == "number" and buttonId > 0, "could not put a button on " .. toolbar)
+
+        assertNamesTheGroup(ancestors(buttonId, "button"), toolbar)
+      end)
+
+      it("is case insensitive about the item type", function()
+        local id, groupName = nested("timer")
+        -- the group is named again here rather than only comparing the two
+        -- calls: two empty lists match each other just as well
+        assertNamesTheGroup(ancestors(id, "TIMER"), groupName)
+        assert.same(ancestors(id, "timer"), ancestors(id, "TIMER"))
+      end)
+    end)
+
     describe("Tests the functionality of getProfiles", function()
       it("lists this profile as loaded, with what it was set up with", function()
         local profiles = getProfiles()

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -412,6 +412,62 @@ describe("Tests Other.lua functions", function()
     end)
   end)
 
+  describe("Tests the functionality of getMudletVersion", function()
+
+    it("answers each documented style with the piece of the version it names", function()
+      local version = getMudletVersion()
+      assert.are.equal(version.major, getMudletVersion("major"))
+      assert.are.equal(version.minor, getMudletVersion("minor"))
+      assert.are.equal(version.revision, getMudletVersion("revision"))
+      -- a development build appends its own suffix, so the version is what the
+      -- string starts with rather than all of it
+      local numbers = ("%d.%d.%d"):format(version.major, version.minor, version.revision)
+      assert.are.equal(numbers, getMudletVersion("string"):sub(1, #numbers))
+    end)
+
+    -- the four-value form is what a script unpacks in one go, so the count and
+    -- the order of the returns are as much a contract as the numbers
+    it("returns the four parts in order when asked for a table", function()
+      local version = getMudletVersion()
+      -- a release build reports no suffix as a nil fourth value rather than by
+      -- returning three, so the count is checked before the values are unpacked
+      assert.are.equal(4, select("#", getMudletVersion("table")))
+      local major, minor, revision, build = getMudletVersion("table")
+      assert.are.equal(version.major, major)
+      assert.are.equal(version.minor, minor)
+      assert.are.equal(version.revision, revision)
+      -- a release build has no suffix, and nil is how that is reported
+      if build ~= nil then
+        assert.are.equal(build, getMudletVersion("build"))
+      end
+    end)
+
+    it("reads the style however it is cased and spaced", function()
+      assert.are.equal(getMudletVersion("major"), getMudletVersion("  MAJOR  "))
+    end)
+
+    -- the two refusals are worded differently on purpose: one is "that is not a
+    -- style", the other is "you passed too many arguments", and collapsing them
+    -- would leave the second mistake looking like the first
+    it("lists the styles it has when refusing one it does not", function()
+      local ok, err = pcall(getMudletVersion, "patch")
+      assert.is_false(ok)
+      for _, style in ipairs({"major", "minor", "revision", "build", "string", "table"}) do
+        assert.is_true(err:find(style, 1, true) ~= nil, style .. " was left out of: " .. tostring(err))
+      end
+      assert.is_true(err:find("takes one (optional) argument", 1, true) ~= nil, tostring(err))
+      -- "only takes one" contains "takes one", so the wording of the other
+      -- refusal has to be ruled out for this to mean anything
+      assert.is_nil(err:find("only takes one", 1, true), "an unknown style was reported as too many arguments: " .. tostring(err))
+    end)
+
+    it("says so separately when given more than the one argument it takes", function()
+      local ok, err = pcall(getMudletVersion, "major", "minor")
+      assert.is_false(ok)
+      assert.is_true(err:find("only takes one (optional) argument", 1, true) ~= nil, tostring(err))
+    end)
+  end)
+
   describe("Tests the functionality of mudletOlderThan", function()
     it("tests the comparisons", function()
       local versionTable = getMudletVersion()
@@ -1080,6 +1136,236 @@ describe("Tests Other.lua functions", function()
       assert.is_table(result)
       assert.equals(getConfig("enableGMCP"), result.enableGMCP)
       assert.equals(getConfig("editorAutoComplete"), result.editorAutoComplete)
+    end)
+
+    -- The modern key and the negotiation-off key it replaced are two spellings
+    -- of one flag, so a script written against either has to see what the other
+    -- one did. getConfig() with no arguments does not list the modern spellings,
+    -- so the generic round-trip loop above never reaches them.
+    it("keeps enableCHARSET the exact inverse of specialForceCharsetNegotiationOff", function()
+      snapshot("enableCHARSET")
+      assert.is_boolean(getConfig("enableCHARSET"))
+
+      assert.is_true(setConfig("enableCHARSET", true))
+      assert.is_true(getConfig("enableCHARSET"))
+      assert.is_false(getConfig("specialForceCharsetNegotiationOff"))
+
+      assert.is_true(setConfig("specialForceCharsetNegotiationOff", true))
+      assert.is_false(getConfig("enableCHARSET"))
+
+      restore("enableCHARSET")
+    end)
+
+    it("keeps enableNEWENVIRON the exact inverse of forceNewEnvironNegotiationOff", function()
+      snapshot("enableNEWENVIRON")
+      assert.is_boolean(getConfig("enableNEWENVIRON"))
+
+      assert.is_true(setConfig("enableNEWENVIRON", true))
+      assert.is_true(getConfig("enableNEWENVIRON"))
+      assert.is_false(getConfig("forceNewEnvironNegotiationOff"))
+
+      assert.is_true(setConfig("forceNewEnvironNegotiationOff", true))
+      assert.is_false(getConfig("enableNEWENVIRON"))
+
+      restore("enableNEWENVIRON")
+    end)
+
+    it("takes showSentText as a boolean, which is the legacy spelling of two of the modes", function()
+      local original = getConfig("showSentText", true)
+      originalValues.showSentText = original
+
+      assert.is_true(setConfig("showSentText", false))
+      assert.equals("never", getConfig("showSentText", true))
+
+      assert.is_true(setConfig("showSentText", true))
+      assert.equals("script", getConfig("showSentText", true))
+
+      setConfig("showSentText", original)
+      originalValues.showSentText = nil
+    end)
+
+    it("refuses a showSentText mode it does not have, and leaves the mode alone", function()
+      -- if a refusal turns out to have applied the value after all, the
+      -- assertion below fails with the mode already changed, so the teardown
+      -- safety net has to know the string form of what it was
+      local original = getConfig("showSentText", true)
+      originalValues.showSentText = original
+
+      local ok, err = setConfig("showSentText", "sometimes")
+      assert.is_nil(ok)
+      assert.is_string(err)
+      assert.equals(original, getConfig("showSentText", true), "a rejected mode was applied anyway")
+
+      -- neither a boolean nor a string is not a mode at all
+      local okType, errType = setConfig("showSentText", 42)
+      assert.is_nil(okType)
+      assert.is_string(errType)
+      assert.equals(original, getConfig("showSentText", true))
+      originalValues.showSentText = nil
+    end)
+
+    -- Each of these keys refuses a value outside its own set. The refusal has to
+    -- carry the set, because that list is the only place a script author can
+    -- read what the key accepts.
+    it("lists what it accepts when refusing a string enum, and changes nothing", function()
+      local enums = {
+        blankLinesBehaviour = {"replacewithspace", "sideways"},
+        controlCharacterHandling = {"picture", "sideways"},
+        ambiguousEAsianWidthCharacters = {"narrow", "sideways"},
+      }
+      for key, pair in pairs(enums) do
+        local expectedInMessage, rejected = pair[1], pair[2]
+        snapshot(key)
+        local before = getConfig(key)
+        local ok, err = setConfig(key, rejected)
+        assert.is_nil(ok, key .. " accepted '" .. rejected .. "'")
+        assert.is_string(err)
+        assert.is_truthy(err:find(expectedInMessage, 1, true),
+          key .. " did not say it accepts '" .. expectedInMessage .. "', got: " .. tostring(err))
+        assert.equals(before, getConfig(key), key .. " was changed by a rejected value")
+        restore(key)
+      end
+    end)
+
+    -- the refusals for blankLinesBehaviour and controlCharacterHandling name
+    -- caretShortcut and commandLineHistorySaveSize instead of the key that was
+    -- actually rejected (#10391)
+    pending("names the key it rejected in every string enum refusal")
+
+    describe("experiment keys", function()
+      -- The two rendering experiments are a group, of which at most one may be
+      -- on. An experiment is written to the profile, so whichever one the group
+      -- arrived with is put back rather than the group being left switched off.
+      local group = "experiment.rendering"
+      local first = group .. ".originalish"
+      local second = group .. ".more-transparent"
+
+      local function allOff()
+        setConfig(first, false)
+        setConfig(second, false)
+      end
+
+      local function restoreGroup()
+        local wasActive = getConfig(group .. ".active")
+        return function()
+          allOff()
+          if wasActive then
+            setConfig(group .. "." .. wasActive, true)
+          end
+        end
+      end
+
+      it("lists the experiments this build knows", function()
+        local list = getConfig("experiment.list")
+        assert.is_table(list)
+        assert.is_true(#list > 0, "no experiments were listed")
+        local names = {}
+        for _, name in ipairs(list) do names[name] = true end
+        assert.is_true(names[first], first .. " was not listed")
+        assert.is_true(names[second], second .. " was not listed")
+      end)
+
+      it("reports an unknown experiment as off rather than refusing to read it", function()
+        assert.is_false(getConfig("experiment.no.such.thing"))
+      end)
+
+      it("refuses to enable an experiment that is not on the list", function()
+        local ok, err = setConfig("experiment.no.such.thing", true)
+        assert.is_nil(ok)
+        assert.is_true(err:find("experiment.no.such.thing", 1, true) ~= nil, tostring(err))
+        assert.is_false(getConfig("experiment.no.such.thing"))
+      end)
+
+      it("lets at most one experiment in a group be active at a time", function()
+        finally(restoreGroup())
+        allOff()
+        assert.is_nil(getConfig(group .. ".active"), "the group started with something active")
+
+        assert.is_true(setConfig(first, true))
+        assert.is_true(getConfig(first))
+        assert.equals("originalish", getConfig(group .. ".active"))
+
+        -- turning the sibling on has to turn this one off, or two mutually
+        -- exclusive renderers are both live
+        assert.is_true(setConfig(second, true))
+        assert.is_false(getConfig(first), "the group let two experiments run at once")
+        assert.equals("more-transparent", getConfig(group .. ".active"))
+
+        assert.is_true(setConfig(second, false))
+        assert.is_nil(getConfig(group .. ".active"))
+      end)
+    end)
+
+    describe("IRC keys", function()
+      -- These are stored in the profile rather than on the Host, and are the
+      -- only config keys that read back through dlgIRC.
+      local ircKeys = {"ircHostName", "ircHostPort", "ircHostSecure", "ircChannels", "ircNickName"}
+
+      local function snapshotIrc()
+        local saved = {}
+        for _, key in ipairs(ircKeys) do
+          saved[key] = getConfig(key)
+        end
+        return function()
+          for _, key in ipairs(ircKeys) do
+            setConfig(key, saved[key])
+          end
+        end
+      end
+
+      it("answers every IRC key with the documented type", function()
+        assert.is_string(getConfig("ircHostName"))
+        assert.is_number(getConfig("ircHostPort"))
+        assert.is_boolean(getConfig("ircHostSecure"))
+        assert.is_string(getConfig("ircChannels"))
+        assert.is_string(getConfig("ircNickName"))
+      end)
+
+      it("round-trips the IRC connection settings", function()
+        finally(snapshotIrc())
+
+        assert.is_true(setConfig("ircHostName", "irc.mudlet-spec.invalid"))
+        assert.equals("irc.mudlet-spec.invalid", getConfig("ircHostName"))
+
+        assert.is_true(setConfig("ircHostPort", 6697))
+        assert.equals(6697, getConfig("ircHostPort"))
+
+        assert.is_true(setConfig("ircHostSecure", true))
+        assert.is_true(getConfig("ircHostSecure"))
+        assert.is_true(setConfig("ircHostSecure", false))
+        assert.is_false(getConfig("ircHostSecure"))
+
+        assert.is_true(setConfig("ircNickName", "MudletSpecNick"))
+        assert.equals("MudletSpecNick", getConfig("ircNickName"))
+      end)
+
+      -- Channels go in as one space separated string and come back joined the
+      -- same way, so a script can hand back what it read
+      it("round-trips a space separated channel list", function()
+        finally(snapshotIrc())
+
+        assert.is_true(setConfig("ircChannels", "#mudlet #mudlet-spec"))
+        assert.equals("#mudlet #mudlet-spec", getConfig("ircChannels"))
+      end)
+
+      -- An unusable port would strand the IRC client on a connect attempt it
+      -- can never make, so the reader falls back rather than handing it out
+      it("reads back the default port when the stored one is out of range", function()
+        finally(snapshotIrc())
+
+        assert.is_true(setConfig("ircHostPort", 6697))
+        assert.equals(6697, getConfig("ircHostPort"))
+
+        -- the writer takes any integer today; whether it starts refusing this
+        -- one is not what is being pinned, only that the reader never answers
+        -- with a port nothing can connect to
+        local stored = setConfig("ircHostPort", 70000)
+        local fallback = getConfig("ircHostPort")
+        assert.is_true(fallback >= 1 and fallback <= 65535, "an unusable port was handed out: " .. tostring(fallback))
+        if stored then
+          assert.are_not.equals(6697, fallback, "the stored port was left in place rather than replaced by the default")
+        end
+      end)
     end)
   end)
 

--- a/src/mudlet-lua/tests/STT_spec.lua
+++ b/src/mudlet-lua/tests/STT_spec.lua
@@ -211,6 +211,27 @@ describe("stt bridge", function()
       assert.is_nil(ok, "an unknown sensitivity should be refused, not guessed at")
       assert.is_string(err)
     end)
+
+    -- toggle() is the one entry point a keybinding is usually wired to, so its
+    -- refusal has to reach the same place start()'s does: a player mashing a
+    -- key with nothing installed otherwise gets silence.
+    it("refuses to toggle before a model is loaded, and announces why", function()
+      if stt.initialized() then return end
+      local seen
+      local handler = registerAnonymousEventHandler("sysSTTError", function(_, message) seen = message end)
+      finally(function() killAnonymousEventHandler(handler) end)
+
+      local ok, err = stt.toggle()
+      assert.is_nil(ok, "toggling with nothing initialized should refuse rather than start")
+      assert.is_string(err)
+      assert.are.equal(err, seen, "the refusal was returned to the caller but never announced")
+      assert.is_false(stt.listening(), "a refused toggle must leave nothing listening")
+    end)
+
+    it("raises on a vocabulary that is not a table", function()
+      assert.has_error(function() stt.setVocabulary("kill") end)
+      assert.has_error(function() stt.setVocabulary(nil) end)
+    end)
   end)
 
   describe("safe when nothing is set up", function()
@@ -275,6 +296,29 @@ describe("stt bridge", function()
       else
         assert.is_nil(ok, "with no engine there is nothing to give the words to")
       end
+    end)
+
+    -- unloadLibrary() latches the library out so the file can be replaced;
+    -- nothing but reloadLibrary() lifts that latch, so a spec that unloads and
+    -- walks away would leave every later stt spec looking at a machine with no
+    -- engine on it
+    it("unloads the engine library on request and hands it back on reload", function()
+      if stt.initialized() or stt.listening() then return end
+      local hadLibrary = stt.available()
+      finally(function() stt.reloadLibrary() end)
+
+      assert.is_true(stt.unloadLibrary(), "unloading with nothing in use should succeed")
+      if hadLibrary then
+        -- the latch is the whole point: without it the next read-shaped call
+        -- maps the module straight back in and the file the caller meant to
+        -- replace is locked again
+        assert.is_false(stt.available(), "the library was mapped straight back in")
+        assert.is_false(stt.getInfo().available, "getInfo re-probed past the unload latch")
+      end
+
+      local reloaded = stt.reloadLibrary()
+      assert.are.equal(hadLibrary, reloaded, "reloadLibrary did not hand back the library that was there before")
+      assert.are.equal(reloaded, stt.available(), "reloadLibrary reports whether the library is available now")
     end)
   end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds 60 specs covering how the Lua API behaves when it is called wrongly, plus a few functions that had no test at all.

- a new `LuaApiContracts_spec.lua` pinning the shared refusal shape: which functions raise, which return `nil, msg`, and what the message says when an argument is the wrong type, out of range, or missing
- `Other_spec.lua` - `setConfig`/`getConfig` across the string enum, numeric and boolean settings, and their refusals
- `Miscallaneous_spec.lua` - `ancestors()`, and assorted string and table helpers
- `STT_spec.lua` - the speech API's argument checking

One behaviour is `pending` rather than asserted, because the message Mudlet produces there is wrong and a green test would cement it.

#### Motivation for adding to Mudlet

Argument checking is a large, cold part of `TLuaInterpreter.cpp` - it is the code every script hits when a user makes a typo, and the error message is the only thing they have to go on. Nothing was pinning those messages, so they could drift or disappear silently. Specs run on the existing binary with no rebuild and are shared with Mudlet Web.

Every new spec was checked to actually bite. A review pass over the branch found three specs that stayed green under sabotage, two that would have leaked profile settings into later tests when an assertion failed, one that asserted a known-wrong message as correct, and two duplicates; all are fixed or removed here.

#### Other info (issues closed, discussion etc)

Full suite on this branch: `4079 successes / 0 failures / 0 errors / 72 pending`, against `4019 / 0 / 0 / 71` on development - so +60 specs and the one deliberate pending, with no existing test disturbed.

Found while writing these and filed separately: #10391 - `setConfig()` error messages name the wrong setting, or lose the message entirely. The pending spec here is waiting on that fix.