### PR TITLE
Infra: Silence GCC 16 -Wsfinae-incomplete false positives from AUTOMOC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,17 @@ if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
 endif()
 
 add_subdirectory(3rdparty/edbee-lib/edbee-lib)
+# edbee-lib's AUTOMOC mocs_compilation.cpp hits the same GCC 16
+# -Wsfinae-incomplete false positives as mudlet_core's (qmetatype.h's
+# is_complete SFINAE instantiated from one moc file while a type defined in a
+# later moc file is incomplete). The per-source property used for mudlet_core
+# does not cross the add_subdirectory() boundary for a generated AUTOMOC file,
+# so silence the warning on the edbee-lib target itself - PRIVATE so it does
+# not propagate to mudlet_core. Scoped to GCC: the flag is GCC-only (GCC 15+)
+# and Clang/MSVC would diagnose the unknown option.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(edbee-lib PRIVATE -Wno-sfinae-incomplete)
+endif()
 add_subdirectory(3rdparty/communi)
 add_subdirectory(3rdparty/qt-tags-widget)
 add_subdirectory(translations/translated)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -700,6 +700,20 @@ set_target_properties(${LIB_MUDLET_TARGET} PROPERTIES
   AUTOMOC ON AUTORCC ON POSITION_INDEPENDENT_CODE ON
   AUTOGEN_ORIGIN_DEPENDS OFF)
 
+# AUTOMOC concatenates every moc_*.cpp into one mocs_compilation.cpp whose
+# include order it controls. With GCC 16's -Wsfinae-incomplete that trips false
+# positives: qmetatype.h's is_complete SFINAE trait is instantiated from one
+# moc file while types defined in a later moc file are still incomplete, so
+# defining them later warns. The generated TU is not hand-written code, so
+# silence the warning there rather than rearranging includes across moc files.
+# Scoped to GCC: -Wsfinae-incomplete is a GCC-only flag (GCC 15+), and GCC
+# silently ignores unknown -Wno- options on older versions, but Clang/MSVC
+# would diagnose the unknown flag.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set_property(SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${LIB_MUDLET_TARGET}_autogen/mocs_compilation.cpp"
+               APPEND PROPERTY COMPILE_OPTIONS -Wno-sfinae-incomplete)
+endif()
+
 if(USE_FONTS)
   target_compile_definitions(${LIB_MUDLET_TARGET} PUBLIC INCLUDE_FONTS)
 endif()

--- a/src/dlgRoomProperties.h
+++ b/src/dlgRoomProperties.h
@@ -27,8 +27,9 @@
 
 #include <QListWidget>
 
+#include "TRoom.h"
+
 class Host;
-class TRoom;
 
 class dlgRoomProperties : public QDialog, public Ui::room_properties
 {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Silences four `-Wsfinae-incomplete` warnings that appear on a clean GCC 16 build, all originating from AUTOMOC's generated `mocs_compilation.cpp` (a SFINAE trait in `qmetatype.h` is instantiated from one moc file while types defined in a later moc file are still incomplete).
- Includes one real include-hygiene fix (`TRoom.h` included in `dlgRoomProperties.h` instead of forward-declared, because its `signal_preview_border(QSet<TRoom*>)` makes MOC register a metatype that runs `is_complete<TRoom>` on the incomplete type) and scoped `-Wno-sfinae-incomplete` on the two generated MOC TUs that only carry bystander false positives (`mudlet_core`'s `mocs_compilation.cpp` and the vendored `edbee-lib`).

#### Motivation for adding to Mudlet
A clean build with the current Debian GCC (16) prints four C++ warnings that are pure noise from auto-generated MOC code - they obscure real warnings and make "does it build clean?" harder to answer. The flag is gated on `CMAKE_CXX_COMPILER_ID STREQUAL "GNU"` (the project already uses that check elsewhere), so Clang/MSVC builds never see the GCC-only flag.

#### Other info (issues closed, discussion etc)
Verified on both compilers available here: a clean GCC 16 build goes from 4 warnings to 0, and a clean Clang 21 build stays at 0 warnings with the flag not applied (the gate holds - Clang never receives the unknown `-Wno-sfinae-incomplete`, so no "unknown warning option" noise). GCC silently ignores unknown `-Wno-` options on older versions, so older GCC is unaffected.

**Test case:** `cmake --preset linux-debug-nosan && cmake --build --preset linux-debug-nosan --target mudlet` with GCC 16 - no warnings. Same with `clang++` via `-DCMAKE_CXX_COMPILER=clang++` - no warnings, and the GCC-only flag is absent from the compile commands.

Assisted-by: GLM 5.2