### PR TITLE
fix: keep Lua autocomplete popup from stealing editor focus

### DIFF
--- a/src/dlgSourceEditorArea.cpp
+++ b/src/dlgSourceEditorArea.cpp
@@ -26,6 +26,7 @@
 
 #include "edbee/edbee.h"
 #include "edbee/models/textdocument.h"
+#include "edbee/texteditorcomponent.h"
 #include "edbee/models/texteditorconfig.h"
 #include "edbee/models/textgrammar.h"
 #include "edbee/views/components/texteditorautocompletecomponent.h"

--- a/src/dlgSourceEditorArea.cpp
+++ b/src/dlgSourceEditorArea.cpp
@@ -26,10 +26,10 @@
 
 #include "edbee/edbee.h"
 #include "edbee/models/textdocument.h"
-#include "edbee/texteditorcomponent.h"
 #include "edbee/models/texteditorconfig.h"
 #include "edbee/models/textgrammar.h"
 #include "edbee/views/components/texteditorautocompletecomponent.h"
+#include "edbee/views/components/texteditorcomponent.h"
 #include "edbee/views/texteditorscrollarea.h"
 #include "edbee/views/textrenderer.h"
 #include "edbee/views/texttheme.h"

--- a/src/dlgSourceEditorArea.cpp
+++ b/src/dlgSourceEditorArea.cpp
@@ -28,9 +28,14 @@
 #include "edbee/models/textdocument.h"
 #include "edbee/models/texteditorconfig.h"
 #include "edbee/models/textgrammar.h"
+#include "edbee/views/components/texteditorautocompletecomponent.h"
 #include "edbee/views/texteditorscrollarea.h"
 #include "edbee/views/textrenderer.h"
 #include "edbee/views/texttheme.h"
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QListWidget>
 
 dlgSourceEditorArea::dlgSourceEditorArea(QWidget* pParentWidget)
 : QWidget(pParentWidget)
@@ -57,4 +62,132 @@ dlgSourceEditorArea::dlgSourceEditorArea(QWidget* pParentWidget)
 
     // disable shadows as their purpose (notify there is more text) is performed by scrollbars already
     edbeeEditorWidget->textScrollArea()->enableShadowWidget(false);
+
+    // keep the keyboard focus with the editor while the autocomplete popup is shown
+    configureAutoCompleteFocus();
+}
+
+// The autocomplete popup used to steal the keyboard focus from the editor:
+// edbee's TextEditorAutoCompleteComponent::updateList() calls setFocus() on its
+// list widget every time the popup is shown or refreshed, which moves the
+// keyboard focus (and, on some platforms, the window activation) out of the
+// editor while the popup is open. Typing then only works through edbee's
+// event-filter forwarding, which loses keys and can leave the editor unusable
+// until the popup is dismissed (see Mudlet issue #5310).
+//
+// Use the same approach as QCompleter instead: the popup and its list are made
+// non-focusable and non-activating so the editor keeps the focus at all times.
+// While the popup is open Qt delivers the key events to the popup widget, so
+// eventFilter() routes the completion keys to the popup list and everything
+// else (normal typing included) to the editor.
+void dlgSourceEditorArea::configureAutoCompleteFocus()
+{
+    auto* autoCompleteComponent = edbeeEditorWidget->autoCompleteComponent();
+    if (!autoCompleteComponent) {
+        return;
+    }
+
+    mpAutoCompleteList = autoCompleteComponent->listWidget();
+    if (!mpAutoCompleteList) {
+        return;
+    }
+
+    mpAutoCompleteMenu = mpAutoCompleteList->parentWidget();
+    mpEditorComponent = edbeeEditorWidget->textEditorComponent();
+    if (!mpAutoCompleteMenu || !mpEditorComponent) {
+        return;
+    }
+
+    // Making the list's focus proxy the editor component turns edbee's
+    // setFocus() call on the list into a no-op: QWidget::setFocus() resolves it
+    // to the focus proxy, which already owns the keyboard focus, so nothing
+    // changes. The widgets are additionally marked as non-activating so the
+    // popup window cannot take the window activation (notably on Windows).
+    mpAutoCompleteList->setFocusProxy(mpEditorComponent);
+    mpAutoCompleteList->setFocusPolicy(Qt::NoFocus);
+    mpAutoCompleteList->setAttribute(Qt::WA_ShowWithoutActivating);
+
+    mpAutoCompleteMenu->setFocusPolicy(Qt::NoFocus);
+    mpAutoCompleteMenu->setAttribute(Qt::WA_ShowWithoutActivating);
+
+    mpAutoCompleteMenu->installEventFilter(this);
+    mpEditorComponent->installEventFilter(this);
+}
+
+// Routes a key press that was received by the autocomplete popup. Every key is
+// consumed here: it is either handed to the popup list (completion keys) or to
+// the editor (normal typing), never back to the popup menu itself, whose own
+// key handling would close the popup or eat the key.
+void dlgSourceEditorArea::routeAutoCompleteKeyPress(QKeyEvent* pKeyEvent)
+{
+    switch (pKeyEvent->key()) {
+    case Qt::Key_Up:
+    case Qt::Key_Down:
+    case Qt::Key_PageUp:
+    case Qt::Key_PageDown:
+    case Qt::Key_Enter:
+    case Qt::Key_Return:
+    case Qt::Key_Tab:
+    case Qt::Key_Escape:
+        // completion keys, handled by edbee's event filter on the list
+        // (navigate the suggestions, accept or cancel the popup)
+        QApplication::sendEvent(mpAutoCompleteList, pKeyEvent);
+        return;
+
+    case Qt::Key_Backspace:
+    case Qt::Key_Shift:
+        // keep the popup open while deleting text or holding Shift
+        QApplication::sendEvent(mpEditorComponent, pKeyEvent);
+        return;
+
+    default:
+        break;
+    }
+
+    if (!pKeyEvent->text().isEmpty() && pKeyEvent->text().at(0).isLetterOrNumber()) {
+        // normal typing: the editor handles the key and refreshes the popup
+        QApplication::sendEvent(mpEditorComponent, pKeyEvent);
+        return;
+    }
+
+    // any other key closes the popup and is then handled by the editor
+    mpAutoCompleteMenu->close();
+    QApplication::sendEvent(mpEditorComponent, pKeyEvent);
+}
+
+bool dlgSourceEditorArea::eventFilter(QObject* pWatched, QEvent* pEvent)
+{
+    if (mpAutoCompleteMenu && pWatched == mpAutoCompleteMenu) {
+        switch (pEvent->type()) {
+        case QEvent::KeyPress:
+            if (mpAutoCompleteMenu->isVisible()) {
+                routeAutoCompleteKeyPress(static_cast<QKeyEvent*>(pEvent));
+                return true;
+            }
+            break;
+
+        case QEvent::InputMethod:
+        case QEvent::ShortcutOverride:
+            // input method and shortcut overrides are handled by the editor,
+            // not by the popup
+            if (mpAutoCompleteMenu->isVisible()) {
+                QApplication::sendEvent(mpEditorComponent, pEvent);
+                return true;
+            }
+            break;
+
+        default:
+            break;
+        }
+
+    } else if (pWatched == mpEditorComponent && pEvent->type() == QEvent::FocusOut
+               && mpAutoCompleteMenu && mpAutoCompleteMenu->isVisible()) {
+        // Qt sends a synthetic FocusOut to the current focus widget when the
+        // popup opens; swallow it so that the editor does not reset its undo
+        // coalescing (or drop the IME state) every time the popup is shown
+        // during typing
+        return true;
+    }
+
+    return QWidget::eventFilter(pWatched, pEvent);
 }

--- a/src/dlgSourceEditorArea.h
+++ b/src/dlgSourceEditorArea.h
@@ -26,6 +26,9 @@
 
 #include "ui_source_editor_area.h"
 
+class QListWidget;
+class QKeyEvent;
+
 class dlgSourceEditorArea : public QWidget, public Ui::source_editor_area
 {
     Q_OBJECT
@@ -33,6 +36,17 @@ class dlgSourceEditorArea : public QWidget, public Ui::source_editor_area
 public:
     Q_DISABLE_COPY(dlgSourceEditorArea)
     explicit dlgSourceEditorArea(QWidget*);
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    void configureAutoCompleteFocus();
+    void routeAutoCompleteKeyPress(QKeyEvent*);
+
+    QListWidget* mpAutoCompleteList = nullptr;
+    QWidget* mpAutoCompleteMenu = nullptr;
+    QWidget* mpEditorComponent = nullptr;
 };
 
 #endif // MUDLET_DLGSOURCEEDITORAREA_H


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Keeps the keyboard focus with the source editor while the Lua autocomplete popup is open, instead of letting the popup take it. `dlgSourceEditorArea` (the widget that owns and configures the edbee editor) now applies the same approach Qt's own `QCompleter` uses for completion popups:

- the popup (`QMenu`) and its `QListWidget` are made non-focusable (`Qt::NoFocus`) and non-activating (`WA_ShowWithoutActivating`);
- the list's focus proxy is pointed at the editor's text component, which turns edbee's internal `listWidget()->setFocus()` call into a no-op;
- a small event filter routes key events while the popup is open: the completion keys (Up/Down/PageUp/PageDown navigate, Enter/Return/Tab accept, Escape cancels) go to the popup list, everything else (normal typing, Backspace, IME input) goes to the editor, and keys that edbee's popup design closes on (e.g. Space, punctuation) close the popup and reach the editor.

#### Motivation for adding to Mudlet

Fixes #5310. Users intermittently lose the ability to type in the Lua editor while the autocomplete popup is showing; pressing Esc removes the popup, but it reappears on the next letter and typing stays blocked.

#### Root cause analysis (Qt event level)

In the bundled edbee-lib, `TextEditorAutoCompleteComponent::updateList()` runs after every character typed/backspaced and does:

```cpp
menuRef_->popup(menuRef_->pos());
listWidgetRef_->setFocus();
```

`menuRef_` is a `QMenu`, i.e. a `Qt::Popup` window. Two Qt behaviours then conspire against the editor:

1. `QWidget::isActiveWindow()` unconditionally reports a *visible* `Qt::Popup` window as active, so `listWidgetRef_->setFocus()` really does move `QApplication::focusWidget()` from the editor's text component to the list (`QWidget::setFocus()` does not consult the focus policy, so setting `Qt::NoFocus` alone does not prevent this).
2. While any popup is open, `QWidgetWindow::handleKeyEvent()` delivers **all** keyboard events to `popup->focusWidget()` (or the popup itself) — never to the editor. The editor only receives text because edbee's event filter forwards letters back to it one by one, and every forwarded character re-enters `updateList()` → `popup()` + `setFocus()` again. This focus ping-pong (plus the popup window activation churn that `WA_ShowWithoutActivating` is missing) loses keys and IME input on Windows, leaving the editor unusable until the popup is dismissed — matching the video in #5310.

Since Qt delivers popup-mode keys to the *popup widget*, the fix routes them from there — the same place `QCompleter` routes them from (`QCompleter::setPopup()` sets `Qt::Popup` + `Qt::NoFocus` + `setFocusProxy(widget)` on its popup, and `QCompleter::eventFilter()` forwards unhandled keys to the source widget):

- `list->setFocusProxy(editorComponent)` makes edbee's `setFocus()` provably do nothing: `QWidget::setFocus()` resolves it to the deepest focus proxy (the editor component), sees `QApplication::focusWidget()` already equals it, and returns early — no FocusOut/FocusIn, no state change.
- `WA_ShowWithoutActivating` on the popup window stops the window-activation steal (notably on Windows), so the main window stays active on every popup refresh.
- The event filter installed on the popup menu mirrors `QCompleter::eventFilter()`'s routing, preserving edbee's existing key semantics exactly (letters/digits/Backspace keep the popup open, Up/Down/PageUp/PageDown navigate the list through edbee's own list filter, Enter/Tab accept, Escape sets `canceled_` so the popup stays dismissed until a new word is typed, other keys close the popup and reach the editor).
- The filter also swallows the synthetic `FocusOut` that `QApplicationPrivate::openPopup()` sends to the current focus widget when the popup first shows — edbee's `TextEditorComponent::focusOutEvent()` resets undo coalescing, which would otherwise fragment the undo stack on every popup appearance (this is the same reason `QCompleter` has its `eatFocusOut` flag).

#### How to reproduce/test

Reproduce (on `development`, Windows):

1. Enable Lua editor autocomplete (Preferences → Editor → "Show an automatic completion list").
2. Open the trigger/script editor and type a Lua prefix with many matches, e.g. `ce` (createButton, createGauge, ...).
3. Keep typing/deleting: on `development` focus can end up in the popup and typing stops working (keys are swallowed or lost); the user must press Esc and the popup reappears on the next letter.

With this PR:

1. Same setup — type `ce`: the popup appears and the editor keeps the caret/focus.
2. Continue typing `createButton`: text appears normally while the popup tracks the word; typing is never blocked.
3. Up/Down/PageUp/PageDown move the selection in the popup; Enter or Tab inserts the selected suggestion; Esc dismisses it and it stays dismissed while editing that word.
4. Backspace keeps the popup updated; pressing Space, punctuation or moving the caret with Left/Right closes the popup (same behaviour as before).
5. Mouse selection: hovering/clicking/double-clicking an entry still selects/inserts it.
6. The editor's undo stack still coalesces a typed word into a single undo step while the popup is open.

No local build was possible for this PR, so it is verified by code inspection against the Qt event flow described above; CI build + reviewer manual test are much appreciated.

#### Other info (issues closed, discussion etc)

Fixes #5310.

/claim #5310

> **Disclosure:** This PR was authored by @Furox-Art (AI-assisted). Happy to adjust anything.
