### PR TITLE
Infra: Let the pipeline benchmark take a line count and a read size

### DIFF
--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -97,6 +97,22 @@ On a machine with other functional-test runs (e.g. parallel worktrees) wrap the
 command in `flock /tmp/mudlet-functional-tests.lock ...` so stub ports and the
 shared config directory do not collide.
 
+Two environment variables reshape the workload for one-off experiments:
+
+- `MUDLET_BENCH_LINES=<n>` generates a corpus of `n` lines instead of the fixed
+  one, for seeing what a burst of, say, 250000 lines does to throughput and
+  memory (the scrollback caps at 100000 lines, so past that the buffer is
+  shrinking as it fills).
+- `MUDLET_BENCH_CHUNK_BYTES=<n>` feeds the corpus in reads of up to `n` bytes,
+  the way a socket delivers it, instead of as one burst. The cuts land mid-line
+  as real reads do.
+
+A run with either set reports `corpus_version 0`, so the compare script refuses
+to set it against a standard run. A chunked run also reports `bench_chunk_bytes`,
+and the script refuses two experimental runs whose line count or read size
+differ, so such runs compare only with a like-for-like run. A knob that is set
+to anything but a positive whole number fails the run rather than being ignored.
+
 Results are printed one per line as `METRIC <name> <value>`, so runs can be
 diffed mechanically (the values below are illustrative, not a target):
 
@@ -333,8 +349,9 @@ is another reason to read these only as relative, same-config references.
 - Always compare **same machine, same build configuration**. The functional-test
   build turns AddressSanitizer on for non-Windows; comparing an ASan build to a
   release build, or across hardware, is meaningless.
-- The whole corpus is fed as one `loopbackTest()` packet per pass rather than in
-  network-sized chunks; this measures processing cost, not socket delivery.
+- By default the whole corpus is fed as one `loopbackTest()` packet per pass
+  rather than in network-sized chunks; this measures processing cost, not socket
+  delivery. `MUDLET_BENCH_CHUNK_BYTES` feeds it in reads instead.
 - Always compare full-binary runs: `peak_rss_kb` (VmHWM) is process-wide and
   monotonic, so filtering to individual test slots changes what it means.
 - All benchmark triggers sit at the root of the trigger tree; real profiles nest

--- a/docs/libmudlet-perf-baseline.md
+++ b/docs/libmudlet-perf-baseline.md
@@ -107,6 +107,20 @@ Two environment variables reshape the workload for one-off experiments:
   the way a socket delivers it, instead of as one burst. The cuts land mid-line
   as real reads do.
 
+Chunked feeding peaks *lower* on memory than one burst rather than higher, and
+the margin widens with the corpus: one burst holds the whole read's `cleandata`
+plus its decoded copy while it works, where the chunk list retains one corpus
+with a single read's worth of transients. `peak_rss_kb` from a
+`linux-debug-nosan` build, two runs a side agreeing within 0.2 MB:
+
+| corpus | one burst | 1 KiB reads |
+| --- | ---: | ---: |
+| 25000 lines (the default) | 363,792 kB | 361,464 kB |
+| 250000 lines | 440,296 kB | 391,224 kB |
+
+So a chunked run's memory figures are only comparable with another chunked run's
+of the same size, which is what the guards below enforce.
+
 A run with either set reports `corpus_version 0`, so the compare script refuses
 to set it against a standard run. A chunked run also reports `bench_chunk_bytes`,
 and the script refuses two experimental runs whose line count or read size

--- a/test/compare-perf-baseline.py
+++ b/test/compare-perf-baseline.py
@@ -64,6 +64,10 @@ HARNESSES = {
             "display_tail_small_cells",
             "display_tail_large_cells",
         ),
+        # Emitted only by a run made with MUDLET_BENCH_CHUNK_BYTES set, so two
+        # such runs compare only if they cut the corpus into reads of the same
+        # size, and neither compares with a run that fed it as one burst.
+        "workload_knobs": ("bench_chunk_bytes",),
         # Throughput for the text and trigger pipelines, plus the shipped default
         # packages on the same corpus - the pipeline metrics run on a bare
         # profile, so only defaults_text_lines_per_sec can see a package costing
@@ -124,7 +128,7 @@ HARNESSES = {
 # have it - but never read as a result either, so it stays out of the table.
 MODE_METRICS = ("bench_frame_hash_mode",)
 
-INVARIANTS = COMMON_INVARIANTS + MODE_METRICS + tuple(name for harness in HARNESSES.values() for name in harness["invariants"])
+INVARIANTS = COMMON_INVARIANTS + MODE_METRICS + tuple(name for harness in HARNESSES.values() for name in harness["invariants"] + harness.get("workload_knobs", ()))
 
 # Wall-clock ceiling for a single benchmark run under --run. The ASan/offscreen
 # functional-test build feeds a huge corpus several times, so this is generous.
@@ -239,6 +243,14 @@ def check_invariants(before, after):
     if before_harness != after_harness:
         fail(f"the before run is a {before_harness} and the after run is a {after_harness} - different benchmarks cannot be compared.")
 
+    for name in HARNESSES[before_harness].get("workload_knobs", ()):
+        if (name in before) != (name in after) or (name in before and before[name] != after[name]):
+            setting = lambda run: f"{run[name]:g}" if name in run else "not set"
+            fail(
+                f"{name} is {setting(before)} in the before run and {setting(after)} in the after run - "
+                "the two runs fed the corpus differently and cannot be compared."
+            )
+
     for name in COMMON_INVARIANTS + HARNESSES[before_harness]["invariants"]:
         in_before = name in before
         in_after = name in after
@@ -249,6 +261,12 @@ def check_invariants(before, after):
                 f"the same {before_harness} harness/build and cannot be compared."
             )
         if before[name] != after[name]:
+            if name == "corpus_version" and 0 in (before[name], after[name]):
+                fail(
+                    "corpus_version 0 marks a run made with MUDLET_BENCH_LINES or MUDLET_BENCH_CHUNK_BYTES "
+                    "set, which reshapes the workload; such a run compares only with another made with the "
+                    "same settings."
+                )
             fail(
                 f"{name} differs ({before[name]:g} vs {after[name]:g}) - the two runs measured "
                 "different workloads or build configurations and cannot be compared. "

--- a/test/functional_tests/PipelineBenchmark.cpp
+++ b/test/functional_tests/PipelineBenchmark.cpp
@@ -102,6 +102,8 @@ private:
     // Both phases feed these identical bytes, so text and trigger numbers are
     // directly comparable.
     QByteArray mCorpus;
+    // The corpus cut into reads when MUDLET_BENCH_CHUNK_BYTES is set:
+    QList<QByteArray> mChunks;
     int mCorpusLines = 0;
     qint64 mCorpusBytes = 0;
     double mTextBestPassSeconds = 0.0;
@@ -476,10 +478,32 @@ private:
         for (int i = 0; i < passes; ++i) {
             QElapsedTimer timer;
             timer.start();
-            host->mTelnet.loopbackTest(mCorpus);
+            if (mChunks.isEmpty()) {
+                host->mTelnet.loopbackTest(mCorpus);
+            } else {
+                for (QByteArray& chunk : mChunks) {
+                    host->mTelnet.loopbackTest(chunk);
+                }
+            }
             best = std::min(best, timer.nsecsElapsed() / 1.0e9);
         }
         return best;
+    }
+
+    // A knob that is set but not a positive whole number fails the run rather
+    // than being ignored, as ignoring it would stamp the run as a standard one.
+    static int positiveKnob(const char* name)
+    {
+        if (!qEnvironmentVariableIsSet(name)) {
+            return 0;
+        }
+        bool ok = false;
+        const int value = qEnvironmentVariable(name).toInt(&ok);
+        if (!ok || value <= 0) {
+            QTest::qFail(qPrintable(qsl("%1=\"%2\" is not a positive whole number").arg(QString::fromLatin1(name), qEnvironmentVariable(name))), __FILE__, __LINE__);
+            return 0;
+        }
+        return value;
     }
 
     static void emitMetric(const char* name, double value)
@@ -562,15 +586,41 @@ private slots:
         // whatever the environment or Lua startup leaves LC_NUMERIC at.
         std::setlocale(LC_NUMERIC, "C");
         initializeQRCResources();
-        mCorpus = generateCorpus(kCorpusLines, mCorpusLines);
+        // MUDLET_BENCH_LINES feeds a corpus of that many lines instead of the
+        // fixed one and MUDLET_BENCH_CHUNK_BYTES feeds it in reads of that size
+        // rather than one burst. Either makes a different workload from the
+        // standard one, so corpus_version is reported as 0 and the compare
+        // script refuses to set such a run against a standard run.
+        const int requestedLines = positiveKnob("MUDLET_BENCH_LINES");
+        const int chunkBytes = positiveKnob("MUDLET_BENCH_CHUNK_BYTES");
+        if (QTest::currentTestFailed()) {
+            return;
+        }
+        const bool linesOverridden = requestedLines > 0;
+        const bool chunked = chunkBytes > 0;
+
+        mCorpus = generateCorpus(linesOverridden ? requestedLines : kCorpusLines, mCorpusLines);
         mCorpusBytes = mCorpus.size();
-        QCOMPARE(mCorpusLines, kCorpusLines);
-        QCOMPARE(mCorpusBytes, kCorpusBytesForVersion);
+        if (linesOverridden) {
+            QCOMPARE(mCorpusLines, requestedLines);
+        } else {
+            QCOMPARE(mCorpusLines, kCorpusLines);
+            QCOMPARE(mCorpusBytes, kCorpusBytesForVersion);
+        }
+        if (chunked) {
+            for (qsizetype offset = 0; offset < mCorpus.size(); offset += chunkBytes) {
+                mChunks.append(mCorpus.mid(offset, chunkBytes));
+            }
+            qInfo().nospace() << "Feeding in " << mChunks.size() << " reads of up to " << chunkBytes << " bytes";
+        }
         // Invariants, emitted here so they are present regardless of which bench
         // slots run: the compare script rejects an ASan-vs-release comparison,
-        // and a comparison across two different corpora.
+        // and a comparison across two different corpora or workloads.
         emitMetric("build_asan", static_cast<qint64>(BENCH_BUILD_ASAN));
-        emitMetric("corpus_version", static_cast<qint64>(kCorpusVersion));
+        emitMetric("corpus_version", static_cast<qint64>((linesOverridden || chunked) ? 0 : kCorpusVersion));
+        if (chunked) {
+            emitMetric("bench_chunk_bytes", static_cast<qint64>(chunkBytes));
+        }
         qInfo().nospace() << "Corpus: " << mCorpusLines << " lines, " << mCorpusBytes << " bytes";
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Two environment variables for `PipelineBenchmark`, for one-off experiments rather than baseline comparisons:

- `MUDLET_BENCH_LINES=<n>` generates a corpus of `n` lines instead of the fixed 25,000, for watching what a burst of 250,000 lines does to throughput and memory once the scrollback cap starts shrinking the buffer.
- `MUDLET_BENCH_CHUNK_BYTES=<n>` feeds the corpus in reads of up to `n` bytes, the way a socket delivers it, with the cuts landing mid-line as real reads do.

A run with either set reports `corpus_version 0`, so `compare-perf-baseline.py` refuses to set it against a standard run and says why. A chunked run also reports `bench_chunk_bytes`, and the script refuses two experimental runs whose read size differs (the existing `text_corpus_lines` invariant already catches a different line count). A knob set to anything but a positive whole number fails the run instead of being ignored, since an ignored knob would stamp the run as a standard one. `docs/libmudlet-perf-baseline.md` documents all of this.

#### Motivation for adding to Mudlet

The benchmark feeds its whole corpus as one loopback call, which is the right fixed workload for a baseline but hides two things a real session has: far more lines than the corpus, and text arriving in socket-sized pieces. Both reshaped workloads were used to look for optimizations in the text pipeline, and having them as knobs is cheaper than patching the benchmark each time.

#### Other info (issues closed, discussion etc)

Without either variable set the benchmark runs exactly as before and reports the same `corpus_version`.

**Test case:** `MUDLET_BENCH_LINES=250000 QT_QPA_PLATFORM=offscreen ./test/functional_tests/PipelineBenchmark` reports `text_corpus_lines 250000` and `corpus_version 0`; without the variable it reports 25,000 lines and the usual `corpus_version`.
