### PR TITLE
Infra: Debug messages reach the Central Debug Console through a sink

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -698,6 +698,12 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
 TConsole::~TConsole()
 {
+    // TDebug holds its sink raw, and a closing profile emits debug lines from
+    // inside teardown, so unhook before any of this console is gone.
+    if (TDebug::sink() == this) {
+        TDebug::setSink(nullptr);
+    }
+
     // Host co-owns the main console's model, so the model - and its buffer -
     // can outlive this view. The buffer's QPointer back-pointer would only null
     // itself once ~QObject() runs, leaving it aimed at a half-destroyed widget
@@ -2226,6 +2232,11 @@ void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgCo
     if (Q_UNLIKELY(mudlet::self()->smMirrorToStdOut)) {
         qDebug().nospace().noquote() << qsl("%1| %2").arg(mConsoleName, msg);
     }
+}
+
+void TConsole::printDebugLine(const QString& text, const QColor& foreground, const QColor& background, const QString& timeStamp)
+{
+    print(text, foreground, background, timeStamp);
 }
 
 void TConsole::printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -29,6 +29,7 @@
 
 #include "TBuffer.h"
 #include "TConsoleModel.h"
+#include "TDebug.h"
 #include "TPrintSink.h"
 
 #include <QDataStream>
@@ -160,9 +161,9 @@ class TSplitter;
 class dlgNotepad;
 
 
-// TPrintSink is the write-only face core code redirects output to; QWidget
-// stays first so moc sees the QObject base it needs.
-class TConsole : public QWidget, public TPrintSink
+// TPrintSink and TDebug::Sink are the write-only faces core code redirects
+// output to; QWidget stays first so moc sees the QObject base it needs.
+class TConsole : public QWidget, public TPrintSink, public TDebug::Sink
 {
     Q_OBJECT
 
@@ -280,6 +281,7 @@ public:
     // until its right-click menu asks for it:
     void showSearchBar();
     void printFormatted(const QString& text, const std::vector<TChar>& formatting, const TLinkStore& sourceLinkStore) override;
+    void printDebugLine(const QString& text, const QColor& foreground, const QColor& background, const QString& timeStamp) override;
     void discardAll() override;
     void discardLastLine() override;
     void printSystemMessage(const QString& msg);

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -25,7 +25,6 @@
 #include "TDebug.h"
 
 #include "TBuffer.h"
-#include "TConsole.h"
 #include "TDebugFilterBar.h"
 #include "TTabBar.h"
 #include "mudlet.h"
@@ -122,22 +121,21 @@ TDebug::TDebug(const QColor& c, const QColor& d, const Category category, const 
 // rather than leaving people to wonder.
 /* static */ void TDebug::announceFilters()
 {
-    QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
-    if (!debugConsole) {
+    if (!smpSink) {
         return;
     }
 
     const int hidden = hiddenCategoryCount();
     if (hidden) {
         //: Shown in the Central Debug Console when it opens with some kinds of message hidden. %n is how many.
-        debugConsole->print(csmTagSystemMessage % tr("%n kind(s) of message are hidden - use the controls below to change that.\n", "", hidden), Qt::white, Qt::darkBlue);
+        smpSink->printDebugLine(csmTagSystemMessage % tr("%n kind(s) of message are hidden - use the controls below to change that.\n", "", hidden), Qt::white, Qt::darkBlue, QString());
     }
 
     if (!smItemFilter.isEmpty()) {
         // Much more drastic than hiding a category - everything that is not
         // about this one item is gone, so it needs saying out loud:
         //: Shown in the Central Debug Console when it opens narrowed to a single trigger, alias, timer and so on. %1 is that item's name.
-        debugConsole->print(csmTagSystemMessage % tr("Showing only messages about \"%1\" - use the controls below to change that.\n").arg(smItemFilter), Qt::white, Qt::darkBlue);
+        smpSink->printDebugLine(csmTagSystemMessage % tr("Showing only messages about \"%1\" - use the controls below to change that.\n").arg(smItemFilter), Qt::white, Qt::darkBlue, QString());
     }
 }
 
@@ -168,8 +166,7 @@ TDebug::TDebug(const QColor& c, const QColor& d, const Category category, const 
 // the user's messages out.
 /* static */ void TDebug::drainPausedQueue()
 {
-    QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
-    if (!debugConsole) {
+    if (!smpSink) {
         return;
     }
 
@@ -177,19 +174,18 @@ TDebug::TDebug(const QColor& c, const QColor& d, const Category category, const 
         // Ahead of the replay, because it is the OLDEST messages that the cap
         // had to throw away - the gap is at the top, not the bottom:
         //: Shown in the Central Debug Console on resuming, when more messages arrived while paused than could be held back.
-        debugConsole->print(csmTagSystemMessage % tr("%n message(s) dropped while paused.\n", "", smPausedDroppedCount), Qt::white, Qt::darkRed);
+        smpSink->printDebugLine(csmTagSystemMessage % tr("%n message(s) dropped while paused.\n", "", smPausedDroppedCount), Qt::white, Qt::darkRed, QString());
         smPausedDroppedCount = 0;
     }
 
     while (!smPausedQueue.isEmpty()) {
-        debugConsole = mudlet::smpDebugConsole;
-        if (!debugConsole) {
-            // Console has gone - leave the remainder queued
+        if (!smpSink) {
+            // Sink has gone - leave the remainder queued
             return;
         }
         const auto message = smPausedQueue.dequeue();
         // Already composed when it arrived, profile marking and all:
-        debugConsole->print(message.mMessage, message.mForeground, message.mBackground, message.mTimeStamp);
+        smpSink->printDebugLine(message.mMessage, message.mForeground, message.mBackground, message.mTimeStamp);
     }
 }
 
@@ -296,7 +292,7 @@ bool TDebug::passesFilters(const Host* pHost)
         return;
     }
 
-    if (Q_UNLIKELY(!mudlet::smpDebugConsole)) {
+    if (Q_UNLIKELY(!smpSink)) {
         if (Q_LIKELY(!line.isEmpty())) {
             // Don't enqueue empty messages
             smMessageQueue.enqueue(TDebugMessage(line, QString(), foreground, background));
@@ -305,15 +301,11 @@ bool TDebug::passesFilters(const Host* pHost)
     }
 
     if (Q_UNLIKELY(!smMessageQueue.isEmpty())) {
-        // The console must have just come on-line - so unload all the messages
-        // stacked up while it did not exist:
-        while (!smMessageQueue.isEmpty()) {
-            QPointer<TConsole> backlogConsole = mudlet::smpDebugConsole;
-            if (!backlogConsole) {
-                break;
-            }
+        // The sink must have just come on-line - so unload all the messages
+        // stacked up while there was none:
+        while (!smMessageQueue.isEmpty() && smpSink) {
             const auto message = smMessageQueue.dequeue();
-            backlogConsole->print(message.mMessage, message.mForeground, message.mBackground);
+            smpSink->printDebugLine(message.mMessage, message.mForeground, message.mBackground, message.mTimeStamp);
         }
     }
 
@@ -322,9 +314,8 @@ bool TDebug::passesFilters(const Host* pHost)
         return;
     }
 
-    QPointer<TConsole> debugConsole = mudlet::smpDebugConsole;
-    if (debugConsole) {
-        debugConsole->print(line, foreground, background);
+    if (smpSink) {
+        smpSink->printDebugLine(line, foreground, background, QString());
     }
 }
 

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -295,7 +295,9 @@ bool TDebug::passesFilters(const Host* pHost)
     if (Q_UNLIKELY(!smpSink)) {
         if (Q_LIKELY(!line.isEmpty())) {
             // Don't enqueue empty messages
-            smMessageQueue.enqueue(TDebugMessage(line, QString(), foreground, background));
+            // Stamped here rather than when the sink turns up, so that a
+            // backlog replayed minutes later still reads as when it happened:
+            smMessageQueue.enqueue(TDebugMessage(line, QString(), foreground, background, QTime::currentTime().toString(TBuffer::smTimeStampFormat)));
         }
         return;
     }

--- a/src/TDebug.h
+++ b/src/TDebug.h
@@ -96,7 +96,28 @@ public:
     // guard, so they appear whatever this is set to:
     inline static bool smDebugMode = false;
 
+    // Where the composed lines end up. The GUI installs the Central Debug
+    // Console; with nothing installed, lines queue as they do before that
+    // console exists. TDebug keeps a raw pointer to the sink and a closing
+    // profile emits lines from inside teardown, so an implementation has to
+    // detach itself before any of it is torn down:
+    class Sink
+    {
+    public:
+        // timeStamp is empty for a line shown as it arrives, and the arrival
+        // time for one replayed after being held back:
+        virtual void printDebugLine(const QString& text, const QColor& foreground, const QColor& background, const QString& timeStamp) = 0;
+
+    protected:
+        ~Sink() = default;
+    };
+
+    static void setSink(Sink* pSink) { smpSink = pSink; }
+    static Sink* sink() { return smpSink; }
+
 private:
+    inline static Sink* smpSink = nullptr;
+
     // A shared map that is uses to put a short identifier on each debug message
     // - the first value is used to create a table to display on changes and the
     // second value is the short identifier used:

--- a/src/TDebug.h
+++ b/src/TDebug.h
@@ -109,7 +109,16 @@ public:
         virtual void printDebugLine(const QString& text, const QColor& foreground, const QColor& background, const QString& timeStamp) = 0;
 
     protected:
-        ~Sink() = default;
+        // Nothing owns a sink through this interface - the Central Debug
+        // Console belongs to its widget parent - so deleting through it is a
+        // compile error. Clearing the pointer here is only a backstop: a
+        // console emits from inside its own teardown, so it detaches earlier.
+        ~Sink()
+        {
+            if (smpSink == this) {
+                smpSink = nullptr;
+            }
+        }
     };
 
     static void setSink(Sink* pSink) { smpSink = pSink; }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5763,6 +5763,7 @@ void mudlet::attachDebugArea(const QString& hostname)
     smpDebugArea = new QMainWindow(nullptr);
     const auto pHost = mHostManager.getHost(hostname);
     smpDebugConsole = new TConsole(pHost, qsl("centralDebug"), TConsole::CentralDebugConsole);
+    TDebug::setSink(smpDebugConsole.data());
     smpDebugConsole->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     smpDebugConsole->setWrapAt(100);
     smpDebugArea->setCentralWidget(smpDebugConsole);

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -387,7 +387,7 @@ set_tests_properties(MultilineTriggerReentrancyTest PROPERTIES TIMEOUT 300)
 # GMCPCharLoginTest creates a fresh profile per test method, so it needs a longer timeout
 set_tests_properties(GMCPCharLoginTest PROPERTIES TIMEOUT 600)
 
-# DebugConsoleFilterTest boots a fresh profile for each of its 24 methods, and timed out against
+# DebugConsoleFilterTest boots a fresh profile for most of its methods, and timed out against
 # the default 60s on the macOS x86_64 runner, where it measured 46.95s when it passed. Waiting on
 # the connection dialog instead of sleeping through it took the Linux run from 30s to 9s, so this
 # is headroom rather than a necessity now, and it is what the other per-method-profile tests use.

--- a/test/functional_tests/DebugConsoleFilterTest.cpp
+++ b/test/functional_tests/DebugConsoleFilterTest.cpp
@@ -599,6 +599,38 @@ private slots:
         QTRY_VERIFY2(!mudlet::smpDebugConsole, "Closing the debug area did not destroy its console");
 
         QVERIFY2(!TDebug::sink(), "The Central Debug Console was destroyed but is still installed as the sink");
+
+        // ...and lines written afterwards wait for the next console instead
+        // of going to the old one:
+        TDebug::setEnabledCategories(TDebug::csmAllCategories);
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "after the console went\n" >> nullptr;
+        RecordingDebugSink late;
+        TDebug::setSink(&late);
+        TDebug::flushMessageQueue();
+        QCOMPARE(late.lines.size(), 1);
+        QVERIFY2(late.lines.at(0).text.contains(qsl("after the console went")), qPrintable(late.lines.at(0).text));
+    }
+
+    void test_announcingFiltersNamesBothKindsAndNeverQueues()
+    {
+        RecordingDebugSink sink;
+        installSink(sink);
+        TDebug::setEnabledCategories({TDebug::Category::TriggerMatch});
+        TDebug::setItemFilter(qsl("Combat trigger"));
+
+        TDebug::announceFilters();
+        QCOMPARE(sink.lines.size(), 2);
+        QVERIFY2(sink.lines.at(0).text.contains(qsl("kind(s) of message are hidden")), qPrintable(sink.lines.at(0).text));
+        QVERIFY2(sink.lines.at(1).text.contains(qsl("Showing only messages about \"Combat trigger\"")), qPrintable(sink.lines.at(1).text));
+
+        // The notice is re-issued every time the console opens, so with no
+        // console it must not pile up for the next one:
+        TDebug::setSink(nullptr);
+        TDebug::announceFilters();
+        RecordingDebugSink late;
+        TDebug::setSink(&late);
+        TDebug::flushMessageQueue();
+        QVERIFY2(late.lines.isEmpty(), qPrintable(late.lines.isEmpty() ? QString() : late.lines.at(0).text));
     }
 
     // The find bar floats over the console rather than sitting in a layout, so

--- a/test/functional_tests/DebugConsoleFilterTest.cpp
+++ b/test/functional_tests/DebugConsoleFilterTest.cpp
@@ -548,10 +548,10 @@ private slots:
         TDebug::setEnabledCategories(TDebug::csmAllCategories);
 
         TDebug::setPaused(true);
-        const QTime before = QTime::currentTime();
+        const QDateTime before = QDateTime::currentDateTime();
         TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "held first\n" >> nullptr;
         TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "held second\n" >> nullptr;
-        const QTime after = QTime::currentTime();
+        const QDateTime after = QDateTime::currentDateTime();
         QVERIFY2(sink.lines.isEmpty(), "A line arriving while paused reached the sink");
         QCOMPARE(TDebug::pausedMessageCount(), 2);
 
@@ -564,9 +564,15 @@ private slots:
         QVERIFY2(sink.lines.at(0).text.contains(qsl("held first")), qPrintable(sink.lines.at(0).text));
         QVERIFY2(sink.lines.at(1).text.contains(qsl("held second")), qPrintable(sink.lines.at(1).text));
         for (const auto& line : sink.lines) {
-            const QTime stamped = QTime::fromString(line.timeStamp, TBuffer::smTimeStampFormat);
-            QVERIFY2(stamped.isValid(), qPrintable(qsl("Replayed line carried no usable time stamp: '%1'").arg(line.timeStamp)));
-            const QString window = qsl("%1- %2").arg(before.toString(TBuffer::smTimeStampFormat), after.toString(TBuffer::smTimeStampFormat));
+            const QTime stampedTime = QTime::fromString(line.timeStamp, TBuffer::smTimeStampFormat);
+            QVERIFY2(stampedTime.isValid(), qPrintable(qsl("Replayed line carried no usable time stamp: '%1'").arg(line.timeStamp)));
+            // The stamp carries no date, so a window that straddles midnight has
+            // to read a small stamp as the next day rather than as the past:
+            QDateTime stamped(before.date(), stampedTime);
+            if (stamped < before) {
+                stamped = stamped.addDays(1);
+            }
+            const QString window = qsl("%1- %2").arg(before.time().toString(TBuffer::smTimeStampFormat), after.time().toString(TBuffer::smTimeStampFormat));
             QVERIFY2(before <= stamped && stamped <= after, qPrintable(qsl("Replayed line was stamped %1, outside its arrival window %2").arg(line.timeStamp, window)));
         }
     }

--- a/test/functional_tests/DebugConsoleFilterTest.cpp
+++ b/test/functional_tests/DebugConsoleFilterTest.cpp
@@ -39,6 +39,34 @@
 // follow the message they belong to, and that pausing holds messages back
 // rather than losing them. The console's own controls are covered here too,
 // since bringing one up needs the same running profile.
+//
+// Where a line ends up is a separate contract: TDebug hands it to whatever
+// TDebug::Sink is installed, and the Central Debug Console is one implementation
+// of that. The sink cases below read lines back through a stand-in instead.
+namespace {
+class RecordingDebugSink : public TDebug::Sink
+{
+public:
+    struct Line
+    {
+        QString text;
+        QColor foreground;
+        QColor background;
+        QString timeStamp;
+    };
+    QList<Line> lines;
+
+    ~RecordingDebugSink()
+    {
+        if (TDebug::sink() == this) {
+            TDebug::setSink(nullptr);
+        }
+    }
+
+    void printDebugLine(const QString& text, const QColor& foreground, const QColor& background, const QString& timeStamp) override { lines.append(Line{text, foreground, background, timeStamp}); }
+};
+} // namespace
+
 class DebugConsoleFilterTest : public QObject
 {
     Q_OBJECT
@@ -474,6 +502,99 @@ private slots:
         QVERIFY2(!debugBufferContains(qsl("about to be discarded")), "A discarded message was replayed on resume");
     }
 
+    void test_lineReachesTheSinkOnceWithItsColours()
+    {
+        RecordingDebugSink sink;
+        installSink(sink);
+        TDebug::setEnabledCategories(TDebug::csmAllCategories);
+
+        TDebug(Qt::red, Qt::yellow, TDebug::Category::TriggerMatch) << "one line\n" >> nullptr;
+
+        QCOMPARE(sink.lines.size(), 1);
+        QVERIFY2(sink.lines.at(0).text.endsWith(qsl("one line\n")), qPrintable(sink.lines.at(0).text));
+        QCOMPARE(sink.lines.at(0).foreground, QColor(Qt::red));
+        QCOMPARE(sink.lines.at(0).background, QColor(Qt::yellow));
+        QVERIFY2(sink.lines.at(0).timeStamp.isEmpty(), "A line shown as it arrived was handed a time stamp to replay");
+    }
+
+    // A profile can start, and say so, before anyone has opened the console.
+    // Those lines are kept, and the first one to find a sink brings them out
+    // ahead of itself in the order they came.
+    void test_linesWrittenWithoutASinkAreReplayedInOrderOnceOneIsInstalled()
+    {
+        RecordingDebugSink sink;
+        installSink(sink);
+        TDebug::setEnabledCategories(TDebug::csmAllCategories);
+        TDebug::setSink(nullptr);
+
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "first with no sink\n" >> nullptr;
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "second with no sink\n" >> nullptr;
+
+        TDebug::setSink(&sink);
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "first with a sink\n" >> nullptr;
+
+        QCOMPARE(sink.lines.size(), 3);
+        QVERIFY2(sink.lines.at(0).text.contains(qsl("first with no sink")), qPrintable(sink.lines.at(0).text));
+        QVERIFY2(sink.lines.at(1).text.contains(qsl("second with no sink")), qPrintable(sink.lines.at(1).text));
+        QVERIFY2(sink.lines.at(2).text.contains(qsl("first with a sink")), qPrintable(sink.lines.at(2).text));
+    }
+
+    // Resuming hands each held line to the sink stamped with the time it
+    // arrived, not the time it was let through.
+    void test_resumingHandsHeldLinesToTheSinkWithTheirArrivalTimes()
+    {
+        RecordingDebugSink sink;
+        installSink(sink);
+        TDebug::setEnabledCategories(TDebug::csmAllCategories);
+
+        TDebug::setPaused(true);
+        const QTime before = QTime::currentTime();
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "held first\n" >> nullptr;
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "held second\n" >> nullptr;
+        const QTime after = QTime::currentTime();
+        QVERIFY2(sink.lines.isEmpty(), "A line arriving while paused reached the sink");
+        QCOMPARE(TDebug::pausedMessageCount(), 2);
+
+        // Long enough that a stamp taken on resume cannot land inside the
+        // arrival window:
+        QTest::qWait(100);
+        TDebug::setPaused(false);
+
+        QCOMPARE(sink.lines.size(), 2);
+        QVERIFY2(sink.lines.at(0).text.contains(qsl("held first")), qPrintable(sink.lines.at(0).text));
+        QVERIFY2(sink.lines.at(1).text.contains(qsl("held second")), qPrintable(sink.lines.at(1).text));
+        for (const auto& line : sink.lines) {
+            const QTime stamped = QTime::fromString(line.timeStamp, TBuffer::smTimeStampFormat);
+            QVERIFY2(stamped.isValid(), qPrintable(qsl("Replayed line carried no usable time stamp: '%1'").arg(line.timeStamp)));
+            const QString window = qsl("%1- %2").arg(before.toString(TBuffer::smTimeStampFormat), after.toString(TBuffer::smTimeStampFormat));
+            QVERIFY2(before <= stamped && stamped <= after, qPrintable(qsl("Replayed line was stamped %1, outside its arrival window %2").arg(line.timeStamp, window)));
+        }
+    }
+
+    // Opening the Central Debug Console makes it the sink...
+    void test_centralDebugConsoleIsInstalledAsTheSink()
+    {
+        startDebuggingProfile();
+
+        QVERIFY(mudlet::smpDebugConsole);
+        QCOMPARE(TDebug::sink(), static_cast<TDebug::Sink*>(mudlet::smpDebugConsole.data()));
+    }
+
+    // ...and destroying it takes it back out, so nothing is left pointing at a
+    // console that has gone. Closing its window is what destroys it, both when
+    // the profile it belongs to closes and when Mudlet does.
+    void test_destroyingTheCentralDebugConsoleDetachesTheSink()
+    {
+        startDebuggingProfile();
+        QVERIFY(TDebug::sink());
+
+        mudlet::smpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
+        mudlet::smpDebugArea->close();
+        QTRY_VERIFY2(!mudlet::smpDebugConsole, "Closing the debug area did not destroy its console");
+
+        QVERIFY2(!TDebug::sink(), "The Central Debug Console was destroyed but is still installed as the sink");
+    }
+
     // The find bar floats over the console rather than sitting in a layout, so
     // nothing but the console itself keeps it in the corner and inside the
     // window.
@@ -527,8 +648,14 @@ private slots:
         // A profile muted by a test that failed part way through would
         // otherwise silence whatever runs next:
         TDebug::enableAllHosts();
+        TDebug::setSink(nullptr);
         TDebug::smDebugMode = false;
 
+        // The debug area has no parent and only the profile-close and
+        // application-close paths take it down, neither of which deleting
+        // mudlet runs - so a console left here would outlive its Host and
+        // make attachDebugArea() a no-op for the next method:
+        delete mudlet::smpDebugArea.data();
         delete mpServer;
         mpServer = nullptr;
         deleteProfileDirectory(mHostname);
@@ -550,6 +677,16 @@ private:
         TDebug::flushMessageQueue();
         mudlet::smpDebugConsole->clear();
         return host;
+    }
+
+    // Installs the stand-in and drains into it whatever earlier methods left
+    // queued while no console existed, so a test only sees the lines it wrote
+    // itself.
+    void installSink(RecordingDebugSink& sink)
+    {
+        TDebug::setSink(&sink);
+        TDebug::flushMessageQueue();
+        sink.lines.clear();
     }
 
     QString joinedDebugBuffer()

--- a/test/functional_tests/DebugConsoleFilterTest.cpp
+++ b/test/functional_tests/DebugConsoleFilterTest.cpp
@@ -539,6 +539,41 @@ private slots:
         QVERIFY2(sink.lines.at(2).text.contains(qsl("first with a sink")), qPrintable(sink.lines.at(2).text));
     }
 
+    // The backlog is stamped when it is written, not when the console that
+    // finally shows it turns up - otherwise five minutes of play looks like it
+    // all happened the moment the Central Debug Console was first opened.
+    void test_backlogIsStampedWhenItIsWrittenNotWhenItIsReplayed()
+    {
+        RecordingDebugSink sink;
+        installSink(sink);
+        TDebug::setEnabledCategories(TDebug::csmAllCategories);
+        TDebug::setSink(nullptr);
+
+        const QDateTime before = QDateTime::currentDateTime();
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "written with no sink\n" >> nullptr;
+        const QDateTime after = QDateTime::currentDateTime();
+        QVERIFY2(sink.lines.isEmpty(), "A line written with no sink installed reached one anyway");
+
+        // Long enough that a stamp taken when the sink arrives cannot land
+        // inside the arrival window:
+        QTest::qWait(100);
+        TDebug::setSink(&sink);
+        TDebug(Qt::blue, Qt::black, TDebug::Category::TriggerMatch) << "written with a sink\n" >> nullptr;
+
+        QCOMPARE(sink.lines.size(), 2);
+        QVERIFY2(sink.lines.at(0).text.contains(qsl("written with no sink")), qPrintable(sink.lines.at(0).text));
+        const QTime stampedTime = QTime::fromString(sink.lines.at(0).timeStamp, TBuffer::smTimeStampFormat);
+        QVERIFY2(stampedTime.isValid(), qPrintable(qsl("Replayed backlog line carried no usable time stamp: '%1'").arg(sink.lines.at(0).timeStamp)));
+        // The stamp carries no date, so a window that straddles midnight has to
+        // read a small stamp as the next day rather than as the past:
+        QDateTime stamped(before.date(), stampedTime);
+        if (stamped < before) {
+            stamped = stamped.addDays(1);
+        }
+        const QString window = qsl("%1- %2").arg(before.time().toString(TBuffer::smTimeStampFormat), after.time().toString(TBuffer::smTimeStampFormat));
+        QVERIFY2(before <= stamped && stamped <= after, qPrintable(qsl("Backlog line was stamped %1, outside its arrival window %2").arg(sink.lines.at(0).timeStamp, window)));
+    }
+
     // Resuming hands each held line to the sink stamped with the time it
     // arrived, not the time it was let through.
     void test_resumingHandsHeldLinesToTheSinkWithTheirArrivalTimes()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
`TDebug` no longer prints to `mudlet::smpDebugConsole`. Each line goes to a `TDebug::Sink`, a small write-only interface nested in `TDebug`; `TConsole` implements it by forwarding to its coloured `print()`. `attachDebugArea()` installs the Central Debug Console as the sink and `~TConsole()` detaches it, so `TDebug.cpp` no longer includes `TConsole.h`. With no sink installed, lines queue exactly as they did before the console existed, and the paused-queue replay keeps its arrival time stamps.

#### Motivation for adding to Mudlet
One slice of the libmudlet split (#8681): core code that reports debug output should not name the widget that shows it. A headless build installs no sink and loses nothing it did not already hold back.

#### Other info (issues closed, discussion etc)
`TDebugFilterBar.cpp` and `Host.cpp` still touch `smpDebugConsole` for widget-side work (font, clear, the filter bar's own notices), as does `TDebug.cpp` for its `mpTabBar` and `smpDebugFilterBar` refreshes; those are left for a later slice. The core widgets audit stays at 149 of 421 - it counts Qt Widgets symbols, and `TDebug.cpp` was already on its clean list.

Detaching in `~TConsole()` is also a small safety gain: the old `QPointer` only nulled itself in `~QObject()`, so a debug line emitted during the console's own teardown - a closing profile does emit them - was printed onto a half-destroyed widget.

`DebugConsoleFilterTest` now destroys the debug area in `cleanup()`. It has no parent and only the profile-close and app-close paths take it down, so it used to outlive its Host across methods and make `attachDebugArea()` a no-op for the next one, which only worked because the surviving console was still what `TDebug` printed to.

**Test case:** `DebugConsoleFilterTest` gains five cases read back through a recording `TDebug::Sink`: a line arrives once with its colours; lines written with no sink are replayed in order on the first line after one is installed; resuming from pause hands held lines over with their arrival time stamps; opening the Central Debug Console installs it as the sink; destroying it detaches. Each was red against a sabotaged production line (no-op `setSink`, dropped detach, skipped backlog drain, dropped install, dropped replay stamp, swapped colours) and green after the restore; full ctest 179/179.

Assisted-by: Claude:claude-fable-5-1