### PR TITLE
Improve: Append received text to the buffer a run at a time

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -109,6 +109,24 @@ constexpr auto NETWORK_LATENCY_TIMEOUT = 10s;
 
 constexpr size_t BUFFER_SIZE = 100000L;
 
+// Where the run of ordinary text starting at buffer[from] ends: the index of
+// the first byte after it that processSocketData() handles on its own (the
+// start of a telnet command, a carriage return, a NUL or a bell), or `to` if
+// the run reaches that far. buffer[from] must not be one of those bytes, as
+// the caller steps back one from the result before its loop steps forward.
+static int textRunEnd(const char* buffer, const int from, const int to)
+{
+    int i = from;
+    while (i < to) {
+        const char ch = buffer[i];
+        if (ch == TN_IAC || ch == '\r' || ch == '\0' || ch == TN_BELL) {
+            break;
+        }
+        ++i;
+    }
+    return i;
+}
+
 // Upper bound on a single telnet subnegotiation (IAC SB ... IAC SE). Real ones
 // (GMCP/MSDP/ATCP/...) are far smaller; this only guards against a server that
 // opens an IAC SB and never sends IAC SE, which would otherwise grow the
@@ -5749,16 +5767,17 @@ Some data loss is likely - please mention this problem to the game admins.)",
                 //this could have set receivedGA to true; we'll handle that later
                 command = "";
             }
-        } else {
-            if (ch == TN_BELL) {
-                // detected here rather than in TTextEdit so it fires once per
-                // received bell, not on every screen refresh
-                emit signal_bell();
-            }
-
-            if (ch != '\r' && ch != '\0') {
-                cleandata += ch;
-            }
+        } else if (ch == TN_BELL) {
+            // detected here rather than in TTextEdit so it fires once per
+            // received bell, not on every screen refresh
+            emit signal_bell();
+            cleandata += ch;
+        } else if (ch != '\r' && ch != '\0') {
+            // Nearly all of a read is text that goes straight through, so it
+            // goes across a run at a time rather than a byte at a time:
+            const int runEnd = textRunEnd(buffer, i, datalen);
+            cleandata.append(buffer + i, runEnd - i);
+            i = runEnd - 1;
         }
     MAIN_LOOP_END:;
         if (recvdGA) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -110,10 +110,12 @@ constexpr auto NETWORK_LATENCY_TIMEOUT = 10s;
 constexpr size_t BUFFER_SIZE = 100000L;
 
 // Where the run of ordinary text starting at buffer[from] ends: the index of
-// the first byte after it that processSocketData() handles on its own (the
-// start of a telnet command, a carriage return, a NUL or a bell), or `to` if
-// the run reaches that far. buffer[from] must not be one of those bytes, as
-// the caller steps back one from the result before its loop steps forward.
+// the first byte after it that the state machine reading the run handles on its
+// own (the start of a telnet command, a carriage return, a NUL or a bell), or
+// `to` if the run reaches that far. buffer[from] must not be one of those
+// bytes, as the caller steps back one from the result before its loop steps
+// forward - both callers therefore need a branch for every one of them, even
+// where that branch only appends the byte.
 static int textRunEnd(const char* buffer, const int from, const int to)
 {
     int i = from;
@@ -5436,10 +5438,19 @@ void cTelnet::slot_processReplayChunk()
                 //this could have set receivedGA to true; we'll handle that later
                 command = "";
             }
-        } else {
-            if (ch != '\r' && ch != '\0') {
-                cleandata += ch;
-            }
+        } else if (ch == TN_BELL) {
+            // Not rung here, unlike the socket path: a replay has never rung
+            // the bell, it only shows it. It still needs a branch of its own,
+            // because textRunEnd() ends a run at a bell: reaching one through
+            // the run branch below would measure an empty run and put the loop
+            // back on the same byte for ever.
+            cleandata += ch;
+        } else if (ch != '\r' && ch != '\0') {
+            // Nearly all of a chunk is text that goes straight through, so it
+            // goes across a run at a time rather than a byte at a time:
+            const int runEnd = textRunEnd(loadBuffer, i, datalen);
+            cleandata.append(loadBuffer + i, runEnd - i);
+            i = runEnd - 1;
         }
 
         if (recvdGA) {

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -93,6 +93,21 @@ private:
         return false;
     }
 
+    // The lines of the main console that carry the given text, so that a
+    // string which ought to have arrived whole shows up as one entry and a
+    // string that got split shows up as several.
+    QStringList linesContaining(const QString& text) const
+    {
+        QStringList lines;
+        TMainConsole* console = mpHost->mpConsole;
+        for (int i = 0; i <= console->buffer.getLastLineNumber(); ++i) {
+            if (console->buffer.line(i).contains(text)) {
+                lines << console->buffer.line(i);
+            }
+        }
+        return lines;
+    }
+
 private slots:
     void initTestCase()
     {
@@ -312,6 +327,57 @@ private slots:
                                             .arg(wasRefused ? qsl("dropped") : qsl("processed"))));
             }
         }
+    }
+
+    // Plain text goes into the line a run at a time, and each run stops at the
+    // bytes the parser handles on its own. The bytes checked here are the ones
+    // that end a run: a bell (which rings once each and stays in the text), an
+    // IAC (which starts a telnet command that is not text) and the carriage
+    // return and NUL that are dropped. Lines commit on the newline, and a byte
+    // that a run failed to stop at is either displayed or splits the line.
+    void bellsInsideTextRingOnceEachAndStayInTheLine()
+    {
+        QSignalSpy bells(&mpHost->mTelnet, &cTelnet::signal_bell);
+        QByteArray data = QByteArrayLiteral("\r\nRUN_A\aRUN_B\aRUN_C\r\n");
+
+        mpHost->mTelnet.processSocketData(data.data(), data.size(), true);
+
+        QCOMPARE(bells.count(), 2);
+        QCOMPARE(linesContaining(qsl("RUN_")), QStringList{qsl("RUN_A\aRUN_B\aRUN_C")});
+    }
+
+    void telnetCommandInsideTextIsTakenOutOfIt()
+    {
+        QByteArray data = QByteArrayLiteral("\r\nRUN_D");
+        data += TN_IAC;
+        data += TN_NOP;
+        data += "RUN_E\r\n";
+
+        mpHost->mTelnet.processSocketData(data.data(), data.size(), true);
+
+        QCOMPARE(linesContaining(qsl("RUN_")), QStringList{qsl("RUN_DRUN_E")});
+    }
+
+    void carriageReturnAndNulInsideTextAreDropped()
+    {
+        QByteArray data = QByteArrayLiteral("\r\nRUN_F\r\0RUN_G\0\rRUN_H\r\n");
+
+        mpHost->mTelnet.processSocketData(data.data(), data.size(), true);
+
+        QCOMPARE(linesContaining(qsl("RUN_")), QStringList{qsl("RUN_FRUN_GRUN_H")});
+    }
+
+    // A run that reaches the end of one read stops there and the next read
+    // carries on the same line.
+    void textRunEndingAtTheEndOfAReadContinuesInTheNext()
+    {
+        QByteArray first = QByteArrayLiteral("\r\nRUN_I");
+        QByteArray second = QByteArrayLiteral("RUN_J\r\n");
+
+        mpHost->mTelnet.processSocketData(first.data(), first.size(), true);
+        mpHost->mTelnet.processSocketData(second.data(), second.size(), true);
+
+        QCOMPARE(linesContaining(qsl("RUN_")), QStringList{qsl("RUN_IRUN_J")});
     }
 
     // Declared last on purpose: on the unfixed code this trips AddressSanitizer,

--- a/test/functional_tests/cTelnetBufferTest.cpp
+++ b/test/functional_tests/cTelnetBufferTest.cpp
@@ -63,6 +63,13 @@
 
 using namespace std::chrono_literals;
 
+// The chunk buffer the replay path reads and the count of bytes in it.
+// cTelnet::loadReplayChunk() fills both before its timer calls
+// slot_processReplayChunk(); they are file-scope globals in ctelnet.cpp rather
+// than members, so a test can stage a chunk in them without a replay file.
+extern char loadBuffer[];
+extern int loadedBytes;
+
 class cTelnetBufferTest : public QObject
 {
     Q_OBJECT
@@ -80,6 +87,9 @@ private:
     // the one immediately after it that it must leave alone.
     static constexpr char scmTerminatorSlot = '\x7b';
     static constexpr char scmPastTheEnd = '\x7c';
+    // Ordinary text as far as the replay state machine is concerned, so a run
+    // that overran its chunk would append it rather than stop at it.
+    static constexpr char scmReplayCanary = '\x7d';
 
     // True if any line in the main console buffer contains the given substring
     bool bufferContains(const QString& text) const
@@ -106,6 +116,22 @@ private:
             }
         }
         return lines;
+    }
+
+    // Stages a chunk in loadBuffer the way loadReplayChunk() does and runs the
+    // replay state machine over it. The byte just past the chunk is a canary
+    // that is not a run boundary, so a run allowed to walk past loadedBytes
+    // would take it into the line: nothing in the replay path writes a
+    // terminator there, unlike processSocketData() which NULs in_buffer[amount]
+    // itself and so cannot be probed this way.
+    void feedReplayChunk(const QByteArray& chunk)
+    {
+        // loadBuffer is BUFFER_SIZE (100000) + 1 bytes; the chunks here are tens
+        QVERIFY(chunk.size() < 1024);
+        std::memcpy(loadBuffer, chunk.constData(), chunk.size());
+        loadBuffer[chunk.size()] = scmReplayCanary;
+        loadedBytes = static_cast<int>(chunk.size());
+        mpHost->mTelnet.slot_processReplayChunk();
     }
 
 private slots:
@@ -368,7 +394,11 @@ private slots:
     }
 
     // A run that reaches the end of one read stops there and the next read
-    // carries on the same line.
+    // carries on the same line. This pins the carry-over, not the read bound
+    // itself: processSocketData() writes its own NUL at in_buffer[amount], and
+    // a NUL ends a run, so a run let past the end of the read would stop on
+    // that terminator and append nothing either way. The replay case below,
+    // where nothing writes a terminator, is the one that can plant a canary.
     void textRunEndingAtTheEndOfAReadContinuesInTheNext()
     {
         QByteArray first = QByteArrayLiteral("\r\nRUN_I");
@@ -378,6 +408,46 @@ private slots:
         mpHost->mTelnet.processSocketData(second.data(), second.size(), true);
 
         QCOMPARE(linesContaining(qsl("RUN_")), QStringList{qsl("RUN_IRUN_J")});
+    }
+
+    // slot_processReplayChunk() runs a second copy of the same state machine
+    // over the chunk loadReplayChunk() leaves in loadBuffer, and it takes its
+    // text in runs too. The bytes checked here are the ones that end a run: an
+    // IAC starting a telnet command, a bell (which this path shows without
+    // ringing, unlike the socket one), and the carriage return and NUL that are
+    // dropped.
+    void replayChunkTextArrivesARunAtATime()
+    {
+        QByteArray chunk = QByteArrayLiteral("\r\nREPLAY_A");
+        chunk += TN_IAC;
+        chunk += TN_NOP;
+        chunk += QByteArrayLiteral("REPLAY_B\aREPLAY_C\r\0REPLAY_D\r\n");
+        const QString expected = qsl("REPLAY_AREPLAY_B\aREPLAY_CREPLAY_D");
+
+        feedReplayChunk(chunk);
+
+        QCOMPARE(linesContaining(qsl("REPLAY_")), QStringList{expected});
+
+        // the same bytes one chunk per byte, which is the byte-at-a-time walk
+        // the loop did before: every run is then one byte long, so this is what
+        // taking them a run at a time has to agree with
+        for (const char ch : chunk) {
+            feedReplayChunk(QByteArray(1, ch));
+        }
+
+        QCOMPARE(linesContaining(qsl("REPLAY_")), (QStringList{expected, expected}));
+    }
+
+    // A run that reaches the end of one chunk stops there and the next chunk
+    // carries on the same line. The canary feedReplayChunk() plants right past
+    // the chunk is ordinary text, so a run that read one byte too far would
+    // show it up in the middle of the line.
+    void replayRunEndingAtTheEndOfAChunkContinuesInTheNext()
+    {
+        feedReplayChunk(QByteArrayLiteral("\r\nREPLAY_E"));
+        feedReplayChunk(QByteArrayLiteral("REPLAY_F\r\n"));
+
+        QCOMPARE(linesContaining(qsl("REPLAY_E")), QStringList{qsl("REPLAY_EREPLAY_F")});
     }
 
     // Declared last on purpose: on the unfixed code this trips AddressSanitizer,


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`cTelnet::processSocketData()` walks each read a byte at a time through a state machine, and for the plain text that makes up nearly all of a read it ended in `cleandata += ch`: one `std::string` append, with its capacity check, per byte. It now finds where the run of ordinary text ends - the next telnet IAC, carriage return, NUL or bell, or the end of the read - and appends the run in one call, then carries on from the byte that ended it. Those four bytes still go through the paths they always did: IAC starts a command, CR and NUL are dropped, a bell rings once and stays in the text.

Four cases in `cTelnetBufferTest` pin each of those run boundaries, plus a run that ends exactly at the end of one read and continues in the next.

`cTelnet::slot_processReplayChunk()` runs a second copy of the same state machine over the chunk `loadReplayChunk()` stages in `loadBuffer`, and now takes its text in runs too (review follow-up, c96848eab). It needs one thing the socket path already had: a bell branch of its own. `textRunEnd()` ends a run at a bell, so a bell reached through the run branch would measure an empty run and leave the loop on the same byte for ever. The branch appends the bell without emitting `signal_bell()`, which is what that path has always done - a replay shows the bell, it does not ring it.

#### Motivation for adding to Mudlet

`PipelineBenchmark` (release build, `linux-release` preset), 8 alternating runs each of development at e4fbc9301 (A) and this branch (B) on an otherwise idle machine, invoked as:

```
QT_QPA_PLATFORM=offscreen /usr/bin/time -v ./test/functional_tests/PipelineBenchmark
```

| metric | A median | B median | B/A | A range | B range |
| --- | ---: | ---: | ---: | --- | --- |
| text_lines_per_sec | 696,238 | 755,780 | 1.086 | 683k..716k | 737k..780k |
| latin1_lines_per_sec | 850,703 | 945,967 | 1.112 | 760k..862k | 911k..1000k |
| trigger_lines_per_sec | 278,592 | 288,160 | 1.034 | 263k..285k | 274k..306k |
| defaults_text_lines_per_sec | 41,777 | 42,466 | 1.016 | 38.3k..42.8k | 39.9k..43.7k |
| display_paints_per_sec | 355 | 359 | 1.012 | 343..365 | 347..368 |
| peak_rss_kb | 362,130 | 361,966 | 1.000 | | |

The text and latin1 ranges do not overlap. Memory is unchanged, as expected. The benchmark has no replay phase, so the replay-side change is not in those numbers; it is the same edit on the path a replayed log takes.

#### Other info (issues closed, discussion etc)

The 13 cases of `cTelnetBufferTest` pass; the new ones fail on the two likely mistakes (stepping past the byte that ended the run, or letting a bell through without ringing it).

Two more cases cover the replay path, taking `cTelnetBufferTest` to 15: one feeds a chunk with IAC, bell, CR and NUL boundaries and compares the line against the same bytes fed one per chunk; the other plants a canary just past the chunk that a run reading one byte too far would take into the line. Unlike `processSocketData()`, which NULs `in_buffer[amount]` itself, nothing terminates a replay chunk - so the replay side is where the read bound can actually be guarded by a functional test, and the socket-side case's comment now says what it really pins (the carry-over between reads).

**Test case:** connect to any game, play normally with prompts, color codes and long room descriptions; text arrives unchanged, including lines that ring the bell. Load a replay (`Replay` in the toolbar, or `loadReplay()`) and it plays back unchanged too. `cTelnetBufferTest` covers the run boundaries on both paths.
