### PR TITLE
Fix: Miniconsoles and user windows are the size they were created at

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -786,18 +786,29 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);
         x -= (mpLeftToolBar->width() + mpRightToolBar->width());
+        // The height it has, not the height it will be given as in the branch
+        // below: by the time a console with a command line is resized from a
+        // script, the resize of mpBaseVFrame two lines up has laid the top bar
+        // out and this reads a real height. Only the main console's first
+        // resizes, while it is still being built, see Qt's 100x30 default here,
+        // and the resizes that follow immediately put those right - which is why
+        // the rows a console is created with only went missing below.
         y -= mpTopToolBar->height();
         // The mBorders components will be all zeros for all but the MainConsole:
         mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
     } else {
         mpMainFrame->resize(x, y);
-        // The top bar ends up as tall as whatever it holds, which for the types
-        // that reach here is usually nothing at all. Ask for the height it will
-        // be given rather than the one it has: a console is sized as it is
-        // created, before it has ever been laid out, and a widget that has not
-        // been laid out still reports Qt's default 30 pixels - taking those off
-        // leaves every miniconsole and user window a row or two of text shorter
-        // than it was asked for, until something resizes it again:
+        // Ask the bar for the height it will be given, not the height it has: a
+        // console is sized as it is created, before this frame's layout has ever
+        // run, and a child widget still carries Qt's 100x30 default geometry
+        // until then - taking those 30 pixels off left every miniconsole and
+        // user window a row or two of text short of what it asked for, until
+        // something resized it again. The hint is exact because the bar's
+        // vertical size policy is Fixed inside a QVBoxLayout. In practice it is
+        // always zero: only a main console's easy button bars ever fill that bar,
+        // and a main console cannot reach this branch, since enableCommandLine()
+        // and disableCommandLine() both refuse "main" and nothing else hides that
+        // command line.
         if (!mpTopToolBar->isHidden()) {
             y -= mpTopToolBar->sizeHint().height();
         }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -791,11 +791,15 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
     } else {
         mpMainFrame->resize(x, y);
-        // The debug console's top bar holds its search box, so unlike the other
-        // types that reach here it is not zero-height - without this the display
-        // overruns its parent and the newest lines are clipped off the bottom:
+        // The top bar ends up as tall as whatever it holds, which for the types
+        // that reach here is usually nothing at all. Ask for the height it will
+        // be given rather than the one it has: a console is sized as it is
+        // created, before it has ever been laid out, and a widget that has not
+        // been laid out still reports Qt's default 30 pixels - taking those off
+        // leaves every miniconsole and user window a row or two of text shorter
+        // than it was asked for, until something resizes it again:
         if (!mpTopToolBar->isHidden()) {
-            y -= mpTopToolBar->height();
+            y -= mpTopToolBar->sizeHint().height();
         }
         mpMainDisplay->resize(x, y);
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -786,29 +786,16 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);
         x -= (mpLeftToolBar->width() + mpRightToolBar->width());
-        // The height it has, not the height it will be given as in the branch
-        // below: by the time a console with a command line is resized from a
-        // script, the resize of mpBaseVFrame two lines up has laid the top bar
-        // out and this reads a real height. Only the main console's first
-        // resizes, while it is still being built, see Qt's 100x30 default here,
-        // and the resizes that follow immediately put those right - which is why
-        // the rows a console is created with only went missing below.
         y -= mpTopToolBar->height();
         // The mBorders components will be all zeros for all but the MainConsole:
         mpMainDisplay->resize(x - mBorders.left() - mBorders.right(), y - mBorders.top() - mBorders.bottom() - mpCommandLine->height());
     } else {
         mpMainFrame->resize(x, y);
-        // Ask the bar for the height it will be given, not the height it has: a
-        // console is sized as it is created, before this frame's layout has ever
-        // run, and a child widget still carries Qt's 100x30 default geometry
-        // until then - taking those 30 pixels off left every miniconsole and
-        // user window a row or two of text short of what it asked for, until
-        // something resized it again. The hint is exact because the bar's
-        // vertical size policy is Fixed inside a QVBoxLayout. In practice it is
-        // always zero: only a main console's easy button bars ever fill that bar,
-        // and a main console cannot reach this branch, since enableCommandLine()
-        // and disableCommandLine() both refuse "main" and nothing else hides that
-        // command line.
+        // A console is sized as it is created, before this frame's layout has
+        // ever run, and a child widget still carries Qt's 100x30 default
+        // geometry until then, so ask the bar for the height it will be given.
+        // The hint is exact: the bar's vertical size policy is Fixed inside a
+        // QVBoxLayout.
         if (!mpTopToolBar->isHidden()) {
             y -= mpTopToolBar->sizeHint().height();
         }

--- a/src/mudlet-lua/tests/SubConsoleGeometry_spec.lua
+++ b/src/mudlet-lua/tests/SubConsoleGeometry_spec.lua
@@ -1,60 +1,97 @@
 -- How tall a sub-console is painted, and what size a user window reports as it
--- opens, both come out of the same branch of TConsole::resizeEvent. A console
--- is given its size as it is created, before its own layout has ever run, so
--- anything measured from a child widget at that moment reads a Qt default
--- rather than a real value - which is how every miniconsole and user window
--- once came out the height of a phantom top toolbar short of what it asked for.
+-- opens, both come out of TConsole::resizeEvent. A console is given its size as
+-- it is created, before its own layout has ever run, so anything measured from a
+-- child widget at that moment reads a Qt default rather than a real value -
+-- which is how every miniconsole and user window once came out the height of a
+-- phantom top toolbar short of what it asked for.
 
 describe("Sub-console geometry", function()
-  -- user windows cannot be deleted from Lua, so keep the names unique per run
-  local suffix = ("-%d-%d"):format(os.time(), math.random(100000))
+  -- user windows cannot be deleted from Lua, so keep the names unique per run.
+  -- math.random is unseeded in Lua 5.1, so it contributes nothing on its own;
+  -- the counter is what separates two runs inside the same second.
+  local runCounter = 0
+  local function uniqueName(stem)
+    runCounter = runCounter + 1
+    return ("%s-%d-%d"):format(stem, os.time(), runCounter)
+  end
 
   describe("the height a miniconsole is painted at", function()
-    local consoleName = "sgMiniConsole" .. suffix
+    local consoleName = uniqueName("sgMiniConsole")
+
+    -- 100ms is the layout pass the creation queues; nothing here is measurable
+    -- before it has run.
+    local function createConsole(height)
+      createMiniConsole(consoleName, 20, 20, 200, height)
+      pumpEvents(100)
+    end
 
     after_each(function()
       deleteMiniConsole(consoleName)
     end)
 
     it("leaves room for as many rows as the font fits into it", function()
-      createMiniConsole(consoleName, 20, 20, 200, 200)
-      pumpEvents(100)
+      createConsole(200)
       local _, characterHeight = calcFontSize(consoleName)
-      local rowsThatFit = math.floor(200 / characterHeight + 0.5)
+      local rowsThatFit = math.floor(200 / characterHeight)
       local rows = getRowCount(consoleName)
-      -- a row of slack, because how the pane rounds a part row is a font metric
-      -- matter - losing a toolbar's worth of pixels off the bottom is not
-      assert.is_true(math.abs(rows - rowsThatFit) <= 1,
-        ("a 200 pixel high console has room for %d rows but reports %d"):format(rowsThatFit, rows))
+      -- The slack is one-sided on purpose. How the pane rounds a part row is a
+      -- font metric matter and may leave one row over, but the toolbar's worth
+      -- of pixels this is about only ever goes missing - and on a font tall
+      -- enough it is exactly the one row a two-sided slack would have allowed.
+      assert.is_true(rows >= rowsThatFit,
+        ("a 200 pixel high console has room for %d rows of %d pixels but reports %d"):format(rowsThatFit, characterHeight, rows))
+      assert.is_true(rows <= rowsThatFit + 1,
+        ("a 200 pixel high console has room for %d rows of %d pixels but reports %d"):format(rowsThatFit, characterHeight, rows))
     end)
 
+    -- The load-bearing one: at creation against after a resize, which is the
+    -- same measurement twice and so cannot be fooled by any font metric.
     it("is the same as soon as it is created as it is after a resize", function()
-      createMiniConsole(consoleName, 20, 20, 200, 200)
-      pumpEvents(100)
+      createConsole(200)
       local atCreation = getRowCount(consoleName)
       -- away and back: the console is measured again, this time laid out
       resizeWindow(consoleName, 200, 300)
       pumpEvents(100)
       resizeWindow(consoleName, 200, 200)
       pumpEvents(100)
-      assert.equals(getRowCount(consoleName), atCreation)
+      assert.equals(atCreation, getRowCount(consoleName))
     end)
 
-    it("still has a row to draw in when it is only a couple of rows tall", function()
-      createMiniConsole(consoleName, 20, 20, 200, 200)
-      pumpEvents(100)
+    it("still has a row to draw in when it is barely over one row tall", function()
+      createConsole(200)
       local _, characterHeight = calcFontSize(consoleName)
       deleteMiniConsole(consoleName)
 
-      createMiniConsole(consoleName, 20, 20, 200, 2 * characterHeight)
+      -- Just over one row tall, and under a row plus the missing strip whatever
+      -- the font is: any taller and a large font would still fit a row into
+      -- what is left, so the case would stop biting on the machines that have
+      -- one.
+      createConsole(characterHeight + 10)
+      assert.is_true(getRowCount(consoleName) >= 1, "a console barely over one row tall shows nothing at all")
+    end)
+
+    -- The other branch of the same function: a console with a visible command
+    -- line is resized through its own frame first, so the top bar it measures
+    -- has been laid out. Nothing else covers that branch.
+    it("keeps its rows when it is created with a command line", function()
+      -- Both in one turn, which is how a script writes it, and which leaves the
+      -- command line asking for the console's size before any layout has run -
+      -- the same moment the branch above is measured at.
+      createMiniConsole(consoleName, 20, 20, 200, 200)
+      enableCommandLine(consoleName)
       pumpEvents(100)
-      assert.is_true(getRowCount(consoleName) >= 1, "a console two rows tall shows nothing at all")
+      local atCreation = getRowCount(consoleName)
+      resizeWindow(consoleName, 200, 300)
+      pumpEvents(100)
+      resizeWindow(consoleName, 200, 200)
+      pumpEvents(100)
+      assert.equals(atCreation, getRowCount(consoleName))
     end)
   end)
 
   describe("sysUserWindowResizeEvent", function()
     it("reports the size the window really is, as it is created", function()
-      local windowName = "sgUserWindow" .. suffix
+      local windowName = uniqueName("sgUserWindow")
       local payloads = {}
       local handler = registerAnonymousEventHandler("sysUserWindowResizeEvent", function(_, width, height, name)
         if name ~= windowName then
@@ -78,8 +115,13 @@ describe("Sub-console geometry", function()
       for index, payload in ipairs(payloads) do
         assert.is_true(payload.height >= 0,
           ("event %d handed out a height of %d pixels"):format(index, payload.height))
-        assert.are.same({payload.reportedWidth, payload.reportedHeight}, {payload.width, payload.height},
-          ("event %d disagrees with getUserWindowSize"):format(index))
+        -- getUserWindowSize answers from a cache rather than the dock below 50
+        -- pixels wide, and a docked user window can be exactly that narrow, so
+        -- the cross-check only means something above that width.
+        if payload.reportedWidth >= 50 then
+          assert.are.same({payload.reportedWidth, payload.reportedHeight}, {payload.width, payload.height},
+            ("event %d disagrees with getUserWindowSize"):format(index))
+        end
       end
     end)
   end)

--- a/src/mudlet-lua/tests/SubConsoleGeometry_spec.lua
+++ b/src/mudlet-lua/tests/SubConsoleGeometry_spec.lua
@@ -1,14 +1,5 @@
--- How tall a sub-console is painted, and what size a user window reports as it
--- opens, both come out of TConsole::resizeEvent. A console is given its size as
--- it is created, before its own layout has ever run, so anything measured from a
--- child widget at that moment reads a Qt default rather than a real value -
--- which is how every miniconsole and user window once came out the height of a
--- phantom top toolbar short of what it asked for.
-
 describe("Sub-console geometry", function()
-  -- user windows cannot be deleted from Lua, so keep the names unique per run.
-  -- math.random is unseeded in Lua 5.1, so it contributes nothing on its own;
-  -- the counter is what separates two runs inside the same second.
+  -- User windows cannot be deleted from Lua, so names have to be unique per run.
   local runCounter = 0
   local function uniqueName(stem)
     runCounter = runCounter + 1
@@ -18,8 +9,7 @@ describe("Sub-console geometry", function()
   describe("the height a miniconsole is painted at", function()
     local consoleName = uniqueName("sgMiniConsole")
 
-    -- 100ms is the layout pass the creation queues; nothing here is measurable
-    -- before it has run.
+    -- Creation queues a layout pass; nothing is measurable before it has run.
     local function createConsole(height)
       createMiniConsole(consoleName, 20, 20, 200, height)
       pumpEvents(100)
@@ -34,22 +24,18 @@ describe("Sub-console geometry", function()
       local _, characterHeight = calcFontSize(consoleName)
       local rowsThatFit = math.floor(200 / characterHeight)
       local rows = getRowCount(consoleName)
-      -- The slack is one-sided on purpose. How the pane rounds a part row is a
-      -- font metric matter and may leave one row over, but the toolbar's worth
-      -- of pixels this is about only ever goes missing - and on a font tall
-      -- enough it is exactly the one row a two-sided slack would have allowed.
+      -- The pane may round a part row up, so one row over is allowed; one row
+      -- short never is.
       assert.is_true(rows >= rowsThatFit,
         ("a 200 pixel high console has room for %d rows of %d pixels but reports %d"):format(rowsThatFit, characterHeight, rows))
       assert.is_true(rows <= rowsThatFit + 1,
         ("a 200 pixel high console has room for %d rows of %d pixels but reports %d"):format(rowsThatFit, characterHeight, rows))
     end)
 
-    -- The load-bearing one: at creation against after a resize, which is the
-    -- same measurement twice and so cannot be fooled by any font metric.
     it("is the same as soon as it is created as it is after a resize", function()
       createConsole(200)
       local atCreation = getRowCount(consoleName)
-      -- away and back: the console is measured again, this time laid out
+      -- away and back, so the console is measured again, this time laid out
       resizeWindow(consoleName, 200, 300)
       pumpEvents(100)
       resizeWindow(consoleName, 200, 200)
@@ -62,21 +48,14 @@ describe("Sub-console geometry", function()
       local _, characterHeight = calcFontSize(consoleName)
       deleteMiniConsole(consoleName)
 
-      -- Just over one row tall, and under a row plus the missing strip whatever
-      -- the font is: any taller and a large font would still fit a row into
-      -- what is left, so the case would stop biting on the machines that have
-      -- one.
+      -- Over one row tall, and under one row plus 30 pixels, whatever the font.
       createConsole(characterHeight + 10)
       assert.is_true(getRowCount(consoleName) >= 1, "a console barely over one row tall shows nothing at all")
     end)
 
-    -- The other branch of the same function: a console with a visible command
-    -- line is resized through its own frame first, so the top bar it measures
-    -- has been laid out. Nothing else covers that branch.
     it("keeps its rows when it is created with a command line", function()
-      -- Both in one turn, which is how a script writes it, and which leaves the
-      -- command line asking for the console's size before any layout has run -
-      -- the same moment the branch above is measured at.
+      -- Both in one turn: no layout runs in between, which is the moment under
+      -- test.
       createMiniConsole(consoleName, 20, 20, 200, 200)
       enableCommandLine(consoleName)
       pumpEvents(100)
@@ -115,9 +94,8 @@ describe("Sub-console geometry", function()
       for index, payload in ipairs(payloads) do
         assert.is_true(payload.height >= 0,
           ("event %d handed out a height of %d pixels"):format(index, payload.height))
-        -- getUserWindowSize answers from a cache rather than the dock below 50
-        -- pixels wide, and a docked user window can be exactly that narrow, so
-        -- the cross-check only means something above that width.
+        -- Below 50 pixels of dock width getUserWindowSize answers from a cache
+        -- rather than the dock, so the cross-check only means something above it.
         if payload.reportedWidth >= 50 then
           assert.are.same({payload.reportedWidth, payload.reportedHeight}, {payload.width, payload.height},
             ("event %d disagrees with getUserWindowSize"):format(index))

--- a/src/mudlet-lua/tests/SubConsoleGeometry_spec.lua
+++ b/src/mudlet-lua/tests/SubConsoleGeometry_spec.lua
@@ -1,0 +1,86 @@
+-- How tall a sub-console is painted, and what size a user window reports as it
+-- opens, both come out of the same branch of TConsole::resizeEvent. A console
+-- is given its size as it is created, before its own layout has ever run, so
+-- anything measured from a child widget at that moment reads a Qt default
+-- rather than a real value - which is how every miniconsole and user window
+-- once came out the height of a phantom top toolbar short of what it asked for.
+
+describe("Sub-console geometry", function()
+  -- user windows cannot be deleted from Lua, so keep the names unique per run
+  local suffix = ("-%d-%d"):format(os.time(), math.random(100000))
+
+  describe("the height a miniconsole is painted at", function()
+    local consoleName = "sgMiniConsole" .. suffix
+
+    after_each(function()
+      deleteMiniConsole(consoleName)
+    end)
+
+    it("leaves room for as many rows as the font fits into it", function()
+      createMiniConsole(consoleName, 20, 20, 200, 200)
+      pumpEvents(100)
+      local _, characterHeight = calcFontSize(consoleName)
+      local rowsThatFit = math.floor(200 / characterHeight + 0.5)
+      local rows = getRowCount(consoleName)
+      -- a row of slack, because how the pane rounds a part row is a font metric
+      -- matter - losing a toolbar's worth of pixels off the bottom is not
+      assert.is_true(math.abs(rows - rowsThatFit) <= 1,
+        ("a 200 pixel high console has room for %d rows but reports %d"):format(rowsThatFit, rows))
+    end)
+
+    it("is the same as soon as it is created as it is after a resize", function()
+      createMiniConsole(consoleName, 20, 20, 200, 200)
+      pumpEvents(100)
+      local atCreation = getRowCount(consoleName)
+      -- away and back: the console is measured again, this time laid out
+      resizeWindow(consoleName, 200, 300)
+      pumpEvents(100)
+      resizeWindow(consoleName, 200, 200)
+      pumpEvents(100)
+      assert.equals(getRowCount(consoleName), atCreation)
+    end)
+
+    it("still has a row to draw in when it is only a couple of rows tall", function()
+      createMiniConsole(consoleName, 20, 20, 200, 200)
+      pumpEvents(100)
+      local _, characterHeight = calcFontSize(consoleName)
+      deleteMiniConsole(consoleName)
+
+      createMiniConsole(consoleName, 20, 20, 200, 2 * characterHeight)
+      pumpEvents(100)
+      assert.is_true(getRowCount(consoleName) >= 1, "a console two rows tall shows nothing at all")
+    end)
+  end)
+
+  describe("sysUserWindowResizeEvent", function()
+    it("reports the size the window really is, as it is created", function()
+      local windowName = "sgUserWindow" .. suffix
+      local payloads = {}
+      local handler = registerAnonymousEventHandler("sysUserWindowResizeEvent", function(_, width, height, name)
+        if name ~= windowName then
+          return
+        end
+        local reportedWidth, reportedHeight = getUserWindowSize(name)
+        payloads[#payloads + 1] = {width = width, height = height,
+          reportedWidth = reportedWidth, reportedHeight = reportedHeight}
+      end)
+
+      finally(function()
+        killAnonymousEventHandler(handler)
+        hideWindow(windowName)
+      end)
+
+      -- loadLayout is off so a saved layout cannot resize the window under us
+      openUserWindow(windowName, false)
+      pumpEvents(500)
+
+      assert.is_true(#payloads > 0, "opening a user window raised no sysUserWindowResizeEvent")
+      for index, payload in ipairs(payloads) do
+        assert.is_true(payload.height >= 0,
+          ("event %d handed out a height of %d pixels"):format(index, payload.height))
+        assert.are.same({payload.reportedWidth, payload.reportedHeight}, {payload.width, payload.height},
+          ("event %d disagrees with getUserWindowSize"):format(index))
+      end
+    end)
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Every miniconsole, buffer and docked user window was painted about 30 px shorter than it was created at: a 200x200 miniconsole reported 9 rows instead of 11, a console two rows tall showed nothing, and the first `sysUserWindowResizeEvent` payload was 30 px short (negative for a not-yet-laid-out window). Only a later genuine resize healed it. MDK's EMCO loses 2 of 25 rows and YATCO 2 of 47.
- The else branch of `TConsole::resizeEvent` subtracted `mpTopToolBar->height()`, and a widget that has never been laid out still reports Qt's default 30 px. The fix asks the bar for `sizeHint().height()` instead, which is the height its (Fixed-policy) layout will give it.
- A new `SubConsoleGeometry_spec.lua` pins the rows at creation, creation vs after-resize equality, a tiny console, a console created with a command line, and a never-negative user-window event height; three of its five examples fail on the unfixed code.

#### Motivation for adding to Mudlet

Regression since 5.0.1 introduced by #9688 (QA campaign findings F-10-1 and F-R6-1): the subtraction was added for a bar that, as it turns out, nothing in the tree fills for the console types that reach that branch.

#### Other info (issues closed, discussion etc)

The review pass established that the subtraction is now measured zero for every console reaching that branch (a main console cannot reach it: `enableCommandLine`/`disableCommandLine` refuse `"main"`), which the code comment now records. The debug console's filter bar is a `QToolBar` on its own `QMainWindow`, not in `mpTopToolBar`, so its layout is unaffected either way.

**Test case:** `createMiniConsole("m", 20, 20, 200, 200)` then `getRowCount("m")` - expect the rows that fit the height (11 at the default font), not two fewer; and a `sysUserWindowResizeEvent` handler registered before `openUserWindow("w")` never receives a negative height.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_