### PR TITLE
Fix: Crash when a keychain job outlives its timeout or its manager

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -158,21 +158,43 @@ void CredentialManager::handleTimeout()
     }
 }
 
+void CredentialManager::trackCurrentJob(QKeychain::Job* job)
+{
+    job->setAutoDelete(false);
+    mCurrentJob = job;
+    mCurrentJobFinished = false;
+    // Direct, unlike the result handlers, so cleanupCurrentOperation() can tell
+    // a job the backend is done with from one it still holds
+    connect(
+            job,
+            &QKeychain::Job::finished,
+            this,
+            [this]() {
+                mCurrentJobFinished = true;
+            },
+            Qt::DirectConnection);
+}
+
 void CredentialManager::cleanupCurrentOperation()
 {
     cleanupTimeout();
 
     if (mCurrentJob) {
-        // A job still here may not have finished, and the backend will still
-        // call back into it, so it cannot be freed yet. Cut it loose to delete
-        // itself when it finishes, keeping the executor's connections to it:
-        // qtkeychain runs jobs one at a time and its executor waits on this
-        // one's finished(). One whose finished() has already fired but whose
-        // queued handler has not run leaks instead (autoDelete is checked at
-        // emit time), which beats freeing one the backend still holds.
         disconnect(mCurrentJob, nullptr, this, nullptr);
         mCurrentJob->setParent(nullptr);
-        mCurrentJob->setAutoDelete(true);
+        if (mCurrentJobFinished) {
+            // The backend is done with it. Its queued handler is normally still
+            // ahead of the deletion, but a DeferredDelete-only flush can get
+            // there first, which is why the handlers hold the job through a
+            // QPointer.
+            mCurrentJob->deleteLater();
+        } else {
+            // The backend will still call back into it, so it cannot be freed
+            // yet. Cut it loose to delete itself when it finishes, keeping the
+            // executor's connections to it: qtkeychain runs jobs one at a time
+            // and its executor waits on this one's finished().
+            mCurrentJob->setAutoDelete(true);
+        }
         mCurrentJob = nullptr;
     }
 
@@ -783,9 +805,7 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
 
     // Store password directly in keychain (keychain handles encryption)
     writeJob->setTextData(password);
-    writeJob->setAutoDelete(false);
-
-    mCurrentJob = writeJob;
+    trackCurrentJob(writeJob);
     mCurrentCallback = callback;
 
     // Set up timeout
@@ -796,7 +816,10 @@ void CredentialManager::storeCredential(const QString& service, const QString& a
             writeJob,
             &QKeychain::WritePasswordJob::finished,
             this,
-            [this, writeJob, service, account, password, profileName]() {
+            [this, writeJob = QPointer<QKeychain::WritePasswordJob>(writeJob), service, account, password, profileName]() {
+                if (!writeJob) {
+                    return;
+                }
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
@@ -870,9 +893,7 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
     // Use service as the key - on Windows, only setKey() value is used as the credential target,
     // so using account ("character") would cause all profiles to share the same credential
     readJob->setKey(service);
-    readJob->setAutoDelete(false);
-
-    mCurrentJob = readJob;
+    trackCurrentJob(readJob);
     mCurrentRetrievalCallback = callback;
 
     // Set up timeout
@@ -883,7 +904,10 @@ void CredentialManager::retrieveCredential(const QString& service, const QString
             readJob,
             &QKeychain::ReadPasswordJob::finished,
             this,
-            [this, readJob, service, account, profileName]() {
+            [this, readJob = QPointer<QKeychain::ReadPasswordJob>(readJob), service, account, profileName]() {
+                if (!readJob) {
+                    return;
+                }
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
@@ -989,9 +1013,7 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
     // Use service as the key - on Windows, only setKey() value is used as the credential target,
     // so using account ("character") would cause all profiles to share the same credential
     deleteJob->setKey(service);
-    deleteJob->setAutoDelete(false);
-
-    mCurrentJob = deleteJob;
+    trackCurrentJob(deleteJob);
     mCurrentCallback = callback;
 
     // Set up timeout
@@ -1002,7 +1024,10 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
             deleteJob,
             &QKeychain::DeletePasswordJob::finished,
             this,
-            [this, deleteJob, service, account, profileName]() {
+            [this, deleteJob = QPointer<QKeychain::DeletePasswordJob>(deleteJob), service, account, profileName]() {
+                if (!deleteJob) {
+                    return;
+                }
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
@@ -1027,15 +1052,17 @@ void CredentialManager::removeCredential(const QString& service, const QString& 
                 mCurrentJob = nullptr;
                 auto* bareJob = new QKeychain::DeletePasswordJob(QString(), this);
                 bareJob->setKey(service);
-                bareJob->setAutoDelete(false);
-                mCurrentJob = bareJob;
+                trackCurrentJob(bareJob);
                 setupTimeout();
 
                 connect(
                         bareJob,
                         &QKeychain::DeletePasswordJob::finished,
                         this,
-                        [this, bareJob, service, account, profileName, primarySuccess, primaryError]() {
+                        [this, bareJob = QPointer<QKeychain::DeletePasswordJob>(bareJob), service, account, profileName, primarySuccess, primaryError]() {
+                            if (!bareJob) {
+                                return;
+                            }
                             if (!isOperationValid()) {
                                 qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";
                                 bareJob->deleteLater();
@@ -1116,9 +1143,7 @@ void CredentialManager::isKeychainAvailable(AvailabilityCallback callback)
     // Test keychain availability by trying to read a non-existent key
     auto* testJob = new QKeychain::ReadPasswordJob(qsl("MudletKeychainTest"), this);
     testJob->setKey(qsl("availability_test"));
-    testJob->setAutoDelete(false);
-
-    mCurrentJob = testJob;
+    trackCurrentJob(testJob);
     mCurrentAvailabilityCallback = callback;
 
     // Set up timeout
@@ -1129,7 +1154,10 @@ void CredentialManager::isKeychainAvailable(AvailabilityCallback callback)
             testJob,
             &QKeychain::ReadPasswordJob::finished,
             this,
-            [this, testJob]() {
+            [this, testJob = QPointer<QKeychain::ReadPasswordJob>(testJob)]() {
+                if (!testJob) {
+                    return;
+                }
                 // Early exit if operation is no longer valid
                 if (!isOperationValid()) {
                     qWarning() << "CredentialManager: Ignoring keychain callback - operation no longer valid";

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -163,13 +163,16 @@ void CredentialManager::cleanupCurrentOperation()
     cleanupTimeout();
 
     if (mCurrentJob) {
-        // If we're destroying or shutting down, avoid disconnect calls that might crash
-        if (!mShuttingDown && !QCoreApplication::closingDown()) {
-            // Safe to disconnect during normal operation
-            mCurrentJob->disconnect();
-        }
-
-        mCurrentJob->deleteLater();
+        // A job still here may not have finished, and the backend will still
+        // call back into it, so it cannot be freed yet. Cut it loose to delete
+        // itself when it finishes, keeping the executor's connections to it:
+        // qtkeychain runs jobs one at a time and its executor waits on this
+        // one's finished(). One whose finished() has already fired but whose
+        // queued handler has not run leaks instead (autoDelete is checked at
+        // emit time), which beats freeing one the backend still holds.
+        disconnect(mCurrentJob, nullptr, this, nullptr);
+        mCurrentJob->setParent(nullptr);
+        mCurrentJob->setAutoDelete(true);
         mCurrentJob = nullptr;
     }
 
@@ -503,9 +506,12 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
     const QString lookupService = service;
 #endif
 
-    auto* oldFormatJob = new QKeychain::ReadPasswordJob(lookupService, this);
+    // No parent: nothing detaches this untracked job before the manager dies
+    // the way cleanupCurrentOperation() does for mCurrentJob, and the backend
+    // will still call back into it
+    auto* oldFormatJob = new QKeychain::ReadPasswordJob(lookupService);
     oldFormatJob->setKey(account); // Old format used account as key
-    oldFormatJob->setAutoDelete(false);
+    oldFormatJob->setAutoDelete(true);
 
     connect(oldFormatJob, &QKeychain::ReadPasswordJob::finished, this, [this, oldFormatJob, service, lookupService, account, profileName, callback]() {
         bool found = (oldFormatJob->error() == QKeychain::NoError);
@@ -515,10 +521,10 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
             qDebug() << "CredentialManager: Found password in old format, migrating to new format";
 
             // Store in new format (key=service) for future use
-            auto* migrateJob = new QKeychain::WritePasswordJob(service, this);
+            auto* migrateJob = new QKeychain::WritePasswordJob(service);
             migrateJob->setKey(service); // New format
             migrateJob->setTextData(password);
-            migrateJob->setAutoDelete(false);
+            migrateJob->setAutoDelete(true);
 
             connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, lookupService, account, password, callback]() {
                 if (migrateJob->error() == QKeychain::NoError) {
@@ -546,7 +552,6 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
                 if (callback) {
                     callback(true, password, QString());
                 }
-                migrateJob->deleteLater();
             });
 
             migrateJob->start();
@@ -567,8 +572,6 @@ void CredentialManager::attemptOldFormatMigration(const QString& service, const 
                 fallbackFileRetrieval(profileName, account, callback);
             }
         }
-
-        oldFormatJob->deleteLater();
     });
 
     oldFormatJob->start();
@@ -589,9 +592,9 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
     qDebug() << "CredentialManager: Linked qtkeychain version:" << QTKEYCHAIN_LINKED_VERSION;
 #endif
 
-    auto* compatJob = new QKeychain::ReadPasswordJob(QString(), this);
+    auto* compatJob = new QKeychain::ReadPasswordJob(QString());
     compatJob->setKey(service);
-    compatJob->setAutoDelete(false);
+    compatJob->setAutoDelete(true);
 
     connect(compatJob, &QKeychain::ReadPasswordJob::finished, this, [this, compatJob, service, account, profileName, callback]() {
         const bool found = (compatJob->error() == QKeychain::NoError);
@@ -602,10 +605,10 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
 
             // Re-store through a normal write (key == service) so the entry lands under the
             // naming scheme of the linked qtkeychain version
-            auto* migrateJob = new QKeychain::WritePasswordJob(service, this);
+            auto* migrateJob = new QKeychain::WritePasswordJob(service);
             migrateJob->setKey(service);
             migrateJob->setTextData(password);
-            migrateJob->setAutoDelete(false);
+            migrateJob->setAutoDelete(true);
 
             connect(migrateJob, &QKeychain::WritePasswordJob::finished, this, [migrateJob, service, password, callback]() {
                 if (migrateJob->error() == QKeychain::NoError) {
@@ -642,7 +645,6 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
                 if (callback) {
                     callback(true, password, QString());
                 }
-                migrateJob->deleteLater();
             });
 
             migrateJob->start();
@@ -658,8 +660,6 @@ void CredentialManager::attemptCompatNamingMigration(const QString& service, con
             }
             attemptOldFormatMigration(service, account, profileName, callback);
         }
-
-        compatJob->deleteLater();
     });
 
     compatJob->start();
@@ -1544,9 +1544,9 @@ void CredentialManager::checkLegacyKeychainFormat(const QString& profileName, st
     // Legacy format used service="Mudlet profile" and key=profileName
     const QString legacyService = qsl("Mudlet profile");
 
-    auto* readJob = new QKeychain::ReadPasswordJob(legacyService, this);
+    auto* readJob = new QKeychain::ReadPasswordJob(legacyService);
     readJob->setKey(profileName);
-    readJob->setAutoDelete(false);
+    readJob->setAutoDelete(true);
 
     connect(readJob, &QKeychain::ReadPasswordJob::finished, this, [readJob, callback, profileName]() {
         bool success = (readJob->error() == QKeychain::NoError);
@@ -1559,7 +1559,6 @@ void CredentialManager::checkLegacyKeychainFormat(const QString& profileName, st
         }
 
         callback(success, password);
-        readJob->deleteLater();
     });
 
     readJob->start();
@@ -1574,9 +1573,9 @@ void CredentialManager::deleteLegacyKeychainEntry(const QString& profileName)
     // Legacy format used service="Mudlet profile" and key=profileName
     const QString legacyService = qsl("Mudlet profile");
 
-    auto* deleteJob = new QKeychain::DeletePasswordJob(legacyService, this);
+    auto* deleteJob = new QKeychain::DeletePasswordJob(legacyService);
     deleteJob->setKey(profileName);
-    deleteJob->setAutoDelete(false);
+    deleteJob->setAutoDelete(true);
 
     connect(deleteJob, &QKeychain::DeletePasswordJob::finished, this, [deleteJob, profileName]() {
         if (deleteJob->error() == QKeychain::NoError) {
@@ -1584,8 +1583,6 @@ void CredentialManager::deleteLegacyKeychainEntry(const QString& profileName)
         } else {
             qDebug() << "CredentialManager: Failed to delete legacy entry for profile" << profileName << ":" << deleteJob->errorString();
         }
-
-        deleteJob->deleteLater();
     });
 
     deleteJob->start();

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -58,6 +58,7 @@ class Job;
 class CredentialManager : public QObject
 {
     Q_OBJECT
+    friend class CredentialManagerTest;
 
 public:
     explicit CredentialManager(QObject* parent = nullptr);

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -109,6 +109,7 @@ private:
     void cleanupTimeout();
     void handleTimeout();
     void cleanupCurrentOperation();
+    void trackCurrentJob(QKeychain::Job* job);
 
     // Safety guard for keychain operation callbacks
     bool isOperationValid() const;
@@ -137,6 +138,7 @@ private:
 
     // Current operation state
     QPointer<QKeychain::Job> mCurrentJob{nullptr};
+    bool mCurrentJobFinished = false;
     QTimer* mTimeoutTimer{nullptr};
     CredentialCallback mCurrentCallback;
     CredentialRetrievalCallback mCurrentRetrievalCallback;

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -77,6 +77,8 @@ private slots:
     void testAsyncApiRefusesTheKeysTheStaticApiRefuses();
     void testATimedOutKeychainJobIsLeftToFinishOnItsOwn();
     void testDestroyingTheManagerLeavesAnInFlightKeychainJobAlive();
+    void testAFinishedJobWhoseHandlerHasNotRunDiesWithTheManager();
+    void testAHandlerRunningAfterItsFinishedJobWasFreedDoesNothing();
     void testAMigrationJobOutlivesTheManager();
     void cleanupTestCase();
 
@@ -793,6 +795,28 @@ void CredentialManagerTest::cleanupTestCase()
 
 #include "CredentialManagerTest.moc"
 
+// Job::start() only queues doStart(); swallowing that call keeps the backend
+// out of the test.
+class DoStartCatcher : public QObject
+{
+public:
+    QPointer<QKeychain::Job> job;
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override
+    {
+        if (event->type() != QEvent::MetaCall) {
+            return false;
+        }
+        auto* keychainJob = qobject_cast<QKeychain::Job*>(watched);
+        if (!keychainJob) {
+            return false;
+        }
+        job = keychainJob;
+        return true;
+    }
+};
+
 // The libsecret and macOS backends call back into the job when the store
 // answers, and a keyring prompt can sit unanswered past the operation timeout.
 // Neither the timeout nor the manager going away may free a job that has not
@@ -801,8 +825,7 @@ void CredentialManagerTest::testATimedOutKeychainJobIsLeftToFinishOnItsOwn()
 {
     CredentialManager manager;
     QPointer<QKeychain::Job> job = new QKeychain::ReadPasswordJob(qsl("Mudlet-test"), &manager);
-    job->setAutoDelete(false);
-    manager.mCurrentJob = job;
+    manager.trackCurrentJob(job);
     bool reported = false;
     manager.mCurrentRetrievalCallback = [&reported](bool success, const QString&, const QString&) {
         reported = !success;
@@ -828,8 +851,7 @@ void CredentialManagerTest::testDestroyingTheManagerLeavesAnInFlightKeychainJobA
 {
     auto* manager = new CredentialManager;
     QPointer<QKeychain::Job> job = new QKeychain::ReadPasswordJob(qsl("Mudlet-test"), manager);
-    job->setAutoDelete(false);
-    manager->mCurrentJob = job;
+    manager->trackCurrentJob(job);
 
     delete manager;
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
@@ -839,31 +861,57 @@ void CredentialManagerTest::testDestroyingTheManagerLeavesAnInFlightKeychainJobA
     delete job;
 }
 
+// The result handlers are queued, so finished() can fire and the manager die
+// before the handler runs. The backend is done with such a job, and nothing
+// else is left to delete it.
+void CredentialManagerTest::testAFinishedJobWhoseHandlerHasNotRunDiesWithTheManager()
+{
+    auto* manager = new CredentialManager;
+    QPointer<QKeychain::Job> job = new QKeychain::ReadPasswordJob(qsl("Mudlet-test"), manager);
+    manager->trackCurrentJob(job);
+    emit job->finished(job);
+
+    delete manager;
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
+    QVERIFY2(!job, "a job the keychain had answered leaked when the manager died");
+}
+
+// A DeferredDelete-only flush frees the job cleanupCurrentOperation() let go
+// of before its queued handler runs.
+void CredentialManagerTest::testAHandlerRunningAfterItsFinishedJobWasFreedDoesNothing()
+{
+    DoStartCatcher catcher;
+    qApp->installEventFilter(&catcher);
+    const auto removeCatcher = qScopeGuard([&catcher]() {
+        qApp->removeEventFilter(&catcher);
+    });
+
+    CredentialManager manager;
+    int reports = 0;
+    manager.retrieveCredential(qsl("Mudlet-test"), qsl("password"), qsl("test-profile"), [&reports](bool, const QString&, const QString&) {
+        ++reports;
+    });
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    QVERIFY(catcher.job);
+    QPointer<QKeychain::Job> job = catcher.job;
+
+    emit job->finished(job);
+    manager.handleTimeout();
+    QCOMPARE(reports, 1);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QVERIFY2(!job, "the finished job was not freed by the flush");
+
+    QTest::failOnWarning(QRegularExpression(qsl("Ignoring keychain callback")));
+    QCoreApplication::sendPostedEvents();
+    QCOMPARE(reports, 1);
+}
+
 // A job the manager does not track (the migration and legacy-format reads and
 // deletes) has nothing to detach it, so it must never be the manager's child.
-// Job::start() only queues doStart(); swallowing that call keeps the backend
-// out of the test.
 void CredentialManagerTest::testAMigrationJobOutlivesTheManager()
 {
-    class DoStartCatcher : public QObject
-    {
-    public:
-        QPointer<QKeychain::Job> job;
-
-    protected:
-        bool eventFilter(QObject* watched, QEvent* event) override
-        {
-            if (event->type() != QEvent::MetaCall) {
-                return false;
-            }
-            auto* keychainJob = qobject_cast<QKeychain::Job*>(watched);
-            if (!keychainJob) {
-                return false;
-            }
-            job = keychainJob;
-            return true;
-        }
-    } catcher;
+    DoStartCatcher catcher;
     qApp->installEventFilter(&catcher);
     const auto removeCatcher = qScopeGuard([&catcher]() {
         qApp->removeEventFilter(&catcher);

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -25,8 +25,17 @@
 
 #include <QDir>
 #include <QFile>
+#include <QPointer>
+#include <QScopeGuard>
+#include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
+
+#if defined(INCLUDE_OWN_QT6_KEYCHAIN)
+#include <qtkeychain/keychain.h>
+#else
+#include <qt6keychain/keychain.h>
+#endif
 
 // Hermetic unit tests: MUDLET_TEST_MODE forces encrypted file storage so these run
 // deterministically on every platform without touching a system keychain. The real
@@ -66,6 +75,9 @@ private slots:
     void testCredentialExistsWithoutHandingOverTheSecret();
     void testAsyncEmptyArgumentsAreReportedThroughTheCallback();
     void testAsyncApiRefusesTheKeysTheStaticApiRefuses();
+    void testATimedOutKeychainJobIsLeftToFinishOnItsOwn();
+    void testDestroyingTheManagerLeavesAnInFlightKeychainJobAlive();
+    void testAMigrationJobOutlivesTheManager();
     void cleanupTestCase();
 
 private:
@@ -780,4 +792,92 @@ void CredentialManagerTest::cleanupTestCase()
 }
 
 #include "CredentialManagerTest.moc"
+
+// The libsecret and macOS backends call back into the job when the store
+// answers, and a keyring prompt can sit unanswered past the operation timeout.
+// Neither the timeout nor the manager going away may free a job that has not
+// finished.
+void CredentialManagerTest::testATimedOutKeychainJobIsLeftToFinishOnItsOwn()
+{
+    CredentialManager manager;
+    QPointer<QKeychain::Job> job = new QKeychain::ReadPasswordJob(qsl("Mudlet-test"), &manager);
+    job->setAutoDelete(false);
+    manager.mCurrentJob = job;
+    bool reported = false;
+    manager.mCurrentRetrievalCallback = [&reported](bool success, const QString&, const QString&) {
+        reported = !success;
+    };
+
+    QSignalSpy finished(job, &QKeychain::Job::finished);
+
+    manager.handleTimeout();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
+    QVERIFY(reported);
+    QVERIFY2(job, "the timed-out job was deleted while the keychain could still call back into it");
+    QVERIFY2(job->autoDelete(), "a job cut loose has to delete itself when it finishes");
+    QVERIFY2(!job->parent(), "a job cut loose must not die with the manager");
+    QVERIFY(!manager.mCurrentJob);
+    // The executor's own connection to finished() has to survive the detach
+    emit job->finished(job);
+    QCOMPARE(finished.count(), 1);
+    delete job;
+}
+
+void CredentialManagerTest::testDestroyingTheManagerLeavesAnInFlightKeychainJobAlive()
+{
+    auto* manager = new CredentialManager;
+    QPointer<QKeychain::Job> job = new QKeychain::ReadPasswordJob(qsl("Mudlet-test"), manager);
+    job->setAutoDelete(false);
+    manager->mCurrentJob = job;
+
+    delete manager;
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
+    QVERIFY2(job, "the job was deleted with the manager while the keychain could still call back into it");
+    QVERIFY(job->autoDelete());
+    delete job;
+}
+
+// A job the manager does not track (the migration and legacy-format reads and
+// deletes) has nothing to detach it, so it must never be the manager's child.
+// Job::start() only queues doStart(); swallowing that call keeps the backend
+// out of the test.
+void CredentialManagerTest::testAMigrationJobOutlivesTheManager()
+{
+    class DoStartCatcher : public QObject
+    {
+    public:
+        QPointer<QKeychain::Job> job;
+
+    protected:
+        bool eventFilter(QObject* watched, QEvent* event) override
+        {
+            if (event->type() != QEvent::MetaCall) {
+                return false;
+            }
+            auto* keychainJob = qobject_cast<QKeychain::Job*>(watched);
+            if (!keychainJob) {
+                return false;
+            }
+            job = keychainJob;
+            return true;
+        }
+    } catcher;
+    qApp->installEventFilter(&catcher);
+    const auto removeCatcher = qScopeGuard([&catcher]() {
+        qApp->removeEventFilter(&catcher);
+    });
+
+    auto* manager = new CredentialManager;
+    manager->attemptOldFormatMigration(qsl("Mudlet-test"), qsl("password"), qsl("test-profile"), nullptr);
+    delete manager;
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+
+    QVERIFY2(catcher.job, "the migration job died with the manager while the keychain could still call back into it");
+    QVERIFY(catcher.job->autoDelete());
+    QVERIFY(!catcher.job->parent());
+    delete catcher.job;
+}
+
 QTEST_MAIN(CredentialManagerTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`CredentialManager` no longer deletes a `QKeychain::Job` that has not finished. When the operation timeout fires, or the manager is destroyed with a job in flight, the job is cut loose instead: the manager's own connections to it are dropped, it is unparented and set to delete itself when it finishes. The migration and legacy-format jobs, which the manager never tracked, are created without a parent for the same reason.

A job that has already finished when the manager cleans up is the other case: its queued result handler has not run yet, and the manager used to drop it without deleting it. The finish is now recorded through a direct connection and such a job is deleted with `deleteLater()`. The handlers hold the job through a `QPointer`, as a DeferredDelete-only flush can free it before they run.

#### Motivation for adding to Mudlet
The libsecret and macOS backends call back into the job when the store answers, and a keyring unlock prompt can sit unanswered past the 30 s timeout. Deleting the job at the timeout, or with the manager, left the backend calling into freed memory. A wildcard `disconnect()` is not an option either: qtkeychain runs jobs one at a time and its executor waits on the current job's `finished()`.

Sentry: MUDLET-6R, MUDLET-6G, MUDLET-6H.

#### Other info (issues closed, discussion etc)

Closes #10454.

**Test case:** five lifetime cases in `CredentialManagerTest`. Three plant an unstarted job and check that the timeout, the manager's destruction, and a migration job started under a manager that then dies all leave the job alive, unparented and self-deleting, with an outside connection to `finished()` intact. Two more check that a finished job whose handler has not run dies with the manager, and that a handler running after its job was freed does nothing. Each fails without the part of the fix it covers; with the fix the binary's 28 cases pass.

Assisted-by: Claude:claude-fable-5-1
