### PR TITLE
Infra: Add tests for caret navigation, command line keys and the accessible text interface

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -37,12 +37,14 @@ set(WINDOW_GROUP_TEST_SOURCES
     CopyAsImageTest.cpp
     DebugConsoleFilterTest.cpp
     FrontendRefreshSeamTest.cpp
+    CommandLineKeyHandlingTest.cpp
     DetachedWindowMenuShortcutsTest.cpp
     FramePacingTest.cpp
     GlyphOverflowTest.cpp
     HyperlinkModelSplitTest.cpp
     LabelAnchorInteractionTest.cpp
     LabelMovieRefusalTest.cpp
+    CaretNavigationTest.cpp
     MainConsoleSelectionTest.cpp
     TabDetachThresholdTest.cpp
     DetachedWindowDiscordButtonTest.cpp
@@ -58,6 +60,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     PastedLinkStateTest.cpp
     ProfileSwitchMiniconsoleTest.cpp
     RecolouredLineCacheTest.cpp
+    TextEditAccessibleInterfaceTest.cpp
     TrackedLinkTrimTest.cpp
     ProfileSwitchShortcutTest.cpp
     SubCommandLineLifetimeTest.cpp

--- a/test/functional_tests/CaretNavigationTest.cpp
+++ b/test/functional_tests/CaretNavigationTest.cpp
@@ -1,0 +1,565 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// Caret mode: the keyboard-only way around the scrollback that Mudlet offers
+// screen-reader users. TTextEdit::keyPressEvent() is the whole of it - arrow
+// and paging keys walking a caret through the buffer, Tab and Ctrl+bracket
+// walking between links, Return activating the link under the caret, the Menu
+// key offering the choices of a link that carries several commands, and any
+// printable key handing both the character and the focus to the command line.
+//
+// A Lua spec cannot press a key in a console. It can read nothing of this
+// either: the caret's line and column are private C++ state on TTextEdit with
+// no scripting accessor, so even the outcome is invisible from Lua.
+//
+// Deliberately not covered: the Shift and Ctrl variants of the arrow keys.
+// Those branches read QGuiApplication::keyboardModifiers(), which is live
+// window-system state that QTest's widget-level key events do not set, so
+// sending Shift+Left here would exercise the plain Left branch and quietly
+// claim to have tested selection.
+
+#include <QFileInfo>
+#include <QFontDatabase>
+#include <QFontInfo>
+#include <QMenu>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "TBuffer.h"
+#include "TCommandLine.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TTextEdit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class CaretNavigationTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-Caret-Navigation");
+    const QString mLocalhost = qsl("localhost");
+    // Three lines of known and deliberately unequal lengths, so a column can be
+    // clamped by one and restored by the next
+    const QString mLongLine = qsl("alpha bravo charlie");
+    const QString mShortLine = qsl("short");
+    const QString mLastLine = qsl("delta echo foxtrot golf");
+    const QString mLinkLine = qsl("LINKONE LINKTWO");
+    const QString mPopupLine = qsl("POPUPLINK");
+    int mLongLineNumber = -1;
+    int mShortLineNumber = -1;
+    int mLastLineNumber = -1;
+    int mLinkLineNumber = -1;
+    int mPopupLineNumber = -1;
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    TTextEdit* pane() const { return mpHost->mpConsole->mUpperPane; }
+
+    TBuffer& consoleBuffer() const { return mpHost->mpConsole->buffer; }
+
+    static void press(TTextEdit* pPane, const Qt::Key key, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) { QTest::keyClick(pPane, key, modifiers); }
+
+    bool runLua(const QString& script) { return mpHost->mLuaInterpreter.compileAndExecuteScript(script); }
+
+    // Handing focus to the command line is done on a chain of single-shot
+    // timers up to 50ms long. Left to fire in a later case, the console's
+    // focus-out handler turns caret mode off in the middle of it.
+    static void drainDeferredFocusChange() { QTest::qWait(80ms); }
+
+    // The menu is parented on the pane and deletes itself when it closes, but
+    // only once the deferred deletion is delivered, so an earlier case's menu
+    // can still be a child when the next one looks.
+    QMenu* openLinkMenu()
+    {
+        for (QMenu* stale : pane()->findChildren<QMenu*>()) {
+            delete stale;
+        }
+        QTest::keyClick(pane(), Qt::Key_Menu);
+        return pane()->findChild<QMenu*>();
+    }
+
+    QString luaGlobal(const char* name) const
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, name);
+        const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
+        lua_pop(L, 1);
+        return value;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+#ifdef INCLUDE_FONTS
+        // src/main.cpp extracts the bundled fonts into the config directory and
+        // FontManager picks them up from there, but no test binary runs it, so
+        // on a machine that has not run Mudlet before there is nothing on disk
+        // to pick up and Qt quietly substitutes another family.
+        for (const QString& file : {qsl(":/fonts/ttf-bitstream-vera-1.10/VeraMono.ttf"), qsl(":/fonts/ttf-bitstream-vera-1.10/VeraMoBd.ttf")}) {
+            QVERIFY2(QFontDatabase::addApplicationFont(file) != -1, qPrintable(qsl("Could not register the bundled font %1").arg(file)));
+        }
+        const QFont bundled(qsl("Bitstream Vera Sans Mono"), 10);
+        QCOMPARE(QFontInfo(bundled).family(), qsl("Bitstream Vera Sans Mono"));
+#endif
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15s), "The test profile never connected to the stub server.");
+        }
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+
+        // More lines than fit on the screen, so paging has somewhere to go
+        for (int line = 0; line < 100; ++line) {
+            mpHost->mpConsole->print(qsl("caret filler %1\n").arg(line));
+        }
+        mpHost->mpConsole->print(qsl("%1\n%2\n%3\n").arg(mLongLine, mShortLine, mLastLine));
+        // Two links on one line, with a plain character between them, so
+        // stepping between links has to land on each one's first column
+        QVERIFY(runLua(qsl("caretLinkOne = ''\n"
+                           "caretLinkTwo = ''\n"
+                           "echoLink('LINKONE', [[caretLinkOne = 'ran']], 'the first link')\n"
+                           "echo(' ')\n"
+                           "echoLink('LINKTWO', [[caretLinkTwo = 'ran']], 'the second link')\n"
+                           "echo('\\n')\n"
+                           "caretPopupA = ''\n"
+                           "caretPopupB = ''\n"
+                           "echoPopup('POPUPLINK', {[[caretPopupA = 'a']], [[caretPopupB = 'b']]}, {'first choice', 'second choice'})\n"
+                           "echo('\\n')")));
+        QTest::qWait(100ms);
+
+        mLongLineNumber = consoleBuffer().lineBuffer.indexOf(mLongLine);
+        mShortLineNumber = consoleBuffer().lineBuffer.indexOf(mShortLine);
+        mLastLineNumber = consoleBuffer().lineBuffer.indexOf(mLastLine);
+        mLinkLineNumber = consoleBuffer().lineBuffer.indexOf(mLinkLine);
+        mPopupLineNumber = consoleBuffer().lineBuffer.indexOf(mPopupLine);
+        QVERIFY2(mLongLineNumber > 0, "the marker lines never reached the buffer");
+        QCOMPARE(mShortLineNumber, mLongLineNumber + 1);
+        QCOMPARE(mLastLineNumber, mLongLineNumber + 2);
+        QCOMPARE(mLinkLineNumber, mLongLineNumber + 3);
+        QCOMPARE(mPopupLineNumber, mLongLineNumber + 4);
+        QVERIFY2(consoleBuffer().getLinkIndexAt(mLinkLineNumber, 0) > 0, "echoLink() put no link on the line it printed");
+        QVERIFY2(consoleBuffer().getLinkIndexAt(mLastLineNumber, 0) == 0, "the line before the links carries a link of its own, so stepping forward would find the wrong one");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void init()
+    {
+        mpHost->setCaretEnabled(true);
+        // Remembered across key presses rather than reset by them, so a column
+        // banked by one test would follow the caret into the next one
+        pane()->mOldCaretColumn = 0;
+        consoleBuffer().setFocusedLink(0);
+    }
+
+    void cleanup()
+    {
+        // Guarded: TConsole::setCaretMode(false) asserts if it is called when
+        // the pane already has its focus proxy back, which a second call does.
+        if (mpHost->caretEnabled()) {
+            mpHost->setCaretEnabled(false);
+        }
+    }
+
+    // Nothing below runs at all unless caret mode is on: without it
+    // keyPressEvent() hands every key straight back to QWidget.
+    void test_withoutCaretModeTheArrowKeysDoNotMoveTheCaret()
+    {
+        mpHost->setCaretEnabled(false);
+        QVERIFY(!mpHost->caretEnabled());
+        pane()->setCaretPosition(mLongLineNumber, 4);
+
+        press(pane(), Qt::Key_Right);
+
+        QCOMPARE(pane()->mCaretColumn, 4);
+
+        // The same key press with caret mode back on, so a press() that never
+        // reached the pane could not be what kept the column still above.
+        // Turning caret mode on parks the caret at the end of the buffer, so
+        // the position has to be set again after it rather than before.
+        mpHost->setCaretEnabled(true);
+        pane()->setCaretPosition(mLongLineNumber, 4);
+        press(pane(), Qt::Key_Right);
+        QCOMPARE(pane()->mCaretColumn, 5);
+    }
+
+    void test_leftAndRightWalkTheCaretAlongALine()
+    {
+        pane()->setCaretPosition(mLongLineNumber, 4);
+
+        press(pane(), Qt::Key_Right);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 5);
+
+        press(pane(), Qt::Key_Left);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 4);
+    }
+
+    // Off the right-hand end of a line and onto the start of the next.
+    void test_rightAtTheEndOfALineMovesToTheStartOfTheNext()
+    {
+        pane()->setCaretPosition(mLongLineNumber, mLongLine.length() - 1);
+
+        press(pane(), Qt::Key_Right);
+
+        QCOMPARE(pane()->mCaretLine, mShortLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 0);
+    }
+
+    // ...and back off the left-hand end onto the end of the previous one.
+    void test_leftAtTheStartOfALineMovesToTheEndOfThePrevious()
+    {
+        pane()->setCaretPosition(mShortLineNumber, 0);
+
+        press(pane(), Qt::Key_Left);
+
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+        QCOMPARE(pane()->mCaretColumn, mLongLine.length() - 1);
+    }
+
+    void test_upAndDownWalkTheCaretBetweenLines()
+    {
+        pane()->setCaretPosition(mLongLineNumber, 3);
+
+        press(pane(), Qt::Key_Down);
+        QCOMPARE(pane()->mCaretLine, mShortLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 3);
+
+        press(pane(), Qt::Key_Up);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 3);
+    }
+
+    // Walking down past a short line must not silently lose the column the user
+    // was in: it is banked, clamped for the short line, and given back once a
+    // line is long enough to hold it again.
+    void test_aColumnLostToAShortLineComesBackOnTheNextLongOne()
+    {
+        pane()->setCaretPosition(mLongLineNumber, 10);
+        QVERIFY2(mShortLine.length() < 10, "the short line is not short enough for the column to be clamped");
+
+        press(pane(), Qt::Key_Down);
+        QCOMPARE(pane()->mCaretLine, mShortLineNumber);
+        QCOMPARE(pane()->mCaretColumn, mShortLine.length() - 1);
+
+        press(pane(), Qt::Key_Down);
+        QCOMPARE(pane()->mCaretLine, mLastLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 10);
+    }
+
+    void test_homeAndEndJumpToTheEndsOfTheCurrentLine()
+    {
+        pane()->setCaretPosition(mLongLineNumber, 7);
+
+        press(pane(), Qt::Key_Home);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 0);
+
+        press(pane(), Qt::Key_End);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+        QCOMPARE(pane()->mCaretColumn, mLongLine.length() - 1);
+    }
+
+    void test_pageUpAndPageDownMoveByAScreenful()
+    {
+        const int screenful = pane()->getScreenHeight();
+        QVERIFY2(screenful > 1 && screenful < mLongLineNumber, "the screen is not a usable size for paging");
+        pane()->setCaretPosition(mLongLineNumber, 0);
+
+        press(pane(), Qt::Key_PageUp);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber - screenful);
+
+        press(pane(), Qt::Key_PageDown);
+        QCOMPARE(pane()->mCaretLine, mLongLineNumber);
+    }
+
+    // The ends of the buffer are walls, not places to fall off.
+    // A step onto the last line either way first, so a key press that did
+    // nothing at all could not pass for the wall being there.
+    void test_theCaretStopsAtBothEndsOfTheBuffer()
+    {
+        pane()->setCaretPosition(1, 3);
+        press(pane(), Qt::Key_Up);
+        QCOMPARE(pane()->mCaretLine, 0);
+        press(pane(), Qt::Key_Up);
+        QCOMPARE(pane()->mCaretLine, 0);
+
+        const int lastLineWithText = consoleBuffer().lineBuffer.length() - 1 - (consoleBuffer().lineBuffer.last().isEmpty() ? 1 : 0);
+        pane()->setCaretPosition(lastLineWithText - 1, 0);
+        press(pane(), Qt::Key_Down);
+        QCOMPARE(pane()->mCaretLine, lastLineWithText);
+        press(pane(), Qt::Key_Down);
+        QCOMPARE(pane()->mCaretLine, lastLineWithText);
+
+        press(pane(), Qt::Key_PageDown);
+        QCOMPARE(pane()->mCaretLine, lastLineWithText);
+    }
+
+    // #7933: a printable key pressed while reading the output is meant to be
+    // the start of a command, so caret mode gets out of the way and the
+    // character is delivered to the command line rather than dropped.
+    void test_aPrintableKeyHandsTheCharacterToTheCommandLine()
+    {
+        TCommandLine* pCommandLine = mpHost->mpConsole->mpCommandLine;
+        QVERIFY(pCommandLine);
+        pCommandLine->clear();
+        pane()->setCaretPosition(mLongLineNumber, 0);
+        QVERIFY(mpHost->caretEnabled());
+
+        QTest::keyClick(pane(), 'z');
+
+        QVERIFY2(!mpHost->caretEnabled(), "caret mode is still on, so the console kept the keyboard");
+        QCOMPARE(pCommandLine->toPlainText(), qsl("z"));
+        pCommandLine->clear();
+        drainDeferredFocusChange();
+    }
+
+    // ...but a key that cannot start a command stays with the caret.
+    void test_aCaretKeyIsNotSentToTheCommandLine()
+    {
+        TCommandLine* pCommandLine = mpHost->mpConsole->mpCommandLine;
+        QVERIFY(pCommandLine);
+        pCommandLine->clear();
+        pane()->setCaretPosition(mLongLineNumber, 4);
+
+        press(pane(), Qt::Key_Left);
+
+        QVERIFY2(mpHost->caretEnabled(), "an arrow key turned caret mode off");
+        QCOMPARE(pCommandLine->toPlainText(), QString());
+        QCOMPARE(pane()->mCaretColumn, 3);
+    }
+
+    // Tab and Shift+Tab are how a screen-reader user finds the links in a page
+    // of output without a mouse.
+    void test_tabAndBacktabStepBetweenTheLinksInTheBuffer()
+    {
+        pane()->setCaretPosition(mLastLineNumber, 0);
+        const int firstLinkColumn = mLinkLine.indexOf(qsl("LINKONE"));
+        const int secondLinkColumn = mLinkLine.indexOf(qsl("LINKTWO"));
+
+        press(pane(), Qt::Key_Tab);
+        QCOMPARE(pane()->mCaretLine, mLinkLineNumber);
+        QCOMPARE(pane()->mCaretColumn, firstLinkColumn);
+
+        press(pane(), Qt::Key_Tab);
+        QCOMPARE(pane()->mCaretLine, mLinkLineNumber);
+        QCOMPARE(pane()->mCaretColumn, secondLinkColumn);
+
+        press(pane(), Qt::Key_Backtab);
+        QCOMPARE(pane()->mCaretLine, mLinkLineNumber);
+        QCOMPARE(pane()->mCaretColumn, firstLinkColumn);
+    }
+
+    // Ctrl+] and Ctrl+[ do the same, for the case where the user has given Tab
+    // away to the caret-mode toggle.
+    void test_ctrlBracketAlsoStepsBetweenLinks()
+    {
+        pane()->setCaretPosition(mLastLineNumber, 0);
+        const int firstLinkColumn = mLinkLine.indexOf(qsl("LINKONE"));
+        const int secondLinkColumn = mLinkLine.indexOf(qsl("LINKTWO"));
+
+        press(pane(), Qt::Key_BracketRight, Qt::ControlModifier);
+        QCOMPARE(pane()->mCaretColumn, firstLinkColumn);
+
+        press(pane(), Qt::Key_BracketRight, Qt::ControlModifier);
+        QCOMPARE(pane()->mCaretColumn, secondLinkColumn);
+
+        press(pane(), Qt::Key_BracketLeft, Qt::ControlModifier);
+        QCOMPARE(pane()->mCaretColumn, firstLinkColumn);
+    }
+
+    // Without the modifier the same keys are ordinary characters, and go to the
+    // command line like any other printable key.
+    void test_aBracketWithoutControlIsJustACharacter()
+    {
+        pane()->setCaretPosition(mLastLineNumber, 0);
+
+        press(pane(), Qt::Key_BracketRight);
+
+        QCOMPARE(pane()->mCaretLine, mLastLineNumber);
+        QCOMPARE(pane()->mCaretColumn, 0);
+        QVERIFY2(!mpHost->caretEnabled(), "a printable key left caret mode on");
+        mpHost->mpConsole->mpCommandLine->clear();
+        drainDeferredFocusChange();
+    }
+
+    // Return on the link under the caret runs it, which is the entire point of
+    // being able to reach it with the keyboard.
+    void test_returnActivatesTheLinkUnderTheCaret()
+    {
+        QVERIFY(runLua(qsl("caretLinkOne = ''")));
+        pane()->setCaretPosition(mLastLineNumber, 0);
+        press(pane(), Qt::Key_Tab);
+        QVERIFY2(consoleBuffer().getFocusedLink() > 0, "no link is focused, so Return has nothing to activate");
+
+        press(pane(), Qt::Key_Return);
+
+        QCOMPARE(luaGlobal("caretLinkOne"), qsl("ran"));
+    }
+
+    // With no link under it, Return is not an activation and must not run the
+    // link the caret visited last.
+    void test_returnOffALinkRunsNothing()
+    {
+        QVERIFY(runLua(qsl("caretLinkOne = ''")));
+        pane()->setCaretPosition(mLinkLineNumber, mLinkLine.indexOf(qsl("LINKONE")));
+        QVERIFY(consoleBuffer().getFocusedLink() > 0);
+        pane()->setCaretPosition(mLongLineNumber, 0);
+        QCOMPARE(consoleBuffer().getFocusedLink(), 0);
+
+        press(pane(), Qt::Key_Return);
+
+        QCOMPARE(luaGlobal("caretLinkOne"), QString());
+    }
+
+    // A link carrying more than one command cannot be activated outright, so
+    // the Menu key offers the choice the mouse would get from a right-click.
+    void test_theMenuKeyOffersEachOfALinksCommands()
+    {
+        pane()->setCaretPosition(mPopupLineNumber, 0);
+        QVERIFY2(consoleBuffer().getFocusedLink() > 0, "no link is focused, so there is no menu to open");
+
+        QMenu* pMenu = openLinkMenu();
+
+        QVERIFY2(pMenu, "no menu appeared for a link with more than one command");
+        QStringList offered;
+        for (const QAction* pAction : pMenu->actions()) {
+            offered << pAction->text();
+        }
+        QCOMPARE(offered, QStringList({qsl("first choice"), qsl("second choice")}));
+        pMenu->close();
+    }
+
+    void test_choosingFromTheMenuRunsThatCommand()
+    {
+        QVERIFY(runLua(qsl("caretPopupA = ''\ncaretPopupB = ''")));
+        pane()->setCaretPosition(mPopupLineNumber, 0);
+        QMenu* pMenu = openLinkMenu();
+        QVERIFY(pMenu);
+        QCOMPARE(pMenu->actions().size(), 2);
+
+        pMenu->actions().at(1)->trigger();
+
+        QCOMPARE(luaGlobal("caretPopupB"), qsl("b"));
+        QCOMPARE(luaGlobal("caretPopupA"), QString());
+        pMenu->close();
+    }
+
+    // With only one command there is nothing to choose between, so the same key
+    // runs it rather than opening a menu of one.
+    void test_theMenuKeyActivatesASingleCommandLinkOutright()
+    {
+        QVERIFY(runLua(qsl("caretLinkOne = ''")));
+        pane()->setCaretPosition(mLinkLineNumber, mLinkLine.indexOf(qsl("LINKONE")));
+        QVERIFY(consoleBuffer().getFocusedLink() > 0);
+
+        QMenu* pMenu = openLinkMenu();
+
+        QVERIFY2(!pMenu, "a link with a single command still opened a menu");
+        QCOMPARE(luaGlobal("caretLinkOne"), qsl("ran"));
+    }
+
+    // Activating a link marks it visited, which is what the announcement and
+    // the styling both read. A link of this case's own, because the ones above
+    // have been activated already and would satisfy the assertion without this
+    // key press doing anything.
+    void test_activatingALinkMarksItVisited()
+    {
+        QVERIFY(runLua(qsl("echoLink('LINKTHREE', [[caretLinkThree = 'ran']], 'the third link')\necho('\\n')")));
+        QTest::qWait(50ms);
+        const int line = consoleBuffer().lineBuffer.indexOf(qsl("LINKTHREE"));
+        QVERIFY2(line > 0, "the third link never reached the buffer");
+        pane()->setCaretPosition(line, 0);
+        const int linkIndex = consoleBuffer().getFocusedLink();
+        QVERIFY(linkIndex > 0);
+        QVERIFY2(!consoleBuffer().isLinkVisited(linkIndex), "the link counts as visited before anything activated it");
+
+        press(pane(), Qt::Key_Return);
+
+        QVERIFY2(consoleBuffer().isLinkVisited(linkIndex), "the activated link was not marked as visited");
+    }
+};
+
+#include "CaretNavigationTest.moc"
+MUDLET_GROUPED_TEST_MAIN(CaretNavigationTest)

--- a/test/functional_tests/CaretNavigationTest.cpp
+++ b/test/functional_tests/CaretNavigationTest.cpp
@@ -547,12 +547,23 @@ private slots:
     void test_activatingALinkMarksItVisited()
     {
         QVERIFY(runLua(qsl("echoLink('LINKTHREE', [[caretLinkThree = 'ran']], 'the third link')\necho('\\n')")));
-        QTest::qWait(50ms);
+        QTest::qWait(100ms);
         const int line = consoleBuffer().lineBuffer.indexOf(qsl("LINKTHREE"));
         QVERIFY2(line > 0, "the third link never reached the buffer");
         pane()->setCaretPosition(line, 0);
         const int linkIndex = consoleBuffer().getFocusedLink();
-        QVERIFY(linkIndex > 0);
+        // Reported in full because this has failed on macOS x86_64 alone and could
+        // not be reproduced elsewhere: the focused link is read out of the TChar
+        // grid, so which of the text and the grid disagreed is the whole diagnosis.
+        QVERIFY2(linkIndex > 0,
+                 qPrintable(qsl("no link focused at line %1 col 0; caret mode %2, text '%3' (%4 chars), grid row %5 cells, lineBuffer %6 lines, buffer %7 lines")
+                                    .arg(line)
+                                    .arg(mpHost->caretEnabled() ? qsl("on") : qsl("off"))
+                                    .arg(consoleBuffer().lineBuffer.at(line))
+                                    .arg(consoleBuffer().lineBuffer.at(line).length())
+                                    .arg(line < static_cast<int>(consoleBuffer().buffer.size()) ? QString::number(consoleBuffer().buffer.at(line).size()) : qsl("out of range"))
+                                    .arg(consoleBuffer().lineBuffer.size())
+                                    .arg(static_cast<int>(consoleBuffer().buffer.size()))));
         QVERIFY2(!consoleBuffer().isLinkVisited(linkIndex), "the link counts as visited before anything activated it");
 
         press(pane(), Qt::Key_Return);

--- a/test/functional_tests/CaretNavigationTest.cpp
+++ b/test/functional_tests/CaretNavigationTest.cpp
@@ -239,6 +239,10 @@ private slots:
         if (mpHost->caretEnabled()) {
             mpHost->setCaretEnabled(false);
         }
+        // A case that moved focus can leave the change undelivered, and it would
+        // otherwise land during the next case - after its init() turned caret
+        // mode back on, so the pane's focusOutEvent turns it straight off again.
+        drainDeferredFocusChange();
     }
 
     // Nothing below runs at all unless caret mode is on: without it
@@ -550,6 +554,15 @@ private slots:
         QTest::qWait(100ms);
         const int line = consoleBuffer().lineBuffer.indexOf(qsl("LINKTHREE"));
         QVERIFY2(line > 0, "the third link never reached the buffer");
+        // Anything that takes focus off the pane while that wait runs turns caret
+        // mode off through focusOutEvent, and setCaretPosition() then returns
+        // before it focuses a link. Linux and Windows hold the focus with a
+        // keyboard grab that setCaretMode() does not do on macOS, which is why
+        // this only ever failed there. The caret is this case's precondition
+        // rather than its subject, so re-establish it instead of racing it.
+        if (!mpHost->caretEnabled()) {
+            mpHost->setCaretEnabled(true);
+        }
         pane()->setCaretPosition(line, 0);
         const int linkIndex = consoleBuffer().getFocusedLink();
         // Reported in full because this has failed on macOS x86_64 alone and could

--- a/test/functional_tests/CommandLineKeyHandlingTest.cpp
+++ b/test/functional_tests/CommandLineKeyHandlingTest.cpp
@@ -1,0 +1,512 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// Everything TCommandLine::event() does with a key press: sending a command,
+// walking the history, completing from the game's output and from the
+// registered suggestions, and the editing keys it has to intercept to keep its
+// completion state honest.
+//
+// None of it is reachable from a Lua spec. Lua can put text into a command line
+// and read it back, but it has no way to press a key in one - which is exactly
+// why UI_spec.lua:6734 ("the callback only fires on a typed Enter"),
+// GeyserCommandLine_spec.lua:152 and GeyserMiniConsole_spec.lua:294 are marked
+// pending. Every branch below hangs off a QKeyEvent arriving at the widget.
+//
+// A fresh sub command line per test rather than the profile's main one: the
+// history list is private and has no reset, so a shared command line would
+// make each test's history depend on the ones that ran before it.
+
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "RecordingTelnetServer.h"
+#include "TCommandLine.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class CommandLineKeyHandlingTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    RecordingTelnetServer* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-CommandLine-Keys");
+    const QString mLocalhost = qsl("localhost");
+    int mLineCounter = 0;
+    QString mLineName;
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    // A command line of this test's own, with an empty history and no
+    // suggestions. Lua cannot delete one again, but it is parented into the
+    // console so the profile's teardown takes it with it.
+    TCommandLine* freshCommandLine()
+    {
+        mLineName = qsl("keyHandlingLine%1").arg(++mLineCounter);
+        auto [created, message] = mpHost->mpConsole->createCommandLine(QString(), mLineName, 0, 0, 300, 30);
+        if (!created) {
+            qWarning() << "CommandLineKeyHandlingTest - could not create a command line:" << message;
+            return nullptr;
+        }
+        TCommandLine* pCommandLine = mpHost->mpConsole->subCommandLineWidget(mLineName);
+        if (pCommandLine) {
+            pCommandLine->mSaveCommands = false;
+        }
+        return pCommandLine;
+    }
+
+    static void type(TCommandLine* pCommandLine, const QString& text) { QTest::keyClicks(pCommandLine, text); }
+
+    static void press(TCommandLine* pCommandLine, const Qt::Key key, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) { QTest::keyClick(pCommandLine, key, modifiers); }
+
+    static QString selection(const TCommandLine* pCommandLine) { return pCommandLine->textCursor().selectedText(); }
+
+    bool runLua(const QString& script) { return mpHost->mLuaInterpreter.compileAndExecuteScript(script); }
+
+    // What a script would see, so a callback that never ran is an empty string
+    // rather than a stale one - every test that reads this clears it first.
+    QString luaGlobal(const char* name) const
+    {
+        lua_State* L = mpHost->mLuaInterpreter.getLuaGlobalState();
+        lua_getglobal(L, name);
+        const QString value = lua_isstring(L, -1) ? QString::fromUtf8(lua_tostring(L, -1)) : QString();
+        lua_pop(L, 1);
+        return value;
+    }
+
+    bool waitForServerToReceive(const QByteArray& text) const
+    {
+        return QTest::qWaitFor(
+                [this, &text]() {
+                    return mpServer->received().contains(text);
+                },
+                5000);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new RecordingTelnetServer(qApp);
+        QVERIFY2(mpServer->start(), "RecordingTelnetServer failed to bind a loopback port");
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15s), "The test profile never connected to the recording server.");
+        }
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // Both preferences change what a key press does rather than only what it
+    // looks like, so each test starts from the shipped defaults.
+    void init()
+    {
+        QVERIFY(mpHost);
+        mpHost->mAutoClearCommandLineAfterSend = false;
+        mpHost->mHighlightHistory = true;
+        mpServer->forgetReceived();
+    }
+
+    void cleanup()
+    {
+        if (!mLineName.isEmpty()) {
+            mpHost->resetCmdLineAction(mLineName);
+            mLineName.clear();
+        }
+    }
+
+    // The floor the rest of the file stands on: without this, a command line
+    // that quietly ignored every key press would still satisfy assertions that
+    // only ever look at what was sent.
+    void test_typedCharactersReachTheDocument()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+        QVERIFY(pCommandLine->toPlainText().isEmpty());
+
+        type(pCommandLine, qsl("say hello"));
+
+        QCOMPARE(pCommandLine->toPlainText(), qsl("say hello"));
+    }
+
+    // Return with no modifiers is what puts a command on the wire.
+    void test_returnSendsWhatWasTyped()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+        QSignalSpy submitted(pCommandLine, &TCommandLine::commandSubmitted);
+
+        type(pCommandLine, qsl("look north"));
+        QVERIFY2(!mpServer->received().contains("look north"), "the command reached the game before Return was pressed");
+
+        press(pCommandLine, Qt::Key_Return);
+
+        QCOMPARE(submitted.count(), 1);
+        QVERIFY2(waitForServerToReceive("look north"), qPrintable(qsl("the game never received the command - it got: %1").arg(QString::fromUtf8(mpServer->received()))));
+    }
+
+    // The keypad's Enter arrives with the keypad modifier set and has to do the
+    // same thing as the main Return.
+    void test_keypadEnterSendsTheCommandToo()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("kneel"));
+        press(pCommandLine, Qt::Key_Enter, Qt::KeypadModifier);
+
+        QVERIFY2(waitForServerToReceive("kneel"), qPrintable(qsl("the game never received the command - it got: %1").arg(QString::fromUtf8(mpServer->received()))));
+    }
+
+    // UI_spec.lua:6734 and GeyserCommandLine_spec.lua:152: setCmdLineAction
+    // redirects a command line away from the game and into a Lua function, and
+    // only a typed Enter makes that happen.
+    void test_returnRunsTheCommandLineActionInsteadOfSending()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        QVERIFY(runLua(qsl("cmdLineActionSaw = ''")));
+        QVERIFY(runLua(qsl("setCmdLineAction('%1', function(text) cmdLineActionSaw = text end)").arg(mLineName)));
+        QVERIFY2(pCommandLine->mActionFunction, "setCmdLineAction did not reach the command line, so the rest of this proves nothing");
+
+        type(pCommandLine, qsl("into the action"));
+        QCOMPARE(luaGlobal("cmdLineActionSaw"), QString());
+
+        press(pCommandLine, Qt::Key_Return);
+
+        QCOMPARE(luaGlobal("cmdLineActionSaw"), qsl("into the action"));
+        // Two escapes rather than one: the action replaces the send, it does not
+        // run alongside it.
+        QTest::qWait(200ms);
+        QVERIFY2(!mpServer->received().contains("into the action"), "the command went to the game as well as to the action");
+    }
+
+    // resetCmdLineAction hands the command line back to the game.
+    void test_resettingTheActionSendsToTheGameAgain()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        QVERIFY(runLua(qsl("cmdLineActionSaw = ''")));
+        QVERIFY(runLua(qsl("setCmdLineAction('%1', function(text) cmdLineActionSaw = text end)").arg(mLineName)));
+        QVERIFY(runLua(qsl("resetCmdLineAction('%1')").arg(mLineName)));
+        QCOMPARE(pCommandLine->mActionFunction, 0);
+
+        type(pCommandLine, qsl("back to the game"));
+        press(pCommandLine, Qt::Key_Return);
+
+        QCOMPARE(luaGlobal("cmdLineActionSaw"), QString());
+        QVERIFY2(waitForServerToReceive("back to the game"), qPrintable(qsl("the game never received the command - it got: %1").arg(QString::fromUtf8(mpServer->received()))));
+    }
+
+    // Shift+Return is the multi-line escape hatch: it adds a line rather than
+    // sending, and the whole lot goes out one command per line afterwards.
+    void test_shiftReturnAddsALineInsteadOfSending()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("north"));
+        press(pCommandLine, Qt::Key_Return, Qt::ShiftModifier);
+        type(pCommandLine, qsl("east"));
+
+        QCOMPARE(pCommandLine->document()->blockCount(), 2);
+        QVERIFY2(!mpServer->received().contains("north"), "Shift+Return sent the line instead of adding to it");
+
+        press(pCommandLine, Qt::Key_Return);
+
+        QVERIFY2(waitForServerToReceive("north"), "the first of the two lines never reached the game");
+        QVERIFY2(waitForServerToReceive("east"), "the second of the two lines never reached the game");
+    }
+
+    // The preference decides what is left in the box afterwards: cleared, or
+    // kept and selected so the next thing typed replaces it.
+    void test_autoClearPreferenceDecidesWhatIsLeftBehind()
+    {
+        mpHost->mAutoClearCommandLineAfterSend = false;
+        TCommandLine* pKept = freshCommandLine();
+        QVERIFY(pKept);
+        type(pKept, qsl("kept"));
+        press(pKept, Qt::Key_Return);
+        QCOMPARE(pKept->toPlainText(), qsl("kept"));
+        QCOMPARE(selection(pKept), qsl("kept"));
+
+        mpHost->mAutoClearCommandLineAfterSend = true;
+        TCommandLine* pCleared = freshCommandLine();
+        QVERIFY(pCleared);
+        type(pCleared, qsl("cleared"));
+        press(pCleared, Qt::Key_Return);
+        QCOMPARE(pCleared->toPlainText(), QString());
+    }
+
+    // Up walks back through what was sent, Down comes forward again, and the
+    // walk stops at the oldest entry rather than running off the end.
+    void test_upAndDownWalkTheCommandHistory()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("alpha"));
+        press(pCommandLine, Qt::Key_Return);
+        type(pCommandLine, qsl("beta"));
+        press(pCommandLine, Qt::Key_Return);
+
+        press(pCommandLine, Qt::Key_Up);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("alpha"));
+        press(pCommandLine, Qt::Key_Up);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("alpha"));
+
+        press(pCommandLine, Qt::Key_Down);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("beta"));
+    }
+
+    // Down on freshly typed text banks it into the history and clears the line -
+    // the "I'll come back to this" gesture.
+    void test_downOnFreshTextBanksItAndClearsTheLine()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("half written"));
+        press(pCommandLine, Qt::Key_Down);
+
+        QCOMPARE(pCommandLine->toPlainText(), QString());
+        QVERIFY2(!mpServer->received().contains("half written"), "banking the line sent it to the game");
+
+        press(pCommandLine, Qt::Key_Up);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("half written"));
+    }
+
+    // With only part of the line selected, Up completes from the history rather
+    // than replacing the line: the matched entry is filled in and the part the
+    // user did not type is left selected, so typing on replaces it.
+    void test_upCompletesFromTheHistoryWhenTheLineIsOnlyPartlySelected()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("hello world"));
+        press(pCommandLine, Qt::Key_Return);
+        // Return leaves the whole line selected, so typing replaces it and
+        // leaves nothing selected - which is the state this branch needs.
+        type(pCommandLine, qsl("hel"));
+        QCOMPARE(pCommandLine->toPlainText(), qsl("hel"));
+        QVERIFY(selection(pCommandLine).isEmpty());
+
+        press(pCommandLine, Qt::Key_Up);
+
+        QCOMPARE(pCommandLine->toPlainText(), qsl("hello world"));
+        QCOMPARE(selection(pCommandLine), qsl("lo world"));
+    }
+
+    // Tab completes the word being typed from what the game has said recently,
+    // and pressing it again cycles on to the next match.
+    void test_tabCompletesAWordFromTheConsoleBuffer()
+    {
+        mpHost->mpConsole->print(qsl("qzxalpha qzxbravo\n"));
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("qzx"));
+        press(pCommandLine, Qt::Key_Tab);
+        const QString first = pCommandLine->toPlainText();
+        QVERIFY2(first == qsl("qzxalpha") || first == qsl("qzxbravo"), qPrintable(qsl("Tab completed to '%1' rather than to either of the words in the buffer").arg(first)));
+
+        press(pCommandLine, Qt::Key_Tab);
+        const QString second = pCommandLine->toPlainText();
+        QVERIFY2(second == qsl("qzxalpha") || second == qsl("qzxbravo"), qPrintable(qsl("a second Tab left '%1', which is neither of the words in the buffer").arg(second)));
+        QVERIFY2(second != first, "a second Tab did not cycle on to the other match");
+
+        // Backtab is the same cycle in reverse
+        press(pCommandLine, Qt::Key_Backtab, Qt::ShiftModifier);
+        QCOMPARE(pCommandLine->toPlainText(), first);
+    }
+
+    // addSuggestion puts a word into the completion pool that the game never
+    // said, and clearSuggestions takes the whole pool away again.
+    void test_tabCompletesRegisteredSuggestionsUntilTheyAreCleared()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+        pCommandLine->addSuggestion(qsl("qzxsuggested"));
+
+        type(pCommandLine, qsl("qzxsug"));
+        press(pCommandLine, Qt::Key_Tab);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("qzxsuggested"));
+
+        TCommandLine* pAfterClearing = freshCommandLine();
+        QVERIFY(pAfterClearing);
+        pAfterClearing->addSuggestion(qsl("qzxsuggested"));
+        pAfterClearing->clearSuggestions();
+        type(pAfterClearing, qsl("qzxsug"));
+        press(pAfterClearing, Qt::Key_Tab);
+        QCOMPARE(pAfterClearing->toPlainText(), qsl("qzxsug"));
+    }
+
+    // A blacklisted word is dropped from the pool even though it is right there
+    // in the game's output, and taking it off the blacklist puts it back.
+    void test_blacklistedWordsAreNeverOffered()
+    {
+        mpHost->mpConsole->print(qsl("qzxkeepme qzxdropme\n"));
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+        pCommandLine->addBlacklist(qsl("qzxdropme"));
+
+        // A prefix both words in the buffer match, so cycling has somewhere to
+        // go and skipping the blacklisted one is a choice rather than a refusal
+        type(pCommandLine, qsl("qzx"));
+        for (int press_ = 0; press_ < 4; ++press_) {
+            press(pCommandLine, Qt::Key_Tab);
+            QVERIFY2(pCommandLine->toPlainText() != qsl("qzxdropme"), "Tab offered a blacklisted word");
+        }
+
+        pCommandLine->clear();
+        type(pCommandLine, qsl("qzxdrop"));
+        press(pCommandLine, Qt::Key_Tab);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("qzxdrop"));
+
+        // The same command line, because the blacklist is a member of it: a
+        // fresh one starts with an empty blacklist and would complete whether
+        // or not removeBlacklist() did anything.
+        pCommandLine->removeBlacklist(qsl("qzxdropme"));
+        pCommandLine->clear();
+        type(pCommandLine, qsl("qzxdrop"));
+        press(pCommandLine, Qt::Key_Tab);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("qzxdropme"));
+    }
+
+    // Escape leaves completion mode, and selects the line so the next thing
+    // typed replaces it.
+    void test_escapeSelectsTheWholeLine()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("abandon this"));
+        QVERIFY(selection(pCommandLine).isEmpty());
+
+        press(pCommandLine, Qt::Key_Escape);
+
+        QCOMPARE(selection(pCommandLine), qsl("abandon this"));
+    }
+
+    // Backspace and Delete are intercepted rather than left to QPlainTextEdit,
+    // so that the completion state shrinks along with the text - but the text
+    // still has to shrink.
+    void test_backspaceAndDeleteStillEditTheLine()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("abc"));
+        press(pCommandLine, Qt::Key_Backspace);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("ab"));
+
+        pCommandLine->moveCursor(QTextCursor::Start);
+        press(pCommandLine, Qt::Key_Delete);
+        QCOMPARE(pCommandLine->toPlainText(), qsl("b"));
+    }
+
+    // Ctrl+Up and Ctrl+Down move the caret inside a multi-line command instead
+    // of walking the history away from under it.
+    void test_ctrlUpAndDownMoveTheCaretRatherThanTheHistory()
+    {
+        TCommandLine* pCommandLine = freshCommandLine();
+        QVERIFY(pCommandLine);
+
+        type(pCommandLine, qsl("first"));
+        press(pCommandLine, Qt::Key_Return);
+        type(pCommandLine, qsl("one"));
+        press(pCommandLine, Qt::Key_Return, Qt::ShiftModifier);
+        type(pCommandLine, qsl("two"));
+        const int lastBlock = pCommandLine->textCursor().blockNumber();
+        QCOMPARE(lastBlock, 1);
+
+        press(pCommandLine, Qt::Key_Up, Qt::ControlModifier);
+
+        QCOMPARE(pCommandLine->textCursor().blockNumber(), 0);
+        QVERIFY2(pCommandLine->toPlainText() != qsl("first"), "Ctrl+Up walked the history instead of moving the caret");
+
+        press(pCommandLine, Qt::Key_Down, Qt::ControlModifier);
+        QCOMPARE(pCommandLine->textCursor().blockNumber(), 1);
+    }
+};
+
+#include "CommandLineKeyHandlingTest.moc"
+MUDLET_GROUPED_TEST_MAIN(CommandLineKeyHandlingTest)

--- a/test/functional_tests/CommandLineKeyHandlingTest.cpp
+++ b/test/functional_tests/CommandLineKeyHandlingTest.cpp
@@ -94,7 +94,19 @@ private:
 
     static void type(TCommandLine* pCommandLine, const QString& text) { QTest::keyClicks(pCommandLine, text); }
 
-    static void press(TCommandLine* pCommandLine, const Qt::Key key, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) { QTest::keyClick(pCommandLine, key, modifiers); }
+    // Real macOS arrow keys arrive with the keypad modifier set, and TCommandLine's
+    // Up/Down handlers only recognise them there when it is present, so a synthesised
+    // event has to carry it too or the key falls through to the editor.
+    static void press(TCommandLine* pCommandLine, const Qt::Key key, const Qt::KeyboardModifiers modifiers = Qt::NoModifier)
+    {
+        Qt::KeyboardModifiers sentModifiers = modifiers;
+#if defined(Q_OS_MACOS)
+        if (key == Qt::Key_Up || key == Qt::Key_Down) {
+            sentModifiers |= Qt::KeypadModifier;
+        }
+#endif
+        QTest::keyClick(pCommandLine, key, sentModifiers);
+    }
 
     static QString selection(const TCommandLine* pCommandLine) { return pCommandLine->textCursor().selectedText(); }
 

--- a/test/functional_tests/TextEditAccessibleInterfaceTest.cpp
+++ b/test/functional_tests/TextEditAccessibleInterfaceTest.cpp
@@ -1,0 +1,552 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// What a screen reader sees when it asks the main console for its text:
+// TAccessibleTextEdit, Mudlet's QAccessibleTextInterface over the scrollback
+// buffer.
+//
+// A Lua spec cannot reach any of it. The interface is handed to Qt's
+// accessibility bridge by a factory that src/main.cpp installs, it is never
+// exposed to the interpreter, and its whole job is to translate between the
+// buffer's line/column coordinates and the flat character offsets the platform
+// bridges speak - a translation with no Lua-visible consequence at all.
+//
+// The factory is installed here as well because MUDLET_GROUPED_TEST_MAIN (like
+// QTEST_MAIN) never runs main(), so without this Qt would hand back the plain
+// QAccessibleWidget and every case below would be measuring Qt rather than
+// Mudlet.
+//
+// Offsets are derived from the buffer rather than written out, since the
+// console starts with Mudlet's own startup messages ahead of anything this test
+// prints.
+
+#include <QAccessible>
+#include <QFileInfo>
+#include <QFontDatabase>
+#include <QFontInfo>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <chrono>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "ProfileTestHelper.h"
+#include "TAccessibleTextEdit.h"
+#include "TMainConsole.h"
+#include "TTextEdit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+class TextEditAccessibleInterfaceTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-Accessible-TextEdit");
+    const QString mLocalhost = qsl("localhost");
+    // Content of its own, so a line can be found by name rather than by index
+    const QString mFirstMarker = qsl("accessible line one");
+    const QString mSecondMarker = qsl("accessible line two");
+    const QString mThirdMarker = qsl("accessible line three");
+
+    // setupConfig() consults portable.txt before the XDG logic
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    TTextEdit* pane() const { return mpHost->mpConsole->mUpperPane; }
+
+    const QStringList& lines() const { return mpHost->mpConsole->buffer.lineBuffer; }
+
+    QString wholeText() const { return lines().join(QChar::LineFeed); }
+
+    int lineOf(const QString& text) const { return lines().indexOf(text); }
+
+    // The offset of the first character of a line, counting the newline that
+    // text() puts between lines.
+    int offsetOfLine(const int line) const
+    {
+        int offset = 0;
+        for (int i = 0; i < line; ++i) {
+            offset += lines().at(i).length() + 1;
+        }
+        return offset;
+    }
+
+    QAccessibleTextInterface* textInterface() const
+    {
+        QAccessibleInterface* pInterface = QAccessible::queryAccessibleInterface(pane());
+        return pInterface ? pInterface->textInterface() : nullptr;
+    }
+
+    bool lineIsOnScreen(const int line) const { return line >= pane()->imageTopLine() && line < pane()->imageTopLine() + pane()->getScreenHeight(); }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+#ifdef INCLUDE_FONTS
+        // src/main.cpp extracts the bundled fonts into the config directory and
+        // FontManager picks them up from there, but no test binary runs it, so
+        // on a machine that has not run Mudlet before there is nothing on disk
+        // to pick up and Qt quietly substitutes another family.
+        for (const QString& file : {qsl(":/fonts/ttf-bitstream-vera-1.10/VeraMono.ttf"), qsl(":/fonts/ttf-bitstream-vera-1.10/VeraMoBd.ttf")}) {
+            QVERIFY2(QFontDatabase::addApplicationFont(file) != -1, qPrintable(qsl("Could not register the bundled font %1").arg(file)));
+        }
+        const QFont bundled(qsl("Bitstream Vera Sans Mono"), 10);
+        QCOMPARE(QFontInfo(bundled).family(), qsl("Bitstream Vera Sans Mono"));
+#endif
+
+        QAccessible::installFactory(TAccessibleTextEdit::textEditFactory);
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15s), "The test profile never connected to the stub server.");
+        }
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+
+        // Enough lines that the first ones are scrolled off the top, which is
+        // what the visibility cases need, followed by the three named ones so
+        // they are on screen at the end.
+        for (int line = 0; line < 200; ++line) {
+            mpHost->mpConsole->print(qsl("filler %1\n").arg(line));
+        }
+        mpHost->mpConsole->print(qsl("%1\n%2\n%3\n").arg(mFirstMarker, mSecondMarker, mThirdMarker));
+        QTest::qWait(100ms);
+
+        QVERIFY2(textInterface(), "no QAccessibleTextInterface for the console - the factory never took");
+        QVERIFY2(lineOf(mSecondMarker) > 0, "the marker lines never reached the buffer");
+        QVERIFY2(pane()->imageTopLine() > 0, "the console never scrolled, so nothing here is off screen");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void cleanup()
+    {
+        if (QAccessibleTextInterface* ti = textInterface()) {
+            ti->removeSelection(0);
+        }
+        // Every case but one needs the marker lines on screen, and the one that
+        // scrolls away from them leaves the view up in the buffer if it fails
+        // part way through.
+        pane()->scrollTo(mpHost->mpConsole->buffer.getLastLineNumber() + 1);
+    }
+
+    // The flat string every other case indexes into: the buffer's lines with a
+    // newline between them, and a length that agrees with it.
+    void test_theTextIsTheWholeBufferJoinedWithNewlines()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const QString all = wholeText();
+
+        QCOMPARE(ti->characterCount(), all.length());
+        QCOMPARE(ti->text(0, all.length()), all);
+        QVERIFY2(all.contains(mSecondMarker), "the text handed out does not contain what was printed");
+    }
+
+    // A line boundary hands back the whole line the offset sits on, newline and
+    // all, framed by the offsets of its first and last characters.
+    void test_textAtOffsetReturnsTheLineTheOffsetIsOn()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int line = lineOf(mSecondMarker);
+        const int lineStart = offsetOfLine(line);
+        int start = 0;
+        int end = 0;
+
+        const QString text = ti->textAtOffset(lineStart + 3, QAccessible::LineBoundary, &start, &end);
+
+        QCOMPARE(text, mSecondMarker + QChar::LineFeed);
+        QCOMPARE(start, lineStart);
+        QCOMPARE(end, lineStart + mSecondMarker.length() + 1);
+    }
+
+    // ...and the before/after forms step a whole line either way.
+    void test_textBeforeAndAfterOffsetStepToTheNeighbouringLines()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int lineStart = offsetOfLine(lineOf(mSecondMarker));
+        int start = 0;
+        int end = 0;
+
+        QCOMPARE(ti->textBeforeOffset(lineStart + 3, QAccessible::LineBoundary, &start, &end), mFirstMarker + QChar::LineFeed);
+        QCOMPARE(ti->textAfterOffset(lineStart + 3, QAccessible::LineBoundary, &start, &end), mThirdMarker + QChar::LineFeed);
+    }
+
+    // There is nothing before the first line, or before the first character, or
+    // after the last one, and asking for any of it has to come back empty
+    // rather than walking off the end of the buffer.
+    void test_steppingOffTheEndsOfTheTextComesBackEmpty()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        int start = -1;
+        int end = -1;
+
+        QCOMPARE(ti->textBeforeOffset(0, QAccessible::LineBoundary, &start, &end), QString());
+        QCOMPARE(start, 0);
+        QCOMPARE(end, 0);
+
+        QCOMPARE(ti->textBeforeOffset(0, QAccessible::CharBoundary, &start, &end), QString());
+        QCOMPARE(start, 0);
+        QCOMPARE(end, 0);
+
+        QCOMPARE(ti->textAfterOffset(ti->characterCount() - 1, QAccessible::CharBoundary, &start, &end), QString());
+        QCOMPARE(start, 0);
+        QCOMPARE(end, 0);
+
+        QCOMPARE(ti->textBeforeOffset(0, QAccessible::WordBoundary, &start, &end), QString());
+        QCOMPARE(start, 0);
+        QCOMPARE(end, 0);
+    }
+
+    // A character boundary walks one code unit at a time, which is what a
+    // screen reader's arrow keys ask for.
+    void test_charBoundaryStepsOneCharacterAtATime()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const QString all = wholeText();
+        const int offset = offsetOfLine(lineOf(mSecondMarker)) + 5;
+        int start = -1;
+        int end = -1;
+
+        QCOMPARE(ti->textAtOffset(offset, QAccessible::CharBoundary, &start, &end), QString(all.at(offset)));
+        QCOMPARE(start, offset);
+        QCOMPARE(end, offset + 1);
+
+        QCOMPARE(ti->textBeforeOffset(offset, QAccessible::CharBoundary, &start, &end), QString(all.at(offset - 1)));
+        QCOMPARE(ti->textAfterOffset(offset, QAccessible::CharBoundary, &start, &end), QString(all.at(offset + 1)));
+    }
+
+    // A word boundary hands back the word the offset is inside.
+    void test_wordBoundaryReturnsTheWordTheOffsetIsIn()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        // "accessible line two", two characters into the first word
+        const int offset = offsetOfLine(lineOf(mSecondMarker)) + 2;
+        int start = -1;
+        int end = -1;
+
+        QCOMPARE(ti->textAtOffset(offset, QAccessible::WordBoundary, &start, &end), qsl("accessible"));
+        QCOMPARE(wholeText().mid(start, end - start), qsl("accessible"));
+    }
+
+    // Only four of Qt's boundary types are implemented; the rest have to be
+    // refused rather than answered with something made up.
+    void test_anUnsupportedBoundaryTypeIsRefused()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        int start = 0;
+        int end = 0;
+
+        QCOMPARE(ti->textAtOffset(offsetOfLine(lineOf(mSecondMarker)), QAccessible::ParagraphBoundary, &start, &end), QString());
+        QCOMPARE(start, -1);
+        QCOMPARE(end, -1);
+    }
+
+    // An offset past the end of the text is an error, not an empty line.
+    void test_anOffsetPastTheEndOfTheTextIsRefused()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        int start = 0;
+        int end = 0;
+
+        QCOMPARE(ti->textAtOffset(ti->characterCount() + 1, QAccessible::LineBoundary, &start, &end), QString());
+        QCOMPARE(start, -1);
+        QCOMPARE(end, -1);
+    }
+
+    // NoBoundary means "everything from here", and each of the three methods
+    // takes a different slice of the text for it.
+    void test_noBoundaryHandsOutTheTextWholesale()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const QString all = wholeText();
+        const int offset = offsetOfLine(lineOf(mSecondMarker));
+        int start = -1;
+        int end = -1;
+
+        QCOMPARE(ti->textAfterOffset(offset, QAccessible::NoBoundary, &start, &end), all.mid(offset));
+        QCOMPARE(start, offset);
+        QCOMPARE(end, all.length());
+
+        QCOMPARE(ti->textBeforeOffset(offset, QAccessible::NoBoundary, &start, &end), all.left(offset));
+        QCOMPARE(ti->textAtOffset(offset, QAccessible::NoBoundary, &start, &end), all);
+    }
+
+    // The caret is stored as a line and a column but addressed as an offset, so
+    // the two have to agree in both directions.
+    void test_theCaretPositionRoundTripsThroughACharacterOffset()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int line = lineOf(mSecondMarker);
+        const int offset = offsetOfLine(line) + 4;
+        pane()->setCaretPosition(0, 0);
+        QVERIFY2(ti->cursorPosition() != offset, "the caret was already where this was going to put it");
+
+        ti->setCursorPosition(offset);
+
+        QCOMPARE(pane()->mCaretLine, line);
+        QCOMPARE(pane()->mCaretColumn, 4);
+        QCOMPARE(ti->cursorPosition(), offset);
+    }
+
+    // An offset that is not in the text leaves the caret alone rather than
+    // moving it somewhere invented.
+    void test_anInvalidCaretPositionIsIgnored()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int offset = offsetOfLine(lineOf(mSecondMarker)) + 4;
+        ti->setCursorPosition(offset);
+        QCOMPARE(ti->cursorPosition(), offset);
+
+        ti->setCursorPosition(-1);
+        QCOMPARE(ti->cursorPosition(), offset);
+
+        ti->setCursorPosition(ti->characterCount() + 1);
+        QCOMPARE(ti->cursorPosition(), offset);
+    }
+
+    // Selecting from the accessibility side has to produce the console's own
+    // selection, and dropping it has to take that away again.
+    void test_addSelectionSelectsTheRangeAndRemoveSelectionClearsIt()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int line = lineOf(mSecondMarker);
+        QVERIFY2(lineIsOnScreen(line), "the line being selected is off screen, so no selection region could be built for it");
+        const int start = offsetOfLine(line);
+        QCOMPARE(ti->selectionCount(), 0);
+
+        ti->addSelection(start, start + mSecondMarker.length());
+
+        QCOMPARE(ti->selectionCount(), 1);
+        int reportedStart = -1;
+        int reportedEnd = -1;
+        ti->selection(0, &reportedStart, &reportedEnd);
+        QCOMPARE(reportedStart, start);
+        QVERIFY2(reportedEnd > reportedStart, "the reported selection is empty although a range was selected");
+
+        ti->removeSelection(0);
+
+        QCOMPARE(ti->selectionCount(), 0);
+    }
+
+    // QAccessibleTextInterface's end offset is the first character that is NOT
+    // selected, so text(start, end) has to hand back exactly what was selected -
+    // which is what a screen reader reads out when it announces a selection.
+    // Mudlet reports one less: addSelection() stores the last selected cell in
+    // mPB and selection() returns that offset unchanged, so the final character
+    // is dropped and a one-character selection comes back as an empty range
+    // while selectionCount() still says there is one. A stock QTextEdit, which
+    // implements the same interface, reports the range asked for.
+    //
+    // QEXPECT_FAIL rather than a weaker assertion, so this case goes red the day
+    // the off-by-one is fixed and the markers can be taken back out.
+    void test_theReportedSelectionRoundTripsThroughTheTextItSelected()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int line = lineOf(mSecondMarker);
+        QVERIFY2(lineIsOnScreen(line), "the line being selected is off screen, so no selection region could be built for it");
+        const int start = offsetOfLine(line);
+        int reportedStart = -1;
+        int reportedEnd = -1;
+
+        ti->addSelection(start, start + mSecondMarker.length());
+        ti->selection(0, &reportedStart, &reportedEnd);
+
+        QCOMPARE(reportedStart, start);
+        QEXPECT_FAIL("", "#10411: selection() reports endOffset - 1, so the last selected character is lost", Continue);
+        QCOMPARE(ti->text(reportedStart, reportedEnd), mSecondMarker);
+
+        ti->removeSelection(0);
+        ti->addSelection(start, start + 1);
+        ti->selection(0, &reportedStart, &reportedEnd);
+
+        QCOMPARE(ti->selectionCount(), 1);
+        QEXPECT_FAIL("", "#10411: a one-character selection is reported as an empty range", Continue);
+        QCOMPARE(reportedEnd - reportedStart, 1);
+    }
+
+    // setSelection is addSelection under another name, and both refuse an index
+    // other than the single selection the console supports.
+    void test_setSelectionOnlySupportsTheFirstSelection()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int start = offsetOfLine(lineOf(mSecondMarker));
+        QCOMPARE(ti->selectionCount(), 0);
+
+        ti->setSelection(1, start, start + 4);
+        QCOMPARE(ti->selectionCount(), 0);
+
+        ti->setSelection(0, start, start + 4);
+        QCOMPARE(ti->selectionCount(), 1);
+    }
+
+    // Offsets that are not in the text select nothing at all.
+    void test_anInvalidSelectionRangeIsRefused()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        QCOMPARE(ti->selectionCount(), 0);
+
+        ti->addSelection(-1, 5);
+        QCOMPARE(ti->selectionCount(), 0);
+
+        ti->addSelection(0, ti->characterCount() + 1);
+        QCOMPARE(ti->selectionCount(), 0);
+    }
+
+    // The rectangle is what a screen magnifier follows, so it has to be one
+    // character cell wide and sit one cell further right for the next offset.
+    void test_characterRectCoversOneCellAndAdvancesWithTheOffset()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int offset = offsetOfLine(lineOf(mSecondMarker)) + 2;
+
+        const QRect first = ti->characterRect(offset);
+        const QRect second = ti->characterRect(offset + 1);
+
+        QVERIFY2(first.isValid() && first.width() > 0 && first.height() > 0, "no rectangle for a character that is on screen");
+        QCOMPARE(second.size(), first.size());
+        QCOMPARE(second.left() - first.left(), first.width());
+        QCOMPARE(second.top(), first.top());
+    }
+
+    // A character that has scrolled off the top has no rectangle at all.
+    void test_characterRectIsEmptyForALineThatIsScrolledOutOfView()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        QVERIFY2(!lineIsOnScreen(0), "the first line is still on screen, so this proves nothing");
+
+        QCOMPARE(ti->characterRect(0), QRect());
+    }
+
+    // The inverse lookup: the point a character was reported at has to lead
+    // back to that character.
+    void test_offsetAtPointFindsTheCharacterUnderIt()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int offset = offsetOfLine(lineOf(mSecondMarker)) + 6;
+        const QRect rect = ti->characterRect(offset);
+        QVERIFY(rect.isValid());
+
+        QCOMPARE(ti->offsetAtPoint(rect.center()), offset);
+    }
+
+    // Scrolling on request is how a screen reader follows a caret it moved into
+    // text that is no longer showing.
+    void test_scrollToSubstringBringsAnOffScreenLineIntoView()
+    {
+        QAccessibleTextInterface* ti = textInterface();
+        QVERIFY(ti);
+        const int line = 5;
+        QVERIFY2(!lineIsOnScreen(line), "the line is already on screen, so this proves nothing");
+
+        ti->scrollToSubstring(offsetOfLine(line), offsetOfLine(line) + 3);
+
+        QVERIFY2(lineIsOnScreen(line), qPrintable(qsl("line %1 is still not showing - the screen starts at line %2").arg(line).arg(pane()->imageTopLine())));
+    }
+
+    // The state a bridge reads to decide how to present the widget.
+    void test_stateReportsSelectableMultiLineText()
+    {
+        QAccessibleInterface* pInterface = QAccessible::queryAccessibleInterface(pane());
+        QVERIFY(pInterface);
+
+        const QAccessible::State state = pInterface->state();
+
+        QVERIFY2(state.selectableText, "the console does not report its text as selectable");
+        QVERIFY2(state.multiLine, "the console does not report itself as multi-line");
+        QVERIFY2(state.focusable, "the console does not report itself as focusable");
+    }
+};
+
+#include "TextEditAccessibleInterfaceTest.moc"
+MUDLET_GROUPED_TEST_MAIN(TextEditAccessibleInterfaceTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Three functional tests, 56 case functions, all joined to the existing `WINDOW_GROUP_TEST_SOURCES` group so each costs a compile rather than a 250MB link.

| Test | Covers |
|---|---|
| `CaretNavigationTest` | caret mode across `TTextEdit`: arrow/Home/End/PageUp/PageDown movement, the old-column restore, both ends of the buffer, link navigation and `markLinkAsVisited`, the Menu key and its single-command-direct-activation branch, focus clearing when the caret leaves a link, and the #7933 printable-key redirect to the command line |
| `CommandLineKeyHandlingTest` | `TCommandLine`: tab completion over the word pool, the blacklist and its removal, `clearSuggestions`, history movement, Shift+Return, Ctrl+Up/Down, the autoclear branches and the command-line action branch |
| `TextEditAccessibleInterfaceTest` | `TAccessibleTextEdit`: the `Value` text join, every offset guard, `cursorPosition`, `removeSelection`, the `setSelection` index guard, the word/character/line boundary finders and the boundary-type refusal, character rects for on- and off-screen lines, and `scrollToSubstring` |

No production code is touched.

#### Motivation for adding to Mudlet

`TAccessibleTextEdit` is the interface screen readers use to read Mudlet's main window (#3342) and had essentially no coverage, which is how the bug below survived. Caret mode and the command line's key handling are the keyboard-only path through the client, and the #7933 printable-key redirect had nothing pinning it.

Every case was proven to bite. Rather than sampling, **all 56 case functions** were shown reachable by at least one sabotage cut across `TAccessibleTextEdit.cpp`, `TTextEdit.cpp` and `TCommandLine.cpp` - 43 legs, each cutting a mechanism and producing the expected red naming the expected case.

Three defects were found in review and fixed before this PR:

- **A vacuous test.** `test_blacklistedWordsAreNeverOffered` called `removeBlacklist()` on one `TCommandLine` and then tested completion on a **fresh** one - and `tabCompleteBlacklist` is a per-instance member (`src/TCommandLine.h:151`), so the second command line started with an empty blacklist and would have completed either way. Proven both directions: gutting `removeBlacklist()` to `Q_UNUSED(word)` against the original left the case green; against the rewrite it goes red. It now uses one command line throughout, and shares a prefix between a kept and a dropped word so skipping the blacklisted one is a choice rather than a refusal to complete at all.
- **Order-fragile scroll state.** The scroll restore in `test_scrollToSubstringBringsAnOffScreenLineIntoView` sat at the end of the case body, so a mid-case failure left the view parked up the buffer and every later case needing the marker lines on screen failed as collateral. Moved to `cleanup()`.
- **Two weak negatives.** Two caret cases asserted "nothing moved" without showing the key press reached the widget at all. Both now carry a positive control - the disabled-caret-mode case re-enables caret mode and repeats the identical press to show the column *does* move, and the buffer-ends case steps onto the boundary line before pushing against it.

One suspected defect was **refuted** by sabotage rather than by argument, which is worth recording because it read exactly like a vacuous assertion: `QVERIFY2(state.focusable, ...)` looked like it would be satisfied by `QAccessibleWidget::state()` regardless. Cutting only `s.focusable = true;` from `TAccessibleTextEdit::state()` turned the case red, so the assertion stands.

#### Other info (issues closed, discussion etc)

Full ctest run on this branch: `100% tests passed, 0 tests failed out of 176`, and three consecutive `-j4` runs gave the same. The branch adds exactly 3 test binaries' worth of cases (`ctest -N` excluding them gives 173).

**Leak-checked properly.** The assigned build tree has `USE_SANITIZER` empty, which silently makes `leakCheckAvailable` false and the leak wrapper inert, so a separate Address-sanitizer tree was configured to verify. The gate was confirmed live before the result was trusted - `USE_SANITIZER:STRING=Address` in the cache, `libasan.so.8` linked, and all three cases carrying `ASAN_OPTIONS=detect_leaks=1`. All three pass. The check was also proven to bite: injecting a `new QString(...)` into one case produced `Direct leak of 24 byte(s) in 1 object(s)` naming the exact line and turned it red. Nothing was added to `leakCheckExcludedTests`.

Order and timing dependence was ruled out empirically rather than assumed: reverse order within each file, 20 openssl-seeded shuffles, and **every one of the 56 case functions run in isolation** - all pass.

Found while writing these and filed separately: **#10411** - `TAccessibleTextEdit::selection()` reports a selection one character shorter than the one made, so a screen reader is told less than the user selected, and a *single-character* selection comes back as an empty range while `selectionCount()` still says there is one. `addSelection()` stores the inclusive last cell and `selection()` returns that offset unchanged, breaking the contract the file's own comment states. A stock `QTextEdit` implementing the same interface round-trips correctly.

That one is covered rather than worked around: `test_theReportedSelectionRoundTripsThroughTheTextItSelected` asserts the *correct* behaviour behind two `QEXPECT_FAIL(..., Continue)` markers naming the issue. Applying the candidate fix turns both into XPASS, which QTest counts as a failure - so the case goes red the day the bug is fixed and the markers come out with it.

---

**The macOS x86_64 failure is diagnosed and fixed** (e4c491d). Only that one leg ever failed, and only in `CaretNavigationTest::test_activatingALinkMarksItVisited`; Linux, Windows and macOS arm64 were always green, and it never reproduced locally.

A commit that made the assertion report the buffer state instead of just failing (`88f2f932`) named the mechanism on the next run:

```
FAIL!  : test_activatingALinkMarksItVisited() 'linkIndex > 0' returned FALSE.
(no link focused at line 108 col 0; caret mode off, text 'LINKTHREE' (9 chars),
 grid row 9 cells, lineBuffer 110 lines, buffer 110 lines)
```

The text and the `TChar` grid agree - 9 characters, 9 cells - so the buffer was fine. The anomaly is `caret mode off`, even though `init()` turns it on before every case. `TTextEdit::focusOutEvent()` (`TTextEdit.cpp:234`) disables caret mode whenever the pane loses focus for anything but window deactivation, and `TTextEdit::setCaretPosition()` (`TTextEdit.cpp:3796`) returns before it focuses a link when caret mode is off. So a focus change landing during this case's 100ms settle leaves the link unfocused, and the assertion is right to fail.

Why macOS alone: `TConsole::setCaretMode(true)` guards its `setFocus(Qt::MouseFocusReason)` and `grabKeyboard()` behind `#if defined(Q_OS_WINDOWS) || defined(Q_OS_LINUX)` (`TConsole.cpp:3009-3015`). Linux and Windows hold the pane's focus with that grab; macOS gets only a plain `setFocus()`, so a pending focus change can still take it.

Reproduced locally on Linux by standing in for that focus change with one line - `mpCommandLine->setFocus(Qt::TabFocusReason)` before the wait - which produced the CI message character for character, down to the same line 108 and the same 110/110 line counts:

```
FAIL!  : test_activatingALinkMarksItVisited() 'linkIndex > 0' returned FALSE.
(no link focused at line 108 col 0; caret mode off, text 'LINKTHREE' (9 chars),
 grid row 9 cells, lineBuffer 110 lines, buffer 110 lines)
```

The fix is in two parts, and was verified against that repro rather than against a green run: `cleanup()` now drains a focus change a case may have left undelivered, so it cannot land inside the next case after its `init()`; and the case re-establishes caret mode where it depends on it, since the caret is that case's precondition rather than its subject. **With the forced focus change still injected, the suite goes to `22 passed, 0 failed`** - so the fix addresses the reproduced mechanism, not just the symptom. With the injection removed it is `22 passed, 0 failed` as well, and the full local suite is `100% tests passed, 0 tests failed out of 176`.

No product bug is filed off this. The caret dropping when the pane loses focus is deliberate and commented as such, and the platform asymmetry is visible in the source but I have no user-visible macOS symptom to attach to it, so it stays an observation rather than a report.
