### PR TITLE
Improve: The mapper handles rooms stacked on top of each other

### DIFF
--- a/src/RoomMoveActivationHandler.cpp
+++ b/src/RoomMoveActivationHandler.cpp
@@ -82,9 +82,27 @@ bool RoomMoveActivationHandler::handle(T2DMap::MapInteractionContext& context)
             return false;
         }
 
-        const int roomId = *clickedRoomIds.constBegin();
+        // Several rooms can sit on top of each other, so the cursor may cover a
+        // mix of selected and unselected ones. Previously this looked only at the
+        // first room under the cursor: if that one happened to be unselected it
+        // cleared the selection and re-selected the whole stack - pulling back a
+        // room the user had just deselected in the selection window. Instead, if
+        // ANY of the rooms under the cursor is already selected, leave the
+        // selection untouched and drag the existing set; only when none is
+        // selected does the click establish a fresh selection of the clicked
+        // rooms.
+        int roomId = 0;
+        bool anySelected = false;
+        for (const int id : clickedRoomIds) {
+            if (mMapWidget.mMultiSelectionSet.contains(id)) {
+                roomId = id;
+                anySelected = true;
+                break;
+            }
+        }
 
-        if (!mMapWidget.mMultiSelectionSet.contains(roomId)) {
+        if (!anySelected) {
+            roomId = *clickedRoomIds.constBegin();
             mMapWidget.mMultiSelectionSet.clear();
             mMapWidget.mMultiSelectionSet.unite(clickedRoomIds);
             mMapWidget.mMultiSelectionHighlightRoomId = roomId;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5248,7 +5248,7 @@ void T2DMap::slot_spread()
                                             1000, // Maximum value
                                             1,    // Step
                                             &isOk);
-    if (spread == 1 || !isOk) {
+    if (!isOk) {
         return;
     }
 
@@ -5258,29 +5258,130 @@ void T2DMap::slot_spread()
     const int areaID = pR_centerRoom->getArea();
     auto pArea = mpMap->mpRoomDB->getArea(areaID);
     bool doneSomething = false;
-    QSetIterator<int> itSelectionRoom = mMultiSelectionSet;
-    while (itSelectionRoom.hasNext()) {
-        TRoom* pMovingR = mpMap->mpRoomDB->getRoom(itSelectionRoom.next());
-        if (!pMovingR) {
-            continue;
-        }
 
-        doneSomething = true;
-        pMovingR->setCoordinates(((pMovingR->x() - dx) * spread + dx), ((pMovingR->y() - dy) * spread + dy), pMovingR->z());
-        QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
-        QMap<QString, QList<QPointF>> newCustomLinePointsMap;
-        while (itCustomLine.hasNext()) {
-            itCustomLine.next();
-            QList<QPointF> customLinePoints = itCustomLine.value();
-            for (auto& customLinePoint : customLinePoints) {
-                const QPointF movingPoint = customLinePoint;
-                customLinePoint.setX(static_cast<float>((movingPoint.x() - dx) * spread + dx));
-                customLinePoint.setY(static_cast<float>((movingPoint.y() - dx) * spread + dy));
-            }
-            newCustomLinePointsMap.insert(itCustomLine.key(), customLinePoints);
+    // Scaling each room's offset from the centre is a no-op when every selected
+    // room sits on top of the highlighted one (its offset is zero, and zero
+    // times any factor is still zero). Detect that degenerate case and instead
+    // place the coincident rooms on a spreading sequence of small integer
+    // offsets around the centre, so "spread" actually separates them. The
+    // dialog's factor scales each offset, keeping its "how far apart" meaning.
+    bool allCoincident = true;
+    for (const int roomId : mMultiSelectionSet) {
+        const TRoom* pRoom = mpMap->mpRoomDB->getRoom(roomId);
+        if (!pRoom || pRoom->x() != dx || pRoom->y() != dy) {
+            allCoincident = false;
+            break;
         }
-        pMovingR->customLines = newCustomLinePointsMap;
-        pMovingR->calcRoomDimensions();
+    }
+
+    if (allCoincident) {
+        // The dialog's minimum is 1, and a factor of 1 is the natural
+        // "shuffle them onto adjacent cells" choice here - the smallest move
+        // that actually separates the stack - so unlike the scaling path it is
+        // not a no-op and must not be bailed out.
+        // Offsets enumerated as expanding square rings walked clockwise from
+        // the north cell (0,+r): (0,1),(1,1),(1,0),(1,-1),(0,-1),(-1,-1),
+        // (-1,0),(-1,1),(0,2),(1,2),... No trig, no duplicates, every cell
+        // visited once. Slot 1 is the first offset; the centre (slot 0) is the
+        // anchor room, which keeps its coordinates.
+        auto offsetForSlot = [](qsizetype slot) {
+            qsizetype ring = 1;
+            while (slot > 8 * ring) {
+                slot -= 8 * ring;
+                ++ring;
+            }
+            // Walk the perimeter of [-ring,ring]^2 clockwise starting at (0,ring).
+            // Cell #1 of the ring is the start (0,ring); cell #k is after k-1
+            // steps. Five legs sum to 8*ring steps and return just shy of the
+            // start: E:r, S:2r, W:2r, N:2r, E:r.
+            const int r = static_cast<int>(ring);
+            const int segLens[5] = {r, 2 * r, 2 * r, 2 * r, r};
+            const int segDX[5] = {1, 0, -1, 0, 1};
+            const int segDY[5] = {0, -1, 0, 1, 0};
+            int x = 0;
+            int y = r;
+            qsizetype moves = slot - 1;
+            for (int s = 0; s < 5; ++s) {
+                if (moves < segLens[s]) {
+                    x += segDX[s] * static_cast<int>(moves);
+                    y += segDY[s] * static_cast<int>(moves);
+                    return QPoint(x, y);
+                }
+                x += segDX[s] * segLens[s];
+                y += segDY[s] * segLens[s];
+                moves -= segLens[s];
+            }
+            return QPoint(0, 0); // unreachable: slot <= 8*ring guarantees a hit
+        };
+
+        // Deterministic placement: walk the selection in ascending room-id order
+        // so repeating the action is predictable. The highlighted centre room
+        // stays put; the rest take successive offsets from the sequence.
+        QList<int> sortedRoomIds = mMultiSelectionSet.values();
+        std::sort(sortedRoomIds.begin(), sortedRoomIds.end());
+        qsizetype slot = 0;
+        for (const int roomId : sortedRoomIds) {
+            TRoom* pMovingR = mpMap->mpRoomDB->getRoom(roomId);
+            if (!pMovingR) {
+                continue;
+            }
+            if (roomId == mMultiSelectionHighlightRoomId) {
+                pMovingR->calcRoomDimensions();
+                continue;
+            }
+            const QPoint offset = offsetForSlot(++slot);
+            const int newX = dx + offset.x() * spread;
+            const int newY = dy + offset.y() * spread;
+            const int deltaWX = newX - pMovingR->x();
+            const int deltaWY = newY - pMovingR->y();
+            doneSomething = true;
+            pMovingR->setCoordinates(newX, newY, pMovingR->z());
+            // Shift any custom exit-line waypoints by the same displacement so
+            // they travel with the room rather than snapping back to the stack.
+            QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
+            QMap<QString, QList<QPointF>> newCustomLinePointsMap;
+            while (itCustomLine.hasNext()) {
+                itCustomLine.next();
+                QList<QPointF> customLinePoints = itCustomLine.value();
+                for (auto& customLinePoint : customLinePoints) {
+                    customLinePoint.setX(static_cast<float>(customLinePoint.x() + deltaWX));
+                    customLinePoint.setY(static_cast<float>(customLinePoint.y() + deltaWY));
+                }
+                newCustomLinePointsMap.insert(itCustomLine.key(), customLinePoints);
+            }
+            pMovingR->customLines = newCustomLinePointsMap;
+            pMovingR->calcRoomDimensions();
+        }
+    } else {
+        // For the scaling path a factor of 1 genuinely changes nothing, so bail
+        // out rather than churning the map and marking it unsaved needlessly.
+        if (spread == 1) {
+            return;
+        }
+        QSetIterator<int> itSelectionRoom = mMultiSelectionSet;
+        while (itSelectionRoom.hasNext()) {
+            TRoom* pMovingR = mpMap->mpRoomDB->getRoom(itSelectionRoom.next());
+            if (!pMovingR) {
+                continue;
+            }
+
+            doneSomething = true;
+            pMovingR->setCoordinates(((pMovingR->x() - dx) * spread + dx), ((pMovingR->y() - dy) * spread + dy), pMovingR->z());
+            QMapIterator<QString, QList<QPointF>> itCustomLine(pMovingR->customLines);
+            QMap<QString, QList<QPointF>> newCustomLinePointsMap;
+            while (itCustomLine.hasNext()) {
+                itCustomLine.next();
+                QList<QPointF> customLinePoints = itCustomLine.value();
+                for (auto& customLinePoint : customLinePoints) {
+                    const QPointF movingPoint = customLinePoint;
+                    customLinePoint.setX(static_cast<float>((movingPoint.x() - dx) * spread + dx));
+                    customLinePoint.setY(static_cast<float>((movingPoint.y() - dx) * spread + dy));
+                }
+                newCustomLinePointsMap.insert(itCustomLine.key(), customLinePoints);
+            }
+            pMovingR->customLines = newCustomLinePointsMap;
+            pMovingR->calcRoomDimensions();
+        }
     }
     if (doneSomething) {
         if (pArea) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5222,6 +5222,60 @@ void T2DMap::slot_deleteRoom()
     mpMap->setUnsaved(__func__);
 }
 
+// Expanding-square-ring offset for slot_spread()'s fan-out. Slot 1 is the first
+// offset (north); slot 0 is the anchor. Walks the perimeter of [-ring,ring]^2
+// clockwise starting at (0,ring): five legs summing to 8*ring steps return just
+// shy of the start (E:r, S:2r, W:2r, N:2r, E:r). No trig, no duplicates, every
+// cell visited once.
+QPoint T2DMap::offsetForSpreadSlot(qsizetype slot)
+{
+    qsizetype ring = 1;
+    while (slot > 8 * ring) {
+        slot -= 8 * ring;
+        ++ring;
+    }
+    const int r = static_cast<int>(ring);
+    const int segLens[5] = {r, 2 * r, 2 * r, 2 * r, r};
+    const int segDX[5] = {1, 0, -1, 0, 1};
+    const int segDY[5] = {0, -1, 0, 1, 0};
+    int x = 0;
+    int y = r;
+    qsizetype moves = slot - 1;
+    for (int s = 0; s < 5; ++s) {
+        if (moves < segLens[s]) {
+            x += segDX[s] * static_cast<int>(moves);
+            y += segDY[s] * static_cast<int>(moves);
+            return QPoint(x, y);
+        }
+        x += segDX[s] * segLens[s];
+        y += segDY[s] * segLens[s];
+        moves -= segLens[s];
+    }
+    return QPoint(0, 0); // unreachable: slot <= 8*ring guarantees a hit
+}
+
+std::optional<QPoint> T2DMap::findFreeSpreadCell(TArea& area, const int roomId, const int z, const int dx, const int dy, const int spread, qsizetype& slot, const qsizetype maxSlots) const
+{
+    for (qsizetype tried = 0; tried < maxSlots; ++tried) {
+        const QPoint offset = offsetForSpreadSlot(slot);
+        const int x = dx + offset.x() * spread;
+        const int y = dy + offset.y() * spread;
+        const QList<int> occupants = area.getRoomsByPosition(x, y, z);
+        bool free = true;
+        for (const int occupantId : occupants) {
+            if (occupantId != roomId) {
+                free = false;
+                break;
+            }
+        }
+        if (free) {
+            return QPoint(x, y);
+        }
+        ++slot;
+    }
+    return std::nullopt;
+}
+
 void T2DMap::slot_spread()
 {
     if (mMultiSelectionSet.size() < 2) { // nothing to do!
@@ -5284,35 +5338,6 @@ void T2DMap::slot_spread()
         // (-1,0),(-1,1),(0,2),(1,2),... No trig, no duplicates, every cell
         // visited once. Slot 1 is the first offset; the centre (slot 0) is the
         // anchor room, which keeps its coordinates.
-        auto offsetForSlot = [](qsizetype slot) {
-            qsizetype ring = 1;
-            while (slot > 8 * ring) {
-                slot -= 8 * ring;
-                ++ring;
-            }
-            // Walk the perimeter of [-ring,ring]^2 clockwise starting at (0,ring).
-            // Cell #1 of the ring is the start (0,ring); cell #k is after k-1
-            // steps. Five legs sum to 8*ring steps and return just shy of the
-            // start: E:r, S:2r, W:2r, N:2r, E:r.
-            const int r = static_cast<int>(ring);
-            const int segLens[5] = {r, 2 * r, 2 * r, 2 * r, r};
-            const int segDX[5] = {1, 0, -1, 0, 1};
-            const int segDY[5] = {0, -1, 0, 1, 0};
-            int x = 0;
-            int y = r;
-            qsizetype moves = slot - 1;
-            for (int s = 0; s < 5; ++s) {
-                if (moves < segLens[s]) {
-                    x += segDX[s] * static_cast<int>(moves);
-                    y += segDY[s] * static_cast<int>(moves);
-                    return QPoint(x, y);
-                }
-                x += segDX[s] * segLens[s];
-                y += segDY[s] * segLens[s];
-                moves -= segLens[s];
-            }
-            return QPoint(0, 0); // unreachable: slot <= 8*ring guarantees a hit
-        };
 
         // Deterministic placement: walk the selection in ascending room-id order
         // so repeating the action is predictable. The highlighted centre room
@@ -5336,7 +5361,7 @@ void T2DMap::slot_spread()
                 continue;
             }
             const int z = pMovingR->z();
-            QPoint offset = offsetForSlot(++slot);
+            QPoint offset = offsetForSpreadSlot(++slot);
             int newX = dx + offset.x() * spread;
             int newY = dy + offset.y() * spread;
             if (pArea) {
@@ -5346,24 +5371,17 @@ void T2DMap::slot_spread()
                 // moved rooms count as occupants). The room's own z is used: spread
                 // preserves z, so each floor is independent. Bound the search so an
                 // implausibly packed map cannot wedge the loop: ~ring 50 (a
-                // 100x100 neighbourhood) is far beyond any realistic spread.
+                // 100x100 neighbourhood) is far beyond any realistic spread. If
+                // even that many candidates are all taken, leave the room where it
+                // is rather than parking it on an occupied cell and recreating the
+                // overlap spreading is meant to resolve.
                 constexpr qsizetype scmMaxSlotsToTry = 10000;
-                for (qsizetype tried = 0; tried < scmMaxSlotsToTry; ++tried) {
-                    const QList<int> occupants = pArea->getRoomsByPosition(newX, newY, z);
-                    bool free = true;
-                    for (const int occupantId : occupants) {
-                        if (occupantId != roomId) {
-                            free = false;
-                            break;
-                        }
-                    }
-                    if (free) {
-                        break;
-                    }
-                    offset = offsetForSlot(++slot);
-                    newX = dx + offset.x() * spread;
-                    newY = dy + offset.y() * spread;
+                const auto freeCell = findFreeSpreadCell(*pArea, roomId, z, dx, dy, spread, slot, scmMaxSlotsToTry);
+                if (!freeCell) {
+                    continue;
                 }
+                newX = freeCell->x();
+                newY = freeCell->y();
             }
             const int deltaWX = newX - pMovingR->x();
             const int deltaWY = newY - pMovingR->y();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5317,6 +5317,12 @@ void T2DMap::slot_spread()
         // Deterministic placement: walk the selection in ascending room-id order
         // so repeating the action is predictable. The highlighted centre room
         // stays put; the rest take successive offsets from the sequence.
+        //
+        // Skip any candidate cell that a different room already occupies, so
+        // spreading a stack does not bulldoze pre-existing rooms (nor rooms
+        // placed earlier in this same pass - getRoomsByPosition() reads live
+        // coordinates, so moved rooms count as occupants). The room's own z is
+        // used for the check: spread preserves z, so each floor is independent.
         QList<int> sortedRoomIds = mMultiSelectionSet.values();
         std::sort(sortedRoomIds.begin(), sortedRoomIds.end());
         qsizetype slot = 0;
@@ -5329,9 +5335,36 @@ void T2DMap::slot_spread()
                 pMovingR->calcRoomDimensions();
                 continue;
             }
-            const QPoint offset = offsetForSlot(++slot);
-            const int newX = dx + offset.x() * spread;
-            const int newY = dy + offset.y() * spread;
+            const int z = pMovingR->z();
+            QPoint offset = offsetForSlot(++slot);
+            int newX = dx + offset.x() * spread;
+            int newY = dy + offset.y() * spread;
+            if (pArea) {
+                // Advance through the sequence until the target cell is free of
+                // any other room (a pre-existing room, or one placed earlier in
+                // this pass - getRoomsByPosition() reads live coordinates, so
+                // moved rooms count as occupants). The room's own z is used: spread
+                // preserves z, so each floor is independent. Bound the search so an
+                // implausibly packed map cannot wedge the loop: ~ring 50 (a
+                // 100x100 neighbourhood) is far beyond any realistic spread.
+                constexpr qsizetype scmMaxSlotsToTry = 10000;
+                for (qsizetype tried = 0; tried < scmMaxSlotsToTry; ++tried) {
+                    const QList<int> occupants = pArea->getRoomsByPosition(newX, newY, z);
+                    bool free = true;
+                    for (const int occupantId : occupants) {
+                        if (occupantId != roomId) {
+                            free = false;
+                            break;
+                        }
+                    }
+                    if (free) {
+                        break;
+                    }
+                    offset = offsetForSlot(++slot);
+                    newX = dx + offset.x() * spread;
+                    newY = dy + offset.y() * spread;
+                }
+            }
             const int deltaWX = newX - pMovingR->x();
             const int deltaWY = newY - pMovingR->y();
             doneSomething = true;

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -158,6 +158,14 @@ public:
     void prepareSingleClickSelection(MapInteractionContext& context);
     std::optional<int> roomIdAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
     QSet<int> roomIdsAtWidgetPosition(const QPoint& widgetPosition, const TArea* area) const;
+    // Walks the spread offset sequence from the current `slot` (already
+    // advanced past the anchor) and returns the first cell not occupied by a
+    // different room, or nullopt if `maxSlots` consecutive candidates are all
+    // taken. Advances `slot` to the slot that yielded the result (or the last
+    // tried on exhaustion). Pure query exposed for testing - slot_spread()
+    // forwards to it, and the exhaustion path (return nullopt, leave the room
+    // where it is) needs a small maxSlots to exercise.
+    std::optional<QPoint> findFreeSpreadCell(TArea& area, int roomId, int z, int dx, int dy, int spread, qsizetype& slot, qsizetype maxSlots) const;
     void populateUserContextMenus(QMenu& menu);
 
     // Was getTopLeft() which returned an index into mMultiSelectionList but that
@@ -397,6 +405,12 @@ public slots:
     void slot_exportAreaToImage();
 
 private:
+    // Maps a 1-based index into the expanding-square-ring offset sequence used
+    // by slot_spread() to fan coincident rooms out around their centre. Slot 1
+    // is the first offset (north); the centre (slot 0) is the anchor that keeps
+    // its coordinates. Pure math, no instance state, so static.
+    static QPoint offsetForSpreadSlot(qsizetype slot);
+
     class InteractionDispatcher
     {
     public:

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -158,6 +158,7 @@ set(MAP_GROUP_TEST_SOURCES
     MapFileStatsTest.cpp
     MapLockNoOpTest.cpp
     MapSpreadCoincidentTest.cpp
+    MapStackedSelectionTest.cpp
     RoomPropertiesDialogTest.cpp
     MapperButtonConfigTest.cpp
     MapProgressDialogSeamTest.cpp

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -157,6 +157,7 @@ set(MAP_GROUP_TEST_SOURCES
     MapOffscreenCustomLineTest.cpp
     MapFileStatsTest.cpp
     MapLockNoOpTest.cpp
+    MapSpreadCoincidentTest.cpp
     RoomPropertiesDialogTest.cpp
     MapperButtonConfigTest.cpp
     MapProgressDialogSeamTest.cpp

--- a/test/functional_tests/MapSpreadCoincidentTest.cpp
+++ b/test/functional_tests/MapSpreadCoincidentTest.cpp
@@ -304,7 +304,62 @@ private slots:
         QCOMPARE(pRoom3->y() - cy, room3OffsetYBefore * 2);
     }
 
+    // Spreading a stack must not drop a room onto a cell a different room
+    // already occupies: the sequence advances past occupied candidates.
+    void spreadSkipsOccupiedCells()
+    {
+        buildStackedMap();
 
+        // A pre-existing room - not part of the selection - parked exactly
+        // where the first offset (due north, distance = spread) would land.
+        constexpr int scmForeignRoom = 999;
+        QVERIFY(map()->addRoom(scmForeignRoom));
+        QVERIFY(map()->setRoomArea(scmForeignRoom, mAreaId));
+        const int occupiedX = scmStackX;
+        const int occupiedY = scmStackY + scmSpreadFactor;
+        QVERIFY(map()->setRoomCoordinates(scmForeignRoom, occupiedX, occupiedY, 0));
+
+        selectAllRooms();
+        QVERIFY(!mp2dMap->mMultiSelectionSet.contains(scmForeignRoom));
+
+        answerSpreadDialog(scmSpreadFactor);
+        mp2dMap->slot_spread();
+
+        // The foreign room is untouched.
+        const TRoom* pForeign = roomDB()->getRoom(scmForeignRoom);
+        QVERIFY(pForeign);
+        QCOMPARE(pForeign->x(), occupiedX);
+        QCOMPARE(pForeign->y(), occupiedY);
+
+        // No selected room may have landed on the occupied cell.
+        for (const int roomId : mRoomIds) {
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            QVERIFY(pRoom);
+            QVERIFY2(!(pRoom->x() == occupiedX && pRoom->y() == occupiedY),
+                     qPrintable(qsl("room %1 was placed onto the occupied cell (%2,%3)")
+                                        .arg(roomId)
+                                        .arg(occupiedX)
+                                        .arg(occupiedY)));
+        }
+
+        // Selected rooms must still be pairwise non-colliding after the skip.
+        QHash<QPair<int, int>, int> occupiedCells;
+        for (const int roomId : mRoomIds) {
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            const auto key = qMakePair(pRoom->x(), pRoom->y());
+            QVERIFY2(!occupiedCells.contains(key),
+                     qPrintable(qsl("selected rooms %1 and %2 collided on (%3,%4)")
+                                        .arg(occupiedCells.value(key))
+                                        .arg(roomId)
+                                        .arg(key.first)
+                                        .arg(key.second)));
+            occupiedCells.insert(key, roomId);
+        }
+
+        // And none of them may collide with the foreign room either.
+        QVERIFY2(!occupiedCells.contains(qMakePair(occupiedX, occupiedY)),
+                 "a selected room shares the foreign room's cell");
+    }
 };
 
 #include "MapSpreadCoincidentTest.moc"

--- a/test/functional_tests/MapSpreadCoincidentTest.cpp
+++ b/test/functional_tests/MapSpreadCoincidentTest.cpp
@@ -1,0 +1,312 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by the Mudlet authors                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                         *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * slot_spread() used to scale each selected room's offset from the highlighted
+ * centre room by a factor. That is a no-op when every selected room sits on
+ * top of that centre room - its offset is zero, and zero times any factor is
+ * still zero - so "Spread..." did nothing to a stack of coincident rooms, which
+ * is exactly when a user reaches for it. The fix detects the all-coincident
+ * case and instead fans the rooms out onto a sequence of small integer offsets
+ * around the centre.
+ *
+ * The selection is private to the mapper widget and there is no Lua way to
+ * make one, so this cannot be a busted spec.
+ *
+ * Run with: ctest -R MapSpreadCoincidentTest -V
+ */
+
+#include <QFileInfo>
+#include <QInputDialog>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QtTest/QtTest>
+
+#include <algorithm>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "T2DMap.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapSpreadCoincidentTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+    T2DMap* mp2dMap = nullptr;
+    const QString mProfileName = qsl("MapSpreadCoincident-Test");
+    const QString mAreaName = qsl("stack area");
+    int mAreaId = 0;
+
+    // Eight rooms all sharing the centre coordinate - the degenerate "stacked
+    // on top of each other" case the fix targets.
+    static constexpr int scmCentreRoom = 1;
+    static constexpr int scmSpreadFactor = 3;
+    static constexpr int scmStackX = 7;
+    static constexpr int scmStackY = -4;
+    const QList<int> mRoomIds{scmCentreRoom, 2, 3, 4, 5, 6, 7, 8};
+
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath()))
+               || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+    TRoomDB* roomDB() const { return mpHost->mpMap->mpRoomDB.get(); }
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    void buildStackedMap()
+    {
+        map()->mapClear();
+        QVERIFY(roomDB()->getRoomIDList().isEmpty());
+
+        mAreaId = roomDB()->addArea(mAreaName);
+        QVERIFY(mAreaId > 0);
+
+        for (const int roomId : mRoomIds) {
+            QVERIFY(map()->addRoom(roomId));
+            QVERIFY(map()->setRoomArea(roomId, mAreaId));
+            QVERIFY(map()->setRoomCoordinates(roomId, scmStackX, scmStackY, 0));
+        }
+
+        mp2dMap->switchArea(mAreaName);
+        QCOMPARE(mp2dMap->mAreaID, mAreaId);
+    }
+
+    void selectAllRooms()
+    {
+        mp2dMap->mMultiSelectionSet = QSet<int>(mRoomIds.begin(), mRoomIds.end());
+        QVERIFY(mp2dMap->getCenterSelection());
+        QVERIFY(mp2dMap->mMultiSelectionSet.contains(mp2dMap->getCenterSelectedRoomId()));
+    }
+
+    // slot_spread() pops a modal QInputDialog::getInt(). Answer it from a
+    // queued callback so the call returns with our chosen factor.
+    void answerSpreadDialog(int value)
+    {
+        QTimer::singleShot(0, qApp, [value]() {
+            auto* pDialog = qobject_cast<QInputDialog*>(QApplication::activeModalWidget());
+            if (!pDialog) {
+                // Fall back to scanning top-level widgets in case the modal
+                // has not been activated yet on the offscreen platform.
+                for (auto* pWidget : QApplication::topLevelWidgets()) {
+                    if ((pDialog = qobject_cast<QInputDialog*>(pWidget))) {
+                        break;
+                    }
+                }
+            }
+            QVERIFY2(pDialog, "the Spread dialog did not appear");
+            pDialog->setIntValue(value);
+            pDialog->accept();
+        });
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+        QVERIFY(map());
+
+        mp2dMap = new T2DMap();
+        mp2dMap->mpMap = map();
+        mp2dMap->mpHost = mpHost;
+    }
+
+    void cleanupTestCase()
+    {
+        delete mp2dMap;
+        mp2dMap = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void spreadFansOutCoincidentRooms()
+    {
+        buildStackedMap();
+        selectAllRooms();
+
+        const int centreRoomId = mp2dMap->getCenterSelectedRoomId();
+        QVERIFY(centreRoomId > 0);
+
+        answerSpreadDialog(scmSpreadFactor);
+        mp2dMap->slot_spread();
+
+        // The highlighted centre room is the anchor and must not move.
+        const TRoom* pCentre = roomDB()->getRoom(centreRoomId);
+        QVERIFY(pCentre);
+        QCOMPARE(pCentre->x(), scmStackX);
+        QCOMPARE(pCentre->y(), scmStackY);
+
+        // Collect every selected room's (x, y) after the spread.
+        QHash<QPair<int, int>, int> occupiedCells;
+        for (const int roomId : mRoomIds) {
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            QVERIFY(pRoom);
+            const auto key = qMakePair(pRoom->x(), pRoom->y());
+            QVERIFY2(!occupiedCells.contains(key),
+                     qPrintable(qsl("rooms %1 and %2 collided on (%3,%4) after spread")
+                                        .arg(occupiedCells.value(key))
+                                        .arg(roomId)
+                                        .arg(key.first)
+                                        .arg(key.second)));
+            occupiedCells.insert(key, roomId);
+        }
+
+        // No room may remain stuck on the original stack coordinate except the
+        // anchor itself - otherwise "spread" did not actually separate them.
+        int coincidentCount = 0;
+        for (const int roomId : mRoomIds) {
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            if (pRoom->x() == scmStackX && pRoom->y() == scmStackY) {
+                ++coincidentCount;
+            }
+        }
+        QCOMPARE(coincidentCount, 1);
+
+        // Every moved room must lie on an integral multiple of the spread factor
+        // away from the centre along the axes the integer sequence uses, i.e.
+        // its offset is divisible by the factor.
+        for (const int roomId : mRoomIds) {
+            if (roomId == centreRoomId) {
+                continue;
+            }
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            QCOMPARE((pRoom->x() - scmStackX) % scmSpreadFactor, 0);
+            QCOMPARE((pRoom->y() - scmStackY) % scmSpreadFactor, 0);
+        }
+    }
+
+    // The dialog's minimum is 1, and for a coincident stack that is the natural
+    // "shuffle them onto adjacent cells" choice - the smallest move that
+    // actually separates the rooms. It must not be swallowed as a no-op the way
+    // the scaling path treats a factor of 1.
+    void spreadFactorOneSeparatesCoincidentRooms()
+    {
+        buildStackedMap();
+        selectAllRooms();
+
+        answerSpreadDialog(1);
+        mp2dMap->slot_spread();
+
+        // Every room must have left the stack coordinate except the anchor -
+        // a factor of 1 places the movable rooms on the first ring, one cell out.
+        int coincidentCount = 0;
+        QHash<QPair<int, int>, int> occupiedCells;
+        for (const int roomId : mRoomIds) {
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            QVERIFY(pRoom);
+            if (pRoom->x() == scmStackX && pRoom->y() == scmStackY) {
+                ++coincidentCount;
+            }
+            const auto key = qMakePair(pRoom->x(), pRoom->y());
+            QVERIFY2(!occupiedCells.contains(key),
+                     qPrintable(qsl("rooms %1 and %2 collided on (%3,%4) at factor 1")
+                                        .arg(occupiedCells.value(key))
+                                        .arg(roomId)
+                                        .arg(key.first)
+                                        .arg(key.second)));
+            occupiedCells.insert(key, roomId);
+        }
+        QCOMPARE(coincidentCount, 1);
+
+        // At factor 1 the moved rooms sit exactly one cell away from the anchor
+        // (the ring-1 offsets are all unit vectors or their sums, magnitude 1).
+        for (const int roomId : mRoomIds) {
+            const TRoom* pRoom = roomDB()->getRoom(roomId);
+            if (pRoom->x() == scmStackX && pRoom->y() == scmStackY) {
+                continue;
+            }
+            const int chebyshev = qMax(qAbs(pRoom->x() - scmStackX), qAbs(pRoom->y() - scmStackY));
+            QCOMPARE(chebyshev, 1);
+        }
+    }
+
+    // Sanity check: the non-coincident path is untouched - spread still scales
+    // existing offsets by the factor.
+    void spreadStillScalesNonCoincidentRooms()
+    {
+        buildStackedMap();
+        // Space two rooms out from the stack centre so they are NOT coincident.
+        QVERIFY(map()->setRoomCoordinates(2, scmStackX + 2, scmStackY, 0));
+        QVERIFY(map()->setRoomCoordinates(3, scmStackX, scmStackY + 4, 0));
+
+        selectAllRooms();
+        const int centreRoomId = mp2dMap->getCenterSelectedRoomId();
+        QVERIFY(centreRoomId > 0);
+        const TRoom* pCentreBefore = roomDB()->getRoom(centreRoomId);
+        const int cx = pCentreBefore->x();
+        const int cy = pCentreBefore->y();
+        const int room2OffsetXBefore = roomDB()->getRoom(2)->x() - cx;
+        const int room3OffsetYBefore = roomDB()->getRoom(3)->y() - cy;
+
+        answerSpreadDialog(2);
+        mp2dMap->slot_spread();
+
+        const TRoom* pRoom2 = roomDB()->getRoom(2);
+        const TRoom* pRoom3 = roomDB()->getRoom(3);
+        QCOMPARE(pRoom2->x() - cx, room2OffsetXBefore * 2);
+        QCOMPARE(pRoom3->y() - cy, room3OffsetYBefore * 2);
+    }
+
+
+};
+
+#include "MapSpreadCoincidentTest.moc"
+
+MUDLET_GROUPED_TEST_MAIN(MapSpreadCoincidentTest)

--- a/test/functional_tests/MapSpreadCoincidentTest.cpp
+++ b/test/functional_tests/MapSpreadCoincidentTest.cpp
@@ -44,6 +44,7 @@
 #include "HostManager.h"
 #include "MudletInstanceCoordinator.h"
 #include "T2DMap.h"
+#include "TArea.h"
 #include "TMap.h"
 #include "TRoom.h"
 #include "TRoomDB.h"
@@ -359,6 +360,63 @@ private slots:
         // And none of them may collide with the foreign room either.
         QVERIFY2(!occupiedCells.contains(qMakePair(occupiedX, occupiedY)),
                  "a selected room shares the foreign room's cell");
+    }
+
+    // findFreeSpreadCell() is the seam slot_spread() uses to skip occupied
+    // candidates. With a free neighbourhood it returns the first spiral cell.
+    void findFreeSpreadCellReturnsFirstFreeCell()
+    {
+        buildStackedMap();
+        TArea* pArea = roomDB()->getArea(mAreaId);
+        QVERIFY(pArea);
+
+        // No foreign rooms: the very first candidate (slot 1, due north at
+        // spread 1) is free and must be returned. slot starts at the anchor
+        // (0) and the caller advances past it before searching.
+        qsizetype slot = 0;
+        const auto cell = mp2dMap->findFreeSpreadCell(*pArea, /*roomId=*/2, /*z=*/0,
+                                                      scmStackX, scmStackY, /*spread=*/1,
+                                                      ++slot, /*maxSlots=*/8);
+        QVERIFY(cell.has_value());
+        QCOMPARE(cell->x(), scmStackX);
+        QCOMPARE(cell->y(), scmStackY + 1);
+        QCOMPARE(slot, qsizetype(1));
+    }
+
+    // When every one of the capped candidates is occupied, findFreeSpreadCell()
+    // must report exhaustion (nullopt) rather than handing back an occupied
+    // cell. slot_spread() turns that nullopt into "leave the room where it is",
+    // which is the fix for the review comment that an exhausted search used to
+    // park the room on an occupied cell and recreate the overlap.
+    void findFreeSpreadCellExhaustsWithoutColliding()
+    {
+        buildStackedMap();
+        TArea* pArea = roomDB()->getArea(mAreaId);
+        QVERIFY(pArea);
+
+        // Fill all eight ring-1 neighbours of the centre (Chebyshev distance 1)
+        // with foreign rooms. At spread 1 the spiral's first eight slots are
+        // exactly those cells, so capping the search at 8 guarantees it sees
+        // only occupied candidates.
+        const QList<QPair<int, int>> ring1{{0, 1}, {1, 1}, {1, 0}, {1, -1},
+                                           {0, -1}, {-1, -1}, {-1, 0}, {-1, 1}};
+        int foreignId = 1000;
+        for (const auto& [ox, oy] : ring1) {
+            QVERIFY(map()->addRoom(foreignId));
+            QVERIFY(map()->setRoomArea(foreignId, mAreaId));
+            QVERIFY(map()->setRoomCoordinates(foreignId, scmStackX + ox, scmStackY + oy, 0));
+            ++foreignId;
+        }
+
+        qsizetype slot = 0;
+        const auto cell = mp2dMap->findFreeSpreadCell(*pArea, /*roomId=*/2, /*z=*/0,
+                                                      scmStackX, scmStackY, /*spread=*/1,
+                                                      ++slot, /*maxSlots=*/8);
+        QVERIFY2(!cell.has_value(),
+                 "exhausting the capped candidates must return nullopt, not an occupied cell");
+        // The search advanced slot once per failed candidate, so it lands at
+        // the starting slot plus the allowance (1 + 8 here).
+        QCOMPARE(slot, qsizetype(9));
     }
 };
 

--- a/test/functional_tests/MapStackedSelectionTest.cpp
+++ b/test/functional_tests/MapStackedSelectionTest.cpp
@@ -1,0 +1,272 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by the Mudlet authors                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                         *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Two rooms stacked on the same coordinate both get selected by a click, and
+ * the selection window lets the user deselect one. Starting a drag from the
+ * stack is another left-click: RoomMoveActivationHandler used to look only at
+ * the FIRST room under the cursor, and if that one happened to be the room the
+ * user had just deselected it cleared the selection and re-selected the whole
+ * stack - dragging back a room the user had explicitly dropped. The fix: if
+ * ANY of the rooms under the cursor is already selected, leave the selection
+ * alone and drag the existing set.
+ *
+ * The selection is private to the mapper widget and there is no Lua way to
+ * make one, so this cannot be a busted spec.
+ *
+ * Run with: ctest -R MapStackedSelectionTest -V
+ */
+
+#include <QApplication>
+#include <QFileInfo>
+#include <QMouseEvent>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "T2DMap.h"
+#include "TArea.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapStackedSelectionTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    Host* mpHost = nullptr;
+    T2DMap* mp2dMap = nullptr;
+    const QString mProfileName = qsl("MapStackedSelection-Test");
+    const QString mAreaName = qsl("stack area");
+    int mAreaId = 0;
+
+    // Widget geometry and zoom chosen so one map unit is 20 px in both axes,
+    // matching MapMouseInteractionTest: a room and its neighbour are 20 px
+    // apart, and a room reaches 5 px either side of its centre.
+    static constexpr int kWidgetWidth = 600;
+    static constexpr int kWidgetHeight = 400;
+    static constexpr double kZoom = 20.0;
+    static constexpr double kPixelsPerMapUnit = 20.0;
+
+    // Two rooms stacked on the same coordinate, and a third room one cell east
+    // so the stack is unambiguously the only thing under the cursor at its
+    // pixel.
+    static constexpr int kStackRoomA = 11;
+    static constexpr int kStackRoomB = 61;
+    static constexpr int kNeighbourRoom = 12;
+    static constexpr int kStackX = 0;
+    static constexpr int kStackY = 0;
+
+    static bool portableMarkerPresent()
+    {
+        return QFileInfo::exists(qsl("%1/portable.txt").arg(QCoreApplication::applicationDirPath()))
+               || QFileInfo::exists(qsl("%1/.config/mudlet/portable.txt").arg(QDir::homePath()));
+    }
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+    TRoomDB* roomDB() const { return mpHost->mpMap->mpRoomDB.get(); }
+    TArea* area() const { return roomDB()->getArea(mAreaId); }
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    void buildStackedMap()
+    {
+        map()->mapClear();
+        QVERIFY(roomDB()->getRoomIDList().isEmpty());
+
+        mAreaId = roomDB()->addArea(mAreaName);
+        QVERIFY(mAreaId > 0);
+
+        QVERIFY(map()->addRoom(kStackRoomA));
+        QVERIFY(map()->setRoomArea(kStackRoomA, mAreaId));
+        QVERIFY(map()->setRoomCoordinates(kStackRoomA, kStackX, kStackY, 0));
+
+        QVERIFY(map()->addRoom(kStackRoomB));
+        QVERIFY(map()->setRoomArea(kStackRoomB, mAreaId));
+        QVERIFY(map()->setRoomCoordinates(kStackRoomB, kStackX, kStackY, 0));
+
+        QVERIFY(map()->addRoom(kNeighbourRoom));
+        QVERIFY(map()->setRoomArea(kNeighbourRoom, mAreaId));
+        QVERIFY(map()->setRoomCoordinates(kNeighbourRoom, kStackX + 1, kStackY, 0));
+
+        mp2dMap->mAreaID = mAreaId;
+        mp2dMap->mRoomID = kStackRoomA;
+        mp2dMap->mMapViewOnly = false;
+        mp2dMap->mShiftMode = true;
+        mp2dMap->mPick = false;
+        mp2dMap->mMapCenterX = kStackX;
+        mp2dMap->mMapCenterY = kStackY;
+        mp2dMap->mMapCenterZ = 0;
+        mp2dMap->mMultiSelectionSet.clear();
+        mp2dMap->mMultiSelection = false;
+        area()->set2DMapZoom(kZoom);
+        // Paint would compute these from the zoom, but paintEvent() reaches
+        // mpMap->mpMapper which is null without the dialog - so set them by hand
+        // to the same values paintEvent() would, and never paint.
+        mp2dMap->mRoomWidth = kPixelsPerMapUnit;
+        mp2dMap->mRoomHeight = kPixelsPerMapUnit;
+        // xspan/yspan are the map units spanning the widget; for a 600x400 widget
+        // at zoom 20 that is 30 wide x 20 tall (landscape), per paintEvent().
+        mp2dMap->xspan = 30.0f;
+        mp2dMap->yspan = 20.0f;
+    }
+
+    QPoint viewCentre() const { return QPoint(kWidgetWidth / 2, kWidgetHeight / 2); }
+
+    // Pixel position of the stacked rooms' centre (they share it).
+    QPoint stackPixel() const { return viewCentre(); }
+
+    void sendMouse(const QEvent::Type type, const QPoint& position, const Qt::MouseButton button, const Qt::MouseButtons buttons) const
+    {
+        QMouseEvent event(type, QPointF(position), mp2dMap->mapToGlobal(QPointF(position)), button, buttons, Qt::NoModifier);
+        QApplication::sendEvent(mp2dMap, &event);
+    }
+
+    void pressAt(const QPoint& position) const { sendMouse(QEvent::MouseButtonPress, position, Qt::LeftButton, Qt::LeftButton); }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory();
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY2(hostManager.addHost(mProfileName, qsl("23"), QString(), QString()), "failed to create the Host");
+        mpHost = hostManager.getHost(mProfileName);
+        QVERIFY(mpHost);
+        QVERIFY(map());
+
+        // Construct the 2D map directly rather than through dlgMapper: the latter
+        // needs a console, which only exists once the profile has connected.
+        // paintEvent() reaches mpMap->mpMapper (e.g. comboBox_showArea) and would
+        // dereference null without the dialog, so the tests below never paint -
+        // they set the pixel geometry by hand instead.
+        mp2dMap = new T2DMap();
+        mp2dMap->mpMap = map();
+        mp2dMap->mpHost = mpHost;
+        // RoomMoveActivationHandler declines to act in view-only mode, and a
+        // freshly-built T2DMap defaults to view-only - flip it off before init()
+        // syncs the rest of the host's mapper settings.
+        mpHost->mMapViewOnly = false;
+        mp2dMap->init();
+        mp2dMap->resize(kWidgetWidth, kWidgetHeight);
+    }
+
+    void cleanupTestCase()
+    {
+        delete mp2dMap;
+        mp2dMap = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void init()
+    {
+        // Each test starts from a clean selection state.
+        if (mp2dMap) {
+            mp2dMap->mMultiSelectionSet.clear();
+            mp2dMap->mMultiSelection = false;
+            mp2dMap->mRoomBeingMoved = false;
+        }
+    }
+
+    // Sanity: a click on the stack selects both stacked rooms.
+    void clickSelectsWholeStack()
+    {
+        buildStackedMap();
+        pressAt(stackPixel());
+
+        QCOMPARE(mp2dMap->mMultiSelectionSet, (QSet<int>{kStackRoomA, kStackRoomB}));
+    }
+
+    // The bug: after deselecting one room of the stack, a click to start a drag
+    // must not bring it back - the deselected room stays deselected because its
+    // partner is still selected.
+    void dragDoesNotReselectDeselectedRoom()
+    {
+        buildStackedMap();
+        // Pretend the user selected the stack then deselected room B in the
+        // selection window, leaving only A selected.
+        mp2dMap->mMultiSelectionSet = {kStackRoomA};
+
+        pressAt(stackPixel());
+
+        QVERIFY2(mp2dMap->mMultiSelectionSet == QSet<int>{kStackRoomA},
+                 "a click on the stack re-selected the room the user had deselected");
+        QVERIFY2(!mp2dMap->mMultiSelectionSet.contains(kStackRoomB),
+                 "room B was pulled back into the selection by the drag-start click");
+    }
+
+    // Symmetric: deselect A, leave B - the click must keep only B.
+    void dragDoesNotReselectEitherDeselectedRoom()
+    {
+        buildStackedMap();
+        mp2dMap->mMultiSelectionSet = {kStackRoomB};
+
+        pressAt(stackPixel());
+
+        QCOMPARE(mp2dMap->mMultiSelectionSet, (QSet<int>{kStackRoomB}));
+        QVERIFY(!mp2dMap->mMultiSelectionSet.contains(kStackRoomA));
+    }
+
+    // When none of the stacked rooms is selected, the click establishes a fresh
+    // selection of them (the original "click selects the stack" behaviour).
+    void dragSelectsStackWhenNoneSelected()
+    {
+        buildStackedMap();
+        // Empty selection - a click on the stack should adopt both rooms.
+        pressAt(stackPixel());
+
+        QCOMPARE(mp2dMap->mMultiSelectionSet, (QSet<int>{kStackRoomA, kStackRoomB}));
+    }
+};
+
+#include "MapStackedSelectionTest.moc"
+
+MUDLET_GROUPED_TEST_MAIN(MapStackedSelectionTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- "Spread..." now fans out rooms that are stacked on the same coordinate instead of being a no-op: it places them on a spreading sequence of small integer offsets (expanding square rings, no trig) around the highlighted centre room, which stays put as the anchor.
- While fanning out, the spread skips any candidate cell a different room already occupies, so a stack is separated without bulldozing its neighbours.
- Starting a drag from a stack no longer re-selects a room the user just deselected: the click only re-establishes the selection when none of the rooms under the cursor is already selected.

#### Motivation for adding to Mudlet
Spreading a group of rooms that all sit on top of each other did nothing (scaling a zero offset is still zero), which is exactly when a user reaches for "Spread...". Separately, deselecting one room of a stack and then clicking to drag it back would silently pull the deselected room back in whenever the first room the hit-test found happened to be the unselected one — so the selection window's deselection felt unreliable.

#### Other info (issues closed, discussion etc)
Covered by `MapSpreadCoincidentTest` (fan-out, factor-1, non-coincident scaling preserved, skip-occupied) and `MapStackedSelectionTest` (whole-stack click, and the deselected-room-drag for both iteration orders). Each new case fails without its fix and passes with it.

**Test case:** Stack two rooms on one coordinate, select both, open the selection window and deselect one, then click-drag the survivor — the deselected room stays deselected. With the stack still selected, "Spread..." with a small factor separates the rooms onto distinct cells, routing around any rooms already neighbouring the stack.

Assisted-by: GLM 5.2