### PR TITLE
Infra: Add specs for the windows MXP asks for with <FRAME>

### DIFF
--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -294,4 +294,199 @@ describe("Tests MXP handling", function()
       assert.is_false(holds(frameLines(), "MXPDEST10 unfinished"), shown)
     end)
   end)
+
+  -- An internal frame takes its space out of the main console, and the main
+  -- window's character grid is the only way to see that: getBorderLeft() and
+  -- its friends report the borders the user set, not the ones MXP adds.
+  describe("Tests the frames MXP asks for", function()
+    local function openFrame(name, attributes)
+      feedTriggers(('<FRAME Name="%s" %s>'):format(name, attributes) .. "\n")
+    end
+
+    local function closeFrame(name)
+      feedTriggers(('<FRAME %s ACTION="close">'):format(name) .. "\n")
+    end
+
+    -- everything the main window gained since it was at line `mark`: a tag that
+    -- was refused is still in the stream and shows up here as text
+    local function mainSince(mark)
+      return table.concat(getLines("main", mark, getLastLineNumber("main") + 1), "|")
+    end
+
+    it("takes the columns an internal frame needs from the main window", function()
+      finally(function() closeFrame("mxpSpecLeftFrame") end)
+      local columns, rows = getColumnCount("main"), getRowCount("main")
+
+      openFrame("mxpSpecLeftFrame", 'Align="left" Width="25%" Height="50%"')
+
+      assert.are.equal("miniconsole", windowType("mxpSpecLeftFrame"))
+      assert.is_true(getColumnCount("main") < columns, ("the main window still has %d columns"):format(getColumnCount("main")))
+      assert.are.equal(rows, getRowCount("main"), "a frame down one side took rows as well as columns")
+
+      closeFrame("mxpSpecLeftFrame")
+
+      assert.is_nil(windowType("mxpSpecLeftFrame"))
+      assert.are.equal(columns, getColumnCount("main"), "the main window did not get its columns back")
+    end)
+
+    it("takes rows instead when the frame is along the bottom", function()
+      finally(function() closeFrame("mxpSpecBottomFrame") end)
+      local columns, rows = getColumnCount("main"), getRowCount("main")
+
+      openFrame("mxpSpecBottomFrame", 'Align="bottom" Width="50%" Height="20%"')
+
+      assert.is_true(getRowCount("main") < rows, ("the main window still has %d rows"):format(getRowCount("main")))
+      assert.are.equal(columns, getColumnCount("main"), "a frame along the bottom took columns as well as rows")
+    end)
+
+    -- a height of "5c" is five lines of the profile's font; read as a percentage
+    -- it would be a twentieth of the window, which is nothing like the same
+    it("reads a size given in characters as characters", function()
+      finally(function()
+        closeFrame("mxpSpecCharsFrame")
+        closeFrame("mxpSpecPercentFrame")
+      end)
+      local rows = getRowCount("main")
+
+      openFrame("mxpSpecCharsFrame", 'Align="bottom" Width="50%" Height="5c"')
+      local rowsTakenByCharacters = rows - getRowCount("main")
+      closeFrame("mxpSpecCharsFrame")
+
+      openFrame("mxpSpecPercentFrame", 'Align="bottom" Width="50%" Height="5%"')
+      local rowsTakenByPercent = rows - getRowCount("main")
+
+      assert.is_true(rowsTakenByCharacters > rowsTakenByPercent,
+        ("five characters took %d rows and five percent took %d"):format(rowsTakenByCharacters, rowsTakenByPercent))
+    end)
+
+    -- CMUD leaves a frame the player has moved or resized alone when the game
+    -- opens it again, and Mudlet follows it
+    it("leaves a frame that is already open at the size it has", function()
+      finally(function() closeFrame("mxpSpecReopenedFrame") end)
+      openFrame("mxpSpecReopenedFrame", 'Align="left" Width="25%" Height="50%"')
+      local frameColumns = getColumnCount("mxpSpecReopenedFrame")
+      local mainColumns = getColumnCount("main")
+
+      openFrame("mxpSpecReopenedFrame", 'Align="left" Width="60%" Height="90%"')
+
+      assert.are.equal(frameColumns, getColumnCount("mxpSpecReopenedFrame"), "the second tag resized the frame")
+      assert.are.equal(mainColumns, getColumnCount("main"), "the second tag took more of the main window")
+    end)
+
+    it("gives an external frame a console without taking main window space", function()
+      finally(function() closeFrame("mxpSpecExternalFrame") end)
+      local columns, rows = getColumnCount("main"), getRowCount("main")
+
+      openFrame("mxpSpecExternalFrame", 'EXTERNAL Width="30%" Height="30%"')
+
+      assert.are.equal("miniconsole", windowType("mxpSpecExternalFrame"))
+      assert.are.equal(columns, getColumnCount("main"))
+      assert.are.equal(rows, getRowCount("main"))
+    end)
+
+    -- DOCK names the frame to dock into and ALIGN=CLIENT makes it a tab of that
+    -- frame rather than a window of its own, so it costs the main window nothing
+    it("docks a frame into another as a tab and closes it with its parent", function()
+      finally(function()
+        closeFrame("mxpSpecTabChild")
+        closeFrame("mxpSpecTabParent")
+      end)
+      openFrame("mxpSpecTabParent", 'Align="right" Width="30%" Height="50%" TITLE="Parent"')
+      local columns = getColumnCount("main")
+
+      openFrame("mxpSpecTabChild", 'DOCK="mxpSpecTabParent" Align="client" TITLE="Tab"')
+
+      assert.are.equal("miniconsole", windowType("mxpSpecTabChild"))
+      assert.are.equal(columns, getColumnCount("main"), "the tab took space of its own instead of sharing its parent's")
+
+      closeFrame("mxpSpecTabParent")
+
+      assert.is_nil(windowType("mxpSpecTabChild"), "the tab outlived the frame it was docked into")
+    end)
+
+    it("shows the tag as text when the frame it names is not there", function()
+      finally(function() closeFrame("mxpSpecFocusFrame") end)
+      openFrame("mxpSpecFocusFrame", 'Align="left" Width="25%" Height="50%"')
+
+      local mark = getLastLineNumber("main")
+      feedTriggers('<FRAME mxpSpecFocusFrame ACTION="focus">MXPFRAME1 focused' .. "\n")
+      local handled = mainSince(mark)
+      assert.is_truthy(handled:find("MXPFRAME1 focused", 1, true), handled)
+      assert.is_falsy(handled:find("<FRAME", 1, true), handled)
+
+      mark = getLastLineNumber("main")
+      feedTriggers('<FRAME mxpSpecNoSuchFrame ACTION="focus">MXPFRAME2 not focused' .. "\n")
+      local refused = mainSince(mark)
+      assert.is_truthy(refused:find("<FRAME mxpSpecNoSuchFrame", 1, true), refused)
+    end)
+
+    -- closing one that is not there is the exception: it answers as though it
+    -- had been, so a game that closes a frame twice does not print its own tag
+    it("says nothing when asked to close a frame that is not there", function()
+      local mark = getLastLineNumber("main")
+      feedTriggers('<FRAME mxpSpecNeverOpened ACTION="close">MXPFRAME3 closed anyway' .. "\n")
+
+      local shown = mainSince(mark)
+      assert.is_truthy(shown:find("MXPFRAME3 closed anyway", 1, true), shown)
+      assert.is_falsy(shown:find("<FRAME", 1, true), shown)
+    end)
+
+    it("refuses a name that is not a plain word", function()
+      finally(function()
+        closeFrame("mxpSpecDotted.name")
+        closeFrame("mxpSpec spaced")
+      end)
+      local columns = getColumnCount("main")
+
+      local mark = getLastLineNumber("main")
+      feedTriggers('<FRAME Name="mxpSpec spaced" Align="left" Width="25%" Height="50%">MXPFRAME4 spaced' .. "\n")
+
+      assert.is_nil(windowType("mxpSpec spaced"))
+      assert.are.equal(columns, getColumnCount("main"))
+      -- the refusal leaves the tag in the stream rather than eating it silently
+      assert.is_truthy(mainSince(mark):find("<FRAME", 1, true), mainSince(mark))
+
+      feedTriggers('<FRAME Name="mxpSpecDotted.name" Align="left" Width="25%" Height="50%">' .. "\n")
+
+      assert.is_nil(windowType("mxpSpecDotted.name"))
+    end)
+
+    it("stops at twenty frames", function()
+      local names = {}
+      for index = 1, 21 do
+        names[index] = ("mxpSpecLimit%d"):format(index)
+      end
+      finally(function()
+        for _, name in ipairs(names) do
+          closeFrame(name)
+        end
+      end)
+
+      for _, name in ipairs(names) do
+        openFrame(name, 'Align="left" Width="2c" Height="2c"')
+      end
+
+      assert.are.equal("miniconsole", windowType(names[20]), "the twentieth frame was refused")
+      assert.is_nil(windowType(names[21]), "a twenty-first frame was allowed")
+    end)
+
+    -- a frame opened while output is redirected belongs to the frame it was
+    -- redirected into, and comes out of that frame's space rather than the main
+    -- window's
+    it("nests a frame opened inside a redirect in the frame it was redirected to", function()
+      finally(function()
+        closeFrame("mxpSpecNestedInner")
+        closeFrame("mxpSpecNestedOuter")
+      end)
+      openFrame("mxpSpecNestedOuter", 'Align="left" Width="40%" Height="60%"')
+      local columns = getColumnCount("main")
+
+      feedTriggers('<DEST mxpSpecNestedOuter><FRAME Name="mxpSpecNestedInner" Align="left" Width="50%" Height="50%"></DEST>' .. "\n")
+
+      assert.are.equal("miniconsole", windowType("mxpSpecNestedInner"))
+      assert.are.equal(columns, getColumnCount("main"), "the nested frame took main window space of its own")
+      assert.is_true(getColumnCount("mxpSpecNestedInner") < getColumnCount("mxpSpecNestedOuter"),
+        "the nested frame is not inside the one it was opened in")
+    end)
+  end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Eleven specs for `<FRAME>`, the MXP tag a game uses to ask for a window of its own. Nothing in the suite covered `TMxpFrameManager` until now, so every branch below was free to change without a test noticing.

The specs measure the main window's character grid rather than its borders, because `getBorderLeft()` and its friends report the borders the *user* set - the ones MXP adds on top are invisible from Lua. What they cover:

- an internal frame down one side takes columns out of the main console and gives them back when it closes; one along the bottom takes rows instead
- `Height="5c"` is read as five characters, not as five percent
- a frame that is already open is left at the size it has when the game sends `<FRAME>` for it again, which is what CMUD does
- an `EXTERNAL` frame gets a console but costs the main window nothing
- `DOCK=` plus `ALIGN=CLIENT` makes a tab of another frame, and closing the parent closes the tab
- a `<FRAME>` naming a frame that is not open is refused and shows up as text, rather than being swallowed - except `ACTION="close"`, which answers as though the frame had been there so a game that closes twice does not print its own tag at the player
- a name that is not a plain word is refused
- the twentieth frame opens and the twenty-first does not
- a frame opened inside a `<DEST>` redirect nests in the frame it was redirected to and comes out of that frame's space

**Test case:** `runTests <path>/src/mudlet-lua/tests/MXP_spec.lua` in the Mudlet self-test profile.

#### Motivation for adding to Mudlet

Each of the eleven was proven to fail by cutting the code it covers, in five batches, so none of them is passing for an unrelated reason:

| cut in `TMxpFrameManager.cpp` (and `Host::setMxpBorders`) | specs that go red |
| --- | --- |
| `setMxpBorders()` body removed | the three that measure the main window's grid |
| the `c` suffix in `calculateFrameSize()` never matches | reads a size given in characters as characters |
| `frameExists` early return, forced `isInternal` | leaves a frame already open, external frame, close a frame that is not there |
| the tab branch, `focusFrame`/`closeFrame`/`validateFrameName`/`canCreateFrame` answers | docks a frame as a tab, shows the tag as text, refuses a bad name, stops at twenty frames |
| the `mCurrentDestination` parent lookup dropped | nests a frame opened inside a redirect |

With the sources restored the whole Lua suite is 4389 successes / 0 failures / 0 errors / 76 pending.

#### Other info (issues closed, discussion etc)

Specs only - no production code changes.
