### PR TITLE
Infra: Speed up CI by having the Intel macOS job build only the binary

### DIFF
--- a/.github/workflows/build-mudlet-pr.yml
+++ b/.github/workflows/build-mudlet-pr.yml
@@ -68,12 +68,15 @@ jobs:
             # Enable AddressSanitizer for PTB and testing builds, but not release
             # builds (tagged Mudlet-*) - ASAN adds significant runtime overhead
             enable_asan: 'true'
+          # Ships the Intel binary only: no test here branches on the host
+          # architecture, so the arm64 job below is the same coverage, and this
+          # is the slower pool.
           - os: macos-15-intel
-            buildname: 'macos (x86_64) / c++, lua tests'
+            buildname: 'macos (x86_64)'
             compiler: clang_64
             qt: '6.11.1'
             deploy: 'deploy'
-            run_tests: 'true'
+            build_tests: 'false'
           - os: macos-15
             buildname: 'macos (arm64) / c++, lua tests'
             compiler: clang_64
@@ -384,6 +387,7 @@ jobs:
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}
           ${{ runner.os == 'macOS' && format('-DLUA_INCLUDE_DIR={0}/.lua/include -DLUA_LIBRARY={0}/.lua/lib/liblua.a', github.workspace) || '' }}
+          -DBUILD_TESTING=${{ matrix.build_tests == 'false' && 'OFF' || 'ON' }}
           -DWITH_SENTRY=ON
           -DSENTRY_SEND_DEBUG=${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}
           -DSENTRY_DSN=${{ secrets.SENTRY_DSN }}
@@ -450,13 +454,14 @@ jobs:
         MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK: 1
 
     - name: (macOS) Run C++ tests
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && matrix.run_tests == 'true'
       working-directory: '${{runner.workspace}}/b/ninja'
       run: ctest --output-on-failure -j $(sysctl -n hw.ncpu)
 
-    # the full ctest run above already covers every functional-labelled test
+    # the full ctest run above already covers every functional-labelled test,
+    # and a BUILD_TESTING=OFF tree has no tests to find - bare ctest exits 8 there
     - name: Run QTest
-      if: matrix.run_tests != 'true'
+      if: matrix.run_tests != 'true' && matrix.build_tests != 'false'
       run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure -j $(nproc)
 
     - name: add ssh-agent for release uploads

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -58,12 +58,15 @@ jobs:
             compiler: clang_64
             gcc_compiler_version: 10
             qt: '6.11.1'
+          # Ships the Intel binary only: no test here branches on the host
+          # architecture, so the arm64 job below is the same coverage, and this
+          # is the slower pool.
           - os: macos-15-intel
-            buildname: 'macos (x86_64) / c++, lua tests'
+            buildname: 'macos (x86_64)'
             compiler: clang_64
             qt: '6.11.1'
             deploy: 'deploy'
-            run_tests: 'true'
+            build_tests: 'false'
           - os: macos-15
             buildname: 'macos (arm64) / c++, lua tests'
             compiler: clang_64
@@ -374,6 +377,7 @@ jobs:
           -DUSE_SANITIZER=${{ matrix.enable_asan == 'true' && !startsWith(github.ref, 'refs/tags/Mudlet-') && 'Address' || '' }}
           -DUSE_ALTERNATE_LINKER=${{ runner.os == 'Linux' && 'mold' || '' }}
           ${{ runner.os == 'macOS' && format('-DLUA_INCLUDE_DIR={0}/.lua/include -DLUA_LIBRARY={0}/.lua/lib/liblua.a', github.workspace) || '' }}
+          -DBUILD_TESTING=${{ matrix.build_tests == 'false' && 'OFF' || 'ON' }}
           -DWITH_SENTRY=ON
           -DSENTRY_SEND_DEBUG=${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event.inputs.scheduled == 'true') && '1' || '0' }}
           -DSENTRY_DSN=${{ secrets.SENTRY_DSN }}
@@ -472,13 +476,14 @@ jobs:
         MUDLET_MEDIA_TESTS_REQUIRE_PLAYBACK: 1
 
     - name: (macOS) Run C++ tests
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && matrix.run_tests == 'true'
       working-directory: '${{runner.workspace}}/b/ninja'
       run: ctest --output-on-failure -j $(sysctl -n hw.ncpu)
 
-    # the full ctest run above already covers every functional-labelled test
+    # the full ctest run above already covers every functional-labelled test,
+    # and a BUILD_TESTING=OFF tree has no tests to find - bare ctest exits 8 there
     - name: Run QTest
-      if: matrix.run_tests != 'true'
+      if: matrix.run_tests != 'true' && matrix.build_tests != 'false'
       run: ctest --test-dir ${{runner.workspace}}/b/ninja -L functional --output-on-failure -j $(nproc)
 
     - name: add ssh-agent for release uploads


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The `macos-15-intel` job now configures with `-DBUILD_TESTING=OFF` and skips the C++ and Lua test steps, so it only produces the Intel binary. A new `build_tests` matrix key drives this; `run_tests` keeps its existing meaning everywhere else.
- Measured on a recent run: Intel took **45m51s** against arm64's **23m12s** for identical work. Per-minute analysis of the ninja log shows all non-test compilation finishes by minute 17 - minutes 17-28 were purely the test tree (342 of 1013 edges, 54 executable links against the 250MB static lib), then 5m26s of ctest and 3m24s of Lua tests on top. Expected: **~46min → ~26min**.
- Renamed that job to `macos (x86_64)`, since it no longer runs tests.

#### Motivation for adding to Mudlet

The Intel runners are the slower pool and had built up a roughly 6 hour macOS queue backlog - one arm64 job in the sample waited 5.5 hours to start - and every minute they spent on tests was a duplicate of what the arm64 job had already proven.

No coverage is lost: no test branches on the host architecture (every `x86_64`/`arm64` mention under `test/` is string *data* in the updater-feed tests), so the arm64 job is the same coverage.

#### Other info (issues closed, discussion etc)

⚠️ **Needs a branch protection change to merge.** `macos (x86_64) / c++, lua tests` is a required status check on `development`; it must become `macos (x86_64)` or this and every other open PR will wait forever on a check that no longer reports. Vadi is handling this.

**Test case:** verified locally that `-DBUILD_TESTING=OFF` configures cleanly and drops all 649 `test/` targets and all 180 ctest cases, while `ON` keeps them; simulated the matrix conditionals across all 8 entries in both workflows to confirm the two `ubuntu` entries still run `Run QTest` and that ubuntu-gcc/arm64 still run the full suite. CI on this PR exercises the change directly.

Assisted-by: Claude:claude-opus-5