### PR TITLE
Infra: Add tests for the script editor's dialogs and tree

### DIFF
--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -109,7 +109,10 @@ class dlgTriggerEditor : public QMainWindow, private Ui::trigger_editor
     // Allow QTest-based test classes to access private members
     friend class dlgTriggerEditorUndoRedoTest;
     friend class EditorBannerViewSwitchTest;
+    friend class EditorClipboardXmlTest;
+    friend class EditorSearchTest;
     friend class ScriptEventHandlerLifetimeTest;
+    friend class TreeWidgetItemMoveTest;
     friend class TriggerEditorDisclosureTest;
     friend class VariableEditorWriteBackTest;
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -122,9 +122,14 @@ set(TRIGGER_GROUP_TEST_SOURCES
 set(EDITOR_GROUP_TEST_SOURCES
     dlgTriggerEditorUndoRedoTest.cpp
     EdbeeReinitTest.cpp
+    EditorClipboardXmlTest.cpp
     EditorBannerViewSwitchTest.cpp
+    ColorTriggerDialogTest.cpp
+    PackageExporterTest.cpp
     EditorWindowPositionTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
+    EditorSearchTest.cpp
+    TreeWidgetItemMoveTest.cpp
     TriggerEditorDisclosureTest.cpp
     TriggerEditorTest.cpp
     VariableEditorWriteBackTest.cpp

--- a/test/functional_tests/ColorTriggerDialogTest.cpp
+++ b/test/functional_tests/ColorTriggerDialogTest.cpp
@@ -1,0 +1,327 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The colour-trigger picker writes its result straight into the TTrigger it was
+ * handed and is only ever reached from a button inside the trigger editor's
+ * pattern row, so there is no Lua entry point a spec could use: the scripting
+ * API can set a colour trigger's ANSI numbers but never goes through the
+ * dialog's slider arithmetic or its "ignore"/"default" sentinels.
+ */
+
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QSlider>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgColorTrigger.h"
+#include "dlgTriggerEditor.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class ColorTriggerDialogTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    TTrigger* mpTrigger = nullptr;
+    const QString mProfileName = qsl("ColorTrigger-Test-Profile");
+    const QString mLocalhost = qsl("localhost");
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    void resetTrigger()
+    {
+        mpTrigger->mColorTrigger = false;
+        mpTrigger->mColorTriggerFgAnsi = TTrigger::scmIgnored;
+        mpTrigger->mColorTriggerBgAnsi = TTrigger::scmIgnored;
+        mpTrigger->mColorTriggerFgColor = QColor();
+        mpTrigger->mColorTriggerBgColor = QColor();
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), qPrintable(qsl("TelnetServerStub failed to start: %1").arg(mpServer->errorString())));
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "No active host available for the test.");
+        QSignalSpy connectedSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectedSpy.wait(1000), "Could not connect with the host.");
+
+        mpTrigger = new TTrigger(nullptr, mpHost);
+        mpTrigger->setRegexCodeList({qsl("^colour$")}, {REGEX_PERL});
+        mpTrigger->registerTrigger();
+        mpTrigger->setName(qsl("qaColourTrigger"));
+    }
+
+    void cleanupTestCase()
+    {
+        mpTrigger = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_basicColorButtonRecordsItsAnsiNumber_data()
+    {
+        QTest::addColumn<bool>("isBackground");
+        QTest::addColumn<QString>("buttonName");
+        QTest::addColumn<int>("ansiNumber");
+
+        QTest::newRow("foreground red") << false << "pushButton_red" << 1;
+        QTest::newRow("foreground white") << false << "pushButton_white" << 7;
+        QTest::newRow("foreground light magenta") << false << "pushButton_Lmagenta" << 13;
+        QTest::newRow("background blue") << true << "pushButton_blue" << 4;
+        QTest::newRow("background light black") << true << "pushButton_Lblack" << 8;
+    }
+
+    void test_basicColorButtonRecordsItsAnsiNumber()
+    {
+        QFETCH(bool, isBackground);
+        QFETCH(QString, buttonName);
+        QFETCH(int, ansiNumber);
+
+        resetTrigger();
+        dlgColorTrigger dialog(nullptr, mpTrigger, isBackground);
+        auto* button = dialog.findChild<QPushButton*>(buttonName);
+        QVERIFY2(button, qPrintable(qsl("the dialog has no %1").arg(buttonName)));
+        QVERIFY2(!mpTrigger->mColorTrigger, "the trigger was already a colour trigger before the button was clicked");
+
+        button->click();
+
+        QVERIFY2(mpTrigger->mColorTrigger, "clicking a colour did not turn the trigger into a colour trigger");
+        if (isBackground) {
+            QCOMPARE(mpTrigger->mColorTriggerBgAnsi, ansiNumber);
+            QCOMPARE(mpTrigger->mColorTriggerBgColor, mpHost->getAnsiColor(ansiNumber, true));
+            QCOMPARE(mpTrigger->mColorTriggerFgAnsi, TTrigger::scmIgnored);
+        } else {
+            QCOMPARE(mpTrigger->mColorTriggerFgAnsi, ansiNumber);
+            QCOMPARE(mpTrigger->mColorTriggerFgColor, mpHost->getAnsiColor(ansiNumber, false));
+            QCOMPARE(mpTrigger->mColorTriggerBgAnsi, TTrigger::scmIgnored);
+        }
+    }
+
+    // The 6x6x6 cube: ANSI 16 + 36r + 6g + b, painted on a 51-per-step ramp
+    void test_rgbSlidersPickFromThe216ColorCube()
+    {
+        resetTrigger();
+        dlgColorTrigger dialog(nullptr, mpTrigger, false);
+
+        dialog.horizontalSlider_red->setValue(3);
+        dialog.horizontalSlider_green->setValue(2);
+        dialog.horizontalSlider_blue->setValue(1);
+        QCOMPARE(dialog.label_rgbValue->text(), qsl("[137]"));
+
+        dialog.pushButton_setUsingRgbValue->click();
+
+        QCOMPARE(mpTrigger->mColorTriggerFgAnsi, 137);
+        QCOMPARE(mpTrigger->mColorTriggerFgColor, QColor(153, 102, 51));
+        QVERIFY(mpTrigger->mColorTrigger);
+    }
+
+    // The 24 greys: ANSI 232 + n, each grey being 10n + 8 on all three channels
+    void test_graySliderPicksFromThe24GrayRamp()
+    {
+        resetTrigger();
+        dlgColorTrigger dialog(nullptr, mpTrigger, true);
+
+        dialog.horizontalSlider_gray->setValue(7);
+        QCOMPARE(dialog.label_grayValue->text(), qsl("[239]"));
+
+        dialog.pushButton_setUsingGrayValue->click();
+
+        QCOMPARE(mpTrigger->mColorTriggerBgAnsi, 239);
+        QCOMPARE(mpTrigger->mColorTriggerBgColor, QColor(78, 78, 78));
+        QVERIFY(mpTrigger->mColorTrigger);
+    }
+
+    // "Ignore" clears one side only, and the trigger stops being a colour
+    // trigger just when neither side is left set
+    void test_ignoreClearsOnlyItsOwnSide()
+    {
+        resetTrigger();
+        mpTrigger->mColorTrigger = true;
+        mpTrigger->mColorTriggerFgAnsi = 2;
+        mpTrigger->mColorTriggerFgColor = mpHost->getAnsiColor(2, false);
+        mpTrigger->mColorTriggerBgAnsi = 4;
+        mpTrigger->mColorTriggerBgColor = mpHost->getAnsiColor(4, true);
+
+        {
+            dlgColorTrigger dialog(nullptr, mpTrigger, true);
+            dialog.buttonBox->button(QDialogButtonBox::Ignore)->click();
+        }
+        QCOMPARE(mpTrigger->mColorTriggerBgAnsi, TTrigger::scmIgnored);
+        QVERIFY2(!mpTrigger->mColorTriggerBgColor.isValid(), "ignoring the background left a colour behind");
+        QCOMPARE(mpTrigger->mColorTriggerFgAnsi, 2);
+        QVERIFY2(mpTrigger->mColorTrigger, "ignoring one side stopped it being a colour trigger while the other side was still set");
+
+        {
+            dlgColorTrigger dialog(nullptr, mpTrigger, false);
+            dialog.buttonBox->button(QDialogButtonBox::Ignore)->click();
+        }
+        QCOMPARE(mpTrigger->mColorTriggerFgAnsi, TTrigger::scmIgnored);
+        QVERIFY2(!mpTrigger->mColorTrigger, "ignoring both sides left it as a colour trigger");
+    }
+
+    void test_defaultButtonRecordsTheDefaultSentinel()
+    {
+        resetTrigger();
+        // start from a concrete colour on both sides so that neither the
+        // sentinel nor the cleared colour can be what was there beforehand
+        mpTrigger->mColorTrigger = true;
+        mpTrigger->mColorTriggerFgAnsi = 2;
+        mpTrigger->mColorTriggerFgColor = mpHost->getAnsiColor(2, false);
+        mpTrigger->mColorTriggerBgAnsi = 4;
+        mpTrigger->mColorTriggerBgColor = mpHost->getAnsiColor(4, true);
+        QVERIFY2(mpTrigger->mColorTriggerFgColor.isValid(), "the foreground did not start out carrying a concrete colour");
+        QVERIFY2(mpTrigger->mColorTriggerBgColor.isValid(), "the background did not start out carrying a concrete colour");
+
+        {
+            dlgColorTrigger dialog(nullptr, mpTrigger, false);
+            dialog.buttonBox->button(QDialogButtonBox::Reset)->click();
+        }
+        QCOMPARE(mpTrigger->mColorTriggerFgAnsi, TTrigger::scmDefault);
+        QVERIFY2(!mpTrigger->mColorTriggerFgColor.isValid(), "the default foreground should not carry a concrete colour");
+
+        {
+            dlgColorTrigger dialog(nullptr, mpTrigger, true);
+            dialog.buttonBox->button(QDialogButtonBox::Reset)->click();
+        }
+        QCOMPARE(mpTrigger->mColorTriggerBgAnsi, TTrigger::scmDefault);
+        QVERIFY2(!mpTrigger->mColorTriggerBgColor.isValid(), "the default background should not carry a concrete colour");
+    }
+
+    // Reopening on a trigger that already uses an extended colour has to unfold
+    // the extra controls and put the sliders back where that colour came from
+    void test_reopeningOnAnExtendedColorRestoresItsControls()
+    {
+        resetTrigger();
+        mpTrigger->mColorTrigger = true;
+        mpTrigger->mColorTriggerFgAnsi = 137;
+
+        {
+            dlgColorTrigger dialog(nullptr, mpTrigger, false);
+            auto* moreColors = dialog.buttonBox->button(QDialogButtonBox::Apply);
+            QVERIFY2(moreColors->isChecked() && !moreColors->isEnabled(), "an RGB-cube colour did not unfold the extra controls");
+            QCOMPARE(dialog.horizontalSlider_red->value(), 3);
+            QCOMPARE(dialog.horizontalSlider_green->value(), 2);
+            QCOMPARE(dialog.horizontalSlider_blue->value(), 1);
+            QCOMPARE(dialog.label_rgbValue->text(), qsl("[137]"));
+        }
+
+        mpTrigger->mColorTriggerBgAnsi = 239;
+        {
+            dlgColorTrigger dialog(nullptr, mpTrigger, true);
+            auto* moreColors = dialog.buttonBox->button(QDialogButtonBox::Apply);
+            QVERIFY2(moreColors->isChecked() && !moreColors->isEnabled(), "a grey-ramp colour did not unfold the extra controls");
+            QCOMPARE(dialog.horizontalSlider_gray->value(), 7);
+            QCOMPARE(dialog.label_grayValue->text(), qsl("[239]"));
+        }
+    }
+
+    // On a basic colour the extra controls stay folded away until asked for,
+    // and "More colors" is deliberately one-shot
+    void test_moreColorsUnfoldsOnceForABasicColor()
+    {
+        resetTrigger();
+        mpTrigger->mColorTriggerFgAnsi = 3;
+
+        dlgColorTrigger dialog(nullptr, mpTrigger, false);
+        QVERIFY2(dialog.groupBox_rgbScale->isHidden(), "the RGB controls were showing for a basic colour");
+        QVERIFY2(dialog.groupBox_grayScale->isHidden(), "the grey controls were showing for a basic colour");
+
+        auto* moreColors = dialog.buttonBox->button(QDialogButtonBox::Apply);
+        QVERIFY(moreColors->isEnabled());
+        moreColors->click();
+
+        QVERIFY2(!dialog.groupBox_rgbScale->isHidden(), "More colors did not unfold the RGB controls");
+        QVERIFY2(!dialog.groupBox_grayScale->isHidden(), "More colors did not unfold the grey controls");
+        QVERIFY2(!moreColors->isEnabled(), "More colors is still offered after it has been used");
+    }
+
+    // The colour buttons carry their colour only in their stylesheet, so the
+    // editor reads it back out with this pair
+    void test_buttonStyleSheetColorsRoundTrip()
+    {
+        const QColor background(0x12, 0x34, 0x56);
+        const QString styleSheet = dlgTriggerEditor::generateButtonStyleSheet(background);
+
+        QCOMPARE(dlgTriggerEditor::parseButtonStyleSheetColors(styleSheet, false), background);
+        const QColor foreground = dlgTriggerEditor::parseButtonStyleSheetColors(styleSheet, true);
+        QVERIFY2(foreground.isValid(), "no readable foreground colour was generated for the button");
+        QVERIFY2(foreground != background, "the generated foreground is the same as the background, so the label would be unreadable");
+
+        // A disabled swatch keeps its lightness but is desaturated, so the
+        // number it stands for must still be readable back off it
+        const QString disabledStyleSheet = dlgTriggerEditor::generateButtonStyleSheet(background, false);
+        QVERIFY2(disabledStyleSheet != styleSheet, "disabling the swatch made no difference to it");
+        QVERIFY(dlgTriggerEditor::parseButtonStyleSheetColors(disabledStyleSheet, false).isValid());
+        // the stylesheet names the colour, so it resolves through the CSS list rather than Qt::darkGray
+        QCOMPARE(dlgTriggerEditor::parseButtonStyleSheetColors(disabledStyleSheet, true), QColor(qsl("darkGray")));
+
+        QVERIFY2(dlgTriggerEditor::generateButtonStyleSheet(QColor()).isEmpty(), "an invalid colour still produced a stylesheet");
+        QVERIFY2(!dlgTriggerEditor::parseButtonStyleSheetColors(QString(), false).isValid(), "an empty stylesheet produced a colour");
+        QVERIFY2(!dlgTriggerEditor::parseButtonStyleSheetColors(qsl("QPushButton {border: 1px solid #8f8f91;}"), false).isValid(), "a stylesheet with no colour produced one");
+    }
+};
+
+#include "ColorTriggerDialogTest.moc"
+MUDLET_GROUPED_TEST_MAIN(ColorTriggerDialogTest)

--- a/test/functional_tests/EditorClipboardXmlTest.cpp
+++ b/test/functional_tests/EditorClipboardXmlTest.cpp
@@ -1,0 +1,362 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Copying an editor item puts Mudlet's own XML on the system clipboard and
+ * pasting reads it back into a new item. Neither half is exposed to Lua - the
+ * scripting API can create items but never round-trips one through the
+ * clipboard - so only a functional test can check the transfer format, the
+ * multi-item separator, and that a paste lands on the undo stack.
+ */
+
+#include <QClipboard>
+#include <QTemporaryDir>
+#include <QTreeWidget>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "ActionUnit.h"
+#include "AliasUnit.h"
+#include "Host.h"
+#include "KeyUnit.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "ScriptUnit.h"
+#include "TAction.h"
+#include "TAlias.h"
+#include "TKey.h"
+#include "TScript.h"
+#include "TTimer.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "TimerUnit.h"
+#include "TriggerUnit.h"
+#include "ctelnet.h"
+#include "dlgTriggerEditor.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class EditorClipboardXmlTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgTriggerEditor* mpEditor = nullptr;
+    const QString mProfileName = qsl("EditorClipboard-Test-Profile");
+    const QString mLocalhost = qsl("localhost");
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    QTreeWidget* treeFor(EditorViewType view) const
+    {
+        switch (view) {
+        case EditorViewType::cmTriggerView:
+            return mpEditor->treeWidget_triggers;
+        case EditorViewType::cmTimerView:
+            return mpEditor->treeWidget_timers;
+        case EditorViewType::cmAliasView:
+            return mpEditor->treeWidget_aliases;
+        case EditorViewType::cmScriptView:
+            return mpEditor->treeWidget_scripts;
+        case EditorViewType::cmActionView:
+            return mpEditor->treeWidget_actions;
+        case EditorViewType::cmKeysView:
+            return mpEditor->treeWidget_keys;
+        default:
+            return nullptr;
+        }
+    }
+
+    void showView(EditorViewType view)
+    {
+        switch (view) {
+        case EditorViewType::cmTriggerView:
+            mpEditor->slot_showTriggers();
+            break;
+        case EditorViewType::cmTimerView:
+            mpEditor->slot_showTimers();
+            break;
+        case EditorViewType::cmAliasView:
+            mpEditor->slot_showAliases();
+            break;
+        case EditorViewType::cmScriptView:
+            mpEditor->slot_showScripts();
+            break;
+        case EditorViewType::cmActionView:
+            mpEditor->slot_showActions();
+            break;
+        case EditorViewType::cmKeysView:
+            mpEditor->slot_showKeys();
+            break;
+        default:
+            break;
+        }
+    }
+
+    int countNamed(EditorViewType view, const QString& name) const
+    {
+        switch (view) {
+        case EditorViewType::cmTriggerView:
+            return static_cast<int>(mpHost->getTriggerUnit()->findItems(name, true, true).size());
+        case EditorViewType::cmTimerView:
+            return static_cast<int>(mpHost->getTimerUnit()->findItems(name, true, true).size());
+        case EditorViewType::cmAliasView:
+            return static_cast<int>(mpHost->getAliasUnit()->findItems(name, true, true).size());
+        case EditorViewType::cmScriptView:
+            return static_cast<int>(mpHost->getScriptUnit()->findItems(name, true, true).size());
+        case EditorViewType::cmActionView:
+            return static_cast<int>(mpHost->getActionUnit()->findItems(name, true, true).size());
+        case EditorViewType::cmKeysView:
+            return static_cast<int>(mpHost->getKeyUnit()->findItems(name, true, true).size());
+        default:
+            return -1;
+        }
+    }
+
+    bool selectInTree(EditorViewType view, const QStringList& names)
+    {
+        QTreeWidget* tree = treeFor(view);
+        if (!tree) {
+            return false;
+        }
+        tree->clearSelection();
+        for (const QString& name : names) {
+            const QList<QTreeWidgetItem*> found = tree->findItems(name, Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
+            if (found.isEmpty()) {
+                return false;
+            }
+            found.first()->setSelected(true);
+            tree->setCurrentItem(found.first(), 0, QItemSelectionModel::NoUpdate);
+        }
+        return true;
+    }
+
+    void populateProfile()
+    {
+        auto* pTrigger = new TTrigger(nullptr, mpHost);
+        pTrigger->setName(qsl("qaClipTrigger"));
+        pTrigger->setRegexCodeList({qsl("^qaClipTrigger$")}, {REGEX_PERL});
+        pTrigger->setScript(qsl("echo(\"clip\")\n"));
+        QVERIFY(pTrigger->registerTrigger());
+
+        auto* pSecondTrigger = new TTrigger(nullptr, mpHost);
+        pSecondTrigger->setName(qsl("qaClipTriggerTwo"));
+        pSecondTrigger->setRegexCodeList({qsl("^qaClipTriggerTwo$")}, {REGEX_PERL});
+        QVERIFY(pSecondTrigger->registerTrigger());
+
+        auto* pAlias = new TAlias(qsl("qaClipAlias"), mpHost);
+        pAlias->setRegexCode(qsl("^qaClipAlias$"));
+        mpHost->getAliasUnit()->registerAlias(pAlias);
+
+        auto* pScript = new TScript(qsl("qaClipScript"), mpHost);
+        pScript->setScript(qsl("-- clip\n"));
+        mpHost->getScriptUnit()->registerScript(pScript);
+
+        auto* pTimer = new TTimer(qsl("qaClipTimer"), QTime(0, 0, 30), mpHost);
+        mpHost->getTimerUnit()->registerTimer(pTimer);
+
+        auto* pKey = new TKey(qsl("qaClipKey"), mpHost);
+        pKey->setKeyCode(Qt::Key_F9);
+        mpHost->getKeyUnit()->registerKey(pKey);
+
+        auto* pAction = new TAction(qsl("qaClipButton"), mpHost);
+        mpHost->getActionUnit()->registerAction(pAction);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), qPrintable(qsl("TelnetServerStub failed to start: %1").arg(mpServer->errorString())));
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "No active host available for the test.");
+        QSignalSpy connectedSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectedSpy.wait(1000), "Could not connect with the host.");
+
+        mudlet::self()->slot_showScriptDialog();
+        QTest::qWait(100ms);
+        mpEditor = mpHost->mpEditorDialog;
+        QVERIFY2(mpEditor, "the editor dialog was not created");
+
+        populateProfile();
+        // The editor built its trees while the profile loaded, so items added
+        // behind its back only appear after the rebuild that Host asks for when
+        // a package is installed - and that rebuild is only queued
+        mpEditor->doCleanReset();
+        QTest::qWait(100ms);
+    }
+
+    void cleanupTestCase()
+    {
+        if (mpHost) {
+            if (auto* pEditor = mpHost->mpEditorDialog.data()) {
+                mpHost->mpEditorDialog = nullptr;
+                delete pEditor;
+            }
+        }
+        mpEditor = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_copyPutsTheItemsOwnXmlOnTheClipboard_data()
+    {
+        QTest::addColumn<int>("view");
+        QTest::addColumn<QString>("itemName");
+        QTest::addColumn<QString>("packageTag");
+
+        QTest::newRow("trigger") << static_cast<int>(EditorViewType::cmTriggerView) << "qaClipTrigger" << "TriggerPackage";
+        QTest::newRow("timer") << static_cast<int>(EditorViewType::cmTimerView) << "qaClipTimer" << "TimerPackage";
+        QTest::newRow("alias") << static_cast<int>(EditorViewType::cmAliasView) << "qaClipAlias" << "AliasPackage";
+        QTest::newRow("script") << static_cast<int>(EditorViewType::cmScriptView) << "qaClipScript" << "ScriptPackage";
+        QTest::newRow("button") << static_cast<int>(EditorViewType::cmActionView) << "qaClipButton" << "ActionPackage";
+        QTest::newRow("key") << static_cast<int>(EditorViewType::cmKeysView) << "qaClipKey" << "KeyPackage";
+    }
+
+    void test_copyPutsTheItemsOwnXmlOnTheClipboard()
+    {
+        QFETCH(int, view);
+        QFETCH(QString, itemName);
+        QFETCH(QString, packageTag);
+        const auto viewType = static_cast<EditorViewType>(view);
+
+        QApplication::clipboard()->clear();
+        showView(viewType);
+        QVERIFY2(selectInTree(viewType, {itemName}), qPrintable(qsl("%1 is not in its tree").arg(itemName)));
+
+        mpEditor->slot_copyXml();
+
+        const QString clipboard = QApplication::clipboard()->text();
+        QVERIFY2(clipboard.contains(qsl("<MudletPackage")), qPrintable(qsl("the clipboard does not hold a Mudlet package: %1").arg(clipboard.left(120))));
+        QVERIFY2(clipboard.contains(qsl("<%1>").arg(packageTag)), qPrintable(qsl("the clipboard does not hold a %1").arg(packageTag)));
+        QVERIFY2(clipboard.contains(itemName), "the copied XML does not name the item that was copied");
+    }
+
+    void test_pastingACopiedItemAddsASecondOne_data() { test_copyPutsTheItemsOwnXmlOnTheClipboard_data(); }
+
+    void test_pastingACopiedItemAddsASecondOne()
+    {
+        QFETCH(int, view);
+        QFETCH(QString, itemName);
+        const auto viewType = static_cast<EditorViewType>(view);
+
+        showView(viewType);
+        QVERIFY(selectInTree(viewType, {itemName}));
+        const int before = countNamed(viewType, itemName);
+        QCOMPARE(before, 1);
+
+        mpEditor->slot_copyXml();
+        mpEditor->slot_pasteXml();
+
+        QCOMPARE(countNamed(viewType, itemName), before + 1);
+        QVERIFY2(treeFor(viewType)->findItems(itemName, Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0).count() == before + 1, "the pasted item did not appear in the tree");
+    }
+
+    // Two selected items go onto the clipboard as one string split by a private
+    // separator, which the paste has to notice and unpick
+    void test_copyingTwoItemsPastesBothOfThem()
+    {
+        mpEditor->slot_showTriggers();
+        QVERIFY(selectInTree(EditorViewType::cmTriggerView, {qsl("qaClipTriggerTwo")}));
+        const int beforeTwo = countNamed(EditorViewType::cmTriggerView, qsl("qaClipTriggerTwo"));
+        const int beforeOne = countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger"));
+        QVERIFY(selectInTree(EditorViewType::cmTriggerView, {qsl("qaClipTrigger"), qsl("qaClipTriggerTwo")}));
+
+        mpEditor->slot_copyXml();
+        QVERIFY2(QApplication::clipboard()->text().contains(qsl("MUDLET_MULTI_ITEM_SEPARATOR")), "two copied items were not separated for a multiple paste");
+
+        mpEditor->slot_pasteXml();
+
+        QCOMPARE(countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger")), beforeOne + 1);
+        QCOMPARE(countNamed(EditorViewType::cmTriggerView, qsl("qaClipTriggerTwo")), beforeTwo + 1);
+        // The clipboard is rewritten one item at a time while pasting, so it has
+        // to be put back the way it was found
+        QVERIFY2(QApplication::clipboard()->text().contains(qsl("MUDLET_MULTI_ITEM_SEPARATOR")), "the multi-item clipboard was not restored after the paste");
+    }
+
+    void test_pastingSomethingThatIsNotAMudletItemChangesNothing()
+    {
+        mpEditor->slot_showTriggers();
+        QVERIFY(selectInTree(EditorViewType::cmTriggerView, {qsl("qaClipTrigger")}));
+        const int before = countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger"));
+
+        QApplication::clipboard()->setText(qsl("just some text a user happened to copy"));
+        mpEditor->slot_pasteXml();
+
+        QCOMPARE(countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger")), before);
+    }
+
+    void test_aPasteCanBeUndoneAndRedone()
+    {
+        mpEditor->slot_showTriggers();
+        QVERIFY(selectInTree(EditorViewType::cmTriggerView, {qsl("qaClipTrigger")}));
+        const int before = countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger"));
+
+        mpEditor->slot_copyXml();
+        mpEditor->slot_pasteXml();
+        QCOMPARE(countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger")), before + 1);
+
+        QVERIFY2(mpEditor->mpUndoStack->canUndo(), "pasting an item did not put anything on the undo stack");
+        mpEditor->mpUndoStack->undo();
+        QCOMPARE(countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger")), before);
+
+        mpEditor->mpUndoStack->redo();
+        QCOMPARE(countNamed(EditorViewType::cmTriggerView, qsl("qaClipTrigger")), before + 1);
+    }
+};
+
+#include "EditorClipboardXmlTest.moc"
+MUDLET_GROUPED_TEST_MAIN(EditorClipboardXmlTest)

--- a/test/functional_tests/EditorClipboardXmlTest.cpp
+++ b/test/functional_tests/EditorClipboardXmlTest.cpp
@@ -97,6 +97,18 @@ private:
         }
     }
 
+    // The rebuild doCleanReset() asks for is only queued, so it is over when the
+    // items planted behind the editor's back are in its trees - which is what
+    // this waits for, rather than for a length of time the machine gets to
+    // decide the meaning of.
+    bool waitForTreeToHold(EditorViewType view, const QString& name) const
+    {
+        QTreeWidget* tree = treeFor(view);
+        return tree != nullptr && QTest::qWaitFor([tree, &name]() {
+                   return !tree->findItems(name, Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0).isEmpty();
+               });
+    }
+
     void showView(EditorViewType view)
     {
         switch (view) {
@@ -228,9 +240,9 @@ private slots:
         populateProfile();
         // The editor built its trees while the profile loaded, so items added
         // behind its back only appear after the rebuild that Host asks for when
-        // a package is installed - and that rebuild is only queued
+        // a package is installed
         mpEditor->doCleanReset();
-        QTest::qWait(100ms);
+        QVERIFY2(waitForTreeToHold(EditorViewType::cmTriggerView, qsl("qaClipTrigger")), "the editor never rebuilt its trees around the items this test planted");
     }
 
     void cleanupTestCase()

--- a/test/functional_tests/EditorSearchTest.cpp
+++ b/test/functional_tests/EditorSearchTest.cpp
@@ -105,6 +105,17 @@ private:
         return found;
     }
 
+    // The rebuild doCleanReset() asks for is only queued, so it is over when the
+    // items planted behind the editor's back are in its trees - which is what
+    // this waits for, rather than for a length of time the machine gets to
+    // decide the meaning of.
+    bool waitForTreeToHold(const QString& name) const
+    {
+        return QTest::qWaitFor([this, &name]() {
+            return !mpEditor->treeWidget_triggers->findItems(name, Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0).isEmpty();
+        });
+    }
+
     QTreeWidgetItem* topLevelResultFor(const QString& itemType) const
     {
         auto* results = mpEditor->treeWidget_searchResults;
@@ -209,7 +220,7 @@ private slots:
         // behind its back are only in them after the same rebuild that Host
         // does when a package is installed
         mpEditor->doCleanReset();
-        QTest::qWait(100ms); // doCleanReset only queues the rebuild
+        QVERIFY2(waitForTreeToHold(qsl("qaSearchTrigger")), "the editor never rebuilt its trees around the items this test planted");
         mpEditor->setSearchOptions(dlgTriggerEditor::SearchOptionNone);
     }
 

--- a/test/functional_tests/EditorSearchTest.cpp
+++ b/test/functional_tests/EditorSearchTest.cpp
@@ -1,0 +1,400 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The editor's search box walks the seven item units itself and files each hit
+ * into a result tree with private data roles saying which field it came from -
+ * none of which Lua can see or drive, so a spec cannot check that a match in a
+ * button's stylesheet or a script's event handler is found and labelled.
+ */
+
+#include <QComboBox>
+#include <QTemporaryDir>
+#include <QTreeWidget>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "ActionUnit.h"
+#include "AliasUnit.h"
+#include "KeyUnit.h"
+#include "ScriptUnit.h"
+#include "TAction.h"
+#include "TAlias.h"
+#include "TKey.h"
+#include "TLuaInterpreter.h"
+#include "TScript.h"
+#include "TTimer.h"
+#include "TimerUnit.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgTriggerEditor.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class EditorSearchTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgTriggerEditor* mpEditor = nullptr;
+    const QString mProfileName = qsl("EditorSearch-Test-Profile");
+    const QString mLocalhost = qsl("localhost");
+    // Deliberately a nonsense word, so every hit found is one this test planted
+    const QString mNeedle = qsl("qaHaystack");
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    void search(const QString& term)
+    {
+        auto* box = mpEditor->comboBox_searchTerms;
+        box->clear();
+        box->addItem(term);
+        mpEditor->slot_searchMudletItems(0);
+    }
+
+    // The result tree is two deep: the first field matched in an item becomes
+    // that item's top-level row, the rest hang off it
+    QStringList resultsFor(const QString& itemType) const
+    {
+        QStringList found;
+        auto* results = mpEditor->treeWidget_searchResults;
+        for (int i = 0, total = results->topLevelItemCount(); i < total; ++i) {
+            QTreeWidgetItem* top = results->topLevelItem(i);
+            if (top->text(0) != itemType) {
+                continue;
+            }
+            found << top->text(2);
+            for (int j = 0, children = top->childCount(); j < children; ++j) {
+                found << top->child(j)->text(2);
+            }
+        }
+        return found;
+    }
+
+    QTreeWidgetItem* topLevelResultFor(const QString& itemType) const
+    {
+        auto* results = mpEditor->treeWidget_searchResults;
+        for (int i = 0, total = results->topLevelItemCount(); i < total; ++i) {
+            if (results->topLevelItem(i)->text(0) == itemType) {
+                return results->topLevelItem(i);
+            }
+        }
+        return nullptr;
+    }
+
+    int totalResultRows() const
+    {
+        auto* results = mpEditor->treeWidget_searchResults;
+        int total = 0;
+        for (int i = 0, tops = results->topLevelItemCount(); i < tops; ++i) {
+            total += 1 + results->topLevelItem(i)->childCount();
+        }
+        return total;
+    }
+
+    void populateProfile()
+    {
+        auto* pTrigger = new TTrigger(nullptr, mpHost);
+        pTrigger->setName(qsl("qaSearchTrigger"));
+        pTrigger->setRegexCodeList({qsl("^%1 pattern$").arg(mNeedle)}, {REGEX_PERL});
+        pTrigger->setCommand(qsl("%1 command").arg(mNeedle));
+        pTrigger->setScript(qsl("-- %1 in lua\nlocal unused = 1\n").arg(mNeedle));
+        QVERIFY(pTrigger->registerTrigger());
+
+        auto* pGroup = new TTrigger(nullptr, mpHost);
+        pGroup->setName(qsl("qaSearchFolder"));
+        pGroup->setIsFolder(true);
+        QVERIFY(pGroup->registerTrigger());
+        auto* pNested = new TTrigger(pGroup, mpHost);
+        pNested->setName(qsl("qaNestedTrigger"));
+        pNested->setRegexCodeList({qsl("%1 nested").arg(mNeedle)}, {REGEX_SUBSTRING});
+        QVERIFY(pNested->registerTrigger());
+
+        auto* pAlias = new TAlias(qsl("qaSearchAlias"), mpHost);
+        pAlias->setRegexCode(qsl("^%1 alias$").arg(mNeedle));
+        pAlias->setCommand(qsl("%1 command").arg(mNeedle));
+        mpHost->getAliasUnit()->registerAlias(pAlias);
+
+        auto* pScript = new TScript(qsl("qaSearchScript"), mpHost);
+        pScript->setEventHandlerList({qsl("%1Event").arg(mNeedle)});
+        pScript->setScript(qsl("-- %1 lives here too\n").arg(mNeedle));
+        mpHost->getScriptUnit()->registerScript(pScript);
+
+        auto* pTimer = new TTimer(qsl("qaSearchTimer"), QTime(0, 0, 30), mpHost);
+        pTimer->setCommand(qsl("%1 command").arg(mNeedle));
+        mpHost->getTimerUnit()->registerTimer(pTimer);
+
+        auto* pKey = new TKey(qsl("qaSearchKey"), mpHost);
+        pKey->setCommand(qsl("%1 command").arg(mNeedle));
+        mpHost->getKeyUnit()->registerKey(pKey);
+
+        auto* pAction = new TAction(qsl("qaSearchButton"), mpHost);
+        pAction->setIsPushDownButton(true);
+        pAction->setCommandButtonDown(qsl("%1 down").arg(mNeedle));
+        pAction->setCommandButtonUp(qsl("%1 up").arg(mNeedle));
+        pAction->css = qsl("QPushButton {\n  border: 1px solid %1;\n}").arg(mNeedle);
+        mpHost->getActionUnit()->registerAction(pAction);
+
+        QVERIFY(mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("qaSearchVariable = \"%1 value\"").arg(mNeedle)));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), qPrintable(qsl("TelnetServerStub failed to start: %1").arg(mpServer->errorString())));
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "No active host available for the test.");
+        QSignalSpy connectedSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectedSpy.wait(1000), "Could not connect with the host.");
+
+        mudlet::self()->slot_showScriptDialog();
+        QTest::qWait(100ms);
+        mpEditor = mpHost->mpEditorDialog;
+        QVERIFY2(mpEditor, "the editor dialog was not created");
+
+        populateProfile();
+        // The editor filled its trees when the profile loaded, so items added
+        // behind its back are only in them after the same rebuild that Host
+        // does when a package is installed
+        mpEditor->doCleanReset();
+        QTest::qWait(100ms); // doCleanReset only queues the rebuild
+        mpEditor->setSearchOptions(dlgTriggerEditor::SearchOptionNone);
+    }
+
+    void cleanupTestCase()
+    {
+        // ~Host would do this, but only if the host is ever destroyed - deleting
+        // the editor here keeps the leak checker satisfied either way
+        if (mpHost) {
+            if (auto* pEditor = mpHost->mpEditorDialog.data()) {
+                mpHost->mpEditorDialog = nullptr;
+                delete pEditor;
+            }
+        }
+        mpEditor = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void cleanup()
+    {
+        if (mpEditor) {
+            mpEditor->setSearchOptions(dlgTriggerEditor::SearchOptionNone);
+        }
+    }
+
+    void test_findsTheNeedleInEveryItemType()
+    {
+        search(mNeedle);
+
+        QCOMPARE(resultsFor(qsl("Trigger")), QStringList({qsl("Command"), qsl("Pattern {1}"), qsl("Lua code (1:4)"), qsl("Pattern {1}")}));
+        QCOMPARE(resultsFor(qsl("Alias")), QStringList({qsl("Command"), qsl("Pattern")}));
+        QCOMPARE(resultsFor(qsl("Script")), QStringList({qsl("Event Handler"), qsl("Lua code (1:4)")}));
+        QCOMPARE(resultsFor(qsl("Timer")), QStringList({qsl("Command")}));
+        QCOMPARE(resultsFor(qsl("Key")), QStringList({qsl("Command")}));
+        QCOMPARE(resultsFor(qsl("Button")), QStringList({qsl("Command {Down}"), qsl("Command {Up}"), qsl("Stylesheet {L: 2 C: 21}")}));
+    }
+
+    // A match inside a folder is only found by the recursive walk, not by the
+    // pass over the unit's root nodes
+    void test_findsMatchesNestedInsideAFolder()
+    {
+        search(qsl("%1 nested").arg(mNeedle));
+
+        auto* result = topLevelResultFor(qsl("Trigger"));
+        QVERIFY2(result, "the nested trigger was not found at all");
+        QCOMPARE(result->text(1), qsl("qaNestedTrigger"));
+        QCOMPARE(result->text(2), qsl("Pattern {1}"));
+    }
+
+    // Every row carries the item type, its id and which field matched, so that
+    // clicking it can jump to the right control
+    void test_recordsWhereEachMatchCameFrom()
+    {
+        search(qsl("qaSearchButton"));
+
+        auto* result = topLevelResultFor(qsl("Button"));
+        QVERIFY(result);
+        QCOMPARE(result->text(2), qsl("Name"));
+        QCOMPARE(static_cast<EditorViewType>(result->data(0, dlgTriggerEditor::ItemRole).toInt()), EditorViewType::cmActionView);
+        QCOMPARE(result->data(0, dlgTriggerEditor::TypeRole).toInt(), static_cast<int>(dlgTriggerEditor::SearchResultIsName));
+        QCOMPARE(result->data(0, dlgTriggerEditor::NameRole).toString(), qsl("qaSearchButton"));
+
+        TAction* pAction = mpHost->getActionUnit()->findAction(qsl("qaSearchButton"));
+        QVERIFY(pAction);
+        QCOMPARE(result->data(0, dlgTriggerEditor::IdRole).toInt(), pAction->getID());
+    }
+
+    void test_caseSensitivityIsOptional()
+    {
+        search(qsl("QAHAYSTACK"));
+        const int caseInsensitiveRows = totalResultRows();
+        QVERIFY2(caseInsensitiveRows > 0, "a differently-cased needle found nothing while matching case-insensitively");
+
+        mpEditor->setSearchOptions(dlgTriggerEditor::SearchOptionCaseSensitive);
+        search(qsl("QAHAYSTACK"));
+        QCOMPARE(totalResultRows(), 0);
+
+        search(mNeedle);
+        QCOMPARE(totalResultRows(), caseInsensitiveRows);
+    }
+
+    void test_wholeWordSearchIgnoresMatchesInsideALongerWord()
+    {
+        search(qsl("qaSearchTrig"));
+        QVERIFY2(totalResultRows() > 0, "a partial word found nothing while matching on substrings");
+
+        mpEditor->setSearchOptions(dlgTriggerEditor::SearchOptionWholeWord);
+        search(qsl("qaSearchTrig"));
+        QCOMPARE(totalResultRows(), 0);
+
+        search(qsl("qaSearchTimer"));
+        QVERIFY2(totalResultRows() > 0, "a whole word was not matched in whole-word mode");
+    }
+
+    // Variables live in the Lua state rather than in a unit, so they are only
+    // walked when the option asks for it
+    void test_variablesAreOnlySearchedWhenAskedFor()
+    {
+        search(qsl("qaSearchVariable"));
+        QVERIFY2(!topLevelResultFor(qsl("Variable")), "a variable was searched without the option being set");
+
+        mpEditor->setSearchOptions(dlgTriggerEditor::SearchOptionIncludeVariables);
+        search(qsl("qaSearchVariable"));
+        auto* result = topLevelResultFor(qsl("Variable"));
+        QVERIFY2(result, "the variable was not found with the option set");
+        QCOMPARE(result->text(1), qsl("qaSearchVariable"));
+        QCOMPARE(result->data(0, dlgTriggerEditor::TypeRole).toInt(), static_cast<int>(dlgTriggerEditor::SearchResultIsName));
+    }
+
+    void test_selectingAResultSwitchesToThatItemsView_data()
+    {
+        QTest::addColumn<QString>("itemName");
+        QTest::addColumn<int>("expectedView");
+
+        QTest::newRow("trigger") << "qaSearchTrigger" << static_cast<int>(EditorViewType::cmTriggerView);
+        QTest::newRow("alias") << "qaSearchAlias" << static_cast<int>(EditorViewType::cmAliasView);
+        QTest::newRow("script") << "qaSearchScript" << static_cast<int>(EditorViewType::cmScriptView);
+        QTest::newRow("timer") << "qaSearchTimer" << static_cast<int>(EditorViewType::cmTimerView);
+        QTest::newRow("key") << "qaSearchKey" << static_cast<int>(EditorViewType::cmKeysView);
+        QTest::newRow("button") << "qaSearchButton" << static_cast<int>(EditorViewType::cmActionView);
+    }
+
+    void test_selectingAResultSwitchesToThatItemsView()
+    {
+        QFETCH(QString, itemName);
+        QFETCH(int, expectedView);
+
+        // start somewhere other than the view being switched to, so that the
+        // switch itself is what the comparison below is measuring
+        if (expectedView == static_cast<int>(EditorViewType::cmTriggerView)) {
+            mpEditor->slot_showAliases();
+        } else {
+            mpEditor->slot_showTriggers();
+        }
+        QVERIFY2(static_cast<int>(mpEditor->mCurrentView) != expectedView, "the editor was already showing the view the result should have switched it to");
+
+        search(itemName);
+        QTreeWidgetItem* result = mpEditor->treeWidget_searchResults->topLevelItem(0);
+        QVERIFY2(result, qPrintable(qsl("%1 was not found").arg(itemName)));
+
+        mpEditor->slot_itemSelectedInSearchResults(result);
+
+        QCOMPARE(static_cast<int>(mpEditor->mCurrentView), expectedView);
+    }
+
+    void test_selectingATriggerResultSelectsThatTriggerInItsTree()
+    {
+        mpEditor->slot_showScripts();
+        search(qsl("qaNestedTrigger"));
+        QTreeWidgetItem* result = mpEditor->treeWidget_searchResults->topLevelItem(0);
+        QVERIFY(result);
+
+        mpEditor->slot_itemSelectedInSearchResults(result);
+
+        QCOMPARE(mpEditor->mCurrentView, EditorViewType::cmTriggerView);
+        QTreeWidgetItem* selected = mpEditor->treeWidget_triggers->currentItem();
+        QVERIFY2(selected, "no trigger became current after its search result was chosen");
+        QCOMPARE(selected->text(0), qsl("qaNestedTrigger"));
+    }
+
+    void test_anEmptyOrUnknownTermProducesNoResults()
+    {
+        search(qsl("qaNothingMatchesThis"));
+        QCOMPARE(totalResultRows(), 0);
+
+        search(mNeedle);
+        QVERIFY(totalResultRows() > 0);
+
+        // An empty combo entry leaves the previous results alone rather than
+        // clearing them, which is what makes the guard worth having
+        mpEditor->comboBox_searchTerms->clear();
+        mpEditor->comboBox_searchTerms->addItem(QString());
+        mpEditor->slot_searchMudletItems(0);
+        QVERIFY(totalResultRows() > 0);
+
+        mpEditor->slot_searchMudletItems(-1);
+        QVERIFY(totalResultRows() > 0);
+    }
+};
+
+#include "EditorSearchTest.moc"
+MUDLET_GROUPED_TEST_MAIN(EditorSearchTest)

--- a/test/functional_tests/PackageExporterTest.cpp
+++ b/test/functional_tests/PackageExporterTest.cpp
@@ -1,0 +1,530 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The package exporter has no Lua entry point at all - installPackage() reads
+ * an .mpackage but nothing in the scripting API writes one - so the only way to
+ * exercise the selection tree, the staging directory and the zip writer is to
+ * build the dialog and drive it.
+ */
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QMimeData>
+#include <QPushButton>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <QTreeWidget>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "TAction.h"
+#include "TAlias.h"
+#include "TKey.h"
+#include "TScript.h"
+#include "TTimer.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgPackageExporter.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class PackageExporterTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QTemporaryDir mExportDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("PackageExporter-Test-Profile");
+    const QString mLocalhost = qsl("localhost");
+
+    const QString mTriggerName = qsl("qaExportedTrigger");
+    const QString mAliasName = qsl("qaExportedAlias");
+    const QString mTimerName = qsl("qaExportedTimer");
+    const QString mScriptName = qsl("qaExportedScript");
+    const QString mKeyName = qsl("qaExportedKey");
+    const QString mActionName = qsl("qaExportedAction");
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    // The exporter maps its own tree items onto the profile's items, so this is
+    // how a test says "tick the row for that trigger"
+    template <typename T>
+    QTreeWidgetItem* itemFor(const QMap<QTreeWidgetItem*, T*>& map, const QString& name) const
+    {
+        for (auto it = map.cbegin(); it != map.cend(); ++it) {
+            if (it.value()->getName() == name) {
+                return it.key();
+            }
+        }
+        return nullptr;
+    }
+
+    // ticking through the raw pointer would crash the whole class if the row
+    // were ever missing, which is exactly when a readable failure is wanted
+    template <typename T>
+    bool tickRow(const QMap<QTreeWidgetItem*, T*>& map, const QString& name) const
+    {
+        QTreeWidgetItem* row = itemFor(map, name);
+        if (!row) {
+            return false;
+        }
+        row->setCheckState(0, Qt::Checked);
+        return true;
+    }
+
+    dlgPackageExporter* makeExporter()
+    {
+        auto* exporter = new dlgPackageExporter(nullptr, mpHost);
+        exporter->show();
+        return exporter;
+    }
+
+    QLineEdit* lineEdit(dlgPackageExporter* exporter, const QString& name) const
+    {
+        auto* widget = exporter->findChild<QLineEdit*>(name);
+        Q_ASSERT(widget);
+        return widget;
+    }
+
+    QPushButton* exportButton(dlgPackageExporter* exporter) const
+    {
+        auto* box = exporter->findChild<QDialogButtonBox*>(qsl("buttonBox"));
+        Q_ASSERT(box);
+        return box->button(QDialogButtonBox::Apply);
+    }
+
+    QString infoText(dlgPackageExporter* exporter) const
+    {
+        auto* label = exporter->findChild<QLabel*>(qsl("infoLabel"));
+        Q_ASSERT(label);
+        return label->text();
+    }
+
+    // displayResultMessage() paints failures in this colour and nothing else in
+    // the dialog uses it, so it is the language-independent "did it fail" test
+    bool reportedFailure(dlgPackageExporter* exporter) const { return infoText(exporter).contains(qsl("#FF6B6B")); }
+
+    // The zip runs on a worker thread behind a QFutureWatcher, which hides the
+    // Close button for the duration and shows it again from its finished
+    // handler - so waiting for it back also guarantees that watcher has been
+    // deleteLater()d rather than leaked past the dialog. The export button is
+    // not usable as the signal: a successful module creation clears the package
+    // name, which disables it again.
+    bool waitForExportToSettle(dlgPackageExporter* exporter)
+    {
+        auto* box = exporter->findChild<QDialogButtonBox*>(qsl("buttonBox"));
+        Q_ASSERT(box);
+        auto* closeButton = box->button(QDialogButtonBox::Close);
+        const bool settled = QTest::qWaitFor(
+                [closeButton]() {
+                    return !closeButton->isHidden();
+                },
+                30000);
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        return settled;
+    }
+
+    // mudlet::unzip() joins its destination onto each archive entry without a
+    // separator, so the trailing slash is load-bearing
+    bool unpackInto(const QString& packageFile, const QTemporaryDir& destination) const { return mudlet::unzip(packageFile, qsl("%1/").arg(destination.path()), QDir(destination.path())); }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(mExportDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), qPrintable(qsl("TelnetServerStub failed to start: %1").arg(mpServer->errorString())));
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "No active host available for the test.");
+        QSignalSpy connectedSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectedSpy.wait(1000), "Could not connect with the host.");
+
+        // getActualPath() falls back to this setting when the user has not
+        // browsed for a location, which is the only way a test can steer where
+        // a package lands without a file dialog
+        mudlet::getQSettings()->setValue(qsl("lastFileDialogLocation"), mExportDir.path());
+
+        auto* pTrigger = new TTrigger(nullptr, mpHost);
+        pTrigger->setRegexCodeList({qsl("^exported$")}, {REGEX_PERL});
+        pTrigger->registerTrigger();
+        pTrigger->setName(mTriggerName);
+        QVERIFY(pTrigger->setScript(qsl("local exported = true\n")));
+        pTrigger->setIsActive(true);
+
+        auto* pAlias = new TAlias(mAliasName, mpHost);
+        pAlias->setRegexCode(qsl("^exported$"));
+        mpHost->getAliasUnit()->registerAlias(pAlias);
+        QVERIFY(pAlias->setScript(qsl("local exported = true\n")));
+        pAlias->setIsActive(true);
+
+        auto* pTimer = new TTimer(mTimerName, QTime(0, 0, 30), mpHost);
+        mpHost->getTimerUnit()->registerTimer(pTimer);
+        QVERIFY(pTimer->setScript(qsl("local exported = true\n")));
+
+        auto* pScript = new TScript(mScriptName, mpHost);
+        mpHost->getScriptUnit()->registerScript(pScript);
+        QVERIFY(pScript->setScript(qsl("local exported = true\n")));
+
+        auto* pKey = new TKey(mKeyName, mpHost);
+        mpHost->getKeyUnit()->registerKey(pKey);
+        QVERIFY(pKey->setScript(qsl("local exported = true\n")));
+
+        auto* pAction = new TAction(mActionName, mpHost);
+        mpHost->getActionUnit()->registerAction(pAction);
+        QVERIFY(pAction->setScript(qsl("local exported = true\n")));
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // list*()/recurse*() walk each unit's root node list into the selection
+    // tree; without them the dialog opens on six empty headings
+    void test_listsEveryItemTypeInTheSelectionTree()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        auto* tree = exporter->findChild<QTreeWidget*>(qsl("treeWidget_exportSelection"));
+        QVERIFY2(tree, "the exporter has no selection tree");
+        QCOMPARE(tree->topLevelItemCount(), 6);
+
+        QVERIFY2(itemFor(exporter->triggerMap, mTriggerName), "the trigger is missing from the selection tree");
+        QVERIFY2(itemFor(exporter->aliasMap, mAliasName), "the alias is missing from the selection tree");
+        QVERIFY2(itemFor(exporter->timerMap, mTimerName), "the timer is missing from the selection tree");
+        QVERIFY2(itemFor(exporter->scriptMap, mScriptName), "the script is missing from the selection tree");
+        QVERIFY2(itemFor(exporter->keyMap, mKeyName), "the key is missing from the selection tree");
+        QVERIFY2(itemFor(exporter->actionMap, mActionName), "the button is missing from the selection tree");
+    }
+
+    void test_refusesToExportWithoutAName()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        QVERIFY2(tickRow(exporter->triggerMap, mTriggerName), qPrintable(qsl("%1 is missing from the selection tree").arg(mTriggerName)));
+        QVERIFY2(lineEdit(exporter, qsl("lineEdit_packageName"))->text().isEmpty(), "the package name field started out filled in");
+
+        exporter->slot_exportPackage();
+
+        QVERIFY2(reportedFailure(exporter), "exporting with no package name did not report a problem");
+        QVERIFY2(!exportButton(exporter)->isEnabled(), "the export button is offered with no package name");
+    }
+
+    void test_refusesToExportWithNothingSelected()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        const QString packageName = qsl("qaEmptyPackage");
+        lineEdit(exporter, qsl("lineEdit_packageName"))->setText(packageName);
+        QVERIFY2(exportButton(exporter)->isEnabled(), "naming the package did not enable the export button");
+
+        exporter->slot_exportPackage();
+
+        QVERIFY2(reportedFailure(exporter), "exporting an empty selection did not report a problem");
+        QVERIFY2(!QFileInfo::exists(qsl("%1/%2.mpackage").arg(mExportDir.path(), packageName)), "an empty selection still wrote a package file");
+    }
+
+    // The whole staging pipeline: config.lua, the items XML, the assets copy
+    // and the zip write
+    void test_exportsSelectedItemsIntoAReadableMpackage()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        const QString packageName = qsl("qaFullPackage");
+        const QString packageFile = qsl("%1/%2.mpackage").arg(mExportDir.path(), packageName);
+        QVERIFY2(!QFileInfo::exists(packageFile), "the package file existed before the export");
+
+        QFile asset(qsl("%1/qaAsset.txt").arg(mExportDir.path()));
+        QVERIFY(asset.open(QIODevice::WriteOnly | QIODevice::Text));
+        asset.write("packaged asset\n");
+        asset.close();
+        exporter->findChild<QListWidget*>(qsl("listWidget_addedFiles"))->addItem(asset.fileName());
+
+        lineEdit(exporter, qsl("lineEdit_packageName"))->setText(packageName);
+        lineEdit(exporter, qsl("lineEdit_author"))->setText(qsl("qaAuthor"));
+        lineEdit(exporter, qsl("lineEdit_title"))->setText(qsl("qaTitle"));
+        lineEdit(exporter, qsl("lineEdit_version"))->setText(qsl("9.9.9"));
+        // no scheme, so normalizedHelpUrl() has to add one
+        lineEdit(exporter, qsl("lineEdit_helpUrl"))->setText(qsl("wiki.mudlet.org/qa"));
+
+        QVERIFY2(tickRow(exporter->triggerMap, mTriggerName), qPrintable(qsl("%1 is missing from the selection tree").arg(mTriggerName)));
+        QVERIFY2(tickRow(exporter->aliasMap, mAliasName), qPrintable(qsl("%1 is missing from the selection tree").arg(mAliasName)));
+        QVERIFY2(tickRow(exporter->timerMap, mTimerName), qPrintable(qsl("%1 is missing from the selection tree").arg(mTimerName)));
+        QVERIFY2(tickRow(exporter->scriptMap, mScriptName), qPrintable(qsl("%1 is missing from the selection tree").arg(mScriptName)));
+        QVERIFY2(tickRow(exporter->keyMap, mKeyName), qPrintable(qsl("%1 is missing from the selection tree").arg(mKeyName)));
+        QVERIFY2(tickRow(exporter->actionMap, mActionName), qPrintable(qsl("%1 is missing from the selection tree").arg(mActionName)));
+
+        exporter->slot_exportPackage();
+        QVERIFY2(waitForExportToSettle(exporter), "the export never finished");
+        QVERIFY2(!reportedFailure(exporter), qPrintable(qsl("the export reported a failure: %1").arg(infoText(exporter))));
+        QVERIFY2(QFileInfo::exists(packageFile), "no package file was written");
+
+        QTemporaryDir unpacked;
+        QVERIFY(unpacked.isValid());
+        QVERIFY2(unpackInto(packageFile, unpacked), "the exported package is not a readable archive");
+
+        QFile config(qsl("%1/config.lua").arg(unpacked.path()));
+        QVERIFY2(config.open(QIODevice::ReadOnly | QIODevice::Text), "the package has no config.lua");
+        const QString configText = QString::fromUtf8(config.readAll());
+        QVERIFY2(configText.contains(qsl("mpackage = [[%1]]").arg(packageName)), qPrintable(qsl("config.lua does not name the package: %1").arg(configText)));
+        QVERIFY2(configText.contains(qsl("author = [[qaAuthor]]")), "config.lua lost the author");
+        QVERIFY2(configText.contains(qsl("version = [[9.9.9]]")), "config.lua lost the version");
+        QVERIFY2(configText.contains(qsl("https://wiki.mudlet.org/qa")), qPrintable(qsl("the scheme-less help URL was not normalised: %1").arg(configText)));
+
+        QFile items(qsl("%1/%2.xml").arg(unpacked.path(), packageName));
+        QVERIFY2(items.open(QIODevice::ReadOnly | QIODevice::Text), "the package has no items XML");
+        const QString itemsXml = QString::fromUtf8(items.readAll());
+        for (const QString& name : {mTriggerName, mAliasName, mTimerName, mScriptName, mKeyName, mActionName}) {
+            QVERIFY2(itemsXml.contains(name), qPrintable(qsl("%1 was selected but is not in the exported XML").arg(name)));
+        }
+
+        QVERIFY2(QFileInfo::exists(qsl("%1/qaAsset.txt").arg(unpacked.path())), "the added asset file is not in the package");
+    }
+
+    // Unticked items must not be dragged along by the export, and their
+    // exportItem flag has to be put back afterwards or the next profile save
+    // writes the wrong set
+    void test_leavesUnselectedItemsOutOfThePackage()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        const QString packageName = qsl("qaPartialPackage");
+        lineEdit(exporter, qsl("lineEdit_packageName"))->setText(packageName);
+        QVERIFY2(tickRow(exporter->scriptMap, mScriptName), qPrintable(qsl("%1 is missing from the selection tree").arg(mScriptName)));
+
+        exporter->slot_exportPackage();
+        QVERIFY2(waitForExportToSettle(exporter), "the export never finished");
+        QVERIFY2(!reportedFailure(exporter), qPrintable(qsl("the export reported a failure: %1").arg(infoText(exporter))));
+
+        QTemporaryDir unpacked;
+        QVERIFY(unpacked.isValid());
+        QVERIFY(unpackInto(qsl("%1/%2.mpackage").arg(mExportDir.path(), packageName), unpacked));
+
+        QFile items(qsl("%1/%2.xml").arg(unpacked.path(), packageName));
+        QVERIFY(items.open(QIODevice::ReadOnly | QIODevice::Text));
+        const QString itemsXml = QString::fromUtf8(items.readAll());
+        QVERIFY2(itemsXml.contains(mScriptName), "the selected script is not in the exported XML");
+        QVERIFY2(!itemsXml.contains(mTriggerName), "an unselected trigger was exported anyway");
+        QVERIFY2(!itemsXml.contains(mAliasName), "an unselected alias was exported anyway");
+    }
+
+    // Module mode writes into the profile directory and installs the result,
+    // which is a different tail of slot_exportPackage() than a plain export
+    void test_moduleCreationModeInstallsWhatItExported()
+    {
+        const QString moduleName = qsl("qaCreatedModule");
+        auto* exporter = makeExporter();
+        // the module has to come back off the host even when an assertion below
+        // ends the test early, or it is left behind for every later case
+        const auto cleanup = qScopeGuard([this, exporter, moduleName]() {
+            delete exporter;
+            if (mpHost->mInstalledModules.contains(moduleName)) {
+                mpHost->uninstallPackage(moduleName, enums::PackageModuleType::ModuleFromUI);
+            }
+        });
+
+        QVERIFY2(!mpHost->mInstalledModules.contains(moduleName), "the module was already installed before the test");
+
+        exporter->setModuleCreationMode(true);
+        QCOMPARE(exportButton(exporter)->text(), qsl("Create Module"));
+
+        lineEdit(exporter, qsl("lineEdit_packageName"))->setText(moduleName);
+        QVERIFY2(tickRow(exporter->aliasMap, mAliasName), qPrintable(qsl("%1 is missing from the selection tree").arg(mAliasName)));
+
+        exporter->slot_exportPackage();
+        QVERIFY2(waitForExportToSettle(exporter), "the module export never finished");
+        QVERIFY2(!reportedFailure(exporter), qPrintable(qsl("the module export reported a failure: %1").arg(infoText(exporter))));
+
+        const QString moduleFile = qsl("%1/%2.mpackage").arg(mudlet::getMudletPath(enums::profileHomePath, mProfileName), moduleName);
+        QVERIFY2(QFileInfo::exists(moduleFile), "module mode did not write the package into the profile directory");
+        QVERIFY2(mpHost->mInstalledModules.contains(moduleName), "module mode exported the file but never installed it");
+
+        QVERIFY2(mpHost->uninstallPackage(moduleName, enums::PackageModuleType::ModuleFromUI), "the module it installed could not be uninstalled again");
+    }
+
+    // preselect*() is how the editor's "create module from this item" entry
+    // arrives with one row already ticked
+    void test_preselectingAnEditorItemTicksItsRow()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        auto* pTrigger = mpHost->getTriggerUnit()->findTrigger(mTriggerName);
+        QVERIFY(pTrigger);
+
+        // stands in for the editor's tree item, which carries the item's ID in
+        // Qt::UserRole
+        QTreeWidgetItem editorItem;
+        editorItem.setData(0, Qt::UserRole, pTrigger->getID());
+
+        QTreeWidgetItem* row = itemFor(exporter->triggerMap, mTriggerName);
+        QVERIFY2(row, "the trigger is missing from the selection tree");
+        QCOMPARE(row->checkState(0), Qt::Unchecked);
+        exporter->preselectTrigger(&editorItem);
+        QCOMPARE(row->checkState(0), Qt::Checked);
+
+        QTreeWidgetItem unknownItem;
+        unknownItem.setData(0, Qt::UserRole, 0);
+        auto* aliasRow = itemFor(exporter->aliasMap, mAliasName);
+        QVERIFY2(aliasRow, "the alias is missing from the selection tree");
+        exporter->preselectAlias(&unknownItem);
+        QCOMPARE(aliasRow->checkState(0), Qt::Unchecked);
+    }
+
+    void test_dependenciesCanBeAddedAndRemoved()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        auto* available = exporter->findChild<QComboBox*>(qsl("DependencyList"));
+        auto* chosen = exporter->findChild<QComboBox*>(qsl("comboBox_dependencies"));
+        QVERIFY(available);
+        QVERIFY(chosen);
+
+        available->addItem(qsl("qaDependency"));
+        available->setCurrentIndex(available->count() - 1);
+        QCOMPARE(chosen->count(), 0);
+
+        exporter->findChild<QPushButton*>(qsl("pushButton_addDependency"))->click();
+        QCOMPARE(chosen->count(), 1);
+        QCOMPARE(chosen->itemText(0), qsl("qaDependency"));
+
+        // Delete on the chosen-dependencies box is handled by the dialog's own
+        // event filter rather than by the combo box
+        QKeyEvent deleteKey(QEvent::KeyPress, Qt::Key_Delete, Qt::NoModifier);
+        QVERIFY2(QCoreApplication::sendEvent(chosen, &deleteKey), "the exporter's event filter did not consume the Delete key");
+        QCOMPARE(chosen->count(), 0);
+    }
+
+    // The description box accepts image files dropped onto it and rewrites them
+    // as markdown references the exporter later resolves
+    void test_descriptionAcceptsDroppedImageFiles()
+    {
+        auto* exporter = makeExporter();
+        const auto cleanup = qScopeGuard([exporter]() {
+            delete exporter;
+        });
+
+        auto* description = exporter->findChild<dlgPackageExporterDescription*>(qsl("textEdit_description"));
+        QVERIFY(description);
+        description->setPlainText(QString());
+
+        const QString imagePath = qsl("%1/qaPicture.png").arg(mExportDir.path());
+        QImage(4, 4, QImage::Format_ARGB32).save(imagePath);
+        QVERIFY(QFileInfo::exists(imagePath));
+
+        QMimeData imageDrop;
+        imageDrop.setUrls({QUrl::fromLocalFile(imagePath)});
+        QVERIFY2(description->canInsertFromMimeData(&imageDrop), "a dropped image was refused");
+        description->insertFromMimeData(&imageDrop);
+
+        QVERIFY2(exporter->mDescriptionImages.contains(imagePath), "the dropped image was not recorded for staging");
+        QVERIFY2(exporter->mPlainDescription.contains(qsl("![Image]($qaPicture.png)")), qPrintable(qsl("no markdown reference was inserted: %1").arg(exporter->mPlainDescription)));
+
+        QMimeData textDrop;
+        textDrop.setText(qsl("just words"));
+        description->insertFromMimeData(&textDrop);
+        QVERIFY2(description->toPlainText().contains(qsl("just words")), "plain text pasted into the description was dropped");
+    }
+
+    void test_copyDirectoryCopiesNestedContent()
+    {
+        QTemporaryDir source;
+        QVERIFY(source.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/nested").arg(source.path())));
+        QFile nested(qsl("%1/nested/file.txt").arg(source.path()));
+        QVERIFY(nested.open(QIODevice::WriteOnly | QIODevice::Text));
+        nested.write("nested\n");
+        nested.close();
+
+        QTemporaryDir destination;
+        QVERIFY(destination.isValid());
+        const QString target = qsl("%1/copied").arg(destination.path());
+
+        dlgPackageExporter::copy_directory(source.path(), target, true);
+
+        QVERIFY2(QFileInfo::exists(qsl("%1/nested/file.txt").arg(target)), "copy_directory did not recurse into subdirectories");
+    }
+};
+
+#include "PackageExporterTest.moc"
+MUDLET_GROUPED_TEST_MAIN(PackageExporterTest)

--- a/test/functional_tests/TreeWidgetItemMoveTest.cpp
+++ b/test/functional_tests/TreeWidgetItemMoveTest.cpp
@@ -1,0 +1,305 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Dragging an item onto a folder in the editor's tree is what reparents the
+ * underlying trigger, alias or timer - the tree widget watches its own model
+ * for the rows moving and pushes the change into the unit. Lua has no way to
+ * reparent an item at all, so none of this is reachable from a spec.
+ */
+
+#include <QDragEnterEvent>
+#include <QMimeData>
+#include <QTemporaryDir>
+#include <QTreeWidget>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "AliasUnit.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "TAlias.h"
+#include "TTimer.h"
+#include "TTreeWidget.h"
+#include "TTrigger.h"
+#include "TelnetServerStub.h"
+#include "TimerUnit.h"
+#include "TriggerUnit.h"
+#include "ctelnet.h"
+#include "dlgTriggerEditor.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class TreeWidgetItemMoveTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgTriggerEditor* mpEditor = nullptr;
+    const QString mProfileName = qsl("TreeWidgetMove-Test-Profile");
+    const QString mLocalhost = qsl("localhost");
+
+    void deleteProfileDirectory(const QString& profileName)
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, profileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    QTreeWidgetItem* itemNamed(QTreeWidget* tree, const QString& name) const
+    {
+        const QList<QTreeWidgetItem*> found = tree->findItems(name, Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0);
+        return found.isEmpty() ? nullptr : found.first();
+    }
+
+    // The reparenting only runs while the tree believes a drag is in flight,
+    // and a synthetic QDropEvent cannot stand in for one: QAbstractItemView's
+    // internal-move handling needs event->source() to be the view itself, which
+    // no hand-made event can claim. Announcing the drag and then moving the row
+    // through the item API reaches the same two model hooks that a real drop does.
+    void moveOntoFolder(TTreeWidget* tree, QTreeWidgetItem* item, QTreeWidgetItem* folder)
+    {
+        QMimeData mimeData;
+        QDragEnterEvent enterEvent(QPoint(1, 1), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+        tree->dragEnterEvent(&enterEvent);
+
+        QTreeWidgetItem* previousParent = item->parent();
+        previousParent->takeChild(previousParent->indexOfChild(item));
+        folder->insertChild(0, item);
+
+        QDragLeaveEvent leaveEvent;
+        tree->dragLeaveEvent(&leaveEvent);
+    }
+
+    void populateProfile()
+    {
+        auto* pTriggerFolder = new TTrigger(nullptr, mpHost);
+        pTriggerFolder->setName(qsl("qaMoveTriggerFolder"));
+        pTriggerFolder->setIsFolder(true);
+        QVERIFY(pTriggerFolder->registerTrigger());
+
+        auto* pTrigger = new TTrigger(nullptr, mpHost);
+        pTrigger->setName(qsl("qaMoveTrigger"));
+        pTrigger->setRegexCodeList({qsl("^qaMoveTrigger$")}, {REGEX_PERL});
+        QVERIFY(pTrigger->registerTrigger());
+
+        auto* pAliasFolder = new TAlias(qsl("qaMoveAliasFolder"), mpHost);
+        pAliasFolder->setIsFolder(true);
+        QVERIFY(mpHost->getAliasUnit()->registerAlias(pAliasFolder));
+
+        auto* pAlias = new TAlias(qsl("qaMoveAlias"), mpHost);
+        pAlias->setRegexCode(qsl("^qaMoveAlias$"));
+        QVERIFY(mpHost->getAliasUnit()->registerAlias(pAlias));
+
+        auto* pTimerFolder = new TTimer(qsl("qaMoveTimerFolder"), QTime(0, 0, 1), mpHost);
+        pTimerFolder->setIsFolder(true);
+        QVERIFY(mpHost->getTimerUnit()->registerTimer(pTimerFolder));
+
+        auto* pTimer = new TTimer(qsl("qaMoveTimer"), QTime(0, 0, 30), mpHost);
+        QVERIFY(mpHost->getTimerUnit()->registerTimer(pTimer));
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), qPrintable(qsl("TelnetServerStub failed to start: %1").arg(mpServer->errorString())));
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "No active host available for the test.");
+        QSignalSpy connectedSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectedSpy.wait(1000), "Could not connect with the host.");
+
+        mudlet::self()->slot_showScriptDialog();
+        QTest::qWait(100ms);
+        mpEditor = mpHost->mpEditorDialog;
+        QVERIFY2(mpEditor, "the editor dialog was not created");
+
+        populateProfile();
+        // The editor built its trees while the profile loaded, so items added
+        // behind its back only appear after the rebuild Host asks for when a
+        // package is installed - and that rebuild is only queued
+        mpEditor->doCleanReset();
+        QTest::qWait(100ms);
+    }
+
+    void cleanupTestCase()
+    {
+        if (mpHost) {
+            if (auto* pEditor = mpHost->mpEditorDialog.data()) {
+                mpHost->mpEditorDialog = nullptr;
+                delete pEditor;
+            }
+        }
+        mpEditor = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_droppingATriggerOnAFolderReparentsItInTheUnit()
+    {
+        mpEditor->slot_showTriggers();
+        auto* tree = mpEditor->treeWidget_triggers;
+        QTreeWidgetItem* folderItem = itemNamed(tree, qsl("qaMoveTriggerFolder"));
+        QTreeWidgetItem* triggerItem = itemNamed(tree, qsl("qaMoveTrigger"));
+        QVERIFY(folderItem && triggerItem);
+
+        TTrigger* pFolder = mpHost->getTriggerUnit()->getTrigger(folderItem->data(0, Qt::UserRole).toInt());
+        TTrigger* pTrigger = mpHost->getTriggerUnit()->getTrigger(triggerItem->data(0, Qt::UserRole).toInt());
+        QVERIFY(pFolder && pTrigger);
+        QVERIFY2(!pTrigger->getParent(), "the trigger was already inside something before the move");
+
+        QSignalSpy movedSpy(tree, &TTreeWidget::itemMoved);
+        moveOntoFolder(tree, triggerItem, folderItem);
+
+        QCOMPARE(pTrigger->getParent(), pFolder);
+        QCOMPARE(movedSpy.count(), 1);
+        const QList<QVariant> arguments = movedSpy.first();
+        QCOMPARE(arguments.at(0).toInt(), pTrigger->getID());
+        QCOMPARE(arguments.at(1).toInt(), 0); // it had no parent
+        QCOMPARE(arguments.at(2).toInt(), pFolder->getID());
+
+        QCOMPARE(folderItem->childCount(), 1);
+        QCOMPARE(folderItem->child(0), triggerItem);
+        QVERIFY2(!triggerItem->icon(0).isNull(), "the moved trigger was left with no icon");
+    }
+
+    void test_droppingAnAliasOnAFolderReparentsItInTheUnit()
+    {
+        mpEditor->slot_showAliases();
+        auto* tree = mpEditor->treeWidget_aliases;
+        QTreeWidgetItem* folderItem = itemNamed(tree, qsl("qaMoveAliasFolder"));
+        QTreeWidgetItem* aliasItem = itemNamed(tree, qsl("qaMoveAlias"));
+        QVERIFY(folderItem && aliasItem);
+
+        TAlias* pFolder = mpHost->getAliasUnit()->getAlias(folderItem->data(0, Qt::UserRole).toInt());
+        TAlias* pAlias = mpHost->getAliasUnit()->getAlias(aliasItem->data(0, Qt::UserRole).toInt());
+        QVERIFY(pFolder && pAlias);
+        QVERIFY2(!pAlias->getParent(), "the alias was already inside something before the move");
+
+        QSignalSpy movedSpy(tree, &TTreeWidget::itemMoved);
+        moveOntoFolder(tree, aliasItem, folderItem);
+
+        QCOMPARE(pAlias->getParent(), pFolder);
+        QCOMPARE(movedSpy.count(), 1);
+    }
+
+    void test_droppingATimerOnAFolderReparentsItAndRepaintsIt()
+    {
+        mpEditor->slot_showTimers();
+        auto* tree = mpEditor->treeWidget_timers;
+        QTreeWidgetItem* folderItem = itemNamed(tree, qsl("qaMoveTimerFolder"));
+        QTreeWidgetItem* timerItem = itemNamed(tree, qsl("qaMoveTimer"));
+        QVERIFY(folderItem && timerItem);
+
+        TTimer* pFolder = mpHost->getTimerUnit()->getTimer(folderItem->data(0, Qt::UserRole).toInt());
+        TTimer* pTimer = mpHost->getTimerUnit()->getTimer(timerItem->data(0, Qt::UserRole).toInt());
+        QVERIFY(pFolder && pTimer);
+        QVERIFY2(!pTimer->getParent(), "the timer was already inside something before the move");
+        // Only the active-timer icons are exercised here: the inactive one is
+        // painted from an icon path that does not exist (#10401)
+        pFolder->setShouldBeActive(true);
+        pTimer->setShouldBeActive(true);
+
+        QSignalSpy movedSpy(tree, &TTreeWidget::itemMoved);
+        moveOntoFolder(tree, timerItem, folderItem);
+
+        QCOMPARE(pTimer->getParent(), pFolder);
+        QCOMPARE(movedSpy.count(), 1);
+        QVERIFY2(!folderItem->child(0)->icon(0).isNull(), "the moved timer was left with no icon");
+    }
+
+    // Outside a drag the tree is a plain view, so rearranging it must not write
+    // anything back into the units
+    void test_movingARowWithNoDragInFlightChangesNothing()
+    {
+        mpEditor->slot_showTriggers();
+        auto* tree = mpEditor->treeWidget_triggers;
+        QTreeWidgetItem* folderItem = itemNamed(tree, qsl("qaMoveTriggerFolder"));
+        QTreeWidgetItem* triggerItem = folderItem->child(0);
+        QVERIFY(triggerItem);
+        TTrigger* pTrigger = mpHost->getTriggerUnit()->getTrigger(triggerItem->data(0, Qt::UserRole).toInt());
+        QVERIFY(pTrigger);
+        TTrigger* parentBefore = pTrigger->getParent();
+
+        QSignalSpy movedSpy(tree, &TTreeWidget::itemMoved);
+        folderItem->takeChild(0);
+        mpEditor->mpTriggerBaseItem->insertChild(0, triggerItem);
+
+        QCOMPARE(movedSpy.count(), 0);
+        QCOMPARE(pTrigger->getParent(), parentBefore);
+    }
+
+    void test_getAllChildrenWalksTheWholeSubtree()
+    {
+        auto* tree = mpEditor->treeWidget_triggers;
+        QTreeWidgetItem* folderItem = itemNamed(tree, qsl("qaMoveTriggerFolder"));
+        QVERIFY(folderItem);
+
+        // The row is nested two levels down so the walk has to recurse to reach
+        // it. Outside a drag the tree writes nothing back into the unit, so a
+        // bare item is enough and needs no trigger behind it.
+        auto* deepItem = new QTreeWidgetItem(folderItem, QStringList{qsl("qaMoveDeepRow")});
+        QVERIFY2(deepItem->parent() == folderItem && folderItem->parent() == mpEditor->mpTriggerBaseItem, "the extra row did not end up two levels below the item being walked");
+
+        QList<QTreeWidgetItem*> collected;
+        tree->getAllChildren(mpEditor->mpTriggerBaseItem, collected);
+
+        QVERIFY2(collected.first() == mpEditor->mpTriggerBaseItem, "the item asked about was not itself included");
+        QVERIFY2(collected.contains(folderItem), "a top-level item was missed");
+        QVERIFY2(collected.contains(deepItem), "a nested item was missed");
+
+        delete folderItem->takeChild(folderItem->indexOfChild(deepItem));
+    }
+};
+
+#include "TreeWidgetItemMoveTest.moc"
+MUDLET_GROUPED_TEST_MAIN(TreeWidgetItemMoveTest)

--- a/test/functional_tests/TreeWidgetItemMoveTest.cpp
+++ b/test/functional_tests/TreeWidgetItemMoveTest.cpp
@@ -78,6 +78,17 @@ private:
         return found.isEmpty() ? nullptr : found.first();
     }
 
+    // The rebuild doCleanReset() asks for is only queued, so it is over when the
+    // items planted behind the editor's back are in its trees - which is what
+    // this waits for, rather than for a length of time the machine gets to
+    // decide the meaning of.
+    bool waitForTreeToHold(const QString& name) const
+    {
+        return QTest::qWaitFor([this, &name]() {
+            return itemNamed(mpEditor->treeWidget_triggers, name) != nullptr;
+        });
+    }
+
     // The reparenting only runs while the tree believes a drag is in flight,
     // and a synthetic QDropEvent cannot stand in for one: QAbstractItemView's
     // internal-move handling needs event->source() to be the view itself, which
@@ -160,9 +171,9 @@ private slots:
         populateProfile();
         // The editor built its trees while the profile loaded, so items added
         // behind its back only appear after the rebuild Host asks for when a
-        // package is installed - and that rebuild is only queued
+        // package is installed
         mpEditor->doCleanReset();
-        QTest::qWait(100ms);
+        QVERIFY2(waitForTreeToHold(qsl("qaMoveTrigger")), "the editor never rebuilt its trees around the items this test planted");
     }
 
     void cleanupTestCase()
@@ -264,14 +275,21 @@ private slots:
         mpEditor->slot_showTriggers();
         auto* tree = mpEditor->treeWidget_triggers;
         QTreeWidgetItem* folderItem = itemNamed(tree, qsl("qaMoveTriggerFolder"));
-        QTreeWidgetItem* triggerItem = folderItem->child(0);
-        QVERIFY(triggerItem);
+        QTreeWidgetItem* triggerItem = itemNamed(tree, qsl("qaMoveTrigger"));
+        QVERIFY(folderItem && triggerItem);
+        // The row has to start this case inside the folder, and a drag is the
+        // only way to put it there with the unit agreeing - the drop case above
+        // leaves it there, but this one cannot be left needing that to have run
+        if (triggerItem->parent() != folderItem) {
+            moveOntoFolder(tree, triggerItem, folderItem);
+        }
+        QCOMPARE(triggerItem->parent(), folderItem);
         TTrigger* pTrigger = mpHost->getTriggerUnit()->getTrigger(triggerItem->data(0, Qt::UserRole).toInt());
         QVERIFY(pTrigger);
         TTrigger* parentBefore = pTrigger->getParent();
 
         QSignalSpy movedSpy(tree, &TTreeWidget::itemMoved);
-        folderItem->takeChild(0);
+        folderItem->takeChild(folderItem->indexOfChild(triggerItem));
         mpEditor->mpTriggerBaseItem->insertChild(0, triggerItem);
 
         QCOMPARE(movedSpy.count(), 0);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Five functional tests, 66 cases, all joined to the existing `EDITOR_GROUP_TEST_SOURCES` group so they cost a compile each rather than a 250MB link each.

| Test | Covers |
|---|---|
| `PackageExporterTest` | `dlgPackageExporter` end to end: the selection tree for all seven item types, both validation refusals, a real `.mpackage` written and unzipped back, module-creation mode, dependencies, and an image dropped into the description |
| `ColorTriggerDialogTest` | `dlgColorTrigger`: the 16 basic buttons, the 216-colour cube, the 24-step grey ramp, the ignore and default sentinels, and reopening on an existing extended colour |
| `EditorSearchTest` | `slot_searchMudletItems` across all six searched item types and nested folders, the three search options, and result activation switching views |
| `EditorClipboardXmlTest` | the editor's copy and paste slots for six item types, multi-item copy, a foreign clipboard payload being ignored, and paste undo/redo |
| `TreeWidgetItemMoveTest` | `TTreeWidget`'s drag-and-drop reparenting of triggers, aliases and timers, and `getAllChildren` |

The only production change is three `friend class` lines added to the list `src/dlgTriggerEditor.h` already keeps for exactly this purpose.

#### Motivation for adding to Mudlet

`src/dlgPackageExporter.cpp` (1243 lines) and `src/dlgColorTrigger.cpp` (191 lines) were at **0.0% coverage** - neither was ever constructed by anything in the test suite. Package export is how everyone ships a Mudlet package, so a regression there is felt by every package author downstream, and it had no safety net at all.

These needed functional tests rather than specs because none of it is reachable from Lua: `dlgPackageExporter` is a dialog with no scripting entry point, the ANSI number `dlgColorTrigger` computes lives in private C++ state, the editor's search results and clipboard slots are private members of `dlgTriggerEditor`, and Lua cannot reparent a trigger at all.

Every case was checked to bite. Across the author and review passes, 36 case/data-row combinations were attacked by breaking the production code they claim to cover - cutting *every* mechanism that could produce the behaviour, not just the obvious one. Three survived and were real defects, now fixed: two cases asserted a value the state already held (so they passed with the code doing nothing), and one depended on tree state an earlier case left behind. Also fixed: a case that leaked an installed module on any early exit, and nine bare pointer dereferences that aborted the whole class instead of failing readably when production was broken.

#### Other info (issues closed, discussion etc)

Full ctest run on this branch: `100% tests passed, 0 tests failed out of 178`, against 173 on development.

Leak-checked properly: the assigned build tree has `USE_SANITIZER` empty, which silently makes `leakCheckAvailable` false and the leak wrapper inert, so a separate Address-sanitizer tree was configured to verify. The five new cases and the whole 13-case editor group both pass under ASAN/LSAN with `detect_leaks=1`. Nothing was added to `leakCheckExcludedTests`.

Found while writing these and filed separately: #10401 - a timer dragged into a folder loses its icon entirely when it and its ancestors are inactive, because `src/TTreeWidget.cpp:323` names a Qt resource that does not exist (`tag_checkbox_grey.png` with an underscore, where the file is `tag_checkbox-grey.png`). It is the only underscore spelling among 21 references. The test works around it and says so.