### PR TITLE
Fix: IRC kicks are shown, server text cannot inject markup, and scripts get the text as sent

### DIFF
--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -23,6 +23,15 @@
 
 #include <IrcTextFormat>
 
+// communi escapes & and < before it strips the IRC formatting codes, and hands
+// out the plain text with those entities still in it; a script wants the text
+// the way it was sent. Only those two are escaped, and &lt; is undone first so
+// that a literal "&lt;" (which came through as "&amp;lt;") survives the trip.
+static QString plainTextForLua(const QString& text)
+{
+    return IrcTextFormat().toPlainText(text).replace(QStringLiteral("&lt;"), QStringLiteral("<")).replace(QStringLiteral("&amp;"), QStringLiteral("&"));
+}
+
 QString IrcMessageFormatter::formatMessage(IrcMessage* message, bool isForLua)
 {
     QString formatted;
@@ -134,7 +143,7 @@ QString IrcMessageFormatter::formatAwayMessage(IrcAwayMessage* message, bool isF
 {
     QString content;
     if (isForLua) {
-        content = IrcTextFormat().toPlainText(message->content());
+        content = plainTextForLua(message->content());
     } else {
         content = IrcTextFormat().toHtml(message->content());
     }
@@ -190,7 +199,7 @@ QString IrcMessageFormatter::formatMotdMessage(IrcMotdMessage* message, bool isF
         QString content, lineEnd;
         if (isForLua) {
             lineEnd = "\n";
-            content = IrcTextFormat().toPlainText(line);
+            content = plainTextForLua(line);
         } else {
             lineEnd = "<br />\n";
             content = IrcTextFormat().toHtml(line);
@@ -248,7 +257,7 @@ QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message, bool
     if (message->isPrivate()) {
         QString content;
         if (isForLua) {
-            content = IrcTextFormat().toPlainText(message->content());
+            content = plainTextForLua(message->content());
         } else {
             content = IrcTextFormat().toHtml(message->content());
         }
@@ -257,7 +266,7 @@ QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message, bool
 
     if (isForLua) {
         // lua only needs the message text.
-        return IrcTextFormat().toPlainText(message->content());
+        return plainTextForLua(message->content());
     }
     const QString content = IrcTextFormat().toHtml(message->content());
     return QObject::tr("&lt;%1%2&gt; [%3] %4").arg(message->nick(), pfx, message->target(), content);
@@ -269,7 +278,7 @@ QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message, bo
         const QString info = QStringList(message->parameters().mid(1)).join(" ");
         QString content;
         if (isForLua) {
-            content = IrcTextFormat().toPlainText(info);
+            content = plainTextForLua(info);
         } else {
             content = IrcTextFormat().toHtml(info);
         }
@@ -296,7 +305,7 @@ QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message, bo
         const QString info = QStringList(message->parameters().mid(1)).join(" ");
         QString content;
         if (isForLua) {
-            content = IrcTextFormat().toPlainText(info);
+            content = plainTextForLua(info);
         } else {
             content = IrcTextFormat().toHtml(info);
         }
@@ -306,7 +315,7 @@ QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message, bo
         const QString info = QStringList(message->parameters().mid(1)).join(" ");
         QString content;
         if (isForLua) {
-            content = IrcTextFormat().toPlainText(info);
+            content = plainTextForLua(info);
         } else {
             content = IrcTextFormat().toHtml(info);
         }
@@ -315,7 +324,7 @@ QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message, bo
     const QString info = QStringList(message->parameters().mid(1)).join(" ");
     QString content;
     if (isForLua) {
-        content = IrcTextFormat().toPlainText(info);
+        content = plainTextForLua(info);
     } else {
         content = IrcTextFormat().toHtml(info);
     }
@@ -351,7 +360,7 @@ QString IrcMessageFormatter::formatPrivateMessage(IrcPrivateMessage* message, bo
 {
     QString content;
     if (isForLua) {
-        content = IrcTextFormat().toPlainText(message->content());
+        content = plainTextForLua(message->content());
     } else {
         content = IrcTextFormat().toHtml(message->content());
     }
@@ -384,7 +393,7 @@ QString IrcMessageFormatter::formatTopicMessage(IrcTopicMessage* message, bool i
 
         QString topic;
         if (isForLua) {
-            topic = IrcTextFormat().toPlainText(message->topic());
+            topic = plainTextForLua(message->topic());
         } else {
             topic = IrcTextFormat().toHtml(message->topic());
         }

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -40,6 +40,9 @@ QString IrcMessageFormatter::formatMessage(IrcMessage* message, bool isForLua)
     case IrcMessage::Join:
         formatted = formatJoinMessage(static_cast<IrcJoinMessage*>(message), isForLua);
         break;
+    case IrcMessage::Kick:
+        formatted = formatKickMessage(static_cast<IrcKickMessage*>(message), isForLua);
+        break;
     case IrcMessage::Mode:
         formatted = formatModeMessage(static_cast<IrcModeMessage*>(message), isForLua);
         break;
@@ -270,7 +273,7 @@ QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message, bo
         } else {
             content = IrcTextFormat().toHtml(info);
         }
-        return QObject::tr("[INFO] %1").arg(info);
+        return QObject::tr("[INFO] %1").arg(content);
     }
 
     switch (message->code()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,21 @@ set_tests_properties(ReleaseChangelogSpanTest PROPERTIES
     ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
 )
 
+# The IRC client's message formatting. Built from the one source it covers rather
+# than linked against the Mudlet library: the formatter is static and reaches for
+# nothing but communi, so this needs neither the library nor the ~250MB a link
+# against it costs every build tree.
+add_executable(IrcMessageFormatterTest
+    IrcMessageFormatterTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/ircmessageformatter.cpp
+)
+target_include_directories(IrcMessageFormatterTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(IrcMessageFormatterTest PRIVATE Qt6::Test communi)
+add_test(NAME IrcMessageFormatterTest COMMAND $<TARGET_FILE:IrcMessageFormatterTest>)
+set_tests_properties(IrcMessageFormatterTest PROPERTIES
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0"
+)
+
 # DiscordTest checks the Lua API permission gating contract by scanning the source
 target_compile_definitions(DiscordTest PRIVATE MUDLET_SRC_DIR="${CMAKE_SOURCE_DIR}/src")
 

--- a/test/IrcMessageFormatterTest.cpp
+++ b/test/IrcMessageFormatterTest.cpp
@@ -1,0 +1,278 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "ircmessageformatter.h"
+
+#include <IrcConnection>
+#include <QtTest/QtTest>
+
+/*
+ * Unit tests for IrcMessageFormatter, which turns what the IRC server says into
+ * the two forms Mudlet shows it in: HTML for the IRC window, and plain text for
+ * the sysIrcMessage event a script sees.
+ *
+ * The formatter is static and depends only on communi, so these tests need
+ * neither a Host nor the Mudlet application stack.
+ *
+ * The window form carries the wall-clock time it was formatted at, so the cases
+ * that need an exact string ask for the Lua form, which does not.
+ */
+class IrcMessageFormatterTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Never opened: a connection is only wanted because communi decodes a
+    // message against one, parents the message to it, and answers
+    // IrcNoticeMessage::isPrivate() by comparing against its nickname
+    IrcConnection mConnection;
+
+    IrcMessage* fromRaw(const QByteArray& raw) { return IrcMessage::fromData(raw, &mConnection); }
+
+    QString forLua(const QByteArray& raw) { return IrcMessageFormatter::formatMessage(fromRaw(raw), true); }
+
+    QString forWindow(const QByteArray& raw) { return IrcMessageFormatter::formatMessage(fromRaw(raw), false); }
+
+private slots:
+    void initTestCase() { mConnection.setNickName(QStringLiteral("me")); }
+
+    void join_namesWhoJoinedAndWhere() { QCOMPARE(forLua(":bob!u@h JOIN #mudlet"), QStringLiteral("! bob has joined #mudlet")); }
+
+    void part_withoutAReason() { QCOMPARE(forLua(":bob!u@h PART #mudlet"), QStringLiteral("! bob has left #mudlet")); }
+
+    void part_withAReason() { QCOMPARE(forLua(":bob!u@h PART #mudlet :getting dinner"), QStringLiteral("! bob has left #mudlet (getting dinner)")); }
+
+    void quit_withoutAReason() { QCOMPARE(forLua(":bob!u@h QUIT"), QStringLiteral("! bob has quit")); }
+
+    void quit_withAReason() { QCOMPARE(forLua(":bob!u@h QUIT :connection reset"), QStringLiteral("! bob has quit (connection reset)")); }
+
+    void nick_namesBothTheOldAndTheNewNick() { QCOMPARE(forLua(":old!u@h NICK :new"), QStringLiteral("! old has changed nick to new")); }
+
+    void mode_namesWhoSetWhatOnWhom() { QCOMPARE(forLua(":bob!u@h MODE #mudlet +o alice"), QStringLiteral("! bob sets mode #mudlet +o alice")); }
+
+    void topic_changed() { QCOMPARE(forLua(":bob!u@h TOPIC #mudlet :a new topic"), QStringLiteral("! bob changed topic")); }
+
+    void topic_cleared() { QCOMPARE(forLua(":bob!u@h TOPIC #mudlet :"), QStringLiteral("! bob cleared topic")); }
+
+    void away_withAReason() { QCOMPARE(forLua(":bob!u@h AWAY :at lunch"), QStringLiteral("! bob is away (at lunch)")); }
+
+    void away_withoutAReasonMeansBack() { QCOMPARE(forLua(":bob!u@h AWAY"), QStringLiteral("! bob is back")); }
+
+    void invite_namesWhoWasInvitedWhere() { QCOMPARE(forLua(":bob!u@h INVITE alice #mudlet"), QStringLiteral("! bob invited to #mudlet")); }
+
+    // A kick is the one thing that happens to a player without their asking, so
+    // silently dropping it leaves them looking at a channel they are no longer in
+    void kick_namesWhoWasKickedByWhom() { QCOMPARE(forLua(":bob!u@h KICK #mudlet alice :behave"), QStringLiteral("! bob kicked alice")); }
+
+    void privateMessage_forLuaIsTheTextAlone() { QCOMPARE(forLua(":bob!u@h PRIVMSG #mudlet :hello there"), QStringLiteral("hello there")); }
+
+    void privateMessage_forTheWindowCarriesTheNickInBold()
+    {
+        const QString html = forWindow(":bob!u@h PRIVMSG #mudlet :hello there");
+        QVERIFY2(html.contains(QStringLiteral("<b>&lt;bob&gt;</b> hello there")), qPrintable(html));
+    }
+
+    // A CTCP ACTION is what /me sends, and reads as narration rather than speech
+    void privateMessage_actionReadsAsNarration() { QCOMPARE(forLua(":bob!u@h PRIVMSG #mudlet :\001ACTION waves\001"), QStringLiteral("* bob waves")); }
+
+    void notice_toTheChannelIsTheTextAloneForLua() { QCOMPARE(forLua(":bob!u@h NOTICE #mudlet :heads up"), QStringLiteral("heads up")); }
+
+    void notice_toTheChannelNamesTheSenderAndTargetForTheWindow()
+    {
+        const QString html = forWindow(":bob!u@h NOTICE #mudlet :heads up");
+        QVERIFY2(html.contains(QStringLiteral("&lt;bob&gt; [#mudlet] heads up")), qPrintable(html));
+    }
+
+    // A notice addressed to this connection's own nickname is a private one, and
+    // is marked as such in both forms so it is not mistaken for channel traffic
+    void notice_toThisConnectionIsMarkedPrivate() { QCOMPARE(forLua(":bob!u@h NOTICE me :just for you"), QStringLiteral("[bob] just for you")); }
+
+    void notice_ctcpVersionReplyIsReportedAsAVersion() { QCOMPARE(forLua(":bob!u@h NOTICE me :\001VERSION Mudlet 5.0\001"), QStringLiteral("! bob version is Mudlet 5.0")); }
+
+    void notice_ctcpTimeReplyIsReportedAsATime() { QCOMPARE(forLua(":bob!u@h NOTICE me :\001TIME Tue Jan 1 00:00:00 2030\001"), QStringLiteral("! bob time is Tue Jan 1 00:00:00 2030")); }
+
+    void numeric_belowThreeHundredIsInformation() { QCOMPARE(forLua(":server 001 me :Welcome to the network"), QStringLiteral("[INFO] Welcome to the network")); }
+
+    // Everything the server sends is put into an HTML document, so the markup
+    // characters in it have to be escaped on the way - an information numeric no
+    // less than any other line
+    void numeric_informationIsEscapedBeforeItReachesTheWindow()
+    {
+        const QString html = forWindow(":server 001 me :<b>not bold</b>");
+        QVERIFY2(!html.contains(QStringLiteral("<b>")), qPrintable(html));
+        QVERIFY2(html.contains(QStringLiteral("&lt;b")), qPrintable(html));
+    }
+
+    void numeric_errorCodesAreMarkedAsErrors() { QCOMPARE(forLua(":server 401 me nosuchnick :No such nick"), QStringLiteral("[ERROR] nosuchnick No such nick")); }
+
+    // The error colour has to be picked from the numeric's own code, since a
+    // numeric error arrives as an ordinary numeric rather than an ERROR command
+    void numeric_errorCodesAreColouredAsErrorsInTheWindow()
+    {
+        const QString html = forWindow(":server 401 me nosuchnick :No such nick");
+        QVERIFY2(html.contains(QStringLiteral("indianred")), qPrintable(html));
+    }
+
+    void numeric_channelUrlIsLabelled() { QCOMPARE(forLua(":server 328 me #mudlet :https://www.mudlet.org/"), QStringLiteral("[Channel URL] #mudlet https://www.mudlet.org/")); }
+
+    void numeric_anythingElseFallsBackToItsOwnCode() { QCOMPARE(forLua(":server 333 me #mudlet bob :1234567890"), QStringLiteral("[333] #mudlet bob 1234567890")); }
+
+    void error_isMarkedAsAnError() { QCOMPARE(forLua("ERROR :Closing link"), QStringLiteral("[ERROR] Closing link")); }
+
+    void unknown_isShownVerbatimRatherThanDropped() { QCOMPARE(forLua(":bob!u@h FROBNICATE one two"), QStringLiteral("? bob FROBNICATE one two")); }
+
+    void pong_reportsHowLongTheReplyTook()
+    {
+        const QString text = forLua(":server PONG server :1234");
+        QVERIFY2(text.contains(QStringLiteral("replied in")), qPrintable(text));
+    }
+
+    // The composed message types are assembled by communi out of several
+    // numerics, so they are built here rather than parsed from one line
+    void names_countsTheUsersForTheWindowAndListsThemForLua()
+    {
+        auto* message = new IrcNamesMessage(&mConnection);
+        message->setParameters({QStringLiteral("#mudlet"), QStringLiteral("alice"), QStringLiteral("bob")});
+        QCOMPARE(IrcMessageFormatter::formatMessage(message, true), QStringLiteral("! #mudlet has 2 users: alice bob"));
+        QVERIFY2(IrcMessageFormatter::formatMessage(message, false).contains(QStringLiteral("! #mudlet has 2 users")), "the window form should carry the count");
+    }
+
+    void motd_putsEveryLineOnItsOwn()
+    {
+        auto* message = new IrcMotdMessage(&mConnection);
+        message->setParameters({QStringLiteral("me"), QStringLiteral("first line"), QStringLiteral("second line")});
+        QCOMPARE(IrcMessageFormatter::formatMessage(message, true), QStringLiteral("[MOTD] first line\n[MOTD] second line\n"));
+    }
+
+    void motd_breaksItsLinesWithMarkupForTheWindow()
+    {
+        auto* message = new IrcMotdMessage(&mConnection);
+        message->setParameters({QStringLiteral("me"), QStringLiteral("first line"), QStringLiteral("second line")});
+        QVERIFY2(IrcMessageFormatter::formatMessage(message, false).contains(QStringLiteral("<br />")), "the window form should break its lines");
+    }
+
+    void whois_reportsTheFieldsTheServerFilledIn()
+    {
+        auto* message = new IrcWhoisMessage(&mConnection);
+        message->setPrefix(QStringLiteral("bob!ident@example.org"));
+        // realName, server, info, account, address, connected since, idle, secure, channels
+        message->setParameters({QStringLiteral("Bob Smith"),
+                                QStringLiteral("irc.example.org"),
+                                QStringLiteral("Example Network"),
+                                QStringLiteral("bobaccount"),
+                                QStringLiteral("192.0.2.1"),
+                                QStringLiteral("0"),
+                                QStringLiteral("3661"),
+                                QStringLiteral("secure"),
+                                QStringLiteral("#mudlet #other")});
+        const QString text = IrcMessageFormatter::formatMessage(message, true);
+        QVERIFY2(text.contains(QStringLiteral("[WHOIS] bob is ident@example.org (Bob Smith)")), qPrintable(text));
+        QVERIFY2(text.contains(QStringLiteral("[WHOIS] bob is logged in as bobaccount")), qPrintable(text));
+        QVERIFY2(text.contains(QStringLiteral("[WHOIS] bob is connected from 192.0.2.1")), qPrintable(text));
+        QVERIFY2(text.contains(QStringLiteral("[WHOIS] bob is using a secure connection")), qPrintable(text));
+        QVERIFY2(text.contains(QStringLiteral("[WHOIS] bob is on #mudlet #other")), qPrintable(text));
+        QVERIFY2(text.contains(QStringLiteral("idle 1 hours 1 mins 1 secs")), qPrintable(text));
+    }
+
+    // Everything the server did not fill in is left out rather than shown empty
+    void whois_leavesOutTheFieldsTheServerDidNotFillIn()
+    {
+        auto* message = new IrcWhoisMessage(&mConnection);
+        message->setPrefix(QStringLiteral("bob!ident@example.org"));
+        message->setParameters({QStringLiteral("Bob Smith"), QStringLiteral("irc.example.org"), QStringLiteral("Example Network")});
+        const QString text = IrcMessageFormatter::formatMessage(message, true);
+        QVERIFY2(!text.contains(QStringLiteral("logged in as")), qPrintable(text));
+        QVERIFY2(!text.contains(QStringLiteral("secure connection")), qPrintable(text));
+        QVERIFY2(!text.contains(QStringLiteral("is on")), qPrintable(text));
+    }
+
+    void whowas_reportsWhoTheyWere()
+    {
+        auto* message = new IrcWhowasMessage(&mConnection);
+        message->setPrefix(QStringLiteral("bob!ident@example.org"));
+        message->setParameters({QStringLiteral("Bob Smith"), QStringLiteral("irc.example.org"), QStringLiteral("Example Network")});
+        const QString text = IrcMessageFormatter::formatMessage(message, true);
+        QVERIFY2(text.contains(QStringLiteral("[WHOWAS] bob was ident@example.org (Bob Smith)")), qPrintable(text));
+    }
+
+    void whoReply_marksAnAwayUser()
+    {
+        auto* message = new IrcWhoReplyMessage(&mConnection);
+        message->setPrefix(QStringLiteral("bob!ident@example.org"));
+        // mask, server, the flags that say away and server operator, real name
+        message->setParameters({QStringLiteral("ident@example.org"), QStringLiteral("irc.example.org"), QStringLiteral("G*"), QStringLiteral("Bob Smith")});
+        const QString text = IrcMessageFormatter::formatMessage(message, true);
+        QCOMPARE(text, QStringLiteral("[WHO] bob (Bob Smith) - away - server operator"));
+    }
+
+    // -------------------------------------------------------------------------
+    // The wrapper every formatted message goes through, which is also what
+    // dlgIRC calls directly for the client's own status lines.
+    // -------------------------------------------------------------------------
+
+    void wrapper_prependsTheTimeForTheWindow()
+    {
+        const QString html = IrcMessageFormatter::formatMessage(QStringLiteral("plain status line"));
+        QVERIFY2(QRegularExpression(QStringLiteral("^\\[\\d\\d:\\d\\d:\\d\\d\\] plain status line$")).match(html).hasMatch(), qPrintable(html));
+    }
+
+    void wrapper_leavesTheLuaFormAlone() { QCOMPARE(IrcMessageFormatter::formatMessage(QStringLiteral("! bob has quit"), QStringLiteral("#f29010"), true), QStringLiteral("! bob has quit")); }
+
+    void wrapper_saysNothingAboutAnEmptyMessage() { QVERIFY(IrcMessageFormatter::formatMessage(QString()).isEmpty()); }
+
+    // The leading character is how the client tells its four kinds of line
+    // apart, and is the only thing that picks their colour
+    void wrapper_coloursByTheLeadingCharacter()
+    {
+        QVERIFY(IrcMessageFormatter::formatMessage(QStringLiteral("! a server event")).startsWith(QStringLiteral("<font color='gray'>")));
+        QVERIFY(IrcMessageFormatter::formatMessage(QStringLiteral("* an action")).startsWith(QStringLiteral("<font color='maroon'>")));
+        QVERIFY(IrcMessageFormatter::formatMessage(QStringLiteral("$ a client notice")).startsWith(QStringLiteral("<font color='#3cc46e'>")));
+        QVERIFY(IrcMessageFormatter::formatMessage(QStringLiteral("[TOPIC] something"), QStringLiteral("#3283bc")).startsWith(QStringLiteral("<font color='#3283bc'>")));
+    }
+
+    void wrapper_fallsBackToTheDefaultColourForABracketedLine()
+    {
+        QVERIFY(IrcMessageFormatter::formatMessage(QStringLiteral("[TOPIC] something"), QString()).contains(QStringLiteral("<font color='#f29010'>")));
+    }
+
+    // -------------------------------------------------------------------------
+    // The two duration helpers, which are also what the whois idle time uses.
+    // -------------------------------------------------------------------------
+
+    void formatDuration_secondsOnly() { QCOMPARE(IrcMessageFormatter::formatDuration(59), QStringLiteral("59 secs")); }
+
+    void formatDuration_zeroStillSaysSeconds() { QCOMPARE(IrcMessageFormatter::formatDuration(0), QStringLiteral("0 secs")); }
+
+    void formatDuration_minutesAndSeconds() { QCOMPARE(IrcMessageFormatter::formatDuration(61), QStringLiteral("1 mins 1 secs")); }
+
+    void formatDuration_hoursMinutesAndSeconds() { QCOMPARE(IrcMessageFormatter::formatDuration(3661), QStringLiteral("1 hours 1 mins 1 secs")); }
+
+    void formatDuration_daysDownToSeconds() { QCOMPARE(IrcMessageFormatter::formatDuration(90061), QStringLiteral("1 days 1 hours 1 mins 1 secs")); }
+
+    // The argument is when the ping was sent, so what comes back is how long ago
+    // that was - allowing for the clock ticking over between the two readings
+    void formatSeconds_countsBackFromNow()
+    {
+        const QString elapsed = IrcMessageFormatter::formatSeconds(static_cast<int>(QDateTime::currentSecsSinceEpoch()) - 5);
+        QVERIFY2(elapsed == QStringLiteral("5s") || elapsed == QStringLiteral("6s"), qPrintable(elapsed));
+    }
+};
+
+QTEST_GUILESS_MAIN(IrcMessageFormatterTest)
+#include "IrcMessageFormatterTest.moc"

--- a/test/IrcMessageFormatterTest.cpp
+++ b/test/IrcMessageFormatterTest.cpp
@@ -119,6 +119,41 @@ private slots:
         QVERIFY2(html.contains(QStringLiteral("&lt;b")), qPrintable(html));
     }
 
+    // communi escapes & and < for the window before it strips the formatting
+    // codes, and the plain text it hands back for a script still has those
+    // entities in it - so they have to be undone, on every path that reaches Lua
+    void lua_getsTheTextAsItWasSent_data()
+    {
+        QTest::addColumn<QByteArray>("raw");
+        QTest::addColumn<QString>("expected");
+
+        QTest::newRow("information numeric") << QByteArrayLiteral(":server 002 me :Fish & Chips <here>") << QStringLiteral("[INFO] Fish & Chips <here>");
+        QTest::newRow("error numeric") << QByteArrayLiteral(":server 401 me nick :Fish & Chips <here>") << QStringLiteral("[ERROR] nick Fish & Chips <here>");
+        QTest::newRow("other numeric") << QByteArrayLiteral(":server 333 me #mudlet :Fish & Chips <here>") << QStringLiteral("[333] #mudlet Fish & Chips <here>");
+        QTest::newRow("channel message") << QByteArrayLiteral(":bob!u@h PRIVMSG #mudlet :Fish & Chips <here>") << QStringLiteral("Fish & Chips <here>");
+        QTest::newRow("action") << QByteArrayLiteral(":bob!u@h PRIVMSG #mudlet :\001ACTION likes Fish & Chips <here>\001") << QStringLiteral("* bob likes Fish & Chips <here>");
+        QTest::newRow("notice") << QByteArrayLiteral(":bob!u@h NOTICE #mudlet :Fish & Chips <here>") << QStringLiteral("Fish & Chips <here>");
+        // Somebody typing an entity by hand must see it come out as typed
+        QTest::newRow("a literal entity survives") << QByteArrayLiteral(":bob!u@h PRIVMSG #mudlet :&amp; &lt; &amp;lt;") << QStringLiteral("&amp; &lt; &amp;lt;");
+        // The formatting codes are still stripped, which is why the plain text
+        // comes from communi in the first place
+        QTest::newRow("formatting codes are still stripped") << QByteArrayLiteral(":bob!u@h PRIVMSG #mudlet :\002Fish\002 & \00304Chips\003 <here>") << QStringLiteral("Fish & Chips <here>");
+    }
+
+    void lua_getsTheTextAsItWasSent()
+    {
+        QFETCH(QByteArray, raw);
+        QFETCH(QString, expected);
+        QCOMPARE(forLua(raw), expected);
+    }
+
+    // The same characters still have to be escaped on their way into the window
+    void window_stillEscapesWhatLuaGetsRaw()
+    {
+        const QString html = forWindow(":bob!u@h PRIVMSG #mudlet :Fish & Chips <here>");
+        QVERIFY2(html.contains(QStringLiteral("Fish &amp; Chips &lt;here>")), qPrintable(html));
+    }
+
     void numeric_errorCodesAreMarkedAsErrors() { QCOMPARE(forLua(":server 401 me nosuchnick :No such nick"), QStringLiteral("[ERROR] nosuchnick No such nick")); }
 
     // The error colour has to be picked from the numeric's own code, since a
@@ -158,6 +193,23 @@ private slots:
         auto* message = new IrcMotdMessage(&mConnection);
         message->setParameters({QStringLiteral("me"), QStringLiteral("first line"), QStringLiteral("second line")});
         QCOMPARE(IrcMessageFormatter::formatMessage(message, true), QStringLiteral("[MOTD] first line\n[MOTD] second line\n"));
+    }
+
+    // A topic reply is composed by communi from the 332 numeric, so it has to
+    // be built by hand here
+    void topic_replyReachesLuaAsItWasSent()
+    {
+        auto* message = new IrcTopicMessage(&mConnection);
+        message->setCommand(QString::number(Irc::RPL_TOPIC));
+        message->setParameters({QStringLiteral("#mudlet"), QStringLiteral("Fish & Chips <here>")});
+        QCOMPARE(IrcMessageFormatter::formatMessage(message, true), QStringLiteral("[TOPIC] Fish & Chips <here>"));
+    }
+
+    void motd_reachesLuaAsItWasSent()
+    {
+        auto* message = new IrcMotdMessage(&mConnection);
+        message->setParameters({QStringLiteral("me"), QStringLiteral("Fish & Chips <here>")});
+        QCOMPARE(IrcMessageFormatter::formatMessage(message, true), QStringLiteral("[MOTD] Fish & Chips <here>\n"));
     }
 
     void motd_breaksItsLinesWithMarkupForTheWindow()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Three bugs in the IRC client's message formatter, and a unit test covering every message kind it handles.

**Kicks were silently dropped.** `IrcMessageFormatter::formatMessage()` had no `case IrcMessage::Kick`, so a kick fell through to `default` and produced an empty string. `dlgIRC` skips an empty result, so nothing appeared in the IRC window and nothing was posted to Lua either. `formatKickMessage()` was already written and unit-testable; it just was never reached.

**Server text could inject markup.** `formatNumericMessage()` escaped an information numeric (`code() < 300`) into a local `content` and then returned the *raw* `info`:

```cpp
content = IrcTextFormat().toHtml(info);
return QObject::tr("[INFO] %1").arg(info);   // content is computed and thrown away
```

A server sending `:server 001 me :<b>not bold</b>` reached the `QTextBrowser` as `[INFO] <b>not bold</b>`. Now it reaches it escaped.

**Scripts received HTML entities instead of the text.** communi's `IrcTextFormat` escapes `&` and `<` *before* it strips the IRC formatting codes, and hands out its plain text with those entities still in it (there is a `// TODO:` over the two lines in `irctextformat.cpp`). Every path that fed a `sysIrcMessage` event went through that plain text, so a channel message of `Fish & Chips <here>` reached Lua as `Fish &amp; Chips &lt;here>` - and the escaping fix above would have made the information numeric do the same. A `plainTextForLua()` helper now undoes the two entities on every Lua path (`&lt;` first, so a literal `&lt;` typed by a user, which arrives as `&amp;lt;`, survives the round trip). The window text is untouched.

`test/IrcMessageFormatterTest.cpp` is new - 61 cases over join, part, quit, nick, mode, topic, away, invite, kick, privmsg, CTCP action, notices (channel, private, VERSION and TIME replies), numerics (information, `ERR_` colouring, channel URL, unrecognised-code fallback), errors, unknown commands, pong, the composed types (names, motd, whois filled and unfilled, whowas, who reply), the `formatMessage(QString, colour, isForLua)` wrapper, both duration helpers, and a table of every Lua path checking that `&` and `<` come out as sent while the formatting codes are still stripped.

#### Motivation for adding to Mudlet

A player who was kicked kept looking at a channel they were no longer in, with nothing to say why - and a script watching for kicks never saw one either.

The escaping bug let whatever an IRC server sends in a `001`-`299` numeric reach a rich-text widget as markup. The formatter already meant to escape it; the escaped copy was just dropped on the floor.

The entity bug meant a script echoing what it heard on IRC printed `&amp;` for every ampersand, and had no way to tell a real `&amp;` from an escaped `&`.

#### Other info (issues closed, discussion etc)

Closes #10534, #10535, #10536.

All three bugs were confirmed empirically before being fixed: the kick case printed an empty string, the numeric case printed `<font color='#f29010'>[12:28:49] [INFO] <b>not bold</b></font>`, and a probe of every Lua path printed `Fish &amp; Chips &lt;here>`. The entity fix was raised by Greptile's review of the numeric change and turned out to be older and wider than the one line it flagged. With the helper reduced to communi's own plain text, all ten new Lua cases fail; with the two replacements in the wrong order, the literal-entity case fails.

The test builds from `src/ircmessageformatter.cpp` directly rather than linking `mudlet_core` - the formatter is static and reaches for nothing but communi, so it needs neither the library nor the ~250MB a link against it costs every build tree. The trade-off is that this file's coverage will not show up in the gcovr numbers, whose search paths only cover `mudlet_core.dir` and `mudlet_executable.dir`.

Full suites on Linux: 175/175 ctest, 4255 busted specs, 0 failures.

Manual testing has not been done by a human yet - please build and try a kick, a server MOTD, and a channel message with an `&` in it seen from a `sysIrcMessage` handler before signing off.


