### PR TITLE
Fix: Crash closing Mudlet while a profile is still loading

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5656,9 +5656,6 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles, const bool offline)
             }
         }
         if (!hostName.isEmpty()) {
-            if (mCloseRequestedDuringProfileLoad) {
-                return;
-            }
             QElapsedTimer timer;
             timer.start();
             doAutoLogin(hostName, offline);
@@ -5671,9 +5668,6 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles, const bool offline)
     for (auto& hostName : hostList) {
         const QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
-            if (mCloseRequestedDuringProfileLoad) {
-                return;
-            }
             QElapsedTimer timer;
             timer.start();
             doAutoLogin(hostName, offline);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -80,6 +80,7 @@
 #include <QMediaPlayer>
 #include <QMessageBox>
 #include <QPoint>
+#include <QScopeGuard>
 #include <QScreen>
 #include <QScrollBar>
 #include <QSettings>
@@ -3869,6 +3870,15 @@ void mudlet::closeEvent(QCloseEvent* event)
 {
     qDebug() << "mudlet::closeEvent(...) INFO - called!";
 
+    if (mProfileLoadsInProgress > 0) {
+        // A profile load pumps the event loop part-way through, and accepting
+        // here would delete every Host underneath the load still using one of
+        // them. Hold the close until it returns.
+        mCloseRequestedDuringProfileLoad = true;
+        event->ignore();
+        return;
+    }
+
     QStringList hostsToDestroy;
     bool abortClose = false;
     // Due to the way that Hosts are stored we cannot do a closeHost(hostName)
@@ -3940,6 +3950,19 @@ void mudlet::closeEvent(QCloseEvent* event)
     // pass the event on so dblsqd can perform an update
     // if automatic updates have been disabled
     event->accept();
+}
+
+void mudlet::endProfileLoad()
+{
+    if (--mProfileLoadsInProgress > 0 || !mCloseRequestedDuringProfileLoad) {
+        return;
+    }
+    mCloseRequestedDuringProfileLoad = false;
+    // Queued: the load's caller is still on the stack, holding a Host this
+    // close deletes
+    QTimer::singleShot(0, this, [this]() {
+        close();
+    });
 }
 
 void mudlet::forceClose()
@@ -5607,6 +5630,10 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 
 void mudlet::startAutoLogin(const QStringList& cliProfiles, const bool offline)
 {
+    ++mProfileLoadsInProgress;
+    const auto loadScope = qScopeGuard([this] {
+        endProfileLoad();
+    });
     QElapsedTimer timer;
     timer.start();
 
@@ -5629,6 +5656,9 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles, const bool offline)
             }
         }
         if (!hostName.isEmpty()) {
+            if (mCloseRequestedDuringProfileLoad) {
+                return;
+            }
             QElapsedTimer timer;
             timer.start();
             doAutoLogin(hostName, offline);
@@ -5641,6 +5671,9 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles, const bool offline)
     for (auto& hostName : hostList) {
         const QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
+            if (mCloseRequestedDuringProfileLoad) {
+                return;
+            }
             QElapsedTimer timer;
             timer.start();
             doAutoLogin(hostName, offline);
@@ -5773,6 +5806,10 @@ void mudlet::doAutoLogin(const QString& profile_name, const bool offline)
         return;
     }
 
+    ++mProfileLoadsInProgress;
+    const auto loadScope = qScopeGuard([this] {
+        endProfileLoad();
+    });
     loadProfile(profile_name, !offline);
 
     slot_connectionDialogueFinished(profile_name, !offline);
@@ -5969,6 +6006,10 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     if (!pHost) {
         return;
     }
+    ++mProfileLoadsInProgress;
+    const auto loadScope = qScopeGuard([this] {
+        endProfileLoad();
+    });
     pHost->mIsProfileLoadingSequence = true;
     // The Host instance gets its TMainConsole here:
     addConsoleForNewHost(pHost);
@@ -7112,6 +7153,10 @@ void mudlet::showChangelogIfUpdated()
 
 Host* mudlet::loadProfile(const QString& profile_name, const bool playOnline, const QString& saveFileName)
 {
+    ++mProfileLoadsInProgress;
+    const auto loadScope = qScopeGuard([this] {
+        endProfileLoad();
+    });
     Host* pHost = mHostManager.getHost(profile_name);
     if (pHost) {
         if (playOnline) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -626,6 +626,7 @@ private:
     void closeHost(const QString&);
     int getDictionaryWordCount(const QString& dictionaryPath);
     void goingDown() { mIsGoingDown = true; }
+    void endProfileLoad();
     void initEdbee();
     void installModulesList(Host*, QStringList);
     void loadMaps();
@@ -686,6 +687,9 @@ private:
     QKeySequence mKeySequencePreviousProfile;
     std::array<QKeySequence, 9> mKeySequencesSwitchToProfile;
     bool mIsGoingDown = false;
+    // A depth, not a flag: the guarded load entry points call one another
+    int mProfileLoadsInProgress = 0;
+    bool mCloseRequestedDuringProfileLoad = false;
     // Whether multi-view is in effect:
     enums::controlsVisibility mMenuBarVisibility = enums::visibleAlways;
     // Used to ensure that mudlet::slot_updateShortcuts() only runs once each

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -69,6 +69,7 @@ set(WINDOW_GROUP_TEST_SOURCES
 
 # Profiles: their config dir, their folders, and loading, saving and deleting them
 set(PROFILE_GROUP_TEST_SOURCES
+    CloseDuringProfileLoadTest.cpp
     ConfigDirOverrideTest.cpp
     ConnectionDialogCrashTest.cpp
     ConnectionDialogFocusTest.cpp

--- a/test/functional_tests/CloseDuringProfileLoadTest.cpp
+++ b/test/functional_tests/CloseDuringProfileLoadTest.cpp
@@ -1,0 +1,150 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * A close delivered from inside a profile load's event-loop pump (the close
+ * button, a desktop shutdown) must be held until the load returns, then happen
+ * on its own: accepting it there deletes every Host underneath the load still
+ * using one of them.
+ */
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+#include <QPointer>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QtTest/QtTest>
+
+class CloseDuringProfileLoadTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    const QString mProfileName = qsl("CloseDuringProfileLoad-Test");
+    const QString mSecondProfileName = qsl("CloseDuringProfileLoad-Test-2");
+    QPointer<mudlet> mWindow;
+    bool mCloseAskedFor = false;
+    bool mCloseRefused = false;
+
+    static bool provisionProfileOnDisk(const QString& name)
+    {
+        return QDir().mkpath(mudlet::getMudletPath(enums::profileHomePath, name)) && mudlet::self()->writeProfileData(name, qsl("url"), qsl("localhost")).first
+               && mudlet::self()->writeProfileData(name, qsl("port"), qsl("23")).first;
+    }
+
+    // Fires from the first event-loop pump inside a load, as the window's
+    // close button or a desktop shutdown would
+    void closeFromTheNextPump()
+    {
+        mCloseAskedFor = false;
+        mCloseRefused = false;
+        QTimer::singleShot(0, mWindow, [this]() {
+            mCloseAskedFor = true;
+            // close() reports false only when its QCloseEvent was ignored
+            mCloseRefused = !mWindow->close();
+        });
+    }
+
+    void verifyTheCloseWasHeldAndThenHappened()
+    {
+        QVERIFY2(mCloseAskedFor, "the load never pumped the event loop, so this test asked for nothing");
+        QVERIFY2(mWindow, "the main window was deleted underneath the profile load");
+        QVERIFY2(mCloseRefused, "the close was accepted in the middle of the profile load");
+        QPointer<Host> host = mWindow->getHostManager().getHost(mProfileName);
+        QVERIFY2(host, "the profile was closed in the middle of its own load");
+
+        // The held close happens on its own once the load returns; the window
+        // is WA_DeleteOnClose, so it goes on a deferred delete once accepted
+        QTRY_VERIFY2_WITH_TIMEOUT(mWindow.isNull(), "the close asked for during the load never happened", 30000);
+        QVERIFY2(host.isNull(), "the window closed but left the profile loaded");
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+    }
+
+    void cleanupTestCase() { mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg); }
+
+    // Each case lets the window close and delete itself, so each gets its own
+    void init()
+    {
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        // A settings file that already holds something is how
+        // mudletUsedBefore() recognises an existing player, which keeps the
+        // first-run UI tour and the starter UI package out of this test
+        mudlet::getQSettings()->setValue(qsl("uiTourShown"), true);
+        mudlet::getQSettings()->sync();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QVERIFY2(mudlet::self()->experiencedMudletPlayer(), "the first-run UI would open over this test");
+        mWindow = mudlet::self();
+    }
+
+    // Already null when the case let the window close; a failed case leaves it
+    void cleanup() { delete mudlet::self(); }
+
+    void test_aCloseDuringAutoLoginWaitsForTheLoadAndSkipsTheNextProfile()
+    {
+        QVERIFY(provisionProfileOnDisk(mProfileName));
+        QVERIFY(provisionProfileOnDisk(mSecondProfileName));
+        closeFromTheNextPump();
+
+        mWindow->startAutoLogin({mProfileName, mSecondProfileName}, true);
+
+        QVERIFY2(mWindow, "the main window was deleted underneath the profile load");
+        QVERIFY2(!mWindow->getHostManager().getHost(mSecondProfileName), "another profile was started after the close was asked for");
+        verifyTheCloseWasHeldAndThenHappened();
+    }
+
+    // The connection dialog loads the profile and then finishes the connection
+    // itself, with no pump between the two
+    void test_aCloseDuringAConnectionDialogLoadWaitsForTheLoad()
+    {
+        QVERIFY(provisionProfileOnDisk(mProfileName));
+        QVERIFY(mWindow->loadProfile(mProfileName, false));
+        closeFromTheNextPump();
+
+        mWindow->slot_connectionDialogueFinished(mProfileName, false);
+
+        verifyTheCloseWasHeldAndThenHappened();
+    }
+};
+
+#include "CloseDuringProfileLoadTest.moc"
+MUDLET_GROUPED_TEST_MAIN(CloseDuringProfileLoadTest)

--- a/test/functional_tests/CloseDuringProfileLoadTest.cpp
+++ b/test/functional_tests/CloseDuringProfileLoadTest.cpp
@@ -119,7 +119,7 @@ private slots:
     // Already null when the case let the window close; a failed case leaves it
     void cleanup() { delete mudlet::self(); }
 
-    void test_aCloseDuringAutoLoginWaitsForTheLoadAndSkipsTheNextProfile()
+    void test_aCloseDuringAutoLoginWaitsForEveryProfileToLoad()
     {
         QVERIFY(provisionProfileOnDisk(mProfileName));
         QVERIFY(provisionProfileOnDisk(mSecondProfileName));
@@ -128,7 +128,7 @@ private slots:
         mWindow->startAutoLogin({mProfileName, mSecondProfileName}, true);
 
         QVERIFY2(mWindow, "the main window was deleted underneath the profile load");
-        QVERIFY2(!mWindow->getHostManager().getHost(mSecondProfileName), "another profile was started after the close was asked for");
+        QVERIFY2(mWindow->getHostManager().getHost(mSecondProfileName), "the close cut the auto-login batch short");
         verifyTheCloseWasHeldAndThenHappened();
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A close requested while a profile is loading (the window's close button, or the desktop shutting down while profiles start up) is held until every load in progress returns, and then happens on its own. Profile loads are counted in `mudlet`, `closeEvent()` ignores the event while one is underway, and the last load to finish re-issues the close.

#### Motivation for adding to Mudlet
Loading a profile pumps the event loop part-way through. A close delivered in one of those pumps was accepted on the spot, which deleted every Host underneath the load that was still using one of them.

Sentry: MUDLET-6Z.

#### Other info (issues closed, discussion etc)

Closes #10452.

**Test case:** `CloseDuringProfileLoadTest` (PROFILE group) covers the auto-login route (two profiles: the close lands during the first, and both are loaded before the close happens) and the connection dialog's route (`loadProfile()` followed by `slot_connectionDialogueFinished()`). On the unfixed code the first case dies with a SegFault; with only the connection-dialog guard removed the second does, so each case pins its own guard.

Assisted-by: Claude:claude-fable-5-1