### PR TITLE
Infra: Host no longer builds its user-window and mapper widgets

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4429,30 +4429,14 @@ std::pair<bool, QString> Host::openWindow(const QString& name, bool loadLayout, 
         return {false, qsl("label with the name '%1' already exists").arg(name)};
     }
 
-    auto hostName(getName());
     auto console = mpConsole->subConsoleWidget(name);
     auto dockwidget = mpConsole->dockWidget(name);
 
     if (!console && !dockwidget) {
         // The name is not used in either the QMaps of all user created TConsole
         // or TDockWidget instances - so we can make a NEW one:
-        dockwidget = new TDockWidget(this, name);
-        dockwidget->setObjectName(qsl("dockWindow_%1_%2").arg(hostName, name));
-        dockwidget->setContentsMargins(0, 0, 0, 0);
-        dockwidget->setWindowTitle(name);
-        mpConsole->registerDockWidget(name, dockwidget);
-        // It wasn't obvious but the parent passed to the TConsole constructor
-        // is sliced down to a QWidget and is NOT a TDockWidget pointer:
-        console = new TConsole(this, name, TConsole::UserWindow, dockwidget->widget());
-        console->setObjectName(qsl("dockWindowConsole_%1_%2").arg(hostName, name));
-        console->setContentsMargins(0, 0, 0, 0);
-        dockwidget->setTConsole(console);
-        console->layerCommandLine->hide();
-        console->setScrollBarVisible(false);
-        mpConsole->registerSubConsole(name, console);
-        dockwidget->setStyleSheet(mProfileStyleSheet);
-        mudlet::self()->addDockWidget(Qt::RightDockWidgetArea, dockwidget);
-        console->setFontSize(10);
+        dockwidget = mpConsole->createUserWindow(name);
+        console = mpConsole->subConsoleWidget(name);
     }
     if (!console || !dockwidget) {
         return {false, qsl("userwindow '%1' already exists").arg(name)};
@@ -5265,13 +5249,6 @@ void Host::createMapper(const bool loadDefaultMap)
     auto pMap = mpMap.data();
     auto hostName(getName());
     mpConsole->createMapperDock(tr("Map - %1").arg(hostName), qsl("dockMap_%1").arg(hostName));
-    // Arrange for TMap member values to be copied from the Host masters so they
-    // are in place when the 2D mapper is created:
-    getPlayerRoomStyleDetails(pMap->mPlayerRoomStyle, pMap->mPlayerRoomOuterDiameterPercentage, pMap->mPlayerRoomInnerDiameterPercentage, pMap->mPlayerRoomOuterColor, pMap->mPlayerRoomInnerColor);
-
-    pMap->mpMapper = new dlgMapper(mpConsole->mpDockableMapWidget, this, pMap); //FIXME: mpHost definieren
-    pMap->mpMapper->setStyleSheet(mProfileStyleSheet);
-    mpConsole->mpDockableMapWidget->setWidget(pMap->mpMapper);
 
     if (loadDefaultMap && pMap->mpRoomDB->isEmpty()) {
         qDebug() << "Host::create_mapper() - restore map case 3.";

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -432,6 +432,29 @@ TDockWidget* TMainConsole::deregisterDockWidget(const QString& name)
     return mDockWidgetMap.take(name);
 }
 
+TDockWidget* TMainConsole::createUserWindow(const QString& name)
+{
+    auto hostName(mpHost->getName());
+    auto dockwidget = new TDockWidget(mpHost, name);
+    dockwidget->setObjectName(qsl("dockWindow_%1_%2").arg(hostName, name));
+    dockwidget->setContentsMargins(0, 0, 0, 0);
+    dockwidget->setWindowTitle(name);
+    registerDockWidget(name, dockwidget);
+    // It wasn't obvious but the parent passed to the TConsole constructor
+    // is sliced down to a QWidget and is NOT a TDockWidget pointer:
+    auto console = new TConsole(mpHost, name, TConsole::UserWindow, dockwidget->widget());
+    console->setObjectName(qsl("dockWindowConsole_%1_%2").arg(hostName, name));
+    console->setContentsMargins(0, 0, 0, 0);
+    dockwidget->setTConsole(console);
+    console->layerCommandLine->hide();
+    console->setScrollBarVisible(false);
+    registerSubConsole(name, console);
+    dockwidget->setStyleSheet(mpHost->mProfileStyleSheet);
+    mudlet::self()->addDockWidget(Qt::RightDockWidgetArea, dockwidget);
+    console->setFontSize(10);
+    return dockwidget;
+}
+
 void TMainConsole::registerScrollBox(const QString& name, TScrollBox* pScrollBox)
 {
     mScrollBoxMap[name] = pScrollBox;
@@ -2515,6 +2538,16 @@ void TMainConsole::createMapperDock(const QString& title, const QString& objectN
 {
     mpDockableMapWidget = new QDockWidget(title);
     mpDockableMapWidget->setObjectName(objectName);
+    // Arrange for TMap member values to be copied from the Host masters so they
+    // are in place when the 2D mapper is created:
+    mpHost->getPlayerRoomStyleDetails(mpHost->mpMap->mPlayerRoomStyle,
+                                      mpHost->mpMap->mPlayerRoomOuterDiameterPercentage,
+                                      mpHost->mpMap->mPlayerRoomInnerDiameterPercentage,
+                                      mpHost->mpMap->mPlayerRoomOuterColor,
+                                      mpHost->mpMap->mPlayerRoomInnerColor);
+    mpHost->mpMap->mpMapper = new dlgMapper(mpDockableMapWidget, mpHost, mpHost->mpMap.data());
+    mpHost->mpMap->mpMapper->setStyleSheet(mpHost->mProfileStyleSheet);
+    mpDockableMapWidget->setWidget(mpHost->mpMap->mpMapper);
 }
 
 void TMainConsole::showMapperScriptReminder()

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -127,6 +127,7 @@ public:
     TConsole* deregisterSubConsole(const QString& name);
     void registerDockWidget(const QString& name, TDockWidget* pDockWidget);
     TDockWidget* deregisterDockWidget(const QString& name);
+    TDockWidget* createUserWindow(const QString& name);
     // For callers that need the widgets themselves.
     TConsole* subConsoleWidget(const QString& name) const { return mSubConsoleMap.value(name); }
     QString subConsoleName(TConsole* pConsole) const { return mSubConsoleMap.key(pConsole); }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Host::openWindow()` no longer constructs the `TDockWidget` + `TConsole` pair for a new user window; that block moves verbatim into `TMainConsole::createUserWindow(name)`, and Host reads the registered console back.
- `Host::createMapper()` no longer constructs the docked `dlgMapper`; `TMainConsole::createMapperDock()` now builds the dock and the mapper together, copying the player-room style details first exactly as the Lua-embedded `createMapper()` path already does.
- Host keeps everything around those bodies unchanged: validation, layout restore, docking areas, map restore/audit and the `mapOpenEvent`.

#### Motivation for adding to Mudlet

libmudlet step 4 (#8681, #9011): `Host` is the per-profile session object and belongs in the widget-free core, so it should ask its concrete view to build widgets rather than `new` them itself. Later steps hoist these two methods onto the console frontend interface; this PR just puts the bodies on the view side.

#### Other info (issues closed, discussion etc)

Pure relocation with identical order of operations, object names, stylesheets and registrations. `grep 'new TDockWidget\|new TConsole\|new dlgMapper\|new QDockWidget' src/Host.cpp` is now empty. Full functional suite 179/179; stubbing the two new bodies reddens 10 existing tests (5 per path), so both paths are covered without new tests. Widgets audit unchanged at 149.

**Test case:** run `openUserWindow("x")` from Lua and open the map with the toolbar button, then save and reload the window layout: the user window and the map dock should appear, dock and restore exactly as before.

Assisted-by: Claude:claude-fable-5-1