### PR TITLE
Infra: Core files print through Host instead of the console widget

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2074,6 +2074,36 @@ void Host::refreshMainConsoleColors()
     mpMainConsoleModel->buffer.updateColors();
 }
 
+void Host::printToMainConsole(const QString& msg)
+{
+    mpConsole->print(msg);
+}
+
+void Host::printToMainConsole(const QString& msg, QColor fgColor, QColor bgColor)
+{
+    mpConsole->print(msg, fgColor, bgColor);
+}
+
+void Host::printSystemMessage(const QString& msg)
+{
+    mpConsole->printSystemMessage(msg);
+}
+
+void Host::printOnDisplay(std::string& data, bool isFromServer)
+{
+    mpConsole->printOnDisplay(data, isFromServer);
+}
+
+void Host::finalizeMainConsole()
+{
+    mpConsole->finalize();
+}
+
+bool Host::mainConsoleShowsTimeStamps() const
+{
+    return mpConsole->showTimeStamps();
+}
+
 void Host::raiseLoggingAnnouncement(const bool isLogging, const QString& logFileName)
 {
     emit signal_loggingAnnouncement(isLogging, logFileName);

--- a/src/Host.h
+++ b/src/Host.h
@@ -53,6 +53,7 @@
 #include <QTextStream>
 
 #include <memory>
+#include <string>
 
 #include "TMxpMudlet.h"
 #include "TMxpProcessor.h"
@@ -375,6 +376,12 @@ public:
     void readPackageConfig(const QString&, QString&, bool, QString* whyNotRead = nullptr);
     QString getPackageConfig(const QString&, bool isModule = false, QString* whyNotRead = nullptr);
     void postMessage(const QString message) { mTelnet.postMessage(message); }
+    void printToMainConsole(const QString& msg);
+    void printToMainConsole(const QString& msg, QColor fgColor, QColor bgColor);
+    void printSystemMessage(const QString& msg);
+    void printOnDisplay(std::string& data, bool isFromServer);
+    void finalizeMainConsole();
+    bool mainConsoleShowsTimeStamps() const;
     QColor getAnsiColor(const int ansiCode, const bool isBackground = false) const;
     QPair<bool, QString> writeProfileData(const QString&, const QString&);
     QString readProfileData(const QString&);

--- a/src/MMCPServer.cpp
+++ b/src/MMCPServer.cpp
@@ -994,8 +994,8 @@ void MMCPServer::clientMessage(const QString& fromStr, const QString& message)
     // other end-of-line indications the text does not get flushed to the
     // display until it does - so actually we need to re-append a final
     // line-feed that we may have previously trimmed off!
-    mpHost->mpConsole->printOnDisplay(trimmedStdStr.append(1, '\n'), false);
-    mpHost->mpConsole->finalize();
+    mpHost->printOnDisplay(trimmedStdStr.append(1, '\n'), false);
+    mpHost->finalizeMainConsole();
 }
 
 /**
@@ -1011,8 +1011,8 @@ void MMCPServer::snoopMessage(const std::string& message)
 
     std::string outStr = ss.str();
 
-    mpHost->mpConsole->printOnDisplay(outStr, false);
-    mpHost->mpConsole->finalize();
+    mpHost->printOnDisplay(outStr, false);
+    mpHost->finalizeMainConsole();
 }
 
 

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -27,7 +27,6 @@
 
 #include "Host.h"
 #include "T2DMap.h"
-#include "TConsole.h"
 #include "TRoomDB.h"
 
 #include <QBuffer>
@@ -373,7 +372,7 @@ void TArea::addRoom(int id)
         }
     } else {
         const QString error = tr("roomID=%1 does not exist, can not set properties of a non-existent room!").arg(id);
-        mpMap->mpHost->mpConsole->printSystemMessage(error);
+        mpMap->mpHost->printSystemMessage(error);
     }
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2275,7 +2275,7 @@ void TBuffer::startServerWrapFlushTimer()
             mpHost->mpConsole->mTriggerEngineMode = true;
             flushPendingServerWrapJoin();
             mpHost->mpConsole->mTriggerEngineMode = false;
-            mpHost->mpConsole->finalize();
+            mpHost->finalizeMainConsole();
         });
     }
     mpServerWrapFlushTimer->start();
@@ -2377,7 +2377,7 @@ void TBuffer::processMxpWatchdogCallback()
                 }
                 commitLine('\r', unusedBufferPosition);
                 hostGuard->mMxpProcessor.getMxpTagBuilder().reset();
-                hostGuard->mpConsole->finalize();
+                hostGuard->finalizeMainConsole();
             });
         }
         mWatchdogPhase = WatchdogPhase::None;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1095,8 +1095,8 @@ void TConsole::slot_toggleReplayRecording()
         }
         if (!telnet.startReplayRecording(mLogFileName)) {
             qWarning() << "TConsole: failed to open replay file for writing:" << telnet.replayRecordingErrorString();
-            //: Informational message displayed when replay recording file could not be opened
-            printSystemMessage(tr("Failed to open replay recording file for writing.") % QChar::LineFeed);
+            //: Informational message displayed when replay recording file could not be opened. %1 is the reason
+            printSystemMessage(tr("Failed to open replay recording file for writing: %1").arg(telnet.replayRecordingErrorString()) % QChar::LineFeed);
             return;
         }
         printSystemMessage(tr("Replay recording has started. File: %1").arg(telnet.replayRecordingFileName()) % QChar::LineFeed);
@@ -1104,9 +1104,9 @@ void TConsole::slot_toggleReplayRecording()
         replayButton->setToolTip(utils::richText(tr("Stop recording of replay")));
     } else {
         if (!telnet.stopReplayRecording()) {
-            qDebug() << "TConsole::slot_toggleReplayRecording: error saving replay: " << telnet.replayRecordingErrorString();
-            //: Informational message displayed when replay recording is stopped but could not be saved
-            printSystemMessage(tr("Replay recording has been stopped, but couldn't be saved.") % QChar::LineFeed);
+            qWarning() << "TConsole::slot_toggleReplayRecording: error saving replay: " << telnet.replayRecordingErrorString();
+            //: Informational message displayed when replay recording is stopped but could not be saved. %1 is the reason
+            printSystemMessage(tr("Replay recording has been stopped, but couldn't be saved: %1").arg(telnet.replayRecordingErrorString()) % QChar::LineFeed);
         } else {
             //: Informational message displayed when replay recording is stopped
             printSystemMessage(tr("Replay recording has been stopped. File: %1").arg(telnet.replayRecordingFileName()) % QChar::LineFeed);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -52,6 +52,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPainter>
+#include <QSaveFile>
 #include <QScrollBar>
 #include <QSettings>
 #include <QShortcut>
@@ -1084,36 +1085,31 @@ void TConsole::slot_toggleReplayRecording()
     if (mType & CentralDebugConsole) {
         return;
     }
-    mRecordReplay = !mRecordReplay;
-    if (mRecordReplay) {
+    cTelnet& telnet = mpHost->mTelnet;
+    if (!telnet.recordingReplay()) {
         const QString directoryLogFile = mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, mProfileName);
         const QString mLogFileName = qsl("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
         const QDir dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
         }
-        mReplayFile.setFileName(mLogFileName);
-        if (!mReplayFile.open(QIODevice::WriteOnly)) {
-            qWarning() << "TConsole: failed to open replay file for writing:" << mReplayFile.errorString();
-            mRecordReplay = false;
+        if (!telnet.startReplayRecording(mLogFileName)) {
+            qWarning() << "TConsole: failed to open replay file for writing:" << telnet.replayRecordingErrorString();
             //: Informational message displayed when replay recording file could not be opened
             printSystemMessage(tr("Failed to open replay recording file for writing.") % QChar::LineFeed);
             return;
         }
-        mReplayStream.setVersion(QDataStream::Qt_5_12);
-        mReplayStream.setDevice(&mReplayFile);
-        mpHost->mTelnet.recordReplay();
-        printSystemMessage(tr("Replay recording has started. File: %1").arg(mReplayFile.fileName()) % QChar::LineFeed);
+        printSystemMessage(tr("Replay recording has started. File: %1").arg(telnet.replayRecordingFileName()) % QChar::LineFeed);
         //: Button tooltip for the replay recording toggle button
         replayButton->setToolTip(utils::richText(tr("Stop recording of replay")));
     } else {
-        if (!mReplayFile.commit()) {
-            qDebug() << "TConsole::slot_toggleReplayRecording: error saving replay: " << mReplayFile.errorString();
+        if (!telnet.stopReplayRecording()) {
+            qDebug() << "TConsole::slot_toggleReplayRecording: error saving replay: " << telnet.replayRecordingErrorString();
             //: Informational message displayed when replay recording is stopped but could not be saved
             printSystemMessage(tr("Replay recording has been stopped, but couldn't be saved.") % QChar::LineFeed);
         } else {
             //: Informational message displayed when replay recording is stopped
-            printSystemMessage(tr("Replay recording has been stopped. File: %1").arg(mReplayFile.fileName()) % QChar::LineFeed);
+            printSystemMessage(tr("Replay recording has been stopped. File: %1").arg(telnet.replayRecordingFileName()) % QChar::LineFeed);
         }
         //: Button tooltip for the replay recording toggle button
         replayButton->setToolTip(utils::richText(tr("Start recording of replay")));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -436,6 +436,13 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
     //: Button tooltip for the replay recording toggle button
     replayButton->setToolTip(utils::richText(tr("Start recording of replay")));
     connect(replayButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleReplayRecording);
+    // cTelnet commits and stops a recording when the connection ends, so the
+    // button must not be left pressed as though one were still running:
+    connect(&mpHost->mTelnet, &cTelnet::signal_disconnected, this, [this]() {
+        replayButton->setChecked(false);
+        //: Button tooltip for the replay recording toggle button
+        replayButton->setToolTip(utils::richText(tr("Start recording of replay")));
+    });
 
     logButton = new QToolButton;
     logButton->setMinimumSize(QSize(30, 30));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1094,6 +1094,10 @@ void TConsole::slot_toggleReplayRecording()
             dirLogFile.mkpath(directoryLogFile);
         }
         if (!telnet.startReplayRecording(mLogFileName)) {
+            // The button has already toggled itself on - clicked() fires after
+            // that - so put it back rather than leave it looking pressed with
+            // no recording behind it:
+            replayButton->setChecked(false);
             qWarning() << "TConsole: failed to open replay file for writing:" << telnet.replayRecordingErrorString();
             //: Informational message displayed when replay recording file could not be opened. %1 is the reason
             printSystemMessage(tr("Failed to open replay recording file for writing: %1").arg(telnet.replayRecordingErrorString()) % QChar::LineFeed);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -31,13 +31,11 @@
 #include "TConsoleModel.h"
 #include "TPrintSink.h"
 
-#include <QDataStream>
 #include <QElapsedTimer>
 #include <QFont>
 #include <QIcon>
 #include <QPixmap>
 #include <QPointer>
-#include <QSaveFile>
 #include <QWidget>
 
 #include <hunspell/hunspell.h>
@@ -420,9 +418,6 @@ public:
     QScrollBar* mpHScrollBar = nullptr;
 
     QElapsedTimer mProcessingTimer;
-    bool mRecordReplay = false;
-    QSaveFile mReplayFile;
-    QDataStream mReplayStream;
 
     bool mTriggerEngineMode = false;
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -41,6 +41,7 @@
 #include "mudlet.h"
 #include "GifTracker.h"
 
+#include <QDataStream>
 #include <QDialog>
 #include <QDockWidget>
 #include <QIcon>
@@ -50,6 +51,7 @@
 #include <QMimeData>
 #include <QProgressDialog>
 #include <QUiLoader>
+#include <QSaveFile>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QSizePolicy>

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1272,7 +1272,7 @@ void TMedia::connectMediaPlayer(std::shared_ptr<TMediaPlayer>& player)
 
         if (TDebug::smDebugMode && mpHost && mpHost->mpConsole) {
             //: %1 is the media backend's own description of what went wrong, e.g. "Failed to load media".
-            mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Media error: %1").arg(errorString)));
+            mpHost->printSystemMessage(qsl("%1\n").arg(tr("Media error: %1").arg(errorString)));
         }
 
         // Only a failure nothing else will report is ended from here. A track that was playing
@@ -1410,7 +1410,7 @@ void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_
         TMedia::purgeStoppedMediaPlayers(list);
 
         if (TDebug::smDebugMode && mediaInstance && mediaInstance->mpHost && mediaInstance->mpHost->mpConsole) {
-            mediaInstance->mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Too many stopped media players. Purging stopped players.")));
+            mediaInstance->mpHost->printSystemMessage(qsl("%1\n").arg(tr("Too many stopped media players. Purging stopped players.")));
         }
 
         if (list.size() > mediaInstance->getMaxUnprunedPlayers()) {
@@ -1418,7 +1418,7 @@ void TMedia::updateList(QList<std::shared_ptr<T>>& list, int index, std::shared_
             list.removeFirst(); // Evict the oldest player to enforce cap
 
             if (TDebug::smDebugMode && mediaInstance && mediaInstance->mpHost && mediaInstance->mpHost->mpConsole) {
-                mediaInstance->mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Too many stopped media players. Removed oldest active player.")));
+                mediaInstance->mpHost->printSystemMessage(qsl("%1\n").arg(tr("Too many stopped media players. Removed oldest active player.")));
             }
         }
     }
@@ -1513,7 +1513,7 @@ std::shared_ptr<TMediaPlayer> TMedia::getMediaPlayer(TMediaData& mediaData)
         qWarning() << "TMedia::getMediaPlayer() - Too many active players for media type. Skipping creation.";
 
         if (TDebug::smDebugMode && mpHost && mpHost->mpConsole) {
-            mpHost->mpConsole->printSystemMessage(qsl("%1\n").arg(tr("Maximum allowed active media players reached for media type. Cannot play additional media.")));
+            mpHost->printSystemMessage(qsl("%1\n").arg(tr("Maximum allowed active media players reached for media type. Cannot play additional media.")));
         }
 
         return nullptr;
@@ -2525,6 +2525,6 @@ void TMedia::printClosedCaption(const TMediaData& mediaData, const QString& acti
         }
     }
 
-    mpHost->mpConsole->print(message);
+    mpHost->printToMainConsole(message);
 }
 // End Private

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -29,6 +29,7 @@
 #include "TMap.h"
 #include "TRoomDB.h"
 
+#include <QDataStream>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -261,8 +262,7 @@ void TRoom::setExitStub(int direction, bool status)
                 exitStubs.append(direction);
             }
         } else {
-            mpRoomDB->mpMap->logError(tr("Cannot set exit stub in given direction in RoomID %1. There is already an exit there!")
-                                              .arg(QString::number(id)));
+            mpRoomDB->mpMap->logError(tr("Cannot set exit stub in given direction in RoomID %1. There is already an exit there!").arg(QString::number(id)));
             // Since there is no change don't proceed to mark map as needing saving
             return;
         }
@@ -372,8 +372,7 @@ bool TRoom::setArea(int areaID)
         mpRoomDB->addArea(areaID);
         pA = mpRoomDB->getArea(areaID);
         if (!pA) { // Oh dear, THAT didn't work
-            mpRoomDB->mpMap->logError(tr("Requested AreaID %1 did not exist and could not be created. Note: Area numbers must be greater than zero!")
-                                              .arg(QString::number(areaID)));
+            mpRoomDB->mpMap->logError(tr("Requested AreaID %1 did not exist and could not be created. Note: Area numbers must be greater than zero!").arg(QString::number(areaID)));
             return false;
         }
     }
@@ -384,8 +383,7 @@ bool TRoom::setArea(int areaID)
         pA2->removeRoom(id);
     } else {
         //: Although this is reported as an error it is not a problem
-        mpRoomDB->mpMap->logError(tr("When setting the Area for RoomID %1 it did not have a current area, this is unexpected but not a problem!")
-                                          .arg(QString::number(id)));
+        mpRoomDB->mpMap->logError(tr("When setting the Area for RoomID %1 it did not have a current area, this is unexpected but not a problem!").arg(QString::number(id)));
     }
 
     area = areaID;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -27,6 +27,7 @@
 #include "T2DMap.h"
 #include "TMap.h"
 
+#include <QDataStream>
 #include <QElapsedTimer>
 #include <QRegularExpression>
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -38,6 +38,7 @@
 #include "VarUnit.h"
 #include "mudlet.h"
 
+#include <QSaveFile>
 #include <QRegularExpression>
 #include <QVersionNumber>
 #include <QtConcurrentRun>

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -33,10 +33,9 @@
 #include "Host.h"
 #include "TBuffer.h"
 #include "TMxpProcessor.h"
-#include "TConsole.h"
+#include "TConsoleModel.h"
 #include "TDebug.h"
 #include "TEvent.h"
-#include "TMainConsole.h"
 #include "TMap.h"
 #include "TMedia.h"
 #include "TRoomDB.h"
@@ -239,9 +238,9 @@ void cTelnet::reset()
     // Half of an ANSI sequence left over from the previous connection can only
     // ever be completed by bytes that will never arrive, so drop it instead of
     // letting it consume the new connection's output. There is nothing to drop
-    // when this runs from the Host constructor, before the profile has a console:
-    if (mpHost->mpConsole) {
-        mpHost->mpConsole->buffer.resetSequenceParserState();
+    // when this runs from the Host constructor, before the profile has a console model:
+    if (auto* pModel = mpHost->mainConsoleModelOrNull()) {
+        pModel->buffer.resetSequenceParserState();
     }
 
     // A fresh connection: the player has not interacted yet, so an unsolicited Char.Login.URL must
@@ -974,10 +973,10 @@ void cTelnet::slot_socketDisconnected()
     }
 
     postData();
-    if (mpHost->mpConsole) {
+    if (auto* pModel = mpHost->mainConsoleModelOrNull()) {
         // A line held back for server-wrap undoing is complete now that the
         // connection is gone - commit it before the disconnect messages:
-        mpHost->mpConsole->buffer.flushPendingServerWrapJoin();
+        pModel->buffer.flushPendingServerWrapJoin();
     }
 
     emit signal_disconnected(mpHost);
@@ -1731,7 +1730,7 @@ void cTelnet::checkNAWS()
     }
     // Use the smaller of the screen width or the wrapAt, then subtract the
     // width of the time stamps if they are showing:
-    int naws_x = std::min(pHost->mScreenWidth, pHost->mWrapAt) - (pHost->mpConsole->showTimeStamps() ? TBuffer::smTimeStampFormat.size() : 0);
+    int naws_x = std::min(pHost->mScreenWidth, pHost->mWrapAt) - (pHost->mainConsoleShowsTimeStamps() ? TBuffer::smTimeStampFormat.size() : 0);
     int naws_y = pHost->mScreenHeight;
     if ((naws_y > 0) && (myOptionState.test(static_cast<size_t>(OPT_NAWS))) && ((mNaws_x != naws_x) || (mNaws_y != naws_y))) {
         sendNAWS(naws_x, naws_y);
@@ -4907,8 +4906,8 @@ void cTelnet::postMessage(QString msg)
             body.removeFirst();
             //: Keep the capitalisation, the translated text at 7 letters max so it aligns nicely
             if (prefix.contains(tr("ERROR")) || prefix.contains(QLatin1String("ERROR"))) {
-                mpHost->mpConsole->print(prefix, Qt::red, mpHost->mBgColor);                                  // Bright Red
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
+                mpHost->printToMainConsole(prefix, Qt::red, mpHost->mBgColor);                                  // Bright Red
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
@@ -4916,93 +4915,93 @@ void cTelnet::postMessage(QString msg)
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 }
                 //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("LUA")) || prefix.contains(QLatin1String("LUA"))) {
-                mpHost->mpConsole->print(prefix, QColor(80, 160, 255), mpHost->mBgColor);                    // Light blue
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(50, 200, 50), mpHost->mBgColor); // Light green
+                mpHost->printToMainConsole(prefix, QColor(80, 160, 255), mpHost->mBgColor);                    // Light blue
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(50, 200, 50), mpHost->mBgColor); // Light green
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(200, 50, 50), mpHost->mBgColor); // Red
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(200, 50, 50), mpHost->mBgColor); // Red
                 }
                 //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("WARN")) || prefix.contains(QLatin1String("WARN"))) {
-                mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                     // Cyan
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 150, 0), mpHost->mBgColor); // Orange
+                mpHost->printToMainConsole(prefix, QColor(0, 150, 190), mpHost->mBgColor);                     // Cyan
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(190, 150, 0), mpHost->mBgColor); // Orange
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 150, 0), mpHost->mBgColor);
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(190, 150, 0), mpHost->mBgColor);
                 }
                 //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("ALERT")) || prefix.contains(QLatin1String("ALERT"))) {
-                mpHost->mpConsole->print(prefix, QColor(190, 100, 50), mpHost->mBgColor);                     // Orange-ish
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
+                mpHost->printToMainConsole(prefix, QColor(190, 100, 50), mpHost->mBgColor);                     // Orange-ish
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 }
                 //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("INFO")) || prefix.contains(QLatin1String("INFO"))) {
-                mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                   // Cyan
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
+                mpHost->printToMainConsole(prefix, QColor(0, 150, 190), mpHost->mBgColor);                   // Cyan
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 }
                 //: Keep the capisalisation, the translated text at 7 letters max so it aligns nicely
             } else if (prefix.contains(tr("OK")) || prefix.contains(QLatin1String("OK"))) {
-                mpHost->mpConsole->print(prefix, QColor(0, 160, 0), mpHost->mBgColor);                        // Light Green
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
+                mpHost->printToMainConsole(prefix, QColor(0, 160, 0), mpHost->mBgColor);                        // Light Green
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orange-ish
                 }
             } else if (prefix.contains(tr("CHAT")) || prefix.contains(QLatin1String("CHAT"))) {
-                mpHost->mpConsole->print(prefix, QColor(255, 255, 50), mpHost->mBgColor);                  // Bright yellow
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
+                mpHost->printToMainConsole(prefix, QColor(255, 255, 50), mpHost->mBgColor);                  // Bright yellow
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(255, 50, 50), mpHost->mBgColor); // Red-ish
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(255, 50, 50), mpHost->mBgColor); // Red-ish
                 }
             } else {                                                                                        // Unrecognised but still in a "[ something ] -  message..." format
-                mpHost->mpConsole->print(prefix, QColor(190, 50, 50), mpHost->mBgColor);                    // Foreground red, background bright grey
-                mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(50, 50, 50), mpHost->mBgColor); //Foreground dark grey, background bright grey
+                mpHost->printToMainConsole(prefix, QColor(190, 50, 50), mpHost->mBgColor);                  // Foreground red, background bright grey
+                mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(50, 50, 50), mpHost->mBgColor); //Foreground dark grey, background bright grey
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
                     temp.replace('\t', QLatin1String("        "));
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if (!body.empty()) {
-                    mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(50, 50, 50), mpHost->mBgColor); //Foreground dark grey, background bright grey
+                    mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(50, 50, 50), mpHost->mBgColor); //Foreground dark grey, background bright grey
                 }
             }
         } else {                                                                                             // No prefix found
-            mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 190, 190), mpHost->mBgColor); //Foreground bright grey
+            mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(190, 190, 190), mpHost->mBgColor); //Foreground bright grey
         }
         messageStack.removeFirst();
     }
@@ -5158,7 +5157,7 @@ void cTelnet::slot_timerPosting()
     mMudData = "";
     mIsTimerPosting = false;
     if (mpHost && mpHost->mpConsole) {
-        mpHost->mpConsole->finalize();
+        mpHost->finalizeMainConsole();
     }
 }
 
@@ -5175,7 +5174,7 @@ void cTelnet::postData()
 
     // All data goes through main console's printOnDisplay which calls
     // translateToPlainText - MXP DEST routing happens inside that process
-    mpHost->mpConsole->printOnDisplay(data, true);
+    mpHost->printOnDisplay(data, true);
     if (mpHost->mMMCPServer && !mpHost->mIsRemoteEchoingActive) {
         mpHost->mMMCPServer->receiveFromPlayer(data);
     }
@@ -5255,11 +5254,25 @@ int cTelnet::decompressBuffer(char*& in_buffer, int& length, char* out_buffer)
 }
 
 
-void cTelnet::recordReplay()
+bool cTelnet::startReplayRecording(const QString& fileName)
 {
+    mReplayFile.setFileName(fileName);
+    if (!mReplayFile.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+    mReplayStream.setVersion(QDataStream::Qt_5_12);
+    mReplayStream.setDevice(&mReplayFile);
     mRecordLastChunkMSecTimeOffset = 0;
     mRecordingChunkTimer.start();
     mRecordingChunkCount = 0;
+    mRecordReplay = true;
+    return true;
+}
+
+bool cTelnet::stopReplayRecording()
+{
+    mRecordReplay = false;
+    return mReplayFile.commit();
 }
 
 bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
@@ -5438,7 +5451,7 @@ void cTelnet::slot_processReplayChunk()
     }
 
     if (mpHost && mpHost->mpConsole) {
-        mpHost->mpConsole->finalize();
+        mpHost->finalizeMainConsole();
     }
     if (loadingReplay) {
         loadReplayChunk();
@@ -5557,15 +5570,15 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (4 of 7) - investigate switching from using `char[]` to `std::array<char>`
     buffer[static_cast<size_t>(datalen)] = '\0';
 
-    if (!loopbackTesting && mpHost && mpHost->mpConsole && mpHost->mpConsole->mRecordReplay) {
+    if (!loopbackTesting && mRecordReplay) {
         ++mRecordingChunkCount;
         // QElapsedTimer::elapsed() returns a qint64, it replaces a
         // previous QTime::elapsed() which returns a int (effectively a
         // qint32):
         qint32 recordingChunkInterval = static_cast<qint32>(mRecordingChunkTimer.elapsed()) - mRecordLastChunkMSecTimeOffset;
-        mpHost->mpConsole->mReplayStream << recordingChunkInterval; // 4 bytes
-        mpHost->mpConsole->mReplayStream << datalen;                // 4 bytes
-        mpHost->mpConsole->mReplayStream.writeRawData(buffer, datalen);
+        mReplayStream << recordingChunkInterval; // 4 bytes
+        mReplayStream << datalen;                // 4 bytes
+        mReplayStream.writeRawData(buffer, datalen);
 #if defined(DEBUG_RECORDING)
         qDebug().noquote().nospace() << "cTelnet::processSocketData(...) INFO - recording chunk: " << mRecordingChunkCount << " is " << datalen
                                      << " bytes and has an interval of: " << recordingChunkInterval << " mSecond since the previous chunk.";
@@ -5791,7 +5804,7 @@ Some data loss is likely - please mention this problem to the game admins.)",
     }
 
     if (mpHost && mpHost->mpConsole) {
-        mpHost->mpConsole->finalize();
+        mpHost->finalizeMainConsole();
     }
 
     mRecordLastChunkMSecTimeOffset = mRecordingChunkTimer.elapsed();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -973,10 +973,10 @@ void cTelnet::slot_socketDisconnected()
     }
 
     postData();
-    if (auto* pModel = mpHost->mainConsoleModelOrNull()) {
+    if (mpHost->mpConsole) {
         // A line held back for server-wrap undoing is complete now that the
         // connection is gone - commit it before the disconnect messages:
-        pModel->buffer.flushPendingServerWrapJoin();
+        mpHost->mainConsoleModel().buffer.flushPendingServerWrapJoin();
     }
 
     emit signal_disconnected(mpHost);
@@ -4988,8 +4988,8 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(255, 50, 50), mpHost->mBgColor); // Red-ish
                 }
-            } else {                                                                                        // Unrecognised but still in a "[ something ] -  message..." format
-                mpHost->printToMainConsole(prefix, QColor(190, 50, 50), mpHost->mBgColor);                  // Foreground red, background bright grey
+            } else {                                                                                          // Unrecognised but still in a "[ something ] -  message..." format
+                mpHost->printToMainConsole(prefix, QColor(190, 50, 50), mpHost->mBgColor);                    // Foreground red, background bright grey
                 mpHost->printToMainConsole(firstLineTail.append('\n'), QColor(50, 50, 50), mpHost->mBgColor); //Foreground dark grey, background bright grey
                 for (int _i = 0; _i < body.size(); ++_i) {
                     QString temp = body.at(_i);
@@ -5000,7 +5000,7 @@ void cTelnet::postMessage(QString msg)
                     mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(50, 50, 50), mpHost->mBgColor); //Foreground dark grey, background bright grey
                 }
             }
-        } else {                                                                                             // No prefix found
+        } else {                                                                                               // No prefix found
             mpHost->printToMainConsole(body.join('\n').append('\n'), QColor(190, 190, 190), mpHost->mBgColor); //Foreground bright grey
         }
         messageStack.removeFirst();
@@ -5256,12 +5256,13 @@ int cTelnet::decompressBuffer(char*& in_buffer, int& length, char* out_buffer)
 
 bool cTelnet::startReplayRecording(const QString& fileName)
 {
-    mReplayFile.setFileName(fileName);
-    if (!mReplayFile.open(QIODevice::WriteOnly)) {
+    if (mRecordReplay) {
         return false;
     }
-    mReplayStream.setVersion(QDataStream::Qt_5_12);
-    mReplayStream.setDevice(&mReplayFile);
+    mpReplayFile = std::make_unique<QSaveFile>(fileName);
+    if (!mpReplayFile->open(QIODevice::WriteOnly)) {
+        return false;
+    }
     mRecordLastChunkMSecTimeOffset = 0;
     mRecordingChunkTimer.start();
     mRecordingChunkCount = 0;
@@ -5272,7 +5273,17 @@ bool cTelnet::startReplayRecording(const QString& fileName)
 bool cTelnet::stopReplayRecording()
 {
     mRecordReplay = false;
-    return mReplayFile.commit();
+    return mpReplayFile && mpReplayFile->commit();
+}
+
+QString cTelnet::replayRecordingFileName() const
+{
+    return mpReplayFile ? mpReplayFile->fileName() : QString();
+}
+
+QString cTelnet::replayRecordingErrorString() const
+{
+    return mpReplayFile ? mpReplayFile->errorString() : QString();
 }
 
 bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
@@ -5576,9 +5587,11 @@ void cTelnet::processSocketData(char* in_buffer, int amount, const bool loopback
         // previous QTime::elapsed() which returns a int (effectively a
         // qint32):
         qint32 recordingChunkInterval = static_cast<qint32>(mRecordingChunkTimer.elapsed()) - mRecordLastChunkMSecTimeOffset;
-        mReplayStream << recordingChunkInterval; // 4 bytes
-        mReplayStream << datalen;                // 4 bytes
-        mReplayStream.writeRawData(buffer, datalen);
+        QDataStream replayStream(mpReplayFile.get());
+        replayStream.setVersion(QDataStream::Qt_5_12);
+        replayStream << recordingChunkInterval; // 4 bytes
+        replayStream << datalen;                // 4 bytes
+        replayStream.writeRawData(buffer, datalen);
 #if defined(DEBUG_RECORDING)
         qDebug().noquote().nospace() << "cTelnet::processSocketData(...) INFO - recording chunk: " << mRecordingChunkCount << " is " << datalen
                                      << " bytes and has an interval of: " << recordingChunkInterval << " mSecond since the previous chunk.";

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -263,6 +263,13 @@ void cTelnet::reset()
 
 cTelnet::~cTelnet()
 {
+    // A recording that is still running would otherwise be thrown away:
+    // ~QSaveFile() calls cancelWriting(), which deletes the temporary file
+    // without ever producing the .dat the user has been recording into.
+    if (mRecordReplay) {
+        stopReplayRecording();
+    }
+
     // Stop all timers immediately
     if (mTimerLogin) {
         mTimerLogin->stop();
@@ -977,6 +984,20 @@ void cTelnet::slot_socketDisconnected()
         // A line held back for server-wrap undoing is complete now that the
         // connection is gone - commit it before the disconnect messages:
         mpHost->mainConsoleModel().buffer.flushPendingServerWrapJoin();
+    }
+
+    // The session being recorded has ended, so commit what was captured rather
+    // than leave it to ~QSaveFile(), which cancels the save and deletes the
+    // temporary file:
+    if (mRecordReplay) {
+        const QString recordedFileName = replayRecordingFileName();
+        if (stopReplayRecording()) {
+            //: Message shown when a replay recording is saved because the connection to the game ended. %1 is the file name
+            postMessage(tr("[ INFO ]  - Replay recording has been stopped and saved. File: %1").arg(recordedFileName));
+        } else {
+            //: Message shown when a replay recording could not be saved after the connection to the game ended. %1 is the reason
+            postMessage(tr("[ WARN ]  - Replay recording has been stopped, but couldn't be saved: %1").arg(replayRecordingErrorString()));
+        }
     }
 
     emit signal_disconnected(mpHost);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -32,12 +32,10 @@
 #include <winsock2.h>
 #endif
 
-#include <QDataStream>
 #include <QElapsedTimer>
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QPointer>
-#include <QSaveFile>
 #include <QScopeGuard>
 #include <QStringList>
 #if defined(QT_NO_SSL)
@@ -52,6 +50,7 @@
 
 #include <bitset>
 #include <iostream>
+#include <memory>
 #include <queue>
 #include <string>
 #include <utility>
@@ -73,6 +72,7 @@
 #endif
 
 class QJsonDocument;
+class QSaveFile;
 class QJsonObject;
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -209,8 +209,8 @@ public:
     bool recordingReplay() const { return mRecordReplay; }
     bool startReplayRecording(const QString& fileName);
     bool stopReplayRecording();
-    QString replayRecordingFileName() const { return mReplayFile.fileName(); }
-    QString replayRecordingErrorString() const { return mReplayFile.errorString(); }
+    QString replayRecordingFileName() const;
+    QString replayRecordingErrorString() const;
     bool loadReplay(const QString&, QString* pErrMsg = nullptr);
     void loadReplayChunk();
     bool isReplaying() { return loadingReplay; }
@@ -566,8 +566,7 @@ private:
     QElapsedTimer mConnectionTimer;
     qint32 mRecordLastChunkMSecTimeOffset = 0;
     int mRecordingChunkCount = 0;
-    QSaveFile mReplayFile;
-    QDataStream mReplayStream;
+    std::unique_ptr<QSaveFile> mpReplayFile;
     bool mRecordReplay = false;
     int mCycleCountMTTS = 0;
     QSet<QString> newEnvironVariablesSent;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -32,10 +32,12 @@
 #include <winsock2.h>
 #endif
 
+#include <QDataStream>
 #include <QElapsedTimer>
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QPointer>
+#include <QSaveFile>
 #include <QScopeGuard>
 #include <QStringList>
 #if defined(QT_NO_SSL)
@@ -204,7 +206,11 @@ public:
     void set_USE_IRE_DRIVER_BUGFIX(bool b) { mUSE_IRE_DRIVER_BUGFIX = b; }
     void cacheHostSettings();
     void setDontReconnect(bool b) { mDontReconnect = b; }
-    void recordReplay();
+    bool recordingReplay() const { return mRecordReplay; }
+    bool startReplayRecording(const QString& fileName);
+    bool stopReplayRecording();
+    QString replayRecordingFileName() const { return mReplayFile.fileName(); }
+    QString replayRecordingErrorString() const { return mReplayFile.errorString(); }
     bool loadReplay(const QString&, QString* pErrMsg = nullptr);
     void loadReplayChunk();
     bool isReplaying() { return loadingReplay; }
@@ -560,6 +566,9 @@ private:
     QElapsedTimer mConnectionTimer;
     qint32 mRecordLastChunkMSecTimeOffset = 0;
     int mRecordingChunkCount = 0;
+    QSaveFile mReplayFile;
+    QDataStream mReplayStream;
+    bool mRecordReplay = false;
     int mCycleCountMTTS = 0;
     QSet<QString> newEnvironVariablesSent;
     bool mReplayHasFaultyFormat = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -38,6 +38,8 @@
 #include "widgetutils.h"
 #include "utils.h"
 
+#include <QDataStream>
+#include <QSaveFile>
 #include <QtConcurrentRun>
 #include <QtMath>
 #include <QtUiTools>

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -32,6 +32,8 @@
 
 #include "mudlet.h"
 
+#include <QDataStream>
+#include <QSaveFile>
 #include <QDesktopServices>
 #include <QScrollBar>
 #include <QSettings>

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -34,6 +34,7 @@
 #include "TTrigger.h"
 #include "XMLexport.h"
 
+#include <QSaveFile>
 #include <QtConcurrentRun>
 #include <QDesktopServices>
 #include <QDirIterator>

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -60,6 +60,8 @@
 #include "MMCPServer.h"
 #include "widgetutils.h"
 
+#include <QDataStream>
+#include <QSaveFile>
 #include <QAccessible>
 #include <QAccessibleAnnouncementEvent>
 #include <QApplication>

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -22,6 +22,8 @@
 #include "updater/Feed.h"
 #include "updater/UpdateDialog.h"
 
+#include <QDataStream>
+#include <QSaveFile>
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QMessageBox>

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     FramePacingTest.cpp
     GlyphOverflowTest.cpp
     HyperlinkModelSplitTest.cpp
+    HostConsolePrintTest.cpp
     LabelAnchorInteractionTest.cpp
     LabelMovieRefusalTest.cpp
     CaretNavigationTest.cpp

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -233,6 +233,9 @@ private slots:
         QVERIFY(telnet.recordingReplay());
         const QString fileName = telnet.replayRecordingFileName();
         QVERIFY(!fileName.isEmpty());
+        QVERIFY(!telnet.startReplayRecording(fileName % qsl(".second")));
+        QCOMPARE(telnet.replayRecordingFileName(), fileName);
+        QVERIFY(telnet.recordingReplay());
 
         const QByteArray sent{"recorded line\r\n"};
         mpServer->sendRaw(sent);

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -23,7 +23,10 @@
 // message printer, the one caller of the coloured print, is driven through
 // Host::postMessage() so its prefix colouring is pinned as well.
 
+#include <QDataStream>
 #include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
@@ -60,6 +63,16 @@ private:
 
     // The buffer keeps an empty line ready after the last line feed, so what
     // was printed most recently is the last non-empty line.
+    bool bufferContains(const QString& text)
+    {
+        for (int i = 0; i <= buffer().getLastLineNumber(); ++i) {
+            if (buffer().line(i).contains(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     int lastTextLine()
     {
         for (int i = buffer().getLastLineNumber(); i >= 0; --i) {
@@ -129,6 +142,7 @@ private slots:
         const int line = lastTextLine();
         QVERIFY(line >= 0);
         QCOMPARE(buffer().line(line), qsl("plain text"));
+        QCOMPARE(buffer().mCursorY, buffer().size());
     }
 
     void test_colouredPrintKeepsItsColours()
@@ -143,6 +157,7 @@ private slots:
         const std::vector<TChar>& chars = buffer().buffer.at(line);
         QCOMPARE(chars.front().foreground(), fg);
         QCOMPARE(chars.front().background(), bg);
+        QCOMPARE(buffer().mCursorY, buffer().size());
     }
 
     void test_systemMessageIsLabelledAndColoured()
@@ -155,6 +170,7 @@ private slots:
         QVERIFY2(text.endsWith(qsl("careful")), qPrintable(text));
         QVERIFY2(text != qsl("careful"), "the system message label is missing");
         QCOMPARE(buffer().buffer.at(line).front().foreground(), mpHost->mpConsole->mSystemMessageFgColor);
+        QCOMPARE(buffer().mCursorY, buffer().size());
     }
 
     void test_serverTextRunsThroughTheDisplayPipeline()
@@ -204,6 +220,51 @@ private slots:
         const std::vector<TChar>& chars = buffer().buffer.at(line);
         QCOMPARE(chars.front().foreground(), QColor(0, 150, 190));
         QCOMPARE(chars.back().foreground(), QColor(0, 160, 0));
+    }
+
+    // Recording is only reachable from the console's button and the menu, so
+    // the file is read back here rather than replayed: the replay timer would
+    // need MUDLET_TEST_MODE, and the bytes are what a user loses if the stream
+    // is never wired to the file.
+    void test_replayRecordingWritesWhatTheGameSent()
+    {
+        cTelnet& telnet = mpHost->mTelnet;
+        mpHost->mpConsole->slot_toggleReplayRecording();
+        QVERIFY(telnet.recordingReplay());
+        const QString fileName = telnet.replayRecordingFileName();
+        QVERIFY(!fileName.isEmpty());
+
+        const QByteArray sent{"recorded line\r\n"};
+        mpServer->sendRaw(sent);
+        QTRY_VERIFY(bufferContains(qsl("recorded line")));
+
+        mpHost->mpConsole->slot_toggleReplayRecording();
+        QVERIFY(!telnet.recordingReplay());
+        QVERIFY2(QFileInfo::exists(fileName), qPrintable(fileName));
+
+        QFile replay(fileName);
+        QVERIFY(replay.open(QIODevice::ReadOnly));
+        QDataStream in(&replay);
+        in.setVersion(QDataStream::Qt_5_12);
+        QByteArray recorded;
+        while (!in.atEnd()) {
+            qint32 interval = 0;
+            qint32 length = 0;
+            in >> interval >> length;
+            QVERIFY(length >= 0);
+            QByteArray chunk(length, '\0');
+            QCOMPARE(in.readRawData(chunk.data(), length), length);
+            recorded += chunk;
+        }
+        QVERIFY2(recorded.contains(sent), recorded.constData());
+    }
+
+    void test_replayRecordingRefusesAnUnwritablePath()
+    {
+        cTelnet& telnet = mpHost->mTelnet;
+        QVERIFY(!telnet.startReplayRecording(qsl("/nonexistent/directory/replay.dat")));
+        QVERIFY(!telnet.recordingReplay());
+        QVERIFY(!telnet.replayRecordingErrorString().isEmpty());
     }
 };
 

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -1,0 +1,211 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+// Core code prints to the profile's main console through Host rather than
+// through the TMainConsole widget. Each Host forwarder is exercised on a live
+// profile and its effect read back off the main console's buffer; the telnet
+// message printer, the one caller of the coloured print, is driven through
+// Host::postMessage() so its prefix colouring is pinned as well.
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <string>
+#include <vector>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "TBuffer.h"
+#include "TConsoleModel.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgConnectionProfiles.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class HostConsolePrintTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = qsl("Test-HostConsolePrint");
+    const QString mLocalhost = qsl("localhost");
+
+    TBuffer& buffer() { return mpHost->mainConsoleModel().buffer; }
+
+    // The buffer keeps an empty line ready after the last line feed, so what
+    // was printed most recently is the last non-empty line.
+    int lastTextLine()
+    {
+        for (int i = buffer().getLastLineNumber(); i >= 0; --i) {
+            if (!buffer().line(i).isEmpty()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own. Sharing the developer's
+        // ~/.config/mudlet means sharing a profile list, so a second copy of
+        // this test running at the same time is told the name it types is
+        // already in use and never gets an enabled Connect button. Since #9712
+        // the opt-in that makes setupConfig() adopt a directory is
+        // $XDG_CONFIG_HOME/mudlet/profiles, not the mudlet directory alone.
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        // Port 0 asks the OS for an ephemeral port so parallel test runs do
+        // not collide on a hardcoded one
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->isListening(), "TelnetServerStub failed to bind a loopback port");
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "Could not create the test profile - see the warning above for the step that timed out.");
+        QSignalSpy connected(&mpHost->mTelnet, &cTelnet::signal_connected);
+        if (connected.isEmpty()) {
+            QVERIFY2(connected.wait(15000), "The test profile never connected to the stub server.");
+        }
+        QVERIFY(mpHost->mpConsole);
+    }
+
+    void cleanupTestCase()
+    {
+        const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+        mpHost = nullptr;
+        delete mudlet::self();
+        delete mpServer;
+        mpServer = nullptr;
+        QDir(profilePath).removeRecursively();
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_plainPrintLandsOnTheMainConsole()
+    {
+        mpHost->printToMainConsole(qsl("plain text\n"));
+
+        const int line = lastTextLine();
+        QVERIFY(line >= 0);
+        QCOMPARE(buffer().line(line), qsl("plain text"));
+    }
+
+    void test_colouredPrintKeepsItsColours()
+    {
+        const QColor fg(200, 10, 20);
+        const QColor bg(10, 20, 200);
+        mpHost->printToMainConsole(qsl("tinted\n"), fg, bg);
+
+        const int line = lastTextLine();
+        QVERIFY(line >= 0);
+        QCOMPARE(buffer().line(line), qsl("tinted"));
+        const std::vector<TChar>& chars = buffer().buffer.at(line);
+        QCOMPARE(chars.front().foreground(), fg);
+        QCOMPARE(chars.front().background(), bg);
+    }
+
+    void test_systemMessageIsLabelledAndColoured()
+    {
+        mpHost->printSystemMessage(qsl("careful\n"));
+
+        const int line = lastTextLine();
+        QVERIFY(line >= 0);
+        const QString text = buffer().line(line);
+        QVERIFY2(text.endsWith(qsl("careful")), qPrintable(text));
+        QVERIFY2(text != qsl("careful"), "the system message label is missing");
+        QCOMPARE(buffer().buffer.at(line).front().foreground(), mpHost->mpConsole->mSystemMessageFgColor);
+    }
+
+    void test_serverTextRunsThroughTheDisplayPipeline()
+    {
+        std::string data{"from the game\n"};
+        mpHost->printOnDisplay(data, true);
+
+        const int line = lastTextLine();
+        QVERIFY(line >= 0);
+        QCOMPARE(buffer().line(line), qsl("from the game"));
+    }
+
+    // Only showNewLines() advances buffer.mCursorY, so a line appended straight
+    // into the buffer leaves it behind until finalize() catches the view up.
+    void test_finalizeCatchesTheViewUpWithTheBuffer()
+    {
+        TBuffer& buf = buffer();
+        const QString text = qsl("appended\n");
+        buf.append(text, 0, text.size(), TChar(mpHost->mFgColor, mpHost->mBgColor));
+        QVERIFY2(buf.mCursorY < buf.size(), "appending alone caught the view up, so finalize() has nothing left to prove");
+
+        mpHost->finalizeMainConsole();
+
+        QCOMPARE(buf.mCursorY, buf.size());
+    }
+
+    void test_timeStampsAreReadOffTheMainConsole()
+    {
+        QVERIFY(!mpHost->mainConsoleShowsTimeStamps());
+
+        mpHost->mpConsole->slot_toggleTimeStamps(true);
+        QVERIFY(mpHost->mainConsoleShowsTimeStamps());
+
+        mpHost->mpConsole->slot_toggleTimeStamps(false);
+        QVERIFY(!mpHost->mainConsoleShowsTimeStamps());
+    }
+
+    // cTelnet::postMessage() is what every "[ INFO ]  - ..." line goes through,
+    // and it colours the prefix and the text after it separately.
+    void test_telnetMessagesArePrintedWithTheirPrefixColours()
+    {
+        mpHost->postMessage(qsl("[ INFO ]  - hello from the test"));
+
+        const int line = lastTextLine();
+        QVERIFY(line >= 0);
+        QCOMPARE(buffer().line(line), qsl("[ INFO ]  - hello from the test"));
+        const std::vector<TChar>& chars = buffer().buffer.at(line);
+        QCOMPARE(chars.front().foreground(), QColor(0, 150, 190));
+        QCOMPARE(chars.back().foreground(), QColor(0, 160, 0));
+    }
+};
+
+#include "HostConsolePrintTest.moc"
+MUDLET_GROUPED_TEST_MAIN(HostConsolePrintTest)

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -124,6 +124,16 @@ private slots:
         QVERIFY(mpHost->mpConsole);
     }
 
+    // A test that fails part-way through would otherwise leave the recording
+    // running, and the next one to touch it would trip on the "already
+    // recording" guard rather than on what it is testing.
+    void cleanup()
+    {
+        if (mpHost && mpHost->mTelnet.recordingReplay()) {
+            mpHost->mTelnet.stopReplayRecording();
+        }
+    }
+
     void cleanupTestCase()
     {
         const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -127,12 +127,34 @@ private slots:
     void cleanupTestCase()
     {
         const QString profilePath = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+
+        // Profile teardown has to commit a recording that is still running:
+        // ~QSaveFile() cancels the save, so the .dat would never appear. The
+        // name is chosen here rather than taken from the console button, whose
+        // second-resolution name can collide with a recording made earlier in
+        // the same second and make an uncommitted save look committed.
+        QString teardownReplay;
+        if (mpHost) {
+            const QString replayDir = mudlet::getMudletPath(enums::profileReplayAndLogFilesPath, mHostname);
+            QDir().mkpath(replayDir);
+            teardownReplay = qsl("%1/teardown.dat").arg(replayDir);
+            if (QFileInfo::exists(teardownReplay) || !mpHost->mTelnet.startReplayRecording(teardownReplay)) {
+                teardownReplay.clear();
+            }
+        }
+
         mpHost = nullptr;
         delete mudlet::self();
         delete mpServer;
         mpServer = nullptr;
+
+        const bool teardownCommitted = !teardownReplay.isEmpty() && QFileInfo::exists(teardownReplay);
+
         QDir(profilePath).removeRecursively();
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+
+        QVERIFY2(!teardownReplay.isEmpty(), "the recording that teardown was meant to commit never started");
+        QVERIFY2(teardownCommitted, qPrintable(qsl("the replay recording running at teardown was not committed to %1").arg(teardownReplay)));
     }
 
     void test_plainPrintLandsOnTheMainConsole()
@@ -268,6 +290,38 @@ private slots:
         QVERIFY(!telnet.startReplayRecording(qsl("/nonexistent/directory/replay.dat")));
         QVERIFY(!telnet.recordingReplay());
         QVERIFY(!telnet.replayRecordingErrorString().isEmpty());
+    }
+
+    // Last, because it drops the connection the earlier tests rely on. What the
+    // game sent has to reach the file even though nothing stops the recording:
+    // an uncommitted QSaveFile takes the whole session down with it.
+    void test_replayRecordingIsCommittedWhenTheConnectionDrops()
+    {
+        cTelnet& telnet = mpHost->mTelnet;
+        mpHost->mpConsole->slot_toggleReplayRecording();
+        QVERIFY(telnet.recordingReplay());
+        const QString fileName = telnet.replayRecordingFileName();
+        QVERIFY(!fileName.isEmpty());
+
+        const QByteArray sent{"dropped mid-recording\r\n"};
+        mpServer->sendRaw(sent);
+        QTRY_VERIFY(bufferContains(qsl("dropped mid-recording")));
+
+        QSignalSpy disconnected(&telnet, &cTelnet::signal_disconnected);
+        telnet.disconnectIt();
+        // A loopback socket can be gone before disconnectIt() returns, and
+        // QSignalSpy::wait() waits for the *next* signal after the ones it
+        // already holds:
+        if (disconnected.isEmpty()) {
+            QVERIFY2(disconnected.wait(15000), "the test profile never noticed the disconnection");
+        }
+
+        QVERIFY(!telnet.recordingReplay());
+        QVERIFY2(QFileInfo::exists(fileName), qPrintable(fileName));
+        QFile replay(fileName);
+        QVERIFY(replay.open(QIODevice::ReadOnly));
+        const QByteArray recorded = replay.readAll();
+        QVERIFY2(recorded.contains(sent), "the recording was committed without what the game sent");
     }
 };
 

--- a/test/functional_tests/MapAreaReassignmentTest.cpp
+++ b/test/functional_tests/MapAreaReassignmentTest.cpp
@@ -33,6 +33,7 @@
  * Run with: ctest -R MapAreaReassignmentTest -V
  */
 
+#include <QDataStream>
 #include <QFileInfo>
 #include <QtTest/QtTest>
 

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -54,6 +54,8 @@
  * Run with: ctest -R MapDownloadTest -V
  */
 
+#include <QDataStream>
+#include <QSaveFile>
 #include <QFileInfo>
 #include <QFrame>
 #include <QHash>

--- a/test/functional_tests/MapFileStatsTest.cpp
+++ b/test/functional_tests/MapFileStatsTest.cpp
@@ -34,6 +34,7 @@
  * Run with: ctest -R MapFileStatsTest -V
  */
 
+#include <QDataStream>
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QTemporaryDir>

--- a/test/functional_tests/MapRoundTripTest.cpp
+++ b/test/functional_tests/MapRoundTripTest.cpp
@@ -36,6 +36,7 @@
  * Run with: ctest -R MapRoundTripTest -V
  */
 
+#include <QDataStream>
 #include <QFileInfo>
 #include <QtTest/QtTest>
 

--- a/test/functional_tests/MapSymbolFontTest.cpp
+++ b/test/functional_tests/MapSymbolFontTest.cpp
@@ -33,6 +33,7 @@
  * Run with: ctest -R MapSymbolFontTest -V
  */
 
+#include <QDataStream>
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/test/functional_tests/ProfileLoadTempFileTest.cpp
+++ b/test/functional_tests/ProfileLoadTempFileTest.cpp
@@ -36,6 +36,7 @@
  * Run with: ctest -R ProfileLoadTempFileTest -V
  */
 
+#include <QSaveFile>
 #include <QtTest/QtTest>
 
 #include <QTemporaryDir>

--- a/test/functional_tests/TMediaLoopTest.cpp
+++ b/test/functional_tests/TMediaLoopTest.cpp
@@ -17,6 +17,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QDataStream>
 #include <QAudioOutput>
 #include <QDeadlineTimer>
 #include <QFileInfo>

--- a/test/functional_tests/VideoOutputHideTest.cpp
+++ b/test/functional_tests/VideoOutputHideTest.cpp
@@ -34,6 +34,7 @@
  * Run with: ctest -R VideoOutputHideTest -V
  */
 
+#include <QDataStream>
 #include <QMediaPlayer>
 #include <QPointer>
 #include <QTemporaryDir>


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `cTelnet`, `MMCPServer`, `TMedia`, `TArea` and `TBuffer` no longer call `print()`, `printSystemMessage()`, `printOnDisplay()`, `finalize()` or `showTimeStamps()` on `mpHost->mpConsole`; `Host` forwards them (`printToMainConsole`, `printSystemMessage`, `printOnDisplay`, `finalizeMainConsole`, `mainConsoleShowsTimeStamps`). Every call site keeps the null guard it had, so behaviour is unchanged.
- `cTelnet`'s two `buffer.` calls go to the core `TConsoleModel` directly, and the replay-recording state (`mRecordReplay`, `mReplayFile`, `mReplayStream`) moves from `TConsole` into `cTelnet`, which is what writes it; the console's toggle button calls `startReplayRecording()` / `stopReplayRecording()`. Same file name, stream version and messages.
- `ctelnet.cpp` drops `TConsole.h` and `TMainConsole.h`; `TArea.cpp` drops `TConsole.h`.

#### Motivation for adding to Mudlet

Part of #8681: until `Host::mpConsole` becomes an interface, Host is the one core class allowed to know the concrete console widget.

#### Other info (issues closed, discussion etc)

Qt Widgets audit count is 149 of 421 before and after (`ctelnet.cpp` still names dialogs and the main window). Sabotage, each forwarder body made a no-op then the full ctest run: plain print -> HostConsolePrintTest; coloured print -> 10 tests (AddonControls, GMCPCharLogin, TelnetConnectFailure, MsdpMalformedDiagnostic, TFeedTriggersRecursion, MapDownload, ActionSelfRemoval, DualPackageModule, MissingDisplayFont, HostConsolePrint); printSystemMessage -> HostConsolePrintTest; printOnDisplay -> 18 tests; finalize -> CopyAsImage, WrapLineRewrap, HostConsolePrint; time stamps -> HostConsolePrintTest. `TBuffer`'s two `mpHost->mpConsole->mTriggerEngineMode` writes are left alone: data-member writes rather than calls, and outside this slice.

**Test case:** `HostConsolePrintTest` (new, in `functional_window_tests`) drives each forwarder on a live profile and reads the main console buffer back; `ctest --preset linux-debug-nosan` 180/180.

Assisted-by: Claude:claude-fable-5-1
