### PR TITLE
Fix: path to AI-ASSISTANTS.md

### DIFF
--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -39,4 +39,4 @@ This directory contains GitHub-specific configuration files and templates that h
 
 ## AI Assistant Integration
 
-This directory includes `copilot-instructions.md` which is part of Mudlet's centralized AI assistant system. For complete information about AI assistant setup, supported tools, and Windows symlink configuration, see **[AI-ASSISTANTS.md](../AI-ASSISTANTS.md)** in the project root.
+This directory includes `copilot-instructions.md` which is part of Mudlet's centralized AI assistant system. For complete information about AI assistant setup, supported tools, and Windows symlink configuration, see **[AI-ASSISTANTS.md](AI-ASSISTANTS.md)**.


### PR DESCRIPTION
`AI-ASSISTANTS.md` now is in docs/.

Corrects one path that referred to the old location.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
