### PR TITLE
Infra: Add specs for the Lua string, table, date and debug modules

### DIFF
--- a/src/mudlet-lua/tests/CursorShapes_spec.lua
+++ b/src/mudlet-lua/tests/CursorShapes_spec.lua
@@ -1,0 +1,59 @@
+describe("Tests CursorShapes.lua", function()
+  local labelName = "cursorShapesSpecLabel"
+
+  setup(function()
+    createLabel(labelName, 0, 0, 20, 20, 1)
+    hideWindow(labelName)
+  end)
+
+  teardown(function()
+    deleteLabel(labelName)
+  end)
+
+  describe("Tests the contract of mudlet.cursor", function()
+    it("Should give every shape a value the C++ label layer accepts", function()
+      -- the numbers are Qt::CursorShape and TMainConsole::setLabelCursor range
+      -- checks them, so one copied in from a newer Qt looks usable but is refused
+      local checked = 0
+      for name, shape in pairs(mudlet.cursor) do
+        checked = checked + 1
+        assert.is_true(setLabelCursor(labelName, shape), ("mudlet.cursor.%s (%s) was refused"):format(name, tostring(shape)))
+      end
+      assert.is_true(checked >= 23, "every documented cursor shape should still be in the table")
+    end)
+
+    it("Should be refused for a shape outside the range the C++ layer knows", function()
+      -- pairs with the assertion above: without it, a layer that accepted
+      -- anything at all would make that loop pass no matter what is in the table
+      local ok, err = setLabelCursor(labelName, 22)
+      assert.is_nil(ok)
+      assert.is_string(err)
+      ok, err = setLabelCursor(labelName, -2)
+      assert.is_nil(ok)
+      assert.is_string(err)
+    end)
+
+    it("Should accept every shape by its name as well as by its number", function()
+      -- nothing reads a label's cursor back, so this can only show the name was
+      -- accepted, not which shape it landed on
+      for name, shape in pairs(mudlet.cursor) do
+        assert.is_true(setLabelCursor(labelName, name), ("the name %q was refused"):format(name))
+        assert.equals("number", type(shape))
+      end
+    end)
+
+    it("Should not give two names the same shape", function()
+      local seen = {}
+      for name, shape in pairs(mudlet.cursor) do
+        assert.is_nil(seen[shape], ("%s and %s both map to shape %s"):format(tostring(seen[shape]), name, tostring(shape)))
+        seen[shape] = name
+      end
+    end)
+
+    it("Should reset through the value resetLabelCursor asks the C++ layer for", function()
+      assert.equals(-1, mudlet.cursor.Reset)
+      assert.is_true(setLabelCursor(labelName, "OpenHand"))
+      assert.is_true(resetLabelCursor(labelName))
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/DateTime_spec.lua
+++ b/src/mudlet-lua/tests/DateTime_spec.lua
@@ -23,6 +23,26 @@ describe("Tests DateTime.lua functions", function()
       _G.cecho = _G.oldcecho
       _G.oldcecho = nil
     end)
+
+    it("should raise its documented assertion for something that is not a number", function()
+      local message = "Please supply a valid number"
+      assert.error_matches(function() shms("not a number") end, message)
+      assert.error_matches(function() shms(nil) end, message)
+      assert.error_matches(function() shms({}) end, message)
+    end)
+
+    it("should accept a number written as a string", function()
+      assert.are.same({'01', '32', '15'}, {shms("5535")})
+    end)
+
+    it("should keep counting hours past 24 rather than wrapping to a new day", function()
+      -- an uptime or a fight timer is not a clock, so 25 hours has to stay 25
+      assert.are.same({'25', '01', '01'}, {shms(90061)})
+    end)
+
+    it("should truncate a fractional second rather than rounding it up", function()
+      assert.are.same({'00', '01', '01'}, {shms(61.9)})
+    end)
   end)
 
   describe("Tests datetime:parse", function()
@@ -118,6 +138,10 @@ describe("Tests DateTime.lua functions", function()
       assert.are.equal(30, back.min)
       assert.are.equal(45, back.sec)
     end)
+
+    -- the isdst lookup calls os.time() on the half built date table before
+    -- anything has checked that the format supplied a day
+    pending("datetime:parse handles a format with no date part - '05:06:07' with '^%H:%M:%S$' raises \"field 'day' missing in date table\" - issue #10415")
   end)
 
   describe("Tests datetime:parse round-trips with string formatting", function()
@@ -165,6 +189,28 @@ describe("Tests DateTime.lua functions", function()
       local p = datetime:_get_pattern(fmt)
       assert.is_not_nil(p:tfind("2025-06-15"))
       assert.is_nil(p:tfind("not-a-date"))
+    end)
+
+    it("passes a directive it does not know through as a literal", function()
+      -- %Z is not in _directives, so it stays in the regex as the two characters
+      -- it is written with rather than becoming a capture group
+      local fmt = "^%Z$"
+      datetime._pattern_cache[fmt] = nil
+      local p = datetime:_get_pattern(fmt)
+      assert.is_not_nil(p:tfind("%Z"))
+      assert.is_nil(p:tfind("Z"))
+      datetime._pattern_cache[fmt] = nil
+    end)
+
+    it("compiles a format only once and hands the same pattern back", function()
+      local fmt = "^dateTimeSpecUncachedFormat %Y$"
+      datetime._pattern_cache[fmt] = nil
+      local before = table.size(datetime._pattern_cache)
+      local first = datetime:_get_pattern(fmt)
+      assert.equals(before + 1, table.size(datetime._pattern_cache))
+      assert.equals(first, datetime:_get_pattern(fmt))
+      assert.equals(before + 1, table.size(datetime._pattern_cache))
+      datetime._pattern_cache[fmt] = nil
     end)
   end)
 

--- a/src/mudlet-lua/tests/DebugTools_spec.lua
+++ b/src/mudlet-lua/tests/DebugTools_spec.lua
@@ -1,4 +1,13 @@
 describe("Tests DebugTools.lua functions", function()
+  describe("Tests the functionality of prettywrite", function()
+    it("Should still format the way inspect does", function()
+      -- prettywrite is the old name for inspect, kept for old scripts; nothing
+      -- inside Mudlet calls it, so nothing else would notice it drifting
+      assert.equals(inspect({1, 2}), prettywrite({1, 2}))
+      assert.equals(inspect({a = {b = 1}}), prettywrite({a = {b = 1}}))
+    end)
+  end)
+
   describe("Tests the functionality of printDebug", function()
     local s
     before_each(function()
@@ -127,6 +136,11 @@ describe("Tests DebugTools.lua functions", function()
       assert.is_truthy(nilAt)
       assert.is_truthy(after)
       assert.is_true(before < nilAt and nilAt < after, "the nil should keep its place between the two strings")
+    end)
+
+    it("Should return nothing, so its result cannot be echoed by accident", function()
+      assert.equals(0, select("#", display("hello")))
+      assert.equals(0, select("#", display("one", "two")))
     end)
   end)
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -435,6 +435,51 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
   end)
 
+  describe("Tests the functionality of copy2html", function()
+    local windowName = "guiUtilsCopyHtmlBuffer"
+
+    setup(function()
+      createBuffer(windowName)
+    end)
+
+    teardown(function()
+      deleteMiniConsole(windowName)
+    end)
+
+    before_each(function()
+      clearWindow(windowName)
+      setFgColor(windowName, 255, 0, 0)
+      setBgColor(windowName, 0, 0, 0)
+      echo(windowName, "a<b&c\n")
+      moveCursor(windowName, 0, 0)
+    end)
+
+    it("Should wrap the line in a span carrying its foreground and background", function()
+      local html = copy2html(windowName)
+      assert.is_truthy(html:find("color: rgb(255,0,0)", 1, true), html)
+      assert.is_truthy(html:find("background: rgb(0,0,0)", 1, true), html)
+      assert.is_truthy(html:find("</span>", 1, true), html)
+    end)
+
+    it("Should escape the characters that would otherwise be markup", function()
+      -- a < in game text must not open a tag, which is why copy2html exists
+      -- rather than callers running copy2decho and swapping the tags
+      local html = copy2html(windowName)
+      assert.is_truthy(html:find("a&lt;b&amp;c", 1, true), html)
+      assert.is_falsy(html:find("a<b&c", 1, true), html)
+      -- copy2decho reads the same line and leaves those characters alone
+      assert.is_truthy(copy2decho(windowName):find("a<b&c", 1, true))
+    end)
+
+    it("Should copy only the substring it was asked for", function()
+      assert.is_truthy(copy2html(windowName, "b&c"):find(">b&amp;c<", 1, true))
+    end)
+
+    it("Should return an empty string for text that is not on the current line", function()
+      assert.equals("", copy2html(windowName, "not on this line"))
+    end)
+  end)
+
   describe("Tests the functionality of _Echoes.Process", function()
     it("Should parse hex patterns correctly", function()
       assert.are.same(

--- a/src/mudlet-lua/tests/LuaGlobal_spec.lua
+++ b/src/mudlet-lua/tests/LuaGlobal_spec.lua
@@ -1,0 +1,89 @@
+describe("Tests LuaGlobal.lua functions", function()
+
+  describe("Tests the functionality of json_to_value", function()
+    it("Should decode an object into a table keyed by its member names", function()
+      local decoded = json_to_value('{"name":"Vadi","level":42,"online":true}')
+      assert.equals("table", type(decoded))
+      assert.equals("Vadi", decoded.name)
+      assert.equals(42, decoded.level)
+      assert.is_true(decoded.online)
+    end)
+
+    it("Should decode an array into a 1-based sequence", function()
+      local decoded = json_to_value('["a","b","c"]')
+      assert.equals(3, #decoded)
+      assert.equals("a", decoded[1])
+      assert.equals("c", decoded[3])
+    end)
+
+    it("Should decode nested objects and arrays", function()
+      local decoded = json_to_value('{"room":{"exits":["n","s"],"num":1234}}')
+      assert.equals(1234, decoded.room.num)
+      assert.equals("n", decoded.room.exits[1])
+      assert.equals("s", decoded.room.exits[2])
+    end)
+
+    it("Should keep a key whose value is JSON null", function()
+      -- GMCP servers use null to say "this field is now unset"; dropping the key
+      -- instead would leave the previous value in place after a table update
+      local decoded = json_to_value('{"target":null}')
+      assert.equals("target", next(decoded))
+      assert.is_not_nil(decoded.target)
+      assert.equals(1, table.size(decoded))
+    end)
+
+    it("Should decode an empty object and an empty array to empty tables", function()
+      assert.equals("table", type(json_to_value('{}')))
+      assert.equals("table", type(json_to_value('[]')))
+      assert.is_nil(next(json_to_value('{}')))
+      assert.is_nil(next(json_to_value('[]')))
+    end)
+
+    it("Should decode \\u escapes into UTF-8", function()
+      local decoded = json_to_value('{"who":"caf\\u00e9"}')
+      assert.equals("café", decoded.who)
+      -- five bytes for four characters: the escape became UTF-8, not a codepoint
+      assert.equals(4, utf8.len(decoded.who))
+      assert.equals(5, #decoded.who)
+    end)
+
+    it("Should raise on input that is not JSON", function()
+      assert.has_error(function() json_to_value('{oops}') end)
+    end)
+  end)
+
+  describe("Tests the functionality of unzip", function()
+    it("Should report a missing archive rather than raising", function()
+      local home = getMudletHomeDir()
+      local echoed
+      local originalCecho = _G.cecho
+      _G.cecho = function(text) echoed = text end
+      finally(function() _G.cecho = originalCecho end)
+      local ok, err = pcall(unzip, home .. "/luaGlobalSpecNoSuchArchive.zip", home .. "/")
+      assert.is_true(ok, tostring(err))
+      assert.is_string(echoed)
+      assert.is_truthy(echoed:find("error unpacking", 1, true))
+    end)
+
+    -- TLuaInterpreter loads the brimworks lua-zip rock as 'zip' and only falls
+    -- back to luazip, but unzip() is written against luazip's z:files() iterator
+    pending("unzip extracts an archive's files and directories - against the lua-zip binding it raises \"attempt to call method 'files'\" - issue #10184")
+  end)
+
+  describe("Tests the globals LuaGlobal.lua seeds", function()
+    it("Should still have gmcp and mssp as tables once every package has loaded", function()
+      -- the protocol handlers index straight into these, so a package loaded
+      -- after this line shadowing either name breaks GMCP for the whole profile
+      assert.equals("table", type(gmcp))
+      assert.equals("table", type(mssp))
+    end)
+
+    it("Should record where the Lua library was loaded from", function()
+      -- the packages list is dofile'd off this path, so a wrong value here means
+      -- the profile ran a different copy of mudlet-lua than the one it reports
+      assert.is_string(luaGlobalPath)
+      assert.is_truthy(lfs.attributes(luaGlobalPath .. "/LuaGlobal.lua"))
+      assert.is_truthy(lfs.attributes(nativeLuaGlobalPath .. "/LuaGlobal.lua"))
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -20,6 +20,11 @@ describe("Tests StringUtils.lua functions", function()
       actualLength = actual:len()
       assert.equals(expectedLength, actualLength)
     end)
+
+    it("should return an empty string when asked for no characters at all", function()
+      assert.equals("", ("This is a test"):cut(0))
+      assert.equals("", (""):cut(0))
+    end)
   end)
 
   describe("Tests the functionality of string.enclose", function()
@@ -47,6 +52,14 @@ describe("Tests StringUtils.lua functions", function()
       local s = "[=[[[This is a test]]]=]"
       local errfn = function() string.enclose(s,1) end
       assert.has_error(errfn, "error: maxlevel too low, 1")
+    end)
+
+    it("should need a maxlevel above the level it actually settles on", function()
+      -- the ceiling is checked before the level is tried, so a string that needs
+      -- one = still fails at maxlevel 1 and only succeeds from 2 upwards
+      assert.has_error(function() string.enclose("[[x]]", 1) end, "error: maxlevel too low, 1")
+      assert.equals("[=[[[x]]]=]", string.enclose("[[x]]", 2))
+      assert.has_error(function() string.enclose("plain", 0) end, "error: maxlevel too low, 0")
     end)
   end)
 
@@ -89,6 +102,20 @@ describe("Tests StringUtils.lua functions", function()
       local str = "123abc"
       local pattern = string.genNocasePattern(str)
       assert.is_truthy(str:find(pattern))
+    end)
+
+    it("should return only the pattern, not gsub's replacement count", function()
+      -- returning gsub directly would hand a second value to every caller, and
+      -- string.format("%s", str:genNocasePattern()) would still look right
+      assert.equals(1, select("#", ("abc"):genNocasePattern()))
+    end)
+
+    it("should leave bytes that are not ASCII letters alone", function()
+      -- %a is byte-wise, so the two bytes of á cannot be case-folded and have to
+      -- survive untouched or the pattern stops matching its own source string
+      local pattern = ("ábc"):genNocasePattern()
+      assert.equals("á[bB][cC]", pattern)
+      assert.is_truthy(("ábc"):find(pattern))
     end)
   end)
 
@@ -215,6 +242,15 @@ describe("Tests StringUtils.lua functions", function()
     it("should leave a string that does not start with a lowercase letter unchanged", function()
       assert.equals("123abc", string.title("123abc"))
     end)
+
+    it("should return only the titled string, not gsub's replacement count", function()
+      assert.equals(1, select("#", ("abc"):title()))
+      assert.equals(1, select("#", ("Abc"):title()))
+    end)
+
+    it("should only capitalise the first letter, not every word", function()
+      assert.equals("This is a test", ("this is a test"):title())
+    end)
   end)
 
   describe("Tests the functionality of string.trim", function()
@@ -242,6 +278,16 @@ describe("Tests StringUtils.lua functions", function()
 
     it("should strip leading and trailing tabs and newlines, not just spaces", function()
       assert.equals("this is a test", ("\t\n  this is a test \n\t"):trim())
+    end)
+
+    it("should leave whitespace inside the string alone", function()
+      assert.equals("a  b", ("  a  b  "):trim())
+      assert.equals("", ("   "):trim())
+    end)
+
+    it("should return only the trimmed string, not gsub's replacement count", function()
+      assert.equals(1, select("#", ("  a  "):trim()))
+      assert.equals(1, select("#", ("a"):trim()))
     end)
   end)
 
@@ -362,6 +408,26 @@ describe("Tests StringUtils.lua functions", function()
 
     it("should error when passed in anything but a string", function()
       assert.has_error(function() f(true) end, "f: bad argument #1 type (str as string expected, got boolean)")
+    end)
+
+    it("should raise the compile error of an expression that is not valid Lua", function()
+      -- swallowing this would silently drop the whole interpolation from the
+      -- string, which is far harder to notice than a raised error
+      assert.error_matches(function() f("{1+}") end, "unexpected symbol")
+      assert.error_matches(function() f("{ this is not lua }") end, "expected near")
+    end)
+
+    it("should interpolate a global and render a missing name as nil", function()
+      _G.stringUtilsSpecGlobal = "seen"
+      local interpolated = f("a {stringUtilsSpecGlobal} b")
+      _G.stringUtilsSpecGlobal = nil
+      assert.equals("a seen b", interpolated)
+      assert.equals("nil", f("{stringUtilsSpecGlobal}"))
+    end)
+
+    it("should not treat % as a format directive", function()
+      assert.equals("100% sure", f("100% sure"))
+      assert.equals("50% of 4 is 2", f("50% of 4 is {4/2}"))
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -644,6 +644,19 @@ describe("Tests TableUtils.lua functions", function()
       }
       assert.equals(nil, table.index_of(tbl, 5))
     end)
+
+    it("should only search the array part, so a hash value is not found", function()
+      -- it walks with ipairs, so there is no index it could return for a keyed
+      -- entry; table.contains is the function that finds those
+      assert.is_nil(table.index_of({name = "found me"}, "found me"))
+      assert.is_true(table.contains({name = "found me"}, "found me"))
+    end)
+
+    it("should stop at the first nil, so entries past a hole are not found", function()
+      local sparse = {"one", nil, "three"}
+      assert.equals(1, table.index_of(sparse, "one"))
+      assert.is_nil(table.index_of(sparse, "three"))
+    end)
   end)
 
   describe("Tests the functionality of table.deepcopy", function()
@@ -924,6 +937,30 @@ describe("Tests TableUtils.lua functions", function()
       local actual = table.update(tblA, tblB)
       assert.same(expected, actual)
     end)
+
+    it("should return a new table and leave both arguments as they were", function()
+      -- the name reads like an in-place update, so callers that rely on it
+      -- returning a copy would be broken by a well meant optimisation
+      local tblA = {a = 1}
+      local tblB = {b = 2}
+      local actual = table.update(tblA, tblB)
+      assert.are_not.equal(tblA, actual)
+      assert.are_not.equal(tblB, actual)
+      assert.same({a = 1}, tblA)
+      assert.same({b = 2}, tblB)
+      actual.c = 3
+      assert.is_nil(tblA.c)
+      assert.is_nil(tblB.c)
+    end)
+
+    it("should merge nested tables into a new table rather than into tblA's", function()
+      local tblA = {nested = {a = 1}}
+      local tblB = {nested = {b = 2}}
+      local actual = table.update(tblA, tblB)
+      assert.same({a = 1, b = 2}, actual.nested)
+      assert.same({a = 1}, tblA.nested)
+      assert.are_not.equal(tblA.nested, actual.nested)
+    end)
   end)
 
   describe("Tests the functionality of table.deepcopy nested independence", function()
@@ -951,6 +988,18 @@ describe("Tests TableUtils.lua functions", function()
       assert.equals(5, table.deepcopy(5))
       assert.equals("text", table.deepcopy("text"))
     end)
+
+    it("should preserve the metatable of a nested table too", function()
+      local mt = {__index = function() return "inherited" end}
+      local original = {inner = setmetatable({}, mt)}
+      local copy = table.deepcopy(original)
+      assert.are_not.equal(original.inner, copy.inner)
+      assert.equals(mt, getmetatable(copy.inner))
+      assert.equals("inherited", copy.inner.anything)
+    end)
+
+    -- table._contains guards against this with a "seen" set; deepcopy has none
+    pending("table.deepcopy copies a table that reaches itself - it recurses until the Lua stack overflows - issue #10414")
   end)
 
   describe("Tests the functionality of spairs on an empty table", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds busted specs for the Lua-side modules that had little or no coverage, taking the suite from **4019 to 4062 successes** (+43 `it()`, +3 `pending()`, 0 failures, 0 errors).

New files:
- `CursorShapes_spec.lua` - pins `mudlet.cursor` against the range `TMainConsole::setLabelCursor` actually accepts, so a shape copied in from a newer Qt is caught here rather than at the point of use.
- `LuaGlobal_spec.lua` - the json decoding contract, the `gmcp`/`mssp` tables the protocol handlers index straight into, and the package path the profile dofiles.

Extended: `StringUtils_spec.lua`, `TableUtils_spec.lua`, `DateTime_spec.lua`, `GUIUtils_spec.lua`, `DebugTools_spec.lua` - `string.cut`/`enclose`/`genNocasePattern`/`title`/`trim`, f-string interpolation, `shms`, `_get_pattern`, `table.index_of`/`deepcopy`/`update`, `copy2html`/`copy2decho`, and `display`.

#### Motivation for adding to Mudlet

These modules are pure Lua that every profile loads, and several of them had no spec at all. Specs cost nothing to run (no rebuild - `mudlet-lua` loads from disk) and are shared with Mudlet Web, so the coverage lands on both platforms.

Every one of the new tests was proven to bite by sabotaging the function it covers and watching that specific test go red - 24 mutations across the seven files, all restored afterwards. Four tests that survived sabotage were fixed or deleted rather than shipped green: one that could not fail under any change to the code it named, one that only restated `json_to_value = yajl.to_value`, and two more that restated assignments rather than testing behaviour.

The pending list was diffed name by name against the baseline: exactly three new entries, nothing lost, no pre-existing test changing state.

#### Other info (issues closed, discussion etc)

Three cases are parked as `pending` because the behaviour they would cover is an open bug, and a green test would cement it:
- `datetime:parse` with a time-only format raises `field 'day' missing in date table` - #10415
- `table.deepcopy` on a table that reaches itself overflows the stack - #10414
- `unzip` is written against luazip's `z:files()` but Mudlet loads the brimworks binding - #10184

Four further bugs were found while writing these and are filed with repros rather than asserted as correct:
- #10428 `string.cut()` splits multi-byte characters and returns invalid UTF-8
- #10427 `shms()` loses the hour and minute magnitude for negative second counts
- #10426 `getRGB()` still throws a raw indexing error for an unknown colour name (item 3 of the closed #2890, which #7634 fixed only for the wrong argument *type*)
- `json_to_value` returning a function for a bare number is already tracked as #10362 / #5732

Also noted while surveying: `src/mudlet-lua/lua/CoreMudlet.lua` is 1194 lines entirely inside `if false then` and is absent from `LuaGlobal.lua`'s package list, so none of it ever executes. That is deliberate rather than dead - `src/mudlet-lua/genDoc.sh` runs `ldoc .` over the whole `lua/` directory, and wrapping signatures in `if false then` is the standard idiom for giving ldoc something to document without defining the function. Recording it here only so the next person to grep for callers does not reach the conclusion I first did.
