### PR TITLE
Fix: Crash draining a large compressed read on Windows

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1120,8 +1120,8 @@ int TLuaInterpreter::feedTelnet(lua_State* L)
         return 2;
     }
 
-    // Same self-feeding-loop guard as feedTriggers(), but each nested telnet
-    // processing frame is large - see scmMaxLoopbackProcessingDepth.
+    // Same self-feeding-loop guard as feedTriggers(); the lower cap is
+    // explained at scmMaxLoopbackProcessingDepth.
     if (host.mTelnet.loopbackProcessingDepth() >= cTelnet::scmMaxLoopbackProcessingDepth) {
         qWarning().nospace() << "TLuaInterpreter::feedTelnet(...) aborting: nested telnet data processing reached the limit of " << cTelnet::scmMaxLoopbackProcessingDepth
                              << " - probably an endless feedTelnet loop.";

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -67,6 +67,8 @@
 #include <QSslError>
 #include <QtGlobal>
 
+#include <memory>
+
 using namespace std::chrono_literals;
 
 constexpr int AUTO_LOGIN_USERNAME_DELAY_MS = 2000;
@@ -280,10 +282,10 @@ cTelnet::~cTelnet()
         mpPostingTimer->stop();
     }
 
-    // Release zlib resources if MCCP compression was still active
-    if (mNeedDecompression) {
-        inflateEnd(&mZstream);
-    }
+    // Unconditional: the end of a compressed stream re-initialises the stream
+    // for the next one while switching decompression off, so the state to free
+    // exists whether or not compression is active
+    inflateEnd(&mZstream);
 
     // Aggressively disconnect the sockets to prevent signals during destruction
     if (mpSocket && mpSocket->state() != QAbstractSocket::UnconnectedState) {
@@ -997,9 +999,7 @@ void cTelnet::slot_socketDisconnected()
  the rules of the "QDateTime::toString(...)" function and may need
  modification for some locales, e.g. France, Spain.*/
                                              .toString(tr("hh:mm:ss.zzz")));
-    if (mNeedDecompression) {
-        inflateEnd(&mZstream);
-    }
+    inflateEnd(&mZstream);
     mNeedDecompression = false;
     reset();
 
@@ -5493,10 +5493,9 @@ void cTelnet::readPendingSocketData()
 
 void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopbackTesting)
 {
-    // Guard against deep re-entry when draining leftover (de)compressed data -
-    // each level allocates ~100 KB on the stack for out_buffer. Per-connection
-    // (a member, not thread-wide) so one profile's drain - or a re-entrant
-    // feedTelnet() - cannot spend another connection's budget.
+    // The cap that bounds a decompression bomb (see scmMaxDecompressionRecursion)
+    // is per-connection - a member, not thread-wide - so one profile's drain, or
+    // a re-entrant feedTelnet(), cannot spend another connection's budget.
     // Being a member, a level leaked by an early return would be permanent:
     // scmMaxDecompressionRecursion of them and the connection refuses all further
     // data, so the count comes off in a guard rather than at each return.
@@ -5515,8 +5514,11 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
         return;
     }
 
-    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (3 of 7) - investigate switching from using `char[]` to `std::array<char>`
-    char out_buffer[BUFFER_SIZE + 10];
+    // On the heap: the drain at the end re-enters this function once per
+    // output buffer, and nine 100 KB frames do not fit in the 1 MB main-thread
+    // stack Windows builds get. The frame is reserved in the prologue, so even
+    // the level the cap refuses pays for one.
+    const std::unique_ptr<char[]> out_buffer(new char[BUFFER_SIZE + 10]);
 
     // read() reports -1 on error and 0 when nothing was available; loopbackTest()
     // narrows a qsizetype into this int, so treat every non-positive value the
@@ -5541,8 +5543,8 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
     int remainingAmount = 0;
 
     if (mNeedDecompression) {
-        datalen = decompressBuffer(in_buffer, amount, out_buffer);
-        buffer = out_buffer;
+        datalen = decompressBuffer(in_buffer, amount, out_buffer.get());
+        buffer = out_buffer.get();
         // decompressBuffer() only fills one output buffer per call and drops
         // out of compression on stream end or a broken stream. Anything it did
         // not consume - more compressed data, or plain data past the stream -
@@ -5668,7 +5670,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
                             int restLength = datalen - i - 3;
 
                             if (restLength > 0) {
-                                datalen = decompressBuffer(buffer, restLength, out_buffer);
+                                datalen = decompressBuffer(buffer, restLength, out_buffer.get());
                                 // queue input left over past this compressed chunk
                                 // (decompressBuffer() advanced 'buffer' to it) for
                                 // reprocessing at the end of this pass
@@ -5676,7 +5678,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
                                     remainingData = buffer;
                                     remainingAmount = restLength;
                                 }
-                                buffer = out_buffer;
+                                buffer = out_buffer.get();
                                 i = -1; // start processing buffer from the beginning.
                             } else {
                                 datalen = 0;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -253,16 +253,16 @@ public:
         processSocketData(data.data(), data.size(), true);
     }
     int loopbackProcessingDepth() const { return mLoopbackProcessingDepth; }
-    // Each nested processSocketData() puts ~100KB of buffers on the stack, so a
-    // self-feeding feedTelnet() loop overflows a 1MB (Windows) stack in only ~8
-    // levels - hence a much lower cap than TriggerUnit::scmMaxProcessingDepth.
+    // Every feedTelnet() level nests inside processSocketData(), so it also
+    // counts against scmMaxDecompressionRecursion; keep this below it, or a
+    // runaway loop reports as dropped data instead of the trigger-named Lua error.
     inline static const int scmMaxLoopbackProcessingDepth = 5;
-    // How many times processSocketData() may re-enter itself to drain data left
-    // over after a decompression pass (compressed input that did not fit in one
+    // How deep processSocketData() may nest (the outermost call counts as one)
+    // while draining data left over after a decompression pass (compressed input that did not fit in one
     // output buffer, or plain data following the compressed stream). Each level
-    // puts ~100 KB (out_buffer) on the stack, so this also caps decompressed
-    // output at ~scmMaxDecompressionRecursion * BUFFER_SIZE per socket read,
-    // which bounds a decompression bomb.
+    // inflates at most one output buffer, so this caps decompressed output at
+    // ~scmMaxDecompressionRecursion * BUFFER_SIZE per socket read, which bounds
+    // a decompression bomb.
     inline static const int scmMaxDecompressionRecursion = 8;
     void cancelLoginTimers();
     void terminateConnection();

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -40,6 +40,7 @@
  * Run with: ctest -R cTelnetBufferTest -V
  */
 
+#include <QFile>
 #include <QFileInfo>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
@@ -49,6 +50,10 @@
 #include <chrono>
 #include <cstring>
 #include <memory>
+
+#if defined(Q_OS_LINUX)
+#include <sys/resource.h>
+#endif
 
 #include "PortableModeTestHelper.h"
 #include "ProfileTestHelper.h"
@@ -92,6 +97,30 @@ private:
         }
         return false;
     }
+
+#if defined(Q_OS_LINUX)
+    // Bytes between the top of the main thread's stack mapping and this frame,
+    // which is the distance the kernel holds against RLIMIT_STACK when the
+    // stack grows. The frame address rather than a local's: under
+    // AddressSanitizer a local can live on the fake stack, off in the heap.
+    static qint64 mainThreadStackInUse()
+    {
+        QFile maps(qsl("/proc/self/maps"));
+        if (!maps.open(QIODevice::ReadOnly)) {
+            return -1;
+        }
+        const auto here = reinterpret_cast<quintptr>(__builtin_frame_address(0));
+        for (const QByteArray& line : maps.readAll().split('\n')) {
+            if (!line.endsWith("[stack]")) {
+                continue;
+            }
+            const QByteArray range = line.left(line.indexOf(' '));
+            const quintptr top = range.mid(range.indexOf('-') + 1).toULongLong(nullptr, 16);
+            return static_cast<qint64>(top - here);
+        }
+        return -1;
+    }
+#endif
 
 private slots:
     void initTestCase()
@@ -146,7 +175,11 @@ private slots:
         QCOMPARE(mpHost->mTelnet.mDecompressionRecursionDepth, 0);
     }
 
-    void cleanup() { QCOMPARE(mpHost->mTelnet.mDecompressionRecursionDepth, 0); }
+    void cleanup()
+    {
+        QCOMPARE(mpHost->mTelnet.mDecompressionRecursionDepth, 0);
+        QVERIFY(!mpHost->mTelnet.mNeedDecompression);
+    }
 
     // The regression test for #1065. processSocketData() is handed `payloadSize`
     // bytes inside a buffer that has two spare bytes after them. It may write
@@ -312,6 +345,64 @@ private slots:
                                             .arg(wasRefused ? qsl("dropped") : qsl("processed"))));
             }
         }
+    }
+
+    // Windows builds give the main thread 1 MB of stack, and a compressed read
+    // that inflates past one output buffer drains the rest by re-entering
+    // processSocketData(), so an eight-level drain must not cost a 100 KB frame
+    // per level. Linux enforces RLIMIT_STACK as the main thread grows and
+    // exposes the mapping in /proc, so here the drain gets 700 KB of growth and
+    // a per-level frame overflows it. Elsewhere the drain runs against the real
+    // limit, which eight levels fit in, so Linux is the arm that bites.
+    void deepDecompressionDrainDoesNotGrowTheStack()
+    {
+#if defined(Q_OS_LINUX)
+        rlimit original{};
+        QCOMPARE(getrlimit(RLIMIT_STACK, &original), 0);
+        const auto restoreLimit = qScopeGuard([original] {
+            setrlimit(RLIMIT_STACK, &original);
+        });
+        const qint64 inUse = mainThreadStackInUse();
+        QVERIFY2(inUse > 0, "could not read the main thread's stack mapping");
+        rlimit ceiling = original;
+        ceiling.rlim_cur = static_cast<rlim_t>(inUse) + 700 * 1024;
+        if (original.rlim_max != RLIM_INFINITY && ceiling.rlim_cur > original.rlim_max) {
+            QSKIP("the hard stack limit is below the ceiling this test needs");
+        }
+        QCOMPARE(setrlimit(RLIMIT_STACK, &ceiling), 0);
+#endif
+        // A drain that stops short leaves decompression switched on, and the
+        // tests that follow would then be inflated as zlib data
+        const auto resetDecompression = qScopeGuard([this] {
+            if (mpHost->mTelnet.mNeedDecompression) {
+                inflateEnd(&mpHost->mTelnet.mZstream);
+                mpHost->mTelnet.mNeedDecompression = false;
+                mpHost->mTelnet.initStreamDecompressor();
+            }
+        });
+        // Eight output buffers' worth, stopping just short of filling the last
+        // so the stream ends inside the eighth level and leaves decompression
+        // switched off for the tests that follow.
+        constexpr qsizetype outputBufferSize = 100000; // BUFFER_SIZE in ctelnet.cpp
+        const QByteArray line = QByteArray("mccp drain ").append(87, 'x').append("\r\n");
+        QByteArray text;
+        text.reserve(8 * outputBufferSize);
+        while (text.size() + line.size() <= 8 * outputBufferSize - 10) {
+            text.append(line);
+        }
+        // qCompress() prefixes the zlib stream with the source length
+        const QByteArray compressed = qCompress(text, 9).mid(4);
+        // One socket read's worth, as readPendingSocketData() hands over
+        QVERIFY(compressed.size() < outputBufferSize);
+        QByteArray backing = compressed;
+        backing.append(scmTerminatorSlot);
+
+        mpHost->mTelnet.mNeedDecompression = true;
+        mpHost->mTelnet.initStreamDecompressor();
+        mpHost->mTelnet.processSocketData(backing.data(), static_cast<int>(compressed.size()), true);
+
+        QVERIFY2(!mpHost->mTelnet.mNeedDecompression, "the compressed stream's end was not reached, so the drain stopped short");
+        QVERIFY(bufferContains(qsl("mccp drain")));
     }
 
     // Declared last on purpose: on the unfixed code this trips AddressSanitizer,


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`cTelnet::processSocketData()` keeps its 100 KB decompression output buffer on the heap instead of the stack. It also frees zlib's stream state in the destructor and on disconnect unconditionally: the end of a compressed stream re-initialises that state while switching decompression off, so the old guard left it to leak.

#### Motivation for adding to Mudlet
A compressed (MCCP) read that inflates past one output buffer drains the rest by re-entering `processSocketData()`, and each level put another 100 KB on the stack. Windows builds give the main thread 1 MB, so the ninth level faulted in the stack probe and crashed the client mid-session.

Sentry: MUDLET-70.

#### Other info (issues closed, discussion etc)

Closes #10451.

**Test case:** `cTelnetBufferTest::deepDecompressionDrainDoesNotGrowTheStack` feeds an eight-level compressed read. On Linux it first lowers `RLIMIT_STACK` to 700 KB of growth, so a per-level stack buffer overflows it (SegFault on the unfixed code) and the heap buffer does not. Elsewhere the drain runs against the real limit.

The "(3 of 7)" TODO from #5780 "ToDo from PR: #5776 - investigate switching from using `char[]` to `std::array<char>`" goes with the stack buffer; the other six keep their numbering.

Assisted-by: Claude:claude-fable-5-1