### PR TITLE
Infra: Add tests for the mapper's mouse handling

### DIFF
--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -143,6 +143,7 @@ set(MAP_GROUP_TEST_SOURCES
     MapCloseDuringImportTest.cpp
     MapDownloadTest.cpp
     MapLevelOfDetailTest.cpp
+    MapMouseInteractionTest.cpp
     MapOffscreenCustomLineTest.cpp
     MapFileStatsTest.cpp
     MapLockNoOpTest.cpp

--- a/test/functional_tests/MapMouseInteractionTest.cpp
+++ b/test/functional_tests/MapMouseInteractionTest.cpp
@@ -1,0 +1,541 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Everything the mapper does with the mouse: which room a point on the widget
+ * is over, and the handlers a press, a drag and a release are dispatched to.
+ *
+ * None of it has a Lua route - the hit test and the selection are private to
+ * the widget, and no scripting call makes a selection or pans the view - so
+ * this cannot be a busted spec.
+ *
+ * The point of a room is worked out from mRoomWidth, the pixels one map unit
+ * is drawn at, which paintEvent() sets. So every test renders a frame first,
+ * and mShiftMode keeps that paint from re-centring the view on the player.
+ *
+ * Run with: ctest -R MapMouseInteractionTest -V
+ */
+
+#include <QFileInfo>
+#include <QMouseEvent>
+#include <QPixmap>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "T2DMap.h"
+#include "TArea.h"
+#include "TMap.h"
+#include "TMapLabel.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgMapper.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapMouseInteractionTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    T2DMap* mp2dMap = nullptr;
+    int mAreaId = 0;
+    const QString mProfileName = qsl("MapMouseInteraction-Test");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort;
+
+    // Wider than it is tall, so the two axes cannot be confused for each other.
+    static constexpr int kWidgetWidth = 600;
+    static constexpr int kWidgetHeight = 400;
+    // Map units across the shorter dimension. With this widget that puts one
+    // map unit at 20 pixels in both directions, so a room and its neighbour are
+    // 20 pixels apart.
+    static constexpr double kZoom = 20.0;
+    static constexpr double kPixelsPerMapUnit = 20.0;
+    // A room is drawn at half the size of its cell, so it reaches 5 pixels
+    // either side of its centre and the 10 pixels to its neighbour are empty.
+    static constexpr double kRoomSize = 0.5;
+
+    // The 3x3 block buildMap() lays out, a unit apart, with the player in the
+    // middle of it.
+    static constexpr int kNorthRoomId = 2;
+    static constexpr int kWestRoomId = 4;
+    static constexpr int kPlayerRoomId = 5;
+    static constexpr int kEastRoomId = 6;
+    static constexpr int kSouthRoomId = 8;
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+
+    TArea* area() const { return map()->mpRoomDB->getArea(mAreaId); }
+
+    bool addRoomAt(const int id, const int x, const int y, const int z) const { return map()->addRoom(id) && map()->setRoomArea(id, mAreaId) && map()->setRoomCoordinates(id, x, y, z); }
+
+    // A 3x3 block of rooms one unit apart, numbered from the north-west corner
+    // along each row, which puts the player in the middle at the origin.
+    void buildMap(const bool gridMode = false)
+    {
+        TMap* pMap = map();
+        pMap->mapClear();
+        mAreaId = pMap->mpRoomDB->addArea(qsl("Mouse Area"));
+        QVERIFY(mAreaId > 0);
+
+        int nextId = 1;
+        for (int y = 1; y >= -1; --y) {
+            for (int x = -1; x <= 1; ++x) {
+                QVERIFY(addRoomAt(nextId++, x, y, 0));
+            }
+        }
+        QVERIFY(area());
+        area()->gridMode = gridMode;
+
+        pMap->mRoomIdHash[pMap->mProfileName] = kPlayerRoomId;
+        pMap->mNewMove = false;
+        pMap->setDefaultAreaShown(false);
+    }
+
+    // Points the mapper at the map buildMap() made and draws it once, which is
+    // what fills in the pixels-per-map-unit the hit test works from.
+    void showMapper(const bool viewOnly)
+    {
+        mpHost->mMapViewOnly = viewOnly;
+        mpHost->mRoomSize = kRoomSize;
+        if (!map()->mpMapper) {
+            mpHost->showHideOrCreateMapper(false);
+        }
+        QVERIFY(map()->mpMapper);
+        mp2dMap = map()->mpMapper->mp2dMap;
+        QVERIFY(mp2dMap);
+        mp2dMap->init();
+        mp2dMap->resize(kWidgetWidth, kWidgetHeight);
+        mp2dMap->mRoomID = kPlayerRoomId;
+        mp2dMap->mAreaID = mAreaId;
+        // paintEvent() re-centres on the player and draws somewhere else unless
+        // the player's room, mRoomID and mShiftMode all agree.
+        mp2dMap->mShiftMode = true;
+        mp2dMap->mPick = false;
+        mp2dMap->mMapCenterX = 0;
+        mp2dMap->mMapCenterY = 0;
+        mp2dMap->mMapCenterZ = 0;
+        mp2dMap->mMultiSelectionSet.clear();
+        // The mapper is made once and reused, so anything a test picked up has
+        // to be put back down before the next one runs.
+        mp2dMap->mLabelHighlighted = false;
+        mp2dMap->mMoveLabel = false;
+        area()->set2DMapZoom(kZoom);
+        renderFrame();
+        QCOMPARE(mp2dMap->mMapViewOnly, viewOnly);
+        QCOMPARE(static_cast<double>(mp2dMap->mRoomWidth), kPixelsPerMapUnit);
+        QCOMPARE(static_cast<double>(mp2dMap->mRoomHeight), kPixelsPerMapUnit);
+    }
+
+    void renderFrame() const
+    {
+        QPixmap target(kWidgetWidth, kWidgetHeight);
+        target.fill(Qt::black);
+        mp2dMap->render(&target, QPoint(), QRegion(), QWidget::DrawWindowBackground);
+    }
+
+    QPoint viewCentre() const { return QPoint(kWidgetWidth / 2, kWidgetHeight / 2); }
+
+    // Where a room that many units east and north of the middle of the view is
+    // drawn, if the mapper puts north up and east right.
+    QPoint pointUnitsFromCentre(const double east, const double north) const { return viewCentre() + QPoint(qRound(east * kPixelsPerMapUnit), qRound(-north * kPixelsPerMapUnit)); }
+
+    // Labels are drawn from their map position down and to the right, so this
+    // is the point that lands in the middle of one.
+    QPoint pointOnLabel(const QVector3D& position, const QSizeF& clickSize) const
+    {
+        return QPoint(qRound(position.x() * kPixelsPerMapUnit + mp2dMap->mRX + clickSize.width() / 2), qRound(position.y() * -1 * kPixelsPerMapUnit + mp2dMap->mRY + clickSize.height() / 2));
+    }
+
+    int addLabel(const QVector3D& position, const QSizeF& clickSize) const
+    {
+        TMapLabel label;
+        label.pos = position;
+        label.size = clickSize;
+        label.clickSize = clickSize;
+        label.text = qsl("a label");
+        const int id = area()->mMapLabels.isEmpty() ? 0 : area()->mMapLabels.lastKey() + 1;
+        area()->mMapLabels.insert(id, label);
+        return id;
+    }
+
+    void sendMouse(const QEvent::Type type, const QPoint& position, const Qt::MouseButton button, const Qt::MouseButtons buttons, const Qt::KeyboardModifiers modifiers) const
+    {
+        QMouseEvent event(type, QPointF(position), mp2dMap->mapToGlobal(QPointF(position)), button, buttons, modifiers);
+        QApplication::sendEvent(mp2dMap, &event);
+    }
+
+    void pressAt(const QPoint& position, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) const { sendMouse(QEvent::MouseButtonPress, position, Qt::LeftButton, Qt::LeftButton, modifiers); }
+
+    void moveTo(const QPoint& position, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) const { sendMouse(QEvent::MouseMove, position, Qt::NoButton, Qt::LeftButton, modifiers); }
+
+    // A press does not itself start a drag: the handlers take the point the
+    // drag runs from off the first move that follows it, so a drag is a press,
+    // a move that does not go anywhere, and then the move that does.
+    void dragFromTo(const QPoint& from, const QPoint& to, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) const
+    {
+        pressAt(from, modifiers);
+        moveTo(from, modifiers);
+        moveTo(to, modifiers);
+        releaseAt(to, modifiers);
+    }
+
+    void releaseAt(const QPoint& position, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) const { sendMouse(QEvent::MouseButtonRelease, position, Qt::LeftButton, Qt::NoButton, modifiers); }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own, so this never reads or writes
+        // the developer's ~/.config/mudlet. Since #9712 the opt-in that makes
+        // setupConfig() adopt a directory is $XDG_CONFIG_HOME/mudlet/profiles,
+        // not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        mudlet::self()->mSkipDefaultPackageInstall = true;
+        deleteProfileDirectory();
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, mPort);
+        QVERIFY(mpHost);
+        QSignalSpy connected(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connected.wait(3000), "could not connect to the telnet stub");
+    }
+
+    void cleanupTestCase()
+    {
+        mp2dMap = nullptr;
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // The view is centred on where the player is, so the middle of the widget
+    // is over the room they are standing in.
+    void test_theRoomYouAreInIsUnderTheMiddleOfTheView()
+    {
+        buildMap();
+        showMapper(true);
+
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(viewCentre(), area()), std::optional<int>(kPlayerRoomId));
+    }
+
+    // North is up and east is right: get either axis or its sign wrong and a
+    // click lands on the room opposite the one under the cursor.
+    void test_theRoomsAroundYouAreDrawnInTheDirectionsTheyLieIn()
+    {
+        buildMap();
+        showMapper(true);
+
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(0, 1), area()), std::optional<int>(kNorthRoomId));
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(0, -1), area()), std::optional<int>(kSouthRoomId));
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(1, 0), area()), std::optional<int>(kEastRoomId));
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(-1, 0), area()), std::optional<int>(kWestRoomId));
+    }
+
+    // A room is drawn smaller than the cell it sits in, so there is a gap
+    // between it and the next one that belongs to neither.
+    void test_thePointBetweenTwoRoomsIsOverNeitherOfThem()
+    {
+        buildMap();
+        showMapper(true);
+
+        QVERIFY2(!mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(0.5, 0), area()).has_value(), "the gap between two rooms was reported as a room");
+        QVERIFY2(!mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(0, 0.5), area()).has_value(), "the gap above a room was reported as a room");
+        // A room is drawn half a unit across, so three tenths of a unit out
+        // from its middle is already past its edge.
+        QVERIFY2(!mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(0.3, 0), area()).has_value(), "a point past the edge of a room was reported as being on it");
+    }
+
+    // In grid mode a room fills its cell, so there is no gap to fall into.
+    void test_inGridModeThereIsNoGapBetweenTwoRooms()
+    {
+        buildMap(true);
+        showMapper(true);
+
+        const auto roomId = mp2dMap->roomIdAtWidgetPosition(pointUnitsFromCentre(0.4, 0), area());
+        QVERIFY2(roomId.has_value(), "no room was found in what is a filled cell in grid mode");
+        QCOMPARE(roomId, std::optional<int>(kPlayerRoomId));
+    }
+
+    // Only the level being shown is clickable, or a room drawn faintly on the
+    // level above would take clicks meant for the one under the cursor.
+    void test_aRoomOnAnotherLevelIsNotUnderTheCursor()
+    {
+        buildMap();
+        const int roomAboveId = 20;
+        QVERIFY(addRoomAt(roomAboveId, 3, 0, 1));
+        showMapper(true);
+
+        const QPoint pointOverTheRoomAbove = pointUnitsFromCentre(3, 0);
+        QVERIFY2(!mp2dMap->roomIdAtWidgetPosition(pointOverTheRoomAbove, area()).has_value(), "a room a level up was picked out of the level being shown");
+
+        mp2dMap->mMapCenterZ = 1;
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(pointOverTheRoomAbove, area()), std::optional<int>(roomAboveId));
+    }
+
+    // Two rooms can share a coordinate, and the mapper offers a choice between
+    // them rather than picking one - so the hit test has to report both.
+    void test_everyRoomStackedOnTheSameSpotIsReported()
+    {
+        buildMap();
+        const int stackedRoomId = 21;
+        QVERIFY(addRoomAt(stackedRoomId, 0, 0, 0));
+        showMapper(true);
+
+        const QSet<int> expected{kPlayerRoomId, stackedRoomId};
+        QCOMPARE(mp2dMap->roomIdsAtWidgetPosition(viewCentre(), area()), expected);
+        QVERIFY2(expected.contains(mp2dMap->roomIdAtWidgetPosition(viewCentre(), area()).value_or(0)), "the single-room hit test named a room that is not on the spot");
+    }
+
+    // Viewing mode is for reading the map, so a plain drag moves the map under
+    // the cursor instead of selecting anything.
+    void test_draggingWhileViewingPansTheMap()
+    {
+        buildMap();
+        showMapper(true);
+
+        dragFromTo(viewCentre(), viewCentre() + QPoint(qRound(kPixelsPerMapUnit), 0));
+
+        // Dragging the map a unit to the right brings the room a unit west of
+        // the middle into it.
+        QCOMPARE(mp2dMap->mMapCenterX, -1.0);
+        QCOMPARE(mp2dMap->mMapCenterY, 0.0);
+        renderFrame();
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(viewCentre(), area()), std::optional<int>(kWestRoomId));
+    }
+
+    // Editing mode gives the drag to the selection rectangle, so panning there
+    // is what Alt is for - as the message the mapper puts up says.
+    void test_holdingAltAndDraggingPansTheMapWhileEditing()
+    {
+        buildMap();
+        showMapper(false);
+
+        dragFromTo(viewCentre(), viewCentre() + QPoint(0, qRound(kPixelsPerMapUnit)), Qt::AltModifier);
+
+        QCOMPARE(mp2dMap->mMapCenterY, -1.0);
+        renderFrame();
+        QCOMPARE(mp2dMap->roomIdAtWidgetPosition(viewCentre(), area()), std::optional<int>(kNorthRoomId));
+    }
+
+    void test_clickingARoomWhileEditingSelectsIt()
+    {
+        buildMap();
+        showMapper(false);
+
+        pressAt(pointUnitsFromCentre(1, 0));
+        releaseAt(pointUnitsFromCentre(1, 0));
+
+        QCOMPARE(mp2dMap->mMultiSelectionSet, QSet<int>{kEastRoomId});
+    }
+
+    void test_draggingABoxOverSeveralRoomsSelectsThemAll()
+    {
+        buildMap();
+        showMapper(false);
+
+        // From above and left of the north-west room down to below and right of
+        // the middle one, which takes in the four rooms of that quarter.
+        dragFromTo(pointUnitsFromCentre(-1.5, 1.5), pointUnitsFromCentre(0.5, -0.5));
+
+        const QSet<int> expected{1, kNorthRoomId, kWestRoomId, kPlayerRoomId};
+        QCOMPARE(mp2dMap->mMultiSelectionSet, expected);
+    }
+
+    // The same drag while viewing pans instead of drawing a box, which is what
+    // the map being locked for viewing means.
+    void test_draggingWhileViewingDrawsNoSelectionBox()
+    {
+        buildMap();
+        showMapper(true);
+
+        dragFromTo(pointUnitsFromCentre(-1.5, 1.5), pointUnitsFromCentre(0.5, -0.5));
+
+        QVERIFY2(mp2dMap->mMultiSelectionSet.isEmpty(), "a drag while the map was locked for viewing selected rooms");
+        QVERIFY2(mp2dMap->mMapCenterX != 0.0, "the drag did not pan the map either");
+    }
+
+    // Without shift a new selection replaces the old one, with it the two add
+    // up - which is the only way to select rooms that are not next to each other.
+    void test_holdingShiftAddsToTheSelectionInsteadOfReplacingIt()
+    {
+        buildMap();
+        showMapper(false);
+
+        pressAt(pointUnitsFromCentre(-1, 0));
+        releaseAt(pointUnitsFromCentre(-1, 0));
+        QCOMPARE(mp2dMap->mMultiSelectionSet, QSet<int>{kWestRoomId});
+
+        pressAt(pointUnitsFromCentre(1, 0), Qt::ShiftModifier);
+        releaseAt(pointUnitsFromCentre(1, 0), Qt::ShiftModifier);
+
+        const QSet<int> expected{kWestRoomId, kEastRoomId};
+        QCOMPARE(mp2dMap->mMultiSelectionSet, expected);
+    }
+
+    // Dragging a room moves it on the map, in whole units, and takes the points
+    // of its custom lines along with it.
+    void test_draggingARoomMovesItAndItsCustomLines()
+    {
+        buildMap();
+        TRoom* pEastRoom = map()->mpRoomDB->getRoom(kEastRoomId);
+        QVERIFY(pEastRoom);
+        pEastRoom->customLines[qsl("n")] = QList<QPointF>{QPointF(1.0, 3.0), QPointF(1.0, 4.0)};
+        pEastRoom->customLinesColor[qsl("n")] = QColor(0, 255, 128);
+        pEastRoom->customLinesStyle[qsl("n")] = Qt::SolidLine;
+        pEastRoom->customLinesArrow[qsl("n")] = false;
+        pEastRoom->calcRoomDimensions();
+        showMapper(false);
+
+        // A custom line's first segment runs out of the middle of the room it
+        // belongs to, so press just short of the middle: on it, the handler that
+        // edits a line's points would take the press instead.
+        dragFromTo(pointUnitsFromCentre(1, -0.2), pointUnitsFromCentre(1, 1.8));
+
+        QCOMPARE(pEastRoom->x(), 1);
+        QCOMPARE(pEastRoom->y(), 2);
+        const QList<QPointF> movedLine = pEastRoom->customLines.value(qsl("n"));
+        QCOMPARE(movedLine.size(), 2);
+        QCOMPARE(movedLine.constFirst(), QPointF(1.0, 5.0));
+        QCOMPARE(movedLine.constLast(), QPointF(1.0, 6.0));
+    }
+
+    // Clicking a map label picks it up, and clicking it again puts it down.
+    void test_clickingALabelPicksItUpAndClickingItAgainPutsItDown()
+    {
+        buildMap();
+        showMapper(false);
+        const QVector3D where(2, 0, 0);
+        const QSizeF clickSize(40, 20);
+        const int labelId = addLabel(where, clickSize);
+
+        pressAt(pointOnLabel(where, clickSize));
+        QVERIFY2(mp2dMap->mLabelHighlighted, "clicking a label did not pick it up");
+        QVERIFY(area()->mMapLabels.value(labelId).highlight);
+
+        pressAt(pointOnLabel(where, clickSize));
+        QVERIFY2(!mp2dMap->mLabelHighlighted, "clicking a picked up label did not put it down");
+        QVERIFY(!area()->mMapLabels.value(labelId).highlight);
+    }
+
+    // Clicking anywhere else drops whatever label was held.
+    void test_clickingAwayFromALabelPutsItDown()
+    {
+        buildMap();
+        showMapper(false);
+        const QVector3D where(2, 0, 0);
+        const QSizeF clickSize(40, 20);
+        addLabel(where, clickSize);
+
+        pressAt(pointOnLabel(where, clickSize));
+        QVERIFY(mp2dMap->mLabelHighlighted);
+
+        pressAt(pointUnitsFromCentre(-3, -3));
+        QVERIFY2(!mp2dMap->mLabelHighlighted, "a click away from the label left it picked up");
+    }
+
+    // A label on a level other than the one being shown is not there to click.
+    void test_aLabelOnAnotherLevelCannotBePickedUp()
+    {
+        buildMap();
+        showMapper(false);
+        const QVector3D where(2, 0, 1);
+        const QSizeF clickSize(40, 20);
+        const int labelId = addLabel(where, clickSize);
+
+        pressAt(pointOnLabel(QVector3D(where.x(), where.y(), 0), clickSize));
+
+        QVERIFY2(!mp2dMap->mLabelHighlighted, "a label a level up was picked up");
+        QVERIFY(!area()->mMapLabels.value(labelId).highlight);
+    }
+
+    // With the map locked for viewing a label stays where it is.
+    void test_aLabelCannotBePickedUpWhileViewing()
+    {
+        buildMap();
+        showMapper(true);
+        const QVector3D where(2, 0, 0);
+        const QSizeF clickSize(40, 20);
+        const int labelId = addLabel(where, clickSize);
+
+        pressAt(pointOnLabel(where, clickSize));
+
+        QVERIFY2(!mp2dMap->mLabelHighlighted, "a label was picked up while the map was locked for viewing");
+        QVERIFY(!area()->mMapLabels.value(labelId).highlight);
+    }
+
+    // A room the map is locked for viewing cannot be dragged out of place by a
+    // stray click.
+    void test_aRoomCannotBeDraggedWhileViewing()
+    {
+        buildMap();
+        showMapper(true);
+
+        dragFromTo(pointUnitsFromCentre(1, 0), pointUnitsFromCentre(1, 2));
+
+        TRoom* pEastRoom = map()->mpRoomDB->getRoom(kEastRoomId);
+        QVERIFY(pEastRoom);
+        QCOMPARE(pEastRoom->x(), 1);
+        QCOMPARE(pEastRoom->y(), 0);
+    }
+};
+
+#include "MapMouseInteractionTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MapMouseInteractionTest)

--- a/test/functional_tests/MapMouseInteractionTest.cpp
+++ b/test/functional_tests/MapMouseInteractionTest.cpp
@@ -156,6 +156,7 @@ private:
         // to be put back down before the next one runs.
         mp2dMap->mLabelHighlighted = false;
         mp2dMap->mMoveLabel = false;
+        mp2dMap->mMultiSelection = false;
         area()->set2DMapZoom(kZoom);
         renderFrame();
         QCOMPARE(mp2dMap->mMapViewOnly, viewOnly);
@@ -217,6 +218,12 @@ private:
     }
 
     void releaseAt(const QPoint& position, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) const { sendMouse(QEvent::MouseButtonRelease, position, Qt::LeftButton, Qt::NoButton, modifiers); }
+
+    void clickAt(const QPoint& position, const Qt::KeyboardModifiers modifiers = Qt::NoModifier) const
+    {
+        pressAt(position, modifiers);
+        releaseAt(position, modifiers);
+    }
 
 private slots:
     void initTestCase()
@@ -380,8 +387,7 @@ private slots:
         buildMap();
         showMapper(false);
 
-        pressAt(pointUnitsFromCentre(1, 0));
-        releaseAt(pointUnitsFromCentre(1, 0));
+        clickAt(pointUnitsFromCentre(1, 0));
 
         QCOMPARE(mp2dMap->mMultiSelectionSet, QSet<int>{kEastRoomId});
     }
@@ -419,12 +425,10 @@ private slots:
         buildMap();
         showMapper(false);
 
-        pressAt(pointUnitsFromCentre(-1, 0));
-        releaseAt(pointUnitsFromCentre(-1, 0));
+        clickAt(pointUnitsFromCentre(-1, 0));
         QCOMPARE(mp2dMap->mMultiSelectionSet, QSet<int>{kWestRoomId});
 
-        pressAt(pointUnitsFromCentre(1, 0), Qt::ShiftModifier);
-        releaseAt(pointUnitsFromCentre(1, 0), Qt::ShiftModifier);
+        clickAt(pointUnitsFromCentre(1, 0), Qt::ShiftModifier);
 
         const QSet<int> expected{kWestRoomId, kEastRoomId};
         QCOMPARE(mp2dMap->mMultiSelectionSet, expected);
@@ -466,11 +470,11 @@ private slots:
         const QSizeF clickSize(40, 20);
         const int labelId = addLabel(where, clickSize);
 
-        pressAt(pointOnLabel(where, clickSize));
+        clickAt(pointOnLabel(where, clickSize));
         QVERIFY2(mp2dMap->mLabelHighlighted, "clicking a label did not pick it up");
         QVERIFY(area()->mMapLabels.value(labelId).highlight);
 
-        pressAt(pointOnLabel(where, clickSize));
+        clickAt(pointOnLabel(where, clickSize));
         QVERIFY2(!mp2dMap->mLabelHighlighted, "clicking a picked up label did not put it down");
         QVERIFY(!area()->mMapLabels.value(labelId).highlight);
     }
@@ -484,10 +488,10 @@ private slots:
         const QSizeF clickSize(40, 20);
         addLabel(where, clickSize);
 
-        pressAt(pointOnLabel(where, clickSize));
+        clickAt(pointOnLabel(where, clickSize));
         QVERIFY(mp2dMap->mLabelHighlighted);
 
-        pressAt(pointUnitsFromCentre(-3, -3));
+        clickAt(pointUnitsFromCentre(-3, -3));
         QVERIFY2(!mp2dMap->mLabelHighlighted, "a click away from the label left it picked up");
     }
 
@@ -500,7 +504,7 @@ private slots:
         const QSizeF clickSize(40, 20);
         const int labelId = addLabel(where, clickSize);
 
-        pressAt(pointOnLabel(QVector3D(where.x(), where.y(), 0), clickSize));
+        clickAt(pointOnLabel(QVector3D(where.x(), where.y(), 0), clickSize));
 
         QVERIFY2(!mp2dMap->mLabelHighlighted, "a label a level up was picked up");
         QVERIFY(!area()->mMapLabels.value(labelId).highlight);
@@ -515,7 +519,7 @@ private slots:
         const QSizeF clickSize(40, 20);
         const int labelId = addLabel(where, clickSize);
 
-        pressAt(pointOnLabel(where, clickSize));
+        clickAt(pointOnLabel(where, clickSize));
 
         QVERIFY2(!mp2dMap->mLabelHighlighted, "a label was picked up while the map was locked for viewing");
         QVERIFY(!area()->mMapLabels.value(labelId).highlight);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds `MapMouseInteractionTest`, 18 functional tests over the 2D mapper's mouse layer - the part of the mapper that turns a click or a drag into a room being picked, selected or moved, a label being picked up, or the view being panned. It joins the existing `functional_map_tests` group binary, so it costs a compile rather than a link, and the whole case runs in under a third of a second.

The tests drive a real `T2DMap` offscreen: a 3x3 block of rooms is laid out, the mapper is created and rendered once so the room geometry is filled in, and then synthetic `QMouseEvent`s are sent to the widget. What is asserted is what a person would see - which room is under the cursor, what ends up selected, where the room ends up.

Covered:

- **Where rooms are on screen** - the room you are in sits under the middle of the view, the rooms around you are drawn in the directions they lie in, the gap between two rooms is over neither of them, a point past a room's edge is off it, grid mode leaves no such gap, a room on another level is not under the cursor, and every room stacked on one spot is reported.
- **Panning** - dragging pans while the map is locked for viewing, and alt-dragging pans while editing.
- **Selecting** - clicking a room selects it, dragging a box selects everything the box covers, shift adds to the selection instead of replacing it, and a drag while viewing draws no selection box.
- **Moving rooms** - dragging a room moves it and takes its custom lines along, and a room cannot be dragged while the map is locked for viewing.
- **Map labels** - clicking a label picks it up and clicking it again puts it down, clicking elsewhere puts it down, a label a level up cannot be picked up, and neither can any label while the map is locked for viewing.

#### Motivation for adding to Mudlet

The mouse handlers behind the mapper (`PanInteractionHandler`, `SelectionRectangleHandler`, `RoomMoveActivationHandler`, `RoomMoveDragHandler`, `LabelInteractionHandler` and the hit testing in `T2DMap`) come to about 1100 lines with almost no test coverage, and they are pure interaction code - there is no Lua entry point to reach them from a spec, so a functional test is the only harness that can. They are also the code most likely to break silently: a sign flip or an off-by-one in the hit test doesn't crash, it just quietly puts the wrong room under the cursor.

Writing these turned up a regression in exactly that shape - since the mouse handlers were split up in #8356 a picked-up map label no longer follows the mouse, because the selection rectangle now handles the move first. The test for it and its fix are in a follow-up PR rather than here.

**Test case:** open the mapper (`Toolbox -> Mapper`), click a room, shift-click another, drag a box over several, drag one of them somewhere, and drag the background to pan. Click a map label to pick it up, click it again to put it down. Then lock the map for viewing (`Map -> View only`) and check that dragging pans instead of selecting or moving, and that labels stay put.

#### Other info (issues closed, discussion etc)

Every test was proven to bite by mutating the code it covers and confirming it goes red. Each batch was applied on its own to an otherwise clean tree:

| Sabotage | What it changed | Went red |
| --- | --- | --- |
| `origin` | the middle of the view stops being the middle of the map | 10 tests |
| `centring` | the hit test stops following the view as it is panned | 2 pan tests |
| `axes` | north stops being up | directions, alt-pan |
| `radius` | a room reaches out twice as far as it is drawn | the gap between rooms |
| `grid-cell` | grid mode looks up the wrong cell | grid mode |
| `z-level` | every level is clickable at once | another level |
| `stacked` | only the first of the rooms on a spot is reported | stacked rooms |
| `pan` | a drag stops moving the view | 3 pan tests |
| `view-only` | the lock for viewing stops holding anything back | 3 view-only tests |
| `shift` | shift stops adding to the selection | shift |
| `rect` | the selection box never grows past where it started | box selection |
| `click-select` | a click stops picking the room under it | 3 selection tests |
| `room-move` | a dragged room stays where it was | room drag |
| `custom-lines` | a moved room leaves its custom lines behind | room drag |
| `label-hit` | a label is looked for away from where it is drawn | 2 label tests |
| `label-toggle` | clicking a label never puts it back down | pick up/put down |
| `label-clear` | a click elsewhere leaves the label held | click away |
| `label-z` | labels on every level are clickable at once | label a level up |
| `label-view-only` | the lock for viewing stops protecting labels | label while viewing |
