### PR TITLE
Improve: Spell check reads its dictionary as soon as it is turned on

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4042,6 +4042,19 @@ void Host::setSpellDic(const QString& newDict)
     }
 }
 
+void Host::setEnableSpellCheck(const bool enable)
+{
+    if (mEnableSpellCheck == enable) {
+        return;
+    }
+    mEnableSpellCheck = enable;
+    // The load-end warm skips a profile with spell check off, so this is when
+    // the dictionary first becomes wanted:
+    if (enable && mpConsole) {
+        QTimer::singleShot(0, mpConsole.data(), &TMainConsole::slot_warmSystemSpellDictionary);
+    }
+}
+
 // When called from dlgProfilePreferences the second flag will only be changed
 // if necessary:
 // DISABLED: - Prevent "None" option for user dictionary - modified to prevent original useDictionary argument from being false:

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4049,8 +4049,11 @@ void Host::setEnableSpellCheck(const bool enable)
     }
     mEnableSpellCheck = enable;
     // The load-end warm skips a profile with spell check off, so this is when
-    // the dictionary first becomes wanted:
-    if (enable && mpConsole) {
+    // the dictionary first becomes wanted. During a profile load there is
+    // nothing to do: the handle is warmed once at the end, after the profile's
+    // own settings have been read - which is what setSystemSpellDictionary()
+    // next door defends against too.
+    if (enable && !mIsProfileLoadingSequence && mpConsole) {
         QTimer::singleShot(0, mpConsole.data(), &TMainConsole::slot_warmSystemSpellDictionary);
     }
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4053,8 +4053,8 @@ void Host::setEnableSpellCheck(const bool enable)
     // nothing to do: the handle is warmed once at the end, after the profile's
     // own settings have been read - which is what setSystemSpellDictionary()
     // next door defends against too.
-    if (enable && !mIsProfileLoadingSequence && mpConsole) {
-        QTimer::singleShot(0, mpConsole.data(), &TMainConsole::slot_warmSystemSpellDictionary);
+    if (enable && !mIsProfileLoadingSequence) {
+        emit signal_spellCheckEnabled();
     }
 }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -229,6 +229,7 @@ public:
     void setDiscordInviteURL(const QString& s);
     const QString& getDiscordInviteURL() const { return mDiscordInviteURL; }
     void setSpellDic(const QString&);
+    void setEnableSpellCheck(const bool enable);
     QString getSpellDic() const;
     void setUserDictionaryOptions(const bool useDictionary, const bool useShared);
     void getUserDictionaryOptions(bool& useDictionary, bool& useShared)

--- a/src/Host.h
+++ b/src/Host.h
@@ -230,6 +230,7 @@ public:
     const QString& getDiscordInviteURL() const { return mDiscordInviteURL; }
     void setSpellDic(const QString&);
     void setEnableSpellCheck(const bool enable);
+    bool getEnableSpellCheck() const { return mEnableSpellCheck; }
     QString getSpellDic() const;
     void setUserDictionaryOptions(const bool useDictionary, const bool useShared);
     void getUserDictionaryOptions(bool& useDictionary, bool& useShared)
@@ -863,7 +864,6 @@ public:
     QStringList mGMCP_merge_table_keys;
     bool mLogStatus = false;
     bool mTimeStampStatus = false;
-    bool mEnableSpellCheck = true;
     QStringList mInstalledPackages;
     // module name = location on disk, sync to other profiles?, priority
     QMap<QString, QStringList> mInstalledModules;
@@ -1183,6 +1183,7 @@ private:
     // These are hidden to prevent them being changed directly, they are also
     // mirrored/cached in the main TConsole's instance so they do not need to be
     // looked up directly by that class:
+    bool mEnableSpellCheck = true;
     bool mEnableUserDictionary = true;
     bool mUseSharedDictionary = false;
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -976,6 +976,9 @@ signals:
     void profileSaveStarted();
     void profileSaveFinished();
     void signal_changeSpellDict(const QString&);
+    // Spell check has just been turned on, so the system dictionary is wanted
+    // where it was not before. The main console reads it off the event loop.
+    void signal_spellCheckEnabled();
     // To tell all TConsole's upper TTextEdit panes to report all Codepoint
     // problems as they arrive as well as a summary upon destruction:
     void signal_changeDebugShowAllProblemCodepoints(const bool);

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -737,7 +737,7 @@ void TCommandLine::adjustHeight()
 
 void TCommandLine::spellCheck()
 {
-    if (!mpHost || !mpHost->mEnableSpellCheck) {
+    if (!mpHost || !mpHost->getEnableSpellCheck()) {
         return;
     }
 
@@ -986,7 +986,7 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
 
     if (event->button() == Qt::RightButton) {
         auto popup = createStandardContextMenu(event->globalPosition().toPoint());
-        if (mpHost->mEnableSpellCheck) {
+        if (mpHost->getEnableSpellCheck()) {
             fillSpellCheckList(event, popup);
             // else the word is in the dictionary - in either case show the context
             // menu - either the one with the prefixed spellings, or the standard one
@@ -1303,7 +1303,7 @@ void TCommandLine::slot_addWord()
 
 void TCommandLine::spellCheckWord(QTextCursor& c)
 {
-    if (!mpHost || !mpHost->mEnableSpellCheck) {
+    if (!mpHost || !mpHost->getEnableSpellCheck()) {
         return;
     }
 
@@ -1403,7 +1403,7 @@ bool TCommandLine::handleCtrlTabChange(QKeyEvent* ke, int tabNumber)
 
 void TCommandLine::recheckWholeLine()
 {
-    if (!mpHost || !mpHost->mEnableSpellCheck) {
+    if (!mpHost || !mpHost->getEnableSpellCheck()) {
         return;
     }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -99,7 +99,6 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
     connect(mudlet::self(), &mudlet::signal_profileMapReloadRequested, this, &TMainConsole::slot_reloadMap, Qt::UniqueConnection);
     connect(this, &TMainConsole::signal_newDataAlert, mudlet::self(), &mudlet::slot_newDataOnHost, Qt::UniqueConnection);
 
-    // Load up the spelling dictionary from the system:
     setSystemSpellDictionary(mpHost->getSpellDic());
     // Reading it costs tens of milliseconds, so it is not read here - but
     // leaving it for the first spell-check would put that wait in front of the
@@ -1845,7 +1844,7 @@ void TMainConsole::slot_warmSystemSpellDictionary()
 {
     // spellCheck() and spellSuggestWord() do not consult this flag, so the
     // lazy getter still serves a script in a profile that has spell check off:
-    if (mpHost->mEnableSpellCheck) {
+    if (mpHost && mpHost->mEnableSpellCheck) {
         getHunspellHandle_system();
     }
 }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -105,6 +105,9 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
     // first word typed, so a queued connection has the event loop do it once
     // the profile has finished loading:
     connect(mudlet::self(), &mudlet::signal_profileLoaded, this, &TMainConsole::slot_warmSystemSpellDictionary, Qt::QueuedConnection);
+    // ...and turning spell check on mid-session is the other moment the
+    // dictionary goes from unwanted to wanted, so it is read the same way
+    connect(mpHost, &Host::signal_spellCheckEnabled, this, &TMainConsole::slot_warmSystemSpellDictionary, Qt::QueuedConnection);
 
     // Load up the spelling dictionary for the profile - needs to handle the
     // absence of files for the first run in a new profile or from an older

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1847,7 +1847,7 @@ void TMainConsole::slot_warmSystemSpellDictionary()
 {
     // spellCheck() and spellSuggestWord() do not consult this flag, so the
     // lazy getter still serves a script in a profile that has spell check off:
-    if (mpHost && mpHost->mEnableSpellCheck) {
+    if (mpHost && mpHost->getEnableSpellCheck()) {
         getHunspellHandle_system();
     }
 }

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -232,6 +232,7 @@ public slots:
     // =>"Copy Map" in another profile to inform a list of
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
+    void slot_warmSystemSpellDictionary();
 
 
 private slots:
@@ -239,7 +240,6 @@ private slots:
     // owns everything else about it.
     void slot_loggingAnnouncement(const bool isLogging, const QString& logFileName);
     void slot_loggingStateChanged(const bool isLogging);
-    void slot_warmSystemSpellDictionary();
 
 
 signals:

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -232,7 +232,6 @@ public slots:
     // =>"Copy Map" in another profile to inform a list of
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
-    void slot_warmSystemSpellDictionary();
 
 
 private slots:
@@ -240,6 +239,7 @@ private slots:
     // owns everything else about it.
     void slot_loggingAnnouncement(const bool isLogging, const QString& logFileName);
     void slot_loggingStateChanged(const bool isLogging);
+    void slot_warmSystemSpellDictionary();
 
 
 signals:

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -443,7 +443,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mEnableCHARSET") = pHost->mEnableCHARSET ? "yes" : "no";
     host.append_attribute("mEnableNEWENVIRON") = pHost->mEnableNEWENVIRON ? "yes" : "no";
     host.append_attribute("mMapStrongHighlight") = pHost->mMapStrongHighlight ? "yes" : "no";
-    host.append_attribute("mEnableSpellCheck") = pHost->mEnableSpellCheck ? "yes" : "no";
+    host.append_attribute("mEnableSpellCheck") = pHost->getEnableSpellCheck() ? "yes" : "no";
     bool enableUserDictionary;
     bool useSharedDictionary;
     pHost->getUserDictionaryOptions(enableUserDictionary, useSharedDictionary);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -783,7 +783,13 @@ void XMLimport::readHost(Host* pHost)
     setBoolAttribute(qsl("mEnableMSDP"), pHost->mEnableMSDP);
     setBoolAttribute(qsl("mEnableMSP"), pHost->mEnableMSP);
     setBoolAttribute(qsl("mMapStrongHighlight"), pHost->mMapStrongHighlight);
-    setBoolAttribute(qsl("mEnableSpellCheck"), pHost->mEnableSpellCheck);
+    // Through the setter rather than at the field, so that turning spell check
+    // on always queues the dictionary read. Nothing is queued here: the whole
+    // import runs inside the profile loading sequence, which the setter skips,
+    // and the warm that follows the load covers whatever was read in.
+    bool enableSpellCheck = false;
+    setBoolAttribute(qsl("mEnableSpellCheck"), enableSpellCheck);
+    pHost->setEnableSpellCheck(enableSpellCheck);
     if (attributes().hasAttribute(QLatin1String("mShowInfo"))) {
         // Old - pre Map Info versions of Mudlet (those before
         // https://github.com/Mudlet/Mudlet/pull/4718) used the above

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -69,14 +69,14 @@ void dlgComposer::init(const QString& newTitle, const QString& newText)
 {
     title->setText(newTitle);
     edit->setPlainText(newText);
-    if (mpHost && mpHost->mEnableSpellCheck) {
+    if (mpHost && mpHost->getEnableSpellCheck()) {
         recheckWholeLine();
     }
 }
 
 bool dlgComposer::eventFilter(QObject* obj, QEvent* event)
 {
-    if (obj == edit && event->type() == QEvent::KeyPress && mpHost && mpHost->mEnableSpellCheck) {
+    if (obj == edit && event->type() == QEvent::KeyPress && mpHost && mpHost->getEnableSpellCheck()) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
 
         QTextCursor oldCursor = edit->textCursor();
@@ -112,7 +112,7 @@ bool dlgComposer::eventFilter(QObject* obj, QEvent* event)
 
 void dlgComposer::slot_spellCheck()
 {
-    if (!mpHost || !mpHost->mEnableSpellCheck) {
+    if (!mpHost || !mpHost->getEnableSpellCheck()) {
         return;
     }
 
@@ -136,7 +136,7 @@ void dlgComposer::slot_spellCheck()
 
 void dlgComposer::spellCheckWord(QTextCursor& c)
 {
-    if (!mpHost || !mpHost->mEnableSpellCheck) {
+    if (!mpHost || !mpHost->getEnableSpellCheck()) {
         return;
     }
 
@@ -193,7 +193,7 @@ void dlgComposer::spellCheckWord(QTextCursor& c)
 
 void dlgComposer::recheckWholeLine()
 {
-    if (!mpHost || !mpHost->mEnableSpellCheck) {
+    if (!mpHost || !mpHost->getEnableSpellCheck()) {
         return;
     }
 
@@ -228,7 +228,7 @@ void dlgComposer::slot_contextMenu(const QPoint& pos)
 {
     auto* popup = edit->createStandardContextMenu();
     popup->setAttribute(Qt::WA_DeleteOnClose);
-    if (mpHost && mpHost->mEnableSpellCheck) {
+    if (mpHost && mpHost->getEnableSpellCheck()) {
         // Convert from widget coordinates to viewport coordinates
         QPoint viewportPos = edit->viewport()->mapFromParent(pos);
         QMouseEvent mouseEvent(QEvent::MouseButtonPress, viewportPos, edit->mapToGlobal(pos), Qt::RightButton, Qt::RightButton, Qt::NoModifier);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -6412,7 +6412,7 @@ void dlgProfilePreferences::applyAll()
         }
 
         if (mSnapshot.dirty(checkBox_spellCheck)) {
-            pHost->mEnableSpellCheck = checkBox_spellCheck->isChecked();
+            pHost->setEnableSpellCheck(checkBox_spellCheck->isChecked());
         }
         if (mSnapshot.anyDirty({radioButton_userDictionary_common, radioButton_userDictionary_profile})) {
             if (radioButton_userDictionary_common->isChecked()) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3877,7 +3877,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
 
     comboBox_dictionary->clear();
-    checkBox_spellCheck->setChecked(pHost->mEnableSpellCheck);
+    checkBox_spellCheck->setChecked(pHost->getEnableSpellCheck());
     bool useUserDictionary = false;
     pHost->getUserDictionaryOptions(useUserDictionary, mUseSharedDictionary);
     // Always set the true radio button first - avoids any problems with

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -188,6 +188,7 @@ set(SETTINGS_GROUP_TEST_SOURCES
     SettingsLiveSyncTest.cpp
     SettingsSearchTest.cpp
     SettingsShellNavigationTest.cpp
+    SettingsSpellCheckEnableTest.cpp
 )
 
 # Teardown: who owns a profile's dialogs and windows, and what becomes of them when it closes

--- a/test/functional_tests/SettingsSpellCheckEnableTest.cpp
+++ b/test/functional_tests/SettingsSpellCheckEnableTest.cpp
@@ -1,0 +1,156 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The system spell dictionary is read once the profile has finished loading,
+ * and only for a profile that has spell check on. Turning spell check on in the
+ * preferences is therefore another way the dictionary goes from unused to
+ * used mid-session, and it has to be read then as well - otherwise the first
+ * word typed pays for it.
+ *
+ * Run with: ctest -R SettingsSpellCheckEnableTest -V
+ */
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <QCheckBox>
+#include <QSignalSpy>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "SettingsTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "dlgProfilePreferences.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+// Not the starting dictionary, so that reading it can only be down to the
+// change made below. Hunspell_create() hands back a handle whether or not the
+// files exist, so the load is logged on every platform.
+static const QString scmDictionary = qsl("en_GB");
+
+// loadSystemSpellDictionary() logs every read it makes, which is the only way to
+// see one without asking for the handle - and asking for it would make the read.
+static QtMessageHandler previousMessageHandler = nullptr;
+static int dictionaryReads = 0;
+
+static void countDictionaryReads(QtMsgType type, const QMessageLogContext& context, const QString& message)
+{
+    if (message.contains(qsl("System Hunspell dictionary \"%1\" loaded").arg(scmDictionary))) {
+        ++dictionaryReads;
+    }
+    if (previousMessageHandler) {
+        previousMessageHandler(type, context, message);
+    }
+}
+
+class SettingsSpellCheckEnableTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgProfilePreferences* mpPreferences = nullptr;
+    const QString mProfileName = qsl("SettingsSpellCheckEnable-Test");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort; // the stub's actual ephemeral port
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own - see the same block in
+        // DialogTeardownTest for why sharing the developer's one does not work
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        TestSettings::deleteProfileDirectory(mProfileName);
+
+        previousMessageHandler = qInstallMessageHandler(countDictionaryReads);
+        mpHost = TestProfile::create(mProfileName, mLocalhost, mPort);
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        qInstallMessageHandler(previousMessageHandler);
+        previousMessageHandler = nullptr;
+        delete mpPreferences;
+        mpPreferences = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            TestSettings::deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_tickingSpellCheckReadsTheDictionary()
+    {
+        // Picking a dictionary queues a read too; the flag makes the slot skip it
+        mpHost->setEnableSpellCheck(false);
+        mpHost->setSpellDic(scmDictionary);
+        QTest::qWait(TestSettings::scmQuietWindow);
+        QCOMPARE(dictionaryReads, 0);
+
+        mpPreferences = new dlgProfilePreferences(mudlet::self(), mpHost);
+        mpPreferences->resize(1060, 760);
+        mpPreferences->show();
+        QVERIFY(QTest::qWaitForWindowExposed(mpPreferences));
+        QVERIFY2(mpPreferences->checkBox_spellCheck->isEnabled(), "the spell check box cannot be ticked");
+        QVERIFY2(!mpPreferences->checkBox_spellCheck->isChecked(), "the spell check box does not show the profile's setting");
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        mpPreferences->checkBox_spellCheck->click();
+        QVERIFY2(TestSettings::waitForApply(applySpy), "the tick never reached the Host");
+        QVERIFY2(mpHost->mEnableSpellCheck, "the tick did not turn spell check on");
+
+        // Nothing here has asked for the handle, so a read now can only be the
+        // one the tick queued
+        QTRY_VERIFY2_WITH_TIMEOUT(dictionaryReads == 1, "turning spell check on left the dictionary unread, for the first word typed to pay for", 5000);
+    }
+};
+
+#include "SettingsSpellCheckEnableTest.moc"
+MUDLET_GROUPED_TEST_MAIN(SettingsSpellCheckEnableTest)

--- a/test/functional_tests/SettingsSpellCheckEnableTest.cpp
+++ b/test/functional_tests/SettingsSpellCheckEnableTest.cpp
@@ -144,7 +144,7 @@ private slots:
         QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
         mpPreferences->checkBox_spellCheck->click();
         QVERIFY2(TestSettings::waitForApply(applySpy), "the tick never reached the Host");
-        QVERIFY2(mpHost->mEnableSpellCheck, "the tick did not turn spell check on");
+        QVERIFY2(mpHost->getEnableSpellCheck(), "the tick did not turn spell check on");
 
         // Nothing here has asked for the handle, so a read now can only be the
         // one the tick queued


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Host::setEnableSpellCheck()` replaces the preferences dialog's direct write of the flag, and reads the system dictionary when spell check goes from off to on
- The warm slot skips a console whose profile has already been closed
- A grouped functional test ticks the box and checks the dictionary is read before anything asks for it

#### Motivation for adding to Mudlet

#10329 (Profiles with many packages load faster) reads the dictionary at load end only for a profile that has spell check on, so turning it on later in the preferences left the first word typed to pay the 9-17 ms read. Closes the gap raised in that PR's review.

#### Other info (issues closed, discussion etc)

**Test case:** `ctest -R SettingsSpellCheckEnableTest`. It fails with the preferences writing the flag directly, and with the setter not queuing the read. Manually: open a profile with spell check off, tick it in the preferences, and stderr shows the `System Hunspell dictionary ... loaded` line on the tick rather than on the first word typed.

Assisted-by: Claude:claude-fable-5-1