### PR TITLE
Infra: Cancel superseded CodeQL runs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,13 @@ on:
     - cron: '0 7 * * 3'
   workflow_dispatch:
 
+# A branch scan only needs the newest commit analysed: five pushes to
+# development in quick succession otherwise hold five full builds at once, and
+# the runner concurrency is shared with every other repository in the org.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: ${{matrix.buildname}}


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Adds a `concurrency` group to the CodeQL workflow, keyed on `github.ref`, with `cancel-in-progress: true`.

#### Motivation for adding to Mudlet

CodeQL had no concurrency group, so every push to `development` started a full analysis and none superseded each other — five were in flight at once earlier today, on five different `development` commits. Each is a cold build (ccache is deliberately absent so the tracer observes every compilation), so five at once held five of the organisation's twenty shared runner slots for the better part of an hour. That pool is shared with every other repository in the org.

#### Other info (issues closed, discussion etc)

Only the newest commit on a branch needs analysing, so nothing is lost — the security dashboard still gets a result for the tip of `development`, just not for commits already superseded. The weekly scheduled scan and `workflow_dispatch` on the same ref collapse into the same group.

Timings from the three most recent successful runs:

| Step | Run A | Run B | Run C |
|---|---|---|---|
| Build Mudlet | 28m | 44m | 43m |
| Perform CodeQL Analysis | 11m | 13m | 14m |
| **Total** | **43m** | **59m** | **59m** |

**Test case:** the block only takes effect once it is on `development`. After merging, push two commits in quick succession — the first CodeQL run should show as cancelled and only the second should complete.

Assisted-by: Claude:claude-opus-5

https://claude.ai/code/session_017pPTDim3e372oYToztYffS