### PR TITLE
Infra: stop the NAWS width test failing pull requests that did not touch it

### DIFF
--- a/test/functional_tests/NawsWidthReportTest.cpp
+++ b/test/functional_tests/NawsWidthReportTest.cpp
@@ -256,6 +256,7 @@ private slots:
     // the game, so it has to be reported - and reported once.
     void showingTheTimestampGutterReportsTheColumnsItTakes()
     {
+        settle(800ms);
         QVERIFY(!mpHost->mpConsole->showTimeStamps());
         const int withoutGutter = reportableWidth(mpHost);
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `NawsWidthReportTest::showingTheTimestampGutterReportsTheColumnsItTakes()` now settles before it
  reads a width and clears the recorded NAWS updates, which is what the other five cases in the
  file already do.

#### Motivation for adding to Mudlet

The case fails intermittently on loaded CI runners, and since it is a shared functional test the
red leg lands on whichever pull request happens to be running - right now #10594, whose whole
change is two lines of Lua in `GeyserAdjustableContainer.lua`, and #10549, which reworks the
telnet decoder. Neither can reach this test, so both are carrying a failure they did not cause.

#### Other info (issues closed, discussion etc)

Fixes #10603.

The case reads `reportableWidth()` and calls `clearNawsUpdates()` with no preceding `settle()`,
and it is the only one of the six that does. `cleanup()` allows 600 ms between cases, which is
enough on an idle machine; when it is not, the previous case is still in flight and the assertion
can go wrong at either end. **The observation** breaks when a report emitted before the clear
arrives after it, giving two updates where one is expected - the CI signature,
`NAWS updates: [74x34, 61x34]`. **The expectation** breaks when `reportableWidth()` reads a window
that has not settled, so the gutter is subtracted from the wrong number - which is how it fails
locally under the reproduction below, `Actual: 61  Expected: 87`, where 61 was the correct report
for a 74-column window and 87 came from reading 100.

Present since the case was added in #10490 (`ea7fe237f`); it has never had that settle, so this is
an oversight rather than a regression.

**The product code is not implicated,** which is worth stating because the CI signature invites the
opposite conclusion. 74 and 61 are both widths the window genuinely had, so reporting both is
correct NAWS behaviour - what is wrong is a test asserting a single report across a boundary it
never waited for. That is a different thing from #10483, where the width reported was one the
window never settled at.

**On the 800 ms.** `settle()` is `QTest::qWait()`, a fixed sleep rather than a wait-until-quiet, so
the number is paid on every run and is worth justifying. With `cleanup()` starved to `settle(0ms)`,
so the previous case's work is guaranteed to still be in flight, the case fails at 0, 50 and
100 ms and passes at 200, 400 and 800 ms - three runs each. 200 ms is therefore the floor on an
idle Apple Silicon machine. In normal operation the case also gets `cleanup()`'s 600 ms, so 800 ms
takes the total quiet before it from 600 ms, which CI has demonstrated is not enough, to 1400 ms,
around seven times the measured requirement. It also matches the sibling that waits on comparable
work: `settle(800ms)` there follows a container attach and relayout, while the `settle(1500ms)`
cases follow `showTab()`, a whole profile tab switch. What this case absorbs is the residue of a
resize, so the relayout tier is the right one.

The floor was measured on an idle machine and CI failed at 600 ms, so the true requirement on a
runner is somewhere above that and cannot be measured from here. 1400 ms has held in every
configuration I could construct.

Note for whoever merges: #10387 also touches this file, but only the accessor swap at line 113, so
there is no conflict with the change here at line 256.

**Test case:**

The flake is reproducible on demand rather than by waiting for CI:

1. In `test/functional_tests/NawsWidthReportTest.cpp`, change `cleanup()`'s `settle(600ms)` to
   `settle(0ms)` - standing in for a loaded runner.
2. `cmake --build --preset macos-debug-nosan --target functional_window_tests`
3. `QT_QPA_PLATFORM=offscreen ctest --preset macos-debug-nosan -R NawsWidthReportTest`

Without this change the gutter case fails and the other seven in the class pass - six consecutive
runs failed that case and only that case. With this change, and `cleanup()` left starved, six
consecutive runs pass, so the fix holds against the condition that breaks it rather than merely
against the default timing. `Naws|Window|Console` selection is 15/15 with `cleanup()` restored.

*Written with AI assistance. Assisted-by: Claude:claude-opus-5*