### PR TITLE
Infra: Lua API reads the main console through Host and its model

### DIFF
--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -61,6 +61,7 @@ QStringList TConsoleModel::lines(int from, int to)
 // the autolog resume on profile load has no button to watch.
 void TConsoleModel::reportFailedLogStart(const QString& path, const QString& reason)
 {
+    mLogStartFailure = qsl("%1: %2").arg(path, reason);
     //: Error shown on the main console when a log file could not be opened. %1 is the file, %2 is the reason
     mpHost->postMessage(QCoreApplication::translate("TConsoleModel", "[ ERROR ] - Could not start logging to \"%1\": %2").arg(path, reason));
     mpHost->raiseLoggingStateChanged(false);

--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -73,6 +73,9 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
     if (!mLogToLogFile) {
         if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
             qWarning() << "TConsoleModel: failed to open autolog file for writing:" << file.errorString();
+            // A clicked checkable button has already flipped itself, so a start
+            // that goes nowhere still has to report the state it left behind
+            mpHost->raiseLoggingStateChanged(false);
             return;
         }
         QTextStream out(&file);
@@ -123,11 +126,13 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             if (!mLogFile.open(QIODevice::ReadWrite)) {
                 qWarning() << "TConsoleModel: failed to open log file for reading/writing:" << mLogFile.errorString();
+                mpHost->raiseLoggingStateChanged(false);
                 return;
             }
         } else {
             if (!mLogFile.open(QIODevice::Append)) {
                 qWarning() << "TConsoleModel: failed to open log file for appending:" << mLogFile.errorString();
+                mpHost->raiseLoggingStateChanged(false);
                 return;
             }
         }

--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -56,6 +56,16 @@ QStringList TConsoleModel::lines(int from, int to)
 // - QFontInfo(Host::getDisplayFont()) is what QWidget::fontInfo() reports for
 //   the main console, because Host::getDisplayFont() hands back that widget's
 //   own QFont - and unlike the widget call it still answers with no widget.
+// A clicked checkable button has already flipped itself, so a start that goes
+// nowhere still has to report the state it left behind - and say why, since
+// the autolog resume on profile load has no button to watch.
+void TConsoleModel::reportFailedLogStart(const QString& path, const QString& reason)
+{
+    //: Error shown on the main console when a log file could not be opened. %1 is the file, %2 is the reason
+    mpHost->postMessage(QCoreApplication::translate("TConsoleModel", "[ ERROR ] - Could not start logging to \"%1\": %2").arg(path, reason));
+    mpHost->raiseLoggingStateChanged(false);
+}
+
 void TConsoleModel::toggleLogging(bool isMessageEnabled)
 {
     // Logging is profile-wide, not per-console: the autolog sentinel, the log
@@ -72,10 +82,8 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
     const QDateTime logDateTime = QDateTime::currentDateTime();
     if (!mLogToLogFile) {
         if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            qWarning() << "TConsoleModel: failed to open autolog file for writing:" << file.errorString();
-            // A clicked checkable button has already flipped itself, so a start
-            // that goes nowhere still has to report the state it left behind
-            mpHost->raiseLoggingStateChanged(false);
+            qWarning() << "TConsoleModel: failed to open autolog file" << loggingPath << "for writing:" << file.errorString();
+            reportFailedLogStart(loggingPath, file.errorString());
             return;
         }
         QTextStream out(&file);
@@ -125,14 +133,16 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
         // implies Truncate."
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             if (!mLogFile.open(QIODevice::ReadWrite)) {
-                qWarning() << "TConsoleModel: failed to open log file for reading/writing:" << mLogFile.errorString();
-                mpHost->raiseLoggingStateChanged(false);
+                qWarning() << "TConsoleModel: failed to open log file" << mLogFileName << "for reading/writing:" << mLogFile.errorString();
+                QFile::remove(loggingPath);
+                reportFailedLogStart(mLogFileName, mLogFile.errorString());
                 return;
             }
         } else {
             if (!mLogFile.open(QIODevice::Append)) {
-                qWarning() << "TConsoleModel: failed to open log file for appending:" << mLogFile.errorString();
-                mpHost->raiseLoggingStateChanged(false);
+                qWarning() << "TConsoleModel: failed to open log file" << mLogFileName << "for appending:" << mLogFile.errorString();
+                QFile::remove(loggingPath);
+                reportFailedLogStart(mLogFileName, mLogFile.errorString());
                 return;
             }
         }

--- a/src/TConsoleModel.cpp
+++ b/src/TConsoleModel.cpp
@@ -27,6 +27,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QFileInfo>
 #include <QFontInfo>
 
 TConsoleModel::TConsoleModel(Host* pHost)
@@ -56,6 +57,26 @@ QStringList TConsoleModel::lines(int from, int to)
 // - QFontInfo(Host::getDisplayFont()) is what QWidget::fontInfo() reports for
 //   the main console, because Host::getDisplayFont() hands back that widget's
 //   own QFont - and unlike the widget call it still answers with no widget.
+namespace {
+// The sentinel's only job is to say that logging was on when the profile last
+// closed: Host reads its bare existence on the next load and clicks the log
+// button. One left behind by a start that never began makes that failure
+// repeat on every launch, and what blocks the sentinel can be a directory,
+// which QFile::remove() will not take.
+void removeAutologSentinel(const QString& path)
+{
+    const QFileInfo sentinel(path);
+    if (!sentinel.exists()) {
+        return;
+    }
+    if (sentinel.isDir()) {
+        QDir().rmdir(path);
+        return;
+    }
+    QFile::remove(path);
+}
+} // namespace
+
 // A clicked checkable button has already flipped itself, so a start that goes
 // nowhere still has to report the state it left behind - and say why, since
 // the autolog resume on profile load has no button to watch.
@@ -84,6 +105,7 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
     if (!mLogToLogFile) {
         if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
             qWarning() << "TConsoleModel: failed to open autolog file" << loggingPath << "for writing:" << file.errorString();
+            removeAutologSentinel(loggingPath);
             reportFailedLogStart(loggingPath, file.errorString());
             return;
         }
@@ -135,14 +157,14 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             if (!mLogFile.open(QIODevice::ReadWrite)) {
                 qWarning() << "TConsoleModel: failed to open log file" << mLogFileName << "for reading/writing:" << mLogFile.errorString();
-                QFile::remove(loggingPath);
+                removeAutologSentinel(loggingPath);
                 reportFailedLogStart(mLogFileName, mLogFile.errorString());
                 return;
             }
         } else {
             if (!mLogFile.open(QIODevice::Append)) {
                 qWarning() << "TConsoleModel: failed to open log file" << mLogFileName << "for appending:" << mLogFile.errorString();
-                QFile::remove(loggingPath);
+                removeAutologSentinel(loggingPath);
                 reportFailedLogStart(mLogFileName, mLogFile.errorString());
                 return;
             }
@@ -157,7 +179,7 @@ void TConsoleModel::toggleLogging(bool isMessageEnabled)
         }
         mLogToLogFile = true;
     } else {
-        QFile::remove(loggingPath);
+        removeAutologSentinel(loggingPath);
         mLogToLogFile = false;
         if (isMessageEnabled) {
             // Likewise raised only once the flag above is down, or the frontend's

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -70,6 +70,7 @@ struct TConsoleModel
     // filename format) is profile-wide, so it only acts on the Host's own main
     // model and returns for any other.
     void toggleLogging(bool isMessageEnabled);
+    void reportFailedLogStart(const QString& path, const QString& reason);
 
     // The count is the distance between the two arguments, not the difference
     // between an inclusive pair, so lines(n, n) is empty rather than one line.

--- a/src/TConsoleModel.h
+++ b/src/TConsoleModel.h
@@ -116,6 +116,9 @@ struct TConsoleModel
     QString mLogFileName;
     QTextStream mLogStream;
     bool mLogToLogFile = false;
+    // The path a failed start could not write and why, for a caller with no
+    // console to read the report off.
+    QString mLogStartFailure;
 };
 
 #endif // MUDLET_TCONSOLEMODEL_H

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1576,6 +1576,11 @@ int TLuaInterpreter::startLogging(lua_State* L)
 
     if (consoleModel.mLogToLogFile != logOn) {
         consoleModel.toggleLogging(false);
+        if (consoleModel.mLogToLogFile != logOn) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "Main console output could not be logged to file: %s", consoleModel.mLogFileName.toUtf8().constData());
+            return 2;
+        }
 
         lua_pushboolean(L, true);
         if (consoleModel.mLogToLogFile) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -32,8 +32,10 @@
 #include "EAction.h"
 #include "Host.h"
 #include "TAlias.h"
+#include "TBuffer.h"
 #include "TCommandLine.h"
 #include "TConsole.h"
+#include "TConsoleModel.h"
 #include "TDebug.h"
 #include "TEvent.h"
 #include "TFlipButton.h"
@@ -1199,7 +1201,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         if (currentEncoding == "UTF-8") {
             // Simple case: the encoding is already what we are using:
             std::string dataStdString{data.toStdString()};
-            host.mpConsole->printOnDisplay(dataStdString);
+            host.printOnDisplay(dataStdString, false);
             lua_pushboolean(L, true);
             return 1;
         }
@@ -1217,7 +1219,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
             }
 
             std::string encodedText{TEncodingHelper::encode(dataQString, currentEncoding).toStdString()};
-            host.mpConsole->printOnDisplay(encodedText);
+            host.printOnDisplay(encodedText, false);
             lua_pushboolean(L, true);
             return 1;
         }
@@ -1233,7 +1235,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         // It is safe to use the data directly now as we have already proved it
         // to be plain ASCII
         std::string dataStdString{dataQString.toStdString()};
-        host.mpConsole->printOnDisplay(dataStdString);
+        host.printOnDisplay(dataStdString, false);
         lua_pushboolean(L, true);
         return 1;
     }
@@ -1241,7 +1243,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
     // else the user is assumed to have coded it themselves into the Game
     // Server's current encoding - the backwards "compatible" form:
     std::string dataStdString{data.toStdString()};
-    host.mpConsole->printOnDisplay(dataStdString);
+    host.printOnDisplay(dataStdString, false);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -1561,40 +1563,36 @@ int TLuaInterpreter::closeUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#startLogging
 int TLuaInterpreter::startLogging(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
     const bool logOn = getVerifiedBool(L, __func__, 1, "turn logging on/off");
+    TConsoleModel& consoleModel = host.mainConsoleModel();
 
     QString savedLogFileName;
-    if (host.mpConsole->mLogToLogFile) {
-        savedLogFileName = host.mpConsole->mLogFileName;
+    if (consoleModel.mLogToLogFile) {
+        savedLogFileName = consoleModel.mLogFileName;
         // Don't assume we will be able to find the file name once recording has
         // stopped.
     }
 
-    if (host.mpConsole->mLogToLogFile != logOn) {
-        host.mpConsole->toggleLogging(false);
-        // Changes state of host.mpConsole->mLogToLogFile, but that can't be
-        // really be called a side-effect!
+    if (consoleModel.mLogToLogFile != logOn) {
+        consoleModel.toggleLogging(false);
 
         lua_pushboolean(L, true);
-        if (host.mpConsole->mLogToLogFile) {
-            host.mpConsole->logButton->setChecked(true);
-            // Sets the button as checked but clicked() & pressed() signals are NOT generated
-            lua_pushfstring(L, "Main console output has started to be logged to file: %s", host.mpConsole->mLogFileName.toUtf8().constData());
-            lua_pushstring(L, host.mpConsole->mLogFileName.toUtf8().constData());
+        if (consoleModel.mLogToLogFile) {
+            lua_pushfstring(L, "Main console output has started to be logged to file: %s", consoleModel.mLogFileName.toUtf8().constData());
+            lua_pushstring(L, consoleModel.mLogFileName.toUtf8().constData());
             lua_pushnumber(L, 1);
         } else {
-            host.mpConsole->logButton->setChecked(false);
             lua_pushfstring(L, "Main console output has stopped being logged to file: %s", savedLogFileName.toUtf8().constData());
-            lua_pushstring(L, host.mpConsole->mLogFileName.toUtf8().constData());
+            lua_pushstring(L, consoleModel.mLogFileName.toUtf8().constData());
             lua_pushnumber(L, 0);
         }
 
     } else {
         lua_pushnil(L);
-        if (host.mpConsole->mLogToLogFile) {
-            lua_pushfstring(L, "Main console output is already being logged to file: %s", host.mpConsole->mLogFileName.toUtf8().constData());
-            lua_pushstring(L, host.mpConsole->mLogFileName.toUtf8().constData());
+        if (consoleModel.mLogToLogFile) {
+            lua_pushfstring(L, "Main console output is already being logged to file: %s", consoleModel.mLogFileName.toUtf8().constData());
+            lua_pushstring(L, consoleModel.mLogFileName.toUtf8().constData());
             lua_pushnumber(L, -1);
         } else {
             lua_pushstring(L, "Main console output was already not being logged to a file.");
@@ -1609,9 +1607,9 @@ int TLuaInterpreter::appendLog(lua_State* L)
 {
     const QString text = getVerifiedString(L, __func__, 1, "text to append to logfile", true);
 
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
 
-    host.mpConsole->buffer.appendLog(text);
+    host.mainConsoleModel().buffer.appendLog(text);
 
     return 0;
 }
@@ -1718,13 +1716,14 @@ int TLuaInterpreter::errorc(lua_State* L)
     }
 
     if (host.mEchoLuaErrors) {
-        if (!host.mpConsole->buffer.isEmpty() && !host.mpConsole->buffer.lineBuffer.at(host.mpConsole->buffer.lineBuffer.size() - 1).isEmpty()) {
+        const TBuffer& buffer = host.mainConsoleModel().buffer;
+        if (!buffer.isEmpty() && !buffer.lineBuffer.at(buffer.lineBuffer.size() - 1).isEmpty()) {
             host.postMessage(qsl("\n"));
         }
-        host.mpConsole->print(qsl("[  LUA  ] - "), QColor(80, 160, 255), QColor(Qt::black));
-        host.mpConsole->print(qsl("ERROR: "), QColor(Qt::blue), QColor(Qt::black));
-        host.mpConsole->print(qsl("%1").arg(luaFunctionInfo), QColor(Qt::green), QColor(Qt::black));
-        host.mpConsole->print(qsl("           %1").arg(luaErrorText), QColor(200, 50, 42), QColor(Qt::black));
+        host.printToMainConsole(qsl("[  LUA  ] - "), QColor(80, 160, 255), QColor(Qt::black));
+        host.printToMainConsole(qsl("ERROR: "), QColor(Qt::blue), QColor(Qt::black));
+        host.printToMainConsole(qsl("%1").arg(luaFunctionInfo), QColor(Qt::green), QColor(Qt::black));
+        host.printToMainConsole(qsl("           %1").arg(luaErrorText), QColor(200, 50, 42), QColor(Qt::black));
     }
     return 0;
 }
@@ -2328,10 +2327,11 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("line number %1 invalid, it should be greater than zero").arg(luaLine));
     }
 
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
     if (name.isEmpty()) {
-        if (luaLine < host.mpConsole->buffer.timeBuffer.size()) {
-            lua_pushstring(L, host.mpConsole->buffer.timeBuffer.at(luaLine).toUtf8().constData());
+        const TBuffer& buffer = host.mainConsoleModel().buffer;
+        if (luaLine < buffer.timeBuffer.size()) {
+            lua_pushstring(L, buffer.timeBuffer.at(luaLine).toUtf8().constData());
             return 1;
         }
         return warnArgumentValue(L, __func__, qsl("line number %1 invalid, it is beyond the last line of the buffer").arg(luaLine));
@@ -4591,10 +4591,9 @@ void TLuaInterpreter::logError(std::string& e, const QString& name, const QStrin
     // Log error to Profile's Main TConsole:
     if (mpHost->mEchoLuaErrors) {
         // ensure the Lua error is on a line of its own and is not prepended to
-        // the previous line, however there is a nasty gotcha in that during
-        // profile loading the (TMainConsole*) Host::mpConsole pointer is
-        // null - but then the buffer must itself be empty:
-        if (mpHost->mpConsole && !mpHost->mpConsole->buffer.isEmpty() && !mpHost->mpConsole->buffer.lineBuffer.at(mpHost->mpConsole->buffer.lineBuffer.size() - 1).isEmpty()) {
+        // the previous line; the model is still null while the Host is being
+        // constructed - but then there is no buffer to be mid-line in
+        if (auto* pModel = mpHost->mainConsoleModelOrNull(); pModel && !pModel->buffer.isEmpty() && !pModel->buffer.lineBuffer.at(pModel->buffer.lineBuffer.size() - 1).isEmpty()) {
             mpHost->postMessage(qsl("\n"));
         }
 
@@ -4623,7 +4622,7 @@ void TLuaInterpreter::logEventError(const QString& event, const QString& error)
     // Log error to Profile's Main TConsole:
     if (mpHost->mEchoLuaErrors) {
         // ensure the Lua error is on a line of its own and is not prepended to the previous line
-        if (!mpHost->mpConsole->buffer.isEmpty() && !mpHost->mpConsole->buffer.lineBuffer.at(mpHost->mpConsole->buffer.lineBuffer.size() - 1).isEmpty()) {
+        if (auto* pModel = mpHost->mainConsoleModelOrNull(); pModel && !pModel->buffer.isEmpty() && !pModel->buffer.lineBuffer.at(pModel->buffer.lineBuffer.size() - 1).isEmpty()) {
             mpHost->postMessage(qsl("\n"));
         }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1578,7 +1578,7 @@ int TLuaInterpreter::startLogging(lua_State* L)
         consoleModel.toggleLogging(false);
         if (consoleModel.mLogToLogFile != logOn) {
             lua_pushnil(L);
-            lua_pushfstring(L, "Main console output could not be logged to file: %s", consoleModel.mLogFileName.toUtf8().constData());
+            lua_pushfstring(L, "Main console output could not be logged to file: %s", consoleModel.mLogStartFailure.toUtf8().constData());
             return 2;
         }
 

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -37,6 +37,7 @@
 #include "TArea.h"
 #include "TCommandLine.h"
 #include "TConsole.h"
+#include "TConsoleModel.h"
 #include "TDebug.h"
 #include "TEvent.h"
 #include "TFlipButton.h"
@@ -3357,9 +3358,9 @@ int TLuaInterpreter::getSubsystemMemoryStats(lua_State* L)
     }
 
     // Main console buffer line count
-    if (host.mpConsole) {
+    if (auto* pModel = host.mainConsoleModelOrNull()) {
         lua_pushstring(L, "console_buffer_lines");
-        lua_pushnumber(L, host.mpConsole->buffer.size());
+        lua_pushnumber(L, pModel->buffer.size());
         lua_settable(L, -3);
     }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -311,6 +311,9 @@ void TMainConsole::slot_loggingAnnouncement(const bool isLogging, const QString&
 
 void TMainConsole::slot_loggingStateChanged(const bool isLogging)
 {
+    // A click has flipped the checkable button already; this is for logging
+    // toggled from Lua, and for a start that failed
+    logButton->setChecked(isLogging);
     logButton->setToolTip(utils::richText(isLogging ? tr("Stop logging game output to log file.") : tr("Start logging game output to log file.")));
 }
 

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -99,6 +99,12 @@ describe("Tests MXP handling", function()
       assertLineShown("\27[1z<B>Greetings < hunters & sorcerers</B>\27[7z", "Greetings < hunters & sorcerers")
     end)
 
+    -- a locked line shows its tags verbatim, so a switch to it that was acted
+    -- on would leave the <B> pair on the line
+    it("ignores an MXP mode switch in text a script fed", function()
+      assertLineShown("\27[2zMXPLOCAL1<B>still parsed</B>", "MXPLOCAL1still parsed")
+    end)
+
     -- an unescaped & running into a non-ASCII character is not an entity, so
     -- the raw bytes have to be passed through for the charset decoder to
     -- reassemble them (follow-up to #9439)

--- a/src/mudlet-lua/tests/Miscallaneous_spec.lua
+++ b/src/mudlet-lua/tests/Miscallaneous_spec.lua
@@ -157,6 +157,22 @@ describe("Tests C++ functions in the Miscallaneous category", function()
       end)
     end)
 
+    describe("Tests the functionality of getSubsystemMemoryStats", function()
+      it("counts the main console's buffer lines", function()
+        if not getSubsystemMemoryStats then
+          pending("only a USE_MEMORY_TRACKING build registers getSubsystemMemoryStats")
+        end
+        local before = getSubsystemMemoryStats().console_buffer_lines
+        -- the buffer keeps an empty line ready after the last line feed, which
+        -- getLineCount() leaves out
+        assert.equals(getLineCount() + 1, before)
+
+        echo("getSubsystemMemoryStats test line\n")
+
+        assert.equals(before + 1, getSubsystemMemoryStats().console_buffer_lines)
+      end)
+    end)
+
     describe("Tests the functionality of getModulePath", function()
       it("should return nil+msg for a module that does not exist", function()
         local path, err = getModulePath("busted-nonexistent-module")

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -42,6 +42,7 @@
 #include "ProfileTestHelper.h"
 #include "TBuffer.h"
 #include "TConsoleModel.h"
+#include "TLuaInterpreter.h"
 #include "TMainConsole.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
@@ -287,7 +288,8 @@ private slots:
         QVERIFY2(!button->isChecked(), "the log button stayed checked although no log was started");
         QVERIFY2(!QFileInfo::exists(mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"))), "a failed log start left the autolog sentinel behind");
         QVERIFY2(bufferContains(qsl("Could not start logging")), "the user was not told why logging did not start");
-        QVERIFY2(mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("local ok, msg = startLogging(true); assert(ok == nil, 'startLogging reported success on a failed start'); assert(msg:find('could not be logged', 1, true), msg)")),
+        QVERIFY2(mpHost->mLuaInterpreter.compileAndExecuteScript(
+                         qsl("local ok, msg = startLogging(true); assert(ok == nil, 'startLogging reported success on a failed start'); assert(msg:find('could not be logged', 1, true), msg)")),
                  "startLogging(true) did not report the failed start");
     }
 

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -20,11 +20,15 @@
 // Core code prints to the profile's main console through Host rather than
 // through the TMainConsole widget. Each Host forwarder is exercised on a live
 // profile and its effect read back off the main console's buffer; the telnet
-// message printer, the one caller of the coloured print, is driven through
-// Host::postMessage() so its prefix colouring is pinned as well.
+// message printer is driven through Host::postMessage() so its prefix
+// colouring is pinned as well, and the Lua error printers through the Lua
+// interpreter, since they read the buffer off the model to decide whether a
+// fresh line is needed first.
 
 #include <QDir>
+#include <QFile>
 #include <QTemporaryDir>
+#include <QToolButton>
 #include <QtTest/QtTest>
 
 #include <string>
@@ -57,6 +61,33 @@ private:
     const QString mLocalhost = qsl("localhost");
 
     TBuffer& buffer() { return mpHost->mainConsoleModel().buffer; }
+
+    bool runLua(const QString& script) { return mpHost->getLuaInterpreter()->compileAndExecuteScript(script); }
+
+    int lineContaining(const QString& needle)
+    {
+        for (int i = buffer().getLastLineNumber(); i >= 0; --i) {
+            if (buffer().line(i).contains(needle)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // Every Lua error printer writes a "[  LUA  ]" header line and the error
+    // text under it, and has to start the header on a fresh line when the
+    // console is mid-line - which the set-up here leaves it.
+    void expectLuaErrorOnItsOwnLine(const QString& script, const QString& errorText)
+    {
+        mpHost->mEchoLuaErrors = true;
+        mpHost->printToMainConsole(qsl("mid-line"));
+        QVERIFY(runLua(script));
+
+        const int line = lineContaining(errorText);
+        QVERIFY2(line >= 2, qPrintable(qsl("no line carries '%1'").arg(errorText)));
+        QVERIFY2(buffer().line(line - 1).startsWith(qsl("[  LUA  ]")), qPrintable(buffer().line(line - 1)));
+        QCOMPARE(buffer().line(line - 2), qsl("mid-line"));
+    }
 
     // The buffer keeps an empty line ready after the last line feed, so what
     // was printed most recently is the last non-empty line.
@@ -120,6 +151,22 @@ private slots:
         mpServer = nullptr;
         QDir(profilePath).removeRecursively();
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void cleanup()
+    {
+        if (!mpHost) {
+            return;
+        }
+        mpHost->mEchoLuaErrors = false;
+        mpHost->mLogDir.clear();
+        if (mpHost->mainConsoleModel().mLogToLogFile) {
+            mpHost->mainConsoleModel().toggleLogging(false);
+        }
+        // A test that failed mid-line must not glue the next test's text onto its own
+        if (!buffer().line(buffer().getLastLineNumber()).isEmpty()) {
+            mpHost->printToMainConsole(qsl("\n"));
+        }
     }
 
     void test_plainPrintLandsOnTheMainConsole()
@@ -191,6 +238,58 @@ private slots:
         mpHost->mpConsole->slot_toggleTimeStamps(false);
         QVERIFY(!mpHost->mainConsoleShowsTimeStamps());
     }
+
+    // startLogging() used to check and uncheck the toolbar button itself; the
+    // button now follows the model's state whichever way logging is toggled.
+    void test_luaStartLoggingDrivesTheLogButton()
+    {
+        QToolButton* button = mpHost->mpConsole->logButton;
+        QVERIFY(!button->isChecked());
+
+        QVERIFY(runLua(qsl("startLogging(true)")));
+        QVERIFY(mpHost->mainConsoleModel().mLogToLogFile);
+        QVERIFY2(button->isChecked(), "the log button did not follow logging being started from Lua");
+
+        QVERIFY(runLua(qsl("startLogging(false)")));
+        QVERIFY(!mpHost->mainConsoleModel().mLogToLogFile);
+        QVERIFY2(!button->isChecked(), "the log button did not follow logging being stopped from Lua");
+    }
+
+    // A click flips a checkable button before its slot runs, so a start that
+    // cannot open its file has to report the state it left behind.
+    void test_failedLogStartLeavesTheButtonUnchecked()
+    {
+        QFile blocker(qsl("%1/not-a-directory").arg(mConfigDir.path()));
+        QVERIFY(blocker.open(QIODevice::WriteOnly));
+        blocker.close();
+        mpHost->mLogDir = qsl("%1/logs").arg(blocker.fileName());
+
+        QToolButton* button = mpHost->mpConsole->logButton;
+        QVERIFY(!button->isChecked());
+        button->click();
+
+        QVERIFY(!mpHost->mainConsoleModel().mLogToLogFile);
+        QVERIFY2(!button->isChecked(), "the log button stayed checked although no log was started");
+    }
+
+    void test_luaErrorsArePrintedWithTheirColours()
+    {
+        mpHost->mEchoLuaErrors = true;
+        QVERIFY(runLua(qsl("printError('hcpt tinted error')")));
+
+        const int line = lineContaining(qsl("hcpt tinted error"));
+        QVERIFY(line >= 1);
+        QCOMPARE(buffer().buffer.at(line).front().foreground(), QColor(200, 50, 42));
+        const QString header = buffer().line(line - 1);
+        QVERIFY2(header.startsWith(qsl("[  LUA  ] - ERROR: ")), qPrintable(header));
+        QCOMPARE(buffer().buffer.at(line - 1).front().foreground(), QColor(80, 160, 255));
+    }
+
+    void test_printErrorStartsOnAFreshLine() { expectLuaErrorOnItsOwnLine(qsl("printError('hcpt errorc boom')"), qsl("hcpt errorc boom")); }
+
+    void test_scriptErrorStartsOnAFreshLine() { expectLuaErrorOnItsOwnLine(qsl("tempAlias('^hcpt-err$', [[error('hcpt alias boom')]])\nexpandAlias('hcpt-err', false)"), qsl("hcpt alias boom")); }
+
+    void test_handlerErrorStartsOnAFreshLine() { expectLuaErrorOnItsOwnLine(qsl("showHandlerError('hcpt-event', 'hcpt handler boom')"), qsl("hcpt handler boom")); }
 
     // cTelnet::postMessage() is what every "[ INFO ]  - ..." line goes through,
     // and it colours the prefix and the text after it separately.

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -104,6 +104,18 @@ private:
         return false;
     }
 
+    // The first line from lineNumber on that contains text - the buffer is shared
+    // by every case, so a search from its start could match an earlier print
+    QString lineContainingFrom(int lineNumber, const QString& text)
+    {
+        for (int i = lineNumber; i <= buffer().getLastLineNumber(); ++i) {
+            if (buffer().line(i).contains(text)) {
+                return buffer().line(i);
+            }
+        }
+        return QString();
+    }
+
     int lastTextLine()
     {
         for (int i = buffer().getLastLineNumber(); i >= 0; --i) {
@@ -279,18 +291,36 @@ private slots:
         QVERIFY(blocker.open(QIODevice::WriteOnly));
         blocker.close();
         mpHost->mLogDir = qsl("%1/logs").arg(blocker.fileName());
+        const QString savedNameFormat = mpHost->mLogFileNameFormat;
+        const QString savedName = mpHost->mLogFileName;
+        mpHost->mLogFileNameFormat.clear();
+        mpHost->mLogFileName = qsl("hcpt-failed-log");
 
         QToolButton* button = mpHost->mpConsole->logButton;
         QVERIFY(!button->isChecked());
+        // The report carries the whole path, so widen the wrap to read it back
+        // off one buffer line
+        buffer().setWrapAt(1000);
+        const int lineBefore = buffer().getLastLineNumber();
         button->click();
 
         QVERIFY(!mpHost->mainConsoleModel().mLogToLogFile);
         QVERIFY2(!button->isChecked(), "the log button stayed checked although no log was started");
+        // The log file name is settled only after the autolog sentinel has been
+        // written, so the start got as far as writing one before it failed
+        const QString logPath = qsl("%1/hcpt-failed-log.txt").arg(mpHost->mLogDir);
+        QCOMPARE(mpHost->mainConsoleModel().mLogFileName, logPath);
         QVERIFY2(!QFileInfo::exists(mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"))), "a failed log start left the autolog sentinel behind");
-        QVERIFY2(bufferContains(qsl("Could not start logging")), "the user was not told why logging did not start");
-        QVERIFY2(mpHost->mLuaInterpreter.compileAndExecuteScript(
-                         qsl("local ok, msg = startLogging(true); assert(ok == nil, 'startLogging reported success on a failed start'); assert(msg:find('could not be logged', 1, true), msg)")),
-                 "startLogging(true) did not report the failed start");
+        const QString report = lineContainingFrom(lineBefore, qsl("Could not start logging"));
+        QVERIFY2(!report.isEmpty(), "the user was not told why logging did not start");
+        const QString fileAndColon = qsl("\"%1\": ").arg(logPath);
+        QVERIFY2(report.contains(fileAndColon) && !report.section(fileAndColon, 1).trimmed().isEmpty(), qPrintable(qsl("the report does not name the file and the reason: %1").arg(report)));
+        QVERIFY2(mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("local ok, msg = startLogging(true); assert(ok == nil, 'startLogging reported success on a failed start'); assert(msg:find('could "
+                                                                     "not be logged', 1, true), msg); assert(msg:find('hcpt-failed-log.txt', 1, true), msg)")),
+                 "startLogging(true) did not report the failed start with its file");
+        mpHost->mLogFileNameFormat = savedNameFormat;
+        mpHost->mLogFileName = savedName;
+        buffer().setWrapAt(mpHost->mWrapAt);
     }
 
     void test_luaErrorsArePrintedWithTheirColours()

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -323,6 +323,32 @@ private slots:
         buffer().setWrapAt(mpHost->mWrapAt);
     }
 
+    // The log file name is settled only after the autolog sentinel is written,
+    // so a start that fails on the sentinel has no current name to report and
+    // Lua has to be told what could not be written instead
+    void test_failedSentinelWriteIsReportedToLua()
+    {
+        const QString sentinel = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"));
+        QVERIFY(QDir().mkpath(sentinel));
+        buffer().setWrapAt(1000);
+        const int lineBefore = buffer().getLastLineNumber();
+
+        const bool ran = runLua(qsl("local ok, msg = startLogging(true)\n"
+                                    "assert(ok == nil, 'startLogging reported success on a failed start')\n"
+                                    "assert(msg:find('could not be logged', 1, true), msg)\n"
+                                    "local _, stop = msg:find([[%1: ]], 1, true)\n"
+                                    "assert(stop, 'the message does not name the sentinel: ' .. msg)\n"
+                                    "assert(#msg > stop, 'the message gives no reason: ' .. msg)")
+                                        .arg(sentinel));
+        QDir().rmdir(sentinel);
+        QVERIFY2(ran, "startLogging(true) did not report the sentinel it could not write and the reason");
+        QVERIFY(!mpHost->mainConsoleModel().mLogToLogFile);
+        QVERIFY2(!QFileInfo::exists(sentinel), "the blocking directory was not removed");
+        const QString report = lineContainingFrom(lineBefore, qsl("Could not start logging"));
+        QVERIFY2(report.contains(qsl("\"%1\": ").arg(sentinel)), qPrintable(report));
+        buffer().setWrapAt(mpHost->mWrapAt);
+    }
+
     void test_luaErrorsArePrintedWithTheirColours()
     {
         mpHost->mEchoLuaErrors = true;

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -29,6 +29,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QScopeGuard>
 #include <QTemporaryDir>
 #include <QToolButton>
 #include <QtTest/QtTest>
@@ -358,6 +359,10 @@ private slots:
     {
         const QString sentinel = mudlet::getMudletPath(enums::profileDataItemPath, mpHost->getName(), qsl("autolog"));
         QVERIFY(QDir().mkpath(sentinel));
+        // Clearing the blocker is the failed start's job and the assertion
+        // below checks that it did it - the guard is only so that a failure
+        // before then does not leave it for the rest of the class:
+        const auto sentinelGuard = qScopeGuard([&sentinel]() { QDir().rmdir(sentinel); });
         buffer().setWrapAt(1000);
         const int lineBefore = buffer().getLastLineNumber();
 
@@ -368,7 +373,6 @@ private slots:
                                     "assert(stop, 'the message does not name the sentinel: ' .. msg)\n"
                                     "assert(#msg > stop, 'the message gives no reason: ' .. msg)")
                                         .arg(sentinel));
-        QDir().rmdir(sentinel);
         QVERIFY2(ran, "startLogging(true) did not report the sentinel it could not write and the reason");
         QVERIFY(!mpHost->mainConsoleModel().mLogToLogFile);
         QVERIFY2(!QFileInfo::exists(sentinel), "the blocking directory was not removed");

--- a/test/functional_tests/HostConsolePrintTest.cpp
+++ b/test/functional_tests/HostConsolePrintTest.cpp
@@ -61,6 +61,8 @@ private:
     QByteArray mSavedXdg;
     TelnetServerStub* mpServer = nullptr;
     Host* mpHost = nullptr;
+    QString mSavedLogFileNameFormat;
+    QString mSavedLogFileName;
     const QString mHostname = qsl("Test-HostConsolePrint");
     const QString mLocalhost = qsl("localhost");
 
@@ -166,6 +168,8 @@ private slots:
             QVERIFY2(connected.wait(15000), "The test profile never connected to the stub server.");
         }
         QVERIFY(mpHost->mpConsole);
+        mSavedLogFileNameFormat = mpHost->mLogFileNameFormat;
+        mSavedLogFileName = mpHost->mLogFileName;
     }
 
     void cleanupTestCase()
@@ -211,6 +215,12 @@ private slots:
         if (mpHost->mainConsoleModel().mLogToLogFile) {
             mpHost->mainConsoleModel().toggleLogging(false);
         }
+        // The logging cases widen the wrap and name a log file of their own;
+        // restoring that here rather than on their success path keeps one
+        // failure from leaking into every case that follows it.
+        mpHost->mLogFileNameFormat = mSavedLogFileNameFormat;
+        mpHost->mLogFileName = mSavedLogFileName;
+        buffer().setWrapAt(mpHost->mWrapAt);
         // A test that fails part-way through would otherwise leave the
         // recording running, and the next one to touch it would trip on the
         // "already recording" guard rather than on what it is testing.
@@ -320,8 +330,6 @@ private slots:
         QVERIFY(blocker.open(QIODevice::WriteOnly));
         blocker.close();
         mpHost->mLogDir = qsl("%1/logs").arg(blocker.fileName());
-        const QString savedNameFormat = mpHost->mLogFileNameFormat;
-        const QString savedName = mpHost->mLogFileName;
         mpHost->mLogFileNameFormat.clear();
         mpHost->mLogFileName = qsl("hcpt-failed-log");
 
@@ -347,9 +355,6 @@ private slots:
         QVERIFY2(mpHost->mLuaInterpreter.compileAndExecuteScript(qsl("local ok, msg = startLogging(true); assert(ok == nil, 'startLogging reported success on a failed start'); assert(msg:find('could "
                                                                      "not be logged', 1, true), msg); assert(msg:find('hcpt-failed-log.txt', 1, true), msg)")),
                  "startLogging(true) did not report the failed start with its file");
-        mpHost->mLogFileNameFormat = savedNameFormat;
-        mpHost->mLogFileName = savedName;
-        buffer().setWrapAt(mpHost->mWrapAt);
     }
 
     // The log file name is settled only after the autolog sentinel is written,
@@ -362,7 +367,9 @@ private slots:
         // Clearing the blocker is the failed start's job and the assertion
         // below checks that it did it - the guard is only so that a failure
         // before then does not leave it for the rest of the class:
-        const auto sentinelGuard = qScopeGuard([&sentinel]() { QDir().rmdir(sentinel); });
+        const auto sentinelGuard = qScopeGuard([&sentinel]() {
+            QDir().rmdir(sentinel);
+        });
         buffer().setWrapAt(1000);
         const int lineBefore = buffer().getLastLineNumber();
 
@@ -378,7 +385,6 @@ private slots:
         QVERIFY2(!QFileInfo::exists(sentinel), "the blocking directory was not removed");
         const QString report = lineContainingFrom(lineBefore, qsl("Could not start logging"));
         QVERIFY2(report.contains(qsl("\"%1\": ").arg(sentinel)), qPrintable(report));
-        buffer().setWrapAt(mpHost->mWrapAt);
     }
 
     void test_luaErrorsArePrintedWithTheirColours()


### PR DESCRIPTION
Stacked on #10493.

#### Brief overview of PR changes/additions
- `TLuaInterpreter.cpp` reads the main console's buffer and log state off `Host::mainConsoleModel()` and prints through `Host::printToMainConsole()` / `Host::printOnDisplay()` instead of `host.mpConsole->...` (50 -> 21 `mpConsole` lines; the rest are view-level calls for the next step).
- The log button follows the model's state in `TMainConsole::slot_loggingStateChanged()` rather than being set by hand from `startLogging()`. A start that cannot open its file now reports its state too, so a clicked button no longer stays lit over a log that never started.
- A log that fails to start says why: the console gets `[ ERROR ] - Could not start logging to "<path>": <reason>`, the `autolog` sentinel written just before is removed again so the next session does not resume a log that never began, and Lua's `startLogging(true)` returns `nil` plus the reason instead of `true`.

#### Motivation for adding to Mudlet
Another slice of #8681: the Lua API implementation has to work against the core model, not the widget.

#### Other info (issues closed, discussion etc)
Behaviour is unchanged apart from the failed-start fixes above. The `console_buffer_lines` spec is pending outside a `USE_MEMORY_TRACKING` build, as the function it reads is only registered there.

**Test case:** `HostConsolePrintTest` gains the log-button (Lua start/stop, failed start: the report line names the log file and the reason, no sentinel left, `mLogFileName` settles on the file, Lua sees `nil` + a reason naming the file) and Lua error printer cases (colours, fresh line for `printError`, a script error and an event handler error); `MXP_spec` pins that `feedTriggers()` text is not treated as the game's; `Miscallaneous_spec` covers `console_buffer_lines`. Each C++ change was sabotaged and turned at least one of these red. A start that fails before the log file name is settled (the autolog sentinel cannot be written) is reported to Lua with the sentinel path and the filesystem error, pinned by making the sentinel a directory.

Assisted-by: Claude:claude-fable-5-1


