### PR TITLE
Fix: Crash from an alias that keeps expanding into itself

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -29,6 +29,7 @@
 #include "Tree.h"
 #include "utils.h"
 
+#include <QDebug>
 #include <QLatin1String>
 #include <QMutableSetIterator>
 #include <QScopeGuard>
@@ -286,6 +287,16 @@ int AliasUnit::getNewID()
 
 bool AliasUnit::processDataStream(const QString& data)
 {
+    if (mProcessingDepth >= scmMaxProcessingDepth) {
+        qWarning().nospace() << "AliasUnit::processDataStream(...) aborting: alias processing recursion reached the limit of " << scmMaxProcessingDepth
+                             << " - probably an alias that expands into itself.";
+        //: %1 is the command being expanded, %2 the depth limit. Shown in the game window when an alias keeps expanding into itself
+        mpHost->postMessage(tr("[ ERROR ] - Alias processing stopped to prevent a crash: \"%1\" was expanded by an alias %2 times in a row, each time producing a command that matched an alias "
+                               "again. It goes to the game unexpanded. Send from the alias with send() rather than expandAlias(), or give it a pattern that does not match what it sends.")
+                                    .arg(data, QString::number(scmMaxProcessingDepth)));
+        return false;
+    }
+
     TLuaInterpreter* Lua = mpHost->getLuaInterpreter();
     Lua->set_lua_string(qsl("command"), data);
     bool state = false;

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -26,6 +26,7 @@
 
 #include "utils.h"
 
+#include <QCoreApplication>
 #include <QList>
 #include <QMap>
 #include <QMultiMap>
@@ -42,6 +43,8 @@ class TAlias;
 
 class AliasUnit
 {
+    Q_DECLARE_TR_FUNCTIONS(AliasUnit) // Needed so we can use tr() even though AliasUnit is NOT derived from QObject
+
     friend class XMLexport;
     friend class XMLimport;
 
@@ -72,6 +75,9 @@ public:
     void markCleanup(TAlias* pT);
     void doCleanup();
     int processingDepth() const { return mProcessingDepth; }
+    // Each nested alias expansion is a C++ stack frame; past this depth the
+    // command goes to the game unexpanded.
+    inline static const int scmMaxProcessingDepth = 50;
 
     QMultiMap<QString, TAlias*> mLookupTable;
     QSet<TAlias*> mCleanupSet;

--- a/src/mudlet-lua/tests/Alias_spec.lua
+++ b/src/mudlet-lua/tests/Alias_spec.lua
@@ -31,6 +31,95 @@ describe("Alias processing", function()
 
     end)
 
+    describe("runaway recursion", function()
+
+        it("stops an alias that keeps expanding into itself", function()
+            local fired = 0
+            local id = tempAlias("^expand_into_myself$", function()
+                fired = fired + 1
+                expandAlias("expand_into_myself", false)
+            end)
+            local sends = 0
+            local handler = registerAnonymousEventHandler("sysDataSendRequest", function(_, command)
+                if command == "expand_into_myself" then
+                    sends = sends + 1
+                end
+            end)
+
+            expandAlias("expand_into_myself", false)
+
+            killAnonymousEventHandler(handler)
+            assert.is_true(killAlias(id), "a temporary alias should be removable by id")
+            -- One run per level; the call past the cap is refused instead of matched
+            assert.are.equal(50, fired)
+            assert.are.equal(1, sends, "the call past the cap should go to the game once, unexpanded")
+        end)
+
+        -- The "command" field of an alias is sent as if typed, so one that
+        -- matches its own pattern recurses without any Lua in between
+        it("stops an alias whose command matches itself", function()
+            if not os.getenv("MUDLET_TEST_MODE") then
+                pending("uninstalling the fixture needs pumpEvents(), which does nothing outside MUDLET_TEST_MODE")
+                return
+            end
+            local path = getMudletHomeDir() .. "/alias-runaway-command.xml"
+            finally(function()
+                -- uninstallPackage() refuses while the profile save the install
+                -- started is still running
+                local removed = false
+                for _ = 1, 100 do
+                    if uninstallPackage("alias-runaway-command") == true then
+                        removed = true
+                        break
+                    end
+                    pumpEvents(50)
+                end
+                os.remove(path)
+                -- let the save the uninstall queues run now rather than during
+                -- the next spec
+                pumpEvents(200)
+                assert.is_true(removed, "could not uninstall the runaway alias package")
+            end)
+            local file = assert(io.open(path, "w"))
+            file:write([[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE MudletPackage>
+<MudletPackage version="1.001">
+	<TriggerPackage />
+	<TimerPackage />
+	<AliasPackage>
+		<Alias isActive="yes" isFolder="no">
+			<name>runaway_command_alias</name>
+			<script></script>
+			<command>runaway_command</command>
+			<packageName></packageName>
+			<regex>^runaway_command$</regex>
+		</Alias>
+	</AliasPackage>
+	<ActionPackage />
+	<ScriptPackage />
+	<KeyPackage />
+	<VariablePackage>
+		<HiddenVariables />
+	</VariablePackage>
+</MudletPackage>
+]])
+            file:close()
+            assert.is_true(installPackage(path))
+
+            local mark = getLastLineNumber("main")
+            expandAlias("runaway_command", false)
+
+            local stopped = false
+            for _, line in ipairs(getLines("main", mark, getLastLineNumber("main") + 1)) do
+                if line:find('Alias processing stopped to prevent a crash: "runaway_command"', 1, true) then
+                    stopped = true
+                end
+            end
+            assert.is_true(stopped, "the runaway alias was not reported on the main console")
+        end)
+
+    end)
+
     -- Test for nested alias processing with self-deletion (GitHub issue #8817)
     -- This verifies the fix that uses mProcessingDepth counter instead of a bool flag
     --


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Alias expansion now stops after 50 nested levels and posts an error to the profile's window naming the command that kept matching, instead of recursing until the stack runs out. The command past the cap goes to the game unexpanded.

#### Motivation for adding to Mudlet
An alias whose command field, or whose script's `expandAlias()` call, matches its own pattern re-enters the alias engine indefinitely. The Lua route dies with a "C stack overflow" error, but the command-field route has no bound at all and crashes the client. The message tells the user which command looped and how to fix the alias.

Sentry: MUDLET-72.

#### Other info (issues closed, discussion etc)

Closes #10450.

**Test case:** two new cases in `Alias_spec.lua`: a `tempAlias` that calls `expandAlias()` on itself (asserts exactly 50 runs and a single send past the cap), and a package-installed alias whose command field matches its own pattern, the route with no Lua in between. On the unfixed binary the first errors with a C stack overflow and the second crashes the process.

Assisted-by: Claude:claude-fable-5-1