### PR TITLE
Fix: Label click callbacks work again with links, and no stray Qt menu

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -37,32 +37,28 @@
 
 using namespace std::chrono_literals;
 
-// Hand-rolled because a case-insensitive text.contains("<a ") answers a different
-// question - it cannot tell a tag from prose that happens to hold "<a " - and
-// because it case-folds every character it walks, while Lua UIs echo into labels on
-// every prompt. Any whitespace counts as the separator because HTML allows any; the
-// styling pass in setText() recognises only the ASCII ones, so an anchor split by a
-// non-breaking space comes out clickable but unstyled.
+// Hand-rolled because a case-insensitive text.contains("<a ") cannot tell a tag
+// from prose that happens to hold "<a ", and case-folds every character it walks.
+// Any whitespace counts as the separator because HTML allows any; the styling pass
+// in setText() recognises only the ASCII ones, so an anchor split by a non-breaking
+// space comes out clickable but unstyled.
 static bool containsAnchorTag(const QString& text)
 {
-    // the nearest '>' the walk has found, which stays the nearest until it is passed
     qsizetype close = -1;
-    // A '<' with fewer than two characters after it is too near the end for a tag
-    // name and a separator, and every later '<' is nearer still.
+    // Every later '<' is nearer the end still, so a '<' too close to it for a tag
+    // name and a separator ends the walk rather than being skipped over.
     for (qsizetype at = text.indexOf(QLatin1Char('<')); at >= 0 && at + 2 < text.size(); at = text.indexOf(QLatin1Char('<'), at + 1)) {
         const char16_t tagName = text.at(at + 1).unicode();
         if ((tagName != u'a' && tagName != u'A') || !text.at(at + 2).isSpace()) {
             continue;
         }
-        // Prose - and game text echoed into a label - holds "<a" and a space too,
-        // so it is only a tag once the '>' that closes it turns up; another '<' on
-        // the way there means this one never was one. An attribute value carrying a
-        // '<' of its own is turned away by that rule, which costs the label its link
-        // interaction; HTML asks for that character to be written &lt; anyway.
+        // Prose holds "<a" and a space too, so it is only a tag once the '>' that
+        // closes it turns up; another '<' on the way there means this one never was
+        // one. That also turns away an attribute value carrying a '<' of its own,
+        // which HTML asks to be written &lt; anyway.
         if (close < at) {
             // Searched for again only once the walk has passed the last one found,
-            // so the '>' scans stay linear over the whole text however many "<a "
-            // it holds
+            // so the '>' scans stay linear over the whole text
             close = text.indexOf(QLatin1Char('>'), at + 3);
             if (close < 0) {
                 // no tag anywhere past here can be closed either
@@ -128,13 +124,6 @@ void TLabel::setText(const QString& text)
 {
     const bool hasAnchor = containsAnchorTag(text);
 
-    // Links only, and only when the label carries one. The selection half of
-    // Qt::TextBrowserInteraction has QLabel swallow the press that the label's click
-    // callback needs, and puts a Copy / Select All menu on the label; links on their
-    // own leave the press to us and still activate on the release. Keyboard as well
-    // as mouse, which is what gives the label the focus policy that puts a link in
-    // reach of Tab and Return. The smaller Copy Link Location menu that links alone
-    // still offer over a link is what contextMenuEvent() below is for.
     setTextInteractionFlags(hasAnchor ? scmLinkInteraction : Qt::TextInteractionFlags(Qt::NoTextInteraction));
 
     // If we have link styling configured and the text contains HTML links,
@@ -206,9 +195,6 @@ void TLabel::setText(const QString& text)
     }
 }
 
-// Whether QLabel has a link of its own to activate in this text, which is the only
-// thing that makes it want a mouse event. containsAnchorTag() answers false for an
-// empty text on its first look, so there is nothing to test ahead of it.
 bool TLabel::carriesLink() const
 {
     return textFormat() == Qt::RichText && containsAnchorTag(text());
@@ -216,11 +202,9 @@ bool TLabel::carriesLink() const
 
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
-    // QLabel needs the press to note which link it landed on, so that the matching
-    // release can activate it - with links-only flags it records the anchor and then
-    // leaves the press ignored, which is what gives the label's own click callback
-    // back. takenByQt only guards against handing the parent an event QLabel did
-    // keep, should those flags ever widen again.
+    // QLabel needs the press to note which link it landed on, so the matching
+    // release can activate it; with links-only flags it records the anchor and
+    // leaves the press ignored, so the label's own click callback still runs.
     bool takenByQt = false;
     if (carriesLink()) {
         QLabel::mousePressEvent(event);
@@ -250,8 +234,7 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
-    // The release is where QLabel activates a link, and where the label's own
-    // release callback has to run whether it did or not
+    // The release is where QLabel activates a link
     bool takenByQt = false;
     if (carriesLink()) {
         QLabel::mouseReleaseEvent(event);
@@ -318,11 +301,9 @@ void TLabel::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
 }
 
-// A label is game UI with its own right-click handling - a script's callback has
-// already run by the time this arrives - so Qt's "Copy Link Location" menu over a
-// link is left out. QWidget's, rather than QLabel's: passing the event on untouched
-// is what a plain widget does, and doing it by calling that keeps this the same
-// answer if Qt ever changes what "untouched" means.
+// A label is game UI with its own right-click handling, so Qt's "Copy Link
+// Location" menu over a link is left out. QWidget's rather than QLabel's: passing
+// the event on untouched is what a plain widget does.
 void TLabel::contextMenuEvent(QContextMenuEvent* event)
 {
     QWidget::contextMenuEvent(event);

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -37,35 +37,32 @@
 
 using namespace std::chrono_literals;
 
-// A case-insensitive text.contains("<a ") answers the same, but it case-folds every
-// character it walks, and Lua UIs echo into labels on every prompt. Any whitespace
-// counts as the separator because HTML allows any; the styling pass in setText()
-// recognises only the ASCII ones, so an anchor split by a non-breaking space comes
-// out clickable but unstyled.
+// Hand-rolled because a case-insensitive text.contains("<a ") answers a different
+// question - it cannot tell a tag from prose that happens to hold "<a " - and
+// because it case-folds every character it walks, while Lua UIs echo into labels on
+// every prompt. Any whitespace counts as the separator because HTML allows any; the
+// styling pass in setText() recognises only the ASCII ones, so an anchor split by a
+// non-breaking space comes out clickable but unstyled.
 static bool containsAnchorTag(const QString& text)
 {
-    const qsizetype length = text.size();
-    qsizetype from = 0;
-    // the last '>' the walk found, which stays the nearest one until it is passed
+    // the nearest '>' the walk has found, which stays the nearest until it is passed
     qsizetype close = -1;
-    while (true) {
-        const qsizetype at = text.indexOf(QLatin1Char('<'), from);
-        // Too near the end for a tag name and a separator, and every later '<' is
-        // nearer still, so there is nothing left to find
-        if (at < 0 || at + 2 >= length) {
-            return false;
-        }
+    // A '<' with fewer than two characters after it is too near the end for a tag
+    // name and a separator, and every later '<' is nearer still.
+    for (qsizetype at = text.indexOf(QLatin1Char('<')); at >= 0 && at + 2 < text.size(); at = text.indexOf(QLatin1Char('<'), at + 1)) {
         const char16_t tagName = text.at(at + 1).unicode();
         if ((tagName != u'a' && tagName != u'A') || !text.at(at + 2).isSpace()) {
-            from = at + 1;
             continue;
         }
         // Prose - and game text echoed into a label - holds "<a" and a space too,
         // so it is only a tag once the '>' that closes it turns up; another '<' on
-        // the way there means this one never was one.
+        // the way there means this one never was one. An attribute value carrying a
+        // '<' of its own is turned away by that rule, which costs the label its link
+        // interaction; HTML asks for that character to be written &lt; anyway.
         if (close < at) {
-            // Searched for again only once the walk has passed the last one
-            // found, so the ranges these scans cover never overlap
+            // Searched for again only once the walk has passed the last one found,
+            // so the '>' scans stay linear over the whole text however many "<a "
+            // it holds
             close = text.indexOf(QLatin1Char('>'), at + 3);
             if (close < 0) {
                 // no tag anywhere past here can be closed either
@@ -76,8 +73,8 @@ static bool containsAnchorTag(const QString& text)
         if (nextOpen < 0 || close < nextOpen) {
             return true;
         }
-        from = nextOpen;
     }
+    return false;
 }
 
 TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
@@ -132,11 +129,13 @@ void TLabel::setText(const QString& text)
     const bool hasAnchor = containsAnchorTag(text);
 
     // Links only, and only when the label carries one. The selection half of
-    // Qt::TextBrowserInteraction is what brings Qt's own context menu to a label,
-    // and it also has QLabel swallow the press that the label's click callback
-    // needs; links on their own leave the press to us and still activate on the
-    // release.
-    setTextInteractionFlags(hasAnchor ? Qt::LinksAccessibleByMouse : Qt::NoTextInteraction);
+    // Qt::TextBrowserInteraction has QLabel swallow the press that the label's click
+    // callback needs, and puts a Copy / Select All menu on the label; links on their
+    // own leave the press to us and still activate on the release. Keyboard as well
+    // as mouse, which is what gives the label the focus policy that puts a link in
+    // reach of Tab and Return. The smaller Copy Link Location menu that links alone
+    // still offer over a link is what contextMenuEvent() below is for.
+    setTextInteractionFlags(hasAnchor ? scmLinkInteraction : Qt::TextInteractionFlags(Qt::NoTextInteraction));
 
     // If we have link styling configured and the text contains HTML links,
     // we need to inject inline styles because QTextDocument doesn't use
@@ -207,15 +206,23 @@ void TLabel::setText(const QString& text)
     }
 }
 
+// Whether QLabel has a link of its own to activate in this text, which is the only
+// thing that makes it want a mouse event. containsAnchorTag() answers false for an
+// empty text on its first look, so there is nothing to test ahead of it.
+bool TLabel::carriesLink() const
+{
+    return textFormat() == Qt::RichText && containsAnchorTag(text());
+}
+
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
-    // QLabel needs the press to note which link it landed on, so that the
-    // matching release can activate it. A link in the text must not cost the
-    // label the click callback a script registered on it, so the callback runs
-    // either way and only the fall-through to the parent is skipped when QLabel
-    // took the press for itself.
+    // QLabel needs the press to note which link it landed on, so that the matching
+    // release can activate it - with links-only flags it records the anchor and then
+    // leaves the press ignored, which is what gives the label's own click callback
+    // back. takenByQt only guards against handing the parent an event QLabel did
+    // keep, should those flags ever widen again.
     bool takenByQt = false;
-    if (!text().isEmpty() && textFormat() == Qt::RichText && containsAnchorTag(text())) {
+    if (carriesLink()) {
         QLabel::mousePressEvent(event);
         takenByQt = event->isAccepted();
     }
@@ -246,7 +253,7 @@ void TLabel::mouseReleaseEvent(QMouseEvent* event)
     // The release is where QLabel activates a link, and where the label's own
     // release callback has to run whether it did or not
     bool takenByQt = false;
-    if (!text().isEmpty() && textFormat() == Qt::RichText && containsAnchorTag(text())) {
+    if (carriesLink()) {
         QLabel::mouseReleaseEvent(event);
         takenByQt = event->isAccepted();
     }
@@ -312,12 +319,13 @@ void TLabel::resizeEvent(QResizeEvent* event)
 }
 
 // A label is game UI with its own right-click handling - a script's callback has
-// already run by the time this arrives - so Qt's "Copy Link Location" menu over
-// a link is left out, and the event is passed on exactly as a label with no link
-// in its text passes it on.
+// already run by the time this arrives - so Qt's "Copy Link Location" menu over a
+// link is left out. QWidget's, rather than QLabel's: passing the event on untouched
+// is what a plain widget does, and doing it by calling that keeps this the same
+// answer if Qt ever changes what "untouched" means.
 void TLabel::contextMenuEvent(QContextMenuEvent* event)
 {
-    event->ignore();
+    QWidget::contextMenuEvent(event);
 }
 
 
@@ -331,7 +339,7 @@ void TLabel::setClickThrough(bool clickthrough)
         setTextInteractionFlags(Qt::NoTextInteraction);
     } else {
         // Re-enable text interaction only if the current text has hyperlinks
-        setTextInteractionFlags(containsAnchorTag(text()) ? Qt::LinksAccessibleByMouse : Qt::NoTextInteraction);
+        setTextInteractionFlags(containsAnchorTag(text()) ? scmLinkInteraction : Qt::TextInteractionFlags(Qt::NoTextInteraction));
     }
 }
 

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -44,19 +44,39 @@ using namespace std::chrono_literals;
 // out clickable but unstyled.
 static bool containsAnchorTag(const QString& text)
 {
+    const qsizetype length = text.size();
     qsizetype from = 0;
+    // the last '>' the walk found, which stays the nearest one until it is passed
+    qsizetype close = -1;
     while (true) {
         const qsizetype at = text.indexOf(QLatin1Char('<'), from);
         // Too near the end for a tag name and a separator, and every later '<' is
         // nearer still, so there is nothing left to find
-        if (at < 0 || at + 2 >= text.size()) {
+        if (at < 0 || at + 2 >= length) {
             return false;
         }
         const char16_t tagName = text.at(at + 1).unicode();
-        if ((tagName == u'a' || tagName == u'A') && text.at(at + 2).isSpace()) {
+        if ((tagName != u'a' && tagName != u'A') || !text.at(at + 2).isSpace()) {
+            from = at + 1;
+            continue;
+        }
+        // Prose - and game text echoed into a label - holds "<a" and a space too,
+        // so it is only a tag once the '>' that closes it turns up; another '<' on
+        // the way there means this one never was one.
+        if (close < at) {
+            // Searched for again only once the walk has passed the last one
+            // found, so the ranges these scans cover never overlap
+            close = text.indexOf(QLatin1Char('>'), at + 3);
+            if (close < 0) {
+                // no tag anywhere past here can be closed either
+                return false;
+            }
+        }
+        const qsizetype nextOpen = text.indexOf(QLatin1Char('<'), at + 3);
+        if (nextOpen < 0 || close < nextOpen) {
             return true;
         }
-        from = at + 1;
+        from = nextOpen;
     }
 }
 
@@ -111,13 +131,12 @@ void TLabel::setText(const QString& text)
 {
     const bool hasAnchor = containsAnchorTag(text);
 
-    // Enable TextBrowserInteraction only when the label contains hyperlinks
-    // This prevents Qt's default context menu from appearing on labels without links
-    if (hasAnchor) {
-        setTextInteractionFlags(Qt::TextBrowserInteraction);
-    } else {
-        setTextInteractionFlags(Qt::NoTextInteraction);
-    }
+    // Links only, and only when the label carries one. The selection half of
+    // Qt::TextBrowserInteraction is what brings Qt's own context menu to a label,
+    // and it also has QLabel swallow the press that the label's click callback
+    // needs; links on their own leave the press to us and still activate on the
+    // release.
+    setTextInteractionFlags(hasAnchor ? Qt::LinksAccessibleByMouse : Qt::NoTextInteraction);
 
     // If we have link styling configured and the text contains HTML links,
     // we need to inject inline styles because QTextDocument doesn't use
@@ -190,14 +209,15 @@ void TLabel::setText(const QString& text)
 
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
-    // If the label has rich text with potential hyperlinks, let QLabel handle the event first
-    // QLabel will emit linkActivated if a link was clicked
+    // QLabel needs the press to note which link it landed on, so that the
+    // matching release can activate it. A link in the text must not cost the
+    // label the click callback a script registered on it, so the callback runs
+    // either way and only the fall-through to the parent is skipped when QLabel
+    // took the press for itself.
+    bool takenByQt = false;
     if (!text().isEmpty() && textFormat() == Qt::RichText && containsAnchorTag(text())) {
         QLabel::mousePressEvent(event);
-        // If QLabel didn't accept the event, then it wasn't a link click
-        if (event->isAccepted()) {
-            return;
-        }
+        takenByQt = event->isAccepted();
     }
 
     if (mpHost && mClickFunction) {
@@ -206,7 +226,7 @@ void TLabel::mousePressEvent(QMouseEvent* event)
         // any parent, e.g. the containing TConsole
         event->accept();
         mudlet::self()->activateProfile(mpHost);
-    } else {
+    } else if (!takenByQt) {
         QWidget::mousePressEvent(event);
     }
 }
@@ -223,13 +243,12 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
-    // If the label has rich text with potential hyperlinks, let QLabel handle the event first
+    // The release is where QLabel activates a link, and where the label's own
+    // release callback has to run whether it did or not
+    bool takenByQt = false;
     if (!text().isEmpty() && textFormat() == Qt::RichText && containsAnchorTag(text())) {
         QLabel::mouseReleaseEvent(event);
-        // If QLabel accepted the event, it was handling a link click
-        if (event->isAccepted()) {
-            return;
-        }
+        takenByQt = event->isAccepted();
     }
 
     auto labelParent = qobject_cast<TConsole*>(parent());
@@ -241,7 +260,7 @@ void TLabel::mouseReleaseEvent(QMouseEvent* event)
     if (mpHost && mReleaseFunction) {
         mpHost->getLuaInterpreter()->callLabelCallbackEvent(mReleaseFunction, event);
         event->accept();
-    } else {
+    } else if (!takenByQt) {
         QWidget::mouseReleaseEvent(event);
     }
 }
@@ -292,6 +311,15 @@ void TLabel::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
 }
 
+// A label is game UI with its own right-click handling - a script's callback has
+// already run by the time this arrives - so Qt's "Copy Link Location" menu over
+// a link is left out, and the event is passed on exactly as a label with no link
+// in its text passes it on.
+void TLabel::contextMenuEvent(QContextMenuEvent* event)
+{
+    event->ignore();
+}
+
 
 void TLabel::setClickThrough(bool clickthrough)
 {
@@ -303,11 +331,7 @@ void TLabel::setClickThrough(bool clickthrough)
         setTextInteractionFlags(Qt::NoTextInteraction);
     } else {
         // Re-enable text interaction only if the current text has hyperlinks
-        if (containsAnchorTag(text())) {
-            setTextInteractionFlags(Qt::TextBrowserInteraction);
-        } else {
-            setTextInteractionFlags(Qt::NoTextInteraction);
-        }
+        setTextInteractionFlags(containsAnchorTag(text()) ? Qt::LinksAccessibleByMouse : Qt::NoTextInteraction);
     }
 }
 

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -39,6 +39,7 @@
 #include <memory>
 
 class Host;
+class QContextMenuEvent;
 class QMouseEvent;
 
 class TLabel : public QLabel
@@ -64,6 +65,7 @@ public:
     void enterEvent(TEnterEvent*) override;
     void resizeEvent(QResizeEvent* event) override;
     void changeEvent(QEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent*) override;
     void setClickThrough(bool clickthrough);
     void setBackgroundColor(const QColor& color);
     void setLinkStyle(const QString& linkColor, const QString& linkVisitedColor, bool underline = true);

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -94,10 +94,9 @@ public:
     QSet<QString>& mVisitedLinks;
 
 private:
-    // Links only, both halves of them. The selection flags are what would cost the
-    // label the press its click callback needs; the keyboard flag is what puts a
-    // link in reach of Tab and Return, which the focus policy QLabel derives from
-    // these flags decides.
+    // The selection flags would cost the label the press its click callback needs;
+    // the keyboard flag puts a link in reach of Tab and Return, through the focus
+    // policy QLabel derives from these flags.
     static constexpr Qt::TextInteractionFlags scmLinkInteraction = Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard;
 
     bool carriesLink() const;

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -94,6 +94,13 @@ public:
     QSet<QString>& mVisitedLinks;
 
 private:
+    // Links only, both halves of them. The selection flags are what would cost the
+    // label the press its click callback needs; the keyboard flag is what puts a
+    // link in reach of Tab and Return, which the focus policy QLabel derives from
+    // these flags decides.
+    static constexpr Qt::TextInteractionFlags scmLinkInteraction = Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard;
+
+    bool carriesLink() const;
     void applyBackgroundColor();
 
     QColor& mBackgroundColor;

--- a/test/functional_tests/LabelAnchorInteractionTest.cpp
+++ b/test/functional_tests/LabelAnchorInteractionTest.cpp
@@ -18,12 +18,12 @@
  ***************************************************************************/
 
 /*
- * A label only gets Qt's link interaction - and with it clickable links - when
- * its text carries an anchor, so which texts count as carrying one decides which
- * links work, whether a right-click brings up a menu of Qt's own, and whether the
- * press still reaches the label's own click callback. None of the interaction
- * flags, a synthesised click on a link, or a context menu event are reachable
- * from Lua, so they all have to be asked of the TLabel directly.
+ * A label gets Qt's link interaction only when its text carries an anchor, so
+ * which texts count as carrying one decides which links work - while the label's
+ * own click callback and its right-click behaviour must not depend on that answer
+ * at all. None of the interaction flags, a synthesised click on a link, or a
+ * context menu event are reachable from Lua, so they all have to be asked of the
+ * TLabel directly.
  *
  * Run with: ctest -R LabelAnchorInteractionTest -V
  */
@@ -82,6 +82,12 @@ private:
         document.setDefaultFont(label()->font());
         return QPoint(static_cast<int>(document.idealWidth()) / 2, static_cast<int>(document.size().height()) / 2);
     }
+
+    // The document above is laid out on its own, without the label's contents
+    // margins or alignment, so a click aimed by it can miss the widget - which
+    // would read as a callback that did not fire rather than as a click that
+    // went nowhere.
+    bool centreIsOnTheLabel() const { return label()->rect().contains(linkCentre()); }
 
 private slots:
     void initTestCase()
@@ -181,6 +187,18 @@ private slots:
         QTest::newRow("anchor split by a newline") << qsl("<a\nhref='https://example.com'>go</a>") << true;
         QTest::newRow("anchor split by a tab") << qsl("<a\thref='https://example.com'>go</a>") << true;
         QTest::newRow("upper case anchor split by a newline") << qsl("<A\nHREF='https://example.com'>go</A>") << true;
+        QTest::newRow("anchor split by a carriage return") << qsl("<a\rhref='https://example.com'>go</a>") << true;
+        QTest::newRow("anchor split by a vertical tab") << qsl("<a\vhref='https://example.com'>go</a>") << true;
+        QTest::newRow("anchor split by a form feed") << qsl("<a\fhref='https://example.com'>go</a>") << true;
+        // QChar::isSpace() and Qt's own HTML parser agree on the Unicode spaces
+        // as well as the ASCII ones - Qt draws each of these as a link - so a
+        // separator test narrower than isSpace() would take the flags away from
+        // text Qt still puts a link in.
+        QTest::newRow("anchor split by a no-break space") << qsl("<a%1href='https://example.com'>go</a>").arg(QChar(0x00a0)) << true;
+        QTest::newRow("anchor split by a thin space") << qsl("<a%1href='https://example.com'>go</a>").arg(QChar(0x2009)) << true;
+        // ...and they agree the other way on the ASCII separators, which are
+        // control characters rather than spaces: Qt draws no link here.
+        QTest::newRow("an ASCII file separator is not a tag separator") << qsl("<a%1href='https://example.com'>go</a>").arg(QChar(0x001c)) << false;
         // an anchor needs attributes, and a bare "<a" cannot be the start of one
         QTest::newRow("anchor tag name only") << qsl("truncated at <a") << false;
         // prose - and game text echoed into a label - holds "<a" and whitespace
@@ -190,6 +208,16 @@ private slots:
         QTest::newRow("an anchor that is never closed") << qsl("<a href='https://example.com'") << false;
         QTest::newRow("a bare <a ahead of a real anchor") << qsl("five <a b <a href='https://example.com'>go</a>") << true;
         QTest::newRow("a word starting with a") << qsl("<abbr title='x'>ab</abbr>") << false;
+        // Prose with nothing after the bare "<a" to say it was not a tag: the
+        // walk has no second '<' to turn it away with, so it answers yes, as the
+        // contains("<a ") this replaced did. What that costs is the flags and
+        // nothing else - the label's own callbacks run either way, and the
+        // context menu case below covers every one of these texts.
+        QTest::newRow("prose with a bare <a and a later >") << qsl("five <a b, ten> c") << true;
+        // An attribute value holding a '<' of its own is turned away by the same
+        // rule, so a label carrying one loses its link interaction. HTML asks
+        // for that character to be written &lt;.
+        QTest::newRow("an anchor whose attribute value holds a <") << qsl("<a href='a<b'>go</a>") << false;
         QTest::newRow("consecutive angle brackets") << qsl("<<a href='https://example.com'>go</a>") << true;
     }
 
@@ -203,11 +231,17 @@ private slots:
         label()->setText(interactive ? qsl("nothing here") : qsl("<a href='https://example.com'>go</a>"));
         label()->setText(text);
 
-        // the whole flag set, not just the link bit: leaving the label selectable
-        // would bring back the context menu these flags exist to keep away, and
-        // would have QLabel swallow the press the label's click callback needs
-        const Qt::TextInteractionFlags expected = interactive ? Qt::TextInteractionFlags(Qt::LinksAccessibleByMouse) : Qt::TextInteractionFlags(Qt::NoTextInteraction);
+        // The whole flag set, not just the link bit: leaving the label selectable
+        // would have QLabel swallow the press the label's click callback needs,
+        // and would put Qt's Copy / Select All menu on it. What keeps Qt's
+        // smaller Copy Link Location menu away is the contextMenuEvent()
+        // override, not these flags.
+        const Qt::TextInteractionFlags expected = interactive ? (Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard) : Qt::TextInteractionFlags(Qt::NoTextInteraction);
         QCOMPARE(label()->textInteractionFlags(), expected);
+        // QLabel derives its focus policy from those flags, and that policy is
+        // the whole of a link's keyboard reachability - which is what the
+        // keyboard flag above is there for.
+        QCOMPARE(label()->focusPolicy(), interactive ? Qt::StrongFocus : Qt::NoFocus);
     }
 
     void test_aLinkSplitByWhitespaceIsClickable()
@@ -217,6 +251,7 @@ private slots:
         label()->resetLinkStyle();
         label()->setText(qsl("<a\nhref='https://example.com'>go</a>"));
 
+        QVERIFY2(centreIsOnTheLabel(), "the point this case clicks is outside the label, so it would miss the link");
         QSignalSpy activated(label(), &QLabel::linkActivated);
         QTest::mouseClick(label(), Qt::LeftButton, Qt::NoModifier, linkCentre());
         QCOMPARE(activated.count(), 1);
@@ -230,7 +265,7 @@ private slots:
         label()->setClickThrough(true);
         label()->setClickThrough(false);
 
-        QCOMPARE(label()->textInteractionFlags(), Qt::TextInteractionFlags(Qt::LinksAccessibleByMouse));
+        QCOMPARE(label()->textInteractionFlags(), Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
     }
 
     void test_aClickOnALinkStillReachesTheLabelsOwnCallbacks()
@@ -246,6 +281,7 @@ private slots:
         // a registration that quietly failed would make the counts below prove
         // nothing at all
         QVERIFY2(luaHolds(qsl("anchorRegistered")), "the callbacks did not reach the label");
+        QVERIFY2(centreIsOnTheLabel(), "the point this case clicks is outside the label, so it would miss the link");
 
         QSignalSpy activated(label(), &QLabel::linkActivated);
         QTest::mouseClick(label(), Qt::LeftButton, Qt::NoModifier, linkCentre());
@@ -273,6 +309,10 @@ private slots:
         label()->resetLinkStyle();
         label()->setText(text);
 
+        // activePopupWidget() is process wide, so a popup left open by anything
+        // earlier would be read as this label's menu
+        QVERIFY2(!QApplication::activePopupWidget(), "a popup was already open before this case sent its context menu event");
+
         // right on the text, which is where Qt looks for an anchor to offer
         const QPoint where = linkCentre();
         QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, where, label()->mapToGlobal(where));
@@ -286,7 +326,10 @@ private slots:
             QTest::qWait(50ms);
         }
         QVERIFY2(!popup, "Qt opened a context menu of its own over the label");
-        QVERIFY2(!menuEvent.isAccepted(), "the label took the context menu event instead of passing it on");
+        // An ignored context menu event is offered to each ancestor in turn, so
+        // this is the label and everything it sits in: a console or main window
+        // that grew a menu of its own would report here too.
+        QVERIFY2(!menuEvent.isAccepted(), "the label, or a widget it sits in, took the context menu event instead of passing it on");
     }
 };
 

--- a/test/functional_tests/LabelAnchorInteractionTest.cpp
+++ b/test/functional_tests/LabelAnchorInteractionTest.cpp
@@ -18,15 +18,17 @@
  ***************************************************************************/
 
 /*
- * A label only gets Qt's text-browser interaction - and with it clickable links
- * and a context menu - when its text carries an anchor, so which texts count as
- * carrying one decides which links work. Neither the interaction flags nor a
- * synthesised click on a link are reachable from Lua, so both have to be asked of
- * the TLabel directly.
+ * A label only gets Qt's link interaction - and with it clickable links - when
+ * its text carries an anchor, so which texts count as carrying one decides which
+ * links work, whether a right-click brings up a menu of Qt's own, and whether the
+ * press still reaches the label's own click callback. None of the interaction
+ * flags, a synthesised click on a link, or a context menu event are reachable
+ * from Lua, so they all have to be asked of the TLabel directly.
  *
  * Run with: ctest -R LabelAnchorInteractionTest -V
  */
 
+#include <QContextMenuEvent>
 #include <QSignalSpy>
 #include <QtTest/QtTest>
 #include <QTextDocument>
@@ -36,6 +38,7 @@
 #include "Host.h"
 #include "MudletInstanceCoordinator.h"
 #include "TLabel.h"
+#include "TLuaInterpreter.h"
 #include "TMainConsole.h"
 #include "TelnetServerStub.h"
 #include "ctelnet.h"
@@ -63,6 +66,12 @@ private:
     QByteArray mSavedXdgConfigHome;
 
     TLabel* label() const { return mpHost->mpConsole->labelWidget(mLabelName); }
+
+    // What a Lua callback counted, since the callbacks themselves only exist in
+    // the interpreter. Read back through the return value rather than
+    // getLuaString(), which reports an absolute stack slot and so only answers
+    // correctly for the first call in a process.
+    bool luaHolds(const QString& condition) const { return mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("assert(%1)").arg(condition)); }
 
     // Where the label's only word of text sits, so a synthesised click lands on
     // the link rather than the empty space around it
@@ -174,6 +183,12 @@ private slots:
         QTest::newRow("upper case anchor split by a newline") << qsl("<A\nHREF='https://example.com'>go</A>") << true;
         // an anchor needs attributes, and a bare "<a" cannot be the start of one
         QTest::newRow("anchor tag name only") << qsl("truncated at <a") << false;
+        // prose - and game text echoed into a label - holds "<a" and whitespace
+        // too, with nothing Qt draws as a link
+        QTest::newRow("prose holding a bare <a") << qsl("five <a\nb, ten <a\nc") << false;
+        QTest::newRow("prose holding a bare <a and a space") << qsl("five <a b, ten <a c") << false;
+        QTest::newRow("an anchor that is never closed") << qsl("<a href='https://example.com'") << false;
+        QTest::newRow("a bare <a ahead of a real anchor") << qsl("five <a b <a href='https://example.com'>go</a>") << true;
         QTest::newRow("a word starting with a") << qsl("<abbr title='x'>ab</abbr>") << false;
         QTest::newRow("consecutive angle brackets") << qsl("<<a href='https://example.com'>go</a>") << true;
     }
@@ -189,8 +204,10 @@ private slots:
         label()->setText(text);
 
         // the whole flag set, not just the link bit: leaving the label selectable
-        // would bring back the context menu these flags exist to keep away
-        QCOMPARE(label()->textInteractionFlags(), interactive ? Qt::TextBrowserInteraction : Qt::NoTextInteraction);
+        // would bring back the context menu these flags exist to keep away, and
+        // would have QLabel swallow the press the label's click callback needs
+        const Qt::TextInteractionFlags expected = interactive ? Qt::TextInteractionFlags(Qt::LinksAccessibleByMouse) : Qt::TextInteractionFlags(Qt::NoTextInteraction);
+        QCOMPARE(label()->textInteractionFlags(), expected);
     }
 
     void test_aLinkSplitByWhitespaceIsClickable()
@@ -213,7 +230,63 @@ private slots:
         label()->setClickThrough(true);
         label()->setClickThrough(false);
 
-        QCOMPARE(label()->textInteractionFlags(), Qt::TextBrowserInteraction);
+        QCOMPARE(label()->textInteractionFlags(), Qt::TextInteractionFlags(Qt::LinksAccessibleByMouse));
+    }
+
+    void test_aClickOnALinkStillReachesTheLabelsOwnCallbacks()
+    {
+        label()->resetLinkStyle();
+        label()->setText(qsl("<a\nhref='https://example.com'>go</a>"));
+
+        mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("anchorClicks = 0\n"
+                                                                 "anchorReleases = 0\n"
+                                                                 "anchorRegistered = setLabelClickCallback('%1', function() anchorClicks = anchorClicks + 1 end)\n"
+                                                                 "anchorRegistered = anchorRegistered and setLabelReleaseCallback('%1', function() anchorReleases = anchorReleases + 1 end)\n")
+                                                                     .arg(mLabelName));
+        // a registration that quietly failed would make the counts below prove
+        // nothing at all
+        QVERIFY2(luaHolds(qsl("anchorRegistered")), "the callbacks did not reach the label");
+
+        QSignalSpy activated(label(), &QLabel::linkActivated);
+        QTest::mouseClick(label(), Qt::LeftButton, Qt::NoModifier, linkCentre());
+
+        // the link the click landed on, and the callbacks the script registered:
+        // a label carrying a link is still a clickable label
+        QCOMPARE(activated.count(), 1);
+        QVERIFY2(luaHolds(qsl("anchorClicks == 1")), "the label's click callback did not fire");
+        QVERIFY2(luaHolds(qsl("anchorReleases == 1")), "the label's release callback did not fire");
+    }
+
+    void test_aRightClickOpensNoMenuOfQtsOwn_data()
+    {
+        QTest::addColumn<QString>("text");
+
+        QTest::newRow("plain text") << qsl("just some words");
+        QTest::newRow("prose holding a bare <a") << qsl("five <a\nb, ten <a\nc");
+        QTest::newRow("a link") << qsl("<a\nhref='https://example.com'>go</a>");
+    }
+
+    void test_aRightClickOpensNoMenuOfQtsOwn()
+    {
+        QFETCH(QString, text);
+
+        label()->resetLinkStyle();
+        label()->setText(text);
+
+        // right on the text, which is where Qt looks for an anchor to offer
+        const QPoint where = linkCentre();
+        QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, where, label()->mapToGlobal(where));
+        QApplication::sendEvent(label(), &menuEvent);
+
+        // Qt's menu is a popup window of its own, so it is there to be found
+        // whether or not the event was accepted
+        QWidget* popup = QApplication::activePopupWidget();
+        if (popup) {
+            popup->close();
+            QTest::qWait(50ms);
+        }
+        QVERIFY2(!popup, "Qt opened a context menu of its own over the label");
+        QVERIFY2(!menuEvent.isAccepted(), "the label took the context menu event instead of passing it on");
     }
 };
 

--- a/test/functional_tests/LabelAnchorInteractionTest.cpp
+++ b/test/functional_tests/LabelAnchorInteractionTest.cpp
@@ -18,11 +18,8 @@
  ***************************************************************************/
 
 /*
- * A label gets Qt's link interaction only when its text carries an anchor, so
- * which texts count as carrying one decides which links work - while the label's
- * own click callback and its right-click behaviour must not depend on that answer
- * at all. None of the interaction flags, a synthesised click on a link, or a
- * context menu event are reachable from Lua, so they all have to be asked of the
+ * Neither a label's text interaction flags, a synthesised click on a link, nor a
+ * context menu event is reachable from Lua, so they all have to be asked of the
  * TLabel directly.
  *
  * Run with: ctest -R LabelAnchorInteractionTest -V
@@ -67,10 +64,9 @@ private:
 
     TLabel* label() const { return mpHost->mpConsole->labelWidget(mLabelName); }
 
-    // What a Lua callback counted, since the callbacks themselves only exist in
-    // the interpreter. Read back through the return value rather than
-    // getLuaString(), which reports an absolute stack slot and so only answers
-    // correctly for the first call in a process.
+    // Read back through the return value rather than getLuaString(), which reports
+    // an absolute stack slot and so only answers correctly for the first call in a
+    // process.
     bool luaHolds(const QString& condition) const { return mpHost->getLuaInterpreter()->compileAndExecuteScript(qsl("assert(%1)").arg(condition)); }
 
     // Where the label's only word of text sits, so a synthesised click lands on
@@ -85,8 +81,7 @@ private:
 
     // The document above is laid out on its own, without the label's contents
     // margins or alignment, so a click aimed by it can miss the widget - which
-    // would read as a callback that did not fire rather than as a click that
-    // went nowhere.
+    // would read as a callback that did not fire.
     bool centreIsOnTheLabel() const { return label()->rect().contains(linkCentre()); }
 
 private slots:
@@ -190,33 +185,27 @@ private slots:
         QTest::newRow("anchor split by a carriage return") << qsl("<a\rhref='https://example.com'>go</a>") << true;
         QTest::newRow("anchor split by a vertical tab") << qsl("<a\vhref='https://example.com'>go</a>") << true;
         QTest::newRow("anchor split by a form feed") << qsl("<a\fhref='https://example.com'>go</a>") << true;
-        // QChar::isSpace() and Qt's own HTML parser agree on the Unicode spaces
-        // as well as the ASCII ones - Qt draws each of these as a link - so a
-        // separator test narrower than isSpace() would take the flags away from
-        // text Qt still puts a link in.
+        // Qt's own HTML parser and QChar::isSpace() agree on the Unicode spaces,
+        // so a narrower separator test would take the flags off a text Qt links.
         QTest::newRow("anchor split by a no-break space") << qsl("<a%1href='https://example.com'>go</a>").arg(QChar(0x00a0)) << true;
         QTest::newRow("anchor split by a thin space") << qsl("<a%1href='https://example.com'>go</a>").arg(QChar(0x2009)) << true;
-        // ...and they agree the other way on the ASCII separators, which are
-        // control characters rather than spaces: Qt draws no link here.
+        // They agree the other way on the ASCII separators, which are control
+        // characters rather than spaces: Qt draws no link here.
         QTest::newRow("an ASCII file separator is not a tag separator") << qsl("<a%1href='https://example.com'>go</a>").arg(QChar(0x001c)) << false;
         // an anchor needs attributes, and a bare "<a" cannot be the start of one
         QTest::newRow("anchor tag name only") << qsl("truncated at <a") << false;
-        // prose - and game text echoed into a label - holds "<a" and whitespace
-        // too, with nothing Qt draws as a link
+        // prose holds "<a" and whitespace too, with nothing Qt draws as a link
         QTest::newRow("prose holding a bare <a") << qsl("five <a\nb, ten <a\nc") << false;
         QTest::newRow("prose holding a bare <a and a space") << qsl("five <a b, ten <a c") << false;
         QTest::newRow("an anchor that is never closed") << qsl("<a href='https://example.com'") << false;
         QTest::newRow("a bare <a ahead of a real anchor") << qsl("five <a b <a href='https://example.com'>go</a>") << true;
         QTest::newRow("a word starting with a") << qsl("<abbr title='x'>ab</abbr>") << false;
-        // Prose with nothing after the bare "<a" to say it was not a tag: the
-        // walk has no second '<' to turn it away with, so it answers yes, as the
-        // contains("<a ") this replaced did. What that costs is the flags and
-        // nothing else - the label's own callbacks run either way, and the
-        // context menu case below covers every one of these texts.
+        // No second '<' to turn the bare "<a" away with, so this answers yes. It
+        // costs the flags and nothing else: the label's own callbacks run either
+        // way.
         QTest::newRow("prose with a bare <a and a later >") << qsl("five <a b, ten> c") << true;
         // An attribute value holding a '<' of its own is turned away by the same
-        // rule, so a label carrying one loses its link interaction. HTML asks
-        // for that character to be written &lt;.
+        // rule. HTML asks for that character to be written &lt;.
         QTest::newRow("an anchor whose attribute value holds a <") << qsl("<a href='a<b'>go</a>") << false;
         QTest::newRow("consecutive angle brackets") << qsl("<<a href='https://example.com'>go</a>") << true;
     }
@@ -231,16 +220,12 @@ private slots:
         label()->setText(interactive ? qsl("nothing here") : qsl("<a href='https://example.com'>go</a>"));
         label()->setText(text);
 
-        // The whole flag set, not just the link bit: leaving the label selectable
-        // would have QLabel swallow the press the label's click callback needs,
-        // and would put Qt's Copy / Select All menu on it. What keeps Qt's
-        // smaller Copy Link Location menu away is the contextMenuEvent()
-        // override, not these flags.
+        // The whole flag set, not just the link bit: a selectable label swallows
+        // the press its click callback needs.
         const Qt::TextInteractionFlags expected = interactive ? (Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard) : Qt::TextInteractionFlags(Qt::NoTextInteraction);
         QCOMPARE(label()->textInteractionFlags(), expected);
-        // QLabel derives its focus policy from those flags, and that policy is
-        // the whole of a link's keyboard reachability - which is what the
-        // keyboard flag above is there for.
+        // QLabel derives its focus policy from those flags, and that policy is the
+        // whole of a link's keyboard reachability.
         QCOMPARE(label()->focusPolicy(), interactive ? Qt::StrongFocus : Qt::NoFocus);
     }
 
@@ -279,15 +264,13 @@ private slots:
                                                                  "anchorRegistered = anchorRegistered and setLabelReleaseCallback('%1', function() anchorReleases = anchorReleases + 1 end)\n")
                                                                      .arg(mLabelName));
         // a registration that quietly failed would make the counts below prove
-        // nothing at all
+        // nothing
         QVERIFY2(luaHolds(qsl("anchorRegistered")), "the callbacks did not reach the label");
         QVERIFY2(centreIsOnTheLabel(), "the point this case clicks is outside the label, so it would miss the link");
 
         QSignalSpy activated(label(), &QLabel::linkActivated);
         QTest::mouseClick(label(), Qt::LeftButton, Qt::NoModifier, linkCentre());
 
-        // the link the click landed on, and the callbacks the script registered:
-        // a label carrying a link is still a clickable label
         QCOMPARE(activated.count(), 1);
         QVERIFY2(luaHolds(qsl("anchorClicks == 1")), "the label's click callback did not fire");
         QVERIFY2(luaHolds(qsl("anchorReleases == 1")), "the label's release callback did not fire");
@@ -327,8 +310,7 @@ private slots:
         }
         QVERIFY2(!popup, "Qt opened a context menu of its own over the label");
         // An ignored context menu event is offered to each ancestor in turn, so
-        // this is the label and everything it sits in: a console or main window
-        // that grew a menu of its own would report here too.
+        // this covers the label and everything it sits in.
         QVERIFY2(!menuEvent.isAccepted(), "the label, or a widget it sits in, took the context menu event instead of passing it on");
     }
 };


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A label whose text carries an anchor written with any whitespace after `<a` (newline, tab, CR, NBSP...) stopped firing its Lua click callback, and prose that merely contained `<a` plus whitespace ("five <a\nb, ten <a\nc", i.e. text a game can send) opened Qt's own Copy / Copy Link Location / Select All menu over the game UI.
- `containsAnchorTag()` now requires the `>` that closes the tag (another `<` first means it never was a tag), so prose no longer counts. It stays one linear walk, measured at no cost on 690 KB of prose.
- Labels with a link take `Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard` instead of `Qt::TextBrowserInteraction`: links still activate on release and stay Tab-reachable, but QLabel no longer swallows the press, so the click callback runs again. `TLabel::contextMenuEvent()` passes the event on as a plain widget does, so no Qt menu appears over a label.
- `LabelAnchorInteractionTest` grows a 31-row matrix (whitespace variants verified against Qt's own HTML parser, prose, unclosed tags, a `<` inside an attribute), a live-link click that checks both the link and the callbacks, right-click cases, and the focus policy. 22 of 31 fail on the unfixed code.

#### Motivation for adding to Mudlet

Regression since 5.0.1 introduced by #10090 (QA findings F-13-1 and F-R7-1). Package authors had no workaround for the lost click; the stray menu stacked on top of Geyser's own right-click menu.

#### Other info (issues closed, discussion etc)

Also restores the callback for the older `<a ` + plain-space spelling (F-13-2), which 5.0.1 had already lost. Text on a label can no longer be drag-selected, which never actually worked (`TLabel::mouseMoveEvent` never reached QLabel).

**Test case:** `createLabel("l", 20, 20, 300, 40, 1); setLabelClickCallback("l", function() echo("clicked\n") end); echo("l", "<a\nhref='x'>go</a>")` - a click prints "clicked" and the link still activates; right-clicking a label showing "five <a\nb" opens no Qt menu.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_