### PR TITLE
Fix: Lua trigger toggles no longer walk the whole editor tree per call

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -27,6 +27,7 @@
 #include "TAlias.h"
 #include "TLuaInterpreter.h"
 #include "Tree.h"
+#include "dlgTriggerEditor.h"
 #include "utils.h"
 
 #include <QDebug>
@@ -391,6 +392,9 @@ bool AliasUnit::enableAlias(const QString& name)
         }
         pT->setIsActive(true);
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshAliasIcon(pT->getID());
+        }
     }
     return found;
 }
@@ -404,6 +408,9 @@ bool AliasUnit::disableAlias(const QString& name)
     for (auto it = begin; it != end; ++it) {
         it.value()->setIsActive(false);
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshAliasIcon(it.value()->getID());
+        }
     }
     return found;
 }

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -27,6 +27,7 @@
 #include "Host.h"
 #include "TKey.h"
 #include "Tree.h"
+#include "dlgTriggerEditor.h"
 #include "utils.h"
 
 #include <QFlags>
@@ -238,6 +239,9 @@ bool KeyUnit::enableKey(const QString& name)
         // whole subtrees, so a corpse never sits under a parent this loop keeps.
         pT->enableKey(name);
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshKeyIcon(pT->getID());
+        }
     }
     return found;
 }
@@ -253,6 +257,9 @@ bool KeyUnit::disableKey(const QString& name)
         // Walks pT's children for the same name as well - see enableKey()
         pT->disableKey(name);
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshKeyIcon(pT->getID());
+        }
     }
     return found;
 }

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -288,6 +288,36 @@ int ScriptUnit::getNewID()
     return ++mMaxID;
 }
 
+bool ScriptUnit::enableScript(const QString& name)
+{
+    bool found = false;
+    for (auto script : std::as_const(mScriptMap)) {
+        if (script->getName() == name) {
+            script->setIsActive(true);
+            found = true;
+            if (mpHost->mpEditorDialog) {
+                mpHost->mpEditorDialog->refreshScriptIcon(script->getID());
+            }
+        }
+    }
+    return found;
+}
+
+bool ScriptUnit::disableScript(const QString& name)
+{
+    bool found = false;
+    for (auto script : std::as_const(mScriptMap)) {
+        if (script->getName() == name) {
+            script->setIsActive(false);
+            found = true;
+            if (mpHost->mpEditorDialog) {
+                mpHost->mpEditorDialog->refreshScriptIcon(script->getID());
+            }
+        }
+    }
+    return found;
+}
+
 void ScriptUnit::compileAll(bool saveLoadingError)
 {
     // Iterate a snapshot of the root list: a script's top-level body, run by

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -53,6 +53,12 @@ public:
     QMap<int, TScript*> getScriptList() { return mScriptMap; }
 
     TScript* getScript(int id);
+    // Activates/deactivates every script with this name and refreshes its
+    // editor tree icon - mirrors TriggerUnit::enableTrigger()/disableTrigger()
+    // so every caller benefits, not just the Lua enableScript()/disableScript()
+    // binding that used to do this inline.
+    bool enableScript(const QString& name);
+    bool disableScript(const QString& name);
     void compileAll(bool saveLoadingError = false);
     bool registerScript(TScript* pT);
     void unregisterScript(TScript* pT);

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -408,6 +408,9 @@ int TLuaInterpreter::disableScript(lua_State* L)
         if (script->getName() == name) {
             cnt++;
             script->setIsActive(false);
+            if (host.mpEditorDialog) {
+                host.mpEditorDialog->refreshScriptIcon(script->getID());
+            }
         }
     }
     if (cnt == 0) {
@@ -470,6 +473,9 @@ int TLuaInterpreter::enableScript(lua_State* L)
         if (script->getName() == name) {
             cnt++;
             script->setIsActive(true);
+            if (host.mpEditorDialog) {
+                host.mpEditorDialog->refreshScriptIcon(script->getID());
+            }
         }
     }
     if (cnt == 0) {

--- a/src/TLuaInterpreterMudletObjects.cpp
+++ b/src/TLuaInterpreterMudletObjects.cpp
@@ -402,18 +402,7 @@ int TLuaInterpreter::disableScript(lua_State* L)
     const QString name = getVerifiedString(L, __func__, 1, "script name");
 
     Host& host = getHostFromLua(L);
-    int cnt = 0;
-    QMap<int, TScript*> const scripts = host.getScriptUnit()->getScriptList();
-    for (auto script : scripts) {
-        if (script->getName() == name) {
-            cnt++;
-            script->setIsActive(false);
-            if (host.mpEditorDialog) {
-                host.mpEditorDialog->refreshScriptIcon(script->getID());
-            }
-        }
-    }
-    if (cnt == 0) {
+    if (!host.getScriptUnit()->disableScript(name)) {
         return warnArgumentValue(L, __func__, qsl("script '%1' not found").arg(name));
     }
 
@@ -467,18 +456,7 @@ int TLuaInterpreter::enableScript(lua_State* L)
     const QString name = getVerifiedString(L, __func__, 1, "script name");
 
     Host& host = getHostFromLua(L);
-    int cnt = 0;
-    QMap<int, TScript*> const scripts = host.getScriptUnit()->getScriptList();
-    for (auto script : scripts) {
-        if (script->getName() == name) {
-            cnt++;
-            script->setIsActive(true);
-            if (host.mpEditorDialog) {
-                host.mpEditorDialog->refreshScriptIcon(script->getID());
-            }
-        }
-    }
-    if (cnt == 0) {
+    if (!host.getScriptUnit()->enableScript(name)) {
         return warnArgumentValue(L, __func__, qsl("script '%1' not found").arg(name));
     }
 

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -28,6 +28,7 @@
 #include "Tree.h"
 #include "mudlet.h"
 #include "TTimer.h"
+#include "dlgTriggerEditor.h"
 #include "utils.h"
 
 #include <QLatin1String>
@@ -363,6 +364,9 @@ bool TimerUnit::enableTimer(const QString& name)
         }
 
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshTimerIcon(pT->getID());
+        }
     }
     return found;
 }
@@ -383,6 +387,9 @@ bool TimerUnit::disableTimer(const QString& name)
 
         pT->disableTimer();
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshTimerIcon(pT->getID());
+        }
     }
     return found;
 }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -26,6 +26,7 @@
 
 #include "Host.h"
 #include "TTrigger.h"
+#include "dlgTriggerEditor.h"
 
 #include <QScopeGuard>
 #include <QStringConverter>
@@ -592,6 +593,9 @@ bool TriggerUnit::enableTrigger(const QString& name)
         }
         it.value()->setIsActive(true);
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshTriggerIcon(it.value()->getID());
+        }
     }
     return found;
 }
@@ -605,6 +609,9 @@ bool TriggerUnit::disableTrigger(const QString& name)
     for (auto it = begin; it != end; ++it) {
         it.value()->setIsActive(false);
         found = true;
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->refreshTriggerIcon(it.value()->getID());
+        }
     }
     return found;
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4142,7 +4142,7 @@ void dlgTriggerEditor::slot_batchMoveEnded()
     mpUndoStack->endMacro();
 }
 
-void dlgTriggerEditor::children_icon_triggers(QTreeWidgetItem* pWidgetItemParent)
+void dlgTriggerEditor::children_icon_triggers(QTreeWidgetItem* pWidgetItemParent, bool touchNotification)
 {
     for (int i = 0; i < pWidgetItemParent->childCount(); i++) {
         QTreeWidgetItem* pItem = pWidgetItemParent->child(i);
@@ -4154,7 +4154,7 @@ void dlgTriggerEditor::children_icon_triggers(QTreeWidgetItem* pWidgetItemParent
         QIcon icon;
         QString itemDescription;
         if (pItem->childCount() > 0) {
-            children_icon_triggers(pItem);
+            children_icon_triggers(pItem, touchNotification);
         }
         if (pT->state()) {
             if (pT->isFilterChain()) {
@@ -4216,7 +4216,9 @@ void dlgTriggerEditor::children_icon_triggers(QTreeWidgetItem* pWidgetItemParent
             iconError = cachedIcon(qsl(":/icons/tools-report-bug.png"));
             itemDescription = descError;
             pItem->setIcon(0, iconError);
-            showError(pT->getError());
+            if (touchNotification) {
+                showError(pT->getError());
+            }
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
@@ -4343,7 +4345,7 @@ void dlgTriggerEditor::activeToggle_timer()
     }
 }
 
-void dlgTriggerEditor::children_icon_timer(QTreeWidgetItem* pWidgetItemParent)
+void dlgTriggerEditor::children_icon_timer(QTreeWidgetItem* pWidgetItemParent, bool touchNotification)
 {
     for (int i = 0; i < pWidgetItemParent->childCount(); i++) {
         QTreeWidgetItem* pItem = pWidgetItemParent->child(i);
@@ -4357,7 +4359,7 @@ void dlgTriggerEditor::children_icon_timer(QTreeWidgetItem* pWidgetItemParent)
         const bool itemActive = (pT->isActive() || pT->shouldBeActive());
 
         if (pItem->childCount() > 0) {
-            children_icon_timer(pItem);
+            children_icon_timer(pItem, touchNotification);
         }
         if (pT->state()) {
             if (pT->isFolder()) {
@@ -4420,7 +4422,9 @@ void dlgTriggerEditor::children_icon_timer(QTreeWidgetItem* pWidgetItemParent)
             iconError = cachedIcon(qsl(":/icons/tools-report-bug.png"));
             itemDescription = descError;
             pItem->setIcon(0, iconError);
-            showError(pT->getError());
+            if (touchNotification) {
+                showError(pT->getError());
+            }
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
@@ -4491,7 +4495,7 @@ void dlgTriggerEditor::activeToggle_alias()
     }
 }
 
-void dlgTriggerEditor::children_icon_alias(QTreeWidgetItem* pWidgetItemParent)
+void dlgTriggerEditor::children_icon_alias(QTreeWidgetItem* pWidgetItemParent, bool touchNotification)
 {
     for (int i = 0; i < pWidgetItemParent->childCount(); i++) {
         QTreeWidgetItem* pItem = pWidgetItemParent->child(i);
@@ -4503,7 +4507,7 @@ void dlgTriggerEditor::children_icon_alias(QTreeWidgetItem* pWidgetItemParent)
         QIcon icon;
         QString itemDescription;
         if (pItem->childCount() > 0) {
-            children_icon_alias(pItem);
+            children_icon_alias(pItem, touchNotification);
         }
         if (pT->state()) {
             if (pT->isFolder()) {
@@ -4548,7 +4552,9 @@ void dlgTriggerEditor::children_icon_alias(QTreeWidgetItem* pWidgetItemParent)
             iconError = cachedIcon(qsl(":/icons/tools-report-bug.png"));
             itemDescription = descError;
             pItem->setIcon(0, iconError);
-            showError(pT->getError());
+            if (touchNotification) {
+                showError(pT->getError());
+            }
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
@@ -4619,7 +4625,7 @@ void dlgTriggerEditor::activeToggle_script()
     }
 }
 
-void dlgTriggerEditor::children_icon_script(QTreeWidgetItem* pWidgetItemParent)
+void dlgTriggerEditor::children_icon_script(QTreeWidgetItem* pWidgetItemParent, bool touchNotification)
 {
     for (int i = 0; i < pWidgetItemParent->childCount(); i++) {
         QTreeWidgetItem* pItem = pWidgetItemParent->child(i);
@@ -4631,7 +4637,7 @@ void dlgTriggerEditor::children_icon_script(QTreeWidgetItem* pWidgetItemParent)
         QIcon icon;
         QString itemDescription;
         if (pItem->childCount() > 0) {
-            children_icon_script(pItem);
+            children_icon_script(pItem, touchNotification);
         }
         if (pT->state()) {
             if (pT->isFolder()) {
@@ -4675,7 +4681,9 @@ void dlgTriggerEditor::children_icon_script(QTreeWidgetItem* pWidgetItemParent)
             iconError = cachedIcon(qsl(":/icons/tools-report-bug.png"));
             itemDescription = descError;
             pItem->setIcon(0, iconError);
-            showError(pT->getError());
+            if (touchNotification) {
+                showError(pT->getError());
+            }
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
@@ -4952,7 +4960,7 @@ void dlgTriggerEditor::activeToggle_key()
     }
 }
 
-void dlgTriggerEditor::children_icon_key(QTreeWidgetItem* pWidgetItemParent)
+void dlgTriggerEditor::children_icon_key(QTreeWidgetItem* pWidgetItemParent, bool touchNotification)
 {
     for (int i = 0; i < pWidgetItemParent->childCount(); i++) {
         QTreeWidgetItem* pItem = pWidgetItemParent->child(i);
@@ -4964,7 +4972,7 @@ void dlgTriggerEditor::children_icon_key(QTreeWidgetItem* pWidgetItemParent)
         QIcon icon;
         QString itemDescription;
         if (pItem->childCount() > 0) {
-            children_icon_key(pItem);
+            children_icon_key(pItem, touchNotification);
         }
         if (pT->state()) {
             if (pT->isFolder()) {
@@ -5009,7 +5017,9 @@ void dlgTriggerEditor::children_icon_key(QTreeWidgetItem* pWidgetItemParent)
             iconError = cachedIcon(qsl(":/icons/tools-report-bug.png"));
             itemDescription = descError;
             pItem->setIcon(0, iconError);
-            showError(pT->getError());
+            if (touchNotification) {
+                showError(pT->getError());
+            }
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
@@ -6422,12 +6432,12 @@ void dlgTriggerEditor::computeAliasIcon(TAlias* pT, QIcon& icon, QString& itemDe
 }
 
 // Restores an alias tree item to its non-error appearance and clears the editor notice.
-void dlgTriggerEditor::setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification)
+void dlgTriggerEditor::setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification, bool respectNewState)
 {
     if (touchNotification) {
         clearEditorNotification();
     }
-    if (pT->checkIfNew()) {
+    if (respectNewState && pT->checkIfNew()) {
         // A freshly added alias keeps its "unsaved" cue until an explicit Save
         // activates it - don't recompute it to an active/inactive icon here.
         pItem->setIcon(0, QIcon(QPixmap(pT->isFolder() ? qsl(":/icons/folder-red.png") : qsl(":/icons/document-save-as.png"))));
@@ -6463,10 +6473,10 @@ void dlgTriggerEditor::showAliasLoopWarning(QTreeWidgetItem* pItem, const QStrin
 
 // Reflects the alias's compile state on its tree item: normal icon when the
 // pattern compiles, faulty-regex error otherwise.
-void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification)
+void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification, bool respectNewState)
 {
     if (pT->state()) {
-        setAliasNormalIcon(pItem, pT, touchNotification);
+        setAliasNormalIcon(pItem, pT, touchNotification, respectNewState);
     } else {
         showAliasError(pItem, pT->getName(), pT->getError(), touchNotification);
     }
@@ -6476,10 +6486,18 @@ void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool 
 // current isActive() state - used when the state changed via the Lua
 // enableAlias()/disableAlias() API rather than the GUI toggle. Only touches
 // the shared editor-wide notification banner when aliasID is the item
-// currently open in the detail pane - otherwise a background state change
-// would clobber whatever diagnostic the user is actually looking at.
+// currently open in the detail pane *and* the Aliases view is the one on
+// screen - mpCurrentAliasItem persists across tab switches, so without the
+// view check a background state change could clobber whatever diagnostic the
+// user is actually looking at in a different view.
 void dlgTriggerEditor::refreshAliasIcon(int aliasID)
 {
+    // The dialog is never deleted once opened (see closeEvent()), so a script
+    // toggling items per prompt line would otherwise pay a tree walk on every
+    // call for the rest of the session even with the editor closed.
+    if (!isVisible()) {
+        return;
+    }
     TAlias* pT = mpHost->getAliasUnit()->getAlias(aliasID);
     if (!pT) {
         return;
@@ -6489,10 +6507,14 @@ void dlgTriggerEditor::refreshAliasIcon(int aliasID)
         return;
     }
 
-    applyAliasState(pItem, pT, pItem == mpCurrentAliasItem);
+    const bool touchNotification = pItem == mpCurrentAliasItem && mCurrentView == EditorViewType::cmAliasView;
+    // A profile's aliases stay TAlias::mIsNew until explicitly saved in the
+    // editor, so respecting that here would paint every Lua-toggled alias
+    // with the "unsaved" icon instead of reporting its actual state.
+    applyAliasState(pItem, pT, touchNotification, false);
 
     if (pItem->childCount() > 0) {
-        children_icon_alias(pItem);
+        children_icon_alias(pItem, touchNotification);
     }
 }
 
@@ -8937,9 +8959,15 @@ void dlgTriggerEditor::computeKeyIcon(TKey* pT, QIcon& icon, QString& itemDescri
 // isActive() state - used when the state changed via the Lua
 // enableKey()/disableKey() API rather than the GUI toggle. Only touches the
 // shared editor-wide notification banner when keyID is the item currently
-// open in the detail pane.
+// open in the detail pane *and* the Keys view is the one on screen -
+// mpCurrentKeyItem persists across tab switches, so without the view check a
+// background state change could clobber a diagnostic in a different view.
 void dlgTriggerEditor::refreshKeyIcon(int keyID)
 {
+    // See refreshAliasIcon() - the dialog outlives its own visibility.
+    if (!isVisible()) {
+        return;
+    }
     TKey* pT = mpHost->getKeyUnit()->getKey(keyID);
     if (!pT) {
         return;
@@ -8949,7 +8977,7 @@ void dlgTriggerEditor::refreshKeyIcon(int keyID)
         return;
     }
 
-    const bool isCurrentItem = (pItem == mpCurrentKeyItem);
+    const bool isCurrentItem = (pItem == mpCurrentKeyItem) && (mCurrentView == EditorViewType::cmKeysView);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
@@ -8968,7 +8996,7 @@ void dlgTriggerEditor::refreshKeyIcon(int keyID)
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
 
     if (pItem->childCount() > 0) {
-        children_icon_key(pItem);
+        children_icon_key(pItem, isCurrentItem);
     }
 }
 
@@ -9199,9 +9227,16 @@ void dlgTriggerEditor::computeScriptIcon(TScript* pT, QIcon& icon, QString& item
 // current isActive() state - used when the state changed via the Lua
 // enableScript()/disableScript() API rather than the GUI toggle. Only
 // touches the shared editor-wide notification banner when scriptID is the
-// item currently open in the detail pane.
+// item currently open in the detail pane *and* the Scripts view is the one
+// on screen - mpCurrentScriptItem persists across tab switches, so without
+// the view check a background state change could clobber a diagnostic in a
+// different view.
 void dlgTriggerEditor::refreshScriptIcon(int scriptID)
 {
+    // See refreshAliasIcon() - the dialog outlives its own visibility.
+    if (!isVisible()) {
+        return;
+    }
     TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
     if (!pT) {
         return;
@@ -9211,7 +9246,7 @@ void dlgTriggerEditor::refreshScriptIcon(int scriptID)
         return;
     }
 
-    const bool isCurrentItem = (pItem == mpCurrentScriptItem);
+    const bool isCurrentItem = (pItem == mpCurrentScriptItem) && (mCurrentView == EditorViewType::cmScriptView);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
@@ -9230,7 +9265,7 @@ void dlgTriggerEditor::refreshScriptIcon(int scriptID)
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
 
     if (pItem->childCount() > 0) {
-        children_icon_script(pItem);
+        children_icon_script(pItem, isCurrentItem);
     }
 }
 void dlgTriggerEditor::populateTimers()
@@ -9333,9 +9368,16 @@ void dlgTriggerEditor::computeTimerIcon(TTimer* pT, QIcon& icon, QString& itemDe
 // current isActive() state - used when the state changed via the Lua
 // enableTimer()/disableTimer() API rather than the GUI toggle. Only touches
 // the shared editor-wide notification banner when timerID is the item
-// currently open in the detail pane.
+// currently open in the detail pane *and* the Timers view is the one on
+// screen - mpCurrentTimerItem persists across tab switches, so without the
+// view check a background state change could clobber a diagnostic in a
+// different view.
 void dlgTriggerEditor::refreshTimerIcon(int timerID)
 {
+    // See refreshAliasIcon() - the dialog outlives its own visibility.
+    if (!isVisible()) {
+        return;
+    }
     TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
     if (!pT) {
         return;
@@ -9345,7 +9387,7 @@ void dlgTriggerEditor::refreshTimerIcon(int timerID)
         return;
     }
 
-    const bool isCurrentItem = (pItem == mpCurrentTimerItem);
+    const bool isCurrentItem = (pItem == mpCurrentTimerItem) && (mCurrentView == EditorViewType::cmTimerView);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
@@ -9364,7 +9406,7 @@ void dlgTriggerEditor::refreshTimerIcon(int timerID)
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
 
     if (pItem->childCount() > 0) {
-        children_icon_timer(pItem);
+        children_icon_timer(pItem, isCurrentItem);
     }
 }
 
@@ -9469,10 +9511,16 @@ void dlgTriggerEditor::computeTriggerIcon(TTrigger* pT, QIcon& icon, QString& it
 // enableTrigger()/disableTrigger() API rather than the GUI toggle, which
 // otherwise leaves the tree icon stale until the next full repopulation.
 // Only touches the shared editor-wide notification banner when triggerID is
-// the item currently open in the detail pane - otherwise a background state
-// change would clobber whatever diagnostic the user is actually looking at.
+// the item currently open in the detail pane *and* the Triggers view is the
+// one on screen - mpCurrentTriggerItem persists across tab switches, so
+// without the view check a background state change could clobber whatever
+// diagnostic the user is actually looking at in a different view.
 void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
 {
+    // See refreshAliasIcon() - the dialog outlives its own visibility.
+    if (!isVisible()) {
+        return;
+    }
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
     if (!pT) {
         return;
@@ -9482,7 +9530,7 @@ void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
         return;
     }
 
-    const bool isCurrentItem = (pItem == mpCurrentTriggerItem);
+    const bool isCurrentItem = (pItem == mpCurrentTriggerItem) && (mCurrentView == EditorViewType::cmTriggerView);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
@@ -9501,7 +9549,7 @@ void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
 
     if (pItem->childCount() > 0) {
-        children_icon_triggers(pItem);
+        children_icon_triggers(pItem, isCurrentItem);
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -9521,15 +9521,55 @@ void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
     if (!isVisible()) {
         return;
     }
-    TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
-    if (!pT) {
-        return;
+    mPendingTriggerIconRefresh.insert(triggerID);
+    if (!mTriggerIconRefreshQueued) {
+        mTriggerIconRefreshQueued = true;
+        QTimer::singleShot(0ms, this, &dlgTriggerEditor::flushPendingTriggerIconRefresh);
     }
-    QTreeWidgetItem* pItem = findItemByID(mpTriggerBaseItem, triggerID);
-    if (!pItem) {
-        return;
-    }
+}
 
+void dlgTriggerEditor::flushPendingTriggerIconRefresh()
+{
+    mTriggerIconRefreshQueued = false;
+    if (mPendingTriggerIconRefresh.isEmpty()) {
+        return;
+    }
+    if (mpTriggerBaseItem && isVisible()) {
+        int remaining = mPendingTriggerIconRefresh.size();
+        refreshTriggerIconsIn(mpTriggerBaseItem, false, remaining);
+    }
+    mPendingTriggerIconRefresh.clear();
+}
+
+// One pass over the tree: repaints every pending item and, since a folder's
+// state changes its descendants' greyed-out look, everything under one. Stops
+// as soon as every pending ID has been seen.
+void dlgTriggerEditor::refreshTriggerIconsIn(QTreeWidgetItem* pParent, bool ancestorDirty, int& remaining)
+{
+    for (int i = 0, n = pParent->childCount(); i < n; ++i) {
+        QTreeWidgetItem* pItem = pParent->child(i);
+        const int id = pItem->data(0, Qt::UserRole).toInt();
+        const bool pending = mPendingTriggerIconRefresh.contains(id);
+        if (pending) {
+            --remaining;
+        }
+        const bool dirty = ancestorDirty || pending;
+        if (dirty) {
+            if (TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(id)) {
+                paintTriggerItem(pItem, pT);
+            }
+        }
+        if (pItem->childCount() > 0 && (dirty || remaining > 0)) {
+            refreshTriggerIconsIn(pItem, dirty, remaining);
+        }
+        if (!ancestorDirty && remaining <= 0) {
+            return;
+        }
+    }
+}
+
+void dlgTriggerEditor::paintTriggerItem(QTreeWidgetItem* pItem, TTrigger* pT)
+{
     const bool isCurrentItem = (pItem == mpCurrentTriggerItem) && (mCurrentView == EditorViewType::cmTriggerView);
     QIcon icon;
     QString itemDescription;
@@ -9545,12 +9585,13 @@ void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
             showError(pT->getError());
         }
     }
-    pItem->setIcon(0, icon);
-    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
-
-    if (pItem->childCount() > 0) {
-        children_icon_triggers(pItem, isCurrentItem);
+    // QIcon has no operator==, so setIcon() always emits dataChanged() and the
+    // view re-measures the row - skip it when the icon is the cached one already
+    // shown, which is every item toggled off and back on within one turn.
+    if (pItem->icon(0).cacheKey() != icon.cacheKey()) {
+        pItem->setIcon(0, icon);
     }
+    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
 }
 
 void dlgTriggerEditor::repopulateVars()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -91,6 +91,9 @@
 // Forward declaration for per-property undo helper (defined later in this file)
 static void pushKeyPropertyCommand(EditorUndoStack* undoStack, Host* host, int keyID, const QString& keyName, const QString& propertyName, const QString& oldStateXML, const QString& newStateXML);
 
+// Forward declaration for the tree item lookup helper (defined later in this file)
+QTreeWidgetItem* findItemByID(QTreeWidgetItem* parent, int itemID);
+
 using namespace std::chrono_literals;
 
 // Used as a QObject::property so that we can keep track of the color for the
@@ -6465,6 +6468,27 @@ void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT)
     }
 }
 
+// Repaints aliasID's tree item (and, if any, its descendants) from its
+// current isActive() state - used when the state changed via the Lua
+// enableAlias()/disableAlias() API rather than the GUI toggle.
+void dlgTriggerEditor::refreshAliasIcon(int aliasID)
+{
+    TAlias* pT = mpHost->getAliasUnit()->getAlias(aliasID);
+    if (!pT) {
+        return;
+    }
+    QTreeWidgetItem* pItem = findItemByID(mpAliasBaseItem, aliasID);
+    if (!pItem) {
+        return;
+    }
+
+    applyAliasState(pItem, pT);
+
+    if (pItem->childCount() > 0) {
+        children_icon_alias(pItem);
+    }
+}
+
 void dlgTriggerEditor::saveAction()
 {
     QTreeWidgetItem* pItem = mpCurrentActionItem;
@@ -8839,52 +8863,7 @@ void dlgTriggerEditor::populateKeys()
         }
         if (key->state()) {
             clearEditorNotification();
-
-            if (key->isFolder()) {
-                itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
-                if (!key->mPackageName.isEmpty()) {
-                    if (key->isActive()) {
-                        if (key->ancestorsActive()) {
-                            icon = cachedIcon(qsl(":/icons/folder-brown.png"));
-                        } else {
-                            icon = cachedIcon(qsl(":/icons/folder-grey.png"));
-                            itemDescription = descInactiveParent.arg(itemDescription);
-                        }
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
-                    }
-                } else if (key->isActive()) {
-                    if (key->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/folder-pink.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-grey.png"));
-                        itemDescription = descInactiveParent.arg(itemDescription);
-                    }
-                } else {
-                    if (key->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/folder-pink-locked.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-grey-locked.png"));
-                    }
-                }
-            } else {
-                if (key->isActive()) {
-                    itemDescription = descActive;
-                    if (key->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox_checked_grey.png"));
-                        itemDescription = descInactiveParent.arg(itemDescription);
-                    }
-                } else {
-                    itemDescription = descInactive;
-                    if (key->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox-grey.png"));
-                    }
-                }
-            }
+            computeKeyIcon(key, icon, itemDescription);
             pItem->setIcon(0, icon);
         } else {
             QIcon iconError;
@@ -8896,6 +8875,89 @@ void dlgTriggerEditor::populateKeys()
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
 }
+
+void dlgTriggerEditor::computeKeyIcon(TKey* pT, QIcon& icon, QString& itemDescription) const
+{
+    const bool itemActive = pT->isActive();
+    if (pT->isFolder()) {
+        itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
+        if (!pT->mPackageName.isEmpty()) {
+            if (pT->isActive()) {
+                if (pT->ancestorsActive()) {
+                    icon = cachedIcon(qsl(":/icons/folder-brown.png"));
+                } else {
+                    icon = cachedIcon(qsl(":/icons/folder-grey.png"));
+                    itemDescription = descInactiveParent.arg(itemDescription);
+                }
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
+            }
+        } else if (pT->isActive()) {
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/folder-pink.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-grey.png"));
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/folder-pink-locked.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-grey-locked.png"));
+            }
+        }
+    } else {
+        if (pT->isActive()) {
+            itemDescription = descActive;
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox_checked_grey.png"));
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            itemDescription = descInactive;
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox-grey.png"));
+            }
+        }
+    }
+}
+
+// Repaints keyID's tree item (and, if any, its descendants) from its current
+// isActive() state - used when the state changed via the Lua
+// enableKey()/disableKey() API rather than the GUI toggle.
+void dlgTriggerEditor::refreshKeyIcon(int keyID)
+{
+    TKey* pT = mpHost->getKeyUnit()->getKey(keyID);
+    if (!pT) {
+        return;
+    }
+    QTreeWidgetItem* pItem = findItemByID(mpKeyBaseItem, keyID);
+    if (!pItem) {
+        return;
+    }
+
+    QIcon icon;
+    QString itemDescription;
+    if (pT->state()) {
+        clearEditorNotification();
+        computeKeyIcon(pT, icon, itemDescription);
+    } else {
+        icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
+        itemDescription = descError;
+        showError(pT->getError());
+    }
+    pItem->setIcon(0, icon);
+    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+
+    if (pItem->childCount() > 0) {
+        children_icon_key(pItem);
+    }
+}
+
 void dlgTriggerEditor::populateActions()
 {
     std::list<TAction*> const baseNodeList_action = mpHost->getActionUnit()->getActionRootNodeList();
@@ -9077,31 +9139,7 @@ void dlgTriggerEditor::populateScripts()
         }
         if (script->state()) {
             clearEditorNotification();
-
-            if (script->isFolder()) {
-                itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
-                if (!script->mPackageName.isEmpty()) {
-                    if (itemActive) {
-                        icon = cachedIcon(qsl(":/icons/folder-brown.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
-                    }
-                } else {
-                    if (itemActive) {
-                        icon = cachedIcon(qsl(":/icons/folder-orange.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-orange-locked.png"));
-                    }
-                }
-            } else {
-                if (script->isActive()) {
-                    icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
-                    itemDescription = descActive;
-                } else {
-                    icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
-                    itemDescription = descInactive;
-                }
-            }
+            computeScriptIcon(script, icon, itemDescription);
             pItem->setIcon(0, icon);
         } else {
             QIcon iconError;
@@ -9111,6 +9149,67 @@ void dlgTriggerEditor::populateScripts()
             showError(script->getError());
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+    }
+}
+
+void dlgTriggerEditor::computeScriptIcon(TScript* pT, QIcon& icon, QString& itemDescription) const
+{
+    const bool itemActive = pT->isActive();
+    if (pT->isFolder()) {
+        itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
+        if (!pT->mPackageName.isEmpty()) {
+            if (itemActive) {
+                icon = cachedIcon(qsl(":/icons/folder-brown.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
+            }
+        } else {
+            if (itemActive) {
+                icon = cachedIcon(qsl(":/icons/folder-orange.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-orange-locked.png"));
+            }
+        }
+    } else {
+        if (pT->isActive()) {
+            icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
+            itemDescription = descActive;
+        } else {
+            icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
+            itemDescription = descInactive;
+        }
+    }
+}
+
+// Repaints scriptID's tree item (and, if any, its descendants) from its
+// current isActive() state - used when the state changed via the Lua
+// enableScript()/disableScript() API rather than the GUI toggle.
+void dlgTriggerEditor::refreshScriptIcon(int scriptID)
+{
+    TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
+    if (!pT) {
+        return;
+    }
+    QTreeWidgetItem* pItem = findItemByID(mpScriptsBaseItem, scriptID);
+    if (!pItem) {
+        return;
+    }
+
+    QIcon icon;
+    QString itemDescription;
+    if (pT->state()) {
+        clearEditorNotification();
+        computeScriptIcon(pT, icon, itemDescription);
+    } else {
+        icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
+        itemDescription = descError;
+        showError(pT->getError());
+    }
+    pItem->setIcon(0, icon);
+    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+
+    if (pItem->childCount() > 0) {
+        children_icon_script(pItem);
     }
 }
 void dlgTriggerEditor::populateTimers()
@@ -9134,64 +9233,7 @@ void dlgTriggerEditor::populateTimers()
         }
         if (timer->state()) {
             clearEditorNotification();
-
-            if (timer->isFolder()) {
-                itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
-                if (!timer->mPackageName.isEmpty()) {
-                    if (itemActive) {
-                        icon = cachedIcon(qsl(":/icons/folder-brown.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
-                    }
-                } else {
-                    if (timer->shouldBeActive()) {
-                        if (timer->ancestorsActive()) {
-                            icon = cachedIcon(qsl(":/icons/folder-green.png"));
-                        } else {
-                            icon = cachedIcon(qsl(":/icons/folder-grey.png"));
-                            itemDescription = descInactiveParent.arg(itemDescription);
-                        }
-                    } else {
-                        if (timer->ancestorsActive()) {
-                            icon = cachedIcon(qsl(":/icons/folder-green-locked.png"));
-                        } else {
-                            icon = cachedIcon(qsl(":/icons/folder-grey-locked.png"));
-                        }
-                    }
-                }
-            } else {
-                if (timer->isOffsetTimer()) {
-                    if (timer->shouldBeActive()) {
-                        itemDescription = descActiveOffsetTimer;
-                        if (timer->ancestorsActive()) {
-                            icon = cachedIcon(qsl(":/icons/offsettimer-on.png"));
-                        } else {
-                            icon = cachedIcon(qsl(":/icons/offsettimer-on-grey.png"));
-                            itemDescription = descInactiveParent.arg(itemDescription);
-                        }
-                    } else {
-                        itemDescription = descInactiveOffsetTimer;
-                        if (timer->ancestorsActive()) {
-                            icon = cachedIcon(qsl(":/icons/offsettimer-off.png"));
-                        } else {
-                            icon = cachedIcon(qsl(":/icons/offsettimer-off-grey.png"));
-                        }
-                    }
-                } else {
-                    if (timer->shouldBeActive()) {
-                        itemDescription = descActive;
-                        if (timer->ancestorsActive()) {
-                            icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
-                        } else {
-                            icon = cachedIcon(qsl(":/icons/tag_checkbox_checked_grey.png"));
-                            itemDescription = descInactiveParent.arg(itemDescription);
-                        }
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
-                        itemDescription = descInactive;
-                    }
-                }
-            }
+            computeTimerIcon(timer, icon, itemDescription);
             pItem->setIcon(0, icon);
         } else {
             QIcon iconError;
@@ -9203,6 +9245,101 @@ void dlgTriggerEditor::populateTimers()
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
     }
 }
+
+void dlgTriggerEditor::computeTimerIcon(TTimer* pT, QIcon& icon, QString& itemDescription) const
+{
+    const bool itemActive = pT->isActive();
+    if (pT->isFolder()) {
+        itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
+        if (!pT->mPackageName.isEmpty()) {
+            if (itemActive) {
+                icon = cachedIcon(qsl(":/icons/folder-brown.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
+            }
+        } else {
+            if (pT->shouldBeActive()) {
+                if (pT->ancestorsActive()) {
+                    icon = cachedIcon(qsl(":/icons/folder-green.png"));
+                } else {
+                    icon = cachedIcon(qsl(":/icons/folder-grey.png"));
+                    itemDescription = descInactiveParent.arg(itemDescription);
+                }
+            } else {
+                if (pT->ancestorsActive()) {
+                    icon = cachedIcon(qsl(":/icons/folder-green-locked.png"));
+                } else {
+                    icon = cachedIcon(qsl(":/icons/folder-grey-locked.png"));
+                }
+            }
+        }
+    } else {
+        if (pT->isOffsetTimer()) {
+            if (pT->shouldBeActive()) {
+                itemDescription = descActiveOffsetTimer;
+                if (pT->ancestorsActive()) {
+                    icon = cachedIcon(qsl(":/icons/offsettimer-on.png"));
+                } else {
+                    icon = cachedIcon(qsl(":/icons/offsettimer-on-grey.png"));
+                    itemDescription = descInactiveParent.arg(itemDescription);
+                }
+            } else {
+                itemDescription = descInactiveOffsetTimer;
+                if (pT->ancestorsActive()) {
+                    icon = cachedIcon(qsl(":/icons/offsettimer-off.png"));
+                } else {
+                    icon = cachedIcon(qsl(":/icons/offsettimer-off-grey.png"));
+                }
+            }
+        } else {
+            if (pT->shouldBeActive()) {
+                itemDescription = descActive;
+                if (pT->ancestorsActive()) {
+                    icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
+                } else {
+                    icon = cachedIcon(qsl(":/icons/tag_checkbox_checked_grey.png"));
+                    itemDescription = descInactiveParent.arg(itemDescription);
+                }
+            } else {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
+                itemDescription = descInactive;
+            }
+        }
+    }
+}
+
+// Repaints timerID's tree item (and, if any, its descendants) from its
+// current isActive() state - used when the state changed via the Lua
+// enableTimer()/disableTimer() API rather than the GUI toggle.
+void dlgTriggerEditor::refreshTimerIcon(int timerID)
+{
+    TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
+    if (!pT) {
+        return;
+    }
+    QTreeWidgetItem* pItem = findItemByID(mpTimerBaseItem, timerID);
+    if (!pItem) {
+        return;
+    }
+
+    QIcon icon;
+    QString itemDescription;
+    if (pT->state()) {
+        clearEditorNotification();
+        computeTimerIcon(pT, icon, itemDescription);
+    } else {
+        icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
+        itemDescription = descError;
+        showError(pT->getError());
+    }
+    pItem->setIcon(0, icon);
+    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+
+    if (pItem->childCount() > 0) {
+        children_icon_timer(pItem);
+    }
+}
+
 void dlgTriggerEditor::populateTriggers()
 {
     std::list<TTrigger*> const baseNodeList = mpHost->getTriggerUnit()->getTriggerRootNodeList();
@@ -9224,64 +9361,7 @@ void dlgTriggerEditor::populateTriggers()
         }
         if (trigger->state()) {
             clearEditorNotification();
-
-            if (trigger->isFilterChain()) {
-                if (itemActive) {
-                    itemDescription = descActiveFilterChain;
-                    if (trigger->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/filter.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/filter-grey.png"));
-                        itemDescription = descInactiveParent.arg(itemDescription);
-                    }
-                } else {
-                    itemDescription = descInactiveFilterChain;
-                    if (trigger->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/filter-locked.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/filter-grey-locked.png"));
-                    }
-                }
-            } else if (trigger->isFolder()) {
-                itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
-                if (!trigger->mPackageName.isEmpty()) {
-                    if (itemActive) {
-                        icon = cachedIcon(qsl(":/icons/folder-brown.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
-                    }
-                } else if (itemActive) {
-                    if (trigger->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/folder-blue.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-grey.png"));
-                        itemDescription = descInactiveParent.arg(itemDescription);
-                    }
-                } else {
-                    if (trigger->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/folder-blue-locked.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/folder-grey-locked.png"));
-                    }
-                }
-            } else {
-                if (itemActive) {
-                    itemDescription = descActive;
-                    if (trigger->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox_checked_grey.png"));
-                        itemDescription = descInactiveParent.arg(itemDescription);
-                    }
-                } else {
-                    itemDescription = descInactive;
-                    if (trigger->ancestorsActive()) {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
-                    } else {
-                        icon = cachedIcon(qsl(":/icons/tag_checkbox-grey.png"));
-                    }
-                }
-            }
+            computeTriggerIcon(trigger, icon, itemDescription);
             pItem->setIcon(0, icon);
         } else {
             QIcon iconError;
@@ -9291,6 +9371,101 @@ void dlgTriggerEditor::populateTriggers()
             showError(trigger->getError());
         }
         pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+    }
+}
+
+void dlgTriggerEditor::computeTriggerIcon(TTrigger* pT, QIcon& icon, QString& itemDescription) const
+{
+    const bool itemActive = pT->isActive();
+    if (pT->isFilterChain()) {
+        if (itemActive) {
+            itemDescription = descActiveFilterChain;
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/filter.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/filter-grey.png"));
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            itemDescription = descInactiveFilterChain;
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/filter-locked.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/filter-grey-locked.png"));
+            }
+        }
+    } else if (pT->isFolder()) {
+        itemDescription = (itemActive ? descActiveFolder : descInactiveFolder);
+        if (!pT->mPackageName.isEmpty()) {
+            if (itemActive) {
+                icon = cachedIcon(qsl(":/icons/folder-brown.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-brown-locked.png"));
+            }
+        } else if (itemActive) {
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/folder-blue.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-grey.png"));
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/folder-blue-locked.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/folder-grey-locked.png"));
+            }
+        }
+    } else {
+        if (itemActive) {
+            itemDescription = descActive;
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox_checked.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox_checked_grey.png"));
+                itemDescription = descInactiveParent.arg(itemDescription);
+            }
+        } else {
+            itemDescription = descInactive;
+            if (pT->ancestorsActive()) {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox.png"));
+            } else {
+                icon = cachedIcon(qsl(":/icons/tag_checkbox-grey.png"));
+            }
+        }
+    }
+}
+
+// Repaints triggerID's tree item (and, if any, its descendants) from its
+// current isActive() state - used when the state changed via the Lua
+// enableTrigger()/disableTrigger() API rather than the GUI toggle, which
+// otherwise leaves the tree icon stale until the next full repopulation.
+void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
+{
+    TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
+    if (!pT) {
+        return;
+    }
+    QTreeWidgetItem* pItem = findItemByID(mpTriggerBaseItem, triggerID);
+    if (!pItem) {
+        return;
+    }
+
+    QIcon icon;
+    QString itemDescription;
+    if (pT->state()) {
+        clearEditorNotification();
+        computeTriggerIcon(pT, icon, itemDescription);
+    } else {
+        icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
+        itemDescription = descError;
+        showError(pT->getError());
+    }
+    pItem->setIcon(0, icon);
+    pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
+
+    if (pItem->childCount() > 0) {
+        children_icon_triggers(pItem);
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6422,9 +6422,11 @@ void dlgTriggerEditor::computeAliasIcon(TAlias* pT, QIcon& icon, QString& itemDe
 }
 
 // Restores an alias tree item to its non-error appearance and clears the editor notice.
-void dlgTriggerEditor::setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT)
+void dlgTriggerEditor::setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification)
 {
-    clearEditorNotification();
+    if (touchNotification) {
+        clearEditorNotification();
+    }
     if (pT->checkIfNew()) {
         // A freshly added alias keeps its "unsaved" cue until an explicit Save
         // activates it - don't recompute it to an active/inactive icon here.
@@ -6440,14 +6442,16 @@ void dlgTriggerEditor::setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT)
 }
 
 // Flags an alias tree item as broken and shows the given error message.
-void dlgTriggerEditor::showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error)
+void dlgTriggerEditor::showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error, bool touchNotification)
 {
     QIcon iconError;
     iconError = cachedIcon(qsl(":/icons/tools-report-bug.png"));
     pItem->setIcon(0, iconError);
     pItem->setText(0, name);
     pItem->setData(0, Qt::AccessibleDescriptionRole, descError);
-    showError(error);
+    if (touchNotification) {
+        showError(error);
+    }
 }
 
 void dlgTriggerEditor::showAliasLoopWarning(QTreeWidgetItem* pItem, const QString& name)
@@ -6459,18 +6463,21 @@ void dlgTriggerEditor::showAliasLoopWarning(QTreeWidgetItem* pItem, const QStrin
 
 // Reflects the alias's compile state on its tree item: normal icon when the
 // pattern compiles, faulty-regex error otherwise.
-void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT)
+void dlgTriggerEditor::applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification)
 {
     if (pT->state()) {
-        setAliasNormalIcon(pItem, pT);
+        setAliasNormalIcon(pItem, pT, touchNotification);
     } else {
-        showAliasError(pItem, pT->getName(), pT->getError());
+        showAliasError(pItem, pT->getName(), pT->getError(), touchNotification);
     }
 }
 
 // Repaints aliasID's tree item (and, if any, its descendants) from its
 // current isActive() state - used when the state changed via the Lua
-// enableAlias()/disableAlias() API rather than the GUI toggle.
+// enableAlias()/disableAlias() API rather than the GUI toggle. Only touches
+// the shared editor-wide notification banner when aliasID is the item
+// currently open in the detail pane - otherwise a background state change
+// would clobber whatever diagnostic the user is actually looking at.
 void dlgTriggerEditor::refreshAliasIcon(int aliasID)
 {
     TAlias* pT = mpHost->getAliasUnit()->getAlias(aliasID);
@@ -6482,7 +6489,7 @@ void dlgTriggerEditor::refreshAliasIcon(int aliasID)
         return;
     }
 
-    applyAliasState(pItem, pT);
+    applyAliasState(pItem, pT, pItem == mpCurrentAliasItem);
 
     if (pItem->childCount() > 0) {
         children_icon_alias(pItem);
@@ -8928,7 +8935,9 @@ void dlgTriggerEditor::computeKeyIcon(TKey* pT, QIcon& icon, QString& itemDescri
 
 // Repaints keyID's tree item (and, if any, its descendants) from its current
 // isActive() state - used when the state changed via the Lua
-// enableKey()/disableKey() API rather than the GUI toggle.
+// enableKey()/disableKey() API rather than the GUI toggle. Only touches the
+// shared editor-wide notification banner when keyID is the item currently
+// open in the detail pane.
 void dlgTriggerEditor::refreshKeyIcon(int keyID)
 {
     TKey* pT = mpHost->getKeyUnit()->getKey(keyID);
@@ -8940,15 +8949,20 @@ void dlgTriggerEditor::refreshKeyIcon(int keyID)
         return;
     }
 
+    const bool isCurrentItem = (pItem == mpCurrentKeyItem);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
-        clearEditorNotification();
+        if (isCurrentItem) {
+            clearEditorNotification();
+        }
         computeKeyIcon(pT, icon, itemDescription);
     } else {
         icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
         itemDescription = descError;
-        showError(pT->getError());
+        if (isCurrentItem) {
+            showError(pT->getError());
+        }
     }
     pItem->setIcon(0, icon);
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
@@ -9183,7 +9197,9 @@ void dlgTriggerEditor::computeScriptIcon(TScript* pT, QIcon& icon, QString& item
 
 // Repaints scriptID's tree item (and, if any, its descendants) from its
 // current isActive() state - used when the state changed via the Lua
-// enableScript()/disableScript() API rather than the GUI toggle.
+// enableScript()/disableScript() API rather than the GUI toggle. Only
+// touches the shared editor-wide notification banner when scriptID is the
+// item currently open in the detail pane.
 void dlgTriggerEditor::refreshScriptIcon(int scriptID)
 {
     TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
@@ -9195,15 +9211,20 @@ void dlgTriggerEditor::refreshScriptIcon(int scriptID)
         return;
     }
 
+    const bool isCurrentItem = (pItem == mpCurrentScriptItem);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
-        clearEditorNotification();
+        if (isCurrentItem) {
+            clearEditorNotification();
+        }
         computeScriptIcon(pT, icon, itemDescription);
     } else {
         icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
         itemDescription = descError;
-        showError(pT->getError());
+        if (isCurrentItem) {
+            showError(pT->getError());
+        }
     }
     pItem->setIcon(0, icon);
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
@@ -9310,7 +9331,9 @@ void dlgTriggerEditor::computeTimerIcon(TTimer* pT, QIcon& icon, QString& itemDe
 
 // Repaints timerID's tree item (and, if any, its descendants) from its
 // current isActive() state - used when the state changed via the Lua
-// enableTimer()/disableTimer() API rather than the GUI toggle.
+// enableTimer()/disableTimer() API rather than the GUI toggle. Only touches
+// the shared editor-wide notification banner when timerID is the item
+// currently open in the detail pane.
 void dlgTriggerEditor::refreshTimerIcon(int timerID)
 {
     TTimer* pT = mpHost->getTimerUnit()->getTimer(timerID);
@@ -9322,15 +9345,20 @@ void dlgTriggerEditor::refreshTimerIcon(int timerID)
         return;
     }
 
+    const bool isCurrentItem = (pItem == mpCurrentTimerItem);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
-        clearEditorNotification();
+        if (isCurrentItem) {
+            clearEditorNotification();
+        }
         computeTimerIcon(pT, icon, itemDescription);
     } else {
         icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
         itemDescription = descError;
-        showError(pT->getError());
+        if (isCurrentItem) {
+            showError(pT->getError());
+        }
     }
     pItem->setIcon(0, icon);
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);
@@ -9440,6 +9468,9 @@ void dlgTriggerEditor::computeTriggerIcon(TTrigger* pT, QIcon& icon, QString& it
 // current isActive() state - used when the state changed via the Lua
 // enableTrigger()/disableTrigger() API rather than the GUI toggle, which
 // otherwise leaves the tree icon stale until the next full repopulation.
+// Only touches the shared editor-wide notification banner when triggerID is
+// the item currently open in the detail pane - otherwise a background state
+// change would clobber whatever diagnostic the user is actually looking at.
 void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
 {
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(triggerID);
@@ -9451,15 +9482,20 @@ void dlgTriggerEditor::refreshTriggerIcon(int triggerID)
         return;
     }
 
+    const bool isCurrentItem = (pItem == mpCurrentTriggerItem);
     QIcon icon;
     QString itemDescription;
     if (pT->state()) {
-        clearEditorNotification();
+        if (isCurrentItem) {
+            clearEditorNotification();
+        }
         computeTriggerIcon(pT, icon, itemDescription);
     } else {
         icon = cachedIcon(qsl(":/icons/tools-report-bug.png"));
         itemDescription = descError;
-        showError(pT->getError());
+        if (isCurrentItem) {
+            showError(pT->getError());
+        }
     }
     pItem->setIcon(0, icon);
     pItem->setData(0, Qt::AccessibleDescriptionRole, itemDescription);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -205,6 +205,14 @@ public:
     void children_icon_timer(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_script(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_action(QTreeWidgetItem* pWidgetItemParent);
+    // Repaints a single item's icon/description from its current TX::isActive()
+    // state, without a full tree rebuild - for GUI-external state changes such
+    // as the enableTrigger()/disableTrigger() family of Lua functions.
+    void refreshTriggerIcon(int triggerID);
+    void refreshAliasIcon(int aliasID);
+    void refreshScriptIcon(int scriptID);
+    void refreshTimerIcon(int timerID);
+    void refreshKeyIcon(int keyID);
     void doCleanReset();
     void writeScript(int id);
     void addVar(bool);
@@ -407,6 +415,10 @@ private:
     void saveTrigger();
     void saveAlias();
     void computeAliasIcon(TAlias* pT, QIcon& icon, QString& itemDescription) const;
+    void computeTriggerIcon(TTrigger* pT, QIcon& icon, QString& itemDescription) const;
+    void computeTimerIcon(TTimer* pT, QIcon& icon, QString& itemDescription) const;
+    void computeScriptIcon(TScript* pT, QIcon& icon, QString& itemDescription) const;
+    void computeKeyIcon(TKey* pT, QIcon& icon, QString& itemDescription) const;
     void setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT);
     void showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error);
     void showAliasLoopWarning(QTreeWidgetItem* pItem, const QString& name);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -419,10 +419,10 @@ private:
     void computeTimerIcon(TTimer* pT, QIcon& icon, QString& itemDescription) const;
     void computeScriptIcon(TScript* pT, QIcon& icon, QString& itemDescription) const;
     void computeKeyIcon(TKey* pT, QIcon& icon, QString& itemDescription) const;
-    void setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT);
-    void showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error);
+    void setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification = true);
+    void showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error, bool touchNotification = true);
     void showAliasLoopWarning(QTreeWidgetItem* pItem, const QString& name);
-    void applyAliasState(QTreeWidgetItem* pItem, TAlias* pT);
+    void applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification = true);
     bool aliasSubstitutionLoops(const QString& regex, const QString& substitution) const;
     void saveTimer();
     void saveKey();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -199,11 +199,17 @@ public:
     void showError(const QString&);
     void showWarning(const QString&, bool announce = true);
     void showInfo(const QString&);
-    void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);
-    void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
-    void children_icon_key(QTreeWidgetItem* pWidgetItemParent);
-    void children_icon_timer(QTreeWidgetItem* pWidgetItemParent);
-    void children_icon_script(QTreeWidgetItem* pWidgetItemParent);
+    // touchNotification: whether an errored descendant may show its error on the
+    // shared editor-wide notification banner. The GUI toggle paths default this
+    // true - the user is looking at the tree they just clicked in - while the
+    // Lua-triggered refreshXIcon() paths pass whether the recursing item is the
+    // one currently open, so a background toggle cannot clobber an unrelated
+    // diagnostic the user is actually reading.
+    void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent, bool touchNotification = true);
+    void children_icon_alias(QTreeWidgetItem* pWidgetItemParent, bool touchNotification = true);
+    void children_icon_key(QTreeWidgetItem* pWidgetItemParent, bool touchNotification = true);
+    void children_icon_timer(QTreeWidgetItem* pWidgetItemParent, bool touchNotification = true);
+    void children_icon_script(QTreeWidgetItem* pWidgetItemParent, bool touchNotification = true);
     void children_icon_action(QTreeWidgetItem* pWidgetItemParent);
     // Repaints a single item's icon/description from its current TX::isActive()
     // state, without a full tree rebuild - for GUI-external state changes such
@@ -419,10 +425,16 @@ private:
     void computeTimerIcon(TTimer* pT, QIcon& icon, QString& itemDescription) const;
     void computeScriptIcon(TScript* pT, QIcon& icon, QString& itemDescription) const;
     void computeKeyIcon(TKey* pT, QIcon& icon, QString& itemDescription) const;
-    void setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification = true);
+    // respectNewState: a freshly-added, not-yet-saved alias keeps its "unsaved"
+    // icon rather than an active/inactive one - true for every GUI-driven path,
+    // since TAlias::mIsNew only ever clears via an explicit Save. The
+    // Lua-triggered refreshAliasIcon() passes false: a profile's aliases are
+    // still "new" until manually saved, so respecting it there painted every
+    // Lua-toggled alias with the save-as icon instead of reporting its state.
+    void setAliasNormalIcon(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification = true, bool respectNewState = true);
     void showAliasError(QTreeWidgetItem* pItem, const QString& name, const QString& error, bool touchNotification = true);
     void showAliasLoopWarning(QTreeWidgetItem* pItem, const QString& name);
-    void applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification = true);
+    void applyAliasState(QTreeWidgetItem* pItem, TAlias* pT, bool touchNotification = true, bool respectNewState = true);
     bool aliasSubstitutionLoops(const QString& regex, const QString& substitution) const;
     void saveTimer();
     void saveKey();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -749,6 +749,13 @@ private:
 
     // keeps track of the dialog reset being queued
     bool mCleanResetQueued = false;
+    // Trigger IDs whose tree icon is stale; painted in one tree walk on the
+    // next event-loop turn rather than one O(tree) lookup per Lua toggle.
+    QSet<int> mPendingTriggerIconRefresh;
+    bool mTriggerIconRefreshQueued = false;
+    void flushPendingTriggerIconRefresh();
+    void refreshTriggerIconsIn(QTreeWidgetItem* pParent, bool ancestorDirty, int& remaining);
+    void paintTriggerItem(QTreeWidgetItem* pItem, TTrigger* pT);
 
     // One QIcon per resource path: a tree of thousands of items would otherwise
     // decode the same handful of PNGs once per item, every time it is rebuilt

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -591,3 +591,7 @@ else()
 endif()
 set_property(TEST TDiscordModeTest APPEND PROPERTY
     ENVIRONMENT_MODIFICATION "${DISCORD_RPC_PATH_VARIABLE}=path_list_prepend:${CMAKE_SOURCE_DIR}/3rdparty/discord/rpc/lib")
+# Report-only: what a Lua enableTrigger()/disableTrigger() call costs on a large
+# trigger tree with the script editor closed and open. Never registered with
+# ctest; run it directly and read the METRIC lines.
+add_functional_test_binary(TriggerToggleEditorBenchmark TriggerToggleEditorBenchmark.cpp)

--- a/test/functional_tests/TriggerEditorTest.cpp
+++ b/test/functional_tests/TriggerEditorTest.cpp
@@ -37,6 +37,8 @@
 #include "PortableModeTestHelper.h"
 #include "ProfileTestHelper.h"
 #include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "dlgTriggerEditor.h"
 #include "SingleLineTextEdit.h"
 #include "TelnetServerStub.h"
 #include "dlgConnectionProfiles.h"
@@ -213,6 +215,66 @@ private slots:
     QFocusEvent tabFocusOut(QEvent::FocusOut, Qt::TabFocusReason);
     QApplication::sendEvent(&edit, &tabFocusOut);
     QVERIFY2(!edit.textCursor().hasSelection(), "focus moving to another widget kept the selection");
+  }
+  // enableTrigger()/disableTrigger() from Lua used to leave the editor's tree
+  // icon stale until something else rebuilt the tree. The repaint is deferred
+  // to the next event-loop turn so a script toggling many triggers per line
+  // pays one tree walk, not one per call - hence the QTRY_ waits.
+  void test_luaToggleRepaintsTheTreeItem() {
+    mudlet::self()->slot_showScriptDialog();
+    QTest::qWait(100ms);
+    dlgTriggerEditor *pEditor = mpHost->mpEditorDialog;
+    QVERIFY2(pEditor, "the editor dialog was not created");
+    TLuaInterpreter *pLua = mpHost->getLuaInterpreter();
+    QVERIFY(pLua->compileAndExecuteScript(
+        qsl("permGroup(\"qaToggleFolder\", \"trigger\")\n"
+            "permRegexTrigger(\"qaToggleLeaf\", \"qaToggleFolder\", "
+            "{\"^qa toggle$\"}, \"\")")));
+    pEditor->doCleanReset();
+    QTreeWidgetItem *pLeaf = nullptr;
+    // The tree is a private Ui member; its objectName is what the .ui gives it
+    auto *pTree = pEditor->findChild<QTreeWidget *>(qsl("treeWidget_triggers"));
+    QVERIFY(pTree);
+    QVERIFY2(QTest::qWaitFor([&]() {
+      const auto found = pTree->findItems(
+          qsl("qaToggleLeaf"),
+          Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive,
+          0);
+      pLeaf = found.isEmpty() ? nullptr : found.first();
+      return pLeaf != nullptr;
+    }), "the editor never rebuilt its tree around the planted trigger");
+    QTreeWidgetItem *pFolder = pLeaf->parent();
+    QVERIFY(pFolder);
+    // The accessible description is written alongside the icon from the same
+    // computed state, so it stands in for the icon here
+    auto description = [](QTreeWidgetItem *pItem) {
+      return pItem->data(0, Qt::AccessibleDescriptionRole).toString();
+    };
+    const QString active = dlgTriggerEditor::tr("activated");
+    const QString inactive = dlgTriggerEditor::tr("deactivated");
+    const QString activeFolder = dlgTriggerEditor::tr("activated folder");
+    const QString inactiveFolder = dlgTriggerEditor::tr("deactivated folder");
+    const QString inactiveParent = dlgTriggerEditor::tr("%1 in a deactivated group").arg(active);
+    QCOMPARE(description(pLeaf), active);
+
+    QVERIFY(pLua->compileAndExecuteScript(qsl("disableTrigger(\"qaToggleLeaf\")")));
+    QTRY_COMPARE(description(pLeaf), inactive);
+
+    QVERIFY(pLua->compileAndExecuteScript(qsl("enableTrigger(\"qaToggleLeaf\")")));
+    QTRY_COMPARE(description(pLeaf), active);
+
+    // A folder's state greys out everything under it
+    QVERIFY(pLua->compileAndExecuteScript(qsl("disableTrigger(\"qaToggleFolder\")")));
+    QTRY_COMPARE(description(pFolder), inactiveFolder);
+    QCOMPARE(description(pLeaf), inactiveParent);
+
+    // Toggled off and back on within one turn: the tree ends where it started
+    QVERIFY(pLua->compileAndExecuteScript(
+        qsl("enableTrigger(\"qaToggleFolder\")\n"
+            "disableTrigger(\"qaToggleLeaf\")\n"
+            "enableTrigger(\"qaToggleLeaf\")")));
+    QTRY_COMPARE(description(pFolder), activeFolder);
+    QCOMPARE(description(pLeaf), active);
   }
 };
 

--- a/test/functional_tests/TriggerToggleEditorBenchmark.cpp
+++ b/test/functional_tests/TriggerToggleEditorBenchmark.cpp
@@ -1,0 +1,358 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+// Report-only benchmark: what a Lua enableTrigger()/disableTrigger() call costs
+// on a profile with many triggers, with the script editor closed versus open.
+// Prints METRIC lines; never registered with ctest.
+//
+//   QT_QPA_PLATFORM=offscreen ./TriggerToggleEditorBenchmark
+
+#include <QElapsedTimer>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTreeWidget>
+#include <QtTest/QtTest>
+#include <chrono>
+#include <clocale>
+#include <cstdio>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TelnetServerStub.h"
+#include "TriggerUnit.h"
+#include "ctelnet.h"
+#include "dlgTriggerEditor.h"
+#include "mudlet.h"
+
+using namespace std::chrono_literals;
+
+class TriggerToggleEditorBenchmark : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgTriggerEditor* mpEditor = nullptr;
+    const QString mProfileName = qsl("TriggerToggleBench-Profile");
+    const QString mLocalhost = qsl("localhost");
+
+    static constexpr int kPasses = 5;
+    // Toggles per pass: each iteration disables then re-enables one trigger.
+    static constexpr int kTogglesPerPass = 1000;
+
+    static void emitMetric(const QString& name, double value)
+    {
+        std::printf("METRIC %s %.3f\n", qPrintable(name), value);
+        std::fflush(stdout);
+    }
+
+    bool runLua(const QString& code) { return mpHost->getLuaInterpreter()->compileAndExecuteScript(code); }
+
+    int mFolders = 0;
+    int mTotal = 0;
+
+    // Adds `folders` more folders of `perFolder` leaf triggers each; leaves are
+    // t_<n> and folders f_<k>, numbering on from whatever is already planted
+    // (permanent triggers cannot be removed from Lua, so each size level grows
+    // the previous one).
+    void plantTriggers(int folders, int perFolder)
+    {
+        const QString script = qsl(R"(
+            local n = %3
+            for f = %4, %4 + %1 - 1 do
+                permGroup("f_" .. f, "trigger")
+                for i = 1, %2 do
+                    n = n + 1
+                    permRegexTrigger("t_" .. n, "f_" .. f, {"^benchmark line " .. n .. "$"}, "")
+                end
+            end
+        )")
+                                       .arg(folders)
+                                       .arg(perFolder)
+                                       .arg(mTotal)
+                                       .arg(mFolders + 1);
+        QVERIFY(runLua(script));
+        mFolders += folders;
+        mTotal += folders * perFolder;
+        mpEditor->doCleanReset();
+        QVERIFY(waitForTreeToHold(qsl("t_%1").arg(mTotal)));
+    }
+
+    // The tree widget is a private Ui member; the object name is what the .ui
+    // file gives it, so this keeps the harness out of the editor's friend list.
+    QTreeWidget* triggerTree() const { return mpEditor->findChild<QTreeWidget*>(qsl("treeWidget_triggers")); }
+
+    bool waitForTreeToHold(const QString& name) const
+    {
+        return QTest::qWaitFor(
+                [this, &name]() {
+                    return !triggerTree()->findItems(name, Qt::MatchCaseSensitive | Qt::MatchFixedString | Qt::MatchRecursive, 0).isEmpty();
+                },
+                30000ms);
+    }
+
+    // Best-of-kPasses seconds for kTogglesPerPass disable+enable pairs. Spread
+    // mode strides through the first `span` leaf triggers with a prime step, so
+    // the toggled items sit at every depth and position of the tree rather than
+    // clustering at its start; "last" mode toggles t_<span> only, the item a
+    // depth-first lookup finds last.
+    double timeToggles(int span, bool spread, bool includeEventProcessing)
+    {
+        const QString script = qsl(R"(
+            local span = %1
+            for i = 1, %2 do
+                local name = %3
+                disableTrigger(name)
+                enableTrigger(name)
+            end
+        )")
+                                       .arg(span)
+                                       .arg(kTogglesPerPass)
+                                       .arg(spread ? qsl("\"t_\" .. (((i * 7919) % span) + 1)") : qsl("\"t_\" .. span"));
+        double best = 1e30;
+        for (int pass = 0; pass < kPasses; ++pass) {
+            QElapsedTimer timer;
+            timer.start();
+            if (!runLua(script)) {
+                return -1.0;
+            }
+            if (includeEventProcessing) {
+                QCoreApplication::processEvents();
+                QCoreApplication::sendPostedEvents();
+            }
+            best = std::min(best, timer.nsecsElapsed() / 1.0e9);
+        }
+        return best;
+    }
+
+    // enableTrigger() on triggers that are already enabled: what a script that
+    // re-arms its triggers defensively every prompt pays for no state change.
+    double timeRedundantEnables(int span)
+    {
+        const QString script = qsl(R"(
+            local span = %1
+            for i = 1, %2 do
+                enableTrigger("t_" .. (((i * 7919) % span) + 1))
+            end
+        )")
+                                       .arg(span)
+                                       .arg(kTogglesPerPass);
+        double best = 1e30;
+        for (int pass = 0; pass < kPasses; ++pass) {
+            QElapsedTimer timer;
+            timer.start();
+            if (!runLua(script)) {
+                return -1.0;
+            }
+            best = std::min(best, timer.nsecsElapsed() / 1.0e9);
+        }
+        return best;
+    }
+
+    // One game line's worth of work: `batch` distinct triggers (or folders)
+    // disabled and re-enabled, then the event loop turned so any deferred
+    // repaint runs. Best-of-kBatchReps microseconds per line.
+    static constexpr int kBatchReps = 40;
+    double timeBatchPerLine(int span, int batch, bool folders)
+    {
+        const QString script = qsl(R"(
+            local span = %1
+            for i = 1, %2 do
+                local name = "%3" .. (((i * 7919) % span) + 1)
+                disableTrigger(name)
+                enableTrigger(name)
+            end
+        )")
+                                       .arg(span)
+                                       .arg(batch)
+                                       .arg(folders ? qsl("f_") : qsl("t_"));
+        double best = 1e30;
+        for (int rep = 0; rep < kBatchReps; ++rep) {
+            QElapsedTimer timer;
+            timer.start();
+            if (!runLua(script)) {
+                return -1.0;
+            }
+            QCoreApplication::processEvents();
+            QCoreApplication::sendPostedEvents();
+            best = std::min(best, timer.nsecsElapsed() / 1.0e6);
+        }
+        return best;
+    }
+
+    double timeFolderToggles(int folders)
+    {
+        const QString script = qsl(R"(
+            for i = 1, %1 do
+                local name = "f_" .. ((i % %2) + 1)
+                disableTrigger(name)
+                enableTrigger(name)
+            end
+        )")
+                                       .arg(kTogglesPerPass / 10)
+                                       .arg(folders);
+        double best = 1e30;
+        for (int pass = 0; pass < kPasses; ++pass) {
+            QElapsedTimer timer;
+            timer.start();
+            if (!runLua(script)) {
+                return -1.0;
+            }
+            best = std::min(best, timer.nsecsElapsed() / 1.0e9);
+        }
+        return best;
+    }
+
+    void report(const QString& label)
+    {
+        const int total = mTotal;
+        const int folders = mFolders;
+        auto us = [](double secs, int toggles) {
+            return secs / toggles * 1.0e6;
+        };
+
+        mpEditor->hide();
+        QCoreApplication::processEvents();
+        QVERIFY(!mpEditor->isVisible());
+        const double hidden = timeToggles(total, true, false);
+        QVERIFY(hidden >= 0);
+        emitMetric(qsl("%1_n%2_editor_closed_us_per_toggle").arg(label).arg(total), us(hidden, 2 * kTogglesPerPass));
+
+        mpEditor->show();
+        mpEditor->slot_showTriggers();
+        QCoreApplication::processEvents();
+        QVERIFY(mpEditor->isVisible());
+        triggerTree()->collapseAll();
+        QCoreApplication::processEvents();
+        const double openCollapsed = timeToggles(total, true, false);
+        QVERIFY(openCollapsed >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_collapsed_us_per_toggle").arg(label).arg(total), us(openCollapsed, 2 * kTogglesPerPass));
+
+        triggerTree()->expandAll();
+        QCoreApplication::processEvents();
+        const double openExpanded = timeToggles(total, true, false);
+        QVERIFY(openExpanded >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_expanded_us_per_toggle").arg(label).arg(total), us(openExpanded, 2 * kTogglesPerPass));
+
+        const double openExpandedLast = timeToggles(total, false, false);
+        QVERIFY(openExpandedLast >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_expanded_last_item_us_per_toggle").arg(label).arg(total), us(openExpandedLast, 2 * kTogglesPerPass));
+
+        const double openExpandedPaint = timeToggles(total, true, true);
+        QVERIFY(openExpandedPaint >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_expanded_plus_events_us_per_toggle").arg(label).arg(total), us(openExpandedPaint, 2 * kTogglesPerPass));
+
+        const double redundant = timeRedundantEnables(total);
+        QVERIFY(redundant >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_expanded_redundant_enable_us_per_call").arg(label).arg(total), us(redundant, kTogglesPerPass));
+
+        // Folder toggles: each repaints the folder's whole subtree.
+        const double folderToggle = timeFolderToggles(folders);
+        QVERIFY(folderToggle >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_expanded_folder_us_per_toggle").arg(label).arg(total), us(folderToggle, 2 * (kTogglesPerPass / 10)));
+
+        for (const int batch : {1, 20, 100}) {
+            const double perLine = timeBatchPerLine(total, batch, false);
+            QVERIFY(perLine >= 0);
+            emitMetric(qsl("%1_n%2_editor_open_expanded_line_of_%3_toggles_us").arg(label).arg(total).arg(batch), perLine * 1.0e3);
+        }
+        const double folderLine = timeBatchPerLine(folders, 5, true);
+        QVERIFY(folderLine >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_expanded_line_of_5_folder_toggles_us").arg(label).arg(total), folderLine * 1.0e3);
+        mpEditor->hide();
+        QCoreApplication::processEvents();
+        const double closedLine = timeBatchPerLine(total, 20, false);
+        QVERIFY(closedLine >= 0);
+        emitMetric(qsl("%1_n%2_editor_closed_line_of_20_toggles_us").arg(label).arg(total), closedLine * 1.0e3);
+        mpEditor->show();
+        mpEditor->slot_showTriggers();
+        QCoreApplication::processEvents();
+
+        // Same toggles with the editor on another view (trigger tree not on screen)
+        mpEditor->slot_showScripts();
+        QCoreApplication::processEvents();
+        const double otherView = timeToggles(total, true, false);
+        QVERIFY(otherView >= 0);
+        emitMetric(qsl("%1_n%2_editor_open_scripts_view_us_per_toggle").arg(label).arg(total), us(otherView, 2 * kTogglesPerPass));
+        mpEditor->slot_showTriggers();
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present");
+        }
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+        std::setlocale(LC_NUMERIC, "C");
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY(mpServer->isListening());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, QString::number(mpServer->serverPort()));
+        QVERIFY2(mpHost, "No active host available for the test.");
+        QSignalSpy connectedSpy(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connectedSpy.wait(2000), "Could not connect with the host.");
+
+        mudlet::self()->slot_showScriptDialog();
+        QTest::qWait(100ms);
+        mpEditor = mpHost->mpEditorDialog;
+        QVERIFY2(mpEditor, "the editor dialog was not created");
+    }
+
+    void cleanupTestCase()
+    {
+        if (mpHost) {
+            if (auto* pEditor = mpHost->mpEditorDialog.data()) {
+                mpHost->mpEditorDialog = nullptr;
+                delete pEditor;
+            }
+        }
+        delete mpServer;
+        if (mudlet::self()) {
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void bench_500()
+    {
+        plantTriggers(10, 50);
+        report(qsl("bench"));
+    }
+
+    void bench_2000()
+    {
+        plantTriggers(30, 50);
+        report(qsl("bench"));
+    }
+
+    void bench_5000()
+    {
+        plantTriggers(60, 50);
+        report(qsl("bench"));
+    }
+};
+#include "TriggerToggleEditorBenchmark.moc"
+QTEST_MAIN(TriggerToggleEditorBenchmark)


### PR DESCRIPTION
Stacked on #10605 - the first three commits are that PR unchanged; only the last two are new. Meant either to be pulled into #10605 or rebased once it lands.

#### Brief overview of PR changes/additions

- `refreshTriggerIcon()` records the ID and repaints every pending item in one depth-first pass on the next event-loop turn, instead of one `findItemByID()` walk over the whole trigger tree per `enableTrigger()`/`disableTrigger()` call. A folder's descendants are repainted in the same pass, and the walk stops once every pending ID has been seen.
- An item whose icon has not changed is not written to: `QIcon` has no `operator==`, so `setIcon()` otherwise always emits `dataChanged()` and makes the view re-measure the row, even for a trigger toggled off and back on within one line.
- Adds `TriggerToggleEditorBenchmark` (report-only, not registered with ctest) and a `TriggerEditorTest` case that fails with the refresh stubbed out.

#### Motivation for adding to Mudlet

With #10605 as-is, a script that toggles triggers every game line pays O(tree size) per call whenever the script editor is open. Measured on a 5000-trigger profile (Linux debug build, no sanitizers, editor open on the expanded tree, best of 40, per game line):

| per line | #10605 | this PR | editor closed |
| --- | --- | --- | --- |
| 20 toggles | 6830 us | 474 us | 72 us |
| 100 toggles | 34685 us | 1084 us | |
| 5 folder toggles | 15693 us | 645 us | |

The same coalescing should be applied to the alias, script, timer and key refresh paths; this PR covers triggers, the type scripts toggle per line.

#### Other info (issues closed, discussion etc)

**Test case:** open the script editor on a profile with a few thousand triggers, run `for i = 1, 100 do disableTrigger("x") enableTrigger("x") end` from the command line while the editor is open - the icon flips as before and the client stays responsive. `ctest -R TriggerEditorTest` covers the icon flip for a leaf and a folder.

Assisted-by: Claude:claude-fable-5-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PtM4gmqS8nro16jY2LQqw

---
_Generated by [Claude Code](https://claude.ai/code/session_017PtM4gmqS8nro16jY2LQqw)_