### PR TITLE
Infra: Action toolbars and MXP frame consoles are built by the main console

### DIFF
--- a/docs/libmudlet-widgets-report.md
+++ b/docs/libmudlet-widgets-report.md
@@ -72,7 +72,7 @@ QtWidgets header includes; `Sym` = QtWidgets class-symbol references.
 | `dlgRoomProperties.cpp` | 2 | 51 | QColorDialog, QMenu, QWidget, QDialog, QLineEdit, QComboBox, QAbstractButton, QSpinBox, QListWidgetItem, QVBoxLayout, QSizePolicy, QListWidget, QListView, QHBoxLayout, QPushButton |
 | `dlgMapper.cpp` | 10 | 41 | QFileDialog, QFrame, QLabel, QListWidget, QMenu, QMessageBox, QProgressBar, QProgressDialog, QPushButton, QVBoxLayout, QWidget, QAbstractButton, QToolButton, QComboBox, QApplication, QDialog, QSizePolicy |
 | `dlgRoomExits.h` | 2 | 49 | QDialog, QStyledItemDelegate, QCheckBox, QWidget, QStyleOptionViewItem, QLineEdit, QTreeWidgetItem, QRadioButton, QSpinBox |
-| `TMainConsole.cpp` | 8 | 39 | QDialog, QDockWidget, QLabel, QLineEdit, QMessageBox, QProgressDialog, QScrollBar, QSizePolicy, QWidget, QApplication |
+| `TMainConsole.cpp` | 9 | 40 | QDialog, QDockWidget, QLabel, QLayout, QLineEdit, QMessageBox, QProgressDialog, QScrollBar, QSizePolicy, QWidget, QApplication |
 | `dlgPackageManager.cpp` | 3 | 42 | QFileDialog, QMessageBox, QProgressDialog, QWidget, QDialog, QLineEdit, QListWidget, QAbstractButton, QListWidgetItem, QButtonGroup |
 | `dlgNotepad.cpp` | 8 | 36 | QApplication, QHBoxLayout, QInputDialog, QLabel, QLineEdit, QMenu, QPlainTextEdit, QToolButton, QWidget, QTabWidget, QMainWindow, QTextEdit |
 | `TTreeWidget.cpp` | 2 | 38 | QHeaderView, QToolTip, QWidget, QTreeWidget, QAbstractItemView, QTreeWidgetItem, QStyle |
@@ -104,9 +104,9 @@ QtWidgets header includes; `Sym` = QtWidgets class-symbol references.
 | `dlgNotepad.h` | 0 | 14 | QLabel, QLineEdit, QPlainTextEdit, QToolButton, QMainWindow, QWidget |
 | `dlgMapper.h` | 0 | 13 | QFrame, QLabel, QProgressBar, QPushButton, QWidget, QMenu |
 | `TDebugFilterBar.h` | 1 | 12 | QToolBar, QLabel, QLineEdit, QMenu, QToolButton, QWidget |
+| `TMainConsole.h` | 1 | 11 | QWidget, QDialog, QDockWidget, QProgressDialog |
 | `TUiTour.h` | 1 | 11 | QWidget, QFrame, QLabel, QPushButton |
 | `updater.cpp` | 2 | 10 | QMessageBox, QPushButton, QApplication, QAbstractButton |
-| `TMainConsole.h` | 1 | 10 | QWidget, QDialog, QDockWidget, QProgressDialog |
 | `updater/UpdateDialog.h` | 1 | 10 | QDialog, QAbstractButton, QLabel, QWidget |
 | `VarUnit.cpp` | 1 | 10 | QTreeWidgetItem |
 | `VarUnit.h` | 0 | 11 | QTreeWidgetItem |
@@ -129,7 +129,6 @@ QtWidgets header includes; `Sym` = QtWidgets class-symbol references.
 | `TCommandLine.h` | 2 | 4 | QPlainTextEdit, QToolButton, QWidget, QMenu |
 | `TEasyButtonBar.h` | 1 | 5 | QWidget, QGridLayout |
 | `TToolBar.h` | 1 | 5 | QDockWidget, QGridLayout, QWidget |
-| `ActionUnit.cpp` | 3 | 2 | QDockWidget, QLayout, QWidget |
 | `dlgActionMainArea.cpp` | 0 | 5 | QWidget, QLineEdit, QSpinBox, QComboBox |
 | `dlgModuleManager.h` | 1 | 4 | QDialog, QWidget, QTableWidgetItem |
 | `LuaInterface.h` | 0 | 5 | QTreeWidgetItem |
@@ -140,6 +139,7 @@ QtWidgets header includes; `Sym` = QtWidgets class-symbol references.
 | `TrailingWhitespaceMarker.cpp` | 1 | 4 | QLineEdit, QPlainTextEdit |
 | `TrailingWhitespaceMarker.h` | 1 | 4 | QLineEdit, QPlainTextEdit |
 | `TScrollBox.h` | 1 | 4 | QScrollArea, QWidget |
+| `ActionUnit.cpp` | 2 | 2 | QDockWidget, QWidget |
 | `DarkTheme.h` | 2 | 2 | QProxyStyle, QStyleFactory, QStyle |
 | `dlgAliasMainArea.cpp` | 0 | 4 | QWidget, QLineEdit |
 | `dlgRoomProperties.h` | 1 | 3 | QListWidget, QDialog, QWidget, QListWidgetItem |

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -716,6 +716,11 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 
 void ActionUnit::updateAllToolbars()
 {
+    // Package removal and XML import get here while the console can be between
+    // windows: moveProfileFromDetachedToMainWindow() pumps events with it detached
+    if (!mpHost->mpConsole) {
+        return;
+    }
     regenerateToolBars();
     regenerateEasyButtonBars();
 }

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -246,14 +246,17 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
     pChild->setDataChanged();
 
     if ((!pOldParent) && (pNewParent)) {
-        if (pChild->mpEasyButtonBar) {
-            mpHost->mpConsole->detachEasyButtonBar(pChild->mpEasyButtonBar, pChild->mLocation);
+        // The bars are the console's widgets; a profile with no view has none to take down
+        TMainConsole* pConsole = mpHost->mpConsole;
+        if (!pConsole) {
+            return;
         }
-        if (pChild->mpToolBar) {
-            if (pChild->mLocation == 4) {
-                pChild->mpToolBar->setFloating(false);
-                mpHost->mpConsole->undockToolBar(pChild->mpToolBar);
-            }
+        if (pChild->mpEasyButtonBar) {
+            pConsole->detachEasyButtonBar(pChild->mpEasyButtonBar, pChild->mLocation);
+        }
+        if (pChild->mpToolBar && pChild->mLocation == 4) {
+            pChild->mpToolBar->setFloating(false);
+            pConsole->undockToolBar(pChild->mpToolBar);
         }
     }
 }
@@ -316,13 +319,12 @@ void ActionUnit::unregisterAction(TAction* pT)
         updateAllToolbars();
         return;
     }
-    if (pT->mpEasyButtonBar && pT->mPackageName.isEmpty()) {
-        mpHost->mpConsole->detachEasyButtonBar(pT->mpEasyButtonBar, pT->mLocation);
-        if (pT->mLocation == 4) {
-            if (pT->mpToolBar) {
-                pT->mpToolBar->setFloating(false);
-                mpHost->mpConsole->undockToolBar(pT->mpToolBar);
-            }
+    TMainConsole* pConsole = mpHost->mpConsole;
+    if (pConsole && pT->mpEasyButtonBar && pT->mPackageName.isEmpty()) {
+        pConsole->detachEasyButtonBar(pT->mpEasyButtonBar, pT->mLocation);
+        if (pT->mLocation == 4 && pT->mpToolBar) {
+            pT->mpToolBar->setFloating(false);
+            pConsole->undockToolBar(pT->mpToolBar);
         }
     }
     removeAction(pT);
@@ -716,8 +718,8 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 
 void ActionUnit::updateAllToolbars()
 {
-    // Package removal and XML import get here while the console can be between
-    // windows: moveProfileFromDetachedToMainWindow() pumps events with it detached
+    // The bars are the console's widgets, so a profile with no view has nothing
+    // to build; the regenerate paths below reach the console only through here
     if (!mpHost->mpConsole) {
         return;
     }

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -35,7 +35,6 @@
 
 #include <QDebug>
 #include <QDockWidget>
-#include <QLayout>
 #include <QMapIterator>
 #include <QPoint>
 #include <QSet>
@@ -248,20 +247,12 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
 
     if ((!pOldParent) && (pNewParent)) {
         if (pChild->mpEasyButtonBar) {
-            if (pChild->mLocation == 0) {
-                mpHost->mpConsole->mpTopToolBar->layout()->removeWidget(pChild->mpEasyButtonBar);
-            }
-            if (pChild->mLocation == 2) {
-                mpHost->mpConsole->mpLeftToolBar->layout()->removeWidget(pChild->mpEasyButtonBar);
-            }
-            if (pChild->mLocation == 3) {
-                mpHost->mpConsole->mpRightToolBar->layout()->removeWidget(pChild->mpEasyButtonBar);
-            }
+            mpHost->mpConsole->detachEasyButtonBar(pChild->mpEasyButtonBar, pChild->mLocation);
         }
         if (pChild->mpToolBar) {
             if (pChild->mLocation == 4) {
                 pChild->mpToolBar->setFloating(false);
-                mudlet::self()->removeDockWidget(pChild->mpToolBar);
+                mpHost->mpConsole->undockToolBar(pChild->mpToolBar);
             }
         }
     }
@@ -326,19 +317,11 @@ void ActionUnit::unregisterAction(TAction* pT)
         return;
     }
     if (pT->mpEasyButtonBar && pT->mPackageName.isEmpty()) {
-        if (pT->mLocation == 0) {
-            mpHost->mpConsole->mpTopToolBar->layout()->removeWidget(pT->mpEasyButtonBar);
-        }
-        if (pT->mLocation == 2) {
-            mpHost->mpConsole->mpLeftToolBar->layout()->removeWidget(pT->mpEasyButtonBar);
-        }
-        if (pT->mLocation == 3) {
-            mpHost->mpConsole->mpRightToolBar->layout()->removeWidget(pT->mpEasyButtonBar);
-        }
+        mpHost->mpConsole->detachEasyButtonBar(pT->mpEasyButtonBar, pT->mLocation);
         if (pT->mLocation == 4) {
             if (pT->mpToolBar) {
                 pT->mpToolBar->setFloating(false);
-                mudlet::self()->removeDockWidget(pT->mpToolBar);
+                mpHost->mpConsole->undockToolBar(pT->mpToolBar);
             }
         }
     }
@@ -403,7 +386,7 @@ void ActionUnit::regenerateToolBars()
                     }
                 }
                 if (!pTB) {
-                    pTB = new TToolBar(mpHost, childAction, childAction->getName(), mudlet::self());
+                    pTB = mpHost->mpConsole->createToolBar(childAction, childAction->getName());
                     mToolBarList.push_back(pTB);
                 }
                 if (childAction->mOrientation == 1) {
@@ -426,7 +409,7 @@ void ActionUnit::regenerateToolBars()
             }
         }
         if (!pTB) {
-            pTB = new TToolBar(mpHost, action, action->getName(), mudlet::self());
+            pTB = mpHost->mpConsole->createToolBar(action, action->getName());
             mToolBarList.push_back(pTB);
         }
         if (action->mOrientation == 1) {
@@ -468,8 +451,7 @@ void ActionUnit::regenerateEasyButtonBars()
                     }
                 }
                 if (!pTB) {
-                    pTB = new TEasyButtonBar(rootAction, childAction->getName(), mpHost->mpConsole->mpTopToolBar);
-                    mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
+                    pTB = mpHost->mpConsole->createEasyButtonBar(rootAction, childAction->getName());
                     mEasyButtonBarList.emplace_back(pTB);
                     childAction->mpEasyButtonBar = pTB; // needed for drag&drop
                 }
@@ -493,8 +475,7 @@ void ActionUnit::regenerateEasyButtonBars()
             }
         }
         if (!pTB) {
-            pTB = new TEasyButtonBar(rootAction, rootAction->getName(), mpHost->mpConsole->mpTopToolBar);
-            mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
+            pTB = mpHost->mpConsole->createEasyButtonBar(rootAction, rootAction->getName());
             mEasyButtonBarList.emplace_back(pTB);
             rootAction->mpEasyButtonBar = pTB; // needed for drag&drop
         }
@@ -636,7 +617,7 @@ void ActionUnit::constructToolbar(TAction* pAction, TToolBar* pToolBar)
 
     if (!pAction->isActive()) {
         pToolBar->setFloating(false);
-        mudlet::self()->removeDockWidget(pToolBar);
+        mpHost->mpConsole->undockToolBar(pToolBar);
         return;
     }
 
@@ -660,7 +641,7 @@ void ActionUnit::constructToolbar(TAction* pAction, TToolBar* pToolBar)
             qWarning().nospace().noquote() << "ActionUnit::constructToolbar(TAction*, TToolBar*) WARNING - no last dockarea was set for the TAction (\"" << pAction->getName()
                                            << "\"), for this toolbar forcing it to the Left one!";
         }
-        mudlet::self()->addDockWidget(((pAction->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pAction->mToolbarLastDockArea : Qt::LeftDockWidgetArea), pToolBar);
+        mpHost->mpConsole->dockToolBar(pToolBar, (pAction->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pAction->mToolbarLastDockArea : Qt::LeftDockWidgetArea);
         if (pAction->mToolbarLastFloatingState) {
             pToolBar->setFloating(true);
             const QPoint pos = QPoint(pAction->mPosX, pAction->mPosY);
@@ -726,20 +707,7 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
     } else {
         pTB->setVerticalOrientation();
     }
-    switch (pA->mLocation) {
-    case 0:
-        mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
-        break;
-    //case 1:
-    //mpHost->mpConsole->mpTopToolBar->layout()->addWidget( pTB );
-    //break;
-    case 2:
-        mpHost->mpConsole->mpLeftToolBar->layout()->addWidget(pTB);
-        break;
-    case 3:
-        mpHost->mpConsole->mpRightToolBar->layout()->addWidget(pTB);
-        break;
-    }
+    mpHost->mpConsole->attachEasyButtonBar(pTB, pA->mLocation);
 
     pTB->setStyleSheet(pTB->mpTAction->css);
     pTB->show();

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -582,6 +582,17 @@ TConsole* TMainConsole::createMiniConsole(const QString& windowname, const QStri
     return nullptr;
 }
 
+TConsole* TMainConsole::createSubConsole(const QString& name, QWidget* parent)
+{
+    auto* pC = new TConsole(mpHost, name, SubConsole, parent);
+    pC->setObjectName(name);
+    const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
+    pC->setFocusProxy(hostCommandLine);
+    pC->mUpperPane->setFocusProxy(hostCommandLine);
+    pC->mLowerPane->setFocusProxy(hostCommandLine);
+    return pC;
+}
+
 TToolBar* TMainConsole::createToolBar(TAction* pAction, const QString& name)
 {
     return new TToolBar(mpHost, pAction, name, mudlet::self());

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -586,10 +586,9 @@ TConsole* TMainConsole::createSubConsole(const QString& name, QWidget* parent)
 {
     auto* pC = new TConsole(mpHost, name, SubConsole, parent);
     pC->setObjectName(name);
-    const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
-    pC->setFocusProxy(hostCommandLine);
-    pC->mUpperPane->setFocusProxy(hostCommandLine);
-    pC->mLowerPane->setFocusProxy(hostCommandLine);
+    pC->setFocusProxy(mpCommandLine);
+    pC->mUpperPane->setFocusProxy(mpCommandLine);
+    pC->mLowerPane->setFocusProxy(mpCommandLine);
     return pC;
 }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -552,22 +552,14 @@ TConsole* TMainConsole::createMiniConsole(const QString& windowname, const QStri
     auto pC = mSubConsoleMap.value(name);
     auto pS = mScrollBoxMap.value(windowname);
     if (!pC) {
+        QWidget* parent = mpMainFrame;
         if (pS) {
-            pC = new TConsole(mpHost, name, SubConsole, pS->widget());
+            parent = pS->widget();
         } else if (pW) {
-            pC = new TConsole(mpHost, name, SubConsole, pW->widget());
-        } else {
-            pC = new TConsole(mpHost, name, SubConsole, mpMainFrame);
+            parent = pW->widget();
         }
-        if (!pC) {
-            return nullptr;
-        }
+        pC = createSubConsole(name, parent);
         registerSubConsole(name, pC);
-        pC->setObjectName(name);
-        const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
-        pC->setFocusProxy(hostCommandLine);
-        pC->mUpperPane->setFocusProxy(hostCommandLine);
-        pC->mLowerPane->setFocusProxy(hostCommandLine);
         pC->resize(width, height);
         pC->mOldX = x;
         pC->mOldY = y;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -28,6 +28,7 @@
 #include "TCommandLine.h"
 #include "TDebug.h"
 #include "TDockWidget.h"
+#include "TEasyButtonBar.h"
 #include "TEvent.h"
 #include "THyperlinkVisibilityManager.h"
 #include "TLabel.h"
@@ -37,6 +38,7 @@
 #include "TScrollBox.h"
 #include "TTextBox.h"
 #include "TTextEdit.h"
+#include "TToolBar.h"
 #include "dlgMapper.h"
 #include "mudlet.h"
 #include "GifTracker.h"
@@ -45,6 +47,7 @@
 #include <QDockWidget>
 #include <QIcon>
 #include <QLabel>
+#include <QLayout>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
@@ -577,6 +580,58 @@ TConsole* TMainConsole::createMiniConsole(const QString& windowname, const QStri
         return pC;
     }
     return nullptr;
+}
+
+TToolBar* TMainConsole::createToolBar(TAction* pAction, const QString& name)
+{
+    return new TToolBar(mpHost, pAction, name, mudlet::self());
+}
+
+TEasyButtonBar* TMainConsole::createEasyButtonBar(TAction* pRootAction, const QString& name)
+{
+    auto* pBar = new TEasyButtonBar(pRootAction, name, mpTopToolBar);
+    mpTopToolBar->layout()->addWidget(pBar);
+    return pBar;
+}
+
+void TMainConsole::attachEasyButtonBar(TEasyButtonBar* pBar, int location)
+{
+    switch (location) {
+    case 0:
+        mpTopToolBar->layout()->addWidget(pBar);
+        break;
+    case 2:
+        mpLeftToolBar->layout()->addWidget(pBar);
+        break;
+    case 3:
+        mpRightToolBar->layout()->addWidget(pBar);
+        break;
+    }
+}
+
+void TMainConsole::detachEasyButtonBar(TEasyButtonBar* pBar, int location)
+{
+    switch (location) {
+    case 0:
+        mpTopToolBar->layout()->removeWidget(pBar);
+        break;
+    case 2:
+        mpLeftToolBar->layout()->removeWidget(pBar);
+        break;
+    case 3:
+        mpRightToolBar->layout()->removeWidget(pBar);
+        break;
+    }
+}
+
+void TMainConsole::dockToolBar(TToolBar* pToolBar, Qt::DockWidgetArea area)
+{
+    mudlet::self()->addDockWidget(area, pToolBar);
+}
+
+void TMainConsole::undockToolBar(TToolBar* pToolBar)
+{
+    mudlet::self()->removeDockWidget(pToolBar);
 }
 
 // This is a scrollBox overlaid on to the main console

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -36,9 +36,12 @@
 
 #include <list>
 
+class TAction;
+class TEasyButtonBar;
 class TMediaPlayer;
 class TScrollBox;
 class TTextBox;
+class TToolBar;
 class QDialog;
 class QDockWidget;
 class QProgressDialog;
@@ -182,6 +185,12 @@ public:
     void disableMapProgressDialogCancel();
     void closeMapProgressDialog();
     void createMapperDock(const QString& title, const QString& objectName);
+    TToolBar* createToolBar(TAction* pAction, const QString& name);
+    TEasyButtonBar* createEasyButtonBar(TAction* pRootAction, const QString& name);
+    void attachEasyButtonBar(TEasyButtonBar* pBar, int location);
+    void detachEasyButtonBar(TEasyButtonBar* pBar, int location);
+    void dockToolBar(TToolBar* pToolBar, Qt::DockWidgetArea area);
+    void undockToolBar(TToolBar* pToolBar);
     void showMapperScriptReminder();
     void showUnpackingProgress(const QString& message, const QString& title);
     void closeUnpackingProgress();

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -58,6 +58,7 @@ public:
     void resetMainConsole();
     void closeEvent(QCloseEvent*) override;
     TConsole* createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height);
+    TConsole* createSubConsole(const QString& name, QWidget* parent);
     bool createScrollBox(const QString& windowname, const QString& name, int x, int y, int width, int height);
     bool raiseWindow(const QString& name);
     bool lowerWindow(const QString& name);

--- a/src/TMxpFrameManager.cpp
+++ b/src/TMxpFrameManager.cpp
@@ -24,7 +24,6 @@
 #include "TDockWidget.h"
 #include "TLabel.h"
 #include "TMainConsole.h"
-#include "TTextEdit.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -641,16 +640,9 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         auto* tabPageLayout = new QVBoxLayout(tabPage);
         tabPageLayout->setContentsMargins(0, 0, 0, 0);
 
-        // Create console directly with tabPage as parent to avoid flash on mpMainFrame
-        // (createMiniConsole parents to mpMainFrame and calls show() before we can intervene)
-        console = new TConsole(mpHost, frame->name, TConsole::SubConsole, tabPage);
-
-        // Setup console properties (mirroring what createMiniConsole does)
-        console->setObjectName(frame->name);
-        const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
-        console->setFocusProxy(hostCommandLine);
-        console->mUpperPane->setFocusProxy(hostCommandLine);
-        console->mLowerPane->setFocusProxy(hostCommandLine);
+        // Parented to the tab page rather than made by createMiniConsole, which
+        // parents to mpMainFrame and calls show() before we can intervene (a flash)
+        console = mainConsole->createSubConsole(frame->name, tabPage);
         console->resize(frameWidth, frameHeight - tabBarHeight);
         console->mOldX = 0;
         console->mOldY = 0;
@@ -667,15 +659,7 @@ void TMxpFrameManager::layoutInternalFrame(TMxpFrame* frame)
         containerLayout->addWidget(tabWidget);
     } else {
         // Floating/borderless: console directly in container, no tab header
-        // Create console directly with containerWidget as parent to avoid flash
-        console = new TConsole(mpHost, frame->name, TConsole::SubConsole, containerWidget);
-
-        // Setup console properties (mirroring what createMiniConsole does)
-        console->setObjectName(frame->name);
-        const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
-        console->setFocusProxy(hostCommandLine);
-        console->mUpperPane->setFocusProxy(hostCommandLine);
-        console->mLowerPane->setFocusProxy(hostCommandLine);
+        console = mainConsole->createSubConsole(frame->name, containerWidget);
         console->resize(frameWidth, frameHeight);
         console->mOldX = 0;
         console->mOldY = 0;
@@ -828,16 +812,8 @@ void TMxpFrameManager::layoutTabFrame(TMxpFrame* frame)
     auto* tabPageLayout = new QVBoxLayout(tabPage);
     tabPageLayout->setContentsMargins(0, 0, 0, 0);
 
-    // Create console directly with tabPage as parent
-    auto* console = new TConsole(mpHost, frame->name, TConsole::SubConsole, tabPage);
-
-    // Setup console properties
     TMainConsole* mainConsole = mpHost->mpConsole;
-    console->setObjectName(frame->name);
-    const auto& hostCommandLine = mainConsole->mpCommandLine;
-    console->setFocusProxy(hostCommandLine);
-    console->mUpperPane->setFocusProxy(hostCommandLine);
-    console->mLowerPane->setFocusProxy(hostCommandLine);
+    auto* console = mainConsole->createSubConsole(frame->name, tabPage);
     console->resize(frameSize.width(), frameSize.height());
     console->mOldX = 0;
     console->mOldY = 0;

--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -274,6 +274,37 @@ private slots:
         QVERIFY2(mudlet::self()->dockWidgetArea(floatingBar->mpToolBar) != Qt::NoDockWidgetArea, "The TToolBar should be docked on the main window");
     }
 
+    // The bars are the console's widgets now, so ActionUnit has to cope with being
+    // asked to rebuild them before a profile has one - Host::uninstallPackage()
+    // reaches updateAllToolbars() on that path. A floating root is the case that
+    // used to survive it: regenerateEasyButtonBars() skips those nodes, and before
+    // the bars moved to the console regenerateToolBars() only touched the main
+    // window, so neither half went near mpConsole.
+    void test_rebuildingToolbarsWithoutAConsoleBuildsNothing()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        auto* actionUnit = host->getActionUnit();
+
+        auto* floatingBar = new TAction(qsl("floatingBar"), host);
+        floatingBar->setIsFolder(true);
+        floatingBar->mLocation = 4;
+        floatingBar->mToolbarLastFloatingState = false;
+        floatingBar->setIsActive(true);
+        actionUnit->registerAction(floatingBar);
+
+        QPointer<TMainConsole> console = host->mpConsole;
+        host->mpConsole = nullptr;
+        actionUnit->updateAllToolbars();
+        host->mpConsole = console;
+
+        QVERIFY2(!floatingBar->mpToolBar, "No bar should have been built while the console was away");
+
+        actionUnit->updateAllToolbars();
+        QVERIFY2(floatingBar->mpToolBar, "The bar should be built once the console is back");
+    }
+
     // Starts a profile the way a user would via the GUI (mirrors the helper in
     // TFeedTriggersRecursionTest).
     void startProfile(const QString& hostname, const QString& address, const QString& port)

--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -238,10 +238,11 @@ private slots:
     }
 
     // ActionUnit only decides which bar an action gets; TMainConsole builds and
-    // places the widgets. A top-bar and a left-bar TEasyButtonBar have to end up
-    // in the console's matching side toolbar (the left one is what proves the
-    // attach step, since every TEasyButtonBar starts life on the top bar), and a
-    // floating TToolBar has to be docked on the main window.
+    // places the widgets. A top-bar, a left-bar and a right-bar TEasyButtonBar
+    // have to end up in the console's matching side toolbar (the side ones are
+    // what prove the attach step, since every TEasyButtonBar starts life on the
+    // top bar), and a floating TToolBar has to be docked on the main window's
+    // left, the area a bar that has never floated gets.
     void test_toolbarsArePlacedByTheMainConsole()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -260,6 +261,7 @@ private slots:
         };
         auto* topBar = makeRoot(qsl("topBar"), 0);
         auto* leftBar = makeRoot(qsl("leftBar"), 2);
+        auto* rightBar = makeRoot(qsl("rightBar"), 3);
         auto* floatingBar = makeRoot(qsl("floatingBar"), 4);
 
         actionUnit->updateAllToolbars();
@@ -269,9 +271,11 @@ private slots:
         QCOMPARE(topBar->mpEasyButtonBar->parentWidget(), console->mpTopToolBar);
         QVERIFY2(leftBar->mpEasyButtonBar, "The left-bar action should have been given a TEasyButtonBar");
         QCOMPARE(leftBar->mpEasyButtonBar->parentWidget(), console->mpLeftToolBar);
+        QVERIFY2(rightBar->mpEasyButtonBar, "The right-bar action should have been given a TEasyButtonBar");
+        QCOMPARE(rightBar->mpEasyButtonBar->parentWidget(), console->mpRightToolBar);
         QVERIFY2(floatingBar->mpToolBar, "The floating action should have been given a TToolBar");
         QCOMPARE(floatingBar->mpToolBar->parentWidget(), static_cast<QWidget*>(mudlet::self()));
-        QVERIFY2(mudlet::self()->dockWidgetArea(floatingBar->mpToolBar) != Qt::NoDockWidgetArea, "The TToolBar should be docked on the main window");
+        QCOMPARE(mudlet::self()->dockWidgetArea(floatingBar->mpToolBar), Qt::LeftDockWidgetArea);
     }
 
     // The bars are the console's widgets now, so ActionUnit has to cope with being
@@ -333,6 +337,81 @@ private slots:
         QVERIFY2(bar, "The bar belongs to the console and has to outlive its action");
         QVERIFY2(bar->isHidden(), "The action hides its bar on the way out");
         QCOMPARE(bar->parentWidget(), console->mpLeftToolBar);
+    }
+
+    // Moving a bar's action under a folder reaches the console the same way, to
+    // take the bar off its side toolbar. Without a console the move itself still
+    // happens and the widget is left where it is.
+    void test_reparentingABarActionWithoutAConsoleLeavesTheBarAlone()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        auto* actionUnit = host->getActionUnit();
+
+        auto* leftBar = new TAction(qsl("leftBar"), host);
+        leftBar->setIsFolder(true);
+        leftBar->mLocation = 2;
+        leftBar->mToolbarLastFloatingState = false;
+        leftBar->setIsActive(true);
+        actionUnit->registerAction(leftBar);
+        auto* folder = new TAction(qsl("folder"), host);
+        folder->setIsFolder(true);
+        folder->setIsActive(true);
+        actionUnit->registerAction(folder);
+        actionUnit->updateAllToolbars();
+        QVERIFY2(leftBar->mpEasyButtonBar, "The left-bar action should have been given a TEasyButtonBar");
+        QPointer<TEasyButtonBar> bar = leftBar->mpEasyButtonBar;
+
+        QPointer<TMainConsole> console = host->mpConsole;
+        host->mpConsole = nullptr;
+        actionUnit->reParentAction(leftBar->getID(), 0, folder->getID());
+        host->mpConsole = console;
+
+        QCOMPARE(leftBar->getParent(), folder);
+        QVERIFY2(bar, "The bar belongs to the console and has to outlive the move");
+        QCOMPARE(bar->parentWidget(), console->mpLeftToolBar);
+    }
+
+    // With a console present, removing a bar's action takes the bar off its side
+    // toolbar; a floating toolbar is only hidden and stays docked on the main
+    // window. The widgets outlive the action either way.
+    void test_removingBarActionsWithAConsoleTakesTheBarsDown()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        auto* actionUnit = host->getActionUnit();
+
+        auto makeRoot = [&](const QString& name, int location) {
+            auto* root = new TAction(name, host);
+            root->setIsFolder(true);
+            root->mLocation = location;
+            root->mToolbarLastFloatingState = false;
+            root->setIsActive(true);
+            actionUnit->registerAction(root);
+            return root;
+        };
+        auto* leftBar = makeRoot(qsl("leftBar"), 2);
+        auto* floatingBar = makeRoot(qsl("floatingBar"), 4);
+        actionUnit->updateAllToolbars();
+
+        TMainConsole* console = host->mpConsole;
+        QPointer<TEasyButtonBar> bar = leftBar->mpEasyButtonBar;
+        QVERIFY2(bar, "The left-bar action should have been given a TEasyButtonBar");
+        QVERIFY2(console->mpLeftToolBar->layout()->indexOf(bar) != -1, "SETUP: the bar is not on the left toolbar to begin with");
+        QPointer<TToolBar> toolbar = floatingBar->mpToolBar;
+        QVERIFY2(toolbar, "The floating action should have been given a TToolBar");
+        QVERIFY2(mudlet::self()->dockWidgetArea(toolbar) != Qt::NoDockWidgetArea, "SETUP: the toolbar is not docked to begin with");
+        QVERIFY2(!toolbar->isHidden(), "SETUP: the toolbar is hidden to begin with");
+
+        delete leftBar;
+        delete floatingBar;
+
+        QVERIFY2(bar, "The bar belongs to the console and has to outlive its action");
+        QCOMPARE(console->mpLeftToolBar->layout()->indexOf(bar), -1);
+        QVERIFY2(toolbar, "The toolbar belongs to the main window and has to outlive its action");
+        QVERIFY2(toolbar->isHidden(), "The removed action's toolbar is still showing");
     }
 
     // Starts a profile the way a user would via the GUI (mirrors the helper in

--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -29,9 +29,11 @@
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
 #include "TAction.h"
+#include "TEasyButtonBar.h"
 #include "TFlipButton.h"
 #include "TLuaInterpreter.h"
 #include "TMainConsole.h"
+#include "TToolBar.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
@@ -233,6 +235,43 @@ private slots:
         QApplication::processEvents();
         QVERIFY2(bufferContains(qsl("Package install failed")), qPrintable(qsl("The failure must reach the profile's message area, but the buffer held: \"%1\"").arg(joinedBuffer())));
         QVERIFY2(bufferContains(reason), qPrintable(qsl("The message must carry the reason \"%1\", but the buffer held: \"%2\"").arg(reason, joinedBuffer())));
+    }
+
+    // ActionUnit only decides which bar an action gets; TMainConsole builds and
+    // places the widgets. A top-bar and a left-bar TEasyButtonBar have to end up
+    // in the console's matching side toolbar (the left one is what proves the
+    // attach step, since every TEasyButtonBar starts life on the top bar), and a
+    // floating TToolBar has to be docked on the main window.
+    void test_toolbarsArePlacedByTheMainConsole()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        auto* actionUnit = host->getActionUnit();
+
+        auto makeRoot = [&](const QString& name, int location) {
+            auto* root = new TAction(name, host);
+            root->setIsFolder(true);
+            root->mLocation = location;
+            root->mToolbarLastFloatingState = false;
+            root->setIsActive(true);
+            actionUnit->registerAction(root);
+            return root;
+        };
+        auto* topBar = makeRoot(qsl("topBar"), 0);
+        auto* leftBar = makeRoot(qsl("leftBar"), 2);
+        auto* floatingBar = makeRoot(qsl("floatingBar"), 4);
+
+        actionUnit->updateAllToolbars();
+
+        TMainConsole* console = host->mpConsole;
+        QVERIFY2(topBar->mpEasyButtonBar, "The top-bar action should have been given a TEasyButtonBar");
+        QCOMPARE(topBar->mpEasyButtonBar->parentWidget(), console->mpTopToolBar);
+        QVERIFY2(leftBar->mpEasyButtonBar, "The left-bar action should have been given a TEasyButtonBar");
+        QCOMPARE(leftBar->mpEasyButtonBar->parentWidget(), console->mpLeftToolBar);
+        QVERIFY2(floatingBar->mpToolBar, "The floating action should have been given a TToolBar");
+        QCOMPARE(floatingBar->mpToolBar->parentWidget(), static_cast<QWidget*>(mudlet::self()));
+        QVERIFY2(mudlet::self()->dockWidgetArea(floatingBar->mpToolBar) != Qt::NoDockWidgetArea, "The TToolBar should be docked on the main window");
     }
 
     // Starts a profile the way a user would via the GUI (mirrors the helper in

--- a/test/functional_tests/ActionSelfRemovalTest.cpp
+++ b/test/functional_tests/ActionSelfRemovalTest.cpp
@@ -275,11 +275,11 @@ private slots:
     }
 
     // The bars are the console's widgets now, so ActionUnit has to cope with being
-    // asked to rebuild them before a profile has one - Host::uninstallPackage()
-    // reaches updateAllToolbars() on that path. A floating root is the case that
-    // used to survive it: regenerateEasyButtonBars() skips those nodes, and before
-    // the bars moved to the console regenerateToolBars() only touched the main
-    // window, so neither half went near mpConsole.
+    // asked to rebuild them for a profile that has no console - the view is
+    // optional. A floating root is the case that used to survive it:
+    // regenerateEasyButtonBars() skips those nodes, and before the bars moved to
+    // the console regenerateToolBars() only touched the main window, so neither
+    // half went near mpConsole.
     void test_rebuildingToolbarsWithoutAConsoleBuildsNothing()
     {
         startProfile(mpHostname, mpLocalhost, mpPort);
@@ -303,6 +303,36 @@ private slots:
 
         actionUnit->updateAllToolbars();
         QVERIFY2(floatingBar->mpToolBar, "The bar should be built once the console is back");
+    }
+
+    // Removing a docked bar's action reaches the console to take the bar down.
+    // With no console there is nothing to take it down from, so the removal has
+    // to leave the widget alone rather than reach through a null pointer.
+    void test_removingADockedBarActionWithoutAConsoleLeavesTheBarAlone()
+    {
+        startProfile(mpHostname, mpLocalhost, mpPort);
+        auto* host = mudlet::self()->getActiveHost();
+        QVERIFY2(host, "No active host available for the test.");
+        auto* actionUnit = host->getActionUnit();
+
+        auto* leftBar = new TAction(qsl("leftBar"), host);
+        leftBar->setIsFolder(true);
+        leftBar->mLocation = 2;
+        leftBar->mToolbarLastFloatingState = false;
+        leftBar->setIsActive(true);
+        actionUnit->registerAction(leftBar);
+        actionUnit->updateAllToolbars();
+        QVERIFY2(leftBar->mpEasyButtonBar, "The left-bar action should have been given a TEasyButtonBar");
+        QPointer<TEasyButtonBar> bar = leftBar->mpEasyButtonBar;
+
+        QPointer<TMainConsole> console = host->mpConsole;
+        host->mpConsole = nullptr;
+        delete leftBar;
+        host->mpConsole = console;
+
+        QVERIFY2(bar, "The bar belongs to the console and has to outlive its action");
+        QVERIFY2(bar->isHidden(), "The action hides its bar on the way out");
+        QCOMPARE(bar->parentWidget(), console->mpLeftToolBar);
     }
 
     // Starts a profile the way a user would via the GUI (mirrors the helper in

--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -29,6 +29,7 @@
 #include "MudletInstanceCoordinator.h"
 #include "TLuaInterpreter.h"
 #include "TMainConsole.h"
+#include "TTextEdit.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
@@ -403,6 +404,33 @@ private slots:
     // behind that resize the main window out from under whatever runs next, so
     // add new tests above this one rather than below it. For the same reason the
     // expectation is evaluated at assert time rather than captured up front.
+    // All three frame layouts get their console from
+    // TMainConsole::createSubConsole(), parented inside the frame (never on
+    // mpMainFrame, where createMiniConsole would flash it) and wired with the
+    // same name and command-line focus proxies createMiniConsole gives out. A
+    // titled frame takes the tabbed layout, an untitled one the borderless
+    // layout, and DOCK plus ALIGN=client becomes a tab inside the titled one.
+    void test_frameConsolesAreBuiltInsideTheirFrame()
+    {
+        QVERIFY(createFrame(qsl("titled"), qsl("right"), qsl("300px"), qsl("100%"), {{qsl("TITLE"), qsl("Titled")}}));
+        QVERIFY(createFrame(qsl("plain"), qsl("left"), qsl("120px"), qsl("100%")));
+        QVERIFY(createFrame(qsl("tab"), qsl("client"), qsl("100%"), qsl("100%"), {{qsl("DOCK"), qsl("titled")}}));
+        const TMxpFrame* titled = mpHost->mMxpFrameManager.getFrame(qsl("titled"));
+        QVERIFY2(titled && titled->tabWidget, "A titled frame should have taken the tabbed layout");
+
+        QWidget* commandLine = mpHost->mpConsole->mpCommandLine;
+        QVERIFY(commandLine);
+        for (const QString& name : {qsl("titled"), qsl("plain"), qsl("tab")}) {
+            const TMxpFrame* frame = mpHost->mMxpFrameManager.getFrame(name);
+            QVERIFY2(frame && frame->widget && frame->console, qPrintable(qsl("Frame %1 should have a widget and a console").arg(name)));
+            QVERIFY2(frame->widget->isAncestorOf(frame->console), qPrintable(qsl("The console of %1 should live inside its frame widget").arg(name)));
+            QCOMPARE(frame->console->objectName(), name);
+            QCOMPARE(frame->console->focusProxy(), commandLine);
+            QCOMPARE(frame->console->mUpperPane->focusProxy(), commandLine);
+            QCOMPARE(frame->console->mLowerPane->focusProxy(), commandLine);
+        }
+    }
+
     void test_rightFrameKeepsClearOfAnAttachedAdjustableContainer()
     {
         runLua(qsl("panel = Adjustable.Container:new({name = 'mxpTestPanel', x = '-25%', y = 0, width = '25%', height = '100%', autoSave = false, autoLoad = false})\n"

--- a/test/functional_tests/MxpFramePlacementTest.cpp
+++ b/test/functional_tests/MxpFramePlacementTest.cpp
@@ -399,11 +399,6 @@ private slots:
         QCOMPARE(mpHost->borders().right(), 300);
     }
 
-    // How the base UI reserves its space, so this is #9698 as reported. Declared
-    // last on purpose: an adjustable container leaves deferred timers of its own
-    // behind that resize the main window out from under whatever runs next, so
-    // add new tests above this one rather than below it. For the same reason the
-    // expectation is evaluated at assert time rather than captured up front.
     // All three frame layouts get their console from
     // TMainConsole::createSubConsole(), parented inside the frame (never on
     // mpMainFrame, where createMiniConsole would flash it) and wired with the
@@ -431,6 +426,11 @@ private slots:
         }
     }
 
+    // How the base UI reserves its space, so this is #9698 as reported. Declared
+    // last on purpose: an adjustable container leaves deferred timers of its own
+    // behind that resize the main window out from under whatever runs next, so
+    // add new tests above this one rather than below it. For the same reason the
+    // expectation is evaluated at assert time rather than captured up front.
     void test_rightFrameKeepsClearOfAnAttachedAdjustableContainer()
     {
         runLua(qsl("panel = Adjustable.Container:new({name = 'mxpTestPanel', x = '-25%', y = 0, width = '25%', height = '100%', autoSave = false, autoLoad = false})\n"


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `ActionUnit` no longer constructs `TToolBar`/`TEasyButtonBar` widgets or reaches into the main window and the side toolbars' layouts; `TMainConsole` gains `createToolBar`, `createEasyButtonBar`, `attachEasyButtonBar`/`detachEasyButtonBar` and `dockToolBar`/`undockToolBar`, and ActionUnit keeps only the logic (which action gets which bar, orientation, css, active state).
- `TMxpFrameManager` gets its three frame sub-consoles from a new `TMainConsole::createSubConsole(name, parent)`, which does the object-name and command-line focus-proxy setup the three sites had each mirrored from `createMiniConsole()`.
- Two functional test cases pin the placement: a top-bar, a left-bar, a right-bar and a floating toolbar action end up in the matching side toolbar or docked on the main window's left, and every MXP frame layout's console lives inside its frame with the expected name and focus proxies.

#### Motivation for adding to Mudlet

libmudlet step 4 (#8681, #9011): `ActionUnit` and the MXP frame manager are core units driven by profile data and server output, so they should ask the concrete view to build and place widgets rather than `new` them and call `QMainWindow` methods themselves.

#### Other info (issues closed, discussion etc)

Pure relocation: same parents, same layouts, same order of operations; the toolbar location-to-side mapping is unchanged. `mudlet::self()->processEventLoopHack()` is the only main-window call left in ActionUnit.cpp. Full functional suite 179/179; stubbing the new methods reddens four existing tests plus the two new cases, which pass again restored. Widgets audit unchanged at 149 offenders (ActionUnit.cpp drops its `QLayout` use). `ActionSelfRemovalTest` also pins a reparent with no console (the tree move happens, the bar stays on its side toolbar), a removal with the console present (the bar leaves its side toolbar, the floating toolbar is hidden) and the right-side toolbar; the console-less reparent is red (segfault) without its guard.

**Test case:** create a button bar at the top, one at the left and a floating toolbar in the editor, toggle them active/inactive and drag the floating one to another dock area; open an MXP-enabled game that sends `<FRAME>` tags. Everything should look and behave exactly as before.

Assisted-by: Claude:claude-fable-5-1
