### PR TITLE
fix: an attached container's border follows its own edge drag

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -298,7 +298,6 @@ function Adjustable.Container:onMove (label, event)
     end
 
     if adjustInfo.x and adjustInfo.name == label.name then
-        self:adjustBorder()
         local x, y = getMousePosition()
         local winw, winh = getMainWindowSize()
         local x1, y1, w, h = self.get_x(), self.get_y(), self:get_width(), self:get_height()
@@ -369,6 +368,8 @@ function Adjustable.Container:onMove (label, event)
                 self:adjustConnectedContainers()
             end
         end
+        -- measured after the drag applies, not before: the border is the container's own size
+        self:adjustBorder()
         adjustInfo.x, adjustInfo.y = x, y
     end
 end

--- a/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
+++ b/src/mudlet-lua/tests/GeyserAdjustableContainer_spec.lua
@@ -647,6 +647,44 @@ describe("Tests the Adjustable.Container mouse handlers", function()
       -- the mouse did not move, so the left edge it grabbed stays where it was
       assert.is_true(math.abs(container:get_width() - 200) <= 1)
     end)
+
+    -- the border an attached container reserves is the container's own size, so
+    -- it has to be measured from the geometry the drag applied and not from the
+    -- geometry that drag replaced
+    it("leaves the border matching the size the drag just applied", function()
+      local topBefore = getBorderTop()
+      finally(function() setBorderTop(topBefore) end)
+      -- resizeBorder arms a timer on the resize event that setBorder raises, and
+      -- nothing keeps its id, so it would fire on a deleted container later
+      local realTempTimer = tempTimer
+      _G.tempTimer = function() return -1 end
+      finally(function() _G.tempTimer = realTempTimer end)
+
+      container:move(0, 0)
+      container:attachToBorder("top")
+
+      -- adjust_Info reads the grabbed edge from the pointer against the label,
+      -- so a click within ten pixels of the bottom takes the bottom edge
+      local grabY = container:get_height() - 5
+      local pointerY = 300
+      local realMousePosition = getMousePosition
+      _G.getMousePosition = function() return 100, pointerY end
+      finally(function() _G.getMousePosition = realMousePosition end)
+
+      container:onClick(container.adjLabel, mouseEvent("LeftButton", 5, grabY))
+      container:onClick(container.adjLabel, mouseEvent("LeftButton", 5, grabY))
+      -- the drag pulls the bottom edge thirty pixels further down
+      pointerY = pointerY + 30
+      container:onMove(container.adjLabel, mouseEvent("LeftButton", 5, grabY))
+
+      assert.are.equal("top", container.attached)
+      -- the drag stores the height as a percentage, so it comes back as a
+      -- fraction of a pixel and setBorderTop takes the whole part of it
+      local reserved = container:get_height() + container:get_y() + container.attachedMargin
+      assert.are.equal(math.floor(reserved), getBorderTop())
+      -- and it really did follow the drag: the height it replaced was 200
+      assert.is_true(container:get_height() > 200)
+    end)
   end)
 
   describe("Adjustable.Container:onClickL", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `Adjustable.Container:onMove` measured the main window border *before* applying the geometry the drag had just worked out, so the border was left one mouse move behind the container - and was never corrected on release either.
- One call moved, from the top of the drag handler to the end of it. No API change, no signature change, no new function.

#### Motivation for adding to Mudlet

Drag an attached container's edge and release while the pointer is still moving. The border stays where the drag was one event ago, and because it is too *small* the console's text area runs up underneath the container and clips the top line - which stays clipped until something else triggers a resize.

The error is exactly the final mouse move's distance, which is pointer travel divided by the events delivered. On a local session at 60-120Hz that measured 0 to 12px over repeated fast releases, usually 0 - and 12px is around half a line of console text on a 22px row. It scales up wherever mouse events arrive more sparsely, such as a loaded machine or a remote or screen-shared session, since the same travel then arrives in fewer, larger steps. After the patch the error is 0px in every case.

#### Other info (issues closed, discussion etc)

Fixes #10593

**What scripts can see, measured.** The only script-visible surface here is the
`AdjustableContainerReposition` event, and it is effectively unchanged. Raises per
mouse move across a five-event drag:

```
before   1,2,2,2,2
after    2,2,2,2,2
```

One extra raise, on the first mouse move of a drag, and nothing else - the steady
state is identical. Payloads are identical on both sides too
(`w=199 h=229 y=0 dragging=true`). That extra raise is not spurious: before the
patch the first mouse move never changed the border at all, so `Host::setBorders`
returned early and raised nothing. Which is the bug, restated.

**The other two differences are small and in the intended direction.**
`adjustBorder` detaches a container dragged out of reach of its border, and it now
judges that from where the drag put the container rather than from where it was, so
a detach lands one mouse move sooner. The threshold is untouched - still 20% of the
window - and a real drag cannot leave the zone and return within a single event.
Separately, with connected containers the last `setBorder*` writer is now this
container with its peers freshly measured, where before it was a peer using this
container's stale figure.

**What it deliberately does not touch.** No constraint arithmetic. `make_percent`
still stores at five decimal places, and 50 alternating drag events leave the height
constraint byte identical (`36.49635%` before and after), so nothing drifts. The
truncation in `setBorderTop` is also left alone - it accounts for a residual 1px
when a percentage-stored height lands just under a whole pixel, and rounding it
instead would be a separate change with its own risks.

**Test case:** attach a container to a border, fill the console with text, then drag the container's edge quickly and release while the pointer is still moving. Before, the top line of console text is partly hidden under the container and stays hidden until you nudge the window edge; after, it is not. `Adjustable.Container:onMove` gains a spec that drives the real handler with the pointer stubbed and asserts the border matches the size the drag applied - it fails on `development` with the pre-drag reservation.

*Written with AI assistance. Assisted-by: Claude:claude-opus-5*
