### PR TITLE
Infra: Speed up Claude Code on the web session startup

### DIFF
--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -152,13 +152,8 @@ apt dependencies, Qt 6.9.0 via aqtinstall under `/opt/qt` (Ubuntu's packaged Qt 
 than the 6.8.2 minimum), the Lua rocks, submodules, and a CMake configure of the
 `linux-debug-nosan` preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the
 documented preset commands work unchanged. It takes ~3 minutes on a cold container and seconds
-on a warm one.
-
-The hook deliberately compiles nothing. It is killed at a hard 10-minute timeout, and only a
-hook that *completes* gets its container state cached — so a warm-up build large enough to be
-worth having is also large enough to abort the hook and throw away the apt and Qt caching with
-it. Budget for a cold ccache instead: the first full build of a session costs ~18 minutes on
-the 4 cores these containers get, and only sessions that actually build pay it.
+on a warm one. ccache starts cold, so budget ~18 minutes for the first full build of a session
+on the 4 cores these containers get.
 
 The hook also pre-configures `build-linux-debug-nosan/` with `-DUSE_ALTERNATE_LINKER=mold`:
 linking is the bulk of a rebuild and mold shrinks it dramatically (PR #9927 measured a CI

--- a/.agents/skills/build-mudlet/SKILL.md
+++ b/.agents/skills/build-mudlet/SKILL.md
@@ -149,13 +149,19 @@ binary under `build-<preset-name>/` instead. Allow up to 10 minutes for a full b
 
 The `.claude/hooks/session-start.sh` SessionStart hook provisions the remote Ubuntu container:
 apt dependencies, Qt 6.9.0 via aqtinstall under `/opt/qt` (Ubuntu's packaged Qt 6.4 is older
-than the 6.8.2 minimum), submodules, and a ccache warm-up build of the `linux-debug-nosan`
-preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the documented preset
-commands work unchanged. On a warm container the hook finishes in seconds and a full build is
-mostly ccache hits — measured 5m25s wall for all targets at 99% hit rate, most of it linking —
-versus ~25 minutes cold. If the container cache is cold the hook itself takes ~30 minutes, once.
+than the 6.8.2 minimum), the Lua rocks, submodules, and a CMake configure of the
+`linux-debug-nosan` preset. The hook exports `CMAKE_PREFIX_PATH` pointing at the aqt Qt, so the
+documented preset commands work unchanged. It takes ~3 minutes on a cold container and seconds
+on a warm one.
+
+The hook deliberately compiles nothing. It is killed at a hard 10-minute timeout, and only a
+hook that *completes* gets its container state cached — so a warm-up build large enough to be
+worth having is also large enough to abort the hook and throw away the apt and Qt caching with
+it. Budget for a cold ccache instead: the first full build of a session costs ~18 minutes on
+the 4 cores these containers get, and only sessions that actually build pay it.
+
 The hook also pre-configures `build-linux-debug-nosan/` with `-DUSE_ALTERNATE_LINKER=mold`:
-linking is the bulk of a warm rebuild and mold shrinks it dramatically (PR #9927 measured a CI
+linking is the bulk of a rebuild and mold shrinks it dramatically (PR #9927 measured a CI
 link tail of 4m13s → 29s). Keep that flag if you reconfigure the tree from scratch.
 Run Mudlet headlessly there with `QT_QPA_PLATFORM=offscreen`.
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,10 +2,19 @@
 # SessionStart hook for Claude Code on the web: provision everything needed to
 # compile Mudlet natively on the Ubuntu 24.04 session container.
 #
-# The container filesystem is cached after this hook completes, so the
-# expensive steps (apt, Qt download, ccache warm-up build) only run when the
-# cache is cold; on a warm container every step short-circuits and the hook
-# finishes in well under a minute.
+# The container filesystem is cached after this hook *completes*, so the
+# expensive steps (apt, Qt download, luarocks) only run when the cache is
+# cold; on a warm container every step short-circuits and the hook finishes
+# in well under a minute.
+#
+# That word "completes" is load-bearing, and it is why nothing here compiles
+# Mudlet. The hook is killed at a hard 10-minute timeout, a full debug build
+# takes ~18 minutes on the 4 cores these containers get, and a hook killed
+# mid-build exits non-zero, so *no* container state is cached - forfeiting
+# the cheap apt/Qt caching to chase the expensive ccache one, and leaving
+# every session to pay the same 10 idle minutes over again. Keep this hook
+# comfortably inside the budget: ccache is left to warm up naturally from
+# whatever the session itself builds.
 set -euo pipefail
 
 # Local checkouts (desktop/CLI) manage their own toolchain - do nothing there.
@@ -169,21 +178,10 @@ if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
   git -C "${CLAUDE_PROJECT_DIR}" submodule update --init --recursive
 
   # Configure the default tree every session (cheap) so it already exists
-  # with Qt and the mold linker wired in - linking dominates a warm rebuild,
-  # and mold cuts the link tail dramatically (see PR #9927; until its
-  # top-level set_alternate_linker() move merges, the flag only reaches the
-  # main mudlet binary, afterwards every target).
+  # with Qt and the mold linker wired in - linking dominates a rebuild, and
+  # mold cuts the link tail dramatically (see PR #9927; until its top-level
+  # set_alternate_linker() move merges, the flag only reaches the main mudlet
+  # binary, afterwards every target).
   cd "${CLAUDE_PROJECT_DIR}"
   cmake --preset linux-debug-nosan -DCMAKE_PREFIX_PATH="${QT_DIR}" -DUSE_ALTERNATE_LINKER=mold
-
-  # Warm the compiler cache once per container image. CMakeLists.txt wires
-  # ccache in automatically, so this one cold build (~20 min) makes every
-  # later session's build mostly cache hits (a few minutes including linking).
-  # The build tree itself is discarded with the session; only ccache persists.
-  CCACHE_DIR_PATH="$(ccache -k cache_dir 2>/dev/null || echo "${HOME}/.cache/ccache")"
-  CACHE_KB="$(du -sk "${CCACHE_DIR_PATH}" 2>/dev/null | cut -f1 || echo 0)"
-  if [ "${CACHE_KB:-0}" -lt 102400 ]; then
-    echo "Cold ccache - running warm-up build..."
-    cmake --build --preset linux-debug-nosan
-  fi
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,19 +2,10 @@
 # SessionStart hook for Claude Code on the web: provision everything needed to
 # compile Mudlet natively on the Ubuntu 24.04 session container.
 #
-# The container filesystem is cached after this hook *completes*, so the
+# The container filesystem is cached after this hook completes, so the
 # expensive steps (apt, Qt download, luarocks) only run when the cache is
 # cold; on a warm container every step short-circuits and the hook finishes
 # in well under a minute.
-#
-# That word "completes" is load-bearing, and it is why nothing here compiles
-# Mudlet. The hook is killed at a hard 10-minute timeout, a full debug build
-# takes ~18 minutes on the 4 cores these containers get, and a hook killed
-# mid-build exits non-zero, so *no* container state is cached - forfeiting
-# the cheap apt/Qt caching to chase the expensive ccache one, and leaving
-# every session to pay the same 10 idle minutes over again. Keep this hook
-# comfortably inside the budget: ccache is left to warm up naturally from
-# whatever the session itself builds.
 set -euo pipefail
 
 # Local checkouts (desktop/CLI) manage their own toolchain - do nothing there.


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The Claude Code on the web SessionStart hook no longer runs a ccache warm-up build; it now
  finishes after apt, Qt, the Lua rocks, submodules and a CMake configure.
- Drops the guard that treated any ccache over 100 MiB as warm — a build killed at the hook
  timeout leaves ~174 MiB behind, so a 46%-populated cache already counted as warm.
- Updates the `build-mudlet` skill to match.

#### Motivation for adding to Mudlet

The hook is killed at a hard 10-minute timeout while a full debug build takes ~18 minutes on the
4 cores these containers get, so the warm-up was cut off halfway every time — and since container
state is only cached when the hook exits cleanly, that non-zero exit also threw away the apt, Qt
and luarocks work, leaving every session to pay 10 idle minutes and then start cold regardless.

#### Other info (issues closed, discussion etc)

Measured on a session container, before and after:

|  | Before | After |
| --- | --- | --- |
| Hook exit code | `1`, aborted at 600,006 ms | `0` |
| Hook, warm container | never reached | 3.9s |
| Hook, cold container | 10 min, then killed | ~3 min |
| Container state cached | no | yes |

ccache now warms naturally from whatever a session itself builds, so only sessions that compile
pay for a build and sessions that only touch Lua specs or docs pay nothing.

**Test case:** start a fresh Claude Code on the web session on this branch — it should reach a
prompt in about three minutes rather than sitting for ten. Verify the hook exits cleanly with
`CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR=$PWD bash .claude/hooks/session-start.sh; echo $?`.
Then start a second session and check `stat -c %y /opt/qt` predates it, confirming the container
state was cached.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvqDjjcFdJy7ybkB1GmfCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvqDjjcFdJy7ybkB1GmfCo)_