### PR TITLE
Infra: Give the build identity a widget-free home in MudletVersion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ set(mudlet_SRCS
     MMCPServer.cpp
     mudlet.cpp
     MudletInstanceCoordinator.cpp
+    MudletVersion.cpp
     MxpTag.cpp
     OAuthClientFlow.cpp
     PackageItemDelegate.cpp
@@ -360,6 +361,7 @@ set(mudlet_HDRS
     MMCPServer.h
     mudlet.h
     MudletInstanceCoordinator.h
+    MudletVersion.h
     MxpTag.h
     OAuthClientFlow.h
     PackageItemDelegate.h
@@ -708,12 +710,15 @@ if(UNIX)
   set(LUA_DEFAULT_DIR "${CMAKE_INSTALL_PREFIX}/share/mudlet/lua")
 endif(UNIX)
 
+# APP_VERSION is PUBLIC because the functional tests link ${LIB_MUDLET_TARGET}
+# and check the version identity it reports.
+target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC APP_VERSION="${APP_VERSION}")
+
 # Define a preprocessor symbol with the default fallback location from which to
 # load installed mudlet lua files. Set LUA_DEFAULT_DIR to a platform-specific
 # value. If LUA_DEFAULT_DIR is unset, the root directory will be used.
 target_compile_definitions(${LIB_MUDLET_TARGET}
   PRIVATE
-    APP_VERSION="${APP_VERSION}"
     APP_TARGET="${APP_TARGET}"
     LUA_DEFAULT_PATH="${LUA_DEFAULT_DIR}"
     LUA_SOURCE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/mudlet-lua/lua")

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "CredentialManager.h"
+#include "MudletVersion.h"
 #include "SecureStringUtils.h"
 #include "utils.h"
 
@@ -414,14 +415,9 @@ void CredentialManager::attemptCollidingMigration(const QString& profileName, co
             const QVersionNumber collidingFormatVersion = QVersionNumber(4, 20, 1);
 
             // Dev/test/PTB builds represent the "next release", so bump version for comparison
-            QFile buildFile(qsl(":/app-build.txt"));
-
-            if (buildFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-                const QString buildSuffix = QString::fromUtf8(buildFile.readAll()).trimmed();
-
-                if (buildSuffix.startsWith(qsl("-dev")) || buildSuffix.startsWith(qsl("-test")) || buildSuffix.startsWith(qsl("-ptb"))) {
-                    appVersion = QVersionNumber(appVersion.majorVersion(), appVersion.minorVersion(), appVersion.microVersion() + 1);
-                }
+            const QString buildSuffix = MudletVersion::build();
+            if (buildSuffix.startsWith(qsl("-dev")) || buildSuffix.startsWith(qsl("-test")) || buildSuffix.startsWith(qsl("-ptb"))) {
+                appVersion = QVersionNumber(appVersion.majorVersion(), appVersion.minorVersion(), appVersion.microVersion() + 1);
             }
 
             if (appVersion > collidingFormatVersion) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -38,6 +38,7 @@
 #include "MMCP.h"
 #include "MMCPServer.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 #include "TCommandLine.h"
 #include "TConsole.h"
 #include "TConsoleModel.h"
@@ -393,7 +394,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         }
     }
 
-    if (mudlet::self()->publicTestVersion) {
+    if (MudletVersion::publicTest()) {
         thankForUsingPTB();
     }
 

--- a/src/MMCPClient.cpp
+++ b/src/MMCPClient.cpp
@@ -22,7 +22,7 @@
 #include "Host.h"
 #include "MMCPServer.h"
 #include "TEvent.h"
-#include "mudlet.h"
+#include "MudletVersion.h"
 
 #include <QHostAddress>
 #include <QTcpSocket>
@@ -508,7 +508,7 @@ void MMCPClient::sendVersion()
 {
     QByteArray versionData;
     versionData.append(static_cast<char>(Version));
-    versionData.append(mudlet::self()->scmVersion.toLatin1());
+    versionData.append(MudletVersion::scmVersion().toLatin1());
     versionData.append(static_cast<char>(End));
     writeData(versionData);
 }

--- a/src/MudletVersion.cpp
+++ b/src/MudletVersion.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "MudletVersion.h"
+
+#include "utils.h"
+
+#include <QDebug>
+#include <QFile>
+#include <QNetworkRequest>
+#include <QSslConfiguration>
+#include <QUrl>
+
+const QString& MudletVersion::build()
+{
+    // Deliberately not a namespace-scope constant: the Qt resource system is
+    // only registered once main() runs, so reading the file any earlier would
+    // silently yield an empty string and make every build look like a release.
+    static const QString appBuild = [] {
+        QFile gitShaFile(qsl(":/app-build.txt"));
+        if (!gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            qWarning() << "MudletVersion::build() failed to open app-build.txt for reading:" << gitShaFile.errorString();
+            return QString();
+        }
+        return QString::fromUtf8(gitShaFile.readAll()).trimmed();
+    }();
+    return appBuild;
+}
+
+const QString& MudletVersion::scmVersion()
+{
+    static const QString version = qsl("Mudlet ") + QString(APP_VERSION) + build();
+    return version;
+}
+
+bool MudletVersion::release()
+{
+    return build().isEmpty();
+}
+
+bool MudletVersion::publicTest()
+{
+    return build().startsWith(qsl("-ptb"));
+}
+
+bool MudletVersion::development()
+{
+    return !release() && !publicTest();
+}
+
+// Enable redirects and HTTPS support for a given url
+void MudletVersion::setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request)
+{
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    request.setRawHeader(QByteArray("User-Agent"), qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, build()).toUtf8());
+#if !defined(QT_NO_SSL)
+    if (url.scheme() == qsl("https")) {
+        const QSslConfiguration config(QSslConfiguration::defaultConfiguration());
+        request.setSslConfiguration(config);
+    }
+#endif
+}

--- a/src/MudletVersion.h
+++ b/src/MudletVersion.h
@@ -1,0 +1,41 @@
+#ifndef MUDLET_MUDLETVERSION_H
+#define MUDLET_MUDLETVERSION_H
+
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QString>
+
+class QNetworkRequest;
+class QUrl;
+
+// Which build of Mudlet this is, and how it names itself to the outside world.
+// Read on first use, so this is usable before any window exists.
+namespace MudletVersion {
+// The suffix CMake writes into :/app-build.txt - empty for an official release,
+// "-ptb..." for a public test build, "-dev..." for everything else.
+const QString& build();
+const QString& scmVersion();
+bool release();
+bool publicTest();
+bool development();
+void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
+} // namespace MudletVersion
+
+#endif // MUDLET_MUDLETVERSION_H

--- a/src/SentryWrapper.cpp
+++ b/src/SentryWrapper.cpp
@@ -18,10 +18,11 @@
  ***************************************************************************/
 
 #include "SentryWrapper.h"
+
+#include "MudletVersion.h"
 #include "utils.h"
 
 #ifdef WITH_SENTRY
-#include <QFile>
 #include <QStandardPaths>
 #include "sentry.h"
 #endif
@@ -58,12 +59,7 @@ void initSentry()
         return;
     }
 
-    QString appBuild;
-    QFile gitShaFile(qsl(":/app-build.txt"));
-    if (gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        appBuild = QString::fromUtf8(gitShaFile.readAll()).trimmed();
-    }
-    const std::string release = qsl("mudlet@%1%2").arg(APP_VERSION, appBuild).toStdString();
+    const std::string release = qsl("mudlet@%1%2").arg(APP_VERSION, MudletVersion::build()).toStdString();
 
     sentry_options_set_database_path(options, path.toUtf8().constData());
     sentry_options_set_release(options, release.c_str());

--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -23,6 +23,7 @@
 
 #include "Host.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -170,7 +171,7 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
             logStream << "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>";
             // put the charset as early as possible as the parser MUST restart when it
             // switches away from the ASCII default
-            logStream << "  <meta name='generator' content='" << QCoreApplication::translate("TMainConsole", "Mudlet MUD Client version: %1%2").arg(APP_VERSION, mudlet::self()->mAppBuild) << "'>\n";
+            logStream << "  <meta name='generator' content='" << QCoreApplication::translate("TMainConsole", "Mudlet MUD Client version: %1%2").arg(APP_VERSION, MudletVersion::build()) << "'>\n";
             // Nice to identify what made the file!
             logStream << "  <title>" << QCoreApplication::translate("TMainConsole", "Mudlet, log from %1 profile").arg(mpHost->getName()) << "</title>\n";
             // Web-page title

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -52,6 +52,7 @@
 #include "dlgModuleManager.h"
 #include "dlgTriggerEditor.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 #if defined(INCLUDE_3DMAPPER)
 #include "glwidget_integration.h"
 #endif
@@ -2648,7 +2649,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
     // report back instead of raising - see checkStringArg()
     const int results = [&L, functionName = __func__]() -> int {
         QByteArray version = QByteArray(APP_VERSION).trimmed();
-        const QByteArray build = mudlet::self()->mAppBuild.trimmed().toLocal8Bit();
+        const QByteArray build = MudletVersion::build().trimmed().toLocal8Bit();
 
         QList<QByteArray> const versionData = version.split('.');
         if (versionData.size() != 3) {
@@ -2731,7 +2732,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
             lua_pushinteger(L, revision);
             lua_settable(L, -3);
             lua_pushstring(L, "build");
-            lua_pushstring(L, mudlet::self()->mAppBuild.trimmed().toUtf8().constData());
+            lua_pushstring(L, MudletVersion::build().trimmed().toUtf8().constData());
             lua_settable(L, -3);
         } else { // NOLINT(readability-else-after-return)
             lua_pushstring(L,
@@ -5233,7 +5234,7 @@ int TLuaInterpreter::performHttpRequest(lua_State* L, const char* functionName, 
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    mudlet::self()->setNetworkRequestDefaults(url, request);
+    MudletVersion::setNetworkRequestDefaults(url, request);
     applyHttpHeaders(L, pos + 3, request);
 
     QByteArray fileToUpload;

--- a/src/TLuaInterpreterNetworking.cpp
+++ b/src/TLuaInterpreterNetworking.cpp
@@ -51,6 +51,7 @@
 #include "dlgTriggerEditor.h"
 #include "mapInfoContributorManager.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 #if defined(INCLUDE_3DMAPPER)
 #include "glwidget_integration.h"
 #endif
@@ -137,7 +138,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    mudlet::self()->setNetworkRequestDefaults(url, request);
+    MudletVersion::setNetworkRequestDefaults(url, request);
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
@@ -729,7 +730,7 @@ int TLuaInterpreter::getHTTP(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    mudlet::self()->setNetworkRequestDefaults(url, request);
+    MudletVersion::setNetworkRequestDefaults(url, request);
     applyHttpHeaders(L, 2, request);
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
@@ -771,7 +772,7 @@ int TLuaInterpreter::deleteHTTP(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    mudlet::self()->setNetworkRequestDefaults(url, request);
+    MudletVersion::setNetworkRequestDefaults(url, request);
     applyHttpHeaders(L, 2, request);
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -36,6 +36,7 @@
 #include "TLuaInterpreter.h"
 #include "mapInfoContributorManager.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 
 #include <QBuffer>
 #include <QDataStream>
@@ -2160,7 +2161,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
 
     if (otherProfileVersion > mDefaultVersion) {
-        if (mudlet::self()->releaseVersion || mudlet::self()->publicTestVersion) {
+        if (MudletVersion::release() || MudletVersion::publicTest()) {
             // This is a release/public test version - should not support any map file versions higher that it was built for
             if (fileVersion) {
                 *fileVersion = otherProfileVersion;
@@ -2753,7 +2754,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     QNetworkRequest request = QNetworkRequest(url);
     pHost->updateProxySettings(mpNetworkAccessManager);
-    mudlet::self()->setNetworkRequestDefaults(url, request);
+    MudletVersion::setNetworkRequestDefaults(url, request);
 
     mExpectedFileSize = 4000000;
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -25,6 +25,7 @@
 #include "TMedia.h"
 
 #include "TDebug.h"
+#include "MudletVersion.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -1189,7 +1190,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
     }
 
     QNetworkRequest request = QNetworkRequest(fileUrl);
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
+    request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, MudletVersion::build()).toUtf8().constData()));
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
 #if !defined(QT_NO_SSL)
     if (fileUrl.scheme() == qsl("https")) {

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -22,6 +22,7 @@
 #include "TMedia.h"
 #include "TConsole.h"
 #include "TLinkStore.h"
+#include "MudletVersion.h"
 
 #include <QSet>
 #include <QStack>
@@ -31,7 +32,7 @@ static const QString PLACEHOLDER_TEXT = QLatin1String("&text;");
 
 QString TMxpMudlet::getVersion()
 {
-    return mudlet::self()->scmVersion;
+    return MudletVersion::scmVersion();
 }
 
 void TMxpMudlet::sendToServer(QString& str)

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -37,6 +37,7 @@
 #include "THyperlinkSelectionManager.h"
 #include "THyperlinkVisibilityManager.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 #include "utils.h"
 #include "widechar_width.h"
 #include "TTextProperties.h"
@@ -2279,7 +2280,7 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     // switches away from the ASCII default
     text.append("  <meta name='generator' content='Mudlet MUD Client version: ");
     text.append(APP_VERSION);
-    text.append(mudlet::self()->mAppBuild);
+    text.append(MudletVersion::build());
     text.append("'>\n");
     // Nice to identify what made the file!
     text.append("  <title>");

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -48,6 +48,7 @@
 #include "dlgComposer.h"
 #include "dlgMapper.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 #if defined(INCLUDE_3DMAPPER)
 #include "glwidget_integration.h"
 #endif
@@ -139,8 +140,8 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
     // to set up the initial encoder
     encodingChanged("UTF-8");
     termType = qsl("Mudlet " APP_VERSION);
-    if (!mudlet::self()->mAppBuild.trimmed().isEmpty()) {
-        termType.append(mudlet::self()->mAppBuild);
+    if (!MudletVersion::build().trimmed().isEmpty()) {
+        termType.append(MudletVersion::build());
     }
 
     command = "";
@@ -2191,7 +2192,7 @@ QString cTelnet::getNewEnvironClientVersion()
     static const auto allInvalidCharacters = QRegularExpression(qsl("[^A-Z,0-9,-,\\/]"));
     static const auto multipleHyphens = QRegularExpression(qsl("-{2,}"));
 
-    if (auto build = mudlet::self()->mAppBuild; !build.trimmed().isEmpty()) {
+    if (const auto build = MudletVersion::build(); !build.trimmed().isEmpty()) {
         clientVersion.append(build);
     }
 
@@ -3110,7 +3111,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += MSDP_VAR;
             output += "CLIENT_VERSION";
             output += MSDP_VAL;
-            output += encodeAndCookBytes(std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData());
+            output += encodeAndCookBytes(std::string(APP_VERSION) + MudletVersion::build().toUtf8().constData());
             output += TN_IAC;
             output += TN_SE;
             socketOutRaw(output);
@@ -3142,7 +3143,7 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output += TN_IAC;
             output += TN_SB;
             output += OPT_ATCP;
-            std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData()
+            std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + MudletVersion::build().toUtf8().constData()
                                       + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
             output += encodeAndCookBytes(atcpOptions);
             output += TN_IAC;
@@ -3173,8 +3174,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             output = TN_IAC;
             output += TN_SB;
             output += OPT_GMCP;
-            // mudlet::self()->mAppBuild could, conceivably contain a non-ASCII character:
-            output += encodeAndCookBytes(std::string(R"(Core.Hello { "client": "Mudlet", "version": ")") + APP_VERSION + mudlet::self()->mAppBuild.toUtf8().constData() + std::string(R"("})"));
+            // MudletVersion::build() could, conceivably contain a non-ASCII character:
+            output += encodeAndCookBytes(std::string(R"(Core.Hello { "client": "Mudlet", "version": ")") + APP_VERSION + MudletVersion::build().toUtf8().constData() + std::string(R"("})"));
             output += TN_IAC;
             output += TN_SE;
             socketOutRaw(output);
@@ -3959,8 +3960,8 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
                 output += TN_IAC;
                 output += TN_SB;
                 output += OPT_ATCP;
-                // mudlet::self()->mAppBuild *could* be a non-ASCII UTF-8 string:
-                std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + mudlet::self()->mAppBuild.toUtf8().constData()
+                // MudletVersion::build() *could* be a non-ASCII UTF-8 string:
+                std::string atcpOptions = std::string("hello Mudlet ") + std::string(APP_VERSION) + MudletVersion::build().toUtf8().constData()
                                           + "\ncomposer 1\nchar_vitals 1\nroom_brief 1\nroom_exits 1\nmap_display 1\n";
                 output += encodeAndCookBytes(atcpOptions);
                 output += TN_IAC;
@@ -4379,7 +4380,7 @@ void cTelnet::downloadAndInstallGUIPackage(const QString& packageName, const QSt
     }
 
     auto request = QNetworkRequest(QUrl(url));
-    mudlet::self()->setNetworkRequestDefaults(url, request);
+    MudletVersion::setNetworkRequestDefaults(url, request);
     mpPackageDownloadReply = mpDownloader->get(request);
 
     connect(mpPackageDownloadReply, &QNetworkReply::downloadProgress, this, &cTelnet::slot_setDownloadProgress);

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -27,6 +27,7 @@
 #include "dlgAboutDialog.h"
 
 #include "mudlet.h"
+#include "MudletVersion.h"
 
 #include <QPainter>
 #include <QTextLayout>
@@ -41,13 +42,13 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent)
 {
     setupUi(this);
 
-    QImage splashImage = mudlet::getSplashScreen(mudlet::self()->releaseVersion, mudlet::self()->publicTestVersion);
+    QImage splashImage = mudlet::getSplashScreen(MudletVersion::release(), MudletVersion::publicTest());
 
     { // Brace code using painter to ensure it is freed at right time...
         QPainter painter(&splashImage);
 
         unsigned fontSize = 16;
-        QString sourceVersionText = QString("Version: " + qsl(APP_VERSION) + mudlet::self()->mAppBuild);
+        QString sourceVersionText = QString("Version: " + qsl(APP_VERSION) + MudletVersion::build());
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
@@ -1523,7 +1524,7 @@ QString dlgAboutDialog::createBuildInfo() const
                    "</table>")
                 .arg(tr("Technical information:"),  // %1
                      tr("Version"),                 // %2
-                     mudlet::self()->scmVersion,    // %3
+                     MudletVersion::scmVersion(),   // %3
                      tr("OS"),                      // %4
                      QSysInfo::prettyProductName(), // %5
                      tr("CPU (64-bits)"),           // %6 - We only support 64-bit now on Windows but retain what we
@@ -1551,7 +1552,7 @@ QString dlgAboutDialog::createBuildInfo() const
                "</table>")
             .arg(tr("Technical information:"),  // %1
                  tr("Version"),                 // %2
-                 mudlet::self()->scmVersion,    // %3
+                 MudletVersion::scmVersion(),   // %3
                  tr("OS"),                      // %4
                  QSysInfo::prettyProductName(), // %5
                  tr("CPU (64-bits)"),           // %6 - We only support 64-bit now on Windows but retain what we
@@ -1574,7 +1575,7 @@ QString dlgAboutDialog::createBuildInfo() const
                    "</table>")
                 .arg(tr("Technical information:"),  // %1
                      tr("Version"),                 // %2
-                     mudlet::self()->scmVersion,    // %3
+                     MudletVersion::scmVersion(),   // %3
                      tr("OS"),                      // %4
                      QSysInfo::prettyProductName(), // %5
                      //: This is shown for all other OSes than Windows.
@@ -1602,7 +1603,7 @@ the usual case.*/
                "</table>")
             .arg(tr("Technical information:"),  // %1
                  tr("Version"),                 // %2
-                 mudlet::self()->scmVersion,    // %3
+                 MudletVersion::scmVersion(),   // %3
                  tr("OS"),                      // %4
                  QSysInfo::prettyProductName(), // %5
                  //: This is shown for all other OSes than Windows.

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -31,6 +31,7 @@
 #include <IrcUser>
 
 #include "mudlet.h"
+#include "MudletVersion.h"
 
 #include <QDesktopServices>
 #include <QScrollBar>
@@ -40,7 +41,7 @@
 
 dlgIRC::dlgIRC(Host* pHost)
 : mpHost(pHost)
-, mRealName(mudlet::self()->scmVersion)
+, mRealName(MudletVersion::scmVersion())
 {
     setupUi(this);
     setWindowIcon(QIcon(qsl(":/icons/mudlet_irc.png")));

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -47,6 +47,7 @@
 #include "dlgTriggerEditor.h"
 #include "edbee/views/texteditorscrollarea.h"
 #include "MMCP.h"
+#include "MudletVersion.h"
 #include "widgetutils.h"
 #include "utils.h"
 
@@ -270,7 +271,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
     mPopulating = false;
 
 #if defined(INCLUDE_UPDATER)
-    if (mudlet::self()->developmentVersion && !qEnvironmentVariableIsSet("DEV_UPDATER")) {
+    if (MudletVersion::development() && !qEnvironmentVariableIsSet("DEV_UPDATER")) {
         // tick the box and make it be "un-untickable" as automatic updates are
         // disabled in dev builds
         checkbox_noAutomaticUpdates->setChecked(true);
@@ -6899,7 +6900,7 @@ void dlgProfilePreferences::applyAll()
     }
 
 #if defined(INCLUDE_UPDATER)
-    if (mSnapshot.dirty(checkbox_noAutomaticUpdates) && (pMudlet->releaseVersion || pMudlet->publicTestVersion || qEnvironmentVariableIsSet("DEV_UPDATER"))) {
+    if (mSnapshot.dirty(checkbox_noAutomaticUpdates) && (MudletVersion::release() || MudletVersion::publicTest() || qEnvironmentVariableIsSet("DEV_UPDATER"))) {
         pMudlet->pUpdater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
     }
 #endif
@@ -7233,7 +7234,7 @@ void dlgProfilePreferences::maybeDownloadEditorThemes()
 
     const QUrl url(themesURL);
     QNetworkRequest request(url);
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
+    request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, MudletVersion::build()).toUtf8().constData()));
     // github uses redirects
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     // load from cache if possible

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "HostManager.h"
 #include "mudlet.h"
 #include "MudletInstanceCoordinator.h"
+#include "MudletVersion.h"
 #include <chrono>
 #include <QCheckBox>
 #include <QCommandLineParser>
@@ -348,24 +349,15 @@ int main(int argc, char* argv[])
     app->setOverrideCursor(QCursor(Qt::WaitCursor));
     app->setOrganizationName(qsl("Mudlet"));
 
-    QFile gitShaFile(":/app-build.txt");
-    if (!gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qWarning() << "main: failed to open app-build.txt for reading:" << gitShaFile.errorString();
-    }
-    const QString appBuild = QString::fromUtf8(gitShaFile.readAll()).trimmed();
-
-    const bool releaseVersion = appBuild.isEmpty();
-    const bool publicTestVersion = appBuild.startsWith("-ptb");
-
-    if (publicTestVersion) {
+    if (MudletVersion::publicTest()) {
         app->setApplicationName(qsl("Mudlet Public Test Build"));
     } else {
         app->setApplicationName(qsl("Mudlet"));
     }
-    if (releaseVersion) {
+    if (MudletVersion::release()) {
         app->setApplicationVersion(APP_VERSION);
     } else {
-        app->setApplicationVersion(QString(APP_VERSION) + appBuild);
+        app->setApplicationVersion(QString(APP_VERSION) + MudletVersion::build());
     }
 
     // The first QSslSocket in the process - every profile's cTelnet holds two -
@@ -540,9 +532,9 @@ int main(int argc, char* argv[])
         texts << appendLF.arg(QCoreApplication::translate("main",
                                                           "%1 %2%3 (with debug symbols, without optimisations)",
                                                           "%1 is the name of the application like mudlet or Mudlet.exe, %2 is the version number like 3.20 and %3 is a build suffix like -dev")
-                                      .arg(QLatin1String(APP_TARGET), QLatin1String(APP_VERSION), appBuild));
+                                      .arg(QLatin1String(APP_TARGET), QLatin1String(APP_VERSION), MudletVersion::build()));
 #else  // ! defined(QT_DEBUG)
-        texts << QString::fromStdString(APP_TARGET " " APP_VERSION " " + appBuild.toStdString() + " \n");
+        texts << QString::fromStdString(APP_TARGET " " APP_VERSION " " + MudletVersion::build().toStdString() + " \n");
 #endif // ! defined(QT_DEBUG)
         texts << appendLF.arg(QCoreApplication::translate("main", "Qt libraries %1 (compilation) %2 (runtime)", "%1 and %2 are version numbers").arg(QLatin1String(QT_VERSION_STR), qVersion()));
         // PLACEMARKER: Date-stamp needing annual update
@@ -650,12 +642,12 @@ int main(int argc, char* argv[])
     const QStringList onlyProfiles = parser.values(onlyPredefinedProfileToShow);
     const bool offlineProfiles = parser.isSet(openOffline);
     const bool showSplash = parser.isSet(showSplashscreen);
-    QImage splashImage = mudlet::getSplashScreen(releaseVersion, publicTestVersion);
+    QImage splashImage = mudlet::getSplashScreen(MudletVersion::release(), MudletVersion::publicTest());
 
     if (showSplash) {
         QPainter painter(&splashImage);
         unsigned fontSize = 16;
-        const QString sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION + appBuild));
+        const QString sourceVersionText = QString(QCoreApplication::translate("main", "Version: %1").arg(APP_VERSION + MudletVersion::build()));
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -36,6 +36,7 @@
 #include "TDebug.h"
 #include "TDebugFilterBar.h"
 #include "MudletInstanceCoordinator.h"
+#include "MudletVersion.h"
 #include "SpeechRecognizer.h"
 #include "SpeechRecognizerFactory.h"
 #include "TDetachedWindow.h"
@@ -85,7 +86,6 @@
 #include <QSettings>
 #include <QShortcut>
 #include <QSplitter>
-#include <QSslConfiguration>
 #include <QStyleFactory>
 #include <QStyleHints>
 #include <QTableWidget>
@@ -976,19 +976,6 @@ void mudlet::init()
     // Must be after setupConfig() created mpSettings and before anything of this run is written
     rememberFirstLaunch(*mpSettings, mudlet::getMudletPath(enums::profilesPath), QDateTime::currentDateTime());
 
-    QFile gitShaFile(":/app-build.txt");
-    if (!gitShaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qWarning() << "mudlet: failed to open app-build.txt for reading:" << gitShaFile.errorString();
-    }
-    const QString gitSha = QString::fromUtf8(gitShaFile.readAll()).trimmed();
-
-    mAppBuild = gitSha;
-    releaseVersion = mAppBuild.isEmpty();
-    publicTestVersion = mAppBuild.startsWith("-ptb");
-    developmentVersion = !releaseVersion && !publicTestVersion;
-
-    scmVersion = qsl("Mudlet ") + QString(APP_VERSION) + gitSha;
-
     mShowIconsOnMenuOriginally = !qApp->testAttribute(Qt::AA_DontShowIconsInMenus);
 
     // Scripts that care whether the player is looking at Mudlet at all - a
@@ -1044,12 +1031,12 @@ void mudlet::init()
 
     setAttribute(Qt::WA_DeleteOnClose);
     const QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setWindowTitle(scmVersion);
-    if (releaseVersion) {
+    setWindowTitle(MudletVersion::scmVersion());
+    if (MudletVersion::release()) {
         setWindowIcon(QIcon(qsl(":/icons/mudlet.png")));
-    } else if (publicTestVersion) {
+    } else if (MudletVersion::publicTest()) {
         setWindowIcon(QIcon(qsl(":/icons/mudlet_ptb_256px.png")));
-    } else { // developmentVersion
+    } else { // a development build
         setWindowIcon(QIcon(qsl(":/icons/mudlet_dev_256px.png")));
     }
     mpMainToolBar = new QToolBar(this);
@@ -1313,7 +1300,7 @@ void mudlet::init()
     mpMainToolBar->widgetForAction(mpActionMultiView)->setObjectName(mpActionMultiView->objectName());
 
 #if defined(INCLUDE_UPDATER)
-    if (publicTestVersion) {
+    if (MudletVersion::publicTest()) {
         mpActionReportIssue = new QAction(tr("Report issue"), this);
         const QStringList issueReportIcons{"face-uncertain.png", "face-surprise.png", "face-smile.png", "face-sad.png", "face-plain.png"};
         auto randomIcon = QRandomGenerator::global()->bounded(issueReportIcons.size());
@@ -1418,15 +1405,15 @@ void mudlet::init()
 #if defined(INCLUDE_UPDATER)
     // Show the update option if the code is present AND if this is a
     // release OR a public test version, or if you're specifically trying to test Sparkle.
-    dactionUpdate->setVisible(releaseVersion || publicTestVersion || qEnvironmentVariableIsSet("DEV_UPDATER"));
-    dactionChangelog->setVisible(releaseVersion || publicTestVersion || qEnvironmentVariableIsSet("DEV_UPDATER"));
+    dactionUpdate->setVisible(MudletVersion::release() || MudletVersion::publicTest() || qEnvironmentVariableIsSet("DEV_UPDATER"));
+    dactionChangelog->setVisible(MudletVersion::release() || MudletVersion::publicTest() || qEnvironmentVariableIsSet("DEV_UPDATER"));
 
     // Show the report issue option if the updater code is present (as it is
     // less likely to be for: {Linux} distribution packaged versions of Mudlet
     // - or people hacking their own versions and neither of those types are
     // going to want the updater to change things for them) AND only for a
     // public test version:
-    if (publicTestVersion) {
+    if (MudletVersion::publicTest()) {
         dactionReportIssue->setVisible(true);
         connect(mpActionReportIssue.data(), &QAction::triggered, this, &mudlet::slot_reportIssue);
         connect(dactionReportIssue, &QAction::triggered, this, &mudlet::slot_reportIssue);
@@ -1567,7 +1554,7 @@ void mudlet::init()
     // shows its "an update is ready" dialog only after the last window closes,
     // so it must outlive the main window - parent it to the application, not to
     // the window that is about to be destroyed:
-    pUpdater = new Updater(qApp, mpSettings, !releaseVersion);
+    pUpdater = new Updater(qApp, mpSettings, !MudletVersion::release());
     connect(pUpdater, &Updater::signal_updateAvailable, this, &mudlet::slot_updateAvailable);
     connect(pUpdater, &Updater::signal_updateCheckFailed, this, &mudlet::slot_updateCheckFailed);
     connect(dactionUpdate, &QAction::triggered, this, &mudlet::slot_manualUpdateCheck);
@@ -3579,10 +3566,10 @@ void mudlet::updateMainWindowTitle()
 
     // Set window title based on whether we have an active profile in the main window
     if (!mainWindowActiveProfileName.isEmpty()) {
-        setWindowTitle(qsl("%1 - %2").arg(mainWindowActiveProfileName, scmVersion));
+        setWindowTitle(qsl("%1 - %2").arg(mainWindowActiveProfileName, MudletVersion::scmVersion()));
     } else {
         // No active profiles in main window, show just the version
-        setWindowTitle(scmVersion);
+        setWindowTitle(MudletVersion::scmVersion());
     }
 }
 
@@ -6987,7 +6974,7 @@ QString mudlet::getMudletPath(const enums::mudletPathType mode, const QString& e
 #if defined(INCLUDE_UPDATER)
 void mudlet::checkUpdatesOnStart()
 {
-    if (!qEnvironmentVariableIsSet("MUDLET_TEST_MODE") && (releaseVersion || publicTestVersion || qEnvironmentVariableIsSet("DEV_UPDATER"))) {
+    if (!qEnvironmentVariableIsSet("MUDLET_TEST_MODE") && (MudletVersion::release() || MudletVersion::publicTest() || qEnvironmentVariableIsSet("DEV_UPDATER"))) {
         // Doesn't check for updates during test runs.
         // Otherwise, try and create an updater (which checks for updates online) if
         // this is a release/public test version, or if you are testing Sparkle (env flag set).
@@ -8151,20 +8138,6 @@ void mudlet::sanitizeUtf8Path(QString& originalLocation, const QString& fileName
 }
 #endif
 
-// Enable redirects and HTTPS support for a given url
-void mudlet::setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request)
-{
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(qsl("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, mudlet::self()->mAppBuild).toUtf8().constData()));
-#if !defined(QT_NO_SSL)
-    if (url.scheme() == qsl("https")) {
-        const QSslConfiguration config(QSslConfiguration::defaultConfiguration());
-        request.setSslConfiguration(config);
-    }
-#endif
-}
-
 void mudlet::activateProfile(Host* pHost)
 {
     QMap<QString, int> hostNameToTabMap;
@@ -8861,7 +8834,7 @@ void mudlet::closeHostOfClosedDetachedWindow(const QString& profileName)
             if (!mHostManager.getHostCount() && !mIsGoingDown) {
                 disableToolbarButtons();
                 slot_showConnectionDialog();
-                setWindowTitle(scmVersion);
+                setWindowTitle(MudletVersion::scmVersion());
             }
         });
     }
@@ -9425,7 +9398,7 @@ void mudlet::moveProfileFromMainToDetachedWindow(const QString& profileName, int
     if (mpTabBar->count() == 0 && mHostManager.getHostCount() == 0 && !mIsGoingDown) {
         disableToolbarButtons();
         slot_showConnectionDialog();
-        setWindowTitle(scmVersion);
+        setWindowTitle(MudletVersion::scmVersion());
     }
 
     // Update toolbar for the moved profile in the target window

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -122,20 +122,12 @@ public:
     static bool loadLuaFunctionList();
     static std::string replaceString(std::string subject, const std::string& search, const std::string& replace);
     static mudlet* self();
-    static void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
     // This method allows better debugging when mudlet::self() is called inappropriately.
     static void start();
     static bool unzip(const QString& archivePath, const QString& destination, const QDir& tmpDir);
     static QImage getSplashScreen(bool releaseVersion, bool testVersion);
 
 
-    QString mAppBuild;
-    // final, official release
-    bool releaseVersion;
-    // unofficial "nightly" build - still a type of a release
-    bool publicTestVersion;
-    // used by developers in everyday coding:
-    bool developmentVersion;
     // "scmMudletXmlDefaultVersion" number represents a major (integer part) and minor
     // (1000ths, range 0 to 999) that is used as a "version" attribute number when
     // writing the <MudletPackage ...> element of all (but maps if I ever get around
@@ -170,7 +162,6 @@ public:
     // translations done high enough will get a gold star to hide the last few percent
     // as well as encourage translators to maintain it
     static const int scmTranslationGoldStar = 95;
-    QString scmVersion;
     QString confPath;
     // These have to be "inline" to satisfy the ODR (One Definition Rule):
     inline static bool smFirstLaunch = false;

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -19,6 +19,7 @@
 
 #include "updater.h"
 #include "mudlet.h"
+#include "MudletVersion.h"
 #include "updater/Feed.h"
 #include "updater/UpdateDialog.h"
 
@@ -362,7 +363,7 @@ void Updater::setupPlatformUpdater()
     // Setup to automatically download the new release when an update is available
     connect(feed.get(), &dblsqd::Feed::ready, this, [=, this]() {
         auto* pMudlet = mudlet::self();
-        if (!pMudlet || pMudlet->developmentVersion) {
+        if (!pMudlet || MudletVersion::development()) {
             return;
         }
 
@@ -796,7 +797,7 @@ bool Updater::shouldShowChangelog()
     return false;
 #endif
 
-    if (mudlet::self()->developmentVersion || !updateAutomatically()) {
+    if (MudletVersion::development() || !updateAutomatically()) {
         return false;
     }
 

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -85,7 +85,8 @@ set(PROFILE_GROUP_TEST_SOURCES
     XMLexportVariablesTest.cpp
 )
 
-# Telnet, and the protocols and escape sequences carried over it
+# Telnet, and the protocols and escape sequences carried over it, and the
+# version identity Mudlet announces over them
 set(TELNET_GROUP_TEST_SOURCES
     CsiCursorForwardTest.cpp
     cTelnetBufferTest.cpp
@@ -105,6 +106,7 @@ set(TELNET_GROUP_TEST_SOURCES
     TelnetTlsPromptTest.cpp
     TOscTest.cpp
     MsdpMalformedDiagnosticTest.cpp
+    MudletVersionTest.cpp
 )
 
 # Triggers and the other scriptable units, and what a running script does to them

--- a/test/functional_tests/MudletVersionTest.cpp
+++ b/test/functional_tests/MudletVersionTest.cpp
@@ -1,0 +1,102 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// The version identity is what Mudlet calls itself to a game server, to the
+// package repository and to the updater, and it used to live on the main
+// window - so it could only be asked once a window existed. This binary never
+// makes one, which is the point: every assertion below runs with
+// mudlet::self() still null.
+//
+// The resource read is checked against the file rather than only for
+// self-consistency. An empty :/app-build.txt and an unregistered resource
+// collection are indistinguishable from build()'s side, and both read as an
+// official release - which is the arm that turns the updater loose and picks
+// the release splash screen.
+
+#include <QFile>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QtTest/QtTest>
+
+#include "MudletVersion.h"
+#include "mudlet.h"
+#include "utils.h"
+
+#include "GroupedTest.h"
+
+class MudletVersionTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Read straight off the resource, so the expectations below are not simply
+    // whatever MudletVersion happened to compute.
+    static QString suffixFromResource()
+    {
+        QFile buildFile(qsl(":/app-build.txt"));
+        if (!buildFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            return QString();
+        }
+        return QString::fromUtf8(buildFile.readAll()).trimmed();
+    }
+
+private slots:
+    void buildComesFromTheResource()
+    {
+        QVERIFY2(mudlet::self() == nullptr, "the version identity has to be readable before a main window exists");
+
+        QFile buildFile(qsl(":/app-build.txt"));
+        QVERIFY2(buildFile.open(QIODevice::ReadOnly | QIODevice::Text), qUtf8Printable(qsl("cannot open :/app-build.txt: %1").arg(buildFile.errorString())));
+
+        QCOMPARE(MudletVersion::build(), QString::fromUtf8(buildFile.readAll()).trimmed());
+    }
+
+    void scmVersionSpellsOutTheBuild()
+    {
+        QCOMPARE(MudletVersion::scmVersion(), qsl("Mudlet ") + QString(APP_VERSION) + suffixFromResource());
+        QCOMPARE(MudletVersion::scmVersion(), qsl("Mudlet ") + QString(APP_VERSION) + MudletVersion::build());
+    }
+
+    void flagsFollowTheBuild()
+    {
+        const QString suffix = suffixFromResource();
+
+        QCOMPARE(MudletVersion::release(), suffix.isEmpty());
+        QCOMPARE(MudletVersion::publicTest(), suffix.startsWith(qsl("-ptb")));
+        QCOMPARE(MudletVersion::development(), !MudletVersion::release() && !MudletVersion::publicTest());
+
+        // Exactly one of the three, whatever this build turns out to be
+        const int matched = (MudletVersion::release() ? 1 : 0) + (MudletVersion::publicTest() ? 1 : 0) + (MudletVersion::development() ? 1 : 0);
+        QCOMPARE(matched, 1);
+    }
+
+    void networkRequestsCarryTheUserAgent()
+    {
+        const QUrl url(qsl("https://www.mudlet.org/"));
+        QNetworkRequest request(url);
+        MudletVersion::setNetworkRequestDefaults(url, request);
+
+        QCOMPARE(request.rawHeader(QByteArray("User-Agent")), (qsl("Mozilla/5.0 (Mudlet/") + QString(APP_VERSION) + suffixFromResource() + qsl(")")).toUtf8());
+        QCOMPARE(request.attribute(QNetworkRequest::RedirectPolicyAttribute).value<QNetworkRequest::RedirectPolicy>(), QNetworkRequest::NoLessSafeRedirectPolicy);
+    }
+};
+
+MUDLET_GROUPED_TEST_MAIN(MudletVersionTest)
+
+#include "MudletVersionTest.moc"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- New namespace `MudletVersion` (`src/MudletVersion.h/.cpp`) answers "which build is this": `build()` (the `:/app-build.txt` suffix), `scmVersion()`, `release()`, `publicTest()`, `development()`, and `setNetworkRequestDefaults()`, which stamps the User-Agent.
- `mudlet::mAppBuild`, `releaseVersion`, `publicTestVersion`, `developmentVersion`, `scmVersion` and `mudlet::setNetworkRequestDefaults()` are gone; every reader (telnet handshakes, MXP, GMCP, Sentry, the updater, dialogs, `main()`) is switched. The three places that re-read the resource file themselves now share the one reader.
- `APP_VERSION` becomes a PUBLIC compile definition of the core target so the functional tests can check the identity it reports.

#### Motivation for adding to Mudlet
Part of the libmudlet program (#8681, #9011): a headless core still has to announce its version to servers and to Sentry, and that must not require a `QMainWindow` to exist first.

#### Other info (issues closed, discussion etc)
Pure relocation, no behaviour change. New `MudletVersionTest` (telnet group) reads the identity before any main window exists and checks it against the resource file, the flags and the User-Agent; verified to fail when `build()` is sabotaged. 180/180 functional tests locally. Widgets audit: 149 of 423, baseline unchanged.

**Test case:** the window title, Help > About, and `getMudletVersion()` in Lua still show the same version and build suffix as before; on a PTB build the "Report issue" action is still present.

Assisted-by: Claude:claude-fable-5-1