### PR TITLE
Fix: Crash opening the editor when the profile's theme is missing

### DIFF
--- a/src/SingleLineTextEdit.cpp
+++ b/src/SingleLineTextEdit.cpp
@@ -93,8 +93,13 @@ void SingleLineTextEdit::setHighlightingEnabled(bool enabled)
 
 void SingleLineTextEdit::setTheme(const QString& themeName)
 {
-    auto edbee = edbee::Edbee::instance();
-    edbee::TextTheme* theme = edbee->themeManager()->theme(themeName);
+    auto themeManager = edbee::Edbee::instance()->themeManager();
+    edbee::TextTheme* theme = themeManager->theme(themeName);
+    if (!theme) {
+        // The profile names a theme whose file was never downloaded to this
+        // machine; use the fallback edbee's own editor paints with so the two agree
+        theme = themeManager->fallbackTheme();
+    }
 
     // set the textedit background and text the same as edbee base settings
     QPalette p = palette();

--- a/src/TriggerHighlighter.cpp
+++ b/src/TriggerHighlighter.cpp
@@ -58,6 +58,9 @@ void TriggerHighlighter::setTheme(const QString& themeName)
     auto edbee = edbee::Edbee::instance();
     auto themeManager = edbee->themeManager();
     edbee::TextTheme* theme = themeManager->theme(themeName);
+    if (!theme) {
+        theme = themeManager->fallbackTheme();
+    }
 
     // set defaults from chosen theme
     edbee::TextThemeRule defaultRule("default", "selector", theme->foregroundColor(), theme->backgroundColor(), false, false, false);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -123,6 +123,7 @@ set(EDITOR_GROUP_TEST_SOURCES
     EdbeeReinitTest.cpp
     EditorBannerViewSwitchTest.cpp
     EditorWindowPositionTest.cpp
+    MissingEditorThemeTest.cpp
     ScriptEventHandlerLifetimeTest.cpp
     TriggerEditorDisclosureTest.cpp
     TriggerEditorTest.cpp

--- a/test/functional_tests/MissingEditorThemeTest.cpp
+++ b/test/functional_tests/MissingEditorThemeTest.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * A profile stores its editor theme by name; the file itself lives in the
+ * shared theme download cache, so a profile moved to another machine can name
+ * a theme that is not there. edbee's editor then paints with its fallback
+ * theme, and the trigger pattern line edits must degrade the same way.
+ *
+ * Run with: ctest -R MissingEditorThemeTest -V
+ */
+
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "SingleLineTextEdit.h"
+#include "mudlet.h"
+
+#include "edbee/edbee.h"
+#include "edbee/views/texttheme.h"
+
+#include "GroupedTest.h"
+
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+class MissingEditorThemeTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+    }
+
+    void cleanupTestCase()
+    {
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_patternEditPaintsWithTheFallbackThemeWhenTheProfilesThemeIsMissing()
+    {
+        auto* themeManager = edbee::Edbee::instance()->themeManager();
+        auto* fallback = themeManager->fallbackTheme();
+        QVERIFY(fallback);
+        const QString missingTheme = qsl("Theme-that-never-reached-this-machine");
+        QVERIFY2(!themeManager->theme(missingTheme), "the theme this test relies on being absent was found");
+
+        SingleLineTextEdit patternEdit;
+        // The fallback is black on white, which a default palette may already
+        // be, so pre-paint with a colour it does not use to prove setTheme()
+        // applied it
+        const QColor sentinel(Qt::magenta);
+        QVERIFY(fallback->backgroundColor() != sentinel && fallback->foregroundColor() != sentinel);
+        QPalette sentinelPalette = patternEdit.palette();
+        sentinelPalette.setColor(QPalette::Base, sentinel);
+        sentinelPalette.setColor(QPalette::Text, sentinel);
+        patternEdit.setPalette(sentinelPalette);
+        patternEdit.viewport()->setPalette(sentinelPalette);
+
+        // The highlighter colours an anchor from the theme's comment scope: green
+        // in the Mudlet theme the constructor applied, and the fallback theme has
+        // no scopes, so afterwards the anchor can only carry its plain colours
+        patternEdit.setPlainText(qsl("^"));
+        auto anchorFormat = [&patternEdit]() {
+            const auto ranges = patternEdit.document()->firstBlock().layout()->formats();
+            return ranges.isEmpty() ? QTextCharFormat() : ranges.first().format;
+        };
+        QCOMPARE(anchorFormat().foreground().color(), QColor(0x00, 0x80, 0x00));
+
+        patternEdit.setTheme(missingTheme);
+
+        QCOMPARE(patternEdit.palette().color(QPalette::Base), fallback->backgroundColor());
+        QCOMPARE(patternEdit.palette().color(QPalette::Text), fallback->foregroundColor());
+        QCOMPARE(patternEdit.viewport()->palette().color(QPalette::Base), fallback->backgroundColor());
+        QCOMPARE(anchorFormat().foreground().color(), fallback->foregroundColor());
+        QCOMPARE(anchorFormat().background().color(), fallback->backgroundColor());
+    }
+};
+
+#include "MissingEditorThemeTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MissingEditorThemeTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`SingleLineTextEdit::setTheme()` and `TriggerHighlighter::setTheme()` fall back to edbee's fallback theme when the named theme is not loaded, instead of dereferencing the null edbee returns for it.

#### Motivation for adding to Mudlet
A profile stores its editor theme by name, but the theme file lives in the shared theme download cache. A profile moved to another machine, or a theme dropped from the pack, names a theme that is not there, and opening the editor crashed on the first trigger pattern line. edbee's own editor already paints with its fallback theme in that case; the pattern edits now degrade the same way.

#### Other info (issues closed, discussion etc)

Closes #10449.

Sentry: MUDLET-60.

**Test case:** `MissingEditorThemeTest` (EDITOR group) sets a sentinel palette on a pattern edit, applies a theme name nothing registered, and checks the palette and the anchor highlighting carry the fallback theme's colours. It segfaults without either hunk of the fix.

Assisted-by: Claude:claude-fable-5-1