### PR TITLE
Fix: Crash reporting no longer starts up during test runs

### DIFF
--- a/src/SentryWrapper.cpp
+++ b/src/SentryWrapper.cpp
@@ -50,6 +50,15 @@
 void initSentry()
 {
 #ifdef WITH_SENTRY
+    // Never arm crashpad for a test run. The Lua suite drives this very binary with
+    // MUDLET_TEST_MODE set, and an armed crashpad answers a crash there by launching
+    // MudletCrashReporter, which blocks on a modal dialog unless "autoSendCrashReports" is already
+    // AlwaysSend. No CI runner has that setting, so a crash would hang the job to its timeout
+    // rather than fail it - and the report would go out as if a player had hit it.
+    if (qEnvironmentVariableIsSet("MUDLET_TEST_MODE")) {
+        return;
+    }
+
     sentry_options_t* options = sentry_options_new();
     std::string runtimeAppDir = getExeDir();
     QString path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/mudlet/sentry";

--- a/test/functional_tests/CrashTestHookTest.cpp
+++ b/test/functional_tests/CrashTestHookTest.cpp
@@ -17,6 +17,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+// The two halves of crash reporting that only a second process can show.
+//
 // MUDLET_CRASH_TEST=1 has to kill Mudlet the moment server text reaches a buffer, since that is the
 // only way we have of exercising crash reporting end to end. The crash it fakes is a write through a
 // null pointer, which is undefined behaviour the compiler may delete outright - clang did, leaving
@@ -28,8 +30,15 @@
 // The test tree is built unoptimised, where the store survives either way; what would catch a
 // regression is Windows, which builds Release with clang on every pull request, and the optimised
 // tag builds.
+//
+// The other half is the guard that stops initSentry() from setting up crash reporting under
+// MUDLET_TEST_MODE - see initSentry() in src/SentryWrapper.cpp for what that costs when it is
+// missing. It needs a child too, because sentry_init() is once-per-process and the control run has
+// to happen in a process this one can throw away.
 
+#include <QDir>
 #include <QProcess>
+#include <QStandardPaths>
 #include <QtTest/QtTest>
 
 #include "GroupedTest.h"
@@ -47,6 +56,40 @@
 static constexpr const char* reachedHookMarker = "reached-the-crash-hook";
 static constexpr const char* childEnvironmentVariable = "MUDLET_CRASH_TEST_CHILD";
 static constexpr int survivedExitCode = 66;
+
+static constexpr const char* sentryChildEnvironmentVariable = "MUDLET_SENTRY_GUARD_CHILD";
+
+#ifdef WITH_SENTRY
+static constexpr const char* databasePathMarker = "sentry-database-path: ";
+static constexpr const char* databaseCreatedMarker = "sentry-database-created: ";
+static constexpr const char* sentryDatabaseSuffix = "/mudlet/sentry";
+
+static QString markedValue(const QString& output, const char* marker)
+{
+    const QString prefix = QString::fromUtf8(marker);
+    const QStringList lines = output.split(QChar::fromLatin1('\n'));
+    for (const QString& line : lines) {
+        if (line.startsWith(prefix)) {
+            return line.mid(prefix.size()).trimmed();
+        }
+    }
+    return {};
+}
+
+// Both the database and the "mudlet" directory holding it, since MUDLET_GROUPED_TEST_MAIN names the
+// cache location after this test rather than after Mudlet - nothing of anyone else's lives in there.
+static void removeSentryDatabase(const QString& databasePath)
+{
+    if (!databasePath.endsWith(QString::fromUtf8(sentryDatabaseSuffix))) {
+        return;
+    }
+    QDir database(databasePath);
+    database.removeRecursively();
+    if (database.cdUp()) {
+        database.removeRecursively();
+    }
+}
+#endif
 
 class CrashTestHookTest : public QObject
 {
@@ -104,6 +147,108 @@ private slots:
         // the parent would read as a crash, passing the test on a hook that did nothing.
         std::_Exit(survivedExitCode);
     }
+
+    // What a child can see of initSentry() from the outside is the crashpad database, which
+    // sentry_init() creates before it starts a backend. That the database is missing is what says
+    // the guard returned before any of it.
+    void initSentryDoesNothingInTestMode()
+    {
+#ifndef WITH_SENTRY
+        QSKIP("initSentry() only sets up anything in a -DWITH_SENTRY=ON build");
+#else
+        // The control run first. Without it, an initSentry() that had stopped creating a database
+        // for some unrelated reason would pass the guarded run below while guarding nothing.
+        QString controlPath;
+        bool controlCreatedDatabase = false;
+        QString diagnosis;
+        QVERIFY2(runSentryChild(false, controlPath, controlCreatedDatabase, diagnosis), qPrintable(diagnosis));
+        QVERIFY2(controlCreatedDatabase,
+                 qPrintable(qsl("initSentry() created no crashpad database at %1 even with MUDLET_TEST_MODE unset, "
+                                "so the guarded run below would prove nothing")
+                                    .arg(controlPath)));
+
+        QString guardedPath;
+        bool guardedCreatedDatabase = true;
+        QVERIFY2(runSentryChild(true, guardedPath, guardedCreatedDatabase, diagnosis), qPrintable(diagnosis));
+        QVERIFY2(!guardedCreatedDatabase, qPrintable(qsl("initSentry() ran under MUDLET_TEST_MODE - it got as far as creating its crashpad database at %1").arg(guardedPath)));
+#endif
+    }
+
+    void reportsWhetherInitSentryCreatedItsDatabase()
+    {
+        if (qEnvironmentVariable(sentryChildEnvironmentVariable) != qsl("1")) {
+            QSKIP("runs only as the child of initSentryDoesNothingInTestMode()");
+        }
+
+#ifdef WITH_SENTRY
+        // MUDLET_GROUPED_TEST_MAIN names the application after this class, so the cache location
+        // initSentry() builds its database path from belongs to this test rather than to whoever
+        // is running it - safe to delete, and empty of any real crash report.
+        const QString databasePath = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QString::fromUtf8(sentryDatabaseSuffix);
+        QDir(databasePath).removeRecursively();
+        QVERIFY(!QDir(databasePath).exists());
+
+        // Announced before initSentry() runs, so the parent can clean up after a child that died
+        // inside it.
+        std::fputs(qPrintable(QString::fromUtf8(databasePathMarker) + databasePath), stdout);
+        std::fputc('\n', stdout);
+        std::fflush(stdout);
+
+        initSentry();
+
+        std::fputs(qPrintable(QString::fromUtf8(databaseCreatedMarker) + (QDir(databasePath).exists() ? qsl("yes") : qsl("no"))), stdout);
+        std::fputc('\n', stdout);
+        std::fflush(stdout);
+#endif
+
+        // _Exit for crashesOnRequest()'s reason, and for one of its own: the control run leaves
+        // sentry initialised on purpose, so LeakSanitizer would report what sentry_init allocated
+        // and fail a child that did exactly what it was asked to.
+        std::_Exit(0);
+    }
+
+private:
+#ifdef WITH_SENTRY
+    bool runSentryChild(const bool testMode, QString& databasePath, bool& createdDatabase, QString& diagnosis)
+    {
+        QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+        environment.insert(QString::fromUtf8(sentryChildEnvironmentVariable), qsl("1"));
+        environment.insert(qsl("QTEST_DISABLE_STACK_DUMP"), qsl("1"));
+        if (testMode) {
+            environment.insert(qsl("MUDLET_TEST_MODE"), qsl("1"));
+        } else {
+            // Removed rather than left unset: ctest sets it for every functional test, so the
+            // control run inherits it from this process.
+            environment.remove(qsl("MUDLET_TEST_MODE"));
+        }
+
+        QProcess child;
+        child.setProcessEnvironment(environment);
+        child.start(QCoreApplication::applicationFilePath(), {qsl("CrashTestHookTest"), qsl("reportsWhetherInitSentryCreatedItsDatabase")});
+        const bool finished = child.waitForStarted(15000) && child.waitForFinished(30000);
+
+        const QString output = QString::fromUtf8(child.readAllStandardOutput());
+        databasePath = markedValue(output, databasePathMarker);
+        const QString createdAnswer = markedValue(output, databaseCreatedMarker);
+        createdDatabase = (createdAnswer == qsl("yes"));
+        // Ahead of any verdict, since the caller's QVERIFY2 returns on a failure rather than
+        // reaching a cleanup below it - and a child that died inside initSentry() is exactly the
+        // case the path was announced early for.
+        removeSentryDatabase(databasePath);
+
+        if (!finished) {
+            diagnosis = qsl("the child never finished (MUDLET_TEST_MODE %1)").arg(testMode ? qsl("set") : qsl("unset"));
+            return false;
+        }
+        if (databasePath.isEmpty() || createdAnswer.isEmpty()) {
+            diagnosis = qsl("the child said nothing about the crashpad database (MUDLET_TEST_MODE %1)\nstdout: %2\nstderr: %3")
+                                .arg(testMode ? qsl("set") : qsl("unset"), output, QString::fromUtf8(child.readAllStandardError()));
+            return false;
+        }
+
+        return true;
+    }
+#endif
 };
 
 #include "CrashTestHookTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `initSentry()` returns straight away when `MUDLET_TEST_MODE` is set, so a test run never sets up crashpad.
- `CrashTestHookTest` gained a case for it, which runs two child processes because `sentry_init()` is once-per-process: a control run with `MUDLET_TEST_MODE` unset, which has to create the crashpad database, and a guarded run that must not.

#### Motivation for adding to Mudlet

Windows builds every pull request `WITH_SENTRY=ON` and then runs the Lua suite against that binary with `MUDLET_TEST_MODE=1`. A crash there launches MudletCrashReporter, which blocks on a modal dialog unless the `autoSendCrashReports` setting is already `AlwaysSend` - no CI runner has that, so the job would hang to its timeout instead of failing, and the report would go out as if a player had hit it.

#### Other info (issues closed, discussion etc)

Closes #10537.

Verified by hand on a `-DWITH_SENTRY=ON` build, crashing a real `mudlet` with `SIGSEGV` under a throwaway `HOME`:

| | crashpad database | minidumps | MudletCrashReporter appeared |
| --- | --- | --- | --- |
| `MUDLET_TEST_MODE` unset | yes | 1 | yes |
| `MUDLET_TEST_MODE=1` | no | 0 | no |

The new test case observes the crashpad database rather than the reporter, since that is what `sentry_init()` creates before it starts a backend, and it is the only half a test binary can see without linking sentry's headers.

**Test case:** build with `-DWITH_SENTRY=ON`, then `ctest -R "^CrashTestHookTest$"`. To confirm the test bites, change the guard in `src/SentryWrapper.cpp` to `if (false && qEnvironmentVariableIsSet("MUDLET_TEST_MODE"))` and re-run - the case fails with `initSentry() ran under MUDLET_TEST_MODE - it got as far as creating its crashpad database at ...`.
