### PR TITLE
Improve: Skip wrap analysis for lines too short to reach the wrap column

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5443,7 +5443,8 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
     // line's width is its length, and a line no wider than the wrap column has
     // no break point to find. LineFeed and Tab are outside that range, so a
     // line needing an embedded break never takes this path.
-    if (lineText.size() <= (isNewline ? maxWidth - indent : maxWidth) && lineText.size() <= mWrapAt) {
+    const qsizetype widthAvailable = std::min<qsizetype>(isNewline ? maxWidth - indent : maxWidth, mWrapAt);
+    if (lineText.size() <= widthAvailable) {
         bool plainAscii = true;
         for (const QChar c : lineText) {
             if (c.unicode() < u' ' || c.unicode() > u'~') {
@@ -5454,6 +5455,13 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
         if (plainAscii) {
             return output;
         }
+    }
+    // Nothing is more than two columns wide and no grapheme cluster is shorter
+    // than one QChar, so a line with at most half the width in QChars cannot
+    // reach the wrap column whatever it holds. Only an embedded line feed can
+    // still break it.
+    if (lineText.size() * 2 <= widthAvailable && !lineText.contains(QChar::LineFeed)) {
+        return output;
     }
 
     QTextBoundaryFinder boundaryFinder(QTextBoundaryFinder::Grapheme, lineText);

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -5456,11 +5456,12 @@ inline QList<WrapInfo> TBuffer::getWrapInfo(const QString& lineText, bool isNewl
             return output;
         }
     }
-    // Nothing is more than two columns wide and no grapheme cluster is shorter
-    // than one QChar, so a line with at most half the width in QChars cannot
-    // reach the wrap column whatever it holds. Only an embedded line feed can
-    // still break it.
-    if (lineText.size() * 2 <= widthAvailable && !lineText.contains(QChar::LineFeed)) {
+    // No grapheme cluster renders wider than graphemeInfo::maxWidth columns -
+    // graphemeInfo::getWidth() in TTextProperties.h holds its return to that -
+    // and none is shorter than one QChar, so a line with at most that fraction
+    // of the width in QChars cannot reach the wrap column whatever it holds.
+    // Only an embedded line feed can still break it.
+    if (lineText.size() * graphemeInfo::maxWidth <= widthAvailable && !lineText.contains(QChar::LineFeed)) {
         return output;
     }
 

--- a/src/TTextProperties.h
+++ b/src/TTextProperties.h
@@ -34,23 +34,30 @@
 
 namespace graphemeInfo {
 
-inline int getWidth(uint unicode, bool mWideAmbigousWidthGlyphs)
+// The most columns a single grapheme cluster can take. Callers rely on this
+// ceiling to avoid measuring text they do not have to: TBuffer::getWrapInfo()
+// multiplies a line's QChar count by it to rule the line out of wrapping
+// without running the Unicode analysis, so a wider value here would silently
+// stop short lines of wide characters from wrapping.
+inline constexpr int maxWidth = 2;
+
+inline int codepointWidth(uint unicode, bool mWideAmbigousWidthGlyphs)
 {
     // https://github.com/ridiculousfish/widecharwidth/issues/11
     if (unicode == 0x1F6E1 || unicode == 0x2318) {
-        return 2;
+        return maxWidth;
     }
 
     // fix to make red heart width 2
     if (unicode == 0x2764) {
-        return 2;
+        return maxWidth;
     }
 
     switch (widechar_wcwidth(unicode)) {
     case 1: // Draw as normal/narrow
         return 1;
     case 2: // Draw as wide
-        return 2;
+        return maxWidth;
     case widechar_nonprint:
         return 0;
     case widechar_non_character:
@@ -59,16 +66,26 @@ inline int getWidth(uint unicode, bool mWideAmbigousWidthGlyphs)
         return 0;
     case widechar_ambiguous:
         // -3 = The character is East-Asian ambiguous width.
-        return mWideAmbigousWidthGlyphs ? 2 : 1;
+        return mWideAmbigousWidthGlyphs ? maxWidth : 1;
     case widechar_private_use:
         return 1;
     case widechar_unassigned:
         return 1;
     case widechar_widened_in_9: // -6 = Width is 1 in Unicode 8, 2 in Unicode 9+.
-        return 2;
+        return maxWidth;
     default:
         return 1; // Got an uncoded return value from widechar_wcwidth(...)
     }
+}
+
+inline int getWidth(uint unicode, bool mWideAmbigousWidthGlyphs)
+{
+    const int width = codepointWidth(unicode, mWideAmbigousWidthGlyphs);
+    // Kept to maxWidth here rather than at each caller, since a wider value
+    // would not be visibly wrong - it would just stop TBuffer::getWrapInfo()
+    // wrapping lines that do reach the wrap column.
+    Q_ASSERT_X(width <= maxWidth, "graphemeInfo::getWidth", "a grapheme wider than graphemeInfo::maxWidth breaks TBuffer::getWrapInfo()'s short-line shortcut");
+    return width > maxWidth ? maxWidth : width;
 }
 
 

--- a/src/mudlet-lua/tests/WrapWidth_spec.lua
+++ b/src/mudlet-lua/tests/WrapWidth_spec.lua
@@ -1,0 +1,48 @@
+-- Lines are only put through the full Unicode line-breaking analysis when
+-- they could reach the wrap column; these check that a line which has to
+-- break never skips it.
+describe("Tests wrapping of lines that hold wide characters", function()
+  local win = "wrapWidthSpecConsole"
+  local wide = "日" -- two columns
+
+  setup(function()
+    createMiniConsole(win, 0, 0, 800, 200)
+    setWindowWrap(win, 40)
+  end)
+
+  teardown(function()
+    deleteMiniConsole(win)
+  end)
+
+  before_each(function()
+    clearWindow(win)
+  end)
+
+  local function contentLines()
+    local lines = {}
+    for _, line in ipairs(getLines(win, 0, getLineCount(win))) do
+      if line ~= "" then
+        lines[#lines + 1] = line
+      end
+    end
+    return lines
+  end
+
+  it("keeps a line of wide characters that fits the width whole", function()
+    echo(win, string.rep(wide, 15) .. "\n") -- 30 columns of a 40 column window
+    assert.are.same({string.rep(wide, 15)}, contentLines())
+  end)
+
+  it("breaks a line of wide characters at the wrap column", function()
+    -- 25 characters is well under 40, but they are 50 columns wide
+    echo(win, string.rep(wide, 25) .. "\n")
+    assert.are.same({string.rep(wide, 20), string.rep(wide, 5)}, contentLines())
+  end)
+
+  it("splits a short line of wide characters at a line feed inserted into it", function()
+    echo(win, string.rep(wide, 10) .. "\n")
+    moveCursor(win, 5, 0)
+    insertText(win, "\n")
+    assert.are.same({string.rep(wide, 5), string.rep(wide, 5)}, contentLines())
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

`TBuffer::getWrapInfo()` decides whether a freshly appended line needs wrapping. It already skips the two `QTextBoundaryFinder` passes (a full Unicode grapheme and line-break analysis of the line) when the line is plain printable ASCII and no longer than the wrap column. Any line with a single accented letter, box-drawing glyph or emoji in it still paid for both passes, whatever its length.

This adds a second shortcut behind the first: nothing renders wider than two columns and no grapheme cluster is shorter than one `QChar`, so a line whose `QChar` count is at most half the available width cannot reach the wrap column. If it also holds no line feed there is nothing to find, and it returns "no wrap" straight away. Lines longer than that, and lines with an embedded line feed, go through the full analysis as before.

That two-column bound is `graphemeInfo::maxWidth` in `TTextProperties.h`, next to the `getWidth()` that has to keep it: `getWidth()` now holds its own return to the constant, so a fourth hand-added special case returning 3 trips an assertion instead of silently stopping short lines of wide characters from wrapping.

`WrapWidth_spec.lua` pins the boundary with two-column CJK characters: 15 of them stay whole in a 40 column window, 25 of them break into 20 and 5, and a line feed inserted into a short line of them still splits it.

#### Motivation for adding to Mudlet

Profiling text ingestion in the pipeline benchmark put the two boundary finders at about 8% of the time, all of it from the roughly 5% of lines that are not plain ASCII. Most such lines in game output are short prompts and status lines with a stray non-ASCII glyph, which this shortcut now handles in a single length check.

`PipelineBenchmark` (release build, `linux-release` preset), 8 alternating runs each of development at e4fbc9301 (A) and this branch (B) on an otherwise idle machine, invoked as:

```
QT_QPA_PLATFORM=offscreen /usr/bin/time -v ./test/functional_tests/PipelineBenchmark
```

| metric | A median | B median | B/A | A range | B range |
| --- | ---: | ---: | ---: | --- | --- |
| text_lines_per_sec | 714,172 | 724,230 | 1.014 | 666k..719k | 680k..731k |
| latin1_lines_per_sec | 857,637 | 896,082 | 1.045 | 835k..867k | 883k..912k |
| trigger_lines_per_sec | 277,106 | 290,628 | 1.049 | 264k..289k | 282k..302k |
| defaults_text_lines_per_sec | 42,266 | 42,764 | 1.012 | 41.1k..43.7k | 41.2k..44.0k |
| display_paints_per_sec | 364 | 363 | 0.997 | 360..366 | 352..373 |
| peak_rss_kb | 362,208 | 362,048 | 1.000 | 361.9k..362.4k | 361.8k..362.3k |

The latin1 corpus has the most lines with a non-ASCII character in them and gains the most; its ranges and the trigger phase's do not overlap. The 1.4% on the UTF-8 text phase is within the run-to-run spread, and memory is unchanged.

#### Other info (issues closed, discussion etc)

Verified with the full busted suite (4368 successes, 0 failures, 77 pending). Which half of the shortcut each test holds, mutated one at a time on this branch and run against the whole suite:

| mutation | failures |
| --- | --- |
| `size()` in place of `size() * 2` | 1 - `WrapWidth_spec.lua` "breaks a line of wide characters at the wrap column" |
| dropping the `!lineText.contains(QChar::LineFeed)` guard | 7 - 3 in `InsertTextNewline_spec.lua`, 3 in `UI_spec.lua`, 1 in `WrapWidth_spec.lua` |

So the `× 2` width factor rests on the new wide-character case alone, and the existing suite is what protects the line-feed guard - an earlier version of this description credited that cascade to the width factor.

**Test case:** in a profile with word wrap at 40, `echo(string.rep("日", 25))` breaks after 20 characters and `echo(string.rep("日", 15))` stays on one line; wrapping of ordinary text is unchanged.
