### PR TITLE
Fix: Saved sign-ins work on unencrypted games, and games learn if sign-ins are kept

### DIFF
--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -284,9 +284,13 @@ void GMCPAuthenticator::sendCredentials(bool interactiveHandoff)
         // A version 2 hand-off is identified by carrying no account, not by being literally {}, so the
         // common fields ride on it - and carrying token_storage here is the whole reason to send it:
         // this message reaches the game before it writes a line of its sign-in screen, which is the last
-        // moment at which it can still decide whether to offer to remember this player. Version 1
-        // predates both that rule and the field, so its hand-off stays the bare {} object that a version
-        // 1 server may still be testing for literally.
+        // moment at which it can still decide whether to offer to remember this player.
+        //
+        // A version 1 exchange keeps the bare {} instead. That is a compatibility choice rather than
+        // anything the standard asks for: the empty hand-off is itself a version 2 addition, so no
+        // version 1 server was ever told to expect one. Mudlet has sent {} to such servers since long
+        // before the standard existed, and some may well have been written against exactly that, so
+        // there is nothing to gain by widening it now.
         addCommonFields(credentials);
     }
 

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -69,13 +69,13 @@ QString providerDisplayName(const QString& id)
 }
 
 // Decodes a field the standard declares boolean, in every form it permits: a JSON boolean, the
-// strings "true"/"false" or "1"/"0" (case-insensitive), or the numbers 1/0. Several MUD drivers have
-// no JSON boolean in their serializer at all - LDMud's json_serialize() among them - which is why the
-// string and number forms exist at all.
+// strings "true"/"false" or "1"/"0" (case-insensitive, surrounding whitespace ignored), or the numbers
+// 1/0. Several MUD drivers have no JSON boolean in their serializer at all - LDMud's json_serialize()
+// among them - which is why the string and number forms exist at all.
 //
 // A value in none of those forms is not a boolean, and returns nullopt so the caller applies that
-// field's documented default. That distinction is the point: the defaults here are not all false, and
-// for a security-bearing field like secure_only the permissive reading is exactly the wrong guess.
+// field's documented default. Keeping "absent" distinct from "false" is the point: no caller here
+// defaults to false, so collapsing the two would quietly answer a security-bearing question wrong.
 std::optional<bool> decodeWireBool(const QJsonValue& value)
 {
     if (value.isBool()) {
@@ -226,12 +226,19 @@ void GMCPAuthenticator::addCommonFields(QJsonObject& payload) const
     // storage and replayed later - which is what lets the game decide whether it can honestly offer to
     // remember this player before it writes its sign-in screen.
     //
-    // Constant true for Mudlet, and honestly so rather than as a shortcut: CredentialManager always has
-    // somewhere to put a token - the system keychain, falling back to its own encrypted file store when
-    // the keychain is unavailable or the install is portable - and nothing here runs unless the profile
-    // has GMCP enabled. The standard asks the question per connection because a client whose store can
-    // go missing must answer for the connection in hand; ours cannot go missing. Qt serialises a real
-    // JSON boolean, which is the form the standard prefers.
+    // Constant true for Mudlet: CredentialManager always has somewhere to attempt the write - the system
+    // keychain, falling back to its own encrypted file store when the keychain is unavailable or the
+    // install is portable. The standard asks per connection because a client that has no store at all has
+    // to say so; ours always has one to try.
+    //
+    // A version 1 server gets the fields too. An unknown member is inert to it, and we already echo
+    // `version` - itself a version 2 addition - to such servers today. Only the hand-off is special-cased
+    // (see sendCredentials), because there the empty object is load-bearing rather than incidental.
+    //
+    // That is a statement of intent rather than a guarantee the write lands: a store that fails anyway is
+    // reported to the player by storeReconnectToken. The standard puts no obligation on a client that
+    // answered true and then could not save - only on one that answered false, which must then discard a
+    // token that arrives. Qt serialises a real JSON boolean, the form the standard prefers.
     payload[qsl("token_storage")] = true;
 }
 
@@ -310,7 +317,10 @@ bool GMCPAuthenticator::sendReconnect(const QString& account, QString token, boo
     // transport is live now rather than the one it was earned on: in the clear that hands the account
     // to anyone on the path. Whether that matters is the issuing server's call, recorded in the token's
     // own requirement when it was minted - so a game that mints and accepts tokens on plain telnet can
-    // use them there, while a token earned over TLS is still never spent in the clear.
+    // use them there. The requirement is the server's to set rather than an invariant enforced here: a
+    // server that mints over TLS and sends an explicit secure_only false has asked for its own token to
+    // be replayable in the clear, and gets that. What is never done is inferring the permissive answer
+    // where the server did not give one - see handleAuthToken for the defaulting.
     if (secureOnly && !mpHost->mTelnet.currentlySecure()) {
         SecureStringUtils::secureStringClear(token);
         qWarning().noquote() << "GMCP Char.Login.Reconnect - refusing to replay the saved sign-in token over an unencrypted connection.";
@@ -386,17 +396,45 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, QString toke
     // connect and falls back to a fresh sign-in, so this is safe under the one-account-per-profile model.
     QPointer<Host> safeHost = mpHost;
     QPointer<CredentialManager> credentialManager = new CredentialManager();
-    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [safeHost, credentialManager](bool success, const QString& errorMessage) {
-        if (!success) {
-            qWarning().noquote() << "GMCP Char.Login.Token - failed to store reconnect token:" << errorMessage;
-            if (safeHost) {
-                //: Shown when the user opted to stay signed in but saving the sign-in token failed, so they will have to sign in again next time.
-                safeHost->postMessage(tr("[ WARN ]  - Could not save your sign-in for next time; you may need to sign in again."));
-            }
-        }
+    // Whether a rotation is in progress belongs to the moment the token arrived, so snapshot it rather
+    // than read it from the callback: the next Char.Login.Default resets mConn while the save is still
+    // in flight, and by then the answer is about a different sign-in.
+    const bool rotatingSavedToken = mConn.reconnectingWithToken;
+    // safeHost stands in for `this` as well: Host owns this authenticator (its QScopedPointer member),
+    // so the authenticator is alive for as long as the Host is.
+    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [this, safeHost, credentialManager, rotatingSavedToken](bool success, const QString& errorMessage) {
         if (credentialManager) {
             credentialManager->deleteLater();
         }
+        // Log before the liveness check: a save can resolve (or time out) after the profile has closed,
+        // and that is precisely when the record of a token that never reached disk matters most.
+        if (!success) {
+            qWarning().noquote() << "GMCP Char.Login.Token - failed to store reconnect token:" << errorMessage;
+        }
+        if (!safeHost) {
+            return;
+        }
+        if (!success) {
+            //: Shown when the user opted to stay signed in but saving the sign-in token failed, so they will have to sign in again next time.
+            safeHost->postMessage(tr("[ WARN ]  - Could not save your sign-in for next time; you may need to sign in again."));
+            return;
+        }
+        // Announced only once the save has actually landed, so a failure is never announced as a success
+        // first; only the first time this connection; and never on a token-reconnect, where the arriving
+        // token is a silent rotation rather than a new opt-in.
+        //
+        // Deliberately not gated on the sign-in attempt still being current, unlike the asynchronous
+        // reads elsewhere in this file. Those gate because acting on a stale result would drive a sign-in
+        // on the wrong connection; this only reports what became of the profile's stored token, which is
+        // true whichever attempt is live by the time the write lands. Gating it would mean a save that
+        // succeeded during a burst of Char.Login.Default frames was never mentioned at all.
+        if (rotatingSavedToken || mConn.announcedTokenSave) {
+            return;
+        }
+        mConn.announcedTokenSave = true;
+        //: Shown once after a browser/OAuth sign-in whose reconnect token was saved, so future connects need no sign-in.
+        //: "Privacy and security" is the name of a page in the preferences dialog; translate it the same way there.
+        safeHost->postMessage(tr("[ INFO ]  - You'll be signed in automatically next time. Manage this under Preferences, Privacy and security."));
     });
 
     // The token is a bearer secret; storePassword has already taken its own copy (inside payload), so
@@ -787,7 +825,8 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                     if (doc.isObject()) {
                         const auto account = doc.object()[qsl("account")].toString();
                         auto token = doc.object()[qsl("token")].toString();
-                        // As in readStoredSignIn: an entry with no requirement stored is read strictly.
+                        // As in readStoredSignIn: an entry whose requirement is missing or unreadable is
+                        // read strictly.
                         const bool secureOnly = decodeWireBool(doc.object()[qsl("secure_only")]).value_or(true);
                         if (!account.isEmpty() && !token.isEmpty()) {
                             QByteArray tokenBytes = token.toUtf8();
@@ -970,24 +1009,27 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
     // Whether this token may only ever be replayed on an encrypted transport. Absent - or in a form
     // that is not a boolean at all - means it inherits the transport it arrived on: a token minted over
     // TLS is encrypted-only, one minted in the clear may be replayed either way. A server that mints
-    // over TLS but accepts replays in the clear has to say so with an explicit false, so silence can
-    // only ever narrow the token's exposure, never widen it.
-    const bool secureOnly = decodeWireBool(obj[qsl("secure_only")]).value_or(mpHost->mTelnet.currentlySecure());
+    // over TLS but accepts replays in the clear has to say so with an explicit false, so on the transport
+    // where a token has any protection to lose, silence can only ever keep it.
+    const auto declaredSecureOnly = obj[qsl("secure_only")];
+    const auto decodedSecureOnly = decodeWireBool(declaredSecureOnly);
+    // A value we could not decode is treated as absent, which is what the standard requires - but unlike
+    // a genuinely absent field it means the server tried to state a transport requirement in a form no
+    // conformant client can read. Nothing else would report that, and the server operator is the only
+    // person who can fix it.
+    if (!decodedSecureOnly && !declaredSecureOnly.isUndefined()) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage
+                                       << " - ignoring a 'secure_only' value that is not a boolean in any form the standard permits; defaulting it to the transport the token arrived on.";
+    }
+    const bool secureOnly = decodedSecureOnly.value_or(mpHost->mTelnet.currentlySecure());
 
     // The server issues this token at its own discretion - the "remember me" decision belongs to the
     // game's flow, not the client - so we simply persist whatever arrives (overwriting on rotation) and
     // offer a local "forget saved sign-in" control in preferences. Move the token in so
     // storeReconnectToken owns the sole copy and can scrub it after persisting.
+    // Announcing that the sign-in was saved belongs to the save's own callback, not here: the store is
+    // asynchronous, so a message posted at this point would promise a save that may still fail.
     storeReconnectToken(account, std::move(token), secureOnly);
-
-    // Let the player know their sign-in will be remembered - but only the first time this connection,
-    // and never on a token-reconnect (where the arriving token is a silent rotation, not a new opt-in).
-    if (!mConn.reconnectingWithToken && !mConn.announcedTokenSave) {
-        mConn.announcedTokenSave = true;
-        //: Shown once after a browser/OAuth sign-in whose reconnect token was saved, so future connects need no sign-in.
-        //: "Privacy and security" is the name of a page in the preferences dialog; translate it the same way there.
-        mpHost->postMessage(tr("[ INFO ]  - You'll be signed in automatically next time. Manage this under Preferences, Privacy and security."));
-    }
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)
     qDebug() << "Stored GMCP reconnect token for account:" << account;
@@ -1096,9 +1138,9 @@ void GMCPAuthenticator::readStoredSignIn(bool allowToken)
                         const auto account = doc.object()[qsl("account")].toString();
                         auto token = doc.object()[qsl("token")].toString();
                         const auto provider = doc.object()[qsl("provider")].toString();
-                        // An entry written before the requirement was stored gets the strict reading, so
-                        // upgrading Mudlet never widens the exposure of a token already on disk; it gains
-                        // the field the next time the server rotates it.
+                        // An entry whose requirement is missing (written before it was stored) or unreadable
+                        // (a corrupted entry) gets the strict reading, so upgrading Mudlet never widens the
+                        // exposure of a token already on disk; it gains the field on the next rotation.
                         const bool secureOnly = decodeWireBool(doc.object()[qsl("secure_only")]).value_or(true);
                         if (!provider.isEmpty()) {
                             mConn.accountProvider = provider;
@@ -1162,8 +1204,8 @@ void GMCPAuthenticator::selectAuthMethod()
         return;
     }
 
-    // Otherwise hand off to the game's own interactive sign-in with an empty Char.Login.Credentials {}
-    // and let the player choose there - even if the profile has a stored password (the game's screen
+    // Otherwise hand off to the game's own interactive sign-in (sendCredentials has the shape that takes
+    // per negotiated version) and let the player choose there - even if the profile has a stored password (the game's screen
     // still accepts it), so a saved password never blocks reaching a provider choice.
     sendCredentials(true);
 }

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -36,10 +36,12 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
+#include <QJsonValue>
 #include <QPointer>
 #include <QTimer>
 #include <QUrl>
 #include <chrono>
+#include <optional>
 
 using namespace std::chrono_literals;
 
@@ -64,6 +66,41 @@ QString providerDisplayName(const QString& id)
         display[0] = display[0].toUpper();
     }
     return display;
+}
+
+// Decodes a field the standard declares boolean, in every form it permits: a JSON boolean, the
+// strings "true"/"false" or "1"/"0" (case-insensitive), or the numbers 1/0. Several MUD drivers have
+// no JSON boolean in their serializer at all - LDMud's json_serialize() among them - which is why the
+// string and number forms exist at all.
+//
+// A value in none of those forms is not a boolean, and returns nullopt so the caller applies that
+// field's documented default. That distinction is the point: the defaults here are not all false, and
+// for a security-bearing field like secure_only the permissive reading is exactly the wrong guess.
+std::optional<bool> decodeWireBool(const QJsonValue& value)
+{
+    if (value.isBool()) {
+        return value.toBool();
+    }
+    if (value.isDouble()) {
+        const double number = value.toDouble();
+        if (number == 1) {
+            return true;
+        }
+        if (number == 0) {
+            return false;
+        }
+        return std::nullopt;
+    }
+    if (value.isString()) {
+        const QString text = value.toString().trimmed().toLower();
+        if (text == qsl("true") || text == qsl("1")) {
+            return true;
+        }
+        if (text == qsl("false") || text == qsl("0")) {
+            return false;
+        }
+    }
+    return std::nullopt;
 }
 } // namespace
 
@@ -181,6 +218,23 @@ void GMCPAuthenticator::saveSupportsSet(const QString& packageMessage, const QSt
 #endif
 }
 
+void GMCPAuthenticator::addCommonFields(QJsonObject& payload) const
+{
+    // Echo the negotiated version so the server can confirm both ends agree.
+    payload[qsl("version")] = mNegotiatedVersion;
+    // Whether a Char.Login.Token minted on this connection would actually be written to protected
+    // storage and replayed later - which is what lets the game decide whether it can honestly offer to
+    // remember this player before it writes its sign-in screen.
+    //
+    // Constant true for Mudlet, and honestly so rather than as a shortcut: CredentialManager always has
+    // somewhere to put a token - the system keychain, falling back to its own encrypted file store when
+    // the keychain is unavailable or the install is portable - and nothing here runs unless the profile
+    // has GMCP enabled. The standard asks the question per connection because a client whose store can
+    // go missing must answer for the connection in hand; ours cannot go missing. Qt serialises a real
+    // JSON boolean, which is the form the standard prefers.
+    payload[qsl("token_storage")] = true;
+}
+
 bool GMCPAuthenticator::clientDrivenOAuthAvailable() const
 {
     // Both fields are only ever stored when the connection is encrypted (see saveSupportsSet), so
@@ -196,14 +250,20 @@ void GMCPAuthenticator::sendCredentials(bool interactiveHandoff)
     QJsonObject credentials;
 
     // Autofill stored credentials only when this is not an explicit interactive hand-off and the game
-    // actually accepts password-credentials; otherwise this stays an empty object, the deliberate
-    // Char.Login.Credentials {} hand-off telling the game to run its own sign-in screen (see
-    // selectAuthMethod).
+    // actually accepts password-credentials; otherwise this is the deliberate hand-off telling the game
+    // to run its own sign-in screen (see selectAuthMethod).
     if (!interactiveHandoff && mSupportedAuthTypes.contains(qsl("password-credentials")) && !character.isEmpty() && !password.isEmpty()) {
         credentials[qsl("account")] = character;
         credentials[qsl("password")] = password;
-        // Echo the negotiated version so the server can confirm both ends agree.
-        credentials[qsl("version")] = mNegotiatedVersion;
+        addCommonFields(credentials);
+    } else if (mNegotiatedVersion >= 2) {
+        // A version 2 hand-off is identified by carrying no account, not by being literally {}, so the
+        // common fields ride on it - and carrying token_storage here is the whole reason to send it:
+        // this message reaches the game before it writes a line of its sign-in screen, which is the last
+        // moment at which it can still decide whether to offer to remember this player. Version 1
+        // predates both that rule and the field, so its hand-off stays the bare {} object that a version
+        // 1 server may still be testing for literally.
+        addCommonFields(credentials);
     }
 
     QJsonDocument doc(credentials);
@@ -244,12 +304,14 @@ void GMCPAuthenticator::sendCredentials(bool interactiveHandoff)
 #endif
 }
 
-bool GMCPAuthenticator::sendReconnect(const QString& account, QString token)
+bool GMCPAuthenticator::sendReconnect(const QString& account, QString token, bool secureOnly)
 {
     // The token signs in to the account without the player's password, and is replayed on whatever
     // transport is live now rather than the one it was earned on: in the clear that hands the account
-    // to anyone on the path.
-    if (!mpHost->mTelnet.currentlySecure()) {
+    // to anyone on the path. Whether that matters is the issuing server's call, recorded in the token's
+    // own requirement when it was minted - so a game that mints and accepts tokens on plain telnet can
+    // use them there, while a token earned over TLS is still never spent in the clear.
+    if (secureOnly && !mpHost->mTelnet.currentlySecure()) {
         SecureStringUtils::secureStringClear(token);
         qWarning().noquote() << "GMCP Char.Login.Reconnect - refusing to replay the saved sign-in token over an unencrypted connection.";
         //: Shown when a saved password-less sign-in cannot be reused because this connection to the game is not encrypted.
@@ -260,7 +322,10 @@ bool GMCPAuthenticator::sendReconnect(const QString& account, QString token)
     QJsonObject payload;
     payload[qsl("account")] = account;
     payload[qsl("token")] = token;
-    payload[qsl("version")] = mNegotiatedVersion;
+    // Redundant here - a client replaying a token evidently stores them - but sending the common fields
+    // uniformly is simpler than special-casing this one message, and the standard forbids a server from
+    // requiring the field here anyway.
+    addCommonFields(payload);
     QByteArray json = QJsonDocument(payload).toJson(QJsonDocument::Compact);
     QString gmcpMessage = QString::fromUtf8(json);
     payload = QJsonObject();
@@ -297,11 +362,14 @@ bool GMCPAuthenticator::sendReconnect(const QString& account, QString token)
     return true;
 }
 
-void GMCPAuthenticator::storeReconnectToken(const QString& account, QString token)
+void GMCPAuthenticator::storeReconnectToken(const QString& account, QString token, bool secureOnly)
 {
     QJsonObject obj;
     obj[qsl("account")] = account;
     obj[qsl("token")] = token;
+    // Stored with the token rather than recomputed at replay time: the requirement belongs to the
+    // connection that minted it, which by then is long gone.
+    obj[qsl("secure_only")] = secureOnly;
     // Keep the provider with the token (in the same protected store) so a later connection can resume
     // this provider's browser sign-in if the token has expired or been revoked by then.
     if (!mConn.accountProvider.isEmpty()) {
@@ -342,7 +410,7 @@ void GMCPAuthenticator::sendResume(const QString& account, const QString& provid
     QJsonObject payload;
     payload[qsl("account")] = account;
     payload[qsl("provider")] = provider;
-    payload[qsl("version")] = mNegotiatedVersion;
+    addCommonFields(payload);
     const QString gmcpMessage = QString::fromUtf8(QJsonDocument(payload).toJson(QJsonDocument::Compact));
 
     std::string output;
@@ -561,7 +629,7 @@ void GMCPAuthenticator::sendAuthCode(QString code, QString codeVerifier, const Q
     } else if (mOAuthNonceRequired) {
         qWarning().noquote() << "GMCP Char.Login.AuthCode - the server asked for a nonce but none was generated, so it cannot verify the ID token's nonce claim.";
     }
-    payload[qsl("version")] = mNegotiatedVersion;
+    addCommonFields(payload);
     QByteArray json = QJsonDocument(payload).toJson(QJsonDocument::Compact);
     QString gmcpMessage = QString::fromUtf8(json);
     payload = QJsonObject();
@@ -719,6 +787,8 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                     if (doc.isObject()) {
                         const auto account = doc.object()[qsl("account")].toString();
                         auto token = doc.object()[qsl("token")].toString();
+                        // As in readStoredSignIn: an entry with no requirement stored is read strictly.
+                        const bool secureOnly = decodeWireBool(doc.object()[qsl("secure_only")]).value_or(true);
                         if (!account.isEmpty() && !token.isEmpty()) {
                             QByteArray tokenBytes = token.toUtf8();
                             const QByteArray storedHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
@@ -733,7 +803,7 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
 #if defined(DEBUG_GMCP_AUTHENTICATION)
                                 qDebug() << "GMCP reconnect token was rotated by another instance; replaying the fresh token";
 #endif
-                                if (sendReconnect(account, std::move(token))) {
+                                if (sendReconnect(account, std::move(token), secureOnly)) {
                                     mConn.retriedRotatedToken = true;
                                     mConn.sentReconnectTokenHash = storedHash;
                                     mConn.reconnectingWithToken = true;
@@ -897,11 +967,18 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
         return;
     }
 
+    // Whether this token may only ever be replayed on an encrypted transport. Absent - or in a form
+    // that is not a boolean at all - means it inherits the transport it arrived on: a token minted over
+    // TLS is encrypted-only, one minted in the clear may be replayed either way. A server that mints
+    // over TLS but accepts replays in the clear has to say so with an explicit false, so silence can
+    // only ever narrow the token's exposure, never widen it.
+    const bool secureOnly = decodeWireBool(obj[qsl("secure_only")]).value_or(mpHost->mTelnet.currentlySecure());
+
     // The server issues this token at its own discretion - the "remember me" decision belongs to the
     // game's flow, not the client - so we simply persist whatever arrives (overwriting on rotation) and
     // offer a local "forget saved sign-in" control in preferences. Move the token in so
     // storeReconnectToken owns the sole copy and can scrub it after persisting.
-    storeReconnectToken(account, std::move(token));
+    storeReconnectToken(account, std::move(token), secureOnly);
 
     // Let the player know their sign-in will be remembered - but only the first time this connection,
     // and never on a token-reconnect (where the arriving token is a silent rotation, not a new opt-in).
@@ -1018,6 +1095,10 @@ void GMCPAuthenticator::readStoredSignIn(bool allowToken)
                         const auto account = doc.object()[qsl("account")].toString();
                         auto token = doc.object()[qsl("token")].toString();
                         const auto provider = doc.object()[qsl("provider")].toString();
+                        // An entry written before the requirement was stored gets the strict reading, so
+                        // upgrading Mudlet never widens the exposure of a token already on disk; it gains
+                        // the field the next time the server rotates it.
+                        const bool secureOnly = decodeWireBool(doc.object()[qsl("secure_only")]).value_or(true);
                         if (!provider.isEmpty()) {
                             mConn.accountProvider = provider;
                         }
@@ -1029,7 +1110,7 @@ void GMCPAuthenticator::readStoredSignIn(bool allowToken)
                             const QByteArray sentHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
                             SecureStringUtils::secureByteArrayClear(tokenBytes);
                             // Move the token in so sendReconnect owns the sole copy and can scrub it either way.
-                            if (sendReconnect(account, std::move(token))) {
+                            if (sendReconnect(account, std::move(token), secureOnly)) {
                                 // This connection is logging in by replaying a saved token, so a Char.Login.Token
                                 // that comes back is a silent rotation rather than a first-time save to announce.
                                 mConn.reconnectingWithToken = true;

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -74,8 +74,9 @@ QString providerDisplayName(const QString& id)
 // among them - which is why the string and number forms exist at all.
 //
 // A value in none of those forms is not a boolean, and returns nullopt so the caller applies that
-// field's documented default. Keeping "absent" distinct from "false" is the point: no caller here
-// defaults to false, so collapsing the two would quietly answer a security-bearing question wrong.
+// field's documented default. Keeping "absent" distinct from "false" is the point: the defaults here
+// are either true or the transport the token arrived on, never a flat false, so collapsing the two
+// would quietly answer a security-bearing question wrong on the transport that has protection to lose.
 std::optional<bool> decodeWireBool(const QJsonValue& value)
 {
     if (value.isBool()) {
@@ -102,6 +103,23 @@ std::optional<bool> decodeWireBool(const QJsonValue& value)
     }
     return std::nullopt;
 }
+
+// The transport requirement recorded in a stored sign-in entry. Missing means the entry predates the
+// field being stored, which is the ordinary case once per profile after an upgrade. Present but
+// undecodable means the protected store holds a value Mudlet never wrote - corruption, or another
+// writer - sitting next to a bearer token about to be replayed, so unlike the missing case it is worth
+// reporting. Both read strictly: never widen a stored token's exposure on a value we could not read.
+bool readStoredTransportRequirement(const QJsonObject& entry)
+{
+    const auto stored = entry[qsl("secure_only")];
+    const auto decoded = decodeWireBool(stored);
+    if (!decoded.has_value() && !stored.isUndefined()) {
+        qWarning().noquote().nospace() << "GMCP Char.Login - the stored sign-in's 'secure_only' is of type " << stored.type()
+                                       << ", which is not a boolean in any form; treating the saved token as replayable only over an encrypted connection.";
+    }
+    return decoded.value_or(true);
+}
+
 } // namespace
 
 GMCPAuthenticator::GMCPAuthenticator(Host* pHost)
@@ -226,10 +244,9 @@ void GMCPAuthenticator::addCommonFields(QJsonObject& payload) const
     // storage and replayed later - which is what lets the game decide whether it can honestly offer to
     // remember this player before it writes its sign-in screen.
     //
-    // Constant true for Mudlet: CredentialManager always has somewhere to attempt the write - the system
-    // keychain, falling back to its own encrypted file store when the keychain is unavailable or the
-    // install is portable. The standard asks per connection because a client that has no store at all has
-    // to say so; ours always has one to try.
+    // Constant true for Mudlet: CredentialManager writes to the system keychain, or to its own encrypted
+    // file store when the install is portable and when a keychain write fails. The standard asks per
+    // connection because a client that has no store at all has to say so; ours always has one to try.
     //
     // A version 1 server gets the fields too. An unknown member is inert to it, and we already echo
     // `version` - itself a version 2 addition - to such servers today. Only the hand-off is special-cased
@@ -396,18 +413,28 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, QString toke
     // connect and falls back to a fresh sign-in, so this is safe under the one-account-per-profile model.
     QPointer<Host> safeHost = mpHost;
     QPointer<CredentialManager> credentialManager = new CredentialManager();
-    // Whether a rotation is in progress belongs to the moment the token arrived, so snapshot it rather
-    // than read it from the callback: the next Char.Login.Default resets mConn while the save is still
-    // in flight, and by then the answer is about a different sign-in.
-    const bool rotatingSavedToken = mConn.reconnectingWithToken;
+    // Whether a successful save here is worth telling the player about at all, decided now rather than
+    // in the callback: both answers belong to the moment the token arrived, and the next
+    // Char.Login.Default resets mConn while the save is still in flight.
+    //
+    // A rotation is not worth announcing - the arriving token replaces one this connection already
+    // signed in with, so the player opted in long ago. Neither is a token this connection could not
+    // replay: if the server scoped it to an encrypted transport and this connection is not one, every
+    // later connect on the same transport refuses it (see sendReconnect) and the player signs in by
+    // hand, so promising the opposite would be knowably false as it was written.
+    const bool worthAnnouncing = !mConn.reconnectingWithToken && !(secureOnly && !mpHost->mTelnet.currentlySecure());
+    // Which sign-in attempt this save belongs to, so its announcement is deduplicated against that
+    // attempt rather than against whichever one happens to be live when the write lands.
+    const auto attemptGeneration = mAuthAttemptGeneration;
     // safeHost stands in for `this` as well: Host owns this authenticator (its QScopedPointer member),
     // so the authenticator is alive for as long as the Host is.
-    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [this, safeHost, credentialManager, rotatingSavedToken](bool success, const QString& errorMessage) {
+    credentialManager->storePassword(mpHost->getName(), qsl("reconnect"), payload, [this, safeHost, credentialManager, worthAnnouncing, attemptGeneration](bool success, const QString& errorMessage) {
         if (credentialManager) {
             credentialManager->deleteLater();
         }
-        // Log before the liveness check: a save can resolve (or time out) after the profile has closed,
-        // and that is precisely when the record of a token that never reached disk matters most.
+        // Log before the liveness check: a save can resolve, or time out, after the profile has closed,
+        // and that is precisely when the record of a token that never reached disk matters most. It does
+        // not cover application shutdown, where CredentialManager drops the callback unrun (see #10587).
         if (!success) {
             qWarning().noquote() << "GMCP Char.Login.Token - failed to store reconnect token:" << errorMessage;
         }
@@ -420,18 +447,20 @@ void GMCPAuthenticator::storeReconnectToken(const QString& account, QString toke
             return;
         }
         // Announced only once the save has actually landed, so a failure is never announced as a success
-        // first; only the first time this connection; and never on a token-reconnect, where the arriving
-        // token is a silent rotation rather than a new opt-in.
+        // first, and at most once per sign-in attempt.
         //
-        // Deliberately not gated on the sign-in attempt still being current, unlike the asynchronous
-        // reads elsewhere in this file. Those gate because acting on a stale result would drive a sign-in
-        // on the wrong connection; this only reports what became of the profile's stored token, which is
-        // true whichever attempt is live by the time the write lands. Gating it would mean a save that
-        // succeeded during a burst of Char.Login.Default frames was never mentioned at all.
-        if (rotatingSavedToken || mConn.announcedTokenSave) {
+        // Whether the announcement happens is deliberately not gated on that attempt still being the
+        // current one, unlike the asynchronous reads elsewhere in this file. Those gate because acting on
+        // a stale result would drive a sign-in on the wrong connection; this only reports what became of
+        // the profile's stored token, which stays true whichever attempt is live by the time the write
+        // lands. Gating it would mean a save that succeeded during a burst of Char.Login.Default frames
+        // was never mentioned at all. The attempt is what the message is deduplicated *against*, which is
+        // why that latch cannot live in mConn: a stale callback would otherwise consume the flag belonging
+        // to whichever attempt had since replaced it.
+        if (!worthAnnouncing || mAnnouncedSaveForAttempt == attemptGeneration) {
             return;
         }
-        mConn.announcedTokenSave = true;
+        mAnnouncedSaveForAttempt = attemptGeneration;
         //: Shown once after a browser/OAuth sign-in whose reconnect token was saved, so future connects need no sign-in.
         //: "Privacy and security" is the name of a page in the preferences dialog; translate it the same way there.
         safeHost->postMessage(tr("[ INFO ]  - You'll be signed in automatically next time. Manage this under Preferences, Privacy and security."));
@@ -826,8 +855,8 @@ void GMCPAuthenticator::retryOrDropRejectedToken()
                         const auto account = doc.object()[qsl("account")].toString();
                         auto token = doc.object()[qsl("token")].toString();
                         // As in readStoredSignIn: an entry whose requirement is missing or unreadable is
-                        // read strictly.
-                        const bool secureOnly = decodeWireBool(doc.object()[qsl("secure_only")]).value_or(true);
+                        // read strictly, and an unreadable one is reported.
+                        const bool secureOnly = readStoredTransportRequirement(doc.object());
                         if (!account.isEmpty() && !token.isEmpty()) {
                             QByteArray tokenBytes = token.toUtf8();
                             const QByteArray storedHash = QCryptographicHash::hash(tokenBytes, QCryptographicHash::Sha256);
@@ -1016,10 +1045,14 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
     // A value we could not decode is treated as absent, which is what the standard requires - but unlike
     // a genuinely absent field it means the server tried to state a transport requirement in a form no
     // conformant client can read. Nothing else would report that, and the server operator is the only
-    // person who can fix it.
-    if (!decodedSecureOnly && !declaredSecureOnly.isUndefined()) {
-        qWarning().noquote().nospace() << "GMCP " << packageMessage
-                                       << " - ignoring a 'secure_only' value that is not a boolean in any form the standard permits; defaulting it to the transport the token arrived on.";
+    // person who can fix it. Say what the fallback actually did, too: the defaulted answer is written to
+    // the store as a definite boolean, so on a cleartext connection an unreadable requirement becomes a
+    // durable "replayable in the clear" that every later read then honours without further complaint.
+    if (!decodedSecureOnly.has_value() && !declaredSecureOnly.isUndefined()) {
+        qWarning().noquote().nospace() << "GMCP " << packageMessage << " - a 'secure_only' value of type " << declaredSecureOnly.type()
+                                       << " is not a boolean in any form the standard permits, so it is being ignored. The token is stored as "
+                                       << (mpHost->mTelnet.currentlySecure() ? "replayable only over an encrypted connection" : "replayable over an unencrypted connection")
+                                       << ", inherited from the transport it arrived on.";
     }
     const bool secureOnly = decodedSecureOnly.value_or(mpHost->mTelnet.currentlySecure());
 
@@ -1141,7 +1174,7 @@ void GMCPAuthenticator::readStoredSignIn(bool allowToken)
                         // An entry whose requirement is missing (written before it was stored) or unreadable
                         // (a corrupted entry) gets the strict reading, so upgrading Mudlet never widens the
                         // exposure of a token already on disk; it gains the field on the next rotation.
-                        const bool secureOnly = decodeWireBool(doc.object()[qsl("secure_only")]).value_or(true);
+                        const bool secureOnly = readStoredTransportRequirement(doc.object());
                         if (!provider.isEmpty()) {
                             mConn.accountProvider = provider;
                         }
@@ -1204,8 +1237,8 @@ void GMCPAuthenticator::selectAuthMethod()
         return;
     }
 
-    // Otherwise hand off to the game's own interactive sign-in (sendCredentials has the shape that takes
-    // per negotiated version) and let the player choose there - even if the profile has a stored password (the game's screen
+    // Otherwise hand off to the game's own interactive sign-in (sendCredentials picks the hand-off shape
+    // for the negotiated version) and let the player choose there - even if the profile has a stored password (the game's screen
     // still accepts it), so a saved password never blocks reaching a provider choice.
     sendCredentials(true);
 }

--- a/src/GMCPAuthenticator.cpp
+++ b/src/GMCPAuthenticator.cpp
@@ -985,7 +985,8 @@ void GMCPAuthenticator::handleAuthToken(const QString& packageMessage, const QSt
     if (!mConn.reconnectingWithToken && !mConn.announcedTokenSave) {
         mConn.announcedTokenSave = true;
         //: Shown once after a browser/OAuth sign-in whose reconnect token was saved, so future connects need no sign-in.
-        mpHost->postMessage(tr("[ INFO ]  - You'll be signed in automatically next time. Manage this under Preferences, Connection."));
+        //: "Privacy and security" is the name of a page in the preferences dialog; translate it the same way there.
+        mpHost->postMessage(tr("[ INFO ]  - You'll be signed in automatically next time. Manage this under Preferences, Privacy and security."));
     }
 
 #if defined(DEBUG_GMCP_AUTHENTICATION)

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -46,9 +46,11 @@ public:
     ~GMCPAuthenticator() = default;
 
     void saveSupportsSet(const QString& packageMessage, const QString& data);
-    // Sends Char.Login.Credentials. With interactiveHandoff true it always sends the empty object {}
-    // (the "run your own sign-in screen" hand-off) even when the profile has stored credentials;
-    // otherwise it autofills the stored character name and password when the game accepts them.
+    // Sends Char.Login.Credentials. With interactiveHandoff true it always sends the "run your own
+    // sign-in screen" hand-off even when the profile has stored credentials; otherwise it autofills the
+    // stored character name and password when the game accepts them. A version 2 hand-off is the
+    // message with no account rather than a literally empty object - it carries the common fields (see
+    // addCommonFields) - while a version 1 one stays {}.
     void sendCredentials(bool interactiveHandoff = false);
     void handleAuthResult(const QString& packageMessage, const QString& data);
     void handleAuthGMCP(const QString& packageMessage, const QString& data);
@@ -79,15 +81,19 @@ private:
     // selectAuthMethod(). allowToken is false on the connection straight after a rejection, so a
     // not-yet-rewritten entry cannot loop us back into another rejected reconnect.
     void readStoredSignIn(bool allowToken);
-    // Returns false when it refused to send: the token is a bearer secret and never goes out over a
-    // cleartext transport. It is scrubbed either way, and only a true return means a result is awaited.
-    bool sendReconnect(const QString& account, QString token);
-    // Sends the resume form of Char.Login.Credentials: {account, provider, version}, no password -
-    // asking the game to restart the browser sign-in for the provider remembered from an earlier
+    // Returns false when it refused to send: the token is a bearer secret, and one the issuing server
+    // scoped to an encrypted transport (secureOnly) never goes out in the clear. It is scrubbed either
+    // way, and only a true return means a result is awaited.
+    bool sendReconnect(const QString& account, QString token, bool secureOnly);
+    // Sends the resume form of Char.Login.Credentials: an account and provider plus the common fields,
+    // no password - asking the game to restart the browser sign-in for the provider remembered from an
+    // earlier
     // Char.Login.URL. The absence of a password (not the presence of provider) is what distinguishes it.
     void sendResume(const QString& account, const QString& provider);
     void handleAuthToken(const QString& packageMessage, const QString& data);
-    void storeReconnectToken(const QString& account, QString token);
+    // secureOnly is the token's transport requirement, stored with it because it belongs to the
+    // connection that minted the token rather than to whichever one later replays it.
+    void storeReconnectToken(const QString& account, QString token, bool secureOnly);
     // After a rejected reconnect: re-reads the store first - another Mudlet instance sharing this
     // profile's keychain may have rotated the (single-use) token, in which case the fresh token is
     // replayed once instead of destroyed. Only a genuinely dead token is dropped, keeping the
@@ -103,6 +109,11 @@ private:
     void resetPerConnectionState();
     // Per socket connection, unlike resetPerConnectionState() which runs per Char.Login.Default.
     void resetForNewConnection();
+
+    // Adds the two fields every client->server Char.Login message may carry: the negotiated version we
+    // are acting on, and token_storage - whether a reconnect token minted on this connection would
+    // actually be kept.
+    void addCommonFields(QJsonObject& payload) const;
 
     bool clientDrivenOAuthAvailable() const;
 
@@ -122,8 +133,10 @@ private:
     // The negotiated Char.Login protocol version the server reported in Char.Login.Default. Absent (a
     // version 1 server or legacy exchange) is treated as 1; we echo this back on our client->server
     // messages (Credentials, Reconnect, resume, AuthCode) so both ends agree on the version even though
-    // base GMCP negotiation is one-directional. The one exception is the empty Char.Login.Credentials {}
-    // hand-off, which carries no fields at all by design.
+    // base GMCP negotiation is one-directional. The one exception is the hand-off on a version 1
+    // exchange, which stays the bare Char.Login.Credentials {} that a version 1 server may be testing
+    // for literally - version 2 defined the hand-off as the message with no account instead, so from
+    // there on it carries the common fields like any other.
     int mNegotiatedVersion = 1;
 
     // Sign-in/token state for a single sign-in attempt, reset as one unit on every Char.Login.Default

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -85,10 +85,9 @@ private:
     // scoped to an encrypted transport (secureOnly) never goes out in the clear. It is scrubbed either
     // way, and only a true return means a result is awaited.
     bool sendReconnect(const QString& account, QString token, bool secureOnly);
-    // Sends the resume form of Char.Login.Credentials: an account and provider plus the common fields,
-    // no password - asking the game to restart the browser sign-in for the provider remembered from an
-    // earlier
-    // Char.Login.URL. The absence of a password (not the presence of provider) is what distinguishes it.
+    // Sends the resume form of Char.Login.Credentials: an account and provider plus the common fields, no
+    // password - asking the game to restart the browser sign-in for the provider remembered from an
+    // earlier Char.Login.URL. The absence of a password (not the presence of provider) distinguishes it.
     void sendResume(const QString& account, const QString& provider);
     void handleAuthToken(const QString& packageMessage, const QString& data);
     // secureOnly is the token's transport requirement, stored with it because it belongs to the
@@ -186,10 +185,13 @@ private:
     // when a superseded recovery leaves the rejected token stored - by then the superseding Default has
     // already consumed the latch, so without re-arming the Default after that could replay the dead token.
     bool mReconnectRejected = false;
-    // Incremented on every per-connection auth reset (each Char.Login.Default). The asynchronous
-    // reconnect-token keychain read captures the value current when it started and re-checks it in its
-    // callback, so a result arriving after a newer connection began is discarded instead of driving a
-    // sign-in on the wrong attempt. Not part of mConn: it must monotonically increase, never reset.
+    // Incremented on every per-connection auth reset - each Char.Login.Default, and each socket connect
+    // or disconnect. The asynchronous reconnect-token keychain read captures the value current when it
+    // started and re-checks it in its callback, so a result arriving after a newer connection began is
+    // discarded instead of driving a sign-in on the wrong attempt. Only work that would *act* on the
+    // connection is gated this way: the token save's announcement deliberately is not, since it reports
+    // what became of the stored token rather than driving anything. Not part of mConn: it must
+    // monotonically increase, never reset.
     unsigned int mAuthAttemptGeneration = 0;
 
     // A server can pack thousands of Char.Login.Default frames into one packet and every sign-in

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -133,9 +133,10 @@ private:
     // version 1 server or legacy exchange) is treated as 1; we echo this back on our client->server
     // messages (Credentials, Reconnect, resume, AuthCode) so both ends agree on the version even though
     // base GMCP negotiation is one-directional. The one exception is the hand-off on a version 1
-    // exchange, which stays the bare Char.Login.Credentials {} that a version 1 server may be testing
-    // for literally - version 2 defined the hand-off as the message with no account instead, so from
-    // there on it carries the common fields like any other.
+    // exchange, which stays the bare Char.Login.Credentials {} Mudlet has always sent such servers -
+    // a compatibility choice, not a protocol requirement, since the empty hand-off is itself a
+    // version 2 addition. From version 2 on it is the message with no account, so it carries the
+    // common fields like any other.
     int mNegotiatedVersion = 1;
 
     // Sign-in/token state for a single sign-in attempt, reset as one unit on every Char.Login.Default

--- a/src/GMCPAuthenticator.h
+++ b/src/GMCPAuthenticator.h
@@ -151,9 +151,6 @@ private:
         // True on a connection that logged in by replaying a saved token, so a Char.Login.Token arriving
         // afterwards is a silent rotation rather than a first-time save worth announcing to the user.
         bool reconnectingWithToken = false;
-        // One-shot guard so the "you'll be signed in automatically next time" notice is shown at most
-        // once per connection, on the first token we persist.
-        bool announcedTokenSave = false;
         // One-shot guard: at most one rotated-token retry per connection, so two instances sharing a
         // store cannot ping-pong retries indefinitely.
         bool retriedRotatedToken = false;
@@ -193,6 +190,16 @@ private:
     // what became of the stored token rather than driving anything. Not part of mConn: it must
     // monotonically increase, never reset.
     unsigned int mAuthAttemptGeneration = 0;
+    // The sign-in attempt whose successful token save has already been announced, so the "you'll be
+    // signed in automatically next time" notice is shown at most once per attempt, on the first token
+    // that attempt actually persists.
+    //
+    // Deliberately NOT part of mConn, unlike the other one-shot guards there: the announcement is made
+    // from the asynchronous save callback, so a save resolving after a newer Char.Login.Default would
+    // otherwise consume - or be suppressed by - a flag belonging to the attempt that replaced it.
+    // Stamping it with the generation keeps each attempt's announcement its own. Zero matches no
+    // attempt, since the constructor's reset makes the first generation 1.
+    unsigned int mAnnouncedSaveForAttempt = 0;
 
     // A server can pack thousands of Char.Login.Default frames into one packet and every sign-in
     // attempt reads the credential store. Throttling bounds that cost by wall clock rather than by how

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -524,8 +524,10 @@ private slots:
 
     void testVersionOneHandoffStaysABareEmptyObject()
     {
-        // Version 1 predates both the common fields and the "a hand-off is the message with no
-        // account" rule, so a version 1 server may still be testing for a literally empty object.
+        // Keeping the bare {} on a version 1 exchange is a compatibility choice, not a protocol rule:
+        // the empty hand-off is itself a version 2 addition, so no version 1 server was specified to
+        // expect one. Mudlet has sent {} to such servers since before the standard, and some may have
+        // been written against that, so this pins the behaviour rather than the standard.
         Host* host = connectAndNegotiate();
         QVERIFY(host);
         host->setLogin(QString());
@@ -670,6 +672,46 @@ private slots:
                                         }),
                  "the second token should overwrite the first");
         QCOMPARE(consoleOccurrences(host, qsl("signed in automatically next time")), 1);
+    }
+
+    void testATokenMintedOverTlsIsAnnounced()
+    {
+        // The ordinary encrypted sign-in: secure_only defaults to true from the transport, and this
+        // connection satisfies it, so the promise holds and is worth making. This is the case that
+        // pins the transport half of worthAnnouncing - drop it and reduce the test to the cleartext
+        // ones and the notice could stop appearing on TLS entirely without anything noticing.
+        Host* host = connectAndNegotiate(true);
+        QVERIFY(host);
+        QVERIFY2(host->mTelnet.currentlySecure(), "precondition: this connection is encrypted");
+
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\"}"));
+
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [](const QJsonObject& entry) {
+                                            return entry.value(qsl("secure_only")) == QJsonValue(true);
+                                        }),
+                 "a token minted over TLS should be stored as encrypted-only");
+        QVERIFY2(waitForConsoleContains(host, qsl("signed in automatically next time")), "a token this connection is able to replay should be announced");
+    }
+
+    void testATokenThisTransportCannotReplayIsNotAnnounced()
+    {
+        // Minted in the clear but scoped by the server to an encrypted transport. Every later connect
+        // on this transport refuses it (see sendReconnect), so promising an automatic sign-in would be
+        // knowably false at the moment it was written. The token is still stored: the requirement may
+        // be met by some future connection.
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        QVERIFY2(!host->mTelnet.currentlySecure(), "precondition: this connection is unencrypted");
+
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\", \"secure_only\": true}"));
+
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [](const QJsonObject& entry) {
+                                            return entry.value(qsl("token")).toString() == qsl("opaque-token") && entry.value(qsl("secure_only")) == QJsonValue(true);
+                                        }),
+                 "the token should still be stored, carrying the requirement the server set");
+        QVERIFY2(!waitForConsoleContains(host, qsl("signed in automatically next time"), 500), "a token this transport cannot replay must not be announced as one that will be");
     }
 
     void testAFailedSaveIsNotAnnouncedAsASuccess()

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -38,6 +38,7 @@
 #include <QDesktopServices>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <QUrlQuery>
 #include <functional>
 
@@ -651,11 +652,24 @@ private slots:
         QVERIFY(host);
         mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\"}"));
         QVERIFY2(waitForConsoleContains(host, qsl("signed in automatically next time")), "saving a reconnect token should be announced once");
+        // Asserted separately rather than as one sentence, which the console wraps across lines. The page
+        // name is pinned because it can silently drift away from where the "Forget saved sign-in" control
+        // actually lives - which is exactly how the notice came to name the wrong page before.
+        QVERIFY2(waitForConsoleContainsUnwrapped(host, qsl("Manage this under Preferences, Privacy and security.")), "the notice should name the preferences page that manages the saved sign-in");
         QVERIFY2(waitForStoredReconnect(host,
                                         [](const QJsonObject& entry) {
                                             return entry.value(qsl("account")).toString() == qsl("acct:char") && entry.value(qsl("token")).toString() == qsl("opaque-token");
                                         }),
                  "the reconnect token should be persisted with the announced account and token");
+
+        // A server may mint repeatedly on one sign-in; the player only needs telling once.
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"second-token\"}"));
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [](const QJsonObject& entry) {
+                                            return entry.value(qsl("token")).toString() == qsl("second-token");
+                                        }),
+                 "the second token should overwrite the first");
+        QCOMPARE(consoleOccurrences(host, qsl("signed in automatically next time")), 1);
     }
 
     void testAFailedSaveIsNotAnnouncedAsASuccess()
@@ -738,29 +752,30 @@ private slots:
         QTest::addColumn<QString>("literal");
         QTest::addColumn<bool>("encrypted");
         QTest::addColumn<bool>("secureOnly");
+        QTest::addColumn<bool>("decodable");
         // Every row is minted on the transport whose inherited default is the OPPOSITE of what it
         // expects, so no row can pass unless the value was really decoded. Run them all over TLS and the
         // true-expecting rows would pass against a decoder that always returned "undecodable".
         //
         // Decodable false, minted over TLS, where an undecoded value would have inherited true:
-        QTest::newRow("JSON false") << qsl("false") << true << false;
-        QTest::newRow("string false") << qsl("\"false\"") << true << false;
-        QTest::newRow("string FALSE") << qsl("\"FALSE\"") << true << false;
-        QTest::newRow("string zero") << qsl("\"0\"") << true << false;
-        QTest::newRow("number zero") << qsl("0") << true << false;
+        QTest::newRow("JSON false") << qsl("false") << true << false << true;
+        QTest::newRow("string false") << qsl("\"false\"") << true << false << true;
+        QTest::newRow("string FALSE") << qsl("\"FALSE\"") << true << false << true;
+        QTest::newRow("string zero") << qsl("\"0\"") << true << false << true;
+        QTest::newRow("number zero") << qsl("0") << true << false << true;
         // Decodable true, minted in the clear, where an undecoded value would have inherited false:
-        QTest::newRow("JSON true") << qsl("true") << false << true;
-        QTest::newRow("string true") << qsl("\"true\"") << false << true;
-        QTest::newRow("padded string True") << qsl("\" True \"") << false << true;
-        QTest::newRow("number one") << qsl("1") << false << true;
+        QTest::newRow("JSON true") << qsl("true") << false << true << true;
+        QTest::newRow("string true") << qsl("\"true\"") << false << true << true;
+        QTest::newRow("padded string True") << qsl("\" True \"") << false << true << true;
+        QTest::newRow("number one") << qsl("1") << false << true << true;
         // Undecodable is absent, never a guess: each of these must land on the transport's own default,
         // which is only demonstrated by pinning it in both directions.
-        QTest::newRow("unrecognised string") << qsl("\"maybe\"") << true << true;
-        QTest::newRow("null") << qsl("null") << true << true;
-        QTest::newRow("array") << qsl("[false]") << true << true;
-        QTest::newRow("out-of-range number") << qsl("2") << false << false;
-        QTest::newRow("fractional number") << qsl("1.5") << false << false;
-        QTest::newRow("object") << qsl("{}") << false << false;
+        QTest::newRow("unrecognised string") << qsl("\"maybe\"") << true << true << false;
+        QTest::newRow("null") << qsl("null") << true << true << false;
+        QTest::newRow("array") << qsl("[false]") << true << true << false;
+        QTest::newRow("out-of-range number") << qsl("2") << false << false << false;
+        QTest::newRow("fractional number") << qsl("1.5") << false << false << false;
+        QTest::newRow("object") << qsl("{}") << false << false << false;
     }
 
     void testSecureOnlyIsDecodedInEveryFormTheStandardAllows()
@@ -768,9 +783,16 @@ private slots:
         QFETCH(QString, literal);
         QFETCH(bool, encrypted);
         QFETCH(bool, secureOnly);
+        QFETCH(bool, decodable);
         Host* host = connectAndNegotiate(encrypted);
         QVERIFY(host);
         QCOMPARE(host->mTelnet.currentlySecure(), encrypted);
+        if (!decodable) {
+            // ignoreMessage fails the test if the message never arrives, so this asserts the diagnostic
+            // rather than merely silencing it: a value no conformant client can read is the one thing the
+            // server operator needs told, and nothing else would tell them.
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl("'secure_only' value of type .* is not a boolean")));
+        }
 
         mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\", \"secure_only\": %1}").arg(literal));
         QVERIFY2(waitForStoredReconnect(host,
@@ -1055,8 +1077,18 @@ private slots:
         QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-B"));
     }
 
+    void testRotatedTokenRefusedOnTransportGroundsIsLeftAlone_data()
+    {
+        QTest::addColumn<QString>("rotatedEntry");
+        QTest::newRow("explicitly encrypted-only") << qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-B\", \"secure_only\": true}");
+        // An instance running an older Mudlet shares the store and writes no requirement at all. The
+        // rotation path has to read that strictly for itself, exactly as readStoredSignIn does.
+        QTest::newRow("written by a Mudlet that stored no requirement") << qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-B\"}");
+    }
+
     void testRotatedTokenRefusedOnTransportGroundsIsLeftAlone()
     {
+        QFETCH(QString, rotatedEntry);
         // The mirror of the case above: the other instance's fresh token requires encryption that this
         // connection does not have. It must not be replayed, and - because it is another instance's live
         // token, not a dead one - must not be destroyed either.
@@ -1074,16 +1106,13 @@ private slots:
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "client did not replay the saved token");
         QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-A"));
 
-        const QString rotatedJson = qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-B\", \"secure_only\": true}");
-        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), rotatedJson));
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), rotatedEntry));
         mpServer->clearReceived();
         mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Reconnect token expired\"}"));
 
         QVERIFY2(waitForConsoleContains(host, qsl("not encrypted")), "the user should be told why the rotated token was not used");
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
-        const QJsonObject stored = readStoredReconnect(host);
-        QCOMPARE(stored.value(qsl("token")).toString(), qsl("token-B"));
-        QCOMPARE(stored.value(qsl("secure_only")), QJsonValue(true));
+        QCOMPARE(readStoredReconnect(host).value(qsl("token")).toString(), qsl("token-B"));
     }
 
     void testRotationReplayClearsTheRejectionLatch()
@@ -1525,6 +1554,21 @@ private:
         return true;
     }
 
+    static int consoleOccurrences(Host* host, const QString& substring)
+    {
+        if (!host || !host->mpConsole) {
+            return 0;
+        }
+        auto& buffer = host->mpConsole->buffer;
+        int seen = 0;
+        for (int i = 0; i <= buffer.getLastLineNumber(); ++i) {
+            if (buffer.line(i).contains(substring)) {
+                ++seen;
+            }
+        }
+        return seen;
+    }
+
     static bool consoleContains(Host* host, const QString& substring)
     {
         if (!host || !host->mpConsole) {
@@ -1537,6 +1581,28 @@ private:
             all.append(QChar::Space);
         }
         return all.contains(substring);
+    }
+
+    // Matches ignoring every space and line break on both sides, so an assertion on a whole sentence does
+    // not depend on where the console happened to wrap it. Use it only where the wording itself is the
+    // thing under test; waitForConsoleContains is the right tool for a short distinctive phrase.
+    bool waitForConsoleContainsUnwrapped(Host* host, const QString& sentence, int timeoutMs = 4000)
+    {
+        static const QRegularExpression whitespace(qsl("\\s+"));
+        const QString needle = QString(sentence).remove(whitespace);
+        return QTest::qWaitFor(
+                [&]() {
+                    if (!host || !host->mpConsole) {
+                        return false;
+                    }
+                    auto& buffer = host->mpConsole->buffer;
+                    QString all;
+                    for (int i = 0; i <= buffer.getLastLineNumber(); ++i) {
+                        all.append(buffer.line(i));
+                    }
+                    return all.remove(whitespace).contains(needle);
+                },
+                timeoutMs);
     }
 
     bool waitForConsoleContains(Host* host, const QString& substring, int timeoutMs = 4000)

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -472,6 +472,9 @@ private slots:
         QCOMPARE(sent.value(qsl("account")).toString(), qsl("player"));
         QCOMPARE(sent.value(qsl("password")).toString(), qsl("secret"));
         QCOMPARE(sent.value(qsl("version")).toInt(), 2);
+        // A real JSON boolean, not the string "true": Qt can serialise one, so the leniency the
+        // standard allows for driver-limited peers is not ours to spend.
+        QCOMPARE(sent.value(qsl("token_storage")), QJsonValue(true));
     }
 
     void testAbsentServerVersionEchoesVersionOne()
@@ -489,9 +492,10 @@ private slots:
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not send Char.Login.Credentials");
         QCOMPARE(sent.value(qsl("account")).toString(), qsl("player"));
         QCOMPARE(sent.value(qsl("version")).toInt(), 1);
+        QCOMPARE(sent.value(qsl("token_storage")), QJsonValue(true));
     }
 
-    void testNoCredentialsHandsOffWithEmptyCredentials()
+    void testNoCredentialsHandsOffToTheGamesSignInScreen()
     {
         Host* host = connectAndNegotiate();
         QVERIFY(host);
@@ -503,7 +507,24 @@ private slots:
 
         QJsonObject sent;
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not hand off with Char.Login.Credentials");
-        QVERIFY2(sent.isEmpty(), "hand-off Char.Login.Credentials should be an empty object");
+        QVERIFY2(isVersionTwoHandoff(sent), qPrintable(qsl("expected the version 2 hand-off, got %1").arg(describe(sent))));
+    }
+
+    void testVersionOneHandoffStaysABareEmptyObject()
+    {
+        // Version 1 predates both the common fields and the "a hand-off is the message with no
+        // account" rule, so a version 1 server may still be testing for a literally empty object.
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        host->setLogin(QString());
+        host->setPass(QString());
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not hand off with Char.Login.Credentials");
+        QVERIFY2(sent.isEmpty(), qPrintable(qsl("a version 1 hand-off must stay the bare {} object, got %1").arg(describe(sent))));
     }
 
     void testDefaultWithoutAuthTypesLeavesTimerAutoLoginAlone_data()
@@ -569,7 +590,7 @@ private slots:
 
         QJsonObject sent;
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not respond");
-        QVERIFY2(sent.isEmpty(), "a partial credential pair must not be autofilled");
+        QVERIFY2(isVersionTwoHandoff(sent), qPrintable(qsl("a partial credential pair must not be autofilled, got %1").arg(describe(sent))));
     }
 
     void testClientDrivenOAuthFieldsIgnoredOnCleartext()
@@ -587,7 +608,7 @@ private slots:
 
         QJsonObject sent;
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "client did not hand off");
-        QVERIFY2(sent.isEmpty(), "client-driven OAuth fields must be ignored on cleartext, yielding an empty hand-off");
+        QVERIFY2(isVersionTwoHandoff(sent), qPrintable(qsl("client-driven OAuth fields must be ignored on cleartext, yielding a hand-off, got %1").arg(describe(sent))));
     }
 
     // ---- Char.Login.URL safety ---------------------------------------------
@@ -626,6 +647,96 @@ private slots:
                  "the reconnect token should be persisted with the announced account and token");
     }
 
+    void testTokenMintedInTheClearIsReplayedInTheClear()
+    {
+        // Issue #10585 end to end: remember-me was unusable on a plain telnet game, because a token
+        // the server had explicitly marked replayable on either transport was stored and then refused
+        // on every later connection. secure_only arrives as a JSON string here because the server that
+        // found this (LDMud) has no JSON boolean to send.
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        QVERIFY2(!host->mTelnet.currentlySecure(), "precondition: this connection is unencrypted");
+        host->setLogin(QString());
+        host->setPass(QString());
+
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"secure_only\": \"false\", \"token\": \"opaque-token\", \"account\": \"acct:char\"}"));
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [](const QJsonObject& entry) {
+                                            return entry.value(qsl("token")).toString() == qsl("opaque-token") && entry.value(qsl("secure_only")) == QJsonValue(false);
+                                        }),
+                 "the token's transport requirement should be stored alongside it");
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "a token the server marked replayable in the clear should be replayed");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("opaque-token"));
+    }
+
+    void testAbsentSecureOnlyInheritsTheIssuingTransport_data()
+    {
+        QTest::addColumn<bool>("encrypted");
+        QTest::newRow("minted in the clear") << false;
+        QTest::newRow("minted over TLS") << true;
+    }
+
+    void testAbsentSecureOnlyInheritsTheIssuingTransport()
+    {
+        QFETCH(bool, encrypted);
+        Host* host = connectAndNegotiate(encrypted);
+        QVERIFY(host);
+        QCOMPARE(host->mTelnet.currentlySecure(), encrypted);
+
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\"}"));
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [encrypted](const QJsonObject& entry) {
+                                            return entry.value(qsl("token")).toString() == qsl("opaque-token") && entry.value(qsl("secure_only")) == QJsonValue(encrypted);
+                                        }),
+                 "an absent secure_only should be defaulted from the transport the token arrived on");
+    }
+
+    void testSecureOnlyIsDecodedInEveryFormTheStandardAllows_data()
+    {
+        QTest::addColumn<QString>("literal");
+        QTest::addColumn<bool>("secureOnly");
+        // Every row is minted over TLS, where an inherited default is true - so each false below is one
+        // the server actually asked for rather than one we fell back to.
+        QTest::newRow("JSON false") << qsl("false") << false;
+        QTest::newRow("string false") << qsl("\"false\"") << false;
+        QTest::newRow("string FALSE") << qsl("\"FALSE\"") << false;
+        QTest::newRow("string zero") << qsl("\"0\"") << false;
+        QTest::newRow("number zero") << qsl("0") << false;
+        QTest::newRow("JSON true") << qsl("true") << true;
+        QTest::newRow("string true") << qsl("\"true\"") << true;
+        QTest::newRow("padded string True") << qsl("\" True \"") << true;
+        QTest::newRow("number one") << qsl("1") << true;
+        // Undecodable is absent, never a guess - and absent here inherits TLS, the strict answer. A
+        // permissive reading of a value we could not parse is what the standard singles out as wrong.
+        QTest::newRow("unrecognised string") << qsl("\"maybe\"") << true;
+        QTest::newRow("out-of-range number") << qsl("2") << true;
+        QTest::newRow("fractional number") << qsl("1.5") << true;
+        QTest::newRow("null") << qsl("null") << true;
+        QTest::newRow("object") << qsl("{}") << true;
+        QTest::newRow("array") << qsl("[false]") << true;
+    }
+
+    void testSecureOnlyIsDecodedInEveryFormTheStandardAllows()
+    {
+        QFETCH(QString, literal);
+        QFETCH(bool, secureOnly);
+        Host* host = connectAndNegotiate(true);
+        QVERIFY(host);
+        QVERIFY2(host->mTelnet.currentlySecure(), "precondition: this connection is encrypted");
+
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\", \"secure_only\": %1}").arg(literal));
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [secureOnly](const QJsonObject& entry) {
+                                            return entry.value(qsl("token")).toString() == qsl("opaque-token") && entry.value(qsl("secure_only")) == QJsonValue(secureOnly);
+                                        }),
+                 qPrintable(qsl("secure_only %1 should have been stored as %2").arg(literal, secureOnly ? qsl("true") : qsl("false"))));
+    }
+
     // ---- Char.Login.Reconnect ----------------------------------------------
 
     void testSavedTokenIsReplayedOnReconnect()
@@ -646,6 +757,7 @@ private slots:
         QCOMPARE(sent.value(qsl("account")).toString(), qsl("acct:char"));
         QCOMPARE(sent.value(qsl("token")).toString(), qsl("saved-token"));
         QCOMPARE(sent.value(qsl("version")).toInt(), 2);
+        QCOMPARE(sent.value(qsl("token_storage")), QJsonValue(true));
     }
 
     void testSavedTokenIsNotReplayedOverCleartext()
@@ -663,7 +775,7 @@ private slots:
 
         QJsonObject sent;
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "the sign-in should fall back to the interactive hand-off");
-        QVERIFY2(sent.isEmpty(), "the fall-back must be the empty {} hand-off");
+        QVERIFY2(isVersionTwoHandoff(sent), qPrintable(qsl("the fall-back must be the hand-off, got %1").arg(describe(sent))));
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
         QVERIFY2(waitForConsoleContains(host, qsl("not encrypted")), "the user should be told why their saved sign-in was not used");
         QVERIFY2(!CredentialManager::retrieveCredential(host->getName(), qsl("reconnect")).isEmpty(), "refusing to send the token must not destroy it");
@@ -673,6 +785,44 @@ private slots:
         mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Invalid credentials\"}"));
         QVERIFY2(waitForConsoleContains(host, qsl("Could not log in to the game")), "a failed interactive sign-in should be reported as one");
         QVERIFY2(!CredentialManager::retrieveCredential(host->getName(), qsl("reconnect")).isEmpty(), "the stored sign-in must survive an unrelated login failure");
+    }
+
+    void testStoredTransportRequirementGatesReplay_data()
+    {
+        QTest::addColumn<QString>("entry");
+        QTest::addColumn<bool>("replayed");
+        QTest::newRow("replayable in the clear") << qsl("{\"account\": \"acct:char\", \"token\": \"saved-token\", \"secure_only\": false}") << true;
+        QTest::newRow("encrypted only") << qsl("{\"account\": \"acct:char\", \"token\": \"saved-token\", \"secure_only\": true}") << false;
+        // Written by a Mudlet from before the requirement was stored: keep the strict reading, so
+        // upgrading never widens the exposure of a token already on disk. It gains the field on the
+        // next rotation.
+        QTest::newRow("no requirement stored") << qsl("{\"account\": \"acct:char\", \"token\": \"saved-token\"}") << false;
+    }
+
+    void testStoredTransportRequirementGatesReplay()
+    {
+        QFETCH(QString, entry);
+        QFETCH(bool, replayed);
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        QVERIFY2(!host->mTelnet.currentlySecure(), "precondition: this connection is unencrypted");
+        host->setLogin(QString());
+        host->setPass(QString());
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), entry));
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        if (replayed) {
+            QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "a token this transport is allowed to carry should have been replayed");
+            QCOMPARE(sent.value(qsl("token")).toString(), qsl("saved-token"));
+            return;
+        }
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "a token this transport may not carry should fall through to the hand-off");
+        QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
+        QVERIFY2(waitForConsoleContains(host, qsl("not encrypted")), "the user should be told why their saved sign-in was not used");
+        QVERIFY2(!CredentialManager::retrieveCredential(host->getName(), qsl("reconnect")).isEmpty(), "a token refused on this transport must not be destroyed");
     }
 
     void testCleartextTokenFallsBackToProviderResume()
@@ -762,6 +912,7 @@ private slots:
         QCOMPARE(sent.value(qsl("provider")).toString(), qsl("discord"));
         QVERIFY2(!sent.contains(qsl("password")), "the resume form must not carry a password");
         QCOMPARE(sent.value(qsl("version")).toInt(), 2);
+        QCOMPARE(sent.value(qsl("token_storage")), QJsonValue(true));
     }
 
     void testProviderFromUrlIsPersistedWithToken()
@@ -872,7 +1023,7 @@ private slots:
 
         QJsonObject sent;
         QVERIFY2(waitForClientGmcp(qsl("Char.Login.Credentials"), sent), "a corrupt stored entry should fall through to the hand-off");
-        QVERIFY2(sent.isEmpty(), "the fall-through must be the empty {} hand-off, not a reconnect or a partial replay");
+        QVERIFY2(isVersionTwoHandoff(sent), qPrintable(qsl("the fall-through must be the hand-off, not a reconnect or a partial replay, got %1").arg(describe(sent))));
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
     }
 
@@ -1273,6 +1424,16 @@ private:
                     return all.contains(substring);
                 },
                 timeoutMs);
+    }
+
+    static QString describe(const QJsonObject& obj) { return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)); }
+
+    // The version 2 interactive hand-off is identified by the absence of account, not by the payload
+    // being literally {}: the common fields ride on it, and token_storage riding there is the whole
+    // point - it reaches the game before the game writes a line of its sign-in screen.
+    static bool isVersionTwoHandoff(const QJsonObject& sent)
+    {
+        return !sent.contains(qsl("account")) && !sent.contains(qsl("password")) && sent.value(qsl("version")).toInt() == 2 && sent.value(qsl("token_storage")) == QJsonValue(true);
     }
 
     // Parse the stored reconnect entry as JSON so tests can assert its exact shape rather than

--- a/test/functional_tests/GMCPCharLoginTest.cpp
+++ b/test/functional_tests/GMCPCharLoginTest.cpp
@@ -23,8 +23,10 @@
 // Reconnect) and on the messages it prints, so future changes cannot silently break
 // authentication.
 
+#include <QDir>
 #include <QFileInfo>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 #include <chrono>
@@ -47,6 +49,7 @@
 #include "ctelnet.h"
 #include "dlgConnectionProfiles.h"
 #include "mudlet.h"
+#include "utils.h"
 
 #include "GroupedTest.h"
 
@@ -441,12 +444,20 @@ private slots:
         mOpenedUrls.clear();
         // Start each test from a clean credential state so a reconnect token saved by an earlier test
         // cannot leak into one that expects none (which would make the client replay it instead).
+        // Clearing the blocking directory here as well as in cleanup() is what makes a hard death - a CI
+        // timeout, a sanitizer abort - survivable: the credential store lives under AppConfigLocation,
+        // which follows XDG_CONFIG_HOME only on Linux, so on macOS and Windows it outlives this run's
+        // temporary config directory, and removeCredential below cannot delete a directory.
+        removeBlockingCredentialDirectory();
         CredentialManager::removeCredential(mHostname, qsl("reconnect"));
         deleteProfileDirectory(mHostname);
     }
 
     void cleanup()
     {
+        // A test that blocked the credential store with a directory must not leave it standing, even
+        // when it failed part way through: every later test's save would be blocked too.
+        removeBlockingCredentialDirectory();
         delete mpServer;
         mpServer = nullptr;
         delete mpDiscovery;
@@ -647,6 +658,32 @@ private slots:
                  "the reconnect token should be persisted with the announced account and token");
     }
 
+    void testAFailedSaveIsNotAnnouncedAsASuccess()
+    {
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+
+        // Block the save by putting a directory exactly where the credential file has to be written -
+        // surgical, removed again by cleanup(), and behaves the same on every platform, unlike revoking
+        // write permission, which is a no-op for root in a container and for an Administrator on Windows.
+        // Seeding a real credential first proves the computed path is the one
+        // actually in use, so a change to the storage scheme fails this test rather than quietly
+        // blocking nothing and letting it pass for the wrong reason.
+        const QString credentialPath = reconnectCredentialPath(host->getName());
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), qsl("seed")));
+        QVERIFY2(QFileInfo::exists(credentialPath), qPrintable(qsl("the credential store no longer files entries at %1").arg(credentialPath)));
+        QVERIFY(CredentialManager::removeCredential(host->getName(), qsl("reconnect")));
+        QVERIFY(QDir().mkpath(credentialPath));
+
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\"}"));
+
+        QVERIFY2(waitForConsoleContains(host, qsl("Could not save your sign-in")), "a save that failed should be reported to the player");
+        // Waits for a message that must never arrive, rather than sampling once: the file-backed store
+        // resolving inline is an implementation detail of MUDLET_TEST_MODE, and this assertion should not
+        // quietly become a race if that ever changes.
+        QVERIFY2(!waitForConsoleContains(host, qsl("signed in automatically next time"), 500), "a failed save must not also be announced as a success");
+    }
+
     void testTokenMintedInTheClearIsReplayedInTheClear()
     {
         // Issue #10585 end to end: remember-me was unusable on a plain telnet game, because a token
@@ -699,35 +736,41 @@ private slots:
     void testSecureOnlyIsDecodedInEveryFormTheStandardAllows_data()
     {
         QTest::addColumn<QString>("literal");
+        QTest::addColumn<bool>("encrypted");
         QTest::addColumn<bool>("secureOnly");
-        // Every row is minted over TLS, where an inherited default is true - so each false below is one
-        // the server actually asked for rather than one we fell back to.
-        QTest::newRow("JSON false") << qsl("false") << false;
-        QTest::newRow("string false") << qsl("\"false\"") << false;
-        QTest::newRow("string FALSE") << qsl("\"FALSE\"") << false;
-        QTest::newRow("string zero") << qsl("\"0\"") << false;
-        QTest::newRow("number zero") << qsl("0") << false;
-        QTest::newRow("JSON true") << qsl("true") << true;
-        QTest::newRow("string true") << qsl("\"true\"") << true;
-        QTest::newRow("padded string True") << qsl("\" True \"") << true;
-        QTest::newRow("number one") << qsl("1") << true;
-        // Undecodable is absent, never a guess - and absent here inherits TLS, the strict answer. A
-        // permissive reading of a value we could not parse is what the standard singles out as wrong.
-        QTest::newRow("unrecognised string") << qsl("\"maybe\"") << true;
-        QTest::newRow("out-of-range number") << qsl("2") << true;
-        QTest::newRow("fractional number") << qsl("1.5") << true;
-        QTest::newRow("null") << qsl("null") << true;
-        QTest::newRow("object") << qsl("{}") << true;
-        QTest::newRow("array") << qsl("[false]") << true;
+        // Every row is minted on the transport whose inherited default is the OPPOSITE of what it
+        // expects, so no row can pass unless the value was really decoded. Run them all over TLS and the
+        // true-expecting rows would pass against a decoder that always returned "undecodable".
+        //
+        // Decodable false, minted over TLS, where an undecoded value would have inherited true:
+        QTest::newRow("JSON false") << qsl("false") << true << false;
+        QTest::newRow("string false") << qsl("\"false\"") << true << false;
+        QTest::newRow("string FALSE") << qsl("\"FALSE\"") << true << false;
+        QTest::newRow("string zero") << qsl("\"0\"") << true << false;
+        QTest::newRow("number zero") << qsl("0") << true << false;
+        // Decodable true, minted in the clear, where an undecoded value would have inherited false:
+        QTest::newRow("JSON true") << qsl("true") << false << true;
+        QTest::newRow("string true") << qsl("\"true\"") << false << true;
+        QTest::newRow("padded string True") << qsl("\" True \"") << false << true;
+        QTest::newRow("number one") << qsl("1") << false << true;
+        // Undecodable is absent, never a guess: each of these must land on the transport's own default,
+        // which is only demonstrated by pinning it in both directions.
+        QTest::newRow("unrecognised string") << qsl("\"maybe\"") << true << true;
+        QTest::newRow("null") << qsl("null") << true << true;
+        QTest::newRow("array") << qsl("[false]") << true << true;
+        QTest::newRow("out-of-range number") << qsl("2") << false << false;
+        QTest::newRow("fractional number") << qsl("1.5") << false << false;
+        QTest::newRow("object") << qsl("{}") << false << false;
     }
 
     void testSecureOnlyIsDecodedInEveryFormTheStandardAllows()
     {
         QFETCH(QString, literal);
+        QFETCH(bool, encrypted);
         QFETCH(bool, secureOnly);
-        Host* host = connectAndNegotiate(true);
+        Host* host = connectAndNegotiate(encrypted);
         QVERIFY(host);
-        QVERIFY2(host->mTelnet.currentlySecure(), "precondition: this connection is encrypted");
+        QCOMPARE(host->mTelnet.currentlySecure(), encrypted);
 
         mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"opaque-token\", \"secure_only\": %1}").arg(literal));
         QVERIFY2(waitForStoredReconnect(host,
@@ -758,6 +801,17 @@ private slots:
         QCOMPARE(sent.value(qsl("token")).toString(), qsl("saved-token"));
         QCOMPARE(sent.value(qsl("version")).toInt(), 2);
         QCOMPARE(sent.value(qsl("token_storage")), QJsonValue(true));
+
+        // A token arriving on a connection that signed in by replaying one is a silent rotation, not a
+        // fresh opt-in, so it is saved without telling the player they will be remembered next time -
+        // they already were.
+        mpServer->sendGmcp(qsl("Char.Login.Token {\"account\": \"acct:char\", \"token\": \"rotated-token\"}"));
+        QVERIFY2(waitForStoredReconnect(host,
+                                        [](const QJsonObject& entry) {
+                                            return entry.value(qsl("token")).toString() == qsl("rotated-token");
+                                        }),
+                 "the rotated token should still be persisted");
+        QVERIFY2(!waitForConsoleContains(host, qsl("signed in automatically next time"), 500), "a silent rotation must not be announced as a new opt-in");
     }
 
     void testSavedTokenIsNotReplayedOverCleartext()
@@ -971,6 +1025,65 @@ private slots:
         QVERIFY2(waitForConsoleContains(host, qsl("saved sign-in has expired")), "the second rejection should be reported, not retried");
         QTest::qWait(300ms);
         QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
+    }
+
+    void testRotatedTokenIsReplayedInTheClearWhenTheServerAllowsIt()
+    {
+        // The rotation path reads the stored requirement for itself. On a plain-telnet game that mints
+        // replayable-in-the-clear tokens - the configuration issue #10585 was reported from - a second
+        // Mudlet instance sharing the store rotates the single-use token, and the retry has to honour
+        // that stored false rather than refuse on transport grounds.
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        QVERIFY2(!host->mTelnet.currentlySecure(), "precondition: this connection is unencrypted");
+        host->setLogin(QString());
+        host->setPass(QString());
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), qsl("{\"account\": \"acct:char\", \"token\": \"token-A\", \"secure_only\": false}")));
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "client did not replay the saved token");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-A"));
+
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-B\", \"secure_only\": false}")));
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Reconnect token expired\"}"));
+
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "the rotated token should be replayed on a transport its requirement allows");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-B"));
+    }
+
+    void testRotatedTokenRefusedOnTransportGroundsIsLeftAlone()
+    {
+        // The mirror of the case above: the other instance's fresh token requires encryption that this
+        // connection does not have. It must not be replayed, and - because it is another instance's live
+        // token, not a dead one - must not be destroyed either.
+        Host* host = connectAndNegotiate();
+        QVERIFY(host);
+        QVERIFY2(!host->mTelnet.currentlySecure(), "precondition: this connection is unencrypted");
+        host->setLogin(QString());
+        host->setPass(QString());
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), qsl("{\"account\": \"acct:char\", \"token\": \"token-A\", \"secure_only\": false}")));
+
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Default {\"version\": 2, \"type\": [\"oauth\", \"password-credentials\"]}"));
+
+        QJsonObject sent;
+        QVERIFY2(waitForClientGmcp(qsl("Char.Login.Reconnect"), sent), "client did not replay the saved token");
+        QCOMPARE(sent.value(qsl("token")).toString(), qsl("token-A"));
+
+        const QString rotatedJson = qsl("{\"account\": \"acct:char\", \"provider\": \"discord\", \"token\": \"token-B\", \"secure_only\": true}");
+        QVERIFY(CredentialManager::storeCredential(host->getName(), qsl("reconnect"), rotatedJson));
+        mpServer->clearReceived();
+        mpServer->sendGmcp(qsl("Char.Login.Result {\"success\": false, \"message\": \"Reconnect token expired\"}"));
+
+        QVERIFY2(waitForConsoleContains(host, qsl("not encrypted")), "the user should be told why the rotated token was not used");
+        QCOMPARE(mpServer->countReceived(qsl("Char.Login.Reconnect")), 0);
+        const QJsonObject stored = readStoredReconnect(host);
+        QCOMPARE(stored.value(qsl("token")).toString(), qsl("token-B"));
+        QCOMPARE(stored.value(qsl("secure_only")), QJsonValue(true));
     }
 
     void testRotationReplayClearsTheRejectionLatch()
@@ -1226,6 +1339,10 @@ private slots:
         QVERIFY(!sent.value(qsl("code_verifier")).toString().isEmpty());
         QCOMPARE(sent.value(qsl("redirect_uri")).toString(), redirectUri.toString());
         QCOMPARE(sent.value(qsl("nonce")).toString(), nonce);
+        // The common fields ride on AuthCode too. Asserted here because this is the only test that
+        // completes a client-driven sign-in, and so the only place the message's shape is observable.
+        QCOMPARE(sent.value(qsl("version")).toInt(), 2);
+        QCOMPARE(sent.value(qsl("token_storage")), QJsonValue(true));
     }
 
     void testAuthCodeOmitsTheNonceWhenTheServerDidNotAskForIt()
@@ -1408,22 +1525,43 @@ private:
         return true;
     }
 
-    bool waitForConsoleContains(Host* host, const QString& substring, int timeoutMs = 4000)
+    static bool consoleContains(Host* host, const QString& substring)
     {
         if (!host || !host->mpConsole) {
             return false;
         }
         auto& buffer = host->mpConsole->buffer;
+        QString all;
+        for (int i = 0; i <= buffer.getLastLineNumber(); ++i) {
+            all.append(buffer.line(i));
+            all.append(QChar::Space);
+        }
+        return all.contains(substring);
+    }
+
+    bool waitForConsoleContains(Host* host, const QString& substring, int timeoutMs = 4000)
+    {
         return QTest::qWaitFor(
                 [&]() {
-                    QString all;
-                    for (int i = 0; i <= buffer.getLastLineNumber(); ++i) {
-                        all.append(buffer.line(i));
-                        all.append(QChar::Space);
-                    }
-                    return all.contains(substring);
+                    return consoleContains(host, substring);
                 },
                 timeoutMs);
+    }
+
+    void removeBlockingCredentialDirectory()
+    {
+        QDir blockedCredential(reconnectCredentialPath(mHostname));
+        if (blockedCredential.exists()) {
+            blockedCredential.removeRecursively();
+        }
+    }
+
+    // Where the file-backed credential store files this profile's reconnect entry. Blocking that exact
+    // path is how a test makes a save fail; see testAFailedSaveIsNotAnnouncedAsASuccess.
+    static QString reconnectCredentialPath(const QString& profileName)
+    {
+        return qsl("%1/profiles/%2/passwords/%3")
+                .arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), utils::sanitizeForPath(profileName), utils::sanitizeForPath(qsl("reconnect")));
     }
 
     static QString describe(const QJsonObject& obj) { return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)); }


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Char.Login.Token`'s `secure_only` is parsed in all three encodings the standard permits, defaulted from the transport the token arrived on when absent or undecodable, stored with the token, and enforced when it is replayed — so a token a game marks replayable in the clear is used there, while one earned over TLS is never spent in the clear unless the game says so. A value in no permitted form is treated as absent and logged, so a server operator can find out their serialiser emits something no client can read.
- Mudlet sends `token_storage`, telling a game whether a reconnect token it mints will actually be kept, so it only offers to remember a player when it can honor the offer. It rides on the version 2 interactive hand-off — the message with no `account`, not a literally empty object — which reaches the game before it writes its sign-in screen. A version 1 hand-off stays `{}`.
- The "you'll be signed in automatically next time" notice is posted only once the save has actually landed, from the credential store's own callback, and points at Privacy and security, where the "Forget saved sign-in" control lives.

#### Motivation for adding to Mudlet

On a game served over plain telnet, "remember me" cannot work at all: the player is asked whether to stay signed in, says yes, the token is stored — and every later connection asks for the password again.

#### Other info (issues closed, discussion etc)

Closes #10585, closes #10563. Standard: [Standards:GMCP_Authentication](https://wiki.mudlet.org/w/Standards:GMCP_Authentication). Server-side counterpart: StickMUD/StickMUD#2496.

A stored entry whose transport requirement is missing or unreadable is read strictly, so upgrading never widens the exposure of a token already on disk; it gains the field on the next rotation.

Some longer-standing weaknesses in reconnect-token storage are left alone here and tracked in #10587: unserialised concurrent writes, unscrubbed token copies, and a store-failure warning that a later success can overtake.

**Test case:** Connect to a `Char.Login` 2 game over plain `telnet://`, sign in, and accept the game's offer to stay signed in. Disconnect and reconnect — the profile signs in via `Char.Login.Reconnect` with no password prompt. Over `telnets://`, a token minted without `secure_only` is still refused on a later cleartext connection. `ctest -R GMCPCharLoginTest` covers both, 61 cases.

Assisted-by: Claude:claude-opus-5