### PR TITLE
Infra: Map files and MXP text reach the profile, not the console widget

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -635,6 +635,193 @@ void Host::loadMap()
     }
 }
 
+// TODO: It may be worth considering moving the (now) three following methods
+// to the TMap class...?
+bool Host::saveMapFile(const QString& location, int saveVersion)
+{
+    QString filename_map = location;
+    if (filename_map.isEmpty()) {
+        filename_map = MudletApp::getMudletPath(enums::profileDateTimeStampedMapPathFileName, mHostName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
+    } else if (const QFileInfo fileInfo(location); fileInfo.isRelative()) {
+        // Resolve the name relative to the profile home directory the way
+        // Host::importMapFile does, rather than against whatever directory
+        // Mudlet happens to have been started in:
+        filename_map = QDir::cleanPath(MudletApp::getMudletPath(enums::profileDataItemPath, mHostName, fileInfo.filePath()));
+    }
+
+    const QDir dir_map(MudletApp::getMudletPath(enums::profileMapsPath, mHostName));
+    if (!dir_map.exists() && !dir_map.mkpath(dir_map.path())) {
+        qDebug().noquote() << "Error saving map: could not make the profile's map directory" << dir_map.path();
+        return false;
+    }
+
+    QSaveFile file_map(filename_map);
+    if (!file_map.open(QIODevice::WriteOnly)) {
+        // Naming the file matters more than usual: a relative location is not
+        // the path the caller typed
+        qDebug().noquote() << "Error saving map to" << filename_map << ":" << file_map.errorString();
+        return false;
+    }
+
+    QDataStream out(&file_map);
+    out.setVersion(QDataStream::Qt_5_12);
+
+    bool saved = mpMap->serialize(out, saveVersion);
+    if (saved && !file_map.commit()) {
+        qDebug() << "Error saving map: " << (file_map.error() == QFile::NoError ? "issue with serializing" : file_map.errorString());
+        saved = false;
+    }
+
+    if (saved) {
+        mpMap->resetUnsaved();
+        mpMap->setSaveError(false);
+    } else {
+        mpMap->setSaveError(true);
+    }
+
+    return saved;
+}
+
+bool Host::loadMapFile(const QString& location)
+{
+    if (!mpMap || !mpMap->mpMapper) {
+        // No map or map currently loaded - so try and created mapper
+        // but don't load a map here by default, we do that below and it may not
+        // be the default map anyhow
+        showHideOrCreateMapper(false);
+    }
+
+    if (!mpMap || !mpMap->mpMapper) {
+        // And that failed so give up
+        return false;
+    }
+
+    mpMap->mapClear();
+
+    // The same resolution saveMapFile and importMapFile use, so that a map
+    // written under a bare name is looked for where it was written:
+    QString filePathName = location;
+    if (const QFileInfo fileInfo(location); !location.isEmpty() && fileInfo.isRelative()) {
+        filePathName = QDir::cleanPath(MudletApp::getMudletPath(enums::profileDataItemPath, mHostName, fileInfo.filePath()));
+    }
+
+    qDebug() << "Host::loadMapFile() - restore map case 1.";
+    mpMap->pushErrorMessagesToFile(tr("Pre-Map loading(1) report"), true);
+    const QDateTime now(QDateTime::currentDateTime());
+
+    bool result = false;
+    if (mpMap->restore(filePathName)) {
+        mpMap->audit();
+        mpMap->mpMapper->mp2dMap->init();
+        mpMap->mpMapper->updateAreaComboBox();
+        mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
+        mpMap->mpMapper->show();
+        result = true;
+    } else {
+        mpMap->mpMapper->mp2dMap->init();
+        mpMap->mpMapper->updateAreaComboBox();
+        mpMap->mpMapper->show();
+    }
+
+    if (filePathName.isEmpty()) {
+        mpMap->pushErrorMessagesToFile(tr("Loading map(1) at %1 report").arg(now.toString(Qt::ISODate)), true);
+    } else {
+        mpMap->pushErrorMessagesToFile(tr(R"(Loading map(1) "%1" at %2 report)").arg(filePathName, now.toString(Qt::ISODate)), true);
+    }
+
+    mpMap->updateArea(-1);
+
+    return result;
+}
+
+// Used by TLuaInterpreter::loadMap() and dlgProfilePreferences for import/load
+// of files ending in ".xml"
+// The TLuaInterpreter::loadMap() supplies a pointer to an error Message which
+// it requires in the event of an error (it should be written in a structure
+// to match "loadMap: XXXXX." format) - the presence of a non-null pointer here
+// should be used to suppress the writing of error messages direct to the
+// console - if possible!
+bool Host::importMapFile(const QString& location, QString* errMsg)
+{
+    if (!mpMap || !mpMap->mpMapper) {
+        // No map or mapper currently loaded/present - so try and create mapper
+        showHideOrCreateMapper(false);
+    }
+
+    if (!mpMap || !mpMap->mpMapper) {
+        // And that failed so give up
+        if (errMsg) {
+            *errMsg = qsl("loadMap: unable to initialise mapper {in TConsole::importMap(...)} - something is wrong!");
+        }
+        return false;
+    }
+
+    // Dump any outstanding map errors from past activities that had not yet
+    // been logged...
+    qDebug() << "Host::importMapFile() - importing map case 1.";
+    mpMap->pushErrorMessagesToFile(tr("Pre-Map importing(1) report"), true);
+    const QDateTime now(QDateTime::currentDateTime());
+
+    bool result = false;
+
+    const QFileInfo fileInfo(location);
+    QString filePathNameString;
+    if (!fileInfo.filePath().isEmpty()) {
+        if (fileInfo.isRelative()) {
+            // Resolve the name relative to the profile home directory:
+            filePathNameString = QDir::cleanPath(MudletApp::getMudletPath(enums::profileDataItemPath, mHostName, fileInfo.filePath()));
+        } else {
+            if (fileInfo.exists()) {
+                filePathNameString = fileInfo.canonicalFilePath(); // Cannot use canonical path if file doesn't exist!
+            } else {
+                filePathNameString = fileInfo.absoluteFilePath();
+            }
+        }
+    }
+
+    QFile file(filePathNameString);
+    if (!file.exists()) {
+        if (!errMsg) {
+            const QString infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
+                                       "%1.")
+                                            .arg(filePathNameString);
+            postMessage(infoMsg);
+        } else {
+            // error message for lua loadMap()
+            *errMsg = tr("loadMap: bad argument #1 value (filename used: \n"
+                         "\"%1\" was not found).")
+                              .arg(filePathNameString);
+        }
+        return false;
+    }
+
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+        if (!errMsg) {
+            const QString infoMsg = tr("[ INFO ]  - Map file located and opened, now parsing it...");
+            postMessage(infoMsg);
+        }
+
+        result = mpMap->importMap(file, errMsg);
+
+        file.close();
+        mpMap->pushErrorMessagesToFile(tr(R"(Importing map(1) "%1" at %2 report)").arg(location, now.toString(Qt::ISODate)));
+    } else {
+        if (!errMsg) {
+            const QString infoMsg = tr(R"([ INFO ]  - Map file located but it could not opened, please check permissions on:"%1".)").arg(filePathNameString);
+            postMessage(infoMsg);
+        } else {
+            *errMsg = tr("loadMap: bad argument #1 value (filename used: \n"
+                         "\"%1\" could not be opened for reading).")
+                              .arg(filePathNameString);
+        }
+        return false;
+    }
+
+    mpMap->updateArea(-1);
+
+    return result;
+}
+
 void Host::startMapAutosave(const int interval)
 {
     if (interval > 0) {
@@ -659,7 +846,7 @@ void Host::autoSaveMap()
 #if defined(DEBUG_MAPAUTOSAVE)
             qDebug().nospace().noquote() << "Host::autoSaveMap() INFO - map auto save initiated at:" << nowString << ".";
 #endif
-            if (!mpConsole->saveMap(MudletApp::getMudletPath(enums::profileMapPathFileName, mHostName, qsl("autosave.dat")))) {
+            if (!saveMapFile(MudletApp::getMudletPath(enums::profileMapPathFileName, mHostName, qsl("autosave.dat")))) {
                 mpMap->setSaveError(true);
             } else {
                 mpMap->setSaveError(false);
@@ -5205,7 +5392,7 @@ bool Host::interceptMapperButton()
 
 // Needed to extract into a separate method from mudlet::slot_mapper() so that
 // we can use it WITHOUT loading a file - at least for the
-// TConsole::importMap(...) case that may need to create a map widget before it
+// Host::importMapFile(...) case that may need to create a map widget before it
 // loads/imports a non-default (last saved map in profile's map directory).
 void Host::showHideOrCreateMapper(const bool loadDefaultMap)
 {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -751,7 +751,7 @@ bool Host::importMapFile(const QString& location, QString* errMsg)
     if (!mpMap || !mpMap->mpMapper) {
         // And that failed so give up
         if (errMsg) {
-            *errMsg = qsl("loadMap: unable to initialise mapper {in TConsole::importMap(...)} - something is wrong!");
+            *errMsg = qsl("loadMap: unable to initialise mapper {in Host::importMapFile(...)} - something is wrong!");
         }
         return false;
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -635,8 +635,8 @@ void Host::loadMap()
     }
 }
 
-// TODO: It may be worth considering moving the (now) three following methods
-// to the TMap class...?
+// The three methods below might be better off on TMap, which is what they all
+// end up talking to.
 bool Host::saveMapFile(const QString& location, int saveVersion)
 {
     QString filename_map = location;

--- a/src/Host.h
+++ b/src/Host.h
@@ -552,6 +552,9 @@ public:
     void setUserBorders(const QMargins);
     void setMxpBorders(const QMargins);
     void loadMap();
+    bool saveMapFile(const QString& location, int saveVersion = 0);
+    bool loadMapFile(const QString& location);
+    bool importMapFile(const QString& location, QString* errMsg = nullptr);
     std::tuple<QString, bool> getCmdLineSettings(const TCommandLine::CommandLineType, const QString&);
     void setCmdLineSettings(const TCommandLine::CommandLineType, const bool, const QString&);
     int getCommandLineHistorySaveSize() const { return mCommandLineHistorySaveSize; }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5403,9 +5403,9 @@ void T2DMap::slot_loadMap()
     settings.setValue("lastFileDialogLocation", lastDir);
 
     if (fileName.endsWith(qsl(".xml"), Qt::CaseInsensitive)) {
-        mpHost->mpConsole->importMap(fileName);
+        mpHost->importMapFile(fileName);
     } else {
-        mpHost->mpConsole->loadMap(fileName);
+        mpHost->loadMapFile(fileName);
     }
 }
 

--- a/src/TLuaInterpreterMapper.cpp
+++ b/src/TLuaInterpreterMapper.cpp
@@ -2731,7 +2731,7 @@ int TLuaInterpreter::loadJsonMap(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadMap
 int TLuaInterpreter::loadMap(lua_State* L)
 {
-    const Host& host = getHostFromLua(L);
+    Host& host = getHostFromLua(L);
 
     QString location;
     if (lua_gettop(L)) {
@@ -2741,7 +2741,7 @@ int TLuaInterpreter::loadMap(lua_State* L)
     bool isOk = false;
     if (!location.isEmpty() && location.endsWith(qsl(".xml"), Qt::CaseInsensitive)) {
         QString errMsg;
-        isOk = host.mpConsole->importMap(location, &errMsg);
+        isOk = host.importMapFile(location, &errMsg);
         if (!isOk) {
             // A false was returned which indicates an error, convert it to a nil
             lua_pushnil(L);
@@ -2754,7 +2754,7 @@ int TLuaInterpreter::loadMap(lua_State* L)
             return 1;
         }
     } else {
-        isOk = host.mpConsole->loadMap(location);
+        isOk = host.loadMapFile(location);
     }
     lua_pushboolean(L, isOk);
     return 1;
@@ -3150,8 +3150,8 @@ int TLuaInterpreter::saveMap(lua_State* L)
         location = lua_tostring(L, 1);
     }
 
-    const Host& host = getHostFromLua(L);
-    const bool error = host.mpConsole->saveMap(location, saveVersion);
+    Host& host = getHostFromLua(L);
+    const bool error = host.saveMapFile(location, saveVersion);
     lua_pushboolean(L, error);
     return 1;
 }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -2138,212 +2138,6 @@ void TMainConsole::finalize()
     }
 }
 
-// TODO: It may be worth considering moving the (now) three following methods
-// to the TMap class...?
-bool TMainConsole::saveMap(const QString& location, int saveVersion)
-{
-    QString filename_map = location;
-    if (filename_map.isEmpty()) {
-        filename_map = MudletApp::getMudletPath(enums::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
-    } else if (const QFileInfo fileInfo(location); fileInfo.isRelative()) {
-        // Resolve the name relative to the profile home directory the way
-        // TMainConsole::importMap does, rather than against whatever directory
-        // Mudlet happens to have been started in:
-        filename_map = QDir::cleanPath(MudletApp::getMudletPath(enums::profileDataItemPath, mProfileName, fileInfo.filePath()));
-    }
-
-    const QDir dir_map(MudletApp::getMudletPath(enums::profileMapsPath, mProfileName));
-    if (!dir_map.exists() && !dir_map.mkpath(dir_map.path())) {
-        qDebug().noquote() << "Error saving map: could not make the profile's map directory" << dir_map.path();
-        return false;
-    }
-
-    QSaveFile file_map(filename_map);
-    if (!file_map.open(QIODevice::WriteOnly)) {
-        // Naming the file matters more than usual: a relative location is not
-        // the path the caller typed
-        qDebug().noquote() << "Error saving map to" << filename_map << ":" << file_map.errorString();
-        return false;
-    }
-
-    QDataStream out(&file_map);
-    out.setVersion(QDataStream::Qt_5_12);
-
-    bool saved = mpHost->mpMap->serialize(out, saveVersion);
-    if (saved && !file_map.commit()) {
-        qDebug() << "Error saving map: " << (file_map.error() == QFile::NoError ? "issue with serializing" : file_map.errorString());
-        saved = false;
-    }
-
-    if (saved) {
-        mpHost->mpMap->resetUnsaved();
-        mpHost->mpMap->setSaveError(false);
-    } else {
-        mpHost->mpMap->setSaveError(true);
-    }
-
-    return saved;
-}
-
-bool TMainConsole::loadMap(const QString& location)
-{
-    Host* pHost = mpHost;
-    if (!pHost) {
-        // Check for valid mpHost pointer (mpHost was/is/will be a QPoint<Host>
-        // in later software versions and is a weak pointer until used
-        // (I think - Slysven ?)
-        return false;
-    }
-
-    if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
-        // No map or map currently loaded - so try and created mapper
-        // but don't load a map here by default, we do that below and it may not
-        // be the default map anyhow
-        pHost->showHideOrCreateMapper(false);
-    }
-
-    if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
-        // And that failed so give up
-        return false;
-    }
-
-    pHost->mpMap->mapClear();
-
-    // The same resolution saveMap and importMap use, so that a map written
-    // under a bare name is looked for where it was written:
-    QString filePathName = location;
-    if (const QFileInfo fileInfo(location); !location.isEmpty() && fileInfo.isRelative()) {
-        filePathName = QDir::cleanPath(MudletApp::getMudletPath(enums::profileDataItemPath, mProfileName, fileInfo.filePath()));
-    }
-
-    qDebug() << "TMainConsole::loadMap() - restore map case 1.";
-    pHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map loading(1) report"), true);
-    const QDateTime now(QDateTime::currentDateTime());
-
-    bool result = false;
-    if (pHost->mpMap->restore(filePathName)) {
-        pHost->mpMap->audit();
-        pHost->mpMap->mpMapper->mp2dMap->init();
-        pHost->mpMap->mpMapper->updateAreaComboBox();
-        pHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
-        pHost->mpMap->mpMapper->show();
-        result = true;
-    } else {
-        pHost->mpMap->mpMapper->mp2dMap->init();
-        pHost->mpMap->mpMapper->updateAreaComboBox();
-        pHost->mpMap->mpMapper->show();
-    }
-
-    if (filePathName.isEmpty()) {
-        pHost->mpMap->pushErrorMessagesToFile(tr("Loading map(1) at %1 report").arg(now.toString(Qt::ISODate)), true);
-    } else {
-        pHost->mpMap->pushErrorMessagesToFile(tr(R"(Loading map(1) "%1" at %2 report)").arg(filePathName, now.toString(Qt::ISODate)), true);
-    }
-
-    pHost->mpMap->updateArea(-1);
-
-    return result;
-}
-
-// Used by TLuaInterpreter::loadMap() and dlgProfilePreferences for import/load
-// of files ending in ".xml"
-// The TLuaInterpreter::loadMap() supplies a pointer to an error Message which
-// it requires in the event of an error (it should be written in a structure
-// to match "loadMap: XXXXX." format) - the presence of a non-null pointer here
-// should be used to suppress the writing of error messages direct to the
-// console - if possible!
-bool TMainConsole::importMap(const QString& location, QString* errMsg)
-{
-    Host* pHost = mpHost;
-    if (!pHost) {
-        // Check for valid mpHost pointer (mpHost was/is/will be a QPoint<Host>
-        // in later software versions and is a weak pointer until used
-        // (I think - Slysven ?)
-        if (errMsg) {
-            *errMsg = qsl("loadMap: NULL Host pointer {in TConsole::importMap(...)} - something is wrong!");
-        }
-        return false;
-    }
-
-    if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
-        // No map or mapper currently loaded/present - so try and create mapper
-        pHost->showHideOrCreateMapper(false);
-    }
-
-    if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
-        // And that failed so give up
-        if (errMsg) {
-            *errMsg = qsl("loadMap: unable to initialise mapper {in TConsole::importMap(...)} - something is wrong!");
-        }
-        return false;
-    }
-
-    // Dump any outstanding map errors from past activities that had not yet
-    // been logged...
-    qDebug() << "TMainConsole::importingMap() - importing map case 1.";
-    pHost->mpMap->pushErrorMessagesToFile(tr("Pre-Map importing(1) report"), true);
-    const QDateTime now(QDateTime::currentDateTime());
-
-    bool result = false;
-
-    const QFileInfo fileInfo(location);
-    QString filePathNameString;
-    if (!fileInfo.filePath().isEmpty()) {
-        if (fileInfo.isRelative()) {
-            // Resolve the name relative to the profile home directory:
-            filePathNameString = QDir::cleanPath(MudletApp::getMudletPath(enums::profileDataItemPath, mProfileName, fileInfo.filePath()));
-        } else {
-            if (fileInfo.exists()) {
-                filePathNameString = fileInfo.canonicalFilePath(); // Cannot use canonical path if file doesn't exist!
-            } else {
-                filePathNameString = fileInfo.absoluteFilePath();
-            }
-        }
-    }
-
-    QFile file(filePathNameString);
-    if (!file.exists()) {
-        if (!errMsg) {
-            const QString infoMsg = tr("[ ERROR ]  - Map file not found, path and name used was:\n"
-                                       "%1.")
-                                            .arg(filePathNameString);
-            pHost->postMessage(infoMsg);
-        } else {
-            // error message for lua loadMap()
-            *errMsg = tr("loadMap: bad argument #1 value (filename used: \n"
-                         "\"%1\" was not found).")
-                              .arg(filePathNameString);
-        }
-        return false;
-    }
-
-    if (file.open(QFile::ReadOnly | QFile::Text)) {
-        if (!errMsg) {
-            const QString infoMsg = tr("[ INFO ]  - Map file located and opened, now parsing it...");
-            pHost->postMessage(infoMsg);
-        }
-
-        result = pHost->mpMap->importMap(file, errMsg);
-
-        file.close();
-        pHost->mpMap->pushErrorMessagesToFile(tr(R"(Importing map(1) "%1" at %2 report)").arg(location, now.toString(Qt::ISODate)));
-    } else {
-        if (!errMsg) {
-            const QString infoMsg = tr(R"([ INFO ]  - Map file located but it could not opened, please check permissions on:"%1".)").arg(filePathNameString);
-            pHost->postMessage(infoMsg);
-        } else {
-            *errMsg = tr("loadMap: bad argument #1 value (filename used: \n"
-                         "\"%1\" could not be opened for reading).")
-                              .arg(filePathNameString);
-        }
-        return false;
-    }
-
-    pHost->mpMap->updateArea(-1);
-
-    return result;
-}
-
 void TMainConsole::slot_reloadMap(QList<QString> profilesList)
 {
     Host* pHost = getHost();
@@ -2360,7 +2154,7 @@ void TMainConsole::slot_reloadMap(QList<QString> profilesList)
     pHost->postMessage(infoMsg);
 
     QString outcomeMsg;
-    if (loadMap(QString())) {
+    if (pHost->loadMapFile(QString())) {
         outcomeMsg = tr("[  OK  ]  - ... System Map reload request completed.");
     } else {
         outcomeMsg = tr("[ WARN ]  - ... System Map reload request failed.");
@@ -2804,7 +2598,7 @@ void TMainConsole::closeEvent(QCloseEvent* event)
 
         if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
             // There is a map loaded - but it *could* have no rooms at all!
-            if (!saveMap(QString())) {
+            if (!mpHost->saveMapFile(QString())) {
                 qWarning() << "TMainConsole::closeEvent(...) WARNING - forced close map save failed";
             }
         }
@@ -2837,7 +2631,7 @@ void TMainConsole::closeEvent(QCloseEvent* event)
             if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
                 // There is a map loaded - but it *could* have no rooms at all!
             ASK_MAP:
-                if (!saveMap(QString())) {
+                if (!mpHost->saveMapFile(QString())) {
                     const int mapChoice = QMessageBox::warning(this,
                                                                tr("Could not save map"),
                                                                tr("Sorry, could not save the map. Would you like to retry or close without saving the map?"),

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -43,9 +43,7 @@
 #include "GifTracker.h"
 
 #include <QDialog>
-#include <QDir>
 #include <QDockWidget>
-#include <QFileInfo>
 #include <QIcon>
 #include <QLabel>
 #include <QLineEdit>

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -200,9 +200,6 @@ public:
     void toggleLogging(bool);
     void printOnDisplay(std::string&, bool isFromServer = false);
     void finalize();
-    bool saveMap(const QString&, int saveVersion = 0);
-    bool loadMap(const QString&);
-    bool importMap(const QString&, QString* errMsg = nullptr);
     void refreshSubconsoles();
 
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2774,7 +2774,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 }
 
 // Called from TLuaInterpreter::loadFile() or dlgProfilePreferences's "loadMap"
-// both via TConsole::importMap( QFile & ) - it is intended to prevent
+// both via Host::importMapFile(...) - it is intended to prevent
 // readXmlMapFile( QFile & ) from being used more than once at a time and to
 // prevent the above callers from using that when a map download is in progress!
 // errMsg if, non-null is for a suitable structured error message to return to
@@ -3030,7 +3030,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
     QString parsingFileName;
     if (!readFile.fileName().endsWith(qsl("xml"), Qt::CaseInsensitive)) {
         parsingFileName = readFile.fileName();
-        parsingWasSuccessful = pHost->mpConsole->loadMap(parsingFileName);
+        parsingWasSuccessful = pHost->loadMapFile(parsingFileName);
     } else {
         parsingFileName = mLocalMapFileName;
         if (!readFile.open(QFile::OpenMode(QFile::ReadOnly | QFile::Text))) {

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -20,7 +20,7 @@
 #include "TMxpMudlet.h"
 #include "Host.h"
 #include "TMedia.h"
-#include "TConsole.h"
+#include "TConsoleModel.h"
 #include "TLinkStore.h"
 #include "MudletApp.h"
 
@@ -167,7 +167,7 @@ void TMxpMudlet::setCaptionForSendEvent(const QString& caption)
 
 TLinkStore& TMxpMudlet::getLinkStore()
 {
-    return mpHost->mpConsole->getLinkStore();
+    return mpHost->mainConsoleModel().buffer.mLinkStore;
 }
 
 // Handle 'stacks' of attribute settings:
@@ -301,9 +301,9 @@ void TMxpMudlet::insertText(const QString& text)
 {
     // Insert text by feeding it back through the MXP processing pipeline
     // This ensures it respects the current line buffer state
-    if (mpHost && mpHost->mpConsole) {
+    if (mpHost) {
         std::string textToInsert = text.toStdString();
-        mpHost->mpConsole->buffer.translateToPlainText(textToInsert, false);
+        mpHost->mainConsoleModel().buffer.translateToPlainText(textToInsert, false);
     }
 }
 
@@ -342,10 +342,10 @@ bool TMxpMudlet::setMxpDestination(const QString& frameName, bool eol, bool eof)
 
 void TMxpMudlet::clearMxpDestination()
 {
-    if (mpHost && mpHost->mpConsole) {
-        mpHost->mpConsole->buffer.flushPendingDestinationContent();
+    if (mpHost) {
+        mpHost->mainConsoleModel().buffer.flushPendingDestinationContent();
         // Reset text formatting to prevent color bleeding from frame content to main console
-        mpHost->mpConsole->buffer.resetCurrentTextFormat();
+        mpHost->mainConsoleModel().buffer.resetCurrentTextFormat();
         mpHost->mMxpFrameManager.clearDestination();
     }
 }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -991,10 +991,8 @@ void dlgMapper::slot_showSaveWarningMenu()
 
     auto* retryAction = new QAction(tr("Retry save"), this);
     connect(retryAction, &QAction::triggered, this, [this]() {
-        if (mpHost && mpHost->mpConsole) {
-            if (mpHost->saveMapFile(QString())) {
-                mpMap->setSaveError(false);
-            }
+        if (mpHost && mpHost->saveMapFile(QString())) {
+            mpMap->setSaveError(false);
         }
     });
     menu->addAction(retryAction);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -356,7 +356,7 @@ void dlgMapper::loadMapFromFile()
         }
         bool success = false;
         if (fileName.endsWith(qsl(".xml"), Qt::CaseInsensitive)) {
-            success = pHost->mpConsole->importMap(fileName);
+            success = pHost->importMapFile(fileName);
         } else if (fileName.endsWith(qsl(".json"), Qt::CaseInsensitive)) {
             auto [ok, errorMessage] = pHost->mpMap->readJsonMapFile(fileName);
             success = ok;
@@ -364,7 +364,7 @@ void dlgMapper::loadMapFromFile()
                 pHost->postMessage(tr("[ ERROR ] - Unable to load JSON map file: %1\nreason: %2.").arg(fileName, errorMessage));
             }
         } else {
-            success = pHost->mpConsole->loadMap(fileName);
+            success = pHost->loadMapFile(fileName);
         }
         if (success) {
             pHost->mpMap->audit();
@@ -992,7 +992,7 @@ void dlgMapper::slot_showSaveWarningMenu()
     auto* retryAction = new QAction(tr("Retry save"), this);
     connect(retryAction, &QAction::triggered, this, [this]() {
         if (mpHost && mpHost->mpConsole) {
-            if (mpHost->mpConsole->saveMap(QString())) {
+            if (mpHost->saveMapFile(QString())) {
                 mpMap->setSaveError(false);
             }
         }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -5938,7 +5938,7 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
     }
     label_mapFileActionResult->show();
 
-    // Ensure the setting is already made as the TConsole::loadMap(...) uses
+    // Ensure the setting is already made as the Host::loadMapFile(...) uses
     // the set value:
     const bool showAuditErrors = TMap::smShowMapAuditErrors;
     mudlet::self()->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
@@ -5948,7 +5948,7 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
     qApp->processEvents(); // Needed to make the above message show up when loading big maps
     if (fileName.endsWith(qsl(".xml"), Qt::CaseInsensitive)) {
         qApp->processEvents(); // Needed to make the above message show up when loading big maps
-        success = pHost->mpConsole->importMap(fileName);
+        success = pHost->importMapFile(fileName);
 
     } else {
         if (fileName.endsWith(qsl(".json"), Qt::CaseInsensitive)) {
@@ -5961,7 +5961,7 @@ void dlgProfilePreferences::loadMap(const QString& fileName)
             }
 
         } else {
-            success = pHost->mpConsole->loadMap(fileName);
+            success = pHost->loadMapFile(fileName);
         }
     }
 
@@ -6073,7 +6073,7 @@ void dlgProfilePreferences::slot_saveMap()
 
         bool success = false;
         if (!fileName.endsWith(qsl(".json"), Qt::CaseInsensitive)) {
-            success = pHost->mpConsole->saveMap(fileName, comboBox_mapFileSaveFormatVersion->currentData().toInt());
+            success = pHost->saveMapFile(fileName, comboBox_mapFileSaveFormatVersion->currentData().toInt());
         } else {
             success = pHost->mpMap->writeJsonMapFile(fileName).first;
         }
@@ -6236,7 +6236,7 @@ void dlgProfilePreferences::slot_copyMap()
     const int oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
 
-    if (!pHost->mpConsole->saveMap(QString())) {
+    if (!pHost->saveMapFile(QString())) {
         label_mapFileActionResult->setText(tr("Could not backup the map - saving it failed."));
         QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
         return;

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -3063,7 +3063,7 @@ describe("Tests saveMap and loadMap", function()
 
   -- Careful with the order of anything added here: a load that fails can still
   -- have emptied the map first, both for a missing binary file
-  -- (TMainConsole::loadMap clears before it restores) and for a map document
+  -- (Host::loadMapFile clears before it restores) and for a map document
   -- that will not parse (TMap::readXmlMapFile clears before it parses), so most
   -- of these leave no map behind for the next spec. A file that is not a map
   -- document at all is the exception: it is refused before the clear.

--- a/src/mudlet-lua/tests/Mapper_spec.lua
+++ b/src/mudlet-lua/tests/Mapper_spec.lua
@@ -3115,6 +3115,21 @@ describe("Tests saveMap and loadMap", function()
       assert.is_truthy(message:find("nosuchmapfile.xml", 1, true))
     end)
 
+    -- the XML import resolves a bare name against the profile directory the
+    -- same way saveMap and loadMap do, so the message has to name where it
+    -- really looked and not the directory Mudlet happens to have been started
+    -- in, which for a spec run is the build or source tree
+    it("resolves a bare XML name against the profile directory", function()
+      local bare = "mapper_spec_norelative.xml"
+      local resolved = getMudletHomeDir() .. "/" .. bare
+      assert.is_false(io.exists(resolved), "the spec needs a name nothing has written")
+
+      local ok, message = loadMap(bare)
+      assert.is_nil(ok)
+      assert.is_string(message)
+      assert.is_truthy(message:find(resolved, 1, true), message)
+    end)
+
     it("returns nil and a message for an XML file it cannot parse", function()
       local file = assert(io.open(brokenXmlPath, "w"))
       file:write("<map><areas><area id=\"1\" name=\"unterminated\">")

--- a/test/functional_tests/HyperlinkModelSplitTest.cpp
+++ b/test/functional_tests/HyperlinkModelSplitTest.cpp
@@ -167,6 +167,36 @@ private slots:
         QVERIFY2(!subConsole->getHyperlinkSelectionManager().isSelected(qsl("splitgroup"), qsl("splitvalue")), "a user window must not share the main console's selection state");
     }
 
+    // The MXP client takes its link store off the model's buffer, so a <SEND>
+    // lands on the characters that buffer wrote. A store of the client's own
+    // would still answer the client's own reads - the caption, the actions on
+    // the queued event - so the proof is taken off the buffer instead: the
+    // character's link index, and the command that index resolves to. Nothing
+    // in Lua reads a stored link command back, which is why this is here rather
+    // than in MXP_spec.
+    void test_anMxpSendLinkIsStoredOnTheModelsBuffer()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        TConsoleModel& model = host->mainConsoleModel();
+
+        // feedTriggers() is not server data, so the ESC[1z a game would send to
+        // open secure mode is inert here; forcing the processor on is what makes
+        // the tag below a tag at all.
+        host->setForceMXPProcessorOn(true);
+        QVERIFY2(host->getLuaInterpreter()->compileAndExecuteScript(qsl("feedTriggers([[MXPSEND1 <SEND \"north\">go north</SEND>]] .. \"\\n\")")),
+                 "feedTriggers() did not run, so no MXP link was ever registered");
+
+        const int lineNumber = lineHolding(model.buffer, qsl("MXPSEND1"));
+        QVERIFY2(lineNumber >= 0, "the line carrying the MXP link never reached the buffer");
+        const QString line = lineTextAt(model.buffer, lineNumber);
+        QCOMPARE(line, qsl("MXPSEND1 go north"));
+
+        const int linkIndex = model.buffer.getLinkIndexAt(lineNumber, line.indexOf(qsl("go north")));
+        QVERIFY2(linkIndex > 0, "the linked characters carry no link index, so the MXP link is not clickable");
+        QCOMPARE(model.buffer.mLinkStore.getLinksConst(linkIndex), QStringList{qsl("send([[north]])")});
+    }
+
     // Concealing rewrites the buffer, and the buffer is the model's. This drives
     // it against a model that never had a widget of any kind, which is what the
     // manager used to refuse to do: performConcealment() and performReveal()

--- a/test/functional_tests/HyperlinkModelSplitTest.cpp
+++ b/test/functional_tests/HyperlinkModelSplitTest.cpp
@@ -197,6 +197,34 @@ private slots:
         QCOMPARE(model.buffer.mLinkStore.getLinksConst(linkIndex), QStringList{qsl("send([[north]])")});
     }
 
+    // The case above cannot tell the model's buffer from the view's, because
+    // TConsole::buffer is a reference bound to the model's - they are one
+    // object whenever a view exists. This is the half that is only the model's:
+    // the MXP client writing text, resolving its link store and ending a
+    // redirect for a profile whose view has gone, which is what a headless one
+    // never had. Driven straight at Host::mMxpClient rather than through
+    // feedTriggers(), which still goes through the console widget.
+    void test_theMxpClientReachesTheModelsBufferWithNoView()
+    {
+        Host* host = startProfile();
+        QVERIFY(host);
+        std::shared_ptr<TConsoleModel> model = host->sharedMainConsoleModel();
+
+        destroyTheView(host);
+        QCOMPARE(&host->mainConsoleModel(), model.get());
+
+        host->mMxpClient.insertText(qsl("MXPNOVIEW1 written with no view\n"));
+        const int lineNumber = lineHolding(model->buffer, qsl("MXPNOVIEW1"));
+        QVERIFY2(lineNumber >= 0, "insertText() never reached the model's buffer");
+        QCOMPARE(lineTextAt(model->buffer, lineNumber), qsl("MXPNOVIEW1 written with no view"));
+
+        QCOMPARE(&host->mMxpClient.getLinkStore(), &model->buffer.mLinkStore);
+
+        // Nothing to read back - the point is that it runs at all, on the
+        // buffer the model owns rather than through a console that has gone.
+        host->mMxpClient.clearMxpDestination();
+    }
+
     // Concealing rewrites the buffer, and the buffer is the model's. This drives
     // it against a model that never had a widget of any kind, which is what the
     // manager used to refuse to do: performConcealment() and performReveal()

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -45,7 +45,7 @@
  * A real profile rather than a bare Host, because the interesting part of the
  * chain is what happens after the bytes land: the reply handler writes the file,
  * parses it, and reports every outcome to the console through Host::postMessage()
- * - and hands a non-XML file to TMainConsole::loadMap(). A Host with no console
+ * - and hands a non-XML file to Host::loadMapFile(). A Host with no console
  * would stack those messages up unread and crash on that last call. It is also
  * the only way to get the frontend wiring at all: those connects are made in
  * mudlet::addConsoleForNewHost(), so a profile built through HostManager::addHost
@@ -1222,7 +1222,7 @@ private slots:
 
     // A destination file name that does not end in "xml" - which an URL not
     // ending in "xml" is what gives it by default - is a binary map file, and
-    // goes to TMainConsole::loadMap() rather than the XML reader.
+    // goes to Host::loadMapFile() rather than the XML reader.
     //
     // After every standalone-progress test on purpose: loadMap() creates the
     // mapper widget, and from then on TMap puts its progress on that widget
@@ -1325,14 +1325,14 @@ private slots:
         const QString destination = qsl("%1/map.dat").arg(saveDir.path());
         // A format version this Mudlet cannot write, which is what Lua's
         // saveMap(fileName, version) hands straight through. A destination that
-        // cannot be opened is no use for this: TMainConsole::saveMap() returns
+        // cannot be opened is no use for this: Host::saveMapFile() returns
         // from that one before it ever reaches the flag.
-        QVERIFY2(!mpHost->mpConsole->saveMap(destination, 9999), "the map save was supposed to fail");
+        QVERIFY2(!mpHost->saveMapFile(destination, 9999), "the map save was supposed to fail");
         QVERIFY2(!QFileInfo::exists(destination), "the failed save wrote a map file anyway");
         QVERIFY(pMap->hasSaveError());
         QVERIFY2(!pMapper->toolButton_saveWarning->isHidden(), "a failed map save left the mapper's warning indicator down");
 
-        QVERIFY2(mpHost->mpConsole->saveMap(destination), "the map save with a supported format version failed");
+        QVERIFY2(mpHost->saveMapFile(destination), "the map save with a supported format version failed");
         QVERIFY(!pMap->hasSaveError());
         QVERIFY2(pMapper->toolButton_saveWarning->isHidden(), "a successful map save left the mapper's warning indicator up");
     }

--- a/test/functional_tests/MapDownloadTest.cpp
+++ b/test/functional_tests/MapDownloadTest.cpp
@@ -44,9 +44,8 @@
  *
  * A real profile rather than a bare Host, because the interesting part of the
  * chain is what happens after the bytes land: the reply handler writes the file,
- * parses it, and reports every outcome to the console through Host::postMessage()
- * - and hands a non-XML file to Host::loadMapFile(). A Host with no console
- * would stack those messages up unread and crash on that last call. It is also
+ * parses it, and reports every outcome to the console through Host::postMessage().
+ * A Host with no console would stack those messages up unread. It is also
  * the only way to get the frontend wiring at all: those connects are made in
  * mudlet::addConsoleForNewHost(), so a profile built through HostManager::addHost
  * has none of them.

--- a/test/functional_tests/MapFileStatsTest.cpp
+++ b/test/functional_tests/MapFileStatsTest.cpp
@@ -105,7 +105,7 @@ private:
         map()->mRoomIdHash[mProfileName] = 1;
     }
 
-    // The same QDataStream setup TMainConsole::saveMap uses. saveVersion 0 means
+    // The same QDataStream setup Host::saveMapFile uses. saveVersion 0 means
     // the map's own; anything else has to be within mMinVersion..mMaxVersion.
     bool writeMapFile(const QString& pathFileName, const int saveVersion = 0) const
     {

--- a/test/functional_tests/MapRenderBenchmark.cpp
+++ b/test/functional_tests/MapRenderBenchmark.cpp
@@ -276,7 +276,7 @@ private slots:
         QVERIFY2(connected.wait(3000), "could not connect to the stub");
 
         // The mapper has to exist before the map is restored into it, exactly
-        // as TMainConsole::loadMap() arranges it.
+        // as Host::loadMapFile() arranges it.
         host->showHideOrCreateMapper(false);
         QVERIFY(host->mpMap);
         QVERIFY(host->mpMap->mpMapper);

--- a/test/functional_tests/MapRoundTripTest.cpp
+++ b/test/functional_tests/MapRoundTripTest.cpp
@@ -25,7 +25,7 @@
  * custom exit lines, doors, exit weights, room/area/map-level userData, room
  * environments, non-ASCII names/symbols, negative coordinates and z-levels
  * plus an area map label. It is saved with TMap::serialize (the same
- * QDataStream setup TMainConsole::saveMap uses), loaded into a fresh Host's
+ * QDataStream setup Host::saveMapFile uses), loaded into a fresh Host's
  * map via TMap::restore + audit (the production load path minus the mapper
  * UI) and compared field by field.
  *


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Saving, loading and importing a map file were `TMainConsole` methods, so everything that touched a map file on disk went through the profile's console widget to do it. They move to `Host` as `saveMapFile()`, `loadMapFile()` and `importMapFile()` - the names differ from the originals because `Host::loadMap()` already means "restore this profile's own map". The callers follow: the map autosave, the map downloader, the mapper dialog, the 2D map's load menu, profile preferences, and Lua's `saveMap()` and `loadMap()`.
- The MXP client reached the main buffer through the widget too: the link store a `<SEND>` writes into, the text an `<HR>` feeds back through the parser, and the flush that ends a `<DEST>` redirect. All three are the console model's buffer, which a live profile always has, so `TMxpMudlet` drops its console widget header.

#### Motivation for adding to Mudlet
Another slice of #8681. Map file I/O is not a widget's job, and after this the mapper, the map downloader and the MXP client have no path into the console widget at all. Stacked on #10472 for `MudletApp::getMudletPath`, which the moved bodies use.

#### Other info (issues closed, discussion etc)
Behavior is unchanged: the three bodies moved as they were, less the null-Host guards, which cannot fire from inside `Host`. The map autosave is the one path that gains something, since it called `mpConsole->saveMap()` with no null check and now needs no console at all. The widgets audit stays at 149, as `TMxpMudlet.cpp` was already in its clean list.

One thing to be aware of rather than a side effect of this PR alone: `tr()` takes its context from the class it sits in, so the ten map messages that moved land under `Host` while the catalogues still hold them under `TMainConsole`. Four of them have live translations in 11 to 15 locales, and those will read in English until Crowdin fills the new context in - the source text is identical, so a pre-translate from the translation memory covers it after the weekly text update. Every later slice of #8681 that moves a method between classes has the same property.

**Test case:** the map cases in `Mapper_spec.lua` pin the three moved methods, and each went red when the moved code was cut: skipping the restore in `loadMapFile()`, returning true from `saveMapFile()` without writing (both the plain and the relative-path case), and leaving the message unset in `importMapFile()`. Import had no case for a bare name, the one arm that resolves against the profile directory, so there is one now: pointing it at `fileInfo.absoluteFilePath()` instead resolves against the build tree and it is the only failure in the suite. For MXP, `MXP_spec.lua` catches a no-op `<DEST>` flush, where color set inside a redirect follows the text back into the main console, and a no-op `insertText()`, where `<HR>` draws no rule. Two cases in `HyperlinkModelSplitTest` cover the link store: one that a store of the client's own would fail, and one that drives `Host::mMxpClient` at a profile whose view has been destroyed, which is the half only the model can serve. The second is the one that answers this PR: restoring the old console expressions makes it fail on `insertText()` reaching nothing, while the first stays green either way, since `TConsole::buffer` is a reference bound to the model's. Full functional suite 180/180 and the Lua specs 4367/0 on Linux.

Assisted-by: Claude:claude-fable-5-1
