### PR TITLE
Fix: Text no longer wraps to the wrong width after resizing or switching profiles

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -5657,6 +5657,9 @@ void Host::setBorders(QMargins borders)
     if (mpConsole.isNull()) {
         return;
     }
+    // A console put away by a tab switch is zero pixels wide, so the resize
+    // event below tells it nothing about the room its new borders leave
+    mpConsole->syncHiddenScreenDimensions();
     auto x = mpConsole->width();
     auto y = mpConsole->height();
     const QSize s = QSize(x, y);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -64,6 +64,10 @@
 using namespace std::chrono_literals;
 
 namespace {
+// The gap the layout leaves between the text panes and the vertical scroll bar.
+// Anything predicting how wide the panes come out has to take it off too.
+constexpr int scrollBarSpacing = 1;
+
 double relativeLuminance(const QColor& color)
 {
     const auto channel = [](const double value) {
@@ -364,7 +368,7 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     layoutLayer->addWidget(splitter);
     layoutLayer->addWidget(mpScrollBar);
     layoutLayer->setContentsMargins(0, 0, 0, 0);
-    layoutLayer->setSpacing(1); // not closer, otherwise there could be performance problems when displaying
+    layoutLayer->setSpacing(scrollBarSpacing); // not closer, otherwise there could be performance problems when displaying
 
     vLayoutLayer->addLayout(layoutLayer);
     vLayoutLayer->addWidget(mpHScrollBar);
@@ -818,28 +822,29 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     // Sync Host dimensions on resize so wraps and NAWS reflect the current pane width.
     if ((mType & MainConsole) && !mpHost.isNull() && mUpperPane && !mUpperPane->visibleRegion().isEmpty()) {
-        const int paneWidthPx = mUpperPane->visibleRegion().boundingRect().width();
-        auto syncHost = [paneWidthPx](Host* host, const QWidget* paneForFont) {
-            if (!host || !paneForFont) {
+        auto syncHost = [](Host* host, const QWidget* pane, const int paneWidthPx) {
+            if (!host || !pane || paneWidthPx < 0) {
                 return;
             }
-            const int fontWidth = QFontMetrics(paneForFont->font()).averageCharWidth();
+            const int fontWidth = QFontMetrics(pane->font()).averageCharWidth();
             if (fontWidth <= 0) {
                 return;
             }
             const int cols = qMax(40, paneWidthPx / fontWidth);
-            if (cols > 0 && cols != host->mScreenWidth) {
+            if (cols != host->mScreenWidth) {
                 host->setScreenDimensions(cols, host->mScreenHeight);
                 QTimer::singleShot(0ms, host, &Host::updateDisplayDimensions);
             }
         };
 
-        syncHost(mpHost.data(), mUpperPane);
+        syncHost(mpHost.data(), mUpperPane, mUpperPane->visibleRegion().boundingRect().width());
 
         // Detached profiles have their own pixel width; only propagate from a main-window console.
         mudlet* const app = mudlet::self();
         const bool inMainWindow = app && !app->getDetachedWindows().contains(mpHost->getName());
         if (inMainWindow) {
+            const QWidget* container = parentWidget();
+            const int containerWidth = container ? container->width() : width();
             for (const auto& otherHostPtr : app->getHostManager()) {
                 Host* otherHost = otherHostPtr.data();
                 if (!otherHost || otherHost == mpHost.data()) {
@@ -852,11 +857,13 @@ void TConsole::resizeEvent(QResizeEvent* event)
                 if (!otherHost->mpConsole || !otherHost->mpConsole->mUpperPane) {
                     continue;
                 }
-                // Visible siblings (multi-view) handle their own resizeEvent.
-                if (!otherHost->mpConsole->mUpperPane->visibleRegion().isEmpty()) {
+                // Only a console put away by a tab switch. One that is merely
+                // sharing the container - multi-view, or a splitter share not
+                // handed out yet - is on screen and sizes itself.
+                if (!otherHost->mpConsole->isHidden()) {
                     continue;
                 }
-                syncHost(otherHost, otherHost->mpConsole->mUpperPane);
+                syncHost(otherHost, otherHost->mpConsole->mUpperPane, otherHost->mpConsole->upperPaneWidthFor(containerWidth));
             }
         }
     }
@@ -2538,12 +2545,37 @@ void TConsole::slot_searchBufferDown()
     print(qsl("%1\n").arg(tr("No search results, sorry!")));
 }
 
+// How wide this console's upper pane comes out when the main window gives the
+// console containerWidth pixels. Deselecting a tab resizes its console to
+// nothing and leaves the panes inside at whatever they last happened to be, so
+// a console in the background cannot simply be measured - but what it will get
+// is not a mystery either, since every main-window console shares a container
+// and only differs in what it takes out of it.
+int TConsole::upperPaneWidthFor(const int containerWidth) const
+{
+    // Each term mirrors what resizeEvent() does with the width it is given, in
+    // the same order, so that the two cannot drift apart.
+    int paneWidth = containerWidth - (mpLeftToolBar->width() + mpRightToolBar->width());
+    if (!mpHost.isNull()) {
+        // The host's borders rather than mBorders: that copy is only refreshed
+        // when the console lays out, so for one that has been in the background
+        // across a setBorderLeft() it is the width it is coming back from.
+        const QMargins borders = mpHost->borders();
+        paneWidth -= borders.left() + borders.right();
+    }
+    if (!mpScrollBar->isHidden()) {
+        paneWidth -= mpScrollBar->width() + scrollBarSpacing;
+    }
+    return qMax(0, paneWidth);
+}
+
 QSize TConsole::getMainWindowSize() const
 {
-    if (isHidden() && mLastMeasuredSize.isValid()) {
-        return mLastMeasuredSize;
-    }
-    const QSize consoleSize = size();
+    // A console put away by a tab switch is resized to nothing while the panes
+    // inside it keep whatever geometry they last had, so it cannot be measured -
+    // but it is going back into the container it came out of, and that can be.
+    const bool predicted = mType == MainConsole && isHidden() && parentWidget();
+    const QSize consoleSize = predicted ? parentWidget()->size() : size();
     const int toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
     const int toolbarHeight = mpTopToolBar->height();
     const int commandLineHeight = mpCommandLine->height();
@@ -2563,7 +2595,9 @@ QSize TConsole::getMainWindowSize() const
         return mLastMeasuredSize.isValid() ? mLastMeasuredSize : mainWindowSize;
     }
 
-    mLastMeasuredSize = mainWindowSize;
+    if (!predicted) {
+        mLastMeasuredSize = mainWindowSize;
+    }
     return mainWindowSize;
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -822,48 +822,18 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     // Sync Host dimensions on resize so wraps and NAWS reflect the current pane width.
     if ((mType & MainConsole) && !mpHost.isNull() && mUpperPane && !mUpperPane->visibleRegion().isEmpty()) {
-        auto syncHost = [](Host* host, const QWidget* pane, const int paneWidthPx) {
-            if (!host || !pane || paneWidthPx < 0) {
-                return;
-            }
-            const int fontWidth = QFontMetrics(pane->font()).averageCharWidth();
-            if (fontWidth <= 0) {
-                return;
-            }
-            const int cols = qMax(40, paneWidthPx / fontWidth);
-            if (cols != host->mScreenWidth) {
-                host->setScreenDimensions(cols, host->mScreenHeight);
-                QTimer::singleShot(0ms, host, &Host::updateDisplayDimensions);
-            }
-        };
+        syncHostScreenDimensions(mUpperPane->visibleRegion().boundingRect().width(), -1);
 
-        syncHost(mpHost.data(), mUpperPane, mUpperPane->visibleRegion().boundingRect().width());
-
-        // Detached profiles have their own pixel width; only propagate from a main-window console.
+        // The consoles put away in background tabs share this one's container
+        // and get no resize event of their own, so they are worked out from here.
+        // A detached profile has a window of its own and says nothing about them.
         mudlet* const app = mudlet::self();
-        const bool inMainWindow = app && !app->getDetachedWindows().contains(mpHost->getName());
-        if (inMainWindow) {
-            const QWidget* container = parentWidget();
-            const int containerWidth = container ? container->width() : width();
+        if (app && !app->getDetachedWindows().contains(mpHost->getName())) {
             for (const auto& otherHostPtr : app->getHostManager()) {
                 Host* otherHost = otherHostPtr.data();
-                if (!otherHost || otherHost == mpHost.data()) {
-                    continue;
+                if (otherHost && otherHost != mpHost.data() && otherHost->mpConsole) {
+                    otherHost->mpConsole->syncHiddenScreenDimensions();
                 }
-                // Skip detached profiles: different container, different width.
-                if (app->getDetachedWindows().contains(otherHost->getName())) {
-                    continue;
-                }
-                if (!otherHost->mpConsole || !otherHost->mpConsole->mUpperPane) {
-                    continue;
-                }
-                // Only a console put away by a tab switch. One that is merely
-                // sharing the container - multi-view, or a splitter share not
-                // handed out yet - is on screen and sizes itself.
-                if (!otherHost->mpConsole->isHidden()) {
-                    continue;
-                }
-                syncHost(otherHost, otherHost->mpConsole->mUpperPane, otherHost->mpConsole->upperPaneWidthFor(containerWidth));
             }
         }
     }
@@ -2545,16 +2515,16 @@ void TConsole::slot_searchBufferDown()
     print(qsl("%1\n").arg(tr("No search results, sorry!")));
 }
 
-// How wide this console's upper pane comes out when the main window gives the
-// console containerWidth pixels. Deselecting a tab resizes its console to
+// How big this console's upper pane comes out when the main window gives the
+// console a container this size. Deselecting a tab resizes its console to
 // nothing and leaves the panes inside at whatever they last happened to be, so
 // a console in the background cannot simply be measured - but what it will get
 // is not a mystery either, since every main-window console shares a container
-// and only differs in what it takes out of it.
+// and only differs in what it takes out of it. Each term mirrors what
+// resizeEvent() does with the size it is given, in the same order, so that the
+// two cannot drift apart.
 int TConsole::upperPaneWidthFor(const int containerWidth) const
 {
-    // Each term mirrors what resizeEvent() does with the width it is given, in
-    // the same order, so that the two cannot drift apart.
     int paneWidth = containerWidth - (mpLeftToolBar->width() + mpRightToolBar->width());
     if (!mpHost.isNull()) {
         // The host's borders rather than mBorders: that copy is only refreshed
@@ -2567,6 +2537,70 @@ int TConsole::upperPaneWidthFor(const int containerWidth) const
         paneWidth -= mpScrollBar->width() + scrollBarSpacing;
     }
     return qMax(0, paneWidth);
+}
+
+int TConsole::upperPaneHeightFor(const int containerHeight) const
+{
+    // A scrolled-back console shows the lower pane as well, and where the user
+    // has dragged the split between the two is not something to guess at
+    if (!mLowerPane->isHidden()) {
+        return -1;
+    }
+    int paneHeight = containerHeight - mpTopToolBar->height();
+    if (!mpHost.isNull()) {
+        const QMargins borders = mpHost->borders();
+        paneHeight -= borders.top() + borders.bottom();
+    }
+    if (mpCommandLine) {
+        paneHeight -= mpCommandLine->height();
+    }
+    if (!mpHScrollBar->isHidden()) {
+        paneHeight -= mpHScrollBar->height();
+    }
+    return qMax(0, paneHeight);
+}
+
+// Either dimension can be -1 to leave what the Host already has.
+void TConsole::syncHostScreenDimensions(const int paneWidthPx, const int paneHeightPx)
+{
+    if (mpHost.isNull() || !mUpperPane) {
+        return;
+    }
+    const QFontMetrics metrics(mUpperPane->font());
+    int cols = mpHost->mScreenWidth;
+    if (paneWidthPx >= 0 && metrics.averageCharWidth() > 0) {
+        cols = qMax(40, paneWidthPx / metrics.averageCharWidth());
+    }
+    int rows = mpHost->mScreenHeight;
+    if (paneHeightPx >= 0 && metrics.height() > 0) {
+        // A pane too short for a single row keeps the height it had: NAWS sends
+        // nothing at all for a height of zero, and the width still has to go out
+        const int predictedRows = paneHeightPx / metrics.height();
+        if (predictedRows > 0) {
+            rows = predictedRows;
+        }
+    }
+    if (cols == mpHost->mScreenWidth && rows == mpHost->mScreenHeight) {
+        return;
+    }
+    mpHost->setScreenDimensions(cols, rows);
+    QTimer::singleShot(0ms, mpHost, &Host::updateDisplayDimensions);
+}
+
+void TConsole::syncHiddenScreenDimensions()
+{
+    // Only a console put away by a tab switch. One that is merely sharing the
+    // container - multi-view, or a splitter share not handed out yet - is on
+    // screen and sizes itself, and a detached one has a window of its own.
+    const QWidget* container = parentWidget();
+    if (mType != MainConsole || mpHost.isNull() || !isHidden() || !container) {
+        return;
+    }
+    mudlet* const app = mudlet::self();
+    if (!app || app->getDetachedWindows().contains(mpHost->getName())) {
+        return;
+    }
+    syncHostScreenDimensions(upperPaneWidthFor(container->width()), upperPaneHeightFor(container->height()));
 }
 
 QSize TConsole::getMainWindowSize() const

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -321,8 +321,9 @@ public:
     void selectCurrentLine();
     // Returns the size of the main buffer area (excluding the command line and toolbars).
     QSize getMainWindowSize() const;
-    // MainConsole only - it charges the profile's own main window borders
-    int upperPaneWidthFor(const int containerWidth) const;
+    // For a MainConsole put away by a tab switch, which no resize event reaches:
+    // works out the size it will come back to and has NAWS report it
+    void syncHiddenScreenDimensions();
     ConsoleType getType() const { return mType; }
     virtual void setProfileName(const QString&);
     // In the next function the first element in the return is an
@@ -496,6 +497,11 @@ private slots:
 private:
     void createFindBar();
     void positionFindBar();
+    // MainConsole only - they take off the profile's own main window borders.
+    // The height is -1 when it cannot be known.
+    int upperPaneWidthFor(const int containerWidth) const;
+    int upperPaneHeightFor(const int containerHeight) const;
+    void syncHostScreenDimensions(const int paneWidthPx, const int paneHeightPx);
     void createSearchOptionIcon();
     void raiseFontChangeEvent();
     void restoreCommandSearchSettings();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -321,6 +321,8 @@ public:
     void selectCurrentLine();
     // Returns the size of the main buffer area (excluding the command line and toolbars).
     QSize getMainWindowSize() const;
+    // MainConsole only - it charges the profile's own main window borders
+    int upperPaneWidthFor(const int containerWidth) const;
     ConsoleType getType() const { return mType; }
     virtual void setProfileName(const QString&);
     // In the next function the first element in the return is an

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -79,6 +79,12 @@ constexpr int AUTO_LOGIN_MAX_DELAY_MS = 60000;
 // cTelnet::checkCharacterModePattern():
 constexpr auto CHARACTER_MODE_DETECT = 3s;
 
+// How long the console has to hold still before its size is reported to the
+// game - see cTelnet::checkNAWS(). Has to outlast the 0.2s timer an adjustable
+// Geyser container re-reserves its border on, which is the longest step of a
+// resize:
+constexpr auto NAWS_SETTLE_TIME = 300ms;
+
 // How long to leave a game alone after a connection attempt to it failed, before
 // trying again for a profile that reconnects automatically. A refused connection
 // comes back at once, so without a wait here the retries are a tight loop. The
@@ -201,6 +207,11 @@ void cTelnet::reset()
     // Stop any pending character-at-a-time detection
     if (mTimerCharacterModeDetect) {
         mTimerCharacterModeDetect->stop();
+    }
+    // A window size waiting to be reported belongs to the connection being
+    // reset, and mNaws_x/mNaws_y are about to be zeroed for the next one
+    if (mTimerNawsUpdate) {
+        mTimerNawsUpdate->stop();
     }
     // Ensure we do not think that the game server is echoing for us:
     mpHost->setRemoteEchoingActive(false);
@@ -1724,6 +1735,22 @@ void cTelnet::abandonNetworkLatencyMeasurement()
 }
 
 void cTelnet::checkNAWS()
+{
+    // A window resize reaches the console as a burst rather than as one event:
+    // Qt lays it out, then any Geyser container attached to a border re-reserves
+    // that border from a timer of its own, which lays the console out again.
+    // Reporting each step would publish widths the window only ever had in
+    // passing - and the game wraps whatever it sends next to them - so wait for
+    // the burst to finish and report the size once.
+    if (!mTimerNawsUpdate) {
+        mTimerNawsUpdate = new QTimer(this);
+        mTimerNawsUpdate->setSingleShot(true);
+        connect(mTimerNawsUpdate, &QTimer::timeout, this, &cTelnet::sendCurrentNAWS);
+    }
+    mTimerNawsUpdate->start(NAWS_SETTLE_TIME);
+}
+
+void cTelnet::sendCurrentNAWS()
 {
     Host* pHost = mpHost;
     if (!pHost || !pHost->mpConsole) {
@@ -3719,8 +3746,10 @@ void cTelnet::processTelnetCommand(const std::string& telnetCommand)
             // used values:
             mNaws_x = 0;
             mNaws_y = 0;
-            // thus sending of the values is performed when we check them:
-            checkNAWS();
+            // Answer the negotiation itself rather than going through the
+            // resize debounce: the game asked for the size now, and games that
+            // draw their login screen from it get one chance to be told.
+            sendCurrentNAWS();
         }
         break;
     }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -431,6 +431,7 @@ private:
     void promptTlsConnectionAvailable();
 #endif
     void sendNAWS(int width, int height);
+    void sendCurrentNAWS();
     void readPendingSocketData();
     QString parseGUIVersionFromJSON(const QJsonObject& json);
     QString parseGUIUrlFromJSON(const QJsonObject& json);
@@ -617,6 +618,7 @@ private:
     // never releases it. See cTelnet::checkCharacterModePattern().
     bool mCharacterModeDetected = false;
     QTimer* mTimerCharacterModeDetect = nullptr;
+    QTimer* mTimerNawsUpdate = nullptr;
 
     // KaVir protocol negotiation tracking
     QVector<unsigned char> mNegotiationOrder;

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     LabelBackgroundPaintTest.cpp
     MxpWatchdogBufferLifetimeTest.cpp
     NarrowWindowWrapTest.cpp
+    NawsWidthReportTest.cpp
     DetachedWindowToolBarIconSizeTest.cpp
     PastedLinkStateTest.cpp
     ProfileSwitchMiniconsoleTest.cpp

--- a/test/functional_tests/NawsWidthReportTest.cpp
+++ b/test/functional_tests/NawsWidthReportTest.cpp
@@ -1,0 +1,316 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vperetokin@hey.com            *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QPointer>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+#include <algorithm>
+#include <chrono>
+
+#include "PortableModeTestHelper.h"
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "TBuffer.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TTabBar.h"
+#include "TelnetServerStub.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// What a game is told about the window it is drawing into. The cases that can
+// read the wire do, through TelnetServerStub, rather than trusting the client's
+// own idea of its size - only what reaches the game can wrap the game's output.
+// The two that assert on Host::mScreenWidth and getMainWindowSize() say so.
+class NawsWidthReportTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    QPointer<Host> mpSecondHost;
+    const QString mHostname = "NawsWidthFirst";
+    const QString mSecondHostname = "NawsWidthSecond";
+    QString mPort;
+    const QString mLocalhost = "localhost";
+
+    void settle(const std::chrono::milliseconds duration = 400ms)
+    {
+        QTest::qWait(duration);
+        QCoreApplication::processEvents();
+    }
+
+    void runLua(Host* pHost, const QString& code) const { QVERIFY2(pHost->getLuaInterpreter()->compileAndExecuteScript(code), qPrintable(code)); }
+
+    void showTab(const QString& hostname) const { mudlet::self()->mpTabBar->setCurrentIndex(mudlet::self()->mpTabBar->tabIndex(hostname)); }
+
+    // What a correctly behaving Mudlet would put on the wire for this profile as
+    // things stand - the console's settled width, less the timestamp gutter,
+    // which is drawn outside the space the game gets to write into.
+    int reportableWidth(const Host* pHost) const
+    {
+        const int gutter = pHost->mpConsole->showTimeStamps() ? TBuffer::smTimeStampFormat.size() : 0;
+        return std::min(pHost->mScreenWidth, pHost->mWrapAt) - gutter;
+    }
+
+    // Cases below run in declaration order but have to stand up on their own
+    // too, since a single one can be named on the grouped binary's command line.
+    // Reports rather than asserts: a QVERIFY here would return from this helper
+    // and leave the case that called it running on a profile that is not there.
+    bool ensureSecondProfile()
+    {
+        if (mpSecondHost) {
+            return true;
+        }
+        if (!QDir().mkpath(mudlet::getMudletPath(enums::profileHomePath, mSecondHostname)) || !mudlet::self()->writeProfileData(mSecondHostname, qsl("url"), mLocalhost).first
+            || !mudlet::self()->writeProfileData(mSecondHostname, qsl("port"), mPort).first) {
+            return false;
+        }
+        // the second argument is offline, so this profile never opens a
+        // connection of its own - the stub only ever sees the first profile
+        runLua(mpHost, qsl("loadProfile('%1', true)").arg(mSecondHostname));
+        for (int attempt = 0; attempt < 20 && mpSecondHost.isNull(); ++attempt) {
+            settle(300ms);
+            mpSecondHost = mudlet::self()->getHostManager().getHost(mSecondHostname);
+        }
+        settle(600ms);
+        return !mpSecondHost.isNull();
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - refusing to touch a portable installation");
+        }
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        mudlet::getQSettings()->setValue(qsl("uiTourShown"), true);
+        mudlet::getQSettings()->sync();
+        mudlet::self()->resize(1200, 800);
+
+        QTimer::singleShot(0ms, qApp, [this]() {
+            mudlet::self()->startAutoLogin({});
+            QTest::qWait(100ms);
+            QVERIFY(mudlet::self()->mpConnectionDialog);
+            QTest::mouseClick(mudlet::self()->mpConnectionDialog->new_profile_button, Qt::LeftButton);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mHostname);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mLocalhost);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Tab);
+            QTest::qWait(100ms);
+            QTest::keyClicks(QApplication::focusWidget(), mPort);
+            QTest::qWait(100ms);
+            QTest::keyClick(QApplication::focusWidget(), Qt::Key_Return);
+        });
+        QSignalSpy profileLoaded(mudlet::self(), &mudlet::signal_profileLoaded);
+        QVERIFY2(profileLoaded.wait(6000), "the first profile did not finish loading");
+        mpHost = mudlet::self()->getActiveHost();
+        QVERIFY(mpHost);
+
+        // IAC DO NAWS, so the client starts reporting its window size at all
+        mpServer->sendRaw(QByteArray("\xFF\xFD\x1F", 3));
+        settle(600ms);
+        // The game asked for the size during negotiation and is entitled to an
+        // answer then, not once some later resize happens to shake one loose.
+        // Without this every case below still passes if the reply never comes.
+        QVERIFY2(!mpServer->nawsUpdates().isEmpty(), "the client never answered IAC DO NAWS");
+    }
+
+    // Leave the window and the gutter as the next case expects to find them,
+    // whether this one passed or not - a QCOMPARE returns from the function, so
+    // a restore written at the end of a case does not run when it fails.
+    void cleanup()
+    {
+        if (mpHost && mpHost->mpConsole && mpHost->mpConsole->showTimeStamps()) {
+            mpHost->mpConsole->slot_toggleTimeStamps(false);
+        }
+        showTab(mHostname);
+        mudlet::self()->resize(1200, 800);
+        settle(600ms);
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // A resize is not one event: the console is laid out, and then any Geyser
+    // container attached to a border re-reserves that border from a timer,
+    // laying it out again at a different width. The game must hear the width
+    // the window settles at, never one it passed through - whatever it is told
+    // is what it wraps its next reply to.
+    void resizeReportsOnlyTheWidthTheWindowSettlesAt()
+    {
+        runLua(mpHost,
+               qsl("nawsProbeContainer = Adjustable.Container:new({name='nawsProbeContainer', x='-30%', y=0, width='30%', height='50%'})\n"
+                   "nawsProbeContainer:attachToBorder('right')"));
+        settle(800ms);
+        QVERIFY2(mpHost->borders().right() > 0, "the container did not reserve a border, so there is no second layout step to wait out");
+
+        mpServer->clearNawsUpdates();
+        mudlet::self()->resize(800, 800);
+        settle(1500ms);
+
+        const auto narrowed = mpServer->nawsUpdates();
+        qInfo() << "NAWS updates for a 1200 -> 800 resize:" << narrowed << "settled width:" << reportableWidth(mpHost);
+        QCOMPARE(narrowed.size(), 1);
+        QCOMPARE(narrowed.constFirst().width(), reportableWidth(mpHost));
+
+        // and the debounce has to re-arm: a timer that only ever fires once
+        // would leave the game wrapping to this width for the rest of the
+        // session, which the single resize above cannot tell apart
+        mpServer->clearNawsUpdates();
+        mudlet::self()->resize(1100, 800);
+        settle(1500ms);
+
+        const auto widened = mpServer->nawsUpdates();
+        qInfo() << "NAWS updates for the resize back out:" << widened << "settled width:" << reportableWidth(mpHost);
+        QCOMPARE(widened.size(), 1);
+        QCOMPARE(widened.constFirst().width(), reportableWidth(mpHost));
+        QVERIFY2(widened.constFirst().width() != narrowed.constFirst().width(), "the second resize reported the first one's width");
+    }
+
+    // The same resize with the timestamp gutter showing, which comes off every
+    // width reported and so makes a mid-resize reading narrower still - narrow
+    // enough for a game to wrap its output to about a third of the window.
+    void resizeWithTimestampsShowingReportsOnlyTheSettledWidth()
+    {
+        mpHost->mpConsole->slot_toggleTimeStamps(true);
+        settle(1200ms);
+
+        mpServer->clearNawsUpdates();
+        mudlet::self()->resize(800, 800);
+        settle(1500ms);
+
+        const auto updates = mpServer->nawsUpdates();
+        qInfo() << "NAWS updates with the timestamp gutter showing:" << updates << "settled width:" << reportableWidth(mpHost);
+        QCOMPARE(updates.size(), 1);
+        QCOMPARE(updates.constFirst().width(), reportableWidth(mpHost));
+    }
+
+    // Showing the gutter is not a resize, but it does take columns away from
+    // the game, so it has to be reported - and reported once.
+    void showingTheTimestampGutterReportsTheColumnsItTakes()
+    {
+        QVERIFY(!mpHost->mpConsole->showTimeStamps());
+        const int withoutGutter = reportableWidth(mpHost);
+
+        mpServer->clearNawsUpdates();
+        mpHost->mpConsole->slot_toggleTimeStamps(true);
+        settle(1500ms);
+
+        const auto updates = mpServer->nawsUpdates();
+        qInfo() << "NAWS updates for showing the gutter:" << updates << "was" << withoutGutter;
+        QCOMPARE(updates.size(), 1);
+        QCOMPARE(updates.constFirst().width(), withoutGutter - TBuffer::smTimeStampFormat.size());
+    }
+
+    // A profile in a background tab has its own borders and its own font, so
+    // the console on screen says nothing about how much room it has. Whatever
+    // it is told while it waits has to be what it finds when it comes back:
+    // anything else re-wraps the backlog the moment the user switches to it.
+    void aBackgroundedProfileIsToldTheWidthItComesBackTo()
+    {
+        QVERIFY2(ensureSecondProfile(), "the second profile did not load");
+
+        // wide borders on this profile, so the two genuinely differ in how much
+        // of the same window they have to write into
+        runLua(mpHost, qsl("setBorderLeft(300) setBorderRight(300)"));
+        showTab(mSecondHostname);
+        settle(1500ms);
+        QVERIFY2(mpHost->mpConsole->isHidden(), "the first profile should be in a background tab by now");
+
+        mpServer->clearNawsUpdates();
+        mudlet::self()->resize(1000, 800);
+        settle(1500ms);
+
+        const int toldWhileHidden = mpHost->mScreenWidth;
+        QVERIFY2(toldWhileHidden != mpSecondHost->mScreenWidth, "the two profiles have different borders, so they cannot both be this wide");
+
+        // and it has to have reached the game, not just the client's own idea
+        // of itself - the profile is still connected while it sits in the tab
+        const auto updates = mpServer->nawsUpdates();
+        QVERIFY2(!updates.isEmpty(), "a backgrounded profile's corrected width never reached its game");
+        QCOMPARE(updates.constLast().width(), reportableWidth(mpHost));
+
+        showTab(mHostname);
+        settle(1500ms);
+        qInfo() << "background profile was told" << toldWhileHidden << "columns, and came back to" << mpHost->mScreenWidth;
+        QCOMPARE(mpHost->mScreenWidth, toldWhileHidden);
+
+        runLua(mpHost, qsl("setBorderLeft(0) setBorderRight(0)"));
+        settle(600ms);
+    }
+
+    // Geyser lays every element out against getMainWindowSize(), so a profile
+    // that reads it while in a background tab has to get the window it will
+    // come back to. Resizing while it is away is what separates that from the
+    // size it last had on screen, which is all it used to be able to report.
+    void aBackgroundedProfileReportsTheWindowItWillComeBackTo()
+    {
+        QVERIFY2(ensureSecondProfile(), "the second profile did not load");
+        showTab(mSecondHostname);
+        settle(1500ms);
+        QVERIFY(mpHost->mpConsole->isHidden());
+
+        mudlet::self()->resize(1000, 800);
+        settle(1500ms);
+        const QSize whileHidden = mpHost->mpConsole->getMainWindowSize();
+
+        showTab(mHostname);
+        settle(1500ms);
+        const QSize onceBack = mpHost->mpConsole->getMainWindowSize();
+
+        qInfo() << "the backgrounded profile reported" << whileHidden << "and came back to" << onceBack;
+        QCOMPARE(whileHidden, onceBack);
+    }
+};
+
+#include "NawsWidthReportTest.moc"
+MUDLET_GROUPED_TEST_MAIN(NawsWidthReportTest)

--- a/test/functional_tests/NawsWidthReportTest.cpp
+++ b/test/functional_tests/NawsWidthReportTest.cpp
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 // What a game is told about the window it is drawing into. The cases that can
 // read the wire do, through TelnetServerStub, rather than trusting the client's
 // own idea of its size - only what reaches the game can wrap the game's output.
-// The two that assert on Host::mScreenWidth and getMainWindowSize() say so.
+// The ones that assert on Host::mScreenWidth and getMainWindowSize() say so.
 class NawsWidthReportTest : public QObject
 {
     Q_OBJECT
@@ -76,6 +76,23 @@ private:
     {
         const int gutter = pHost->mpConsole->showTimeStamps() ? TBuffer::smTimeStampFormat.size() : 0;
         return std::min(pHost->mScreenWidth, pHost->mWrapAt) - gutter;
+    }
+
+    static QSize screenSize(const Host* pHost) { return QSize(pHost->mScreenWidth, pHost->mScreenHeight); }
+
+    // The wire carries min(columns, wrapAt) and the console never goes under 40
+    // columns, so only a width strictly between the two can show a prediction
+    // to be right or wrong
+    static bool measurableWidth(const Host* pHost) { return pHost->mScreenWidth > 40 && pHost->mScreenWidth < pHost->mWrapAt; }
+
+    // For a failure message: everything the game was told, in order
+    static QByteArray describe(const QList<QSize>& updates)
+    {
+        QStringList parts;
+        for (const QSize& update : updates) {
+            parts << qsl("%1x%2").arg(update.width()).arg(update.height());
+        }
+        return qsl("NAWS updates: [%1]").arg(parts.join(qsl(", "))).toUtf8();
     }
 
     // Cases below run in declaration order but have to stand up on their own
@@ -157,15 +174,19 @@ private slots:
         QVERIFY2(!mpServer->nawsUpdates().isEmpty(), "the client never answered IAC DO NAWS");
     }
 
-    // Leave the window and the gutter as the next case expects to find them,
-    // whether this one passed or not - a QCOMPARE returns from the function, so
-    // a restore written at the end of a case does not run when it fails.
+    // Leave the window, the gutter and the borders as the next case expects to
+    // find them, whether this one passed or not - a QCOMPARE returns from the
+    // function, so a restore written at the end of a case does not run when it
+    // fails.
     void cleanup()
     {
         if (mpHost && mpHost->mpConsole && mpHost->mpConsole->showTimeStamps()) {
             mpHost->mpConsole->slot_toggleTimeStamps(false);
         }
         showTab(mHostname);
+        if (mpHost) {
+            mpHost->setUserBorders(QMargins());
+        }
         mudlet::self()->resize(1200, 800);
         settle(600ms);
     }
@@ -198,8 +219,7 @@ private slots:
         settle(1500ms);
 
         const auto narrowed = mpServer->nawsUpdates();
-        qInfo() << "NAWS updates for a 1200 -> 800 resize:" << narrowed << "settled width:" << reportableWidth(mpHost);
-        QCOMPARE(narrowed.size(), 1);
+        QVERIFY2(narrowed.size() == 1, describe(narrowed).constData());
         QCOMPARE(narrowed.constFirst().width(), reportableWidth(mpHost));
 
         // and the debounce has to re-arm: a timer that only ever fires once
@@ -210,8 +230,7 @@ private slots:
         settle(1500ms);
 
         const auto widened = mpServer->nawsUpdates();
-        qInfo() << "NAWS updates for the resize back out:" << widened << "settled width:" << reportableWidth(mpHost);
-        QCOMPARE(widened.size(), 1);
+        QVERIFY2(widened.size() == 1, describe(widened).constData());
         QCOMPARE(widened.constFirst().width(), reportableWidth(mpHost));
         QVERIFY2(widened.constFirst().width() != narrowed.constFirst().width(), "the second resize reported the first one's width");
     }
@@ -229,8 +248,7 @@ private slots:
         settle(1500ms);
 
         const auto updates = mpServer->nawsUpdates();
-        qInfo() << "NAWS updates with the timestamp gutter showing:" << updates << "settled width:" << reportableWidth(mpHost);
-        QCOMPARE(updates.size(), 1);
+        QVERIFY2(updates.size() == 1, describe(updates).constData());
         QCOMPARE(updates.constFirst().width(), reportableWidth(mpHost));
     }
 
@@ -246,8 +264,7 @@ private slots:
         settle(1500ms);
 
         const auto updates = mpServer->nawsUpdates();
-        qInfo() << "NAWS updates for showing the gutter:" << updates << "was" << withoutGutter;
-        QCOMPARE(updates.size(), 1);
+        QVERIFY2(updates.size() == 1, describe(updates).constData());
         QCOMPARE(updates.constFirst().width(), withoutGutter - TBuffer::smTimeStampFormat.size());
     }
 
@@ -255,37 +272,99 @@ private slots:
     // the console on screen says nothing about how much room it has. Whatever
     // it is told while it waits has to be what it finds when it comes back:
     // anything else re-wraps the backlog the moment the user switches to it.
-    void aBackgroundedProfileIsToldTheWidthItComesBackTo()
+    void aBackgroundedProfileIsToldTheSizeItComesBackTo()
     {
         QVERIFY2(ensureSecondProfile(), "the second profile did not load");
 
-        // wide borders on this profile, so the two genuinely differ in how much
+        // The container from the first case re-reserves its border from a timer
+        // of its own when this profile comes back, which would move the goalposts
+        // between the two readings compared here; this case is about borders
+        // that stay where they were put.
+        runLua(mpHost, qsl("if nawsProbeContainer then nawsProbeContainer:detach() end"));
+        // Borders on this profile only, so the two genuinely differ in how much
         // of the same window they have to write into
-        runLua(mpHost, qsl("setBorderLeft(300) setBorderRight(300)"));
+        runLua(mpHost, qsl("setBorderLeft(150) setBorderRight(150)"));
         showTab(mSecondHostname);
         settle(1500ms);
         QVERIFY2(mpHost->mpConsole->isHidden(), "the first profile should be in a background tab by now");
 
+        const QSize before = screenSize(mpHost);
         mpServer->clearNawsUpdates();
-        mudlet::self()->resize(1000, 800);
+        // narrower and shorter, so a stale row count shows up as well
+        mudlet::self()->resize(1000, 600);
         settle(1500ms);
 
-        const int toldWhileHidden = mpHost->mScreenWidth;
-        QVERIFY2(toldWhileHidden != mpSecondHost->mScreenWidth, "the two profiles have different borders, so they cannot both be this wide");
+        const QSize toldWhileHidden = screenSize(mpHost);
+        QVERIFY2(measurableWidth(mpHost), "at the 40 column floor or the wrap-at ceiling this case cannot tell a right prediction from a wrong one");
+        QVERIFY2(toldWhileHidden.width() != mpSecondHost->mScreenWidth, "the two profiles have different borders, so they cannot both be this wide");
+        QVERIFY2(toldWhileHidden.height() != before.height(), "the window lost height, but the hidden profile was never told a new row count");
 
         // and it has to have reached the game, not just the client's own idea
         // of itself - the profile is still connected while it sits in the tab
         const auto updates = mpServer->nawsUpdates();
-        QVERIFY2(!updates.isEmpty(), "a backgrounded profile's corrected width never reached its game");
-        QCOMPARE(updates.constLast().width(), reportableWidth(mpHost));
+        QVERIFY2(!updates.isEmpty(), "a backgrounded profile's corrected size never reached its game");
+        QCOMPARE(updates.constLast(), QSize(reportableWidth(mpHost), toldWhileHidden.height()));
 
         showTab(mHostname);
         settle(1500ms);
-        qInfo() << "background profile was told" << toldWhileHidden << "columns, and came back to" << mpHost->mScreenWidth;
-        QCOMPARE(mpHost->mScreenWidth, toldWhileHidden);
+        QCOMPARE(screenSize(mpHost), toldWhileHidden);
+        // so coming back gave the game nothing new to re-wrap to
+        QVERIFY2(mpServer->nawsUpdates().size() == updates.size(), describe(mpServer->nawsUpdates()).constData());
+    }
 
-        runLua(mpHost, qsl("setBorderLeft(0) setBorderRight(0)"));
-        settle(600ms);
+    // A script can move its own profile's borders while that profile waits in a
+    // background tab - a UI reacting to something the game sent, say. No resize
+    // reaches a console that is zero pixels wide, so the game has to be told
+    // from the border change itself, or it wraps to the old size until the
+    // user switches back and it is corrected under them.
+    void aBackgroundedProfileThatMovesItsBordersIsToldTheSizeItComesBackTo()
+    {
+        QVERIFY2(ensureSecondProfile(), "the second profile did not load");
+        runLua(mpHost, qsl("if nawsProbeContainer then nawsProbeContainer:detach() end"));
+        showTab(mSecondHostname);
+        settle(1500ms);
+        QVERIFY2(mpHost->mpConsole->isHidden(), "the first profile should be in a background tab by now");
+
+        const QSize before = screenSize(mpHost);
+        mpServer->clearNawsUpdates();
+        // The window keeps its size here, so the side borders have to take the
+        // width under the wrap-at ceiling on their own for the wire to show it
+        runLua(mpHost, qsl("setBorderLeft(250) setBorderRight(250) setBorderTop(100)"));
+        settle(1500ms);
+
+        const auto updates = mpServer->nawsUpdates();
+        QVERIFY2(!updates.isEmpty(), "the game was not told about borders moved while the profile was in the background");
+        const QSize toldWhileHidden = screenSize(mpHost);
+        QVERIFY2(measurableWidth(mpHost), "at the 40 column floor or the wrap-at ceiling this case cannot tell a right prediction from a wrong one");
+        QVERIFY2(toldWhileHidden.height() < before.height(), "the top border took rows away, but the hidden profile was not told fewer");
+        QCOMPARE(updates.constLast(), QSize(reportableWidth(mpHost), toldWhileHidden.height()));
+
+        showTab(mHostname);
+        settle(1500ms);
+        QCOMPARE(screenSize(mpHost), toldWhileHidden);
+    }
+
+    // The game is told nothing at all for a height of zero, so borders that
+    // leave the profile no rows must not cost it the width it would otherwise
+    // have been told - that is still what its text wraps to.
+    void aBackgroundedProfileLeftNoRowsIsStillToldItsWidth()
+    {
+        QVERIFY2(ensureSecondProfile(), "the second profile did not load");
+        runLua(mpHost, qsl("if nawsProbeContainer then nawsProbeContainer:detach() end"));
+        showTab(mSecondHostname);
+        settle(1500ms);
+        QVERIFY2(mpHost->mpConsole->isHidden(), "the first profile should be in a background tab by now");
+
+        const int rowsBefore = mpHost->mScreenHeight;
+        QVERIFY(rowsBefore > 0);
+        mpServer->clearNawsUpdates();
+        runLua(mpHost, qsl("setBorderLeft(250) setBorderRight(250) setBorderTop(%1)").arg(mpHost->mpConsole->parentWidget()->height()));
+        settle(1500ms);
+
+        const auto updates = mpServer->nawsUpdates();
+        QVERIFY2(!updates.isEmpty(), "borders that left no rows cost the game the profile's new width");
+        QVERIFY2(measurableWidth(mpHost), "at the 40 column floor or the wrap-at ceiling this case cannot tell a right prediction from a wrong one");
+        QCOMPARE(updates.constLast(), QSize(reportableWidth(mpHost), rowsBefore));
     }
 
     // Geyser lays every element out against getMainWindowSize(), so a profile
@@ -307,7 +386,6 @@ private slots:
         settle(1500ms);
         const QSize onceBack = mpHost->mpConsole->getMainWindowSize();
 
-        qInfo() << "the backgrounded profile reported" << whileHidden << "and came back to" << onceBack;
         QCOMPARE(whileHidden, onceBack);
     }
 };

--- a/test/functional_tests/TelnetServerStub.cpp
+++ b/test/functional_tests/TelnetServerStub.cpp
@@ -84,6 +84,7 @@ void TelnetServerStub::onNewConnection()
     }
     mpClient = client;
     mHadClient = true;
+    mReceived.clear();
     qInfo().noquote() << qsl("🔌 Client connected: %1").arg(client->peerAddress().toString());
 
     if (!mPendingData.isEmpty()) {
@@ -108,6 +109,10 @@ void TelnetServerStub::onNewConnection()
         }
     });
 
+    connect(client, &QTcpSocket::readyRead, this, [this, client]() {
+        collectNawsUpdates(client);
+    });
+
     // ~QTcpSocket emits disconnected() from ~QAbstractSocket, by which point the
     // socket is no longer a QTcpSocket - so hold it as the base type here.
     connect(client, &QTcpSocket::disconnected, [safeSocket = QPointer<QAbstractSocket>(client)]() {
@@ -117,4 +122,56 @@ void TelnetServerStub::onNewConnection()
         qInfo().noquote() << qsl("Client disconnected: %1").arg(safeSocket->peerAddress().toString());
         safeSocket->deleteLater();
     });
+}
+
+void TelnetServerStub::collectNawsUpdates(QTcpSocket* socket)
+{
+    if (!socket) {
+        return;
+    }
+    mReceived.append(socket->readAll());
+
+    // IAC SB NAWS <width hi> <width lo> <height hi> <height lo> IAC SE, with any
+    // of those four bytes sent twice when it is 0xFF - which a width or height
+    // whose low byte is 255 is enough to produce - so the frame is not a fixed
+    // nine bytes and cannot be stepped over as though it were.
+    static const QByteArray nawsHeader = QByteArray("\xFF\xFA\x1F", 3);
+    static const QByteArray nawsFooter = QByteArray("\xFF\xF0", 2);
+    qsizetype at = 0;
+    qsizetype keepFrom = -1;
+    while ((at = mReceived.indexOf(nawsHeader, at)) >= 0) {
+        qsizetype cursor = at + nawsHeader.size();
+        int payload[4] = {};
+        bool whole = true;
+        for (int& byte : payload) {
+            if (cursor >= mReceived.size()) {
+                whole = false;
+                break;
+            }
+            byte = static_cast<unsigned char>(mReceived.at(cursor++));
+            if (byte == 0xFF) {
+                // the doubled half, which carries no value of its own
+                ++cursor;
+            }
+        }
+        if (!whole || cursor + nawsFooter.size() > mReceived.size()) {
+            // the rest of it is still in flight - hold this frame's bytes back
+            keepFrom = at;
+            break;
+        }
+        if (mReceived.mid(cursor, nawsFooter.size()) != nawsFooter) {
+            // Not a subnegotiation this stub understands. Skipping the header
+            // rather than a whole frame keeps the scan aligned on whatever
+            // really is a NAWS update further along.
+            qWarning() << "TelnetServerStub: a NAWS subnegotiation did not end in IAC SE - ignoring it";
+            at += nawsHeader.size();
+            continue;
+        }
+        mNawsUpdates.append(QSize(payload[0] * 256 + payload[1], payload[2] * 256 + payload[3]));
+        at = cursor + nawsFooter.size();
+    }
+    // Everything the client sends comes through here, so hold back only what a
+    // frame still being delivered needs: the part of it that has arrived, or
+    // failing that the couple of bytes that could be a header cut in half.
+    mReceived = keepFrom >= 0 ? mReceived.mid(keepFrom) : mReceived.right(nawsHeader.size() - 1);
 }

--- a/test/functional_tests/TelnetServerStub.h
+++ b/test/functional_tests/TelnetServerStub.h
@@ -21,10 +21,12 @@
 #define TELNET_SERVER_STUB_H
 
 #include <QPointer>
+#include <QSize>
 #include <QtNetwork/QTcpServer>
 #include <QtNetwork/QTcpSocket>
 #include <QTimer>
 #include <QDebug>
+#include <QVector>
 
 class TelnetServerStub : public QTcpServer
 {
@@ -34,6 +36,8 @@ class TelnetServerStub : public QTcpServer
     QPointer<QTcpSocket> mpClient;
     QByteArray mPendingData;
     bool mHadClient = false;
+    QByteArray mReceived;
+    QVector<QSize> mNawsUpdates;
 
 public:
     explicit TelnetServerStub(QObject* parent = nullptr);
@@ -49,8 +53,18 @@ public:
     void sendRaw(const QByteArray& data);
     bool clientConnected() const { return !mpClient.isNull(); }
 
+    // Every NAWS subnegotiation the client has sent since the last
+    // clearNawsUpdates(), in the order they arrived. Tests that care about what
+    // a game is told about the window read this rather than the client's own
+    // idea of its size - only what reaches the wire can wrap the game's output.
+    const QVector<QSize>& nawsUpdates() const { return mNawsUpdates; }
+    void clearNawsUpdates() { mNawsUpdates.clear(); }
+
 private slots:
     void onNewConnection();
+
+private:
+    void collectNawsUpdates(QTcpSocket* socket);
 };
 
 #endif // TELNET_SERVER_STUB_H


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The window size is reported to the game once the resize has settled, rather than once per layout step. A resize passes through several intermediate widths, and the game was wrapping its next reply to one of them.
- A profile waiting in a background tab now keeps the width and height it will come back to, instead of picking up whichever profile is on screen, so its scrollback no longer re-wraps on a tab switch. Moving its borders while it waits re-reports the size too.
- `getMainWindowSize()` measures the window a hidden profile will return to, so Geyser lays elements out against the real size and not the half-width one the console has while another profile is switching in.

One 1400 -> 900 resize with an `Adjustable.Container` on the right border. On the left the game is told 40 columns partway through and wraps a paragraph to them, then told 47; on the right it is told 47, once.

<img width="1096" height="953" alt="Before and after a resize" src="https://github.com/user-attachments/assets/69f5fe04-c1eb-430d-a108-77a6ec74439a" />

Two profiles in one window, the window resized while ProfileA waits in a background tab and ProfileB is in front with `setBorderLeft(380) setBorderRight(380)`. On the left ProfileA's game is told ProfileB's 40 columns while ProfileA is away; on the right it is only ever told widths ProfileA has.

<img width="2244" height="1014" alt="ProfileA coming back from a background tab" src="https://github.com/user-attachments/assets/277dcaa8-dd7e-425e-9a1c-da12b0462f58" />

#### Motivation for adding to Mudlet

Anyone with an adjustable Geyser container on a border - which the starter interface installs by default - saw the game's text wrap to a fraction of the window after resizing it, and saw wrapping go wrong again when moving from profile to profile.

#### Other info (issues closed, discussion etc)

Closes #10483, closes #10484, closes #10485.

`NawsWidthReportTest` reads the NAWS subnegotiations off the wire through `TelnetServerStub` rather than trusting the client's own idea of its size, since only what reaches the game can wrap the game's output. Six of its seven cases fail against `development` and pass here; the seventh guards the debounce against a gutter toggle. Full functional suite 180/180, Lua specs 4366 passing.

**Test case:** open a profile, run `chat = Adjustable.Container:new({name="chat", x="-40%", y=0, width="40%", height="60%"}) chat:attachToBorder("right")`, then resize the window - the game's text should wrap to the width the window settles at, with nothing narrower in between.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Vadim Peretokin <vadim.peretokin@mudlet.org>
