### PR TITLE
Infra: Fix wiki links broken by the Compiling Mudlet rewrite

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,8 +67,8 @@ signals:
     void profileChanged(const QString& name);
 ```    
 * in general: write modern C++20 code, but avoid C++ exceptions, templates, and concepts as those have performance/complexity considerations, avoiding which has made Mudlet the success it is today.
-* use clang-format for formatting your code with [.clang-format](https://github.com/Mudlet/Mudlet/blob/development/.clang-format) settings. To get started, check out Clang Format in the [Setting up IDE's](https://wiki.mudlet.org/w/Compiling_Mudlet) section.
-* use clang-tidy linting with [.clang-tidy](https://github.com/Mudlet/Mudlet/blob/development/.clang-tidy) settings. To get started, check out Clang Tidy in the [Setting up IDE's](https://wiki.mudlet.org/w/Compiling_Mudlet) section
+* use clang-format for formatting your code with [.clang-format](https://github.com/Mudlet/Mudlet/blob/development/.clang-format) settings. To get started, check out Clang Format in the [Setting up IDEs](https://wiki.mudlet.org/w/Compiling_Mudlet#Setting_up_IDEs) section.
+* use clang-tidy linting with [.clang-tidy](https://github.com/Mudlet/Mudlet/blob/development/.clang-tidy) settings. To get started, check out Clang Tidy in the [Setting up IDEs](https://wiki.mudlet.org/w/Compiling_Mudlet#Setting_up_IDEs) section
 * additionally, use [clazy]([url](https://github.com/KDE/clazy)) for linting as well
 * use braces {} around all statements (ie, `if`'s and so on), even if they are one line
 * use `qsl()` to wrap Qt strings, this ensures they're created at compile time

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -148,7 +148,7 @@ The project uses the `.clang-format` configuration in the repo root. This ensure
 
 ### Static analysis
 
-For complete setup instructions on how to run static analysis during a build, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Static_Analysis
+For complete setup instructions on how to run static analysis during a build, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Static_analysis
 
 ### Git
 

--- a/docs/platform-builds.md
+++ b/docs/platform-builds.md
@@ -2,7 +2,7 @@
 
 ## Building on macOS
 
-For complete setup instructions, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Compiling_on_macOS
+For complete setup instructions, see: https://wiki.mudlet.org/w/Compiling_Mudlet#macOS
 
 **Essential build commands:**
 
@@ -37,7 +37,7 @@ reached `Max cache size`, raise it with `ccache -M <n>G`.
 
 ## Building on Windows
 
-For complete setup instructions, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Compiling_on_Windows
+For complete setup instructions, see: https://wiki.mudlet.org/w/Compiling_Mudlet#Windows
 
 Builds run under MSYS2, in the **CLANG64** environment — open a CLANG64 shell, not MINGW64, and
 check it is a real MSYS2 shell rather than Git for Windows' bash carrying an inherited `MSYSTEM`


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Retargets three section links at the rewritten wiki article's new headings: `#Compiling_on_macOS` → `#macOS`, `#Compiling_on_Windows` → `#Windows`, and `#Static_Analysis` → `#Static_analysis`.
- Anchors the two `docs/CONTRIBUTING.md` links that promise a "Setting up IDEs" section but land on the page root, and drops a stray apostrophe in the link text.

#### Motivation for adding to Mudlet

The wiki's Compiling Mudlet article has been rewritten around `CMakePresets.json`. It keeps its title, so no page URL changes — but the rewrite renamed the headings, and every link here that targets a section broke with them. The `#Static_Analysis` case is the easy one to miss: only the capital A differs, and MediaWiki anchors are case-sensitive past the first character.

#### Other info (issues closed, discussion etc)

Part of #10599. That issue originally described a rename to "Building Mudlet"; the article keeps its existing title, so the page-URL half of it is void and only the anchors need changing.

`CLAUDE.md` and `AGENTS.md` are symlinks to `docs/ai-instructions.md`, so the single edit there covers all three paths. Bare page links in `README.md`, `COMPILE` and `.agents/skills/build-mudlet/SKILL.md` are unaffected and deliberately untouched.

The rewritten page is now published, so the links this PR replaces are the ones currently broken and the new anchors resolve today. No reason left to hold it back.

**Test case:** Follow each changed link and confirm it lands on the named section of https://wiki.mudlet.org/w/Compiling_Mudlet rather than the top of the page. No code changes, so no build or test impact.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Michael Conley <sousesider@gmail.com>