### PR TITLE
Infra: Add specs for selections that do not fit their line

### DIFF
--- a/src/mudlet-lua/tests/TextEditSelection_spec.lua
+++ b/src/mudlet-lua/tests/TextEditSelection_spec.lua
@@ -95,16 +95,22 @@ describe("Tests selection against lines it does not fit", function()
       assert.equals("bravo", (getSelection(window)))
     end)
 
-    it("rejects a start past the end of the line", function()
-      moveCursor(window, 0, 2)
-      assert.is_false(selectSection(window, 5, 1))
-    end)
-
-    it("rejects a length that runs off the end of the line", function()
+    it("rejects a start past the end of the line without disturbing the selection", function()
       moveCursor(window, 0, 2)
       assert.is_true(selectSection(window, 0, 4))
       assert.equals("echo", (getSelection(window)))
+
+      assert.is_false(selectSection(window, 5, 1))
+      assert.equals("echo", (getSelection(window)))
+    end)
+
+    it("rejects a length that runs off the end of the line without disturbing the selection", function()
+      moveCursor(window, 0, 2)
+      assert.is_true(selectSection(window, 0, 4))
+      assert.equals("echo", (getSelection(window)))
+
       assert.is_false(selectSection(window, 2, 3))
+      assert.equals("echo", (getSelection(window)))
     end)
   end)
 

--- a/src/mudlet-lua/tests/TextEditSelection_spec.lua
+++ b/src/mudlet-lua/tests/TextEditSelection_spec.lua
@@ -1,0 +1,241 @@
+-- What the selection API does when the selection does not fit the line it is
+-- pointed at: an empty line, a negative start, a selection left behind on a
+-- line shorter than the one it was made on, and an attribute applied to part of
+-- a line rather than all of it. Plus the overflow event that a console which
+-- cannot scroll raises once its text no longer fits the pane.
+
+-- Distinct lengths and words on every line, so an off-by-one or a swapped
+-- axis produces a different answer rather than the right one by luck.
+local fixture = {
+  "alpha bravo charlie delta",
+  "",
+  "echo",
+  "foxtrot golf hotel india juliet",
+}
+
+local function buildFixture(window)
+  clearWindow(window)
+  -- clearWindow() leaves one empty line behind and does not move the user
+  -- cursor, so the line has to be deleted for line 0 to be the first echo
+  moveCursor(window, 0, 0)
+  deleteLine(window)
+  for _, line in ipairs(fixture) do
+    echo(window, line .. "\n")
+  end
+end
+
+describe("Tests selection against lines it does not fit", function()
+  local window = "textEditSelectionTest"
+
+  setup(function()
+    createMiniConsole(window, 0, 0, 400, 300)
+    -- wider than the longest fixture line, so nothing wraps onto a second
+    -- line and shifts every line number after it
+    setWindowWrap(window, 80)
+  end)
+
+  teardown(function()
+    deleteMiniConsole(window)
+  end)
+
+  before_each(function()
+    -- setBold() and friends also change the format the window echoes with, so
+    -- clear that before the fixture is written or a previous test's attribute
+    -- ends up on every line of it
+    deselect(window)
+    resetFormat(window)
+    buildFixture(window)
+    assert.are.same(fixture, getLines(window, 0, #fixture))
+  end)
+
+  describe("Tests selectString on a line it cannot match", function()
+    it("returns -1 and clears the selection when the line is empty", function()
+      moveCursor(window, 0, 0)
+      assert.equals(6, selectString(window, "bravo", 1))
+      assert.equals("bravo", (getSelection(window)))
+
+      moveCursor(window, 0, 1)
+      assert.equals(-1, selectString(window, "bravo", 1))
+
+      -- a bare -1 that left the old selection in place would report the
+      -- stale start of 6, which no longer fits the empty line
+      local text, start, length = getSelection(window)
+      assert.equals("", text)
+      assert.equals(0, start)
+      assert.equals(0, length)
+    end)
+
+    it("returns -1 and clears the selection when the text is absent", function()
+      moveCursor(window, 0, 3)
+      assert.equals(8, selectString(window, "golf", 1))
+      assert.equals("golf", (getSelection(window)))
+
+      assert.equals(-1, selectString(window, "kilo", 1))
+      local text, start, length = getSelection(window)
+      assert.equals("", text)
+      assert.equals(0, start)
+      assert.equals(0, length)
+    end)
+
+    it("returns -1 when there are fewer matches than asked for", function()
+      -- line 0 holds exactly five "a"s, the last of them the final character
+      moveCursor(window, 0, 0)
+      assert.equals(24, selectString(window, "a", 5))
+      assert.equals(-1, selectString(window, "a", 6))
+    end)
+  end)
+
+  describe("Tests selectSection rejecting out of range arguments", function()
+    it("rejects a negative start without disturbing the selection", function()
+      moveCursor(window, 0, 0)
+      assert.is_true(selectSection(window, 6, 5))
+      assert.equals("bravo", (getSelection(window)))
+
+      assert.is_false(selectSection(window, -1, 5))
+      assert.equals("bravo", (getSelection(window)))
+    end)
+
+    it("rejects a start past the end of the line", function()
+      moveCursor(window, 0, 2)
+      assert.is_false(selectSection(window, 5, 1))
+    end)
+
+    it("rejects a length that runs off the end of the line", function()
+      moveCursor(window, 0, 2)
+      assert.is_true(selectSection(window, 0, 4))
+      assert.equals("echo", (getSelection(window)))
+      assert.is_false(selectSection(window, 2, 3))
+    end)
+  end)
+
+  describe("Tests getSelection after the cursor moves", function()
+    it("reports the selection stale when the new line is too short for it", function()
+      moveCursor(window, 0, 3)
+      assert.is_true(selectSection(window, 19, 5))
+      assert.equals("india", (getSelection(window)))
+
+      -- the selection is still 19 characters in, which line 2 does not reach
+      moveCursor(window, 0, 2)
+      local text, message = getSelection(window)
+      assert.is_nil(text)
+      assert.is_string(message)
+    end)
+
+    it("reads the same columns off a line that is long enough", function()
+      moveCursor(window, 0, 3)
+      assert.is_true(selectSection(window, 6, 5))
+      assert.equals("t gol", (getSelection(window)))
+
+      moveCursor(window, 0, 0)
+      local text, start, length = getSelection(window)
+      assert.equals("bravo", text)
+      assert.equals(6, start)
+      assert.equals(5, length)
+    end)
+  end)
+
+  describe("Tests attributes applied to part of a line", function()
+    -- reading an attribute back needs the cursor on the character, and
+    -- getTextFormat() prefers the selection over the cursor when one is live
+    local function boldAt(column, line)
+      deselect(window)
+      moveCursor(window, column, line)
+      return getTextFormat(window).bold
+    end
+
+    it("bolds only the selected columns", function()
+      moveCursor(window, 0, 0)
+      assert.is_true(selectSection(window, 6, 5))
+      assert.is_false(getTextFormat(window).bold)
+
+      setBold(window, true)
+      assert.is_true(getTextFormat(window).bold)
+
+      -- the character after the selection is what an attribute run that ran on
+      -- to the end of the line would also have picked up
+      assert.is_true(boldAt(6, 0))
+      assert.is_true(boldAt(10, 0))
+      assert.is_false(boldAt(11, 0))
+      assert.is_false(boldAt(5, 0))
+    end)
+
+    it("bolds the last character when the selection reaches the end of the line", function()
+      moveCursor(window, 0, 2)
+      assert.is_true(selectSection(window, 0, 4))
+      assert.is_false(getTextFormat(window).bold)
+
+      setBold(window, true)
+      assert.is_true(boldAt(0, 2))
+      assert.is_true(boldAt(3, 2))
+      assert.is_false(boldAt(0, 3))
+    end)
+  end)
+end)
+
+describe("Tests sysWindowOverflowEvent", function()
+  local window = "textEditOverflowTest"
+  local events = {}
+  local handler
+
+  setup(function()
+    createMiniConsole(window, 0, 0, 400, 100)
+    setWindowWrap(window, 80)
+    handler = registerAnonymousEventHandler("sysWindowOverflowEvent", function(_, name, amount)
+      events[#events + 1] = {window = name, amount = amount}
+    end)
+  end)
+
+  teardown(function()
+    if handler then
+      killAnonymousEventHandler(handler)
+    end
+    deleteMiniConsole(window)
+  end)
+
+  before_each(function()
+    events = {}
+    clearWindow(window)
+    moveCursor(window, 0, 0)
+    deleteLine(window)
+  end)
+
+  -- echo one line at a time so the line count creeps up to the pane's capacity
+  -- rather than jumping past it
+  local function fillToCapacity(rows)
+    while getLineCount(window) + 1 < rows do
+      echo(window, "fill\n")
+    end
+    return getLineCount(window) + 1
+  end
+
+  it("raises the event only once the lines no longer fit", function()
+    local rows = getRowCount(window)
+    assert.is_true(rows >= 3, "the pane is too short to tell a full buffer from an overflowing one")
+    disableScrolling(window)
+    assert.is_false(scrollingActive(window))
+
+    assert.equals(rows, fillToCapacity(rows))
+    assert.equals(0, #events, "the event fired while the lines still fitted")
+
+    echo(window, "one line too many\n")
+    assert.equals(1, #events)
+    assert.equals(window, events[1].window)
+    assert.equals(1, events[1].amount)
+
+    echo(window, "two lines too many\n")
+    assert.equals(2, #events)
+    assert.equals(2, events[2].amount)
+  end)
+
+  it("stays quiet while the window can scroll", function()
+    local rows = getRowCount(window)
+    enableScrolling(window)
+    assert.is_true(scrollingActive(window))
+
+    fillToCapacity(rows)
+    for _ = 1, 3 do
+      echo(window, "past the bottom\n")
+    end
+    assert.equals(0, #events)
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds `src/mudlet-lua/tests/TextEditSelection_spec.lua`, 12 `it()` blocks covering what the selection API does when the selection does not fit the line it is pointed at:

- `selectString()` returning -1 *and clearing the selection* - on an empty line, on absent text, and when asked for more matches than the line holds.
- `selectSection()` rejecting a negative start, a start past the end of the line, and a length that runs off the end - each asserting the existing selection was left alone.
- `getSelection()` reporting a selection stale once the cursor moves to a line too short for it, with the matching case that a long enough line still reads.
- `setBold()` on a selection that stops short of end-of-line, checking the character immediately after the selection did *not* pick the attribute up.
- `sysWindowOverflowEvent`, raised by a non-scrolling miniconsole once its text no longer fits, and staying quiet while the window can scroll.

#### Motivation for adding to Mudlet

These are cold paths in the coverage baseline - `TConsole::select()`'s post-loop `deselect(); return -1;`, `selectSection()`'s `from < 0` rejection, `getSelection()`'s stale-selection return, `TBuffer::applyAttribute()`'s partial-line early exit, and the whole 12-line body of `TConsole::handleLinesOverflowEvent()`, none of which had a test.

Suite goes from `4019 successes / 0 failures / 0 errors / 71 pending` to `4031 / 0 / 0 / 71` - exactly the 12 new blocks, with the pending list identical name by name.

Every case was checked to actually bite by cutting the C++ it covers and watching the right test go red. Two of the five legs were re-run independently against a separate build tree: removing both `deselect()` calls from `TConsole::select()` and the `linesSpare >= 0` early return from `handleLinesOverflowEvent()` together took the file from `12 successes / 0 failures` to `9 / 3`, with the three failures landing on exactly the intended cases.

Fixtures are four lines of distinct lengths and distinct words, so an off-by-one or a swapped axis gives a different answer rather than the right one by luck. Each rejection case pins the precondition first - asserts the selection *is* something else, calls the thing that should be refused, asserts it is unchanged.

#### Other info (issues closed, discussion etc)

`TTextEdit.cpp` itself yielded nothing spec-reachable: its uncovered mass is `keyPressEvent`, `slot_analyseSelection`, the picture/OEM-font replacement called only from painting, the mouse handlers, and the scroll family, which has no Lua entry point. So the specs target the state behind it - `TConsole`'s selection and cursor, and `TBuffer`'s attribute application - through the APIs that do have one.

No bugs found in the paths covered; every cold branch behaved as written.

Both `describe` blocks build their own miniconsole in `setup()` and delete it in `teardown()`, the anonymous event handler is killed there too, and `before_each` clears the selection and resets the format before rebuilding the fixture so an attribute cannot bleed into the ~4000 tests that follow.
