### PR TITLE
Improve: Use 16 bytes instead of 44 for every character in the scrollback buffer

### DIFF
--- a/src/TAccessibleTextEdit.cpp
+++ b/src/TAccessibleTextEdit.cpp
@@ -513,8 +513,8 @@ QString TAccessibleTextEdit::attributes(int offset, int* startOffset, int* endOf
     // same attribute signature so the screen reader doesn't have to re-query
     // for every single character. Per the IAccessible2 spec, *startOffset and
     // *endOffset describe the range over which the returned attributes apply.
-    const QColor& sigFg = charStyle.foreground();
-    const QColor& sigBg = charStyle.background();
+    const QRgb sigFg = charStyle.foregroundRgba();
+    const QRgb sigBg = charStyle.backgroundRgba();
     const bool sigSelected = charStyle.isSelected();
     const int caretCol = edit->mCaretColumn;
     const bool caretOnThisLine = edit->mpHost->caretEnabled() && edit->mCaretLine == line;
@@ -532,7 +532,7 @@ QString TAccessibleTextEdit::attributes(int offset, int* startOffset, int* endOf
             return false;
         }
         const TChar& other = bufferLine.at(col);
-        return other.linkIndex() == linkIndex && other.allDisplayAttributes() == attributes && other.foreground() == sigFg && other.background() == sigBg && other.isSelected() == sigSelected;
+        return other.linkIndex() == linkIndex && other.allDisplayAttributes() == attributes && other.foregroundRgba() == sigFg && other.backgroundRgba() == sigBg && other.isSelected() == sigSelected;
     };
 
     int runStartCol = column;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -300,16 +300,6 @@ bool TChar::operator==(const TChar& other)
     return mLinkIndex == other.mLinkIndex && mFgColor == other.mFgColor && mBgColor == other.mBgColor && mFlags == other.mFlags;
 }
 
-// Copy constructor - because it is clearing the Selected flag it is NOT a
-// default copy constructor:
-TChar::TChar(const TChar& copy)
-: mFgColor(copy.mFgColor)
-, mBgColor(copy.mBgColor)
-, mFlags(copy.mFlags & ~Selected)
-, mLinkIndex(copy.mLinkIndex)
-{
-}
-
 quint8 TChar::alternateFont() const
 {
     // As this is the most likely case check it first:

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -279,16 +279,16 @@ QList<RawQueryParameter> splitOscQueryParameters(const QString& query)
 } // anonymous namespace
 
 TChar::TChar(const QColor& foreground, const QColor& background, const TChar::AttributeFlags flags, const int linkIndex)
-: mFgColor(foreground)
-, mBgColor(background)
+: mFgColor(foreground.rgba())
+, mBgColor(background.rgba())
 , mFlags(flags)
 , mLinkIndex(linkIndex)
 {
 }
 
 TChar::TChar(TConsole* pC)
-: mFgColor(pC ? pC->mFormatCurrent.foreground() : QColorConstants::White)
-, mBgColor(pC ? pC->mFormatCurrent.background() : QColorConstants::Black)
+: mFgColor(pC ? pC->mFormatCurrent.mFgColor : QColorConstants::White.rgba())
+, mBgColor(pC ? pC->mFormatCurrent.mBgColor : QColorConstants::Black.rgba())
 , mFlags(pC ? pC->mFormatCurrent.allDisplayAttributes() : AttributeFlag::None)
 {
 }
@@ -297,31 +297,15 @@ TChar::TChar(TConsole* pC)
 // not be wanted in every case:
 bool TChar::operator==(const TChar& other)
 {
-    if (mIsSelected != other.mIsSelected) {
-        return false;
-    }
-    if (mLinkIndex != other.mLinkIndex) {
-        return false;
-    }
-    if (mFgColor != other.mFgColor) {
-        return false;
-    }
-    if (mBgColor != other.mBgColor) {
-        return false;
-    }
-    if (mFlags != other.mFlags) {
-        return false;
-    }
-    return true;
+    return mLinkIndex == other.mLinkIndex && mFgColor == other.mFgColor && mBgColor == other.mBgColor && mFlags == other.mFlags;
 }
 
-// Copy constructor - because it is resetting the mIsSelected flag it is NOT a
+// Copy constructor - because it is clearing the Selected flag it is NOT a
 // default copy constructor:
 TChar::TChar(const TChar& copy)
 : mFgColor(copy.mFgColor)
 , mBgColor(copy.mBgColor)
-, mFlags(copy.mFlags)
-, mIsSelected(false)
+, mFlags(copy.mFlags & ~Selected)
 , mLinkIndex(copy.mLinkIndex)
 {
 }
@@ -723,9 +707,9 @@ void TBuffer::addLink(bool trigMode, const QString& text, QStringList& command, 
     const int id = mLinkStore.addLinks(command, hint, mpHost, luaReference);
 
     if (!trigMode) {
-        append(text, 0, text.length(), format.mFgColor, format.mBgColor, format.mFlags, id);
+        append(text, 0, text.length(), format.foreground(), format.background(), format.mFlags, id);
     } else {
-        appendLine(text, 0, text.length(), format.mFgColor, format.mBgColor, format.mFlags, id);
+        appendLine(text, 0, text.length(), format.foreground(), format.background(), format.mFlags, id);
     }
 }
 
@@ -1594,18 +1578,18 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
             if (!mLinkOriginalCharacters.contains(mCurrentHyperlinkLinkId)) {
                 mLinkOriginalCharacters[mCurrentHyperlinkLinkId] = c;
 #if defined(DEBUG_OSC_PROCESSING)
-                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId << " with ANSI colors: fg=" << c.mFgColor.name()
-                                             << " bg=" << c.mBgColor.name() << " flags=" << c.mFlags;
+                qDebug().nospace().noquote() << "TBuffer::translateToPlainText(): Stored original character for link " << mCurrentHyperlinkLinkId << " with ANSI colors: fg=" << c.foreground().name()
+                                             << " bg=" << c.background().name() << " flags=" << c.mFlags;
 #endif
             }
 
             // Apply base styling first (if any)
             if (mCurrentHyperlinkStyling.hasForegroundColor) {
-                c.mFgColor = mCurrentHyperlinkStyling.foregroundColor;
+                c.setForeground(mCurrentHyperlinkStyling.foregroundColor);
             }
 
             if (mCurrentHyperlinkStyling.hasBackgroundColor) {
-                c.mBgColor = mCurrentHyperlinkStyling.backgroundColor;
+                c.setBackground(mCurrentHyperlinkStyling.backgroundColor);
             }
 
             // For preset-only links, base styling may be empty but pseudo-class styling exists
@@ -1613,10 +1597,10 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
             Mudlet::HyperlinkStyling effectiveStyling = getEffectiveHyperlinkStyling(mCurrentHyperlinkLinkId);
             if (effectiveStyling.hasCustomStyling) {
                 if (effectiveStyling.hasForegroundColor) {
-                    c.mFgColor = effectiveStyling.foregroundColor;
+                    c.setForeground(effectiveStyling.foregroundColor);
                 }
                 if (effectiveStyling.hasBackgroundColor) {
-                    c.mBgColor = effectiveStyling.backgroundColor;
+                    c.setBackground(effectiveStyling.backgroundColor);
                 }
                 if (effectiveStyling.isBold) {
                     c.mFlags |= TChar::Bold;
@@ -1700,11 +1684,11 @@ void TBuffer::translateToPlainTextInner(std::string& incoming, const bool isFrom
         }
 
         if (mpHost->mMxpClient.hasFgColor()) {
-            c.mFgColor = mpHost->mMxpClient.getFgColor();
+            c.setForeground(mpHost->mMxpClient.getFgColor());
         }
 
         if (mpHost->mMxpClient.hasBgColor()) {
-            c.mBgColor = mpHost->mMxpClient.getBgColor();
+            c.setBackground(mpHost->mMxpClient.getBgColor());
         }
 
         if (isTwoTCharsNeeded) {
@@ -1961,7 +1945,7 @@ void TBuffer::commitLineData(QString line, std::vector<TChar> chars, const char 
         // a line an earlier trigger in this pass recolored has to keep its
         // originals somewhere. materialisePreTriggerPassLine() copies them out
         // when something first overwrites them rather than up front, because
-        // most lines are never touched and the copy is 44 bytes a character.
+        // most lines are never touched and the copy is a whole line of TChars.
         // Any pass already running is about to lose the pass state to this one,
         // so its line has to be copied out now - a recolor made from inside this
         // pass would aim the barrier at this line instead:
@@ -2324,7 +2308,7 @@ const TChar* TBuffer::preTriggerPassLineUniformColors(int lineNumber)
         // The first character only stands in for the rest of them while this
         // compares colors the same way the trigger it answers for does
         const bool uniform = std::all_of(passLine.cbegin() + 1, passLine.cend(), [&first](const TChar& character) {
-            return sameColor(first.foreground(), character.foreground()) && sameColor(first.background(), character.background());
+            return first.foregroundRgba() == character.foregroundRgba() && first.backgroundRgba() == character.backgroundRgba();
         });
         mPreTriggerPassLineUniformity = uniform ? PassLineUniformity::Uniform : PassLineUniformity::Mixed;
     }
@@ -5044,7 +5028,7 @@ void TBuffer::resetColors()
 
 void TBuffer::append(const QString& text, int sub_start, int sub_end, const TChar& format, int linkID)
 {
-    append(text, sub_start, sub_end, format.mFgColor, format.mBgColor, format.mFlags, linkID);
+    append(text, sub_start, sub_end, format.foreground(), format.background(), format.mFlags, linkID);
 }
 
 // A link index only means anything to the store that issued it, so an index from
@@ -5299,7 +5283,7 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
         buffer[y].insert(buffer[y].begin() + x, static_cast<std::size_t>(insertedText.size()), format);
         syncPreTriggerPassLine(y);
     } else {
-        appendLine(insertedText, 0, insertedText.size(), format.mFgColor, format.mBgColor, format.mFlags);
+        appendLine(insertedText, 0, insertedText.size(), format.foreground(), format.background(), format.mFlags);
     }
     return true;
 }
@@ -5360,8 +5344,8 @@ void TBuffer::paste(QPoint& P, const TBuffer& chunk)
         QPoint P_current(x + cx, y);
         insertInLine(P_current,
                      QString(chunk.lineBuffer.at(0).at(cx)),
-                     TChar(chunk.buffer.at(0).at(cx).mFgColor,
-                           chunk.buffer.at(0).at(cx).mBgColor,
+                     TChar(chunk.buffer.at(0).at(cx).foreground(),
+                           chunk.buffer.at(0).at(cx).background(),
                            chunk.buffer.at(0).at(cx).mFlags,
                            remapLinkId(chunk.mLinkStore, chunk.buffer.at(0).at(cx).linkIndex(), remappedLinkIds)));
     }
@@ -6337,7 +6321,7 @@ bool TBuffer::applyFgColor(const QPoint& P_begin, const QPoint& P_end, const QCo
                     return true;
                 }
 
-                buffer.at(y).at(x++).mFgColor = newColor;
+                buffer.at(y).at(x++).setForeground(newColor);
             }
         }
         return true;
@@ -6379,7 +6363,7 @@ bool TBuffer::applyBgColor(const QPoint& P_begin, const QPoint& P_end, const QCo
                     return true;
                 }
 
-                buffer.at(y).at(x++).mBgColor = newColor;
+                buffer.at(y).at(x++).setBackground(newColor);
             }
         }
         return true;
@@ -6429,8 +6413,8 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     }
 
     TChar::AttributeFlags currentFlags = TChar::None;
-    QColor currentFgColor(Qt::black);
-    QColor currentBgColor(Qt::black);
+    QRgb currentFgColor = qRgb(0, 0, 0);
+    QRgb currentBgColor = qRgb(0, 0, 0);
     int currentLinkIndex = 0;
     // This combination of color values (black on black) cannot usefully be used in practice
     // - so use as initialization values
@@ -6449,8 +6433,8 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
         s.append(qsl("<span style=\"color: rgb(200,150,0); background: %1; \">%2").arg(timeStampBgColor.name(), timeBuffer.at(row).left(TBuffer::smTimeStampFormat.length())));
         // Set the current idea of what the formatting is so we can spot if it
         // changes:
-        currentFgColor = QColor(200, 150, 0);
-        currentBgColor = timeStampBgColor;
+        currentFgColor = qRgb(200, 150, 0);
+        currentBgColor = timeStampBgColor.rgba();
         currentFlags = TChar::None;
         // We are no longer before the first span - so we need to flag that
         // there will be one to close:
@@ -6474,15 +6458,15 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
     for (auto cookedPos = static_cast<size_t>(pos); pos < lastPos; ++cookedPos, ++pos) {
         const int charLinkIndex = buffer.at(cookedRow).at(cookedPos).linkIndex();
         // Do we need to start a new span?
-        if (firstSpan || buffer.at(cookedRow).at(cookedPos).mFgColor != currentFgColor || buffer.at(cookedRow).at(cookedPos).mBgColor != currentBgColor
+        if (firstSpan || buffer.at(cookedRow).at(cookedPos).foregroundRgba() != currentFgColor || buffer.at(cookedRow).at(cookedPos).backgroundRgba() != currentBgColor
             || (buffer.at(cookedRow).at(cookedPos).mFlags & TChar::TestMask) != currentFlags || charLinkIndex != currentLinkIndex) {
             if (firstSpan) {
                 firstSpan = false; // The first span - won't need to close the previous one
             } else {
                 s.append(QLatin1String("</span>"));
             }
-            currentFgColor = buffer.at(cookedRow).at(cookedPos).mFgColor;
-            currentBgColor = buffer.at(cookedRow).at(cookedPos).mBgColor;
+            currentFgColor = buffer.at(cookedRow).at(cookedPos).foregroundRgba();
+            currentBgColor = buffer.at(cookedRow).at(cookedPos).backgroundRgba();
             currentFlags = buffer.at(cookedRow).at(cookedPos).mFlags & TChar::TestMask;
             currentLinkIndex = charLinkIndex;
 
@@ -6549,8 +6533,8 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
             if (currentFlags & TChar::Reverse) {
                 // Swap the fore and background colours:
                 s.append(qsl("<span%9 style=\"color: rgb(%1,%2,%3); background: rgb(%4,%5,%6);%7%8")
-                         .arg(QString::number(currentBgColor.red()), QString::number(currentBgColor.green()), QString::number(currentBgColor.blue()), // args 1 to 3
-                              QString::number(currentFgColor.red()), QString::number(currentFgColor.green()), QString::number(currentFgColor.blue()), // args 4 to 6
+                         .arg(QString::number(qRed(currentBgColor)), QString::number(qGreen(currentBgColor)), QString::number(qBlue(currentBgColor)), // args 1 to 3
+                              QString::number(qRed(currentFgColor)), QString::number(qGreen(currentFgColor)), QString::number(qBlue(currentFgColor)), // args 4 to 6
                               currentFlags & TChar::Bold ? QLatin1String(" font-weight: bold;") : QString(), // arg 7
                               currentFlags & TChar::Italic ? QLatin1String(" font-style: italic;") : QString(), // arg 8
                               blinkClass) // arg 9
@@ -6558,8 +6542,8 @@ QString TBuffer::bufferToHtml(const bool showTimeStamp /*= false*/, const int ro
                          + qsl("\">"));
             } else {
                 s.append(qsl("<span%9 style=\"color: rgb(%1,%2,%3); background: rgb(%4,%5,%6);%7%8")
-                         .arg(QString::number(currentFgColor.red()), QString::number(currentFgColor.green()), QString::number(currentFgColor.blue()), // args 1 to 3
-                              QString::number(currentBgColor.red()), QString::number(currentBgColor.green()), QString::number(currentBgColor.blue()), // args 4 to 6
+                         .arg(QString::number(qRed(currentFgColor)), QString::number(qGreen(currentFgColor)), QString::number(qBlue(currentFgColor)), // args 1 to 3
+                              QString::number(qRed(currentBgColor)), QString::number(qGreen(currentBgColor)), QString::number(qBlue(currentBgColor)), // args 4 to 6
                               currentFlags & TChar::Bold ? QLatin1String(" font-weight: bold;") : QString(), // arg 7
                               currentFlags & TChar::Italic ? QLatin1String(" font-style: italic;") : QString(), // arg 8
                               blinkClass) // arg 9
@@ -8411,7 +8395,7 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 matchingCharacters++;
                 static int charUpdateCount = 0;
                 if (charUpdateCount++ < 2) { // Only log first 2 characters to avoid spam
-                    qDebug() << "[OSC] Before update - char with linkIndex" << linkIndex << "- FgColor:" << tchar.mFgColor.name() << "hasFg:" << effectiveStyling.hasForegroundColor
+                    qDebug() << "[OSC] Before update - char with linkIndex" << linkIndex << "- FgColor:" << tchar.foreground().name() << "hasFg:" << effectiveStyling.hasForegroundColor
                              << "new fg:" << (effectiveStyling.hasForegroundColor ? effectiveStyling.foregroundColor.name() : "none");
                 }
 #endif
@@ -8423,13 +8407,16 @@ void TBuffer::updateLinkCharacters(int linkIndex)
                 if (useAnsiBase && mLinkOriginalCharacters.contains(linkIndex)) {
                     TChar originalChar = mLinkOriginalCharacters.value(linkIndex);
 #if defined(DEBUG_OSC_PROCESSING)
-                    qDebug() << "[OSC] Restoring ANSI base for link" << linkIndex << "- Original FgColor:" << originalChar.mFgColor.name() << "Original BgColor:" << originalChar.mBgColor.name()
-                             << "Original Bold:" << bool(originalChar.mFlags & TChar::Bold) << "Current FgColor:" << tchar.mFgColor.name() << "Current Bold:" << bool(tchar.mFlags & TChar::Bold);
+                    qDebug() << "[OSC] Restoring ANSI base for link" << linkIndex << "- Original FgColor:" << originalChar.foreground().name()
+                             << "Original BgColor:" << originalChar.background().name() << "Original Bold:" << bool(originalChar.mFlags & TChar::Bold)
+                             << "Current FgColor:" << tchar.foreground().name() << "Current Bold:" << bool(tchar.mFlags & TChar::Bold);
 #endif
                     // Restore ANSI base - these will be overridden below if styling specifies them
                     tchar.mFgColor = originalChar.mFgColor;
                     tchar.mBgColor = originalChar.mBgColor;
-                    tchar.mFlags = originalChar.mFlags; // Restore ALL ANSI formatting flags including decorations
+                    // Restore ALL ANSI formatting flags including decorations,
+                    // keeping the character selected if it is now
+                    tchar.mFlags = (tchar.mFlags & TChar::Selected) | (originalChar.mFlags & ~TChar::Selected);
 
                     // DON'T continue here - let the pseudo-class styling below override the ANSI base
                     // This allows e.g. :visited{color:#bb66dd} to work with ANSI base formatting
@@ -8439,21 +8426,21 @@ void TBuffer::updateLinkCharacters(int linkIndex)
 
                 // Update foreground color
                 if (effectiveStyling.hasForegroundColor) {
-                    tchar.mFgColor = effectiveStyling.foregroundColor;
+                    tchar.setForeground(effectiveStyling.foregroundColor);
 #if defined(DEBUG_OSC_PROCESSING)
                     static int fgUpdateCount = 0;
                     if (fgUpdateCount++ < 2) {
-                        qDebug() << "[OSC] Applied FG color to link" << linkIndex << "- New FgColor:" << tchar.mFgColor.name();
+                        qDebug() << "[OSC] Applied FG color to link" << linkIndex << "- New FgColor:" << tchar.foreground().name();
                     }
 #endif
                 }
 
                 // Update background color - restore original if not specified in styling
                 if (effectiveStyling.hasBackgroundColor) {
-                    tchar.mBgColor = effectiveStyling.backgroundColor;
+                    tchar.setBackground(effectiveStyling.backgroundColor);
                 } else {
                     // Restore the original background color from when the link was created
-                    tchar.mBgColor = mLinkOriginalBackgrounds.value(linkIndex, mBackGroundColor);
+                    tchar.setBackground(mLinkOriginalBackgrounds.value(linkIndex, mBackGroundColor));
                 }
 
                 // Update text decorations (only for CSS styling, not ANSI-base)

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -153,8 +153,16 @@ public:
     explicit TChar(TConsole* pC = nullptr);
     // Another non-default constructor:
     TChar(const QColor& foreground, const QColor& background, const TChar::AttributeFlags flags = TChar::None, const int linkIndex = 0);
-    // User defined copy-constructor:
-    TChar(const TChar&);
+    // User defined copy-constructor, defined here because filling a run of
+    // text with its format and copying out a finished line both go through it
+    // once per character:
+    TChar(const TChar& copy)
+    : mFgColor(copy.mFgColor)
+    , mBgColor(copy.mBgColor)
+    , mFlags(copy.mFlags & ~Selected)
+    , mLinkIndex(copy.mLinkIndex)
+    {
+    }
     // Under the rule of three, because we have a user defined copy-constructor,
     // we should also have a destructor and an assignment operator but they can,
     // in this case, be default ones:

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -43,7 +43,6 @@
 #include <QVarLengthArray>
 #include <QVector>
 
-#include <cstring>
 #include <deque>
 #include <memory>
 #include <string>
@@ -76,22 +75,6 @@ public:
     }
 };
 
-// Only two RGB colors compare as a plain comparison of the front of the object,
-// which can be inlined here rather than made as a call into Qt. HSV, HSL and
-// ExtendedRgb all compare approximately - HSV counts hue 0 and hue 36000 as the
-// same red - so those are left to QColor::operator==(). Every color a trigger
-// actually sees is RGB, which makes the fast path the predicted one.
-constexpr size_t COLOR_COMPARED_BYTES = sizeof(QColor::Spec) + 5 * sizeof(ushort);
-static_assert(sizeof(QColor) == 16 && COLOR_COMPARED_BYTES == 14, "QColor is no longer a spec word followed by five component words - use QColor::operator==() instead of sameColor()");
-
-inline bool sameColor(const QColor& left, const QColor& right)
-{
-    if (Q_LIKELY(left.spec() == QColor::Rgb && right.spec() == QColor::Rgb)) {
-        return std::memcmp(&left, &right, COLOR_COMPARED_BYTES) == 0;
-    }
-    return left == right;
-}
-
 class TChar
 {
     friend class TBuffer;
@@ -114,9 +97,9 @@ public:
         UnderlineWavy = 0x400000,     // 0000 0000 0100 0000 0000 0000 0000 0000
         UnderlineDotted = 0x800000,   // 0000 0000 1000 0000 0000 0000 0000 0000
         UnderlineDashed = 0x1000000,  // 0000 0001 0000 0000 0000 0000 0000 0000
-        // NOT a replacement for TCHAR_INVERSE, that is now covered by the
-        // separate isSelected bool but they must be EX-ORed at the point of
-        // painting the Character
+        // NOT a replacement for TCHAR_INVERSE, that is now the Selected flag
+        // below, but they must be EX-ORed at the point of painting the
+        // Character
         Reverse = 0x20,               // 0000 0000 0000 0000 0000 0000 0010 0000
         // Flashing less than 150 times a minute:
         Blink = 0x40,                 // 0000 0000 0000 0000 0000 0000 0100 0000
@@ -155,7 +138,11 @@ public:
         // and has been given a highlight to indicate that:
         Found = 0x100000,             // 0000 0000 0001 0000 0000 0000 0000 0000
         // Replaces TCHAR_ECHO 16
-        Echo = 0x200000               // 0000 0000 0010 0000 0000 0000 0000 0000
+        Echo = 0x200000,              // 0000 0000 0010 0000 0000 0000 0000 0000
+        // Part of the text selection in the console showing it. Not a display
+        // attribute (it is outside TestMask) and it does not survive copying
+        // the character - see the copy constructor:
+        Selected = 0x2000000          // 0000 0010 0000 0000 0000 0000 0000 0000
     };
     // clang-format on
     Q_DECLARE_FLAGS(AttributeFlags, AttributeFlag)
@@ -185,25 +172,29 @@ public:
     bool operator==(const TChar&);
     void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor)
     {
-        mFgColor = newForeGroundColor;
-        mBgColor = newBackGroundColor;
+        mFgColor = newForeGroundColor.rgba();
+        mBgColor = newBackGroundColor.rgba();
     }
     // Only considers the flags within TestMask - so not Echo or Found:
     void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes) { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
-    void setForeground(const QColor& newColor) { mFgColor = newColor; }
-    void setBackground(const QColor& newColor) { mBgColor = newColor; }
+    void setForeground(const QColor& newColor) { mFgColor = newColor.rgba(); }
+    void setBackground(const QColor& newColor) { mBgColor = newColor.rgba(); }
     void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes)
     {
         setColors(newFgColor, newBgColor);
         setAllDisplayAttributes(newDisplayAttributes);
     }
 
-    const QColor& foreground() const { return mFgColor; }
-    const QColor& background() const { return mBgColor; }
+    QColor foreground() const { return QColor::fromRgba(mFgColor); }
+    QColor background() const { return QColor::fromRgba(mBgColor); }
+    // The stored form of the colors, for comparing against another color
+    // without building a QColor to do it:
+    QRgb foregroundRgba() const { return mFgColor; }
+    QRgb backgroundRgba() const { return mBgColor; }
     AttributeFlags allDisplayAttributes() const { return mFlags & TestMask; }
-    void select() { mIsSelected = true; }
-    void deselect() { mIsSelected = false; }
-    bool isSelected() const { return mIsSelected; }
+    void select() { mFlags |= Selected; }
+    void deselect() { mFlags &= ~Selected; }
+    bool isSelected() const { return mFlags & Selected; }
     int linkIndex() const { return mLinkIndex; }
     bool isBold() const { return mFlags & Bold; }
     bool isItalic() const { return mFlags & Italic; }
@@ -302,11 +293,12 @@ public:
     }
 
 private:
-    QColor mFgColor;
-    QColor mBgColor;
+    // Every line of scrollback holds one of these per character, so the colors
+    // are kept as ARGB values rather than as a pair of 16-byte QColors. The
+    // colors the text pipeline sees are all 8-bit RGB, which QRgb holds exactly.
+    QRgb mFgColor = 0;
+    QRgb mBgColor = 0;
     AttributeFlags mFlags = None;
-    // Kept as a separate flag because it must often be handled separately
-    bool mIsSelected = false;
     int mLinkIndex = 0;
     // Note: Decoration colors (underline/overline/strikeout) are stored in TLinkStore
     // for memory efficiency - they are looked up via linkIndex() at render time.
@@ -315,6 +307,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
 // std::vector only relocates by moving if the move cannot throw; otherwise it
 // falls back to the copy-constructor, which deselects.
 static_assert(std::is_nothrow_move_constructible_v<TChar>);
+static_assert(sizeof(TChar) == 16, "TChar has grown - every character of every buffered line is one of these");
 
 
 class TBuffer

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -868,6 +868,9 @@ inline QDebug& operator<<(QDebug& debug, const TChar::AttributeFlags& attributes
     if (attributes & TChar::UnderlineDashed) {
         presentAttributes << QLatin1String("UnderlineDashed (0x1000000)");
     }
+    if (attributes & TChar::Selected) {
+        presentAttributes << QLatin1String("Selected (0x2000000)");
+    }
     if (presentAttributes.isEmpty()) {
         result.append(QLatin1String("None (0x0))"));
     } else {

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -53,12 +53,18 @@ void TMxpMudlet::popColor()
 
 void TMxpMudlet::pushColor(QList<QColor>& stack, const QString& color)
 {
-    if (color.isEmpty()) {
+    // A name the client does not know gives an invalid QColor, which a TChar
+    // would store as opaque black - so treat it like an attribute that was not
+    // given at all and carry on with the color in force, as an empty name has
+    // always done. Repeating that color rather than not pushing is what keeps
+    // the stack in step with popColor().
+    const QColor newColor(color);
+    if (!newColor.isValid()) {
         if (!stack.isEmpty()) {
             stack.push_back(stack.last());
         }
     } else {
-        stack.push_back(QColor(color));
+        stack.push_back(newColor);
     }
 }
 void TMxpMudlet::popColor(QList<QColor>& stack)

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -913,15 +913,19 @@ bool TTrigger::match_color_pattern(int line, int patternNumber, int posOffset, i
         return false; // no color settings to match against
     }
 
-    // Nothing below changes any of these, but the colour comparison is an
-    // out-of-line call that the compiler has to assume might, so read them once
-    // rather than once per character of the line:
     const int ansiFg = pCT->ansiFg;
     const int ansiBg = pCT->ansiBg;
-    const QColor& patternFg = pCT->mFgColor;
-    const QColor& patternBg = pCT->mBgColor;
-    const QColor& defaultFg = consoleModel.mFgColor;
-    const QColor& defaultBg = consoleModel.mBgColor;
+    // Compared in the form the characters store their colors in, so that a
+    // line's worth of comparisons converts nothing. A pattern color the table
+    // has no color for (an ignored aspect, or an ANSI code outside the table)
+    // is an invalid QColor, which would convert to opaque black and match
+    // black text - it matches nothing instead, as it always has:
+    const bool patternFgValid = pCT->mFgColor.isValid();
+    const bool patternBgValid = pCT->mBgColor.isValid();
+    const QRgb patternFg = pCT->mFgColor.rgba();
+    const QRgb patternBg = pCT->mBgColor.rgba();
+    const QRgb defaultFg = consoleModel.mFgColor.rgba();
+    const QRgb defaultBg = consoleModel.mBgColor.rgba();
     const int passLineSize = pPassLine ? static_cast<int>(pPassLine->size()) : 0;
 
     // This allows matching against the current default colours (-2) and
@@ -930,8 +934,8 @@ bool TTrigger::match_color_pattern(int line, int patternNumber, int posOffset, i
     // all parts of the text come from the Server and can be determined to
     // have come from a decoded ANSI code number:
     const auto colorsMatch = [&](const TChar& character) {
-        return ((ansiFg == scmIgnored) || ((ansiFg == scmDefault) && sameColor(defaultFg, character.foreground())) || sameColor(patternFg, character.foreground()))
-               && ((ansiBg == scmIgnored) || ((ansiBg == scmDefault) && sameColor(defaultBg, character.background())) || sameColor(patternBg, character.background()));
+        return ((ansiFg == scmIgnored) || ((ansiFg == scmDefault) && character.foregroundRgba() == defaultFg) || (patternFgValid && character.foregroundRgba() == patternFg))
+               && ((ansiBg == scmIgnored) || ((ansiBg == scmDefault) && character.backgroundRgba() == defaultBg) || (patternBgValid && character.backgroundRgba() == patternBg));
     };
 
     // A snapshot that stops short of the window cannot answer for the text past

--- a/src/mudlet-lua/tests/MXP_spec.lua
+++ b/src/mudlet-lua/tests/MXP_spec.lua
@@ -119,6 +119,70 @@ describe("Tests MXP handling", function()
     end)
   end)
 
+  -- A colour name the client does not know gives an invalid QColor, and a
+  -- character keeps its colours as ARGB, where an invalid colour and opaque
+  -- black are both 0xFF000000. So an unknown name has to be dropped before it
+  -- reaches the character: the text keeps the colour it had rather than turning
+  -- black, which a black foreground colour trigger would then match.
+  describe("Tests an MXP colour name the client does not know", function()
+    -- the foreground colour of the text holding the needle, read off the main
+    -- window. selectSection() works on the line the cursor is on and counts
+    -- columns from zero, where string.find() counts from one
+    local function foregroundOf(needle)
+      local lastLine = getLastLineNumber("main")
+      for lineNumber = lastLine, math.max(0, lastLine - 20), -1 do
+        local line = getLines("main", lineNumber, lineNumber + 1)[1]
+        local at = line and line:find(needle, 1, true)
+        if at then
+          moveCursor("main", 0, lineNumber)
+          selectSection("main", at - 1, #needle)
+          local colour = getTextFormat("main").foreground
+          -- a selection left behind is what a later replace() would act on
+          deselect("main")
+          return colour
+        end
+      end
+      return nil
+    end
+
+    local function isBlack(colour)
+      return colour ~= nil and colour[1] == 0 and colour[2] == 0 and colour[3] == 0
+    end
+
+    it("colours the text when it knows the name", function()
+      feedTriggers([[<COLOR fore="red">MXPCOLOUR1 red</COLOR>]] .. "\n")
+      assert.are.same({255, 0, 0}, foregroundOf("MXPCOLOUR1"))
+    end)
+
+    it("leaves the text the colour it had when it does not know the name", function()
+      feedTriggers("MXPCOLOUR2 plain\n")
+      local plain = foregroundOf("MXPCOLOUR2")
+      assert.is_truthy(plain)
+      -- telling an unknown colour from black is the whole point, so a profile
+      -- whose text is black anyway would prove nothing
+      assert.is_false(isBlack(plain), "this profile's own text colour is black, so this case cannot tell the two apart")
+
+      feedTriggers([[<COLOR fore="notacolour">MXPCOLOUR3 unknown</COLOR>]] .. "\n")
+      assert.are.same(plain, foregroundOf("MXPCOLOUR3"))
+    end)
+
+    it("does not turn the text black for a colour trigger to match", function()
+      _G.MxpSpec = {fired = false}
+      -- tempColorTrigger's fossilised remap: argument 2 is colour index 0, black
+      local id = tempColorTrigger(2, -1, function() _G.MxpSpec.fired = true end)
+      assert.is_number(id)
+
+      feedTriggers([[<COLOR fore="notacolour">MXPCOLOUR4 unknown</COLOR>]] .. "\n")
+
+      local fired = _G.MxpSpec.fired
+      -- kill before asserting: a leaked colour trigger matches by colour and
+      -- would fire on the lines later specs feed
+      killTrigger(id)
+      _G.MxpSpec = nil
+      assert.is_false(fired, "an unknown MXP colour name must not leave the text black")
+    end)
+  end)
+
   -- <DEST> hands the game a print sink other than the main window: everything
   -- between it and </DEST> goes into the named frame's own console, which is a
   -- miniconsole registered under the frame's name so Lua can read it back like

--- a/src/mudlet-lua/tests/Trigger_spec.lua
+++ b/src/mudlet-lua/tests/Trigger_spec.lua
@@ -1219,6 +1219,21 @@ describe("Trigger processing", function()
             assert.is_true(fired, "the remapped red-on-black colour trigger should fire on red-on-black text")
         end)
 
+        -- a colour argument past the 256-colour table has no colour to match
+        -- against, and it must not fall back to matching some colour instead
+        it("never matches a foreground code the colour table has no colour for", function()
+            _G.TrigSpec = {fired = false}
+            -- bg arg 4 -> index 1 (red -> SGR 41); fg 300 is outside the table
+            local id = tempColorTrigger(300, 4, function() _G.TrigSpec.fired = true end)
+            assert.is_number(id)
+            -- black on red: black is what a colour the table cannot supply
+            -- would decay to if it were compared as a colour at all
+            feedTriggers("\n\27[30;41mColorTrigNoTableColor\27[0m\n")
+            local fired = _G.TrigSpec.fired
+            killTrigger(id)
+            assert.is_false(fired, "a foreground code outside the colour table must not match any text")
+        end)
+
         it("rejects ignoring both foreground and background", function()
             local id, err = tempColorTrigger(-1, -1, function() end)
             if type(id) == "number" and id > 0 then killTrigger(id) end


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`TChar` is the per-character record of every buffered line, and it was 44 bytes: two `QColor`s (16 bytes each), a link index, the flags word and a separate `bool` for "part of the selection". It is now 16 bytes:

- the two colors are stored as `QRgb` (8-bit ARGB, which is all the text pipeline ever produces) and converted to a `QColor` only when something asks for one;
- the selection state is a flag bit (`TChar::Selected`) outside `TestMask`, so nothing that compares display attributes sees it, and the copy constructor clears it as it cleared the bool before;
- a `static_assert(sizeof(TChar) == 16)` keeps it that size.

The hot comparisons - color-trigger matching in `TTrigger::match_color_pattern`, the span breaks in `TBuffer::bufferToHtml`, the run walk in `TAccessibleTextEdit` - compare the stored `QRgb` directly instead of building `QColor`s, and the `sameColor()` memcmp shortcut in `TBuffer.h` goes away with them. The `TChar::foreground()`/`background()` accessors keep their `QColor` result, so no caller outside these files changes.

One subtlety is pinned by a spec: a color trigger whose color the table has no entry for (an ignored aspect, or an ANSI code past 255 that `tempColorTrigger` accepts from Lua) holds an invalid `QColor`, which would convert to opaque black and start matching black text. It still matches nothing, and `Trigger_spec.lua` fails without that guard.

#### Motivation for adding to Mudlet

A line of scrollback is a `std::vector<TChar>` with one entry per character, so the size of `TChar` is the size of the buffer. Cutting it from 44 to 16 bytes takes 39% off peak memory in the pipeline benchmark and, because less memory moves through the cache, makes text ingestion 20% faster and trigger matching 8% faster.

`PipelineBenchmark` (release build, `linux-release` preset), 8 alternating runs each of development at e4fbc9301 (A) and this branch (B) on an otherwise idle machine, invoked as:

```
QT_QPA_PLATFORM=offscreen /usr/bin/time -v ./test/functional_tests/PipelineBenchmark
```

| metric | A median | B median | B/A | A range | B range |
| --- | ---: | ---: | ---: | --- | --- |
| text_lines_per_sec | 700,249 | 843,241 | 1.204 | 674k..719k | 773k..862k |
| latin1_lines_per_sec | 853,282 | 1,046,825 | 1.227 | 812k..881k | 988k..1080k |
| trigger_lines_per_sec | 283,121 | 305,707 | 1.080 | 257k..296k | 254k..315k |
| display_paints_per_sec | 368 | 358 | 0.975 | 341..389 | 349..375 |
| defaults_text_lines_per_sec | 42,417 | 42,991 | 1.014 | 39.0k..44.1k | 41.6k..45.6k |
| peak_rss_kb | 361,820 | 222,234 | 0.614 | 361.6k..362.4k | 221.2k..223.1k |
| defaults_peak_rss_kb | 411,474 | 264,632 | 0.643 | 411.4k..411.9k | 264.2k..264.7k |

The text and latin1 ranges do not overlap. The defaults phase (the Generic Mapper's default triggers) is dominated by Lua, so it neither gains nor loses, and the display phase moves within its spread.

The second commit defines the `TChar` copy constructor in the header. Filling a run of text with its format and copying out a finished line call it once per character, and out of line it showed as about 6% of text ingestion in a sampled profile; the first commit alone measured 1.166 on `text_lines_per_sec` in an earlier campaign of the same shape, so it is worth about 3% of the above.

#### Other info (issues closed, discussion etc)

Verified with the full busted suite (4367 successes, 0 failures) and the 61 window, telnet and trigger functional tests; the new spec fails without the invalid-color guard and passes with it.

The same invalid-color case reaches a character through MXP, which stored a color without checking it was valid: with `.rgba()` in a `TChar`, an unknown `<COLOR fore="...">` name became opaque black rather than staying distinguishable from it. `TMxpMudlet::pushColor()` now drops an unknown name the way it always dropped an empty one, pinned by `MXP_spec.lua` (review follow-up, 871ef8d33).

Related: #10549 also touches this per-character path - it removes the finished-line copy that the second commit here inlines the copy constructor for, so the two overlap rather than add up.

**Test case:** open a profile, connect to any game or `echo` a few thousand lines, select text with the mouse, run a color trigger against colored output, and copy a selection as HTML; scrollback, selection and colors behave as before. `PipelineBenchmark` reports `peak_rss_kb` about 39% below development.
