### PR TITLE
Infra: Add specs for replay playback and named stopwatches

### DIFF
--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -1497,15 +1497,18 @@ describe("Tests C++ functions in the Miscallaneous category", function()
           return
         end
         local replay = getMudletHomeDir() .. "/mudlet-spec-gmcp-replay.dat"
+        -- the gmcp table is the profile's, so whatever was under this key before
+        -- goes back afterwards
+        local previousReplay = gmcp.Replay
+        gmcp.Replay = nil
         finally(function()
           os.remove(replay)
-          gmcp.Replay = nil
+          gmcp.Replay = previousReplay
         end)
         -- IAC SB <GMCP> ... IAC SE, which only the telnet state machine can pick
         -- out of the stream - played back as text it would just be printed
         writeFile(replay, chunk(10, "\255\250\201Replay.Marker {\"note\":\"seen\"}\255\240mudlet-spec-gmcp-replay-line\r\n"))
         local mark = getLastLineNumber("main")
-        assert.is_nil(gmcp.Replay)
 
         assert.is_true(loadReplay(replay))
 

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -1405,8 +1405,30 @@ describe("Tests C++ functions in the Miscallaneous category", function()
         return string.char(math.floor(value / 16777216) % 256, math.floor(value / 65536) % 256, math.floor(value / 256) % 256, value % 256)
       end
 
+      -- one record: the delay in milliseconds before it, the number of bytes
+      -- in it, and then those bytes
+      local function chunk(delay, payload)
+        return bigEndian32(delay) .. bigEndian32(#payload) .. payload
+      end
+
+      -- the shape PR #4400 wrote for a while, where the delay took eight bytes
+      -- instead of four - Mudlet still reads it
+      local function wideChunk(delay, payload)
+        return string.rep("\0", 4) .. chunk(delay, payload)
+      end
+
       local function writeReplay(path, payload)
-        writeFile(path, bigEndian32(0) .. bigEndian32(#payload) .. payload)
+        writeFile(path, chunk(0, payload))
+      end
+
+      local function playedBack(mark, marker)
+        for _ = 1, 40 do
+          pumpEvents(50)
+          if contains(textFrom(mark), marker) then
+            return true
+          end
+        end
+        return false
       end
 
       it("raises a Lua error when called with no arguments", function()
@@ -1447,17 +1469,74 @@ describe("Tests C++ functions in the Miscallaneous category", function()
 
         assert.is_true(loadReplay(replay))
 
-        local arrived = false
-        for _ = 1, 40 do
-          pumpEvents(50)
-          arrived = contains(textFrom(mark), "mudlet-spec-replayed-line")
-          if arrived then
-            break
-          end
-        end
-        assert.is_true(arrived, "the replay did not reach the console")
+        assert.is_true(playedBack(mark, "mudlet-spec-replayed-line"), "the replay did not reach the console")
         -- whether a replay is running is application-wide, so let this one run
         -- out before the next spec asks for one
+        pumpEvents(200)
+      end)
+
+      it("plays back a replay written with the eight byte delay", function()
+        if not testMode then
+          pending("letting the replay timer run needs MUDLET_TEST_MODE")
+          return
+        end
+        local replay = getMudletHomeDir() .. "/mudlet-spec-wide-replay.dat"
+        finally(function() os.remove(replay) end)
+        writeFile(replay, wideChunk(10, "mudlet-spec-wide-replay-line\r\n"))
+        local mark = getLastLineNumber("main")
+
+        assert.is_true(loadReplay(replay))
+
+        assert.is_true(playedBack(mark, "mudlet-spec-wide-replay-line"), "the replay did not reach the console")
+        pumpEvents(200)
+      end)
+
+      it("acts on telnet negotiation that was recorded with the text", function()
+        if not testMode then
+          pending("letting the replay timer run needs MUDLET_TEST_MODE")
+          return
+        end
+        local replay = getMudletHomeDir() .. "/mudlet-spec-gmcp-replay.dat"
+        finally(function()
+          os.remove(replay)
+          gmcp.Replay = nil
+        end)
+        -- IAC SB <GMCP> ... IAC SE, which only the telnet state machine can pick
+        -- out of the stream - played back as text it would just be printed
+        writeFile(replay, chunk(10, "\255\250\201Replay.Marker {\"note\":\"seen\"}\255\240mudlet-spec-gmcp-replay-line\r\n"))
+        local mark = getLastLineNumber("main")
+        assert.is_nil(gmcp.Replay)
+
+        assert.is_true(loadReplay(replay))
+
+        assert.is_true(playedBack(mark, "mudlet-spec-gmcp-replay-line"), "the replay did not reach the console")
+        assert.is_truthy(gmcp.Replay and gmcp.Replay.Marker, "the subnegotiation recorded in the replay was played back as text instead of acted on")
+        assert.equals("seen", gmcp.Replay.Marker.note)
+        pumpEvents(200)
+      end)
+
+      it("refuses a second replay while one is still running", function()
+        if not testMode then
+          pending("letting the replay timer run needs MUDLET_TEST_MODE")
+          return
+        end
+        local first = getMudletHomeDir() .. "/mudlet-spec-first-replay.dat"
+        local second = getMudletHomeDir() .. "/mudlet-spec-second-replay.dat"
+        finally(function()
+          os.remove(first)
+          os.remove(second)
+        end)
+        writeFile(first, chunk(400, "mudlet-spec-first-replay-line\r\n"))
+        writeFile(second, chunk(10, "mudlet-spec-second-replay-line\r\n"))
+        local mark = getLastLineNumber("main")
+
+        assert.is_true(loadReplay(first))
+        local ok, err = loadReplay(second)
+
+        assert.is_nil(ok)
+        assert.is_true(contains(err, "already be in progress"), tostring(err))
+        assert.is_true(playedBack(mark, "mudlet-spec-first-replay-line"), "the replay that was accepted did not reach the console")
+        assert.is_false(contains(textFrom(mark), "mudlet-spec-second-replay-line"), "the replay that was refused played anyway")
         pumpEvents(200)
       end)
     end)

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -790,6 +790,12 @@ describe("Tests Other.lua functions", function()
         assert.is_boolean(t.negative)
       end)
 
+      it("returns nil and a message for an unknown id", function()
+        local ok, err = getStopWatchBrokenDownTime(444444)
+        assert.is_nil(ok)
+        assert.is_string(err)
+      end)
+
       it("flags negative elapsed time with the negative field", function()
         local id = track(createStopWatch(false))
         adjustStopWatch(id, -90) -- one minute thirty seconds in the past
@@ -815,6 +821,101 @@ describe("Tests Other.lua functions", function()
         local ok, err = deleteStopWatch(555555)
         assert.is_nil(ok)
         assert.is_string(err)
+      end)
+    end)
+
+    -- Every one of these takes a name where the tests above pass an id, which
+    -- is a separate lookup in Host: an id goes straight to the stopwatch, while
+    -- a name has to be resolved to one first.
+    describe("naming a stopwatch instead of giving its id", function()
+      it("startStopWatch and stopStopWatch both take a name", function()
+        local id = track(createStopWatch("stopwatchSpecByNameRun"))
+        assert.is_true(startStopWatch("stopwatchSpecByNameRun"))
+        assert.is_true(getStopWatches()[id].isRunning)
+        adjustStopWatch(id, 6)
+
+        assertClose(6, stopStopWatch("stopwatchSpecByNameRun"))
+        assert.is_false(getStopWatches()[id].isRunning)
+      end)
+
+      it("setStopWatchName renames the stopwatch that currently has that name", function()
+        local id = track(createStopWatch("stopwatchSpecOldName"))
+
+        assert.is_true(setStopWatchName("stopwatchSpecOldName", "stopwatchSpecNewName"))
+
+        assert.equals("stopwatchSpecNewName", getStopWatches()[id].name)
+        local ok, err = getStopWatchTime("stopwatchSpecOldName")
+        assert.is_nil(ok, "the stopwatch still answers to the name it was renamed away from")
+        assert.is_string(err)
+      end)
+
+      it("getStopWatchBrokenDownTime takes a name", function()
+        local id = track(createStopWatch("stopwatchSpecBrokenDownByName"))
+        adjustStopWatch(id, 2 * 60 + 5)
+
+        local elapsed = getStopWatchBrokenDownTime("stopwatchSpecBrokenDownByName")
+
+        assert.equals(2, elapsed.minutes)
+        assert.equals(5, elapsed.seconds)
+      end)
+
+      it("says which name it could not find", function()
+        local ok, err = startStopWatch("stopwatchSpecNoSuchWatch")
+        assert.is_nil(ok)
+        assert.is_truthy(err:find("stopwatchSpecNoSuchWatch", 1, true), err)
+
+        ok, err = stopStopWatch("stopwatchSpecNoSuchWatch")
+        assert.is_nil(ok)
+        assert.is_truthy(err:find("stopwatchSpecNoSuchWatch", 1, true), err)
+
+        ok, err = setStopWatchName("stopwatchSpecNoSuchWatch", "stopwatchSpecIrrelevant")
+        assert.is_nil(ok)
+        assert.is_truthy(err:find("stopwatchSpecNoSuchWatch", 1, true), err)
+      end)
+    end)
+
+    describe("starting a stopwatch that is already running", function()
+      -- startStopWatch(id) resets the stopwatch back to zero first, which is
+      -- what it has always done; passing false asks for the elapsed time so far
+      -- to be kept, and then starting one that is already running is refused
+      it("keeps the elapsed time when asked not to reset", function()
+        local id = track(createStopWatch(false))
+        adjustStopWatch(id, 20)
+
+        assert.is_true(startStopWatch(id, false))
+
+        assertClose(20, getStopWatchTime(id))
+        stopStopWatch(id)
+      end)
+
+      it("throws the elapsed time away when not asked to keep it", function()
+        local id = track(createStopWatch(false))
+        adjustStopWatch(id, 20)
+
+        assert.is_true(startStopWatch(id))
+
+        assertClose(0, getStopWatchTime(id))
+        stopStopWatch(id)
+      end)
+
+      it("refuses a second start that would keep the elapsed time", function()
+        local id = track(createStopWatch(false))
+        assert.is_true(startStopWatch(id, false))
+        finally(function() stopStopWatch(id) end)
+
+        local ok, err = startStopWatch(id, false)
+
+        assert.is_nil(ok)
+        assert.is_truthy(err:find("already running", 1, true), err)
+      end)
+
+      it("refuses to stop one that is already stopped", function()
+        local id = track(createStopWatch("stopwatchSpecAlreadyStopped"))
+
+        local ok, err = stopStopWatch("stopwatchSpecAlreadyStopped")
+
+        assert.is_nil(ok)
+        assert.is_truthy(err:find("already stopped", 1, true), err)
       end)
     end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Twelve specs across two areas that the existing blocks do not reach.

**Replay playback** (`Miscallaneous_spec.lua`, extending the `loadReplay` block added in #10413, which covers a blank name, a missing file, a corrupt file and one plain playback):

- a replay written with the **eight byte delay** - PR #4400 wrote that shape by accident for a while and Mudlet still reads it, so `mReplayHasFaultyFormat` has a live consequence
- **telnet negotiation recorded with the text is acted on**, not printed - a GMCP subnegotiation in the stream sets `gmcp.Replay.Marker` rather than appearing as characters
- a **second replay is refused** while one is still running, and the refused one does not play

**Stopwatches** (`Other_spec.lua`): the existing block works almost entirely by id. These cover the name-based overloads, which are a separate lookup in `Host`, and the reset-on-start behaviour:

- `startStopWatch`/`stopStopWatch`, `setStopWatchName` and `getStopWatchBrokenDownTime` all taking a name
- the failure message says **which** name it could not find
- `startStopWatch(id, false)` keeps the elapsed time; `startStopWatch(id)` throws it away
- a second `startStopWatch(id, false)` on a running stopwatch is refused, and stopping an already-stopped one is refused
- `getStopWatchBrokenDownTime` on an unknown id returns nil and a message

Every one of the twelve was proven to fail without the code it covers, by cutting that code out of `ctelnet.cpp`, `mudlet.cpp`, `Host.cpp`, `TLuaInterpreter.cpp` or `TLuaInterpreterMudletObjects.cpp` and watching it go red. Two of those needed care:

- the second-replay case needs **both** guards cut at once - `mudlet::loadReplay`'s `mpToolBarReplay` check and `cTelnet::loadReplay`'s `replayStart()` check each refuse on their own, so cutting either alone leaves the spec green
- cutting the chunk loop instead wedges the replay system for every later spec, so it reddens all four replay specs at once and attributes nothing; the GMCP case was pinned with a narrow cut that leaves text playback working and only stops IAC being recognised

A thirteenth spec was written and then dropped: it fed a line across two replay chunks and asserted the two halves came back as one line. It passes on its own and fails in a full suite run, because `cTelnet`'s 300 ms posting timer can flush the first half before the second chunk arrives - the outcome is a race between two timers, not a behaviour worth pinning. (Setting the second chunk's delay to 0 makes the full suite pass, which is what identified the race; that margin is still too thin for CI.)

The existing playback spec's inline wait loop moves into a `playedBack()` helper the new specs share, and `writeReplay()` now builds its record through the same `chunk()` helper the new ones use.

#### Motivation for adding to Mudlet

Replay playback runs its own copy of the telnet state machine (`cTelnet::slot_processReplayChunk`), and nothing was exercising the parts of it that make a replay different from a live socket: the second file format, and negotiation embedded in recorded text. The stopwatch name overloads are a second code path in `Host` that the id-based specs never touch.

Both are specs rather than functional tests, so they cost no build time and Mudlet Web gets the coverage too.

#### Other info (issues closed, discussion etc)

Builds on #10413, which added the `loadReplay` block. No production code changes.

**Test case:** open the `Mudlet self-test` profile and `runTests <repo>/src/mudlet-lua/tests/Miscallaneous_spec.lua`, then the same for `Other_spec.lua` - or run the whole suite headlessly per `src/mudlet-lua/tests/README.md`, which is 4378 passed / 0 failed with this branch applied.
