### PR TITLE
Fix: Crash after deleting the special exit being edited in the room exits dialog

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -303,6 +303,25 @@ void dlgRoomExits::slot_endEditSpecialExits()
     specialExits->clearSelection();
 }
 
+// The Delete key removes the selected special exits (see
+// ExitsTreeWidget::keyPressEvent()), and one of them may be the item being
+// edited.
+void dlgRoomExits::slot_specialExitRowsAboutToBeRemoved(const QModelIndex& parent, const int first, const int last)
+{
+    if (!mpEditItem || parent.isValid()) {
+        return;
+    }
+    for (int row = first; row <= last; ++row) {
+        if (specialExits->topLevelItem(row) == mpEditItem) {
+            mpEditItem = nullptr;
+            mEditColumn = -1;
+            button_endEditing->setDisabled(true);
+            button_addSpecialExit->setEnabled(true);
+            return;
+        }
+    }
+}
+
 void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
 {
     if (!button_endEditing->isEnabled()) {
@@ -1908,6 +1927,7 @@ void dlgRoomExits::init()
     connect(button_addSpecialExit, &QAbstractButton::clicked,                      this, &dlgRoomExits::slot_addSpecialExit);
     connect(specialExits,          &QTreeWidget::itemClicked,                      this, &dlgRoomExits::slot_editSpecialExit);
     connect(specialExits,          &QTreeWidget::itemClicked,                      this, &dlgRoomExits::slot_checkModified);
+    connect(specialExits->model(), &QAbstractItemModel::rowsAboutToBeRemoved,     this, &dlgRoomExits::slot_specialExitRowsAboutToBeRemoved);
     connect(button_endEditing,     &QAbstractButton::clicked,                      this, &dlgRoomExits::slot_endEditSpecialExits);
     connect(button_endEditing,     &QAbstractButton::clicked,                      this, &dlgRoomExits::slot_checkModified);
     connect(nw,                    &QLineEdit::textEdited,                         this, &dlgRoomExits::slot_nw_textEdited);

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -279,8 +279,8 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
 
     init();
 
-    specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitRoomId, new RoomIdLineEditDelegate);
-    specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitWeight, new WeightSpinBoxDelegate);
+    specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitRoomId, new RoomIdLineEditDelegate(specialExits));
+    specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitWeight, new WeightSpinBoxDelegate(specialExits));
 }
 
 dlgRoomExits::~dlgRoomExits() = default;

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -116,6 +116,7 @@ class dlgRoomExits : public QDialog, public Ui::room_exits
 {
     Q_OBJECT
     friend class RoomIdLineEditDelegate;
+    friend class RoomExitsDeletedEditItemTest;
 
 public:
     Q_DISABLE_COPY(dlgRoomExits)
@@ -146,6 +147,7 @@ public slots:
     void slot_addSpecialExit();
     void slot_editSpecialExit(QTreeWidgetItem*, int);
     void slot_endEditSpecialExits();
+    void slot_specialExitRowsAboutToBeRemoved(const QModelIndex&, int, int);
     void slot_ne_textEdited(const QString&);
     void slot_n_textEdited(const QString&);
     void slot_nw_textEdited(const QString&);

--- a/src/exitstreewidget.h
+++ b/src/exitstreewidget.h
@@ -32,11 +32,12 @@ class ExitsTreeWidget : public QTreeWidget
 
     friend class RoomIdLineEditDelegate;
     friend class dlgRoomExits;
+    friend class RoomExitsDeletedEditItemTest;
 
     // The indexes that are used to identify the columns in the special exits
     // treewidget have been collected into an enumeration so that we can
-    // tweak them and change all of them correctly - and by making the
-    // dlgRoomExits class a friend that can use the same set as defined here.
+    // tweak them and change all of them correctly - and the friend classes
+    // above can use the same set as defined here.
     // Note that if any of these numbers are modified/extended the
     // corresponding headings in the ./src/ui/room_exits.ui file will need
     // to be adjusted as well - and visa versa:

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -145,6 +145,7 @@ set(MAP_GROUP_TEST_SOURCES
     MapRoomGeometryTest.cpp
     MapRoundTripTest.cpp
     MapSymbolFontTest.cpp
+    RoomExitsDeletedEditItemTest.cpp
 )
 
 # Packages and modules: installing them, saving them and removing them

--- a/test/functional_tests/RoomExitsDeletedEditItemTest.cpp
+++ b/test/functional_tests/RoomExitsDeletedEditItemTest.cpp
@@ -1,0 +1,132 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The room exits dialog remembers which special exit is being edited, and the
+ * Delete key removes whichever special exits are selected - the one being
+ * edited included. Ending the edit, saving, and clicking another exit all go
+ * through that item, so the dialog has to forget it before the tree deletes it.
+ */
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "TMap.h"
+#include "TRoomDB.h"
+#include "dlgRoomExits.h"
+#include "exitstreewidget.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+class RoomExitsDeletedEditItemTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("RoomExitsDeletedEditItem-Test");
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the test Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+
+        TMap* map = mpHost->mpMap.data();
+        const int areaId = map->mpRoomDB->addArea(qsl("Exits Area"));
+        QVERIFY(areaId > 0);
+        QVERIFY(map->addRoom(1) && map->setRoomArea(1, areaId));
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        if (mudlet::self()) {
+            QDir(mudlet::getMudletPath(enums::profileHomePath, mProfileName)).removeRecursively();
+        }
+        delete mudlet::self();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_deletingTheSpecialExitBeingEditedForgetsIt()
+    {
+        dlgRoomExits dialog(mpHost, 1);
+        dialog.show();
+        dialog.activateWindow();
+        QVERIFY(QTest::qWaitForWindowActive(&dialog));
+        dialog.slot_addSpecialExit();
+        dialog.slot_addSpecialExit();
+        dialog.slot_addSpecialExit();
+        QCOMPARE(dialog.specialExits->topLevelItemCount(), 3);
+
+        QTreeWidgetItem* edited = dialog.specialExits->topLevelItem(1);
+        dialog.slot_editSpecialExit(edited, ExitsTreeWidget::colIndex_command);
+        QCOMPARE(dialog.mpEditItem, edited);
+
+        // Delete acts on the selection, not on the item being edited, and takes
+        // the selected exits one at a time, so the edited one moves up a row
+        // before its turn
+        dialog.specialExits->topLevelItem(0)->setSelected(true);
+        edited->setSelected(true);
+        dialog.specialExits->setFocus();
+        QTRY_VERIFY2(dialog.specialExits->hasFocus(), "the exits tree did not take the focus, so the Delete key would be ignored");
+        QTest::keyClick(dialog.specialExits, Qt::Key_Delete);
+        QCOMPARE(dialog.specialExits->topLevelItemCount(), 1);
+
+        QVERIFY2(!dialog.mpEditItem, "the dialog still points at the special exit that was just deleted");
+        QCOMPARE(dialog.mEditColumn, -1);
+        QVERIFY2(dialog.button_addSpecialExit->isEnabled(), "the dialog is still in editing mode with nothing being edited");
+        QVERIFY(!dialog.button_endEditing->isEnabled());
+
+        // The paths that go through mpEditItem must still work, and editing must
+        // carry on with the remaining exit
+        dialog.slot_endEditSpecialExits();
+        dialog.slot_editSpecialExit(dialog.specialExits->topLevelItem(0), ExitsTreeWidget::colIndex_command);
+        dialog.slot_endEditSpecialExits();
+        QVERIFY(!dialog.mpEditItem);
+    }
+};
+
+#include "RoomExitsDeletedEditItemTest.moc"
+MUDLET_GROUPED_TEST_MAIN(RoomExitsDeletedEditItemTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The room exits dialog keeps a raw pointer to the special exit whose cell is being edited. Pressing Delete in the exits tree removes the selected exits, and if the edited one is among them the pointer dangles: the next click on another exit or the End Editing button reads freed memory.

The dialog now watches the tree model's `rowsAboutToBeRemoved` and forgets the edited item when its row goes, restoring the Add and End Editing buttons with it.

The dialog's two column delegates are now parented to the exits tree. They were created without a parent and the view never takes ownership of them, so every open of the dialog leaked both. The new test was the first to run the dialog under LeakSanitizer.

#### Motivation for adding to Mudlet

Crash reported in Sentry.

#### Other info (issues closed, discussion etc)

Closes #10455.

Sentry: MUDLET-6P.

**Test case:** `RoomExitsDeletedEditItemTest` (map group) opens the dialog, adds three special exits, starts editing the second, selects the first two and presses Delete. Delete takes the selected exits one at a time, so the edited one moves up a row before its turn. It asserts the dialog forgot the edited item and re-enabled the Add button, then ends editing and edits again. Without the `rowsAboutToBeRemoved` connection it fails at the dangling pointer check.

Assisted-by: Claude:claude-fable-5-1
