### PR TITLE
Fix: Crash when Mudlet exits shortly after starting up

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,8 +372,15 @@ int main(int argc, char* argv[])
     // has Qt parse every system CA certificate on the constructing thread,
     // which lands squarely inside profile load. Doing the same initialisation
     // on a pool thread now means the parse is normally over before a profile
-    // opens:
-    QThreadPool::globalInstance()->start([]() {
+    // opens.
+    // The pool is a local so that every early return from main() joins the
+    // thread on the way out: the warm-up holds Qt's TLS backend mutex while it
+    // loads the backend plugin, and static destruction pulls that mutex and the
+    // plugin machinery out from under it. The global pool cannot serve here -
+    // waiting on it would also wait for whatever QtConcurrent work a profile
+    // left running.
+    QThreadPool sslWarmupPool;
+    sslWarmupPool.start([]() {
         QSslConfiguration::defaultConfiguration();
     });
 
@@ -1151,6 +1158,11 @@ int main(int argc, char* argv[])
     // with some OS's choice of wait cursor - you might wish to temporarily disable
     // the earlier setOverrideCursor() line and this one.
     int result = app->exec();
+
+    // Before the QApplication goes, not just before main() returns: the TLS
+    // plugin loader connects to qApp, so a warm-up still running here would
+    // reach for one that has already been deleted.
+    sslWarmupPool.waitForDone();
 
     // Explicitly delete QApplication BEFORE main() returns to ensure Qt cleanup
     // happens before __cxa_finalize_ranges runs static destructors. This prevents

--- a/test/functional_tests/AppStartupTeardownTest.cpp
+++ b/test/functional_tests/AppStartupTeardownTest.cpp
@@ -1,0 +1,132 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Functional test for the way out of main() (#10460).
+ *
+ * Every other functional test links mudlet_core and builds its own
+ * QApplication, so nothing in the tree runs src/main.cpp and nothing sees what
+ * happens as it returns. main() hands the SSL warm-up to a thread and then
+ * leaves, and leaving is where static destruction takes Qt's TLS backend mutex
+ * and its library store out from under whatever is still running: the process
+ * reports "QMutex: destroying locked mutex" and dies inside freed plugin
+ * machinery.
+ *
+ * --version is the shortest path through main() that still starts the warm-up -
+ * initSentry(), the QApplication, mudlet::start(), setupConfig() and the
+ * translators, then an immediate return from the version branch - so it leaves
+ * a background task the least room to finish and fails first. It stops short of
+ * init(), so nothing here registers a telnet handler or writes a desktop file;
+ * the sandbox below is for what setupConfig() reads, not for writes.
+ *
+ * It is a race, so one clean exit proves nothing; hence the repeats. The
+ * regression this covers failed all six of six runs on a Linux debug build.
+ *
+ * Run with: ctest -R AppStartupTeardownTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include "GroupedTest.h"
+
+#ifndef MUDLET_APP_BINARY
+// Set by test/functional_tests/CMakeLists.txt. Without it there is no binary to
+// drive and every case below would pass having run nothing, so fail the build
+// rather than go quietly green if this file is ever moved out of that group.
+#error "AppStartupTeardownTest needs MUDLET_APP_BINARY - see test/functional_tests/CMakeLists.txt"
+#endif
+
+class AppStartupTeardownTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Enough runs to catch a warm-up that only sometimes loses the race, few
+    // enough that the whole case stays well inside its ctest timeout
+    static constexpr int scmRunCount = 8;
+    static constexpr int scmStartTimeoutMs = 10000;
+    static constexpr int scmFinishTimeoutMs = 20000;
+
+    static QString appBinary() { return QString::fromUtf8(MUDLET_APP_BINARY); }
+
+    // setupConfig() consults portable.txt beside the executable, and
+    // $HOME/.config/mudlet/portable.txt, before it ever looks at
+    // XDG_CONFIG_HOME - so with either one present the child runs against the
+    // real portable config, and an invalid path there makes it qFatal() and
+    // read as exactly the crash this test hunts. DialogTeardownTest skips for
+    // the same reason; the executable here is the application, not this binary.
+    static bool portableMarkerWouldWin()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QFileInfo(appBinary()).absolutePath())) || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+private slots:
+    void exitsCleanlyAfterEveryStartup()
+    {
+        QVERIFY2(QFileInfo::exists(appBinary()), qPrintable(qsl("no application binary at %1").arg(appBinary())));
+        if (portableMarkerWouldWin()) {
+            QSKIP("a portable.txt would send the child at the real config instead of the sandbox");
+        }
+
+        for (int run = 1; run <= scmRunCount; ++run) {
+            // A root of its own per run, so the child reads none of the
+            // developer's profiles and leaves nothing behind. Creating
+            // mudlet/profiles is what makes XDG_CONFIG_HOME outrank the legacy
+            // ~/.config/mudlet, see utils::xdgConfigDir()
+            QTemporaryDir sandbox;
+            QVERIFY2(sandbox.isValid(), qPrintable(sandbox.errorString()));
+            QVERIFY(QDir().mkpath(qsl("%1/config/mudlet/profiles").arg(sandbox.path())));
+
+            QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+            environment.insert(qsl("XDG_CONFIG_HOME"), qsl("%1/config").arg(sandbox.path()));
+            environment.insert(qsl("XDG_DATA_HOME"), qsl("%1/data").arg(sandbox.path()));
+            // Keeps a WITH_SENTRY build's crashpad database out of the real cache
+            environment.insert(qsl("XDG_CACHE_HOME"), qsl("%1/cache").arg(sandbox.path()));
+            environment.insert(qsl("QT_QPA_PLATFORM"), qsl("offscreen"));
+            environment.insert(qsl("MUDLET_TEST_MODE"), qsl("1"));
+            // The application deliberately never deletes its QApplication on
+            // this path, and Qt's CA store stays loaded for the process
+            // lifetime, so a leak check here would only ever report those
+            environment.insert(qsl("ASAN_OPTIONS"), qsl("detect_leaks=0"));
+
+            QProcess mudlet;
+            mudlet.setProcessEnvironment(environment);
+            mudlet.setProgram(appBinary());
+            mudlet.setArguments({qsl("--version")});
+            mudlet.start();
+
+            const QString where = qsl("run %1 of %2").arg(QString::number(run), QString::number(scmRunCount));
+            QVERIFY2(mudlet.waitForStarted(scmStartTimeoutMs), qPrintable(qsl("%1: %2").arg(where, mudlet.errorString())));
+            QVERIFY2(mudlet.waitForFinished(scmFinishTimeoutMs), qPrintable(qsl("%1: --version never finished").arg(where)));
+
+            const QString output = QString::fromUtf8(mudlet.readAllStandardOutput());
+            const QString diagnostics = qsl("%1, stderr:\n%2").arg(where, QString::fromUtf8(mudlet.readAllStandardError()));
+            QVERIFY2(mudlet.exitStatus() == QProcess::NormalExit, qPrintable(qsl("mudlet --version crashed on leaving main(); %1").arg(diagnostics)));
+            QVERIFY2(mudlet.exitCode() == 0, qPrintable(qsl("mudlet --version exited %1; %2").arg(QString::number(mudlet.exitCode()), diagnostics)));
+            // Without this the case would still pass against a main() that
+            // returned before ever reaching the warm-up, and cover nothing. The
+            // application name is the one part of that banner no translation
+            // touches - mudlet, mudlet.exe or Mudlet, depending on the platform
+            QVERIFY2(output.contains(qsl("mudlet"), Qt::CaseInsensitive), qPrintable(qsl("no version banner, so main() never reached the version branch; %1").arg(diagnostics)));
+        }
+    }
+};
+
+#include "AppStartupTeardownTest.moc"
+MUDLET_GROUPED_TEST_MAIN(AppStartupTeardownTest)

--- a/test/functional_tests/AppStartupTeardownTest.cpp
+++ b/test/functional_tests/AppStartupTeardownTest.cpp
@@ -102,8 +102,11 @@ private slots:
             environment.insert(qsl("MUDLET_TEST_MODE"), qsl("1"));
             // The application deliberately never deletes its QApplication on
             // this path, and Qt's CA store stays loaded for the process
-            // lifetime, so a leak check here would only ever report those
-            environment.insert(qsl("ASAN_OPTIONS"), qsl("detect_leaks=0"));
+            // lifetime, so a leak check here would only ever report those.
+            // Appended rather than replacing what ctest set, since the runtime
+            // takes the last setting of a flag and the earlier ones stay.
+            const QString inheritedSanitizerOptions = environment.value(qsl("ASAN_OPTIONS"));
+            environment.insert(qsl("ASAN_OPTIONS"), inheritedSanitizerOptions.isEmpty() ? qsl("detect_leaks=0") : qsl("%1:detect_leaks=0").arg(inheritedSanitizerOptions));
 
             QProcess mudlet;
             mudlet.setProcessEnvironment(environment);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -193,6 +193,7 @@ set(SETTINGS_GROUP_TEST_SOURCES
 
 # Teardown: who owns a profile's dialogs and windows, and what becomes of them when it closes
 set(TEARDOWN_GROUP_TEST_SOURCES
+    AppStartupTeardownTest.cpp
     DialogTeardownTest.cpp
     HostChildTeardownTest.cpp
     HostWidgetDecouplingTest.cpp
@@ -316,6 +317,14 @@ add_grouped_test_binary(functional_starterui_tests ${STARTERUI_GROUP_TEST_SOURCE
 add_grouped_test_binary(functional_teardown_tests ${TEARDOWN_GROUP_TEST_SOURCES})
 add_grouped_test_binary(functional_media_tests ${MEDIA_GROUP_TEST_SOURCES})
 
+# AppStartupTeardownTest runs the shipped application instead of linking it, so it
+# needs that binary's path and needs it built by the time ctest runs. Naming the
+# target literally is deliberate: EXE_MUDLET_TARGET is a plain variable local to
+# src/CMakeLists.txt, so a rename there fails generation here rather than quietly
+# depending on nothing.
+add_dependencies(functional_teardown_tests mudlet_executable)
+target_compile_definitions(functional_teardown_tests PRIVATE MUDLET_APP_BINARY="$<TARGET_FILE:mudlet_executable>")
+
 # Every list's cases, so a grouped test's properties are the solo ones verbatim
 foreach(test_name ${allFunctionalTestNames})
     if(leakCheckAvailable AND NOT test_name IN_LIST leakCheckExcludedTests)
@@ -372,6 +381,10 @@ endforeach()
 # ResetProfileTest creates a full profile per test method, so it needs a longer
 # timeout than the default 60s
 set_tests_properties(ResetProfileTest PROPERTIES TIMEOUT 300)
+
+# AppStartupTeardownTest starts the whole application eight times over, and a
+# sanitiser build spends seconds on each of those start-ups
+set_tests_properties(AppStartupTeardownTest PROPERTIES TIMEOUT 300)
 
 # Undo/redo tests need a longer timeout due to large batch operations
 set_tests_properties(dlgTriggerEditorUndoRedoTest PROPERTIES TIMEOUT 300)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The SSL warm-up added in "Improve: Profiles with many packages load faster" (#10329) runs on the global thread pool, which nothing waits for, so `main()` can return while it is still loading Qt's TLS backend plugin. Static destruction then takes the backend mutex and the library store out from under it: `QMutex: destroying locked mutex`, then a death inside freed plugin machinery. `mudlet --version` aborted 6 of 6 runs on a Linux debug build, 0 of 12 with this change.
- The warm-up now runs on a function-local `QThreadPool`, so every route out of `main()` joins it. The global pool cannot serve - waiting on it would also wait for whatever QtConcurrent work a profile left running. On the `exec()` path the join is explicit, ahead of `delete app`, because the TLS plugin loader connects to `qApp`.
- Adds `AppStartupTeardownTest`, which starts the shipped binary eight times over. Every other functional test links `mudlet_core` and builds its own `QApplication`, so until now nothing in the tree ran `src/main.cpp` at all, let alone watched it return.

#### Motivation for adding to Mudlet

Any short-lived run - `--version`, `--help`, the Windows updater relaunch - could abort instead of exiting, and a quick quit after startup hits the same race.

#### Other info (issues closed, discussion etc)

Closes #10460.

**Test case:** `mudlet --version` prints the version and exits 0 every time, and `ctest -R AppStartupTeardownTest -V` passes.