### PR TITLE
Improve: Scripts are told when mute and other settings change

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4364,6 +4364,56 @@ void Host::setDebugShowAllProblemCodepoints(const bool state)
     }
 }
 
+void Host::raiseSettingChangedEvent(const QString& settingName, const bool value)
+{
+    // The profile's own file is read before the console exists, so a value arriving from it is not a change to report:
+    if (!mpConsole) {
+        return;
+    }
+
+    TEvent event{};
+    event.mArgumentList.append(qsl("sysSettingChanged"));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(settingName);
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(value ? qsl("1") : qsl("0"));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
+    raiseEvent(event);
+}
+
+bool Host::changeSetting(bool& setting, const bool state, const QString& settingName)
+{
+    if (setting == state) {
+        return false;
+    }
+    setting = state;
+    raiseSettingChangedEvent(settingName, state);
+    return true;
+}
+
+bool Host::setEnableClosedCaption(const bool state)
+{
+    return changeSetting(mEnableClosedCaption, state, qsl("enableClosedCaption"));
+}
+
+bool Host::setAdvertiseScreenReader(const bool state)
+{
+    return changeSetting(mAdvertiseScreenReader, state, qsl("advertiseScreenReader"));
+}
+
+bool Host::setAnnounceIncomingText(const bool state)
+{
+    return changeSetting(mAnnounceIncomingText, state, qsl("announceIncomingText"));
+}
+
+void Host::setMapperPanelVisible(const bool state)
+{
+    if (mpMap && mpMap->mpMapper) {
+        mpMap->mpMapper->slot_setMapperPanelVisible(state);
+    }
+    changeSetting(mShowPanel, state, qsl("mapperPanelVisible"));
+}
+
 void Host::setCompactInputLine(const bool state)
 {
     if (mCompactInputLine != state) {
@@ -4375,6 +4425,7 @@ void Host::setCompactInputLine(const bool state)
         if (mpConsole && mpConsole->mpButtonMainLayer) {
             mpConsole->mpButtonMainLayer->setVisible(!state);
         }
+        raiseSettingChangedEvent(qsl("compactInputLine"), state);
     }
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -4381,29 +4381,37 @@ void Host::raiseSettingChangedEvent(const QString& settingName, const bool value
     raiseEvent(event);
 }
 
-bool Host::changeSetting(bool& setting, const bool state, const QString& settingName)
+void Host::changeSetting(bool& setting, const bool state, const QString& settingName)
 {
     if (setting == state) {
-        return false;
+        return;
     }
     setting = state;
     raiseSettingChangedEvent(settingName, state);
-    return true;
 }
 
-bool Host::setEnableClosedCaption(const bool state)
+void Host::setEnableClosedCaption(const bool state)
 {
-    return changeSetting(mEnableClosedCaption, state, qsl("enableClosedCaption"));
+    changeSetting(mEnableClosedCaption, state, qsl("enableClosedCaption"));
 }
 
-bool Host::setAdvertiseScreenReader(const bool state)
+void Host::setAdvertiseScreenReader(const bool state)
 {
-    return changeSetting(mAdvertiseScreenReader, state, qsl("advertiseScreenReader"));
+    if (mAdvertiseScreenReader == state) {
+        return;
+    }
+    mAdvertiseScreenReader = state;
+    // The game hears about it before the scripts do, so a handler that writes
+    // the value back leaves it informed of the final value by the nested call
+    // rather than of a value that no longer holds:
+    mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
+    mTelnet.sendInfoNewEnvironValue(qsl("MTTS"));
+    raiseSettingChangedEvent(qsl("advertiseScreenReader"), state);
 }
 
-bool Host::setAnnounceIncomingText(const bool state)
+void Host::setAnnounceIncomingText(const bool state)
 {
-    return changeSetting(mAnnounceIncomingText, state, qsl("announceIncomingText"));
+    changeSetting(mAnnounceIncomingText, state, qsl("announceIncomingText"));
 }
 
 void Host::setMapperPanelVisible(const bool state)

--- a/src/Host.h
+++ b/src/Host.h
@@ -479,9 +479,9 @@ public:
     // Only ever raised for a setting that really changed, or a handler that
     // writes the value back through setConfig() would loop.
     void raiseSettingChangedEvent(const QString& settingName, const bool value);
-    bool setEnableClosedCaption(const bool state);
-    bool setAdvertiseScreenReader(const bool state);
-    bool setAnnounceIncomingText(const bool state);
+    void setEnableClosedCaption(const bool state);
+    void setAdvertiseScreenReader(const bool state);
+    void setAnnounceIncomingText(const bool state);
     void setMapperPanelVisible(const bool state);
     QPointer<TConsole> findConsole(QString name);
 
@@ -1012,9 +1012,8 @@ private slots:
     void slot_saveProfileAfterPackageChange();
 
 private:
-    // Stores a boolean setting and tells scripts about it, reporting whether it
-    // was a change at all.
-    bool changeSetting(bool& setting, const bool state, const QString& settingName);
+    // Stores a boolean setting and tells scripts about it.
+    void changeSetting(bool& setting, const bool state, const QString& settingName);
     void setBorders(const QMargins);
     void installPackageFonts(const QString& packageName);
     void processGMCPDiscordStatus(const QJsonObject& discordInfo);

--- a/src/Host.h
+++ b/src/Host.h
@@ -476,6 +476,13 @@ public:
     bool debugShowAllProblemCodepoints() const { return mDebugShowAllProblemCodepoints; }
     void setCompactInputLine(const bool state);
     bool getCompactInputLine() const { return mCompactInputLine; }
+    // Only ever raised for a setting that really changed, or a handler that
+    // writes the value back through setConfig() would loop.
+    void raiseSettingChangedEvent(const QString& settingName, const bool value);
+    bool setEnableClosedCaption(const bool state);
+    bool setAdvertiseScreenReader(const bool state);
+    bool setAnnounceIncomingText(const bool state);
+    void setMapperPanelVisible(const bool state);
     QPointer<TConsole> findConsole(QString name);
 
     QPair<bool, QStringList> getLines(const QString& windowName, const int lineFrom, const int lineTo);
@@ -1005,6 +1012,9 @@ private slots:
     void slot_saveProfileAfterPackageChange();
 
 private:
+    // Stores a boolean setting and tells scripts about it, reporting whether it
+    // was a change at all.
+    bool changeSetting(bool& setting, const bool state, const QString& settingName);
     void setBorders(const QMargins);
     void installPackageFonts(const QString& packageName);
     void processGMCPDiscordStatus(const QJsonObject& discordInfo);

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -61,6 +61,8 @@ public:
     Iter begin() { return Iter(this, true); }
     Iter end() { return Iter(this, false); }
     bool hostLoaded(const QString& hostname) const;
+    // A copy to walk while doing anything that may open or close a profile
+    QList<QSharedPointer<Host>> hostList() const { return mHostPool.values(); }
 
 private:
     HostMap mHostPool;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8100,10 +8100,6 @@ int TLuaInterpreter::setConfig(lua_State* L)
             return success();
         }
 #endif
-        if (key == qsl("mapperPanelVisible")) {
-            host.mpMap->mpMapper->slot_setMapperPanelVisible(getVerifiedBool(L, __func__, 2, "value"));
-            return success();
-        }
         if (key == qsl("mapShowRoomBorders")) {
             host.mMapperShowRoomBorders = getVerifiedBool(L, __func__, 2, "value");
             return success();
@@ -8397,10 +8393,11 @@ int TLuaInterpreter::setConfig(lua_State* L)
     }
 
     if (key == qsl("compactInputLine")) {
-        const bool value = getVerifiedBool(L, __func__, 2, "value");
-        host.setCompactInputLine(value);
+        host.setCompactInputLine(getVerifiedBool(L, __func__, 2, "value"));
         if (currentHost) {
-            mudlet::self()->dactionInputLine->setChecked(value);
+            // A handler of the event the setter raised may have written the
+            // opposite value back, so the menu item follows what is held now:
+            mudlet::self()->dactionInputLine->setChecked(host.getCompactInputLine());
         }
 
         return success();
@@ -8409,16 +8406,20 @@ int TLuaInterpreter::setConfig(lua_State* L)
         host.mEditorAutoComplete = getVerifiedBool(L, __func__, 2, "value");
         return success();
     }
+    if (key == qsl("mapperPanelVisible")) {
+        host.setMapperPanelVisible(getVerifiedBool(L, __func__, 2, "value"));
+        return success();
+    }
     if (key == qsl("announceIncomingText")) {
-        host.mAnnounceIncomingText = getVerifiedBool(L, __func__, 2, "value");
+        host.setAnnounceIncomingText(getVerifiedBool(L, __func__, 2, "value"));
         return success();
     }
     if (key == qsl("advertiseScreenReader")) {
-        host.mAdvertiseScreenReader = getVerifiedBool(L, __func__, 2, "value");
+        host.setAdvertiseScreenReader(getVerifiedBool(L, __func__, 2, "value"));
         return success();
     }
     if (key == qsl("enableClosedCaption")) {
-        host.mEnableClosedCaption = getVerifiedBool(L, __func__, 2, "value");
+        host.setEnableClosedCaption(getVerifiedBool(L, __func__, 2, "value"));
         return success();
     }
     if (key == qsl("blankLinesBehaviour")) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -508,7 +508,11 @@ void dlgMapper::slot_togglePanel()
 {
     // The host holds the setting; widget_panel->isVisible() is also false while
     // the whole map dock is hidden, which would make this a no-op:
-    mpHost->setMapperPanelVisible(!mpHost->mShowPanel);
+    const bool show = !mpHost->mShowPanel;
+    // This widget is not necessarily the one the host knows as mpMap->mpMapper,
+    // which is all the setter pushes the change to:
+    slot_setMapperPanelVisible(show);
+    mpHost->setMapperPanelVisible(show);
 }
 
 void dlgMapper::slot_setMapperPanelVisible(bool panelVisible)

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -506,13 +506,14 @@ void dlgMapper::slot_toggleStrongHighlight(int toggle)
 
 void dlgMapper::slot_togglePanel()
 {
-    dlgMapper::slot_setMapperPanelVisible(!widget_panel->isVisible());
+    // The host holds the setting; widget_panel->isVisible() is also false while
+    // the whole map dock is hidden, which would make this a no-op:
+    mpHost->setMapperPanelVisible(!mpHost->mShowPanel);
 }
 
 void dlgMapper::slot_setMapperPanelVisible(bool panelVisible)
 {
     widget_panel->setVisible(panelVisible);
-    mpHost->mShowPanel = panelVisible;
 }
 
 void dlgMapper::slot_toggle3DView(const bool is3DMode)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -6833,16 +6833,16 @@ void dlgProfilePreferences::applyAll()
             pHost->mMMCPShowSnoopInMainConsole = checkBox_mmcpSnoopInMainConsole->isChecked();
         }
         if (mSnapshot.dirty(checkBox_announceIncomingText)) {
-            pHost->mAnnounceIncomingText = checkBox_announceIncomingText->isChecked();
+            pHost->setAnnounceIncomingText(checkBox_announceIncomingText->isChecked());
         }
         if (mSnapshot.dirty(checkBox_advertiseScreenReader)) {
-            pHost->mAdvertiseScreenReader = checkBox_advertiseScreenReader->isChecked();
+            pHost->setAdvertiseScreenReader(checkBox_advertiseScreenReader->isChecked());
         }
         if (mSnapshot.dirty(checkBox_enableOSC8Hyperlinks)) {
             pHost->mEnableOSC8Hyperlinks = checkBox_enableOSC8Hyperlinks->isChecked();
         }
         if (mSnapshot.dirty(checkBox_enableClosedCaption)) {
-            pHost->mEnableClosedCaption = checkBox_enableClosedCaption->isChecked();
+            pHost->setEnableClosedCaption(checkBox_enableClosedCaption->isChecked());
         }
 
         if (mSnapshot.dirty(checkBox_expectCSpaceIdInColonLessMColorCode)) {
@@ -8473,8 +8473,7 @@ void dlgProfilePreferences::slot_toggleAdvertiseScreenReader(const bool state)
         return;
     }
 
-    if (pHost->mAdvertiseScreenReader != state) {
-        pHost->mAdvertiseScreenReader = state;
+    if (pHost->setAdvertiseScreenReader(state)) {
         pHost->mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
         pHost->mTelnet.sendInfoNewEnvironValue(qsl("MTTS"));
     }
@@ -8496,8 +8495,8 @@ void dlgProfilePreferences::slot_toggleEnableOSC8Hyperlinks(const bool state)
 
 void dlgProfilePreferences::slot_toggleEnableClosedCaption(const bool state)
 {
-    if (mpHost && mpHost->mEnableClosedCaption != state) {
-        mpHost->mEnableClosedCaption = state;
+    if (mpHost) {
+        mpHost->setEnableClosedCaption(state);
     }
 }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -6832,17 +6832,8 @@ void dlgProfilePreferences::applyAll()
         if (mSnapshot.dirty(checkBox_mmcpSnoopInMainConsole)) {
             pHost->mMMCPShowSnoopInMainConsole = checkBox_mmcpSnoopInMainConsole->isChecked();
         }
-        if (mSnapshot.dirty(checkBox_announceIncomingText)) {
-            pHost->setAnnounceIncomingText(checkBox_announceIncomingText->isChecked());
-        }
-        if (mSnapshot.dirty(checkBox_advertiseScreenReader)) {
-            pHost->setAdvertiseScreenReader(checkBox_advertiseScreenReader->isChecked());
-        }
         if (mSnapshot.dirty(checkBox_enableOSC8Hyperlinks)) {
             pHost->mEnableOSC8Hyperlinks = checkBox_enableOSC8Hyperlinks->isChecked();
-        }
-        if (mSnapshot.dirty(checkBox_enableClosedCaption)) {
-            pHost->setEnableClosedCaption(checkBox_enableClosedCaption->isChecked());
         }
 
         if (mSnapshot.dirty(checkBox_expectCSpaceIdInColonLessMColorCode)) {
@@ -6896,6 +6887,18 @@ void dlgProfilePreferences::applyAll()
                     it->second->swap(sequence);
                 }
             }
+        }
+
+        // Last, because these setters run script handlers synchronously, which
+        // may do anything to the Host this block is still writing to
+        if (mSnapshot.dirty(checkBox_announceIncomingText)) {
+            pHost->setAnnounceIncomingText(checkBox_announceIncomingText->isChecked());
+        }
+        if (mSnapshot.dirty(checkBox_advertiseScreenReader)) {
+            pHost->setAdvertiseScreenReader(checkBox_advertiseScreenReader->isChecked());
+        }
+        if (mSnapshot.dirty(checkBox_enableClosedCaption)) {
+            pHost->setEnableClosedCaption(checkBox_enableClosedCaption->isChecked());
         }
     }
 
@@ -8467,15 +8470,8 @@ void dlgProfilePreferences::slot_changeControlCharacterHandling()
 
 void dlgProfilePreferences::slot_toggleAdvertiseScreenReader(const bool state)
 {
-    Host* pHost = mpHost;
-
-    if (!pHost) {
-        return;
-    }
-
-    if (pHost->setAdvertiseScreenReader(state)) {
-        pHost->mTelnet.sendInfoNewEnvironValue(qsl("SCREEN_READER"));
-        pHost->mTelnet.sendInfoNewEnvironValue(qsl("MTTS"));
+    if (mpHost) {
+        mpHost->setAdvertiseScreenReader(state);
     }
 }
 

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -1333,6 +1333,93 @@ describe("Tests Other.lua functions", function()
     -- actually rejected (#10391)
     pending("names the key it rejected in every string enum refusal")
 
+    -- A setting that changed raises sysSettingChanged with its getConfig key
+    -- and the new value. Writing the value a setting already holds raises
+    -- nothing, which is what keeps a handler that echoes the value back
+    -- through setConfig from looping.
+    describe("sysSettingChanged", function()
+      -- Each entry keeps what the handler was handed plus what getConfig()
+      -- returned from inside the handler: the second one is what says the
+      -- setting was already updated when the event went out. The handler is
+      -- killed by the caller's own finally(), because busted keeps only one of
+      -- those per test and the restore has to share it.
+      local function record()
+        local events = {}
+        local id = registerAnonymousEventHandler("sysSettingChanged", function(_, key, value)
+          events[#events + 1] = {key = key, value = value, readBack = getConfig(key)}
+        end)
+        return events, function() killAnonymousEventHandler(id) end
+      end
+
+      local function assertOneEvent(events, key, value)
+        assert.equals(1, #events, "expected one sysSettingChanged for " .. key .. ", got " .. #events)
+        assert.equals(key, events[1].key)
+        assert.equals(value, events[1].value, "the event carried " .. tostring(events[1].value) .. " for " .. key)
+        assert.equals(value, events[1].readBack, "getConfig(\"" .. key .. "\") inside the handler did not read the new value")
+      end
+
+      local booleanKeys = {
+        "muteMediaAPI",
+        "muteMediaGame",
+        "compactInputLine",
+        "mapperPanelVisible",
+        "enableClosedCaption",
+        "advertiseScreenReader",
+        "announceIncomingText",
+      }
+
+      for _, key in ipairs(booleanKeys) do
+        it("raises once when " .. key .. " changes, and not when it is set to what it holds", function()
+          snapshot(key)
+          local events, kill = record()
+          finally(function()
+            kill()
+            restore(key)
+          end)
+
+          local target = not getConfig(key)
+
+          assert.is_true(setConfig(key, target))
+          assertOneEvent(events, key, target)
+
+          assert.is_true(setConfig(key, target))
+          assert.equals(1, #events, key .. " raised again for a value that did not change")
+        end)
+      end
+
+      -- A handler is allowed to write the value back. The second write is a
+      -- real change, so it raises in turn, and stops there because the third
+      -- write would not change anything.
+      it("lets a handler write the opposite value back without looping", function()
+        snapshot("muteMediaAPI")
+        setConfig("muteMediaAPI", false)
+
+        local events = {}
+        local vetoed = false
+        local id = registerAnonymousEventHandler("sysSettingChanged", function(_, key, value)
+          if key ~= "muteMediaAPI" then
+            return
+          end
+          events[#events + 1] = value
+          if value == true and not vetoed then
+            vetoed = true
+            setConfig("muteMediaAPI", false)
+          end
+        end)
+        finally(function()
+          killAnonymousEventHandler(id)
+          restore("muteMediaAPI")
+        end)
+
+        assert.is_true(setConfig("muteMediaAPI", true))
+
+        assert.is_false(getConfig("muteMediaAPI"), "the value the handler wrote back is not the one that stuck")
+        assert.equals(2, #events, "expected the change and the handler's write-back, got " .. #events)
+        assert.equals(true, events[1])
+        assert.equals(false, events[2])
+      end)
+    end)
+
     describe("experiment keys", function()
       -- The two rendering experiments are a group, of which at most one may be
       -- on. An experiment is written to the profile, so whichever one the group

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6208,6 +6208,10 @@ void mudlet::slot_multiView(const bool state)
 
 void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction, bool isAPINotGame, const QString& unmuteText, const QString& muteText)
 {
+    // Read before the flag below is assigned: the rest of this function runs
+    // either way, because it also re-syncs the actions with the flag
+    const bool changed = (isAPINotGame ? mMuteAPI : mMuteGame) != state;
+
     if (toolbarAction->isChecked() != state || menuAction->isChecked() != state) {
         toolbarAction->setChecked(state);
         menuAction->setChecked(state);
@@ -6275,6 +6279,21 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
             }
         }
     }
+
+    if (changed) {
+        // Muting is application-wide rather than per profile, so every open
+        // profile is told about it
+        const QString settingName = isAPINotGame ? qsl("muteMediaAPI") : qsl("muteMediaGame");
+        for (const auto& pHost : mHostManager) {
+            if ((isAPINotGame ? mMuteAPI : mMuteGame) != state) {
+                // A handler in an earlier profile wrote the opposite value
+                // back; that nested call already told every profile, so the
+                // rest of this loop would report a value nothing holds any more
+                break;
+            }
+            pHost->raiseSettingChangedEvent(settingName, state);
+        }
+    }
 }
 
 void mudlet::slot_muteAPI(const bool state)
@@ -6335,10 +6354,6 @@ void mudlet::slot_toggleCompactInputLine()
 // Called by the menu-item's action itself, that DOES pass the checked state:
 void mudlet::slot_compactInputLine(const bool state)
 {
-    if (dactionInputLine->isChecked() != state) {
-        // Ensure the menu item reflectes the actual state:
-        dactionInputLine->setChecked(state);
-    }
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
@@ -6349,6 +6364,12 @@ void mudlet::slot_compactInputLine(const bool state)
             mpCurrentActiveHost->postMessage(infoMsg);
             mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown = true;
         }
+    }
+    // Ensure the menu item reflects the actual state - a handler of the event
+    // the setter raised may have written the opposite value back:
+    const bool held = mpCurrentActiveHost ? mpCurrentActiveHost->getCompactInputLine() : state;
+    if (dactionInputLine->isChecked() != held) {
+        dactionInputLine->setChecked(held);
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6357,20 +6357,22 @@ void mudlet::slot_toggleCompactInputLine()
 // Called by the menu-item's action itself, that DOES pass the checked state:
 void mudlet::slot_compactInputLine(const bool state)
 {
-    if (mpCurrentActiveHost) {
-        mpCurrentActiveHost->setCompactInputLine(state);
+    // The setter runs the event handlers, which may close this profile, so the
+    // host is held and re-checked rather than read off the member each time:
+    QPointer<Host> pHost = mpCurrentActiveHost;
+    if (pHost) {
+        pHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
-        if (QKeySequence* shortcut = mpShortcutsManager->getSequence(qsl("Compact input line"));
-            state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
+        if (QKeySequence* shortcut = mpShortcutsManager->getSequence(qsl("Compact input line")); pHost && state && !pHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
             //: Here %1 will be replaced with the keyboard shortcut, default is ALT+L.
             const QString infoMsg = tr("[ INFO ]  - Compact input line set. Press \"%1\" to show bottom-right buttons again.").arg(shortcut->toString(QKeySequence::NativeText));
-            mpCurrentActiveHost->postMessage(infoMsg);
-            mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown = true;
+            pHost->postMessage(infoMsg);
+            pHost->mTutorialForCompactLineAlreadyShown = true;
         }
     }
     // Ensure the menu item reflects the actual state - a handler of the event
     // the setter raised may have written the opposite value back:
-    const bool held = mpCurrentActiveHost ? mpCurrentActiveHost->getCompactInputLine() : state;
+    const bool held = pHost ? pHost->getCompactInputLine() : state;
     if (dactionInputLine->isChecked() != held) {
         dactionInputLine->setChecked(held);
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6282,9 +6282,12 @@ void mudlet::toggleMute(bool state, QAction* toolbarAction, QAction* menuAction,
 
     if (changed) {
         // Muting is application-wide rather than per profile, so every open
-        // profile is told about it
+        // profile is told about it. The handlers run Lua synchronously and may
+        // open a profile, which inserts into the live host map, so this walks
+        // a copy the way HostManager's own broadcasts do:
         const QString settingName = isAPINotGame ? qsl("muteMediaAPI") : qsl("muteMediaGame");
-        for (const auto& pHost : mHostManager) {
+        const QList<QSharedPointer<Host>> hosts = mHostManager.hostList();
+        for (const auto& pHost : hosts) {
             if ((isAPINotGame ? mMuteAPI : mMuteGame) != state) {
                 // A handler in an earlier profile wrote the opposite value
                 // back; that nested call already told every profile, so the

--- a/test/functional_tests/SettingsRoundTripTest.cpp
+++ b/test/functional_tests/SettingsRoundTripTest.cpp
@@ -48,6 +48,7 @@
 #include "MMCP.h"
 #include "MudletInstanceCoordinator.h"
 #include "TConsole.h"
+#include "TLuaInterpreter.h"
 #include "TMap.h"
 #include "TelnetServerStub.h"
 #include "dlgProfilePreferences.h"
@@ -106,6 +107,31 @@ private:
         emit mpPreferences->lineEdit_mmcpPort->editingFinished();
         applyAndWait(applySpy);
         closePreferences();
+    }
+
+    bool runLua(const QString& code) const { return mpHost->getLuaInterpreter()->compileAndExecuteScript(code); }
+
+    int settingChangedCount(const char* key) const
+    {
+        lua_State* L = mpHost->getLuaInterpreter()->getLuaGlobalState();
+        lua_getglobal(L, "settingChangedCounts");
+        lua_getfield(L, -1, key);
+        const int count = lua_isnumber(L, -1) ? static_cast<int>(lua_tointeger(L, -1)) : 0;
+        lua_pop(L, 2);
+        return count;
+    }
+
+    // Lua type and value of the last event for that key, as "boolean:true";
+    // empty when no event ever arrived for it
+    QString settingChangedValue(const char* key) const
+    {
+        lua_State* L = mpHost->getLuaInterpreter()->getLuaGlobalState();
+        lua_getglobal(L, "settingChangedValues");
+        lua_getfield(L, -1, key);
+        const char* value = lua_tostring(L, -1);
+        const QString result = value ? QString::fromUtf8(value) : QString();
+        lua_pop(L, 2);
+        return result;
     }
 
     static bool comboItemEnabled(const QComboBox* pComboBox, const int row)
@@ -771,6 +797,55 @@ private slots:
         for (const ColorReset& reset : resets) {
             QVERIFY2(*reset.pColor == reset.expected, reset.name);
         }
+    }
+
+    // sysSettingChanged is what a script watches to follow a setting it does not
+    // own. A Lua spec can only reach setConfig; the dialog is the other writer,
+    // and it writes twice - the live slot as the box is ticked, then the
+    // debounced apply, which rewrites every control it finds dirty. The second
+    // write must not raise a second event.
+    void test_theAccessibilityCheckboxesEachRaiseOneSettingChangedEvent()
+    {
+        const bool priorClosedCaption = mpHost->mEnableClosedCaption;
+        const bool priorScreenReader = mpHost->mAdvertiseScreenReader;
+        const bool priorAnnounce = mpHost->mAnnounceIncomingText;
+        restoreLater([=, this]() {
+            mpHost->mEnableClosedCaption = priorClosedCaption;
+            mpHost->mAdvertiseScreenReader = priorScreenReader;
+            mpHost->mAnnounceIncomingText = priorAnnounce;
+        });
+
+        QVERIFY(runLua(qsl("settingChangedCounts = {}\n"
+                           "settingChangedValues = {}\n"
+                           "settingChangedHandler = registerAnonymousEventHandler('sysSettingChanged', function(_, key, value)\n"
+                           "  settingChangedCounts[key] = (settingChangedCounts[key] or 0) + 1\n"
+                           "  settingChangedValues[key] = type(value) .. ':' .. tostring(value)\n"
+                           "end)\n")));
+        restoreLater([this]() {
+            runLua(qsl("killAnonymousEventHandler(settingChangedHandler)"));
+        });
+
+        openPreferences();
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+
+        // Nothing spins the event loop between these three, so the debounce
+        // cannot have run by the time the counts below are read
+        mpPreferences->checkBox_enableClosedCaption->setChecked(!priorClosedCaption);
+        mpPreferences->checkBox_advertiseScreenReader->setChecked(!priorScreenReader);
+        mpPreferences->checkBox_announceIncomingText->setChecked(!priorAnnounce);
+
+        QCOMPARE(settingChangedCount("enableClosedCaption"), 1);
+        QCOMPARE(settingChangedValue("enableClosedCaption"), priorClosedCaption ? qsl("boolean:false") : qsl("boolean:true"));
+        QCOMPARE(settingChangedCount("advertiseScreenReader"), 1);
+        QCOMPARE(settingChangedValue("advertiseScreenReader"), priorScreenReader ? qsl("boolean:false") : qsl("boolean:true"));
+        QCOMPARE(settingChangedCount("announceIncomingText"), 0);
+
+        QVERIFY2(applyAndWait(applySpy), "the debounce never wrote the settings back");
+
+        QCOMPARE(settingChangedCount("announceIncomingText"), 1);
+        QCOMPARE(settingChangedValue("announceIncomingText"), priorAnnounce ? qsl("boolean:false") : qsl("boolean:true"));
+        QVERIFY2(settingChangedCount("enableClosedCaption") == 1, "the apply raised enableClosedCaption again for a value the live slot had already stored");
+        QVERIFY2(settingChangedCount("advertiseScreenReader") == 1, "the apply raised advertiseScreenReader again for a value the live slot had already stored");
     }
 };
 

--- a/test/functional_tests/TelnetNewEnvironTest.cpp
+++ b/test/functional_tests/TelnetNewEnvironTest.cpp
@@ -250,6 +250,29 @@ private:
         return EnvironVariable{};
     }
 
+    // The named variable out of every INFO captured since the last clear. One
+    // preference can stand behind several variables - the screen reader one is
+    // also a bit in MTTS - so each gets its own INFO and this looks across them
+    // rather than insisting on a single reply the way soleReplyVariables does.
+    EnvironVariable infoVariableNamed(const QByteArray& name, QString& problem)
+    {
+        problem.clear();
+        QList<EnvironVariable> updates;
+        const QList<Subnegotiation> replies = newEnvironReplies();
+        for (const Subnegotiation& reply : replies) {
+            if (reply.payload.isEmpty() || reply.payload.at(0) != NEW_ENVIRON_INFO) {
+                problem = qsl("a captured NEW_ENVIRON reply was not an INFO");
+                return {};
+            }
+            updates.append(variablesIn(reply.payload.mid(1)));
+        }
+        const EnvironVariable found = variableNamed(updates, name);
+        if (found.name.isEmpty()) {
+            problem = qsl("no INFO carried %1, out of %2 variable(s) in %3 reply(s)").arg(QString::fromUtf8(name), QString::number(updates.size()), QString::number(replies.size()));
+        }
+        return found;
+    }
+
 private slots:
     void initTestCase()
     {
@@ -648,6 +671,36 @@ private slots:
         QCOMPARE(updated.type, NEW_ENVIRON_USERVAR);
         QCOMPARE(updated.name, QByteArray("SCREEN_READER"));
         QCOMPARE(updated.value, QByteArray("1"));
+    }
+
+    // Telling the game is the setter's job, not each caller's: the preferences
+    // dialog, setConfig() from a script and anything added later all inform the
+    // game by storing the value, with no send of their own.
+    void test_theScreenReaderSetterInformsTheGameOnItsOwn()
+    {
+        enableNewEnviron();
+        requestSend({});
+        QCOMPARE(newEnvironReplies().size(), 1);
+
+        mpServer->forgetReceived();
+        mpHost->setAdvertiseScreenReader(true);
+
+        QString problem;
+        EnvironVariable screenReader = infoVariableNamed("SCREEN_READER", problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(screenReader.value, QByteArray("1"));
+
+        // Written the value it already holds, the setter has nothing to report,
+        // so the game is not handed an update that says nothing changed.
+        mpServer->forgetReceived();
+        mpHost->setAdvertiseScreenReader(true);
+        QVERIFY2(newEnvironReplies().isEmpty(), "an INFO went out for a value the setting already held");
+
+        mpServer->forgetReceived();
+        mpHost->setAdvertiseScreenReader(false);
+        screenReader = infoVariableNamed("SCREEN_READER", problem);
+        QVERIFY2(problem.isEmpty(), qPrintable(problem));
+        QCOMPARE(screenReader.value, QByteArray("0"));
     }
 
     // An INFO is only owed to a game that asked for the variable in the first


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `sysSettingChanged` now also fires, with the `getConfig` key and the new boolean, for `muteMediaAPI`, `muteMediaGame`, `compactInputLine`, `mapperPanelVisible`, `enableClosedCaption`, `advertiseScreenReader` and `announceIncomingText`. It fires only on a real change, after the value is stored (so `getConfig(key)` inside the handler already reads the new value), and never while a profile file is being loaded. The two mute keys are application-wide and are raised into every open profile.
- The three accessibility settings and the mapper panel get `Host` setters shared by `setConfig`, the Preferences dialog and the mapper's own toggle, so every entry point raises exactly once. `setConfig("mapperPanelVisible", ...)` now also works without a mapper open.
- A spec block in `Other_spec.lua` drives every key through `setConfig` and a handler that writes the value back; `SettingsRoundTripTest` covers the Preferences path a spec cannot reach. Both failed before the change.

#### Motivation for adding to Mudlet

A UI package with its own music player had no way to follow the toolbar Mute button, so its mute indicator went out of step with what the player actually heard. The same gap covered every other toggle on the toolbar and menus that a UI might mirror.

#### Other info (issues closed, discussion etc)

- Wiki: the `sysSettingChanged` entry needs the seven keys added, payload `(event, key, boolean)`.
- Handlers may write a value back through `setConfig`; the second write raises in turn and stops there, because a third write would not change anything.
- `setConfig("advertiseScreenReader", ...)` now also sends the SCREEN_READER and MTTS NEW-ENVIRON updates to a connected game, because the sends live in the Host setter. Before this only the Preferences checkbox sent them.

**Test case:** open a profile and paste

```lua
lua registerAnonymousEventHandler("sysSettingChanged", function(_, key, value) cecho("\n<cyan>sysSettingChanged " .. key .. " = " .. tostring(value) .. "\n") end)
```

Click the toolbar Mute button: two lines, `muteMediaAPI = true` and `muteMediaGame = true`. Click it again: both `false`. Alt+L prints `compactInputLine`, the mapper's panel button prints `mapperPanelVisible`, and ticking "closed captions" in Preferences prints `enableClosedCaption` exactly once.

Assisted-by: Claude:claude-fable-5-1
