### PR TITLE
Infra: Fix a flaky main window size Lua test

### DIFF
--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -6137,14 +6137,14 @@ describe("Main window size and saved layout", function()
     assert.is_true(tallHeight <= smallHeight + 300)
   end)
 
-  -- Everything getColumnCount("main") is made of, read together with the
-  -- size, so a column count that disagrees with the width says which of them
-  -- moved: the font, the borders or the pane itself.
+  -- What Lua can see of getColumnCount("main")'s inputs, read with the size,
+  -- so a column count that disagrees with the width says which of them moved:
+  -- the font, the user borders, or by elimination the pane itself.
   local function mainConsoleGeometry()
     local width, height = getMainWindowSize()
     local fontName = getFont("main")
     local fontSize = getFontSize("main")
-    local charWidth, charHeight = calcFontSize(fontSize, fontName)
+    local charWidth, charHeight = calcFontSize("main")
     local attached = {}
     if Adjustable and Adjustable.Container and Adjustable.Container.Attached then
       for side, containers in pairs(Adjustable.Container.Attached) do
@@ -6164,23 +6164,34 @@ describe("Main window size and saved layout", function()
 
   local function describeGeometry(geometry)
     local pixelsPerColumn = geometry.columns > 0 and geometry.width / geometry.columns or 0
-    return ("%dx%d px, %dx%d cells (%.1f px per column), font %s %d (%dx%d px per cell), borders left %d right %d top %d bottom %d, attached containers: %s"):format(
+    return ("%dx%d px, %dx%d cells (%.1f window px per column), font %s %d (%dx%d px per cell), borders left %d right %d top %d bottom %d, attached containers: %s"):format(
       geometry.width, geometry.height, geometry.columns, geometry.rows, pixelsPerColumn,
       geometry.fontName, geometry.fontSize, geometry.charWidth, geometry.charHeight,
       geometry.borders.left, geometry.borders.right, geometry.borders.top, geometry.borders.bottom,
       #geometry.attached > 0 and table.concat(geometry.attached, " ") or "none")
   end
 
-  -- Width and column count at intervals after a reading, to show a
-  -- disagreement between the two either clearing or staying put.
-  local function traceSettling()
-    local samples = {}
-    for _ = 1, 10 do
+  -- A container attached to a border - the starter interface keeps one on the
+  -- right - reserves its border again from a 0.2 s timer after every resize,
+  -- so the column count goes on moving for that long after the size has
+  -- settled. Read once nothing has moved for twice that.
+  local function settledMainConsoleGeometry()
+    local geometry = mainConsoleGeometry()
+    local unchangedForMs = 0
+    for _ = 1, 40 do
       pumpEvents(50)
-      local width = getMainWindowSize()
-      samples[#samples + 1] = ("%d/%d"):format(width, getColumnCount("main"))
+      local latest = mainConsoleGeometry()
+      if latest.width == geometry.width and latest.columns == geometry.columns then
+        unchangedForMs = unchangedForMs + 50
+        if unchangedForMs >= 400 then
+          return latest
+        end
+      else
+        unchangedForMs = 0
+      end
+      geometry = latest
     end
-    return table.concat(samples, " ")
+    return geometry
   end
 
   it("a main window that loses more than half its width is reported at the width it has", function()
@@ -6189,16 +6200,11 @@ describe("Main window size and saved layout", function()
     end
     finally(restoreMainWindowSize)
     setMainWindowSize(1600, 700)
-    pumpEvents(200)
-    local wide = mainConsoleGeometry()
+    local wide = settledMainConsoleGeometry()
 
     setMainWindowSize(300, 700)
-    pumpEvents(200)
-    local narrow = mainConsoleGeometry()
-    -- after both readings, so it cannot change their timing
-    local settling = traceSettling()
-    local report = ("\n  wide:     %s\n  narrow:   %s\n  settling: %s"):format(
-      describeGeometry(wide), describeGeometry(narrow), settling)
+    local narrow = settledMainConsoleGeometry()
+    local report = ("\n  wide:   %s\n  narrow: %s"):format(describeGeometry(wide), describeGeometry(narrow))
 
     -- the main window has a minimum width of its own, so how narrow it really
     -- became is read off the column count rather than assumed; that and

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -6137,6 +6137,52 @@ describe("Main window size and saved layout", function()
     assert.is_true(tallHeight <= smallHeight + 300)
   end)
 
+  -- Everything getColumnCount("main") is made of, read together with the
+  -- size, so a column count that disagrees with the width says which of them
+  -- moved: the font, the borders or the pane itself.
+  local function mainConsoleGeometry()
+    local width, height = getMainWindowSize()
+    local fontName = getFont("main")
+    local fontSize = getFontSize("main")
+    local charWidth, charHeight = calcFontSize(fontSize, fontName)
+    local attached = {}
+    if Adjustable and Adjustable.Container and Adjustable.Container.Attached then
+      for side, containers in pairs(Adjustable.Container.Attached) do
+        for containerName in pairs(containers) do
+          attached[#attached + 1] = side .. ":" .. containerName
+        end
+      end
+    end
+    return {
+      width = width, height = height,
+      columns = getColumnCount("main"), rows = getRowCount("main"),
+      fontName = fontName, fontSize = fontSize,
+      charWidth = charWidth, charHeight = charHeight,
+      borders = getBorderSizes(), attached = attached,
+    }
+  end
+
+  local function describeGeometry(geometry)
+    local pixelsPerColumn = geometry.columns > 0 and geometry.width / geometry.columns or 0
+    return ("%dx%d px, %dx%d cells (%.1f px per column), font %s %d (%dx%d px per cell), borders left %d right %d top %d bottom %d, attached containers: %s"):format(
+      geometry.width, geometry.height, geometry.columns, geometry.rows, pixelsPerColumn,
+      geometry.fontName, geometry.fontSize, geometry.charWidth, geometry.charHeight,
+      geometry.borders.left, geometry.borders.right, geometry.borders.top, geometry.borders.bottom,
+      #geometry.attached > 0 and table.concat(geometry.attached, " ") or "none")
+  end
+
+  -- Width and column count at intervals after a reading, to show a
+  -- disagreement between the two either clearing or staying put.
+  local function traceSettling()
+    local samples = {}
+    for _ = 1, 10 do
+      pumpEvents(50)
+      local width = getMainWindowSize()
+      samples[#samples + 1] = ("%d/%d"):format(width, getColumnCount("main"))
+    end
+    return table.concat(samples, " ")
+  end
+
   it("a main window that loses more than half its width is reported at the width it has", function()
     if not resizableWindowAvailable() then
       return
@@ -6144,26 +6190,29 @@ describe("Main window size and saved layout", function()
     finally(restoreMainWindowSize)
     setMainWindowSize(1600, 700)
     pumpEvents(200)
-    local wideWidth = getMainWindowSize()
-    local wideColumns = getColumnCount("main")
+    local wide = mainConsoleGeometry()
 
     setMainWindowSize(300, 700)
     pumpEvents(200)
-    local narrowWidth = getMainWindowSize()
-    local narrowColumns = getColumnCount("main")
+    local narrow = mainConsoleGeometry()
+    -- after both readings, so it cannot change their timing
+    local settling = traceSettling()
+    local report = ("\n  wide:     %s\n  narrow:   %s\n  settling: %s"):format(
+      describeGeometry(wide), describeGeometry(narrow), settling)
 
     -- the main window has a minimum width of its own, so how narrow it really
     -- became is read off the column count rather than assumed; that and
     -- getMainWindowSize() have to tell the same story
-    if narrowColumns * 2 >= wideColumns then
-      pending("this display would not take the main window below half its width")
+    if narrow.columns * 2 >= wide.columns then
+      pending("this display would not take the main window below half its width" .. report)
       return
     end
     -- the console holds fewer than half the columns it did, so the width it
     -- reports has to have more than halved with them; merely falling would also
     -- be true of a size that only got part of the way down
-    assert.is_true(narrowWidth * 2 < wideWidth,
-      ("getMainWindowSize reported %d, down from %d, while the console went from %d to %d columns"):format(narrowWidth, wideWidth, wideColumns, narrowColumns))
+    assert.is_true(narrow.width * 2 < wide.width,
+      ("getMainWindowSize reported %d, down from %d, while the console went from %d to %d columns%s"):format(
+        narrow.width, wide.width, wide.columns, narrow.columns, report))
   end)
 
   it("the main window can be put back the size it was", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- The "loses more than half its width" UI spec reads the main console's size and column count once they have held still for 400 ms, instead of at a fixed 200 ms.
- Its pending and failure messages now include the geometry behind the numbers: font, cell size, user borders and any Adjustable container attached to a border.

#### Motivation for adding to Mudlet
The spec failed on development (run 33880455659) and on #10378 with identical numbers: 84 to 31 columns while the width went 1312 to 704 px. The starter interface's container is attached to the right border and re-reserves it from a 0.2 s timer after every resize, so a read at 200 ms raced that timer and saw the wide window's 333 px border on the narrow one. Reading at 150 ms reproduces the CI message deterministically; with the settle loop the suite is green and the report shows the border settling to 181 px.

#### Other info (issues closed, discussion etc)
Under Xvfb the main window bottoms out at 704 px, so on CI this spec is pending unless the timer interferes; the geometry report now shows that in the summary.

**Test case:** run the Lua specs (`.claude/scripts/run-lua-tests.sh`); the spec ends pending with a wide/narrow geometry report and no failure.

Assisted-by: Claude:claude-fable-5-1