### PR TITLE
Fix: Editing a room's exits redraws the map and marks it unsaved

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1001,6 +1001,13 @@ void dlgRoomExits::save()
         pA->determineAreaExitsOfRoom(pR->getId());
     }
 
+    // Repaint the mapper so the changed exits/doors/locks show immediately -
+    // without this the map stays stale until the next scroll/pan forces a
+    // paint. updateArea() queues a throttled mp2dMap->update(). Also mark the
+    // map unsaved, since editing exits is a map change.
+    mpHost->mpMap->updateArea(pR->getArea());
+    mpHost->mpMap->setUnsaved(__func__);
+
     close();
 }
 

--- a/test/functional_tests/RoomExitsDialogTest.cpp
+++ b/test/functional_tests/RoomExitsDialogTest.cpp
@@ -40,6 +40,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QRadioButton>
+#include <QSignalSpy>
 #include <QSpinBox>
 #include <QTemporaryDir>
 #include <QTreeWidget>
@@ -672,6 +673,39 @@ private slots:
 
         QVERIFY(mpRoomIdDelegate.isNull());
         QVERIFY(mpWeightDelegate.isNull());
+    }
+
+    // Changing an exit (here flipping a door to locked) and closing the dialog
+    // must repaint the mapper and mark the map unsaved - previously the map
+    // stayed stale until the next scroll/pan, and the edit was not even marked
+    // unsaved.
+    void saveRepaintsTheMapAndMarksItUnsaved()
+    {
+        buildMap();
+        map()->resetUnsaved();
+        QCOMPARE(subject()->getDoor(qsl("n")), 2); // closed, from buildMap
+
+        auto* pDlg = openDialogOn(scmSubjectRoom);
+        QVERIFY(pDlg->doortype_closed_n->isChecked());
+        // Flip the north door to locked.
+        pDlg->doortype_locked_n->setChecked(true);
+        QVERIFY(pDlg->doortype_locked_n->isChecked());
+
+        QSignalSpy areaChangedSpy(map(), &TMap::signal_areaChanged);
+        QVERIFY(areaChangedSpy.isValid());
+        QVERIFY(!map()->isUnsaved());
+
+        pDlg->save();
+
+        // The door change was committed to the room.
+        QCOMPARE(subject()->getDoor(qsl("n")), 3); // locked
+        // The map was marked unsaved.
+        QVERIFY2(map()->isUnsaved(), "editing exits did not mark the map unsaved");
+        // updateArea() queues a throttled repaint that emits signal_areaChanged
+        // for the subject's area - drain the queued call and check it arrived.
+        QVERIFY2(areaChangedSpy.wait(1000), "updateArea() did not repaint the map (signal_areaChanged never fired)");
+        QCOMPARE(areaChangedSpy.count(), 1);
+        QCOMPARE(areaChangedSpy.takeFirst().at(0).toInt(), subject()->getArea());
     }
 };
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Closing the Room Exits dialog after editing an exit (e.g. locking a door) now redraws the mapper immediately, instead of leaving the map stale until the next scroll or pan.
- Such an edit now also marks the map unsaved, so it is not silently lost on close.

#### Motivation for adding to Mudlet
Editing a room's exits changed the underlying data but the dialog's save() never told the mapper to repaint, so the change was invisible until something else forced a paint - and it did not even mark the map as changed. Both made exits editing feel broken and risked losing the edit.

#### Other info (issues closed, discussion etc)
save() now calls `mpMap->updateArea(roomArea)` (queues a throttled `mp2dMap->update()`, the same path the room-properties dialog already uses) and `mpMap->setUnsaved(__func__)`. Covered by `RoomExitsDialogTest::saveRepaintsTheMapAndMarksItUnsaved`, which fails without the fix (the repaint signal never fires) and passes with it.

**Test case:** Open a room's exits, set a door to locked, close the dialog - the map updates right away (no need to scroll), and the map shows as unsaved.

Assisted-by: GLM 5.2