### PR TITLE
Fix: a media start position now starts the track there in all cases on Linux

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1221,6 +1221,50 @@ QString TMedia::setupMediaAbsolutePathFileName(TMediaData& mediaData)
     return absolutePathFileName;
 }
 
+// A start position can only be applied once the media is loaded, seekable and playing, which on a
+// backend that loads asynchronously is several signals after play() was called - seeking any
+// earlier is dropped without a word and the track plays from its beginning (#10459). Hooked to
+// both signals that can complete that set, so whichever arrives last performs the seek.
+void TMedia::seekToMediaStart(const std::shared_ptr<TMediaPlayer>& player)
+{
+    QMediaPlayer* mediaPlayer = player->mediaPlayer();
+
+    if (!mediaPlayer->isSeekable() || mediaPlayer->playbackState() != QMediaPlayer::PlayingState) {
+        return;
+    }
+
+    const QMediaPlayer::MediaStatus mediaStatus = mediaPlayer->mediaStatus();
+
+    if (mediaStatus != QMediaPlayer::LoadedMedia && mediaStatus != QMediaPlayer::BufferingMedia && mediaStatus != QMediaPlayer::BufferedMedia) {
+        return;
+    }
+
+    const int startPosition = player->mediaData().mediaStart();
+
+    if (startPosition <= TMediaData::MediaStartDefault) {
+        return;
+    }
+
+    // Seeking to or past the end leaves the player playing at its last frame forever - no
+    // EndOfMedia, so nothing releases the source or sends sysMediaFinished, and the profile runs
+    // out of players. A server is free to send a start longer than the track, so play it from the
+    // beginning instead, which is what an unseekable start did before.
+    const qint64 duration = mediaPlayer->duration();
+
+    if (duration > 0 && startPosition >= duration) {
+        return;
+    }
+
+    // Both signals fire again as the track buffers, and the position is what says the seek has
+    // already been made: without this a track would be dragged back to its start position each
+    // time one of them arrived.
+    if (mediaPlayer->position() >= startPosition) {
+        return;
+    }
+
+    mediaPlayer->setPosition(startPosition);
+}
+
 void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 {
     if (!player || !player->mediaPlayer()) {
@@ -1232,11 +1276,9 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
     // Seekable changed connection
     disconnect(player->mediaPlayer(), &QMediaPlayer::seekableChanged, nullptr, nullptr);
-    connect(player->mediaPlayer(), &QMediaPlayer::seekableChanged, this, [weakPlayer](bool seekable) {
+    connect(player->mediaPlayer(), &QMediaPlayer::seekableChanged, this, [weakPlayer](bool) {
         if (auto lockedPlayer = weakPlayer.lock()) { // Ensure the player is still valid
-            if (seekable) {
-                lockedPlayer->mediaPlayer()->setPosition(lockedPlayer->mediaData().mediaStart());
-            }
+            seekToMediaStart(lockedPlayer);
         }
     });
 
@@ -1244,6 +1286,8 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
     disconnect(player->mediaPlayer(), &QMediaPlayer::mediaStatusChanged, nullptr, nullptr);
     connect(player->mediaPlayer(), &QMediaPlayer::mediaStatusChanged, this, [this, weakPlayer](QMediaPlayer::MediaStatus mediaStatus) {
         if (auto lockedPlayer = weakPlayer.lock()) {
+            seekToMediaStart(lockedPlayer);
+
             if (mediaStatus == QMediaPlayer::EndOfMedia) {
                 if (lockedPlayer->playlist() && !lockedPlayer->playlist()->isEmpty()) {
                     QUrl nextMedia = lockedPlayer->playlist()->next();

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -283,6 +283,7 @@ private:
     bool processUrl(TMediaData& mediaData);
     void downloadFile(TMediaData& mediaData);
     QString setupMediaAbsolutePathFileName(TMediaData& mediaData);
+    static void seekToMediaStart(const std::shared_ptr<TMediaPlayer>& player);
     void connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player);
     static void purgeStoppedMediaPlayers(QList<std::shared_ptr<TMediaPlayer>>& mediaList);
     template <typename T>

--- a/src/mudlet-lua/tests/Media_spec.lua
+++ b/src/mudlet-lua/tests/Media_spec.lua
@@ -771,6 +771,65 @@ describe("Media playback effects with a generated sound file", function()
     assert.equals(0, #getPlayingSounds())
   end)
 
+  it("a start position begins playback part way into the file", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
+    writeSoundFiles()
+    assert.is_true(playSoundFile({name = longSoundFile, start = 9700, key = "busted-started-late"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    -- 300ms of the ten second file is left after the start position, so a
+    -- finish inside waitForCount's five seconds is the seek having taken
+    -- effect: a start position that was ignored plays all ten.
+    waitForCount("sysMediaFinished", finished, 1)
+    assert.equals(1, #finished)
+    assert.equals("busted-started-late", finished[1].key)
+    assert.equals(0, #getPlayingSounds())
+  end)
+
+  it("a start position and a finish position play the window between them", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
+    writeSoundFiles()
+    -- The finish position is measured from the start of the file rather than
+    -- from the start position, so this is 400ms of playing from 5000ms in.
+    assert.is_true(playSoundFile({name = longSoundFile, start = 5000, finish = 5400, key = "busted-window"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    waitForCount("sysMediaFinished", finished, 1)
+    assert.equals(1, #finished)
+    assert.equals("busted-window", finished[1].key)
+    assert.equals(0, #getPlayingSounds())
+  end)
+
+  it("a start position past the end of the file plays the file instead of hanging", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
+    writeSoundFiles()
+    -- Seeking to or past the end leaves the player sitting at its last frame with no
+    -- end-of-media, so nothing would ever release it or send sysMediaFinished. A server
+    -- is free to name a start longer than the track, so an out of range one is dropped.
+    assert.is_true(playSoundFile({name = soundFile, start = 60000, key = "busted-start-past-end"}))
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)))
+
+    waitForCount("sysMediaFinished", finished, 1)
+    assert.equals(1, #finished)
+    assert.equals("busted-start-past-end", finished[1].key)
+    assert.equals(0, #getPlayingSounds())
+  end)
+
   it("a sysMediaFinished handler that starts a sound leaves the caller's own request playing", function()
     if mediaPlaybackUnavailable() then
       return
@@ -1576,6 +1635,33 @@ describe("Media playback effects with a generated sound file", function()
     waitForCount("sysMediaFinished", finished, 1)
     assert.equals(1, #finished)
     assert.equals("busted-gmcp-music", finished[1].key)
+  end)
+
+  it("a Client.Media.Play message begins playback at the start position it names", function()
+    if mediaPlaybackUnavailable() then
+      return
+    end
+    local finished = {}
+    collect("sysMediaFinished", finished)
+
+    writeSoundFiles()
+    stopGmcpMediaAfterwards()
+
+    -- Once as a number and once as the string the protocol also allows, since
+    -- the two are read by different branches of the same field parser. Both
+    -- leave 300ms of the ten second file to play, so a finish inside
+    -- waitForCount's five seconds is the seek having taken effect.
+    feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "start": 9700, "key": "busted-gmcp-start-number"}')
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)), gmcpRefused)
+    waitForCount("sysMediaFinished", finished, 1)
+    assert.equals(1, #finished)
+    assert.equals("busted-gmcp-start-number", finished[1].key)
+
+    feedGmcp('Client.Media.Play {"name": "' .. longSoundFile .. '", "start": "9700", "key": "busted-gmcp-start-string"}')
+    assert.equals("sysMediaStarted", (waitForEvent("sysMediaStarted", 5000)), gmcpRefused)
+    waitForCount("sysMediaFinished", finished, 2)
+    assert.equals(2, #finished)
+    assert.equals("busted-gmcp-start-string", finished[2].key)
   end)
 
   it("a Client.Media.Stop message ends what a Client.Media.Play started", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

A `start` position on `playSoundFile`/`playMusicFile` and on a `Client.Media.Play` message was ignored - the track always played from its beginning.

`QMediaPlayer` only accepts `setPosition()` once the media is loaded, seekable and playing. On the FFmpeg backend that is several signals after `play()` returns, so both places that tried to apply the start position were too early:

- `TMedia::play()` seeks immediately after `play()`, while the media is still `LoadingMedia`.
- the `seekableChanged` handler seeks as soon as the player reports seekable, which happens while it is still `LoadingMedia` too.

Neither seek reports an error; they are dropped and the track plays in full.

The seek now goes through one `seekToMediaStart()` helper, hooked to both `seekableChanged` and `mediaStatusChanged`, so whichever of those completes the loaded/seekable/playing set performs the seek. Repeat signals are ignored once the position is past the start, so a track is not dragged back to its start position as it buffers.

Making the seek actually land exposed a second problem, so this also guards it: seeking to or past the end of the track leaves the player sitting on its last frame with no `EndOfMedia`, which means the source is never released, `sysMediaFinished` never fires, and repeat requests allocate new players until the profile's cap is reached and media stops working. A server is free to name a `start` longer than the track, so an out-of-range one is dropped and the track plays from the beginning.

#### Motivation for adding to Mudlet

`start` is part of the MUD Client Media Protocol and Mudlet has advertised it since the feature landed, but it has never had any effect. Games using it to resume a track partway, or to play one region of a longer file, get the whole file instead.

#### Other info (issues closed, discussion etc)

Closes #10459.

Four specs in `Media_spec.lua` cover it, all timing playback against a generated ten second file so an ignored start position shows up as a track that runs ten times too long:

- a `start` on `playSoundFile`
- a `start` together with a `finish`
- a `start` on `Client.Media.Play`, as both a number and the string form the protocol also allows
- a `start` past the end of the file, which must still finish

Verified they fail without the change: the first three fail against `development`, and the fourth fails against the fix with the out-of-range guard removed.
