### PR TITLE
Fix: Console scroll bar is visible again on Windows

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -52,10 +52,12 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QPainter>
+#include <QProxyStyle>
 #include <QScrollBar>
 #include <QSettings>
 #include <QShortcut>
 #include <QSplitter>
+#include <QStyleOptionSlider>
 #include <QTextBoundaryFinder>
 #include <QVideoWidget>
 #include <chrono>
@@ -89,6 +91,47 @@ QColor readableLinkColor(const QColor& background)
 {
     const QColor lightBlue(80, 160, 255);
     return contrastRatio(QColor(Qt::blue), background) >= contrastRatio(lightBlue, background) ? QColor(Qt::blue) : lightBlue;
+}
+
+// Windows 11 colours the handle for the application's colour scheme rather than
+// for the surface it sits on - black at 45% alpha, invisible on a black console.
+// A style and not a style sheet: a widget's own style sheet outranks every other
+// rule, so a sheet here would drop a profile's setProfileStyleSheet() rules.
+class ConsoleScrollBarStyle : public QProxyStyle
+{
+public:
+    static constexpr const char* csHandleColorProperty = "mudletScrollBarHandleColor";
+
+    void drawComplexControl(const ComplexControl control, const QStyleOptionComplex* pOption, QPainter* pPainter, const QWidget* pWidget) const override
+    {
+        const auto* pSlider = qstyleoption_cast<const QStyleOptionSlider*>(pOption);
+        const QColor handleColor = pWidget ? pWidget->property(csHandleColorProperty).value<QColor>() : QColor();
+        if (control != CC_ScrollBar || !pSlider || !handleColor.isValid()) {
+            QProxyStyle::drawComplexControl(control, pOption, pPainter, pWidget);
+            return;
+        }
+
+        if (pSlider->minimum >= pSlider->maximum) {
+            return;
+        }
+
+        const QRect handle = subControlRect(CC_ScrollBar, pOption, SC_ScrollBarSlider, pWidget);
+        const int inset = 3;
+        const QRectF handleRect = (pSlider->orientation == Qt::Vertical) ? QRectF(handle).adjusted(inset, 0, -inset, 0) : QRectF(handle).adjusted(0, inset, 0, -inset);
+
+        pPainter->save();
+        pPainter->setRenderHint(QPainter::Antialiasing);
+        pPainter->setPen(Qt::NoPen);
+        pPainter->setBrush(handleColor);
+        pPainter->drawRoundedRect(handleRect, 4, 4);
+        pPainter->restore();
+    }
+};
+
+QStyle* consoleScrollBarStyle()
+{
+    static auto* pStyle = new ConsoleScrollBarStyle;
+    return pStyle;
 }
 } // namespace
 
@@ -321,6 +364,8 @@ TConsole::TConsole(Host* pH, const QString& name, const ConsoleType type, QWidge
 
     mpScrollBar->setFixedWidth(15);
     mpHScrollBar->setFixedHeight(15);
+    mpScrollBar->setStyle(consoleScrollBarStyle());
+    mpHScrollBar->setStyle(consoleScrollBarStyle());
 
     splitter = new TSplitter(Qt::Vertical, layer);
     splitter->setObjectName(qsl("splitter_%1_%2").arg(mProfileName, mConsoleName));
@@ -1182,6 +1227,20 @@ void TConsole::changeColors()
         buffer.mWrapAt = mpHost->mWrapAt;
         buffer.mWrapIndent = mpHost->mWrapIndentCount;
         buffer.mWrapHangingIndent = mpHost->mWrapHangingIndentCount;
+    }
+
+    updateScrollBarStyle();
+}
+
+void TConsole::updateScrollBarStyle()
+{
+    const QColor background = (mType == MainConsole) ? mpHost->mBgColor : mBgColor;
+    // 200 is the lowest alpha clearing a 3:1 contrast ratio on every background a profile can set
+    const QColor handle = contrastRatio(Qt::white, background) >= contrastRatio(Qt::black, background) ? QColor(255, 255, 255, 200) : QColor(0, 0, 0, 200);
+
+    for (QScrollBar* pScrollBar : {mpScrollBar, mpHScrollBar}) {
+        pScrollBar->setProperty(ConsoleScrollBarStyle::csHandleColorProperty, handle);
+        pScrollBar->update();
     }
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -111,24 +111,35 @@ public:
             return;
         }
 
+        // The groove, the arrows and the hover feedback stay the base style's work, but
+        // its handle is masked out: ours is alpha blended, so it would take its colour
+        // from that handle instead of from the console it was measured against.
+        QStyleOptionSlider baseOption(*pSlider);
+        baseOption.subControls &= ~SC_ScrollBarSlider;
+        QProxyStyle::drawComplexControl(control, &baseOption, pPainter, pWidget);
+
+        // QCommonStyle hands back a full-length handle when there is nothing to
+        // scroll, which would paint a bar down the whole console.
         if (pSlider->minimum >= pSlider->maximum) {
             return;
         }
 
         const QRect handle = subControlRect(CC_ScrollBar, pOption, SC_ScrollBarSlider, pWidget);
-        const int inset = 3;
+        // Centres a 9 pixel handle in the 15 pixel bar the console pins.
+        constexpr int inset = 3;
+        constexpr int cornerRadius = 4;
         const QRectF handleRect = (pSlider->orientation == Qt::Vertical) ? QRectF(handle).adjusted(inset, 0, -inset, 0) : QRectF(handle).adjusted(0, inset, 0, -inset);
 
-        // Outlined in the opposite colour because a background image is painted on
-        // an ancestor and shows through the groove: the fill alone can land on
-        // anything, but fill and outline cannot both blend into the same surface.
+        // Outlined in the opposite colour because a background image on an ancestor shows
+        // through the groove: a fill alone can land on a matching image, a fill and its
+        // outline cannot both blend into one surface.
         const QColor outlineColor(255 - handleColor.red(), 255 - handleColor.green(), 255 - handleColor.blue(), handleColor.alpha());
 
         pPainter->save();
         pPainter->setRenderHint(QPainter::Antialiasing);
         pPainter->setPen(QPen(outlineColor, 1));
         pPainter->setBrush(handleColor);
-        pPainter->drawRoundedRect(handleRect.adjusted(0.5, 0.5, -0.5, -0.5), 4, 4);
+        pPainter->drawRoundedRect(handleRect.adjusted(0.5, 0.5, -0.5, -0.5), cornerRadius, cornerRadius);
         pPainter->restore();
     }
 };

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -119,11 +119,16 @@ public:
         const int inset = 3;
         const QRectF handleRect = (pSlider->orientation == Qt::Vertical) ? QRectF(handle).adjusted(inset, 0, -inset, 0) : QRectF(handle).adjusted(0, inset, 0, -inset);
 
+        // Outlined in the opposite colour because a background image is painted on
+        // an ancestor and shows through the groove: the fill alone can land on
+        // anything, but fill and outline cannot both blend into the same surface.
+        const QColor outlineColor(255 - handleColor.red(), 255 - handleColor.green(), 255 - handleColor.blue(), handleColor.alpha());
+
         pPainter->save();
         pPainter->setRenderHint(QPainter::Antialiasing);
-        pPainter->setPen(Qt::NoPen);
+        pPainter->setPen(QPen(outlineColor, 1));
         pPainter->setBrush(handleColor);
-        pPainter->drawRoundedRect(handleRect, 4, 4);
+        pPainter->drawRoundedRect(handleRect.adjusted(0.5, 0.5, -0.5, -0.5), 4, 4);
         pPainter->restore();
     }
 };

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -111,9 +111,9 @@ public:
             return;
         }
 
-        // The groove, the arrows and the hover feedback stay the base style's work, but
-        // its handle is masked out: ours is alpha blended, so it would take its colour
-        // from that handle instead of from the console it was measured against.
+        // The groove and the arrows stay the base style's work, but its handle is masked
+        // out - and with it the handle's own hover state - because ours is alpha blended
+        // and would otherwise take its colour from that handle rather than the console.
         QStyleOptionSlider baseOption(*pSlider);
         baseOption.subControls &= ~SC_ScrollBarSlider;
         QProxyStyle::drawComplexControl(control, &baseOption, pPainter, pWidget);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -44,6 +44,7 @@
 
 #include <QAccessibleInterface>
 #include <QAccessibleWidget>
+#include <QApplication>
 #include <QFile>
 #include <QFrame>
 #include <QHBoxLayout>
@@ -97,6 +98,32 @@ QColor readableLinkColor(const QColor& background)
 // for the surface it sits on - black at 45% alpha, invisible on a black console.
 // A style and not a style sheet: a widget's own style sheet outranks every other
 // rule, so a sheet here would drop a profile's setProfileStyleSheet() rules.
+//
+// Only that style is taken over. Every other style Mudlet meets draws its handle
+// against the groove it paints underneath it, so it is visible on any console
+// colour already, and it carries the hover and pressed feedback that this
+// painting cannot - measured on Linux/Fusion, the platform handle stands at
+// 19.8:1 against a black console where a handle drawn here reaches 20.1:1.
+bool consoleScrollBarStyleWanted()
+{
+    const QStyle* pStyle = QApplication::style();
+    if (!pStyle) {
+        return false;
+    }
+
+    // Mudlet's application style is a proxy - AltFocusMenuBarDisable, or DarkTheme -
+    // and those carry no object name of their own, so it comes from the style wrapped.
+    QString styleName = pStyle->objectName();
+    if (styleName.isEmpty()) {
+        if (const auto* pProxy = qobject_cast<const QProxyStyle*>(pStyle); pProxy && pProxy->baseStyle()) {
+            styleName = pProxy->baseStyle()->objectName();
+        }
+    }
+    // Windows 10's style is not this one: it paints an opaque handle on a light
+    // track, which has the same contrast whatever the console is set to.
+    return !styleName.compare(qsl("windows11"), Qt::CaseInsensitive);
+}
+
 class ConsoleScrollBarStyle : public QProxyStyle
 {
 public:
@@ -106,7 +133,11 @@ public:
     {
         const auto* pSlider = qstyleoption_cast<const QStyleOptionSlider*>(pOption);
         const QColor handleColor = pWidget ? pWidget->property(csHandleColorProperty).value<QColor>() : QColor();
-        if (control != CC_ScrollBar || !pSlider || !handleColor.isValid()) {
+        // Asked here rather than when the style is installed, so that replacing the
+        // application style - which the appearance setting does - is picked up without
+        // every console having to be told, and so a test can stand a Windows 11 style
+        // in on a platform that has none.
+        if (control != CC_ScrollBar || !pSlider || !handleColor.isValid() || !consoleScrollBarStyleWanted()) {
             QProxyStyle::drawComplexControl(control, pOption, pPainter, pWidget);
             return;
         }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -505,6 +505,7 @@ private:
     void createSearchOptionIcon();
     void raiseFontChangeEvent();
     void restoreCommandSearchSettings();
+    void updateScrollBarStyle();
 
     ConsoleType mType = UnknownType;
     // the size the last resize reported to Lua

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -71,6 +71,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     ConsoleSearchBarTest.cpp
     WrapLineRewrapTest.cpp
     ScrollLostOnPartialRepaintTest.cpp
+    ScrollBarContrastTest.cpp
 )
 
 # Profiles: their config dir, their folders, and loading, saving and deleting them

--- a/test/functional_tests/ScrollBarContrastTest.cpp
+++ b/test/functional_tests/ScrollBarContrastTest.cpp
@@ -105,7 +105,16 @@ private:
     {
         runLua(qsl("setBackgroundColor(%1, %2, %3)").arg(background.red()).arg(background.green()).arg(background.blue()));
         QScrollBar* pScrollBar = mpHost->mpConsole->mpScrollBar;
+        const QRect handle = handleRect(pScrollBar);
+        if (handle.isEmpty()) {
+            return 1.0;
+        }
 
+        return contrastRatio(renderScrollBarOn(background).pixelColor(handle.center()), background);
+    }
+
+    static QRect handleRect(QScrollBar* pScrollBar)
+    {
         QStyleOptionSlider option;
         option.initFrom(pScrollBar);
         option.orientation = pScrollBar->orientation();
@@ -115,12 +124,7 @@ private:
         option.singleStep = pScrollBar->singleStep();
         option.sliderPosition = pScrollBar->sliderPosition();
         option.sliderValue = pScrollBar->value();
-        const QRect handle = pScrollBar->style()->subControlRect(QStyle::CC_ScrollBar, &option, QStyle::SC_ScrollBarSlider, pScrollBar);
-        if (handle.isEmpty()) {
-            return 1.0;
-        }
-
-        return contrastRatio(renderScrollBarOn(background).pixelColor(handle.center()), background);
+        return pScrollBar->style()->subControlRect(QStyle::CC_ScrollBar, &option, QStyle::SC_ScrollBarSlider, pScrollBar);
     }
 
     static int countPixels(const QImage& shot, const QColor& wanted)
@@ -230,6 +234,50 @@ private slots:
         const QColor background(0, 0, 255);
         const qreal contrast = handleContrastOn(background);
         QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a blue console was only %1:1").arg(contrast, 0, 'f', 2)));
+    }
+
+    // A background image is painted on MainDisplay, an ancestor of the scroll bar,
+    // so it shows through the groove: the handle has to stand out against the image
+    // and not merely against the colour stored underneath it.
+    void test_handleStandsOutOnALightBackgroundImage()
+    {
+        const QString imagePath = qsl("%1/white.png").arg(mConfigDir.path());
+        QImage white(8, 8, QImage::Format_RGB32);
+        white.fill(Qt::white);
+        QVERIFY(white.save(imagePath));
+
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        runLua(qsl("setBackgroundImage([[%1]], 1)").arg(imagePath));
+        QTest::qWait(100ms);
+
+        QScrollBar* pScrollBar = mpHost->mpConsole->mpScrollBar;
+        QWidget* pDisplay = pScrollBar;
+        for (QWidget* pW = pScrollBar; pW; pW = pW->parentWidget()) {
+            if (pW->objectName() == qsl("MainDisplay")) {
+                pDisplay = pW;
+            }
+        }
+        QVERIFY(pDisplay != pScrollBar);
+
+        QImage shot(pDisplay->size(), QImage::Format_RGB32);
+        shot.fill(Qt::magenta);
+        pDisplay->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
+
+        const QRect handle = handleRect(pScrollBar).translated(pScrollBar->mapTo(pDisplay, QPoint()));
+        const QColor image = shot.pixelColor(handle.center().x(), handle.top() - 6);
+        int standingOut = 0;
+        for (int y = handle.top(); y <= handle.bottom(); ++y) {
+            for (int x = handle.left(); x <= handle.right(); ++x) {
+                if (contrastRatio(shot.pixelColor(x, y), image) >= 3.0) {
+                    ++standingOut;
+                }
+            }
+        }
+
+        runLua(qsl("resetBackgroundImage()"));
+        QTest::qWait(50ms);
+        QVERIFY2(image == QColor(Qt::white), qPrintable(qsl("the background image did not reach the scroll bar - it rendered %1").arg(image.name())));
+        QVERIFY2(standingOut >= handle.height(), qPrintable(qsl("only %1 of the handle's %2 pixels stood out against the background image").arg(standingOut).arg(handle.width() * handle.height())));
     }
 
     // setAppStyleSheet() has to keep winning too - QApplication::setStyle() skips

--- a/test/functional_tests/ScrollBarContrastTest.cpp
+++ b/test/functional_tests/ScrollBarContrastTest.cpp
@@ -199,6 +199,7 @@ private slots:
 
     void cleanupTestCase()
     {
+        delete mudlet::smpDebugArea;
         delete mpServer;
         mpServer = nullptr;
         mpHost = nullptr;
@@ -264,7 +265,9 @@ private slots:
         QVERIFY(!handle.isEmpty());
 
         const qreal contrast = contrastRatio(renderWidget(pScrollBar, background).pixelColor(handle.center()), background);
-        mudlet::smpDebugArea->hide();
+        // Nothing else destroys it: the debug area is parentless and only a profile
+        // closing takes it down, so it would outlive the Host its console points at.
+        delete mudlet::smpDebugArea;
         QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against the debug console's %1 background was only %2:1").arg(background.name(), QString::number(contrast, 'f', 2))));
     }
 
@@ -326,7 +329,16 @@ private slots:
         // Measured against the image and not against the groove: a base style that
         // paints an opaque groove hides the image on that platform, but one that
         // leaves it clear - as Windows 11 does - puts the image right behind the handle.
-        const QColor image = shot.pixelColor(pDisplay->width() / 2, pDisplay->height() / 2);
+        // Taken from what was written rather than sampled, because every pixel of the
+        // display could be a glyph of the text the handle was given to scroll.
+        const QColor image(Qt::white);
+        int imagePixels = 0;
+        for (int y = 0; y < shot.height(); y += 4) {
+            for (int x = 0; x < shot.width(); x += 4) {
+                imagePixels += (shot.pixelColor(x, y) == image) ? 1 : 0;
+            }
+        }
+
         int standingOut = 0;
         for (int y = handle.top(); y <= handle.bottom(); ++y) {
             for (int x = handle.left(); x <= handle.right(); ++x) {
@@ -338,7 +350,8 @@ private slots:
 
         runLua(qsl("resetBackgroundImage()"));
         QTest::qWait(50ms);
-        QVERIFY2(image == QColor(Qt::white), qPrintable(qsl("the background image did not reach the scroll bar - it rendered %1").arg(image.name())));
+        const int sampled = ((shot.width() + 3) / 4) * ((shot.height() + 3) / 4);
+        QVERIFY2(imagePixels > sampled / 2, qPrintable(qsl("the background image did not reach the console - only %1 of %2 sampled pixels were its white").arg(imagePixels).arg(sampled)));
         QVERIFY2(standingOut >= handle.height(), qPrintable(qsl("only %1 of the handle's %2 pixels stood out against the background image").arg(standingOut).arg(handle.width() * handle.height())));
     }
 

--- a/test/functional_tests/ScrollBarContrastTest.cpp
+++ b/test/functional_tests/ScrollBarContrastTest.cpp
@@ -88,16 +88,17 @@ private:
         return (std::max(a, b) + 0.05) / (std::min(a, b) + 0.05);
     }
 
-    // The groove is deliberately left unpainted, so a screen grab would only prove
-    // that whatever sits behind the console is visible.
-    QImage renderScrollBarOn(const QColor& background)
+    // Pre-filled because the console background is painted by an ancestor: rendering
+    // the bar on its own would otherwise leave whatever it does not cover undefined.
+    static QImage renderWidget(QWidget* pWidget, const QColor& background)
     {
-        QScrollBar* pScrollBar = mpHost->mpConsole->mpScrollBar;
-        QImage shot(pScrollBar->size(), QImage::Format_RGB32);
+        QImage shot(pWidget->size(), QImage::Format_RGB32);
         shot.fill(background);
-        pScrollBar->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
+        pWidget->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
         return shot;
     }
+
+    QImage renderScrollBarOn(const QColor& background) { return renderWidget(mpHost->mpConsole->mpScrollBar, background); }
 
     // Sampled at the middle of the handle so a stray antialiased edge cannot stand
     // in for it.
@@ -112,6 +113,10 @@ private:
 
         return contrastRatio(renderScrollBarOn(background).pixelColor(handle.center()), background);
     }
+
+    // Kept in step with ConsoleScrollBarStyle in TConsole.cpp by hand: the style lives
+    // in an anonymous namespace, so the name cannot be shared.
+    static constexpr const char* csHandleColorProperty = "mudletScrollBarHandleColor";
 
     static QRect handleRect(QScrollBar* pScrollBar)
     {
@@ -186,7 +191,8 @@ private slots:
         fillConsoleSoTheHandleHasSomewhereToSit();
 
         // The console keeps its own style, so this only reaches the scroll bar
-        // if the fix is absent:
+        // if the fix is absent. Never put back, which is safe only because every
+        // case in a grouped test binary runs in its own process.
         qApp->setStyle(new ColourSchemeOnlyScrollBarStyle);
         QTest::qWait(50ms);
     }
@@ -215,11 +221,14 @@ private slots:
     {
         const QColor background(255, 255, 255);
         const qreal contrast = handleContrastOn(background);
-        QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a white console was only %1:1").arg(contrast, 0, 'f', 2)));
+        // A higher bar than the other backgrounds: black at 45% alpha over white is
+        // #8d8d8d, which already clears 3:1, so only a stricter bound can fail here.
+        QVERIFY2(contrast >= 4.5, qPrintable(qsl("handle contrast against a white console was only %1:1").arg(contrast, 0, 'f', 2)));
     }
 
     // The hardest background to sit on - neither a white nor a black handle has much
-    // room, so too transparent a handle shows up here first.
+    // room, so an over-transparent handle, or one blended over the base style's own
+    // handle instead of over the console, shows up here first.
     void test_handleStandsOutOnAMidGreyConsole()
     {
         const QColor background(127, 127, 127);
@@ -234,6 +243,58 @@ private slots:
         const QColor background(0, 0, 255);
         const qreal contrast = handleContrastOn(background);
         QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a blue console was only %1:1").arg(contrast, 0, 'f', 2)));
+    }
+
+    // The debug console paints its own black background rather than the desktop
+    // theme's, so it has the same problem and takes the same handle.
+    void test_handleStandsOutOnTheDebugConsole()
+    {
+        mudlet::self()->attachDebugArea(mHostname);
+        QVERIFY(!mudlet::smpDebugConsole.isNull());
+        mudlet::smpDebugArea->show();
+        QTest::qWait(100ms);
+
+        QScrollBar* pScrollBar = mudlet::smpDebugConsole->mpScrollBar;
+        pScrollBar->setRange(0, 100);
+        pScrollBar->setPageStep(10);
+        pScrollBar->setValue(50);
+
+        const QColor background = mudlet::smpDebugConsole->getConsoleBgColor();
+        const QRect handle = handleRect(pScrollBar);
+        QVERIFY(!handle.isEmpty());
+
+        const qreal contrast = contrastRatio(renderWidget(pScrollBar, background).pixelColor(handle.center()), background);
+        mudlet::smpDebugArea->hide();
+        QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against the debug console's %1 background was only %2:1").arg(background.name(), QString::number(contrast, 'f', 2))));
+    }
+
+    // The handle is inset on the axis it is thin on, so the two orientations take
+    // opposite arms - swapping them leaves a handle that fills the bar's width.
+    void test_theHorizontalHandleIsInsetFromTheLongEdges()
+    {
+        QScrollBar* pScrollBar = mpHost->mpConsole->mpHScrollBar;
+        pScrollBar->show();
+        QTest::qWait(50ms);
+        pScrollBar->setRange(0, 100);
+        pScrollBar->setPageStep(10);
+        pScrollBar->setValue(50);
+
+        // Only the handle changes between two renders that differ solely in the handle
+        // colour, so the pixels that differ are exactly the ones Mudlet drew.
+        const QVariant handleColor = pScrollBar->property(csHandleColorProperty);
+        const QImage painted = renderWidget(pScrollBar, Qt::black);
+        pScrollBar->setProperty(csHandleColorProperty, QColor(255, 0, 0, 200));
+        const QImage recoloured = renderWidget(pScrollBar, Qt::black);
+        pScrollBar->setProperty(csHandleColorProperty, handleColor);
+
+        int drawnOnTheTopEdge = 0;
+        int drawnInTheMiddle = 0;
+        for (int x = 0; x < painted.width(); ++x) {
+            drawnOnTheTopEdge += (painted.pixelColor(x, 0) != recoloured.pixelColor(x, 0)) ? 1 : 0;
+            drawnInTheMiddle += (painted.pixelColor(x, painted.height() / 2) != recoloured.pixelColor(x, painted.height() / 2)) ? 1 : 0;
+        }
+        QVERIFY2(drawnInTheMiddle > 0, "nothing was drawn along the middle of the horizontal scroll bar");
+        QVERIFY2(drawnOnTheTopEdge == 0, qPrintable(qsl("%1 pixels were drawn on the horizontal scroll bar's top edge, which should be groove").arg(drawnOnTheTopEdge)));
     }
 
     // A background image is painted on MainDisplay, an ancestor of the scroll bar,
@@ -259,12 +320,13 @@ private slots:
         }
         QVERIFY(pDisplay != pScrollBar);
 
-        QImage shot(pDisplay->size(), QImage::Format_RGB32);
-        shot.fill(Qt::magenta);
-        pDisplay->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
+        const QImage shot = renderWidget(pDisplay, Qt::magenta);
 
         const QRect handle = handleRect(pScrollBar).translated(pScrollBar->mapTo(pDisplay, QPoint()));
-        const QColor image = shot.pixelColor(handle.center().x(), handle.top() - 6);
+        // Measured against the image and not against the groove: a base style that
+        // paints an opaque groove hides the image on that platform, but one that
+        // leaves it clear - as Windows 11 does - puts the image right behind the handle.
+        const QColor image = shot.pixelColor(pDisplay->width() / 2, pDisplay->height() / 2);
         int standingOut = 0;
         for (int y = handle.top(); y <= handle.bottom(); ++y) {
             for (int x = handle.left(); x <= handle.right(); ++x) {

--- a/test/functional_tests/ScrollBarContrastTest.cpp
+++ b/test/functional_tests/ScrollBarContrastTest.cpp
@@ -1,0 +1,267 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QPainter>
+#include <QProxyStyle>
+#include <QScrollBar>
+#include <QSignalSpy>
+#include <QStyleOptionSlider>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+#include <chrono>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// Stands in for the Windows 11 style of #9341, which colours the whole scroll bar
+// from the application's colour scheme - black at 45% alpha - whatever it sits on.
+// That style does not exist on Linux, so it is reproduced here.
+class ColourSchemeOnlyScrollBarStyle : public QProxyStyle
+{
+public:
+    void drawComplexControl(const ComplexControl control, const QStyleOptionComplex* pOption, QPainter* pPainter, const QWidget* pWidget) const override
+    {
+        if (control == CC_ScrollBar) {
+            pPainter->fillRect(pOption->rect, QColor(0, 0, 0, 0x72));
+            return;
+        }
+        QProxyStyle::drawComplexControl(control, pOption, pPainter, pWidget);
+    }
+};
+
+// Lua cannot see a widget's pixels, so the contrast is checked here rather than
+// in a spec.
+class ScrollBarContrastTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "ScrollBarContrast-Test-Host";
+    QString mPort;
+    const QString mLocalhost = "localhost";
+
+    void runLua(const QString& script) { QVERIFY2(mpHost->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(script)); }
+
+    static qreal relativeLuminance(const QColor& colour)
+    {
+        auto channel = [](qreal value) {
+            return value <= 0.03928 ? value / 12.92 : std::pow((value + 0.055) / 1.055, 2.4);
+        };
+        return 0.2126 * channel(colour.redF()) + 0.7152 * channel(colour.greenF()) + 0.0722 * channel(colour.blueF());
+    }
+
+    static qreal contrastRatio(const QColor& first, const QColor& second)
+    {
+        const qreal a = relativeLuminance(first);
+        const qreal b = relativeLuminance(second);
+        return (std::max(a, b) + 0.05) / (std::min(a, b) + 0.05);
+    }
+
+    // The groove is deliberately left unpainted, so a screen grab would only prove
+    // that whatever sits behind the console is visible.
+    QImage renderScrollBarOn(const QColor& background)
+    {
+        QScrollBar* pScrollBar = mpHost->mpConsole->mpScrollBar;
+        QImage shot(pScrollBar->size(), QImage::Format_RGB32);
+        shot.fill(background);
+        pScrollBar->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
+        return shot;
+    }
+
+    // Sampled at the middle of the handle so a stray antialiased edge cannot stand
+    // in for it.
+    qreal handleContrastOn(const QColor& background)
+    {
+        runLua(qsl("setBackgroundColor(%1, %2, %3)").arg(background.red()).arg(background.green()).arg(background.blue()));
+        QScrollBar* pScrollBar = mpHost->mpConsole->mpScrollBar;
+
+        QStyleOptionSlider option;
+        option.initFrom(pScrollBar);
+        option.orientation = pScrollBar->orientation();
+        option.minimum = pScrollBar->minimum();
+        option.maximum = pScrollBar->maximum();
+        option.pageStep = pScrollBar->pageStep();
+        option.singleStep = pScrollBar->singleStep();
+        option.sliderPosition = pScrollBar->sliderPosition();
+        option.sliderValue = pScrollBar->value();
+        const QRect handle = pScrollBar->style()->subControlRect(QStyle::CC_ScrollBar, &option, QStyle::SC_ScrollBarSlider, pScrollBar);
+        if (handle.isEmpty()) {
+            return 1.0;
+        }
+
+        return contrastRatio(renderScrollBarOn(background).pixelColor(handle.center()), background);
+    }
+
+    static int countPixels(const QImage& shot, const QColor& wanted)
+    {
+        int painted = 0;
+        for (int y = 0; y < shot.height(); ++y) {
+            for (int x = 0; x < shot.width(); ++x) {
+                if (shot.pixelColor(x, y) == wanted) {
+                    ++painted;
+                }
+            }
+        }
+        return painted;
+    }
+
+    void fillConsoleSoTheHandleHasSomewhereToSit()
+    {
+        runLua(qsl("for i = 1, 500 do echo('scroll bar contrast line ' .. i .. '\\n') end"));
+        QTRY_VERIFY(mpHost->mpConsole->mpScrollBar->maximum() > mpHost->mpConsole->mpScrollBar->minimum());
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, mPort);
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy connected(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!connected.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+        QVERIFY(mpHost->mpConsole);
+        QVERIFY(!mpHost->mpConsole->mpScrollBar->size().isEmpty());
+        fillConsoleSoTheHandleHasSomewhereToSit();
+
+        // The console keeps its own style, so this only reaches the scroll bar
+        // if the fix is absent:
+        qApp->setStyle(new ColourSchemeOnlyScrollBarStyle);
+        QTest::qWait(50ms);
+    }
+
+    void cleanupTestCase()
+    {
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        if (mudlet::self()) {
+            const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+            delete mudlet::self();
+            QDir(path).removeRecursively();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_handleStandsOutOnTheDefaultBlackConsole()
+    {
+        const QColor background(0, 0, 0);
+        const qreal contrast = handleContrastOn(background);
+        QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a black console was only %1:1").arg(contrast, 0, 'f', 2)));
+    }
+
+    void test_handleStandsOutOnAWhiteConsole()
+    {
+        const QColor background(255, 255, 255);
+        const qreal contrast = handleContrastOn(background);
+        QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a white console was only %1:1").arg(contrast, 0, 'f', 2)));
+    }
+
+    // The hardest background to sit on - neither a white nor a black handle has much
+    // room, so too transparent a handle shows up here first.
+    void test_handleStandsOutOnAMidGreyConsole()
+    {
+        const QColor background(127, 127, 127);
+        const qreal contrast = handleContrastOn(background);
+        QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a mid grey console was only %1:1").arg(contrast, 0, 'f', 2)));
+    }
+
+    // Blue is dark to the eye but middling by HSL lightness, so picking the
+    // handle by lightness rather than by contrast gets this one wrong.
+    void test_handleStandsOutOnABlueConsole()
+    {
+        const QColor background(0, 0, 255);
+        const qreal contrast = handleContrastOn(background);
+        QVERIFY2(contrast >= 3.0, qPrintable(qsl("handle contrast against a blue console was only %1:1").arg(contrast, 0, 'f', 2)));
+    }
+
+    // setAppStyleSheet() has to keep winning too - QApplication::setStyle() skips
+    // widgets that carry their own style, so this path is easy to cut off.
+    void test_anAppStyleSheetStillColoursTheScrollBar()
+    {
+        const QColor background(0, 0, 0);
+        const QColor wanted(0, 255, 0);
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        runLua(qsl("setAppStyleSheet[[QScrollBar{background-color: rgb(0, 255, 0);}]]"));
+        QTest::qWait(50ms);
+
+        const int painted = countPixels(renderScrollBarOn(background), wanted);
+        runLua(qsl("setAppStyleSheet[[]]"));
+        QTest::qWait(50ms);
+        QVERIFY2(painted > 0, "setAppStyleSheet() no longer reaches the console's scroll bar");
+    }
+
+    // A profile that styles its own scroll bars has to keep winning.
+    void test_aProfileStyleSheetStillColoursTheScrollBar()
+    {
+        const QColor background(0, 0, 0);
+        const QColor wanted(255, 0, 0);
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        runLua(qsl("setProfileStyleSheet[[QScrollBar{background-color: rgb(255, 0, 0);}]]"));
+        QTest::qWait(50ms);
+
+        const int painted = countPixels(renderScrollBarOn(background), wanted);
+        runLua(qsl("setProfileStyleSheet[[]]"));
+        QVERIFY2(painted > 0, "a profile style sheet no longer reaches the console's scroll bar");
+    }
+};
+
+#include "ScrollBarContrastTest.moc"
+MUDLET_GROUPED_TEST_MAIN(ScrollBarContrastTest)

--- a/test/functional_tests/ScrollBarContrastTest.cpp
+++ b/test/functional_tests/ScrollBarContrastTest.cpp
@@ -21,6 +21,7 @@
 #include <QProxyStyle>
 #include <QScrollBar>
 #include <QSignalSpy>
+#include <QStyleFactory>
 #include <QStyleOptionSlider>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
@@ -46,6 +47,11 @@ using namespace std::chrono_literals;
 class ColourSchemeOnlyScrollBarStyle : public QProxyStyle
 {
 public:
+    // Named for it as well as drawing like it: the console only paints a handle of
+    // its own when the Windows 11 style is the one that would otherwise draw it, and
+    // that is decided by the application style's name.
+    ColourSchemeOnlyScrollBarStyle() { setObjectName(qsl("windows11")); }
+
     void drawComplexControl(const ComplexControl control, const QStyleOptionComplex* pOption, QPainter* pPainter, const QWidget* pWidget) const override
     {
         if (control == CC_ScrollBar) {
@@ -383,6 +389,35 @@ private slots:
         const int painted = countPixels(renderScrollBarOn(background), wanted);
         runLua(qsl("setProfileStyleSheet[[]]"));
         QVERIFY2(painted > 0, "a profile style sheet no longer reaches the console's scroll bar");
+    }
+
+    // The other half of the fix: every other style draws a handle that is visible on
+    // its own groove and carries hover and pressed feedback with it, so the console
+    // leaves it alone - and the bar then renders identically whether it has been
+    // given a handle colour or not.
+    //
+    // Last, because it swaps the application style out and the stand-in it puts back
+    // is not the one the cases above were given.
+    void test_anOrdinaryStyleKeepsItsOwnHandle()
+    {
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        QStyle* pOrdinaryStyle = QStyleFactory::create(qsl("fusion"));
+        QVERIFY2(pOrdinaryStyle, "Fusion is built into Qt on every platform, so this should not happen");
+        qApp->setStyle(pOrdinaryStyle);
+        QTest::qWait(50ms);
+
+        QScrollBar* pScrollBar = mpHost->mpConsole->mpScrollBar;
+        const QVariant handleColor = pScrollBar->property(csHandleColorProperty);
+        QVERIFY2(handleColor.value<QColor>().isValid(), "the console stopped working out a handle colour at all");
+
+        const QImage painted = renderScrollBarOn(Qt::black);
+        pScrollBar->setProperty(csHandleColorProperty, QVariant());
+        const QImage styleOnly = renderScrollBarOn(Qt::black);
+        pScrollBar->setProperty(csHandleColorProperty, handleColor);
+
+        qApp->setStyle(new ColourSchemeOnlyScrollBarStyle);
+        QTest::qWait(50ms);
+        QVERIFY2(painted == styleOnly, "the console painted a handle of its own over a style whose handle was fine as it was");
     }
 };
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The console's scroll bars now take their handle color from the console's own background, picking whichever of white or black has the most contrast against it, instead of from the desktop theme.
- Only the Windows 11 style is taken over. The console asks which style would otherwise draw the handle and leaves every other one alone, so Linux and macOS render exactly as they did - handle shape, hover and pressed feedback included. Windows 10's style is left alone too: it paints an opaque handle on a light track, which has the same contrast whatever the console is set to.
- Done as a `QStyle` on the two scroll bar widgets rather than a style sheet, so `setProfileStyleSheet()` and `setAppStyleSheet()` scroll bar rules still win - a widget's own style sheet would have outranked them.
- The handle is outlined in the opposite color, because a background image is painted on an ancestor widget and shows through the groove - a fill alone can land on a matching image, but a fill and its outline cannot both blend into one surface.
- Every console gets this, so on Windows 11 that is the main console, the debug console, and any miniconsole or user window, each taking its handle from its own background. No other scroll bar in Mudlet is touched.

#### Motivation for adding to Mudlet

Windows 11 colors a scroll bar handle for the application's color scheme rather than for the surface it sits on - black at 45% alpha - so on the default black console it is black on black and the scroll bar cannot be seen at all.

#### Other info (issues closed, discussion etc)

Closes #9341.

Measured on Windows 11 with the shipped 5.0.0 build: the widget is there and laid out (`disableScrollBar()` moves the console from 104 to 105 columns), the band is 100% `#000000` on a black console, and `#8D8D8D` on a white one - exactly the arithmetic of black at 45% alpha. The patched painting was then run against the real `QWindows11Style` on that machine: `#c8c8c8` at 12.55:1 on a black console, `#373737` at 11.90:1 on a white one.

An earlier revision painted the handle on every platform. Rendering the real console on Linux with Fusion showed why that is not wanted: against the default black console the platform's own handle stands at 19.8:1 where a handle painted here reaches 20.1:1, so there is nothing to gain and the platform's hover and pressed feedback to lose - the base style's handle has to be masked out for the alpha-blended one to take its color from the console rather than from it. #10789 is the harness those renders came from.

The trade the gate makes, recorded for the next person: on Linux the platform handle measures 1.12:1 against its own groove in dark appearance and 1.18:1 on a white console, so those two cases keep a handle that is hard to pick out. They are Fusion looking like Fusion rather than the bug in #9341, where the handle is not merely low contrast but the same color as what it sits on.

**Test case:** on Windows 11, open a profile, receive enough text to scroll, and look at the right-hand edge of the console - the handle should be visible. Then `setBackgroundColor(255, 255, 255)` and check it is still visible, and `setProfileStyleSheet[[QScrollBar{background-color: rgb(255,0,0);}]]` to confirm a script still overrides it. The debug console's scroll bar should be visible too. On Linux and macOS the scroll bar should look exactly as it does on `development` - `ScrollBarContrastTest::test_anOrdinaryStyleKeepsItsOwnHandle` asserts that the bar renders identically there whether the console worked out a handle color or not.

Assisted-by: Claude:claude-opus-5

<img width="628" height="343" alt="scrollbar-before-after" src="https://github.com/user-attachments/assets/c2a1dff1-21ce-426b-b338-bc787385811a" />
