### PR TITLE
Fix: A map label you pick up follows the mouse again

### DIFF
--- a/src/SelectionRectangleHandler.cpp
+++ b/src/SelectionRectangleHandler.cpp
@@ -49,7 +49,13 @@ bool SelectionRectangleHandler::matches(const T2DMap::MapInteractionContext& con
     case QEvent::MouseButtonPress:
         return context.button == Qt::LeftButton && !context.isCustomLineDrawing && !context.isRoomBeingMoved && !context.modifiers.testFlag(Qt::AltModifier);
     case QEvent::MouseMove:
-        return context.isMultiSelectionActive || context.isSizingLabel;
+        if (context.isSizingLabel) {
+            return true;
+        }
+        // A label that has been picked up follows the mouse, so the selection
+        // rectangle stands aside for it - the order the single mouse move
+        // handler used to run these two in.
+        return context.isMultiSelectionActive && !context.isLabelHighlighted;
     case QEvent::MouseButtonRelease:
         return context.button == Qt::LeftButton && (context.isMultiSelectionActive || context.isSizingLabel);
     default:

--- a/test/functional_tests/MapMouseInteractionTest.cpp
+++ b/test/functional_tests/MapMouseInteractionTest.cpp
@@ -521,6 +521,24 @@ private slots:
         QVERIFY(!area()->mMapLabels.value(labelId).highlight);
     }
 
+    // A label that has been picked up follows the mouse until it is put down.
+    void test_aPickedUpLabelFollowsTheMouse()
+    {
+        buildMap();
+        showMapper(false);
+        const QVector3D where(2, 0, 0);
+        const QSizeF clickSize(40, 20);
+        const int labelId = addLabel(where, clickSize);
+
+        pressAt(pointOnLabel(where, clickSize));
+        QVERIFY(mp2dMap->mLabelHighlighted);
+        moveTo(pointUnitsFromCentre(3, 1));
+
+        const QVector3D moved = area()->mMapLabels.value(labelId).pos;
+        QCOMPARE(static_cast<double>(moved.x()), 3.0);
+        QCOMPARE(static_cast<double>(moved.y()), 1.0);
+    }
+
     // A room the map is locked for viewing cannot be dragged out of place by a
     // stray click.
     void test_aRoomCannotBeDraggedWhileViewing()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

A map label you have picked up follows the mouse again.

Before the mapper's mouse handling was split into separate handlers in #8356, a single `mouseMoveEvent` ran the "move the highlighted label" block before the "resize the selection rectangle" block. The split turned those two into `LabelInteractionHandler` (priority 150) and `SelectionRectangleHandler` (priority 200), which inverted the order - and since the dispatcher stops at the first handler that returns true, the selection rectangle now takes every mouse move and the label never gets one. Clicking a label still highlights it, but dragging it draws a selection box instead of moving the label.

The fix is in `SelectionRectangleHandler::matches`: it no longer claims a mouse move while a label is held, which puts the old ordering back. Sizing a label is unaffected - that case is answered first and still takes the move.

#### Motivation for adding to Mudlet

Moving a map label by dragging it is how you place labels on a map, and it has been broken since 4.20.0.

**Test case:** open the mapper, right-click on an empty spot and create a label, then click the label and drag it. It should follow the mouse. Right-clicking the label and choosing "Move" should also still work, and dragging out a selection box over rooms should be unchanged.

#### Before / after

| Before | After |
| --- | --- |
| ![before](https://gist.githubusercontent.com/vadi2/457a2e4e20e1d4934020e9f27d1a7133/raw/5d9025f6070d24d9371eb886ef62da8941942813/pr10492-before.png) | ![after](https://gist.githubusercontent.com/vadi2/457a2e4e20e1d4934020e9f27d1a7133/raw/5d9025f6070d24d9371eb886ef62da8941942813/pr10492-after.png) |

Label picked up and the mouse moved to (3, 1): before, the label stayed put and a selection box formed instead; after, the label follows the mouse to its new spot.

#### Other info (issues closed, discussion etc)

Closes #10532.

Depends on #10491, which adds the test file this builds on - the new `test_aPickedUpLabelFollowsTheMouse` case goes in there. It was the test that found this, and it goes red on the current code:

```
FAIL!  : MapMouseInteractionTest::test_aPickedUpLabelFollowsTheMouse() Compared doubles are not the same (fuzzy compare)
   Actual   (static_cast<double>(moved.x())): 2
   Expected (3.0)                           : 3
```

All 15 map test cases pass with the change in.

