### PR TITLE
Infra: Add tests for the console's search bar

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     WindowBackgroundTest.cpp
     WindowLayoutSaveTest.cpp
     WindowStateGettersTest.cpp
+    ConsoleSearchBarTest.cpp
     WrapLineRewrapTest.cpp
 )
 
@@ -523,6 +524,9 @@ set_tests_properties(FrontendRefreshSeamTest PROPERTIES TIMEOUT 300)
 # HyperlinkModelSplitTest creates a fresh profile per test method, and one of
 # them waits out a deliberately long OSC 8 reveal delay, so it needs a longer timeout
 set_tests_properties(HyperlinkModelSplitTest PROPERTIES TIMEOUT 300)
+
+# ConsoleSearchBarTest creates a fresh profile per test method, so it needs a longer timeout
+set_tests_properties(ConsoleSearchBarTest PROPERTIES TIMEOUT 300)
 
 # NarrowWindowWrapTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(NarrowWindowWrapTest PROPERTIES TIMEOUT 300)

--- a/test/functional_tests/ConsoleSearchBarTest.cpp
+++ b/test/functional_tests/ConsoleSearchBarTest.cpp
@@ -100,9 +100,8 @@ private:
         return count;
     }
 
-    bool waitForTextInBuffer(const QString& text, const int timeoutMs = 5000)
+    bool waitForTextInBuffer(TMainConsole* console, const QString& text, const int timeoutMs = 5000)
     {
-        TMainConsole* console = mudlet::self()->getActiveHost()->mpConsole;
         return QTest::qWaitFor(
                 [console, &text]() {
                     return lineHolding(console, text) > -1;
@@ -112,21 +111,25 @@ private:
 
     TMainConsole* startSearchableProfile()
     {
-        startProfile(mHostname, mLocalhost, mPort);
-        auto* host = mudlet::self()->getActiveHost();
+        Host* host = startProfile(mHostname, mLocalhost, mPort);
+        if (!host) {
+            return nullptr;
+        }
         TMainConsole* console = host->mpConsole;
 
         // Room for the longest fixture line, so that what the assertions below
         // count as one line cannot be wrapped into two:
         console->setWrapAt(200);
         mpServer->sendRaw(searchableText().toUtf8());
-        if (!waitForTextInBuffer(qsl("nothing else moves."))) {
+        if (!waitForTextInBuffer(console, qsl("nothing else moves."))) {
             return nullptr;
         }
         return console;
     }
 
-    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    // Reports what went wrong and hands back nothing, so the caller's own
+    // assertion ends the test instead of the null host doing it.
+    Host* startProfile(const QString& hostname, const QString& address, const QString& port)
     {
         QTimer::singleShot(0, qApp, [hostname, address, port]() {
             const auto dialog = []() {
@@ -178,17 +181,21 @@ private:
 
         QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
         if (!spy.wait(5000)) {
-            QFAIL("Profile took too long to load.");
+            qWarning() << "Profile took too long to load.";
+            return nullptr;
         }
         auto* host = mudlet::self()->getActiveHost();
         if (!host) {
-            QFAIL("No active host available for the test.");
+            qWarning() << "No active host available for the test.";
+            return nullptr;
         }
 
         QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
         if (!spy2.wait(2000)) {
-            QFAIL("Could not connect with the host.");
+            qWarning() << "Could not connect with the host.";
+            return nullptr;
         }
+        return host;
     }
 
     void deleteProfileDirectory(const QString& profileName) { deleteDirectory(mudlet::getMudletPath(enums::profileHomePath, profileName)); }
@@ -246,7 +253,7 @@ private slots:
     void test_aNewSearchStartsAtTheEndAndMarksEveryHitOnTheLineItStopsOn()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
         const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
@@ -265,7 +272,7 @@ private slots:
     void test_searchingAgainStepsToTheMatchAboveTheOneItIsOn()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
         const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
@@ -282,7 +289,7 @@ private slots:
     void test_searchingDownComesBackTowardsTheEndOfTheBuffer()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
         const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
@@ -301,7 +308,7 @@ private slots:
     void test_searchingDownWithNothingBelowTheCurrentLineDoesNothing()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         console->mpBufferSearchBox->setText(qsl("gorbash"));
         console->slot_searchBufferDown();
@@ -314,7 +321,7 @@ private slots:
     void test_theCaseSensitiveOptionSkipsALineThatOnlyMatchesWithoutIt()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
         const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
@@ -336,7 +343,7 @@ private slots:
     void test_aNewTermClearsWhatTheOldOneMarkedAndStartsOver()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
         const int dustyLine = lineHolding(console, qsl("a dusty road"));
@@ -357,7 +364,7 @@ private slots:
     void test_aTermThatIsNowhereInTheBufferSaysSo()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         console->mpBufferSearchBox->setText(qsl("dragonfruit"));
         console->slot_searchBufferUp();
@@ -371,7 +378,7 @@ private slots:
     void test_anEmptyTermIsNotSearchedFor()
     {
         auto* console = startSearchableProfile();
-        QVERIFY2(console, "the fixture text never reached the buffer");
+        QVERIFY2(console, "the profile never started, or the fixture text never reached its buffer - see the warning above");
 
         console->mpBufferSearchBox->setText(QString());
         console->slot_searchBufferUp();
@@ -385,8 +392,8 @@ private slots:
     // are left on the text with nothing on screen to say why.
     void test_hidingTheFindBarClearsWhatTheSearchMarked()
     {
-        startProfile(mHostname, mLocalhost, mPort);
-        auto* host = mudlet::self()->getActiveHost();
+        Host* host = startProfile(mHostname, mLocalhost, mPort);
+        QVERIFY2(host, "the profile never started");
         mudlet::self()->attachDebugArea(host->getName());
 
         auto* console = mudlet::smpDebugConsole.data();

--- a/test/functional_tests/ConsoleSearchBarTest.cpp
+++ b/test/functional_tests/ConsoleSearchBarTest.cpp
@@ -1,0 +1,415 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QDir>
+#include <QLineEdit>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TMainConsole.h"
+#include "TTextEdit.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// The search bar over the console is reachable only from its own widgets: there
+// is no Lua binding for it, which is why none of it has ever been under test.
+// What it does is entirely in what it leaves behind - which line the search is
+// now on, and which characters are marked as found - so that is what these
+// assert, rather than anything about how the result is drawn.
+class ConsoleSearchBarTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    const QString mHostname = "Test-ConsoleSearch";
+    QString mPort; // assigned the stub's actual ephemeral port in init()
+    const QString mLocalhost = "localhost";
+
+    // One line carries the term once in lower case and a later one carries it
+    // twice in upper case, so a single fixture answers where a search starts,
+    // how far each step takes it, and what the case-sensitivity option changes.
+    static QString searchableText()
+    {
+        return qsl("gorbash sleeps by the fire.\r\n"
+                   "a dusty road leads north.\r\n"
+                   "GORBASH stirs and GORBASH yawns.\r\n"
+                   "nothing else moves.\r\n");
+    }
+
+    // The last line holding the text, since a search starts at the end of the
+    // buffer and the profile's own startup lines sit above the fixture.
+    static int lineHolding(TConsole* console, const QString& text)
+    {
+        for (int i = console->buffer.getLastLineNumber(); i >= 0; --i) {
+            if (console->buffer.lineBuffer.at(i).contains(text)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    static int markedCharactersOn(TConsole* console, const int lineNumber)
+    {
+        int count = 0;
+        for (const auto& character : console->buffer.buffer.at(lineNumber)) {
+            if (character.isFound()) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    static int markedLineCount(TConsole* console)
+    {
+        int count = 0;
+        for (int i = console->buffer.getLastLineNumber(); i >= 0; --i) {
+            if (markedCharactersOn(console, i) > 0) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    bool waitForTextInBuffer(const QString& text, const int timeoutMs = 5000)
+    {
+        TMainConsole* console = mudlet::self()->getActiveHost()->mpConsole;
+        return QTest::qWaitFor(
+                [console, &text]() {
+                    return lineHolding(console, text) > -1;
+                },
+                timeoutMs);
+    }
+
+    TMainConsole* startSearchableProfile()
+    {
+        startProfile(mHostname, mLocalhost, mPort);
+        auto* host = mudlet::self()->getActiveHost();
+        TMainConsole* console = host->mpConsole;
+
+        // Room for the longest fixture line, so that what the assertions below
+        // count as one line cannot be wrapped into two:
+        console->setWrapAt(200);
+        mpServer->sendRaw(searchableText().toUtf8());
+        if (!waitForTextInBuffer(qsl("nothing else moves."))) {
+            return nullptr;
+        }
+        return console;
+    }
+
+    void startProfile(const QString& hostname, const QString& address, const QString& port)
+    {
+        QTimer::singleShot(0, qApp, [hostname, address, port]() {
+            const auto dialog = []() {
+                return mudlet::self()->mpConnectionDialog.data();
+            };
+
+            mudlet::self()->startAutoLogin({});
+
+            if (!QTest::qWaitFor(
+                        [&dialog]() {
+                            return dialog() && dialog()->isVisible();
+                        },
+                        5000)) {
+                qWarning() << "the connection dialog never appeared";
+                return;
+            }
+
+            const auto waitForFocus = [](QWidget* field, const char* name) {
+                if (QTest::qWaitFor(
+                            [field]() {
+                                return QApplication::focusWidget() == field;
+                            },
+                            5000)) {
+                    return true;
+                }
+                qWarning() << "focus never reached the" << name << "field";
+                return false;
+            };
+
+            QTest::mouseClick(dialog()->new_profile_button, Qt::LeftButton);
+            if (!waitForFocus(dialog()->profile_name_entry, "profile name")) {
+                return;
+            }
+            QTest::keyClicks(dialog()->profile_name_entry, hostname);
+            QTest::keyClick(dialog()->profile_name_entry, Qt::Key_Tab);
+
+            if (!waitForFocus(dialog()->host_name_entry, "server address")) {
+                return;
+            }
+            QTest::keyClicks(dialog()->host_name_entry, address);
+            QTest::keyClick(dialog()->host_name_entry, Qt::Key_Tab);
+
+            if (!waitForFocus(dialog()->port_entry, "port")) {
+                return;
+            }
+            QTest::keyClicks(dialog()->port_entry, port);
+            QTest::keyClick(dialog()->port_entry, Qt::Key_Return);
+        });
+
+        QSignalSpy spy(mudlet::self(), &mudlet::signal_profileLoaded);
+        if (!spy.wait(5000)) {
+            QFAIL("Profile took too long to load.");
+        }
+        auto* host = mudlet::self()->getActiveHost();
+        if (!host) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy spy2(&(host->mTelnet), &cTelnet::signal_connected);
+        if (!spy2.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+    }
+
+    void deleteProfileDirectory(const QString& profileName) { deleteDirectory(mudlet::getMudletPath(enums::profileHomePath, profileName)); }
+
+    void deleteDirectory(const QString& path)
+    {
+        QDir dir(path);
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+    }
+
+    void cleanupTestCase() { mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg); }
+
+    void init()
+    {
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), "TelnetServerStub failed to bind a loopback port");
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mHostname);
+    }
+
+    void cleanup()
+    {
+        const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        delete mudlet::self();
+        delete mpServer;
+        mpServer = nullptr;
+        deleteDirectory(profilePath);
+    }
+
+    // A search is for the most recent thing said, so it starts at the end of the
+    // buffer and works back - and it marks the whole line it stops on, not just
+    // the first hit on it.
+    void test_aNewSearchStartsAtTheEndAndMarksEveryHitOnTheLineItStopsOn()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
+        const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
+        QVERIFY(laterLine > earlierLine && earlierLine > -1);
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferUp();
+
+        QCOMPARE(console->mCurrentSearchResult, laterLine);
+        QCOMPARE(markedCharactersOn(console, laterLine), 14);
+        QCOMPARE(markedCharactersOn(console, earlierLine), 0);
+    }
+
+    // Searching for the same thing again is how the earlier times it was said
+    // are got to, and what is already marked stays marked as that happens.
+    void test_searchingAgainStepsToTheMatchAboveTheOneItIsOn()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
+        const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferUp();
+        console->slot_searchBufferUp();
+
+        QCOMPARE(console->mCurrentSearchResult, earlierLine);
+        QCOMPARE(markedCharactersOn(console, earlierLine), 7);
+        QCOMPARE(markedCharactersOn(console, laterLine), 14);
+    }
+
+    void test_searchingDownComesBackTowardsTheEndOfTheBuffer()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
+        const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferUp();
+        console->slot_searchBufferUp();
+        QCOMPARE(console->mCurrentSearchResult, earlierLine);
+
+        console->slot_searchBufferDown();
+        QCOMPARE(console->mCurrentSearchResult, laterLine);
+    }
+
+    // A search that has not moved off the end of the buffer yet has nothing
+    // below it, and saying so would be worse than staying quiet.
+    void test_searchingDownWithNothingBelowTheCurrentLineDoesNothing()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferDown();
+
+        QCOMPARE(console->mCurrentSearchResult, static_cast<int>(console->buffer.lineBuffer.size()));
+        QCOMPARE(markedLineCount(console), 0);
+        QCOMPARE(lineHolding(console, qsl("No search results")), -1);
+    }
+
+    void test_theCaseSensitiveOptionSkipsALineThatOnlyMatchesWithoutIt()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
+        const int earlierLine = lineHolding(console, qsl("gorbash sleeps"));
+
+        console->mpAction_searchCaseSensitive->trigger();
+        QVERIFY2(console->mpAction_searchCaseSensitive->isChecked(), "triggering the menu entry did not turn case sensitivity on");
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferUp();
+
+        QCOMPARE(console->mCurrentSearchResult, earlierLine);
+        QCOMPARE(markedCharactersOn(console, laterLine), 0);
+        QCOMPARE(markedCharactersOn(console, earlierLine), 7);
+    }
+
+    // Typing a different term starts a search of its own: what the last one
+    // marked goes, and the new one begins at the end of the buffer again rather
+    // than carrying on from where the last one had got to.
+    void test_aNewTermClearsWhatTheOldOneMarkedAndStartsOver()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        const int laterLine = lineHolding(console, qsl("GORBASH stirs"));
+        const int dustyLine = lineHolding(console, qsl("a dusty road"));
+        QVERIFY(dustyLine < laterLine);
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferUp();
+        QCOMPARE(console->mCurrentSearchResult, laterLine);
+
+        console->mpBufferSearchBox->setText(qsl("dusty"));
+        console->slot_searchBufferUp();
+
+        QCOMPARE(console->mCurrentSearchResult, dustyLine);
+        QCOMPARE(markedCharactersOn(console, dustyLine), 5);
+        QCOMPARE(markedCharactersOn(console, laterLine), 0);
+    }
+
+    void test_aTermThatIsNowhereInTheBufferSaysSo()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        console->mpBufferSearchBox->setText(qsl("dragonfruit"));
+        console->slot_searchBufferUp();
+
+        QVERIFY2(lineHolding(console, qsl("No search results, sorry!")) > -1, "a search that matched nothing did not say so");
+        QCOMPARE(markedLineCount(console), 0);
+    }
+
+    // An empty box is the state the search bar opens in, so pressing Return in
+    // it must not report that nothing was found.
+    void test_anEmptyTermIsNotSearchedFor()
+    {
+        auto* console = startSearchableProfile();
+        QVERIFY2(console, "the fixture text never reached the buffer");
+
+        console->mpBufferSearchBox->setText(QString());
+        console->slot_searchBufferUp();
+
+        QCOMPARE(lineHolding(console, qsl("No search results")), -1);
+        QCOMPARE(markedLineCount(console), 0);
+    }
+
+    // Only the Central Debug Console keeps its search widgets in a find bar of
+    // their own. Putting that bar away has to take the marks with it, or they
+    // are left on the text with nothing on screen to say why.
+    void test_hidingTheFindBarClearsWhatTheSearchMarked()
+    {
+        startProfile(mHostname, mLocalhost, mPort);
+        auto* host = mudlet::self()->getActiveHost();
+        mudlet::self()->attachDebugArea(host->getName());
+
+        auto* console = mudlet::smpDebugConsole.data();
+        QVERIFY(console);
+        console->clear();
+        console->print(qsl("gorbash stirs\n"));
+
+        console->showSearchBar();
+        QVERIFY2(!console->mpFindBar.isNull(), "the Central Debug Console was built without a find bar");
+        // Not isVisible(): the console's own window is never shown in a test,
+        // and that would make every child of it invisible whatever the bar did.
+        QVERIFY2(!console->mpFindBar->isHidden(), "the find bar did not come up");
+
+        console->mpBufferSearchBox->setText(qsl("gorbash"));
+        console->slot_searchBufferUp();
+        QCOMPARE(markedLineCount(console), 1);
+
+        QVERIFY(QMetaObject::invokeMethod(console, "hideSearchBar"));
+
+        QVERIFY2(console->mpFindBar->isHidden(), "the find bar stayed up");
+        QCOMPARE(markedLineCount(console), 0);
+    }
+};
+
+#include "ConsoleSearchBarTest.moc"
+MUDLET_GROUPED_TEST_MAIN(ConsoleSearchBarTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds `ConsoleSearchBarTest`: 9 tests over the search bar that sits under the console, which had none.

Searching a console is reachable only from its own widgets - there is no Lua binding for it - so none of it has ever run in a test. What the tests assert is what the search leaves behind: which line it is now on, and which characters it has marked as found.

- **Where a search starts and stops.** A new search starts at the end of the buffer and works back to the most recent match, marking every occurrence on the line it stops on rather than just the first; searching again steps to the match above, keeping what is already marked; searching down comes back towards the end; and a search still sitting at the end of the buffer has nothing below it, so pressing down does nothing at all rather than reporting a failure.
- **The case-sensitivity option.** Off, a search finds a line that differs only in case; on, it skips it.
- **Starting over.** A different term clears what the last one marked and begins at the end of the buffer again instead of carrying on from where the last search had got to.
- **Saying nothing was found.** A term that is nowhere in the buffer prints "No search results, sorry!", and an empty term - the state the bar opens in - does not.
- **The Central Debug Console's find bar**, the one console whose search widgets live in a bar of their own: putting it away takes the marks with it.

#### Motivation for adding to Mudlet

Every slot behind the search bar was never-run code. Between them they hold the buffer position a repeat search depends on, the highlighting the pane draws, and four guards deciding when a search should do nothing - all of it changeable without a test noticing.

#### Other info (issues closed, discussion etc)

**Test case:**

Type something into the box under the console and press Return, then Return again to step back through the earlier times it was said. The magnifying glass sets case sensitivity. In the Central Debug Console, Ctrl+F brings the bar up and Escape puts it away.

Every one of the 9 was proven to fail without the code it covers, by breaking the search in batches and checking which went red:

| batch | what was broken | tests that went red |
| --- | --- | --- |
| marking | only the first hit on a line marked, and nothing said when a search found nothing | 3 |
| always case sensitive | the case-sensitivity option ignored, matching only exactly | 4 |
| never case sensitive | the option ignored the other way, always matching loosely | 1 |
| guards | the four early returns removed: an empty term, a search already at the end, the clearing a new term does, and the clearing that putting the find bar away does | 4 |
| stepping | each step starting from the line the search is already on, and the line it stops at not recorded | 5 |
