### PR TITLE
Fix: The 2D mapper no longer freezes on a map with a room at the coordinate limit

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1822,17 +1822,8 @@ QSize T2DMap::lodRoomBlobSize() const
 // defined - a zoom has no upper bound, and at a ten-millionth of a pixel per
 // room the range is billions of cells wide, which a double holds and an int
 // does not.
-// A zoom far enough out to overflow the float span leaves a room zero pixels
-// wide and the inverse transform dividing zero by zero. A NaN has no ordering
-// for qBound to clamp, and the comparisons settle both bounds the same way, so
-// clamping one collapses the range instead of widening it - hence the caller
-// naming the end that stands in for it, which draws every room into the one
-// pixel the map has become.
-static int clampedRoomCoordinate(const double coordinate, const int nanFallback)
+static int clampedRoomCoordinate(const double coordinate)
 {
-    if (std::isnan(coordinate)) {
-        return nanFallback;
-    }
     return static_cast<int>(qBound(static_cast<double>(INT_MIN), coordinate, static_cast<double>(INT_MAX)));
 }
 
@@ -1848,10 +1839,25 @@ static int clampedRoomCoordinate(const double coordinate, const int nanFallback)
 // an extra cell only costs an index lookup that comes back empty.
 QRect T2DMap::viewportRoomBounds(const float rx0, const float ry0, const float roomWidth, const float roomHeight, const float widgetWidth, const float widgetHeight)
 {
-    const int minX = clampedRoomCoordinate(std::floor(static_cast<double>(-rx0) / roomWidth) - 1.0, INT_MIN);
-    const int maxX = clampedRoomCoordinate(std::ceil(static_cast<double>(widgetWidth - rx0) / roomWidth) + 1.0, INT_MAX);
-    const int minY = clampedRoomCoordinate(std::floor(static_cast<double>(ry0 - widgetHeight) / roomHeight) - 1.0, INT_MIN);
-    const int maxY = clampedRoomCoordinate(std::ceil(static_cast<double>(ry0) / roomHeight) + 1.0, INT_MAX);
+    // A zoom far enough out overflows the float span, which leaves a room zero
+    // pixels across and every bound below dividing by that zero. Nothing that
+    // division returns can be clamped into a range: an infinity pins a bound
+    // onto whichever end its sign points at, and a NaN pins it onto the lower
+    // end whichever bound it is, since qBound is qMax(min, qMin(max, val)) and
+    // no comparison against a NaN is true. Which of the two each bound gets is
+    // not even the same on every machine - the pan offsets are qRound()ed from
+    // zero times that infinite span, and int(NaN) is INT_MIN on x86-64 and 0 on
+    // ARM64 - so leaving it to the clamp collapses the viewport onto one end of
+    // the coordinate space and the map comes out blank. Answer "everything"
+    // once instead, which is what 5.0.1 drew: every room into the one pixel the
+    // map has become.
+    if (!(roomWidth > 0.0f) || !(roomHeight > 0.0f)) {
+        return QRect(QPoint(INT_MIN, INT_MIN), QPoint(INT_MAX, INT_MAX));
+    }
+    const int minX = clampedRoomCoordinate(std::floor(static_cast<double>(-rx0) / roomWidth) - 1.0);
+    const int maxX = clampedRoomCoordinate(std::ceil(static_cast<double>(widgetWidth - rx0) / roomWidth) + 1.0);
+    const int minY = clampedRoomCoordinate(std::floor(static_cast<double>(ry0 - widgetHeight) / roomHeight) - 1.0);
+    const int maxY = clampedRoomCoordinate(std::ceil(static_cast<double>(ry0) / roomHeight) + 1.0);
     return QRect(QPoint(minX, minY), QPoint(maxX, maxY));
 }
 
@@ -2065,8 +2071,9 @@ void T2DMap::drawGridModeRooms(QPainter& painter,
             QDebug dbg(profileOutput);
             dbg.noquote().nospace() << "drawGridModeRooms (" << lodPathName << ") timing (ms):" << " total:" << (timeIndex + timeCollect + timeBlit) << " indexSetup:" << timeIndex
                                     << " collect+pixelWrite:" << timeCollect << " imageBlit:" << timeBlit << " visibleRooms:" << roomCount
-                                    << " viewportCells:" << (static_cast<qint64>(maxX) - minX + 1) * (static_cast<qint64>(maxY) - minY + 1) << " viewportBounds: x[" << minX << "," << maxX << "] y["
-                                    << minY << "," << maxY << "]" << " roomSizePx:" << mRoomWidth << " gridIndexRooms:" << gridIndex.size() << " gridIndexBytes:" << gridIndex.memoryEstimateBytes();
+                                    << " viewportColumns:" << (static_cast<qint64>(maxX) - minX + 1) << " viewportRows:" << (static_cast<qint64>(maxY) - minY + 1) << " viewportBounds: x[" << minX
+                                    << "," << maxX << "] y[" << minY << "," << maxY << "]" << " roomSizePx:" << mRoomWidth << " gridIndexRooms:" << gridIndex.size()
+                                    << " gridIndexBytes:" << gridIndex.memoryEstimateBytes();
         }
 
         // Handle double-click speedwalk via grid-cell lookup.  The pixel-level
@@ -2393,8 +2400,8 @@ void T2DMap::drawGridModeRooms(QPainter& painter,
         QDebug dbg(profileOutput);
         dbg.noquote().nospace() << "drawGridModeRooms timing (ms):" << " total:" << (timeIndex + timeCollect + timeBatchDraw + timeCollision + timeDecor) << " indexSetup:" << timeIndex
                                 << " collect(gridIndex):" << timeCollect << " batchDraw:" << timeBatchDraw << " collision:" << timeCollision << " decor:" << timeDecor << " visibleRooms:" << roomCount
-                                << " viewportCells:" << (static_cast<qint64>(maxX) - minX + 1) * (static_cast<qint64>(maxY) - minY + 1) << " viewportBounds: x[" << minX << "," << maxX << "] y["
-                                << minY << "," << maxY << "]" << " gridIndexRooms:" << gridIndex.size() << " gridIndexBytes:" << gridIndex.memoryEstimateBytes();
+                                << " viewportColumns:" << (static_cast<qint64>(maxX) - minX + 1) << " viewportRows:" << (static_cast<qint64>(maxY) - minY + 1) << " viewportBounds: x[" << minX << ","
+                                << maxX << "] y[" << minY << "," << maxY << "]" << " gridIndexRooms:" << gridIndex.size() << " gridIndexBytes:" << gridIndex.memoryEstimateBytes();
     }
 }
 
@@ -3376,6 +3383,17 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     painter.restore();
 }
 
+// Not QRect::contains(): it works out which way round the rectangle is by
+// computing left - 1, which is not a value when a viewport bound has reached
+// the coordinate limit - and a map holding a room out there is exactly when one
+// has. The comparison it makes of the wrapped result then comes out inverted,
+// so a room off the side of the viewport is reported as inside it and one
+// inside it as off the side.
+static bool withinViewportBounds(const QRect& bounds, const int x, const int y)
+{
+    return x >= bounds.left() && x <= bounds.right() && y >= bounds.top() && y <= bounds.bottom();
+}
+
 void T2DMap::paintRoomExits(QPainter& painter,
                             QPen& pen,
                             QList<ExitToPaint>& exitList,
@@ -3481,7 +3499,7 @@ void T2DMap::paintRoomExits(QPainter& painter,
         // the in-progress custom line happens to lead to:
         if (customLineDestinationTarget > 0 && !alreadyListed.contains(customLineDestinationTarget)) {
             const TRoom* pTargetRoom = mpMap->mpRoomDB->getRoom(customLineDestinationTarget);
-            if (pTargetRoom && pTargetRoom->getArea() == mAreaID && pTargetRoom->z() == zLevel && roomBounds.contains(pTargetRoom->x(), pTargetRoom->y())) {
+            if (pTargetRoom && pTargetRoom->getArea() == mAreaID && pTargetRoom->z() == zLevel && withinViewportBounds(roomBounds, pTargetRoom->x(), pTargetRoom->y())) {
                 roomsToPaint.append(customLineDestinationTarget);
             }
         }
@@ -3491,7 +3509,7 @@ void T2DMap::paintRoomExits(QPainter& painter,
             TRoom* pRoomWithCustomLines = mpMap->mpRoomDB->getRoom(customLineRoomId);
             // Rooms inside the bounds are in the list already, and painting a
             // room's exits twice does not look like painting them once.
-            if (!pRoomWithCustomLines || roomBounds.contains(pRoomWithCustomLines->x(), pRoomWithCustomLines->y())) {
+            if (!pRoomWithCustomLines || withinViewportBounds(roomBounds, pRoomWithCustomLines->x(), pRoomWithCustomLines->y())) {
                 continue;
             }
             roomsToPaint.append(customLineRoomId);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1822,8 +1822,17 @@ QSize T2DMap::lodRoomBlobSize() const
 // defined - a zoom has no upper bound, and at a ten-millionth of a pixel per
 // room the range is billions of cells wide, which a double holds and an int
 // does not.
-static int clampedRoomCoordinate(const double coordinate)
+// A zoom far enough out to overflow the float span leaves a room zero pixels
+// wide and the inverse transform dividing zero by zero. A NaN has no ordering
+// for qBound to clamp, and the comparisons settle both bounds the same way, so
+// clamping one collapses the range instead of widening it - hence the caller
+// naming the end that stands in for it, which draws every room into the one
+// pixel the map has become.
+static int clampedRoomCoordinate(const double coordinate, const int nanFallback)
 {
+    if (std::isnan(coordinate)) {
+        return nanFallback;
+    }
     return static_cast<int>(qBound(static_cast<double>(INT_MIN), coordinate, static_cast<double>(INT_MAX)));
 }
 
@@ -1839,10 +1848,10 @@ static int clampedRoomCoordinate(const double coordinate)
 // an extra cell only costs an index lookup that comes back empty.
 QRect T2DMap::viewportRoomBounds(const float rx0, const float ry0, const float roomWidth, const float roomHeight, const float widgetWidth, const float widgetHeight)
 {
-    const int minX = clampedRoomCoordinate(std::floor(static_cast<double>(-rx0) / roomWidth) - 1.0);
-    const int maxX = clampedRoomCoordinate(std::ceil(static_cast<double>(widgetWidth - rx0) / roomWidth) + 1.0);
-    const int minY = clampedRoomCoordinate(std::floor(static_cast<double>(ry0 - widgetHeight) / roomHeight) - 1.0);
-    const int maxY = clampedRoomCoordinate(std::ceil(static_cast<double>(ry0) / roomHeight) + 1.0);
+    const int minX = clampedRoomCoordinate(std::floor(static_cast<double>(-rx0) / roomWidth) - 1.0, INT_MIN);
+    const int maxX = clampedRoomCoordinate(std::ceil(static_cast<double>(widgetWidth - rx0) / roomWidth) + 1.0, INT_MAX);
+    const int minY = clampedRoomCoordinate(std::floor(static_cast<double>(ry0 - widgetHeight) / roomHeight) - 1.0, INT_MIN);
+    const int maxY = clampedRoomCoordinate(std::ceil(static_cast<double>(ry0) / roomHeight) + 1.0, INT_MAX);
     return QRect(QPoint(minX, minY), QPoint(maxX, maxY));
 }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1839,18 +1839,13 @@ static int clampedRoomCoordinate(const double coordinate)
 // an extra cell only costs an index lookup that comes back empty.
 QRect T2DMap::viewportRoomBounds(const float rx0, const float ry0, const float roomWidth, const float roomHeight, const float widgetWidth, const float widgetHeight)
 {
-    // A zoom far enough out overflows the float span, which leaves a room zero
-    // pixels across and every bound below dividing by that zero. Nothing that
-    // division returns can be clamped into a range: an infinity pins a bound
-    // onto whichever end its sign points at, and a NaN pins it onto the lower
-    // end whichever bound it is, since qBound is qMax(min, qMin(max, val)) and
-    // no comparison against a NaN is true. Which of the two each bound gets is
-    // not even the same on every machine - the pan offsets are qRound()ed from
-    // zero times that infinite span, and int(NaN) is INT_MIN on x86-64 and 0 on
-    // ARM64 - so leaving it to the clamp collapses the viewport onto one end of
-    // the coordinate space and the map comes out blank. Answer "everything"
-    // once instead, which is what 5.0.1 drew: every room into the one pixel the
-    // map has become.
+    // A zoom far enough out leaves a room zero pixels across, and every bound
+    // below then divides by that zero. The clamp cannot rescue the result: qBound
+    // is qMax(min, qMin(max, val)) and no comparison against a NaN is true, so a
+    // NaN pins a bound onto the lower end whichever bound it is, an infinity onto
+    // the end its sign points at, and int(NaN) is INT_MIN on x86-64 but 0 on
+    // ARM64. Answer the whole coordinate range instead: every room into the one
+    // pixel the map has become.
     if (!(roomWidth > 0.0f) || !(roomHeight > 0.0f)) {
         return QRect(QPoint(INT_MIN, INT_MIN), QPoint(INT_MAX, INT_MAX));
     }
@@ -3383,12 +3378,9 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     painter.restore();
 }
 
-// Not QRect::contains(): it works out which way round the rectangle is by
-// computing left - 1, which is not a value when a viewport bound has reached
-// the coordinate limit - and a map holding a room out there is exactly when one
-// has. The comparison it makes of the wrapped result then comes out inverted,
-// so a room off the side of the viewport is reported as inside it and one
-// inside it as off the side.
+// Not QRect::contains(): it works out which way round the rectangle is from
+// left - 1, which overflows once a viewport bound reaches the coordinate limit,
+// and its comparison against the wrapped result then comes out inverted.
 static bool withinViewportBounds(const QRect& bounds, const int x, const int y)
 {
     return x >= bounds.left() && x <= bounds.right() && y >= bounds.top() && y <= bounds.bottom();

--- a/src/TAreaGridIndex.cpp
+++ b/src/TAreaGridIndex.cpp
@@ -27,9 +27,8 @@ const TAreaGridIndex::RoomIds TAreaGridIndex::csmEmptyCell;
 // zoomed-out one covers more rows than exist, so neither wins outright - the
 // smaller key count is the one to get through.
 //
-// The probing loops count in qint64 rather than int: a viewport can reach the
-// coordinate limit, and an int counter at INT_MAX never compares greater than
-// it - it overflows back to INT_MIN and the loop runs forever.
+// The probing loops count in qint64 because an int counter at INT_MAX overflows
+// back to INT_MIN rather than passing a bound of INT_MAX, and never terminates.
 static void appendRoomsInYRange(const QHash<int, TAreaGridIndex::RoomIds>& yMap, int minY, int maxY, QList<int>& result)
 {
     const qint64 wantedRows = static_cast<qint64>(maxY) - minY + 1;

--- a/src/TAreaGridIndex.cpp
+++ b/src/TAreaGridIndex.cpp
@@ -26,12 +26,16 @@ const TAreaGridIndex::RoomIds TAreaGridIndex::csmEmptyCell;
 // it. A zoomed-in viewport covers a handful of the rows a level occupies and a
 // zoomed-out one covers more rows than exist, so neither wins outright - the
 // smaller key count is the one to get through.
+//
+// The probing loops count in qint64 rather than int: a viewport can reach the
+// coordinate limit, and an int counter at INT_MAX never compares greater than
+// it - it overflows back to INT_MIN and the loop runs forever.
 static void appendRoomsInYRange(const QHash<int, TAreaGridIndex::RoomIds>& yMap, int minY, int maxY, QList<int>& result)
 {
     const qint64 wantedRows = static_cast<qint64>(maxY) - minY + 1;
     if (wantedRows > 0 && wantedRows < yMap.size()) {
-        for (int y = minY; y <= maxY; ++y) {
-            const auto yIt = yMap.constFind(y);
+        for (qint64 y = minY; y <= maxY; ++y) {
+            const auto yIt = yMap.constFind(static_cast<int>(y));
             if (yIt == yMap.constEnd()) {
                 continue;
             }
@@ -55,8 +59,8 @@ static void appendRoomsInYRangeWithCollisions(const QHash<int, TAreaGridIndex::R
 {
     const qint64 wantedRows = static_cast<qint64>(maxY) - minY + 1;
     if (wantedRows > 0 && wantedRows < yMap.size()) {
-        for (int y = minY; y <= maxY; ++y) {
-            const auto yIt = yMap.constFind(y);
+        for (qint64 y = minY; y <= maxY; ++y) {
+            const auto yIt = yMap.constFind(static_cast<int>(y));
             if (yIt == yMap.constEnd()) {
                 continue;
             }
@@ -190,8 +194,8 @@ QList<int> TAreaGridIndex::roomsInViewport(int z, int minX, int maxX, int minY, 
     const auto& xyMap = *zIt;
     const qint64 wantedColumns = static_cast<qint64>(maxX) - minX + 1;
     if (wantedColumns > 0 && wantedColumns < xyMap.size()) {
-        for (int x = minX; x <= maxX; ++x) {
-            const auto xIt = xyMap.constFind(x);
+        for (qint64 x = minX; x <= maxX; ++x) {
+            const auto xIt = xyMap.constFind(static_cast<int>(x));
             if (xIt == xyMap.constEnd()) {
                 continue;
             }
@@ -218,8 +222,8 @@ QList<QPair<int, bool>> TAreaGridIndex::roomsInViewportWithCollisions(int z, int
     const auto& xyMap = *zIt;
     const qint64 wantedColumns = static_cast<qint64>(maxX) - minX + 1;
     if (wantedColumns > 0 && wantedColumns < xyMap.size()) {
-        for (int x = minX; x <= maxX; ++x) {
-            const auto xIt = xyMap.constFind(x);
+        for (qint64 x = minX; x <= maxX; ++x) {
+            const auto xIt = xyMap.constFind(static_cast<int>(x));
             if (xIt == xyMap.constEnd()) {
                 continue;
             }

--- a/src/mudlet-lua/tests/MapViewportLimits_spec.lua
+++ b/src/mudlet-lua/tests/MapViewportLimits_spec.lua
@@ -1,0 +1,90 @@
+-- The 2D mapper works out which rooms could be on screen by inverting the
+-- transform that puts them there, and the coordinates that come back are
+-- clamped into an int because that is what a room coordinate is. Two ordinary
+-- things push a bound onto the clamp: a map that holds a room out at the edge
+-- of the coordinate space, and a zoom far enough out that the span it divides
+-- by stops being a finite number. Either way the scan is asked for a range
+-- ending at the largest int there is, and a scan that cannot get past that
+-- last column never comes back - the paint never finishes and the client stops
+-- dead. So each example here hangs rather than fails when it regresses, and
+-- the run times out instead of reporting.
+
+local kFarX = 2147483647
+-- More occupied columns than any viewport here asks for, so the scan probes
+-- the columns it wants rather than walking every column the area has: it is
+-- the probing route that stops terminating.
+local kColumns = 600
+-- One pixel per room on the 600x400 map window below, which is where the
+-- viewport's right-hand bound lands exactly on the coordinate limit. The
+-- scroll wheel reaches it.
+local kOnePixelPerRoomZoom = 400
+
+describe("Tests 2D map painting at the limits of the coordinate space", function()
+  local areaId
+  local nearRoom, farRoom
+  local roomIds = {}
+
+  setup(function()
+    assert.is_true(openMapWidget(0, 0, 600, 400))
+    areaId = addAreaName("ViewportLimitsSpec")
+
+    local function makeRoom(x)
+      local id = createRoomID()
+      addRoom(id)
+      setRoomArea(id, areaId)
+      setRoomCoordinates(id, x, 0, 0)
+      roomIds[#roomIds + 1] = id
+      return id
+    end
+
+    for x = 0, kColumns - 1 do
+      makeRoom(x)
+    end
+    nearRoom = roomIds[1]
+    farRoom = makeRoom(kFarX)
+  end)
+
+  teardown(function()
+    for _, id in ipairs(roomIds) do
+      deleteRoom(id)
+    end
+    deleteArea("ViewportLimitsSpec")
+    -- Mapper_spec.lua opens the map widget for itself and asserts that it did,
+    -- so leave it as this file found it.
+    closeMapWidget()
+  end)
+
+  -- The repaint a zoom or a centring asks for is deferred onto the event loop,
+  -- so it only happens once the loop gets a turn. A scan that never returns
+  -- takes the pump with it and nothing below this line runs again.
+  local function repaint()
+    updateMap()
+    pumpEvents(300)
+  end
+
+  it("paints an area holding a room at the coordinate limit", function()
+    assert.is_true(centerview(farRoom))
+    repaint()
+    assert.are.equal(farRoom, getPlayerRoom())
+  end)
+
+  it("paints that room at a zoom of one pixel per room", function()
+    assert.is_true(centerview(farRoom))
+    repaint()
+    assert.is_true(setMapZoom(kOnePixelPerRoomZoom, areaId))
+    repaint()
+    assert.are.equal(kOnePixelPerRoomZoom, getMapZoom(areaId))
+  end)
+
+  it("paints at a zoom far enough out to overflow the viewport span", function()
+    finally(function()
+      setMapZoom(20, areaId)
+      repaint()
+    end)
+    assert.is_true(centerview(nearRoom))
+    repaint()
+    assert.is_true(setMapZoom(1e40, areaId))
+    repaint()
+    assert.are.equal(1e40, getMapZoom(areaId))
+  end)
+end)

--- a/src/mudlet-lua/tests/MapViewportLimits_spec.lua
+++ b/src/mudlet-lua/tests/MapViewportLimits_spec.lua
@@ -1,35 +1,19 @@
--- The 2D mapper works out which rooms could be on screen by inverting the
--- transform that puts them there, and the coordinates that come back are
--- clamped into an int because that is what a room coordinate is. Two ordinary
--- things push a bound onto the clamp. A map holding a room out at the edge of
--- the coordinate space asks for a range that ends at the largest int there is,
--- and a scan that cannot get past that last column never comes back - the paint
--- never finishes and the client stops dead. A zoom far enough out that the span
--- it divides by stops being a finite number puts both bounds on one end of that
--- space instead, which draws nothing at all where 5.0.1 drew the whole map into
--- one pixel. So the first of these hangs rather than fails when it regresses,
--- and the run times out instead of reporting.
+-- These cases hang rather than fail when they regress: the run times out
+-- instead of reporting.
 
 local kFarX = 2147483647
 -- More occupied columns than any viewport here asks for, so the scan probes the
--- columns it wants rather than walking every column the area has: it is the
--- probing route that stops terminating. How many columns a viewport wants is
--- about half the map window's width in rooms, so the margin over that has to be
--- wide enough that no platform's window chrome can close it.
+-- columns it wants rather than walking every column the area has. The margin is
+-- wide because how many it wants tracks the map window's width.
 local kColumns = 2000
 -- One pixel per room on the 600x400 map window below, which puts the viewport's
--- right-hand bound past the coordinate limit and so, once it is clamped, onto
--- it, over a range narrow enough for the scan to probe. The scroll wheel
--- reaches this zoom.
+-- right-hand bound onto the coordinate limit once it is clamped.
 local kOnePixelPerRoomZoom = 400
--- Far enough out that the span overflows a float. That setMapZoom() accepts it
--- is the status quo rather than the requirement here - nothing validates an
--- upper bound - and what this pins is what the mapper does with it once it has.
+-- Far enough out that the span overflows a float.
 local kSpanOverflowingZoom = 1e40
--- An ordinary zoom, and the one the parking area below is kept at. Both are
--- distinct from each other, from the zooms above, and from the 20 an untouched
--- area carries - so the mapper reporting either of them is the mapper showing
--- the one area that has it, which only a repaint can make true.
+-- Distinct from each other, from the zooms above, and from the 20 an untouched
+-- area carries, so the mapper reporting either is the mapper showing the one
+-- area that has it.
 local kOrdinaryZoom = 21
 local kParkZoom = 31
 
@@ -50,9 +34,8 @@ describe("Tests 2D map painting at the limits of the coordinate space", function
 
   setup(function()
     originalRoom = getPlayerRoom()
-    -- Tolerant rather than asserting: a spec that ran before this one may have
-    -- left the widget open, and failing here would leave the rooms below and
-    -- the widget itself to every spec that runs after.
+    -- Tolerant rather than asserting: an earlier spec may have left the widget
+    -- open, and failing here would leak the rooms below to every spec after.
     closeMapWidget()
     assert.is_true(openMapWidget(0, 0, 600, 400))
 
@@ -87,10 +70,9 @@ describe("Tests 2D map painting at the limits of the coordinate space", function
     closeMapWidget()
   end)
 
-  -- The no-argument getMapZoom() reports the area the mapper is SHOWING, and
-  -- only a repaint moves it onto the area a centring asked for - so waiting for
-  -- it to name a zoom is waiting for a paint of that area to have happened. A
-  -- scan that never returns takes the pump with it and nothing below runs again.
+  -- The no-argument getMapZoom() reports the area the mapper is SHOWING, and only
+  -- a repaint moves it onto the area a centring asked for, so waiting for it to
+  -- name a zoom is waiting for a paint of that area.
   local function waitForTheMapperToShow(zoom)
     local waitedMs = 0
     while getMapZoom() ~= zoom and waitedMs < 5000 do
@@ -101,10 +83,10 @@ describe("Tests 2D map painting at the limits of the coordinate space", function
     return getMapZoom() == zoom
   end
 
-  -- Parking on another area first is what makes the wait below mean something:
-  -- from an area the mapper is already showing, the zoom it reports changes the
-  -- moment the zoom is stored, paint or no paint. Storing the zoom before the
-  -- centring is what makes the paint that is waited for the paint at that zoom.
+  -- Parking on another area first is what makes the wait mean something: from an
+  -- area the mapper already shows, the reported zoom changes the moment it is
+  -- stored, paint or no paint. Storing the zoom before the centring is what makes
+  -- the paint waited for the paint at that zoom.
   local function showAtZoom(roomId, zoom)
     assert.is_true(centerview(parkRoom))
     assert.is_true(waitForTheMapperToShow(kParkZoom),

--- a/src/mudlet-lua/tests/MapViewportLimits_spec.lua
+++ b/src/mudlet-lua/tests/MapViewportLimits_spec.lua
@@ -1,90 +1,137 @@
 -- The 2D mapper works out which rooms could be on screen by inverting the
 -- transform that puts them there, and the coordinates that come back are
 -- clamped into an int because that is what a room coordinate is. Two ordinary
--- things push a bound onto the clamp: a map that holds a room out at the edge
--- of the coordinate space, and a zoom far enough out that the span it divides
--- by stops being a finite number. Either way the scan is asked for a range
--- ending at the largest int there is, and a scan that cannot get past that
--- last column never comes back - the paint never finishes and the client stops
--- dead. So each example here hangs rather than fails when it regresses, and
--- the run times out instead of reporting.
+-- things push a bound onto the clamp. A map holding a room out at the edge of
+-- the coordinate space asks for a range that ends at the largest int there is,
+-- and a scan that cannot get past that last column never comes back - the paint
+-- never finishes and the client stops dead. A zoom far enough out that the span
+-- it divides by stops being a finite number puts both bounds on one end of that
+-- space instead, which draws nothing at all where 5.0.1 drew the whole map into
+-- one pixel. So the first of these hangs rather than fails when it regresses,
+-- and the run times out instead of reporting.
 
 local kFarX = 2147483647
--- More occupied columns than any viewport here asks for, so the scan probes
--- the columns it wants rather than walking every column the area has: it is
--- the probing route that stops terminating.
-local kColumns = 600
--- One pixel per room on the 600x400 map window below, which is where the
--- viewport's right-hand bound lands exactly on the coordinate limit. The
--- scroll wheel reaches it.
+-- More occupied columns than any viewport here asks for, so the scan probes the
+-- columns it wants rather than walking every column the area has: it is the
+-- probing route that stops terminating. How many columns a viewport wants is
+-- about half the map window's width in rooms, so the margin over that has to be
+-- wide enough that no platform's window chrome can close it.
+local kColumns = 2000
+-- One pixel per room on the 600x400 map window below, which puts the viewport's
+-- right-hand bound past the coordinate limit and so, once it is clamped, onto
+-- it, over a range narrow enough for the scan to probe. The scroll wheel
+-- reaches this zoom.
 local kOnePixelPerRoomZoom = 400
+-- Far enough out that the span overflows a float. That setMapZoom() accepts it
+-- is the status quo rather than the requirement here - nothing validates an
+-- upper bound - and what this pins is what the mapper does with it once it has.
+local kSpanOverflowingZoom = 1e40
+-- An ordinary zoom, and the one the parking area below is kept at. Both are
+-- distinct from each other, from the zooms above, and from the 20 an untouched
+-- area carries - so the mapper reporting either of them is the mapper showing
+-- the one area that has it, which only a repaint can make true.
+local kOrdinaryZoom = 21
+local kParkZoom = 31
 
 describe("Tests 2D map painting at the limits of the coordinate space", function()
-  local areaId
-  local nearRoom, farRoom
+  local areaId, parkAreaId
+  local nearRoom, farRoom, parkRoom
+  local originalRoom
   local roomIds = {}
 
-  setup(function()
-    assert.is_true(openMapWidget(0, 0, 600, 400))
-    areaId = addAreaName("ViewportLimitsSpec")
+  local function makeRoom(areaOfRoom, x)
+    local id = createRoomID()
+    addRoom(id)
+    setRoomArea(id, areaOfRoom)
+    setRoomCoordinates(id, x, 0, 0)
+    roomIds[#roomIds + 1] = id
+    return id
+  end
 
-    local function makeRoom(x)
-      local id = createRoomID()
-      addRoom(id)
-      setRoomArea(id, areaId)
-      setRoomCoordinates(id, x, 0, 0)
-      roomIds[#roomIds + 1] = id
-      return id
-    end
+  setup(function()
+    originalRoom = getPlayerRoom()
+    -- Tolerant rather than asserting: a spec that ran before this one may have
+    -- left the widget open, and failing here would leave the rooms below and
+    -- the widget itself to every spec that runs after.
+    closeMapWidget()
+    assert.is_true(openMapWidget(0, 0, 600, 400))
+
+    areaId = addAreaName("ViewportLimitsSpec")
+    parkAreaId = addAreaName("ViewportLimitsSpecPark")
 
     for x = 0, kColumns - 1 do
-      makeRoom(x)
+      makeRoom(areaId, x)
     end
     nearRoom = roomIds[1]
-    farRoom = makeRoom(kFarX)
+    farRoom = makeRoom(areaId, kFarX)
+    parkRoom = makeRoom(parkAreaId, 0)
+
+    assert.is_true(setMapZoom(kParkZoom, parkAreaId))
+    assert.is_true(setMapZoom(kOrdinaryZoom, areaId))
   end)
 
   teardown(function()
+    -- Back to the room the profile was standing in before any of its rooms go,
+    -- or every spec after this one starts with the player on a deleted room.
+    if originalRoom and originalRoom > 0 then
+      centerview(originalRoom)
+      pumpEvents(100)
+    end
     for _, id in ipairs(roomIds) do
       deleteRoom(id)
     end
     deleteArea("ViewportLimitsSpec")
+    deleteArea("ViewportLimitsSpecPark")
     -- Mapper_spec.lua opens the map widget for itself and asserts that it did,
     -- so leave it as this file found it.
     closeMapWidget()
   end)
 
-  -- The repaint a zoom or a centring asks for is deferred onto the event loop,
-  -- so it only happens once the loop gets a turn. A scan that never returns
-  -- takes the pump with it and nothing below this line runs again.
-  local function repaint()
-    updateMap()
-    pumpEvents(300)
+  -- The no-argument getMapZoom() reports the area the mapper is SHOWING, and
+  -- only a repaint moves it onto the area a centring asked for - so waiting for
+  -- it to name a zoom is waiting for a paint of that area to have happened. A
+  -- scan that never returns takes the pump with it and nothing below runs again.
+  local function waitForTheMapperToShow(zoom)
+    local waitedMs = 0
+    while getMapZoom() ~= zoom and waitedMs < 5000 do
+      updateMap()
+      pumpEvents(10)
+      waitedMs = waitedMs + 10
+    end
+    return getMapZoom() == zoom
+  end
+
+  -- Parking on another area first is what makes the wait below mean something:
+  -- from an area the mapper is already showing, the zoom it reports changes the
+  -- moment the zoom is stored, paint or no paint. Storing the zoom before the
+  -- centring is what makes the paint that is waited for the paint at that zoom.
+  local function showAtZoom(roomId, zoom)
+    assert.is_true(centerview(parkRoom))
+    assert.is_true(waitForTheMapperToShow(kParkZoom),
+      "the mapper never moved off the area under test, so the paint below would prove nothing")
+    assert.is_true(setMapZoom(zoom, areaId))
+    assert.is_true(centerview(roomId))
+    assert.is_true(waitForTheMapperToShow(zoom),
+      ("the mapper never painted the area under test at a zoom of %g"):format(zoom))
   end
 
   it("paints an area holding a room at the coordinate limit", function()
-    assert.is_true(centerview(farRoom))
-    repaint()
+    showAtZoom(farRoom, kOrdinaryZoom)
     assert.are.equal(farRoom, getPlayerRoom())
   end)
 
   it("paints that room at a zoom of one pixel per room", function()
-    assert.is_true(centerview(farRoom))
-    repaint()
-    assert.is_true(setMapZoom(kOnePixelPerRoomZoom, areaId))
-    repaint()
+    showAtZoom(farRoom, kOnePixelPerRoomZoom)
     assert.are.equal(kOnePixelPerRoomZoom, getMapZoom(areaId))
   end)
 
   it("paints at a zoom far enough out to overflow the viewport span", function()
     finally(function()
-      setMapZoom(20, areaId)
-      repaint()
+      setMapZoom(kOrdinaryZoom, areaId)
+      updateMap()
+      pumpEvents(100)
     end)
-    assert.is_true(centerview(nearRoom))
-    repaint()
-    assert.is_true(setMapZoom(1e40, areaId))
-    repaint()
-    assert.are.equal(1e40, getMapZoom(areaId))
+    showAtZoom(nearRoom, kSpanOverflowingZoom)
+    assert.are.equal(kSpanOverflowingZoom, getMapZoom(areaId))
   end)
 end)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,8 +69,10 @@ foreach(test_name ${UNIT_TESTS})
 endforeach()
 
 # A regression in what EventLoopPumpTest covers hangs rather than fails, so cap
-# it well under ctest's default 25 minutes.
-set_tests_properties(EventLoopPumpTest PROPERTIES TIMEOUT 60)
+# it well under ctest's default 25 minutes. The same goes for the coordinate
+# limit cases in TAreaGridIndexTest, which never return once a viewport scan
+# stops terminating.
+set_tests_properties(EventLoopPumpTest TAreaGridIndexTest PROPERTIES TIMEOUT 60)
 
 # TKeySequenceEditTest's focus traversal cases need an active window, which an X
 # server with no window manager never gives them, so a plain `xvfb-run ctest`

--- a/test/TAreaGridIndexTest.cpp
+++ b/test/TAreaGridIndexTest.cpp
@@ -42,6 +42,27 @@
  * - isEmpty / clear / size
  * - Integration: add + full rebuild + remove + move
  */
+namespace {
+// More occupied columns (rows) than any range below asks for, so the scan probes
+// the cells it wants instead of walking the ones the index has - probing is the
+// loop that stopped terminating at the coordinate limit.
+constexpr int cOccupiedCells = 600;
+
+void addRoomsAlongX(TAreaGridIndex& idx)
+{
+    for (int i = 0; i < cOccupiedCells; ++i) {
+        idx.addRoom(i + 1, 0, i, 0);
+    }
+}
+
+void addRoomsAlongY(TAreaGridIndex& idx)
+{
+    for (int i = 0; i < cOccupiedCells; ++i) {
+        idx.addRoom(i + 1, 0, 0, i);
+    }
+}
+} // namespace
+
 class TAreaGridIndexTest : public QObject
 {
     Q_OBJECT
@@ -488,20 +509,19 @@ private slots:
     // -------------------------------------------------------------------------
     // Ranges that reach the limits of the coordinate space
     //
-    // A viewport bound is a room coordinate clamped into int, so a map holding
-    // a room out at the edge of that space - or a zoom so far out that the map
-    // collapses to a point - asks for a range that ends at INT_MAX. Probing
-    // such a range one column at a time is the arithmetic that never gets past
-    // its last step, so each of these cases hangs rather than answers wrongly
-    // when it regresses: run the binary under a timeout.
+    // A viewport bound is a room coordinate clamped into int, so a map holding a
+    // room out at the edge of that space asks for a range that ends at INT_MAX,
+    // and a zoom so far out that the map collapses to a point asks for the whole
+    // range. Probing a range that ends at INT_MAX one column at a time is the
+    // arithmetic that never gets past its last step, so each of these cases
+    // hangs rather than answers wrongly when it regresses: run the binary under
+    // a timeout.
     // -------------------------------------------------------------------------
 
     void roomsInViewport_rangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
     {
         TAreaGridIndex idx;
-        for (int i = 0; i < 600; ++i) {
-            idx.addRoom(i + 1, 0, i, 0);
-        }
+        addRoomsAlongX(idx);
         idx.addRoom(9999, 0, INT_MAX, 0);
 
         // 201 of the 601 occupied columns are wanted, so probing them is the
@@ -514,9 +534,7 @@ private slots:
     void roomsInViewport_oneColumnWideAtTheCoordinateLimit_returnsTheRoomsInIt()
     {
         TAreaGridIndex idx;
-        for (int i = 0; i < 600; ++i) {
-            idx.addRoom(i + 1, 0, i, 0);
-        }
+        addRoomsAlongX(idx);
         idx.addRoom(9999, 0, INT_MAX, 0);
 
         const QList<int> result = idx.roomsInViewport(0, INT_MAX, INT_MAX, -10, 10);
@@ -527,9 +545,7 @@ private slots:
     void roomsInViewport_rangeStartingAtTheCoordinateLimit_returnsTheRoomsInIt()
     {
         TAreaGridIndex idx;
-        for (int i = 0; i < 600; ++i) {
-            idx.addRoom(i + 1, 0, i, 0);
-        }
+        addRoomsAlongX(idx);
         idx.addRoom(9999, 0, INT_MIN, 0);
 
         const QList<int> result = idx.roomsInViewport(0, INT_MIN, INT_MIN + 200, -10, 10);
@@ -537,6 +553,10 @@ private slots:
         QCOMPARE(result, QList<int>({9999}));
     }
 
+    // Three rooms is fewer than the 2^32 columns the range covers, so this is
+    // the key-walking branch rather than the probing one: what it pins is that
+    // the widest range there is still answers, which is what an absurd zoom now
+    // asks for.
     void roomsInViewport_theWholeCoordinateRange_returnsEveryRoom()
     {
         TAreaGridIndex idx;
@@ -553,9 +573,7 @@ private slots:
     void roomsInViewport_yRangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
     {
         TAreaGridIndex idx;
-        for (int i = 0; i < 600; ++i) {
-            idx.addRoom(i + 1, 0, 0, i);
-        }
+        addRoomsAlongY(idx);
         idx.addRoom(9999, 0, 0, INT_MAX);
 
         const QList<int> result = idx.roomsInViewport(0, 0, 0, INT_MAX - 200, INT_MAX);
@@ -566,9 +584,7 @@ private slots:
     void roomsInViewportWithCollisions_rangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
     {
         TAreaGridIndex idx;
-        for (int i = 0; i < 600; ++i) {
-            idx.addRoom(i + 1, 0, i, 0);
-        }
+        addRoomsAlongX(idx);
         idx.addRoom(9998, 0, INT_MAX, 0);
         idx.addRoom(9999, 0, INT_MAX, 0);
 
@@ -583,9 +599,7 @@ private slots:
     void roomsInViewportWithCollisions_yRangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
     {
         TAreaGridIndex idx;
-        for (int i = 0; i < 600; ++i) {
-            idx.addRoom(i + 1, 0, 0, i);
-        }
+        addRoomsAlongY(idx);
         idx.addRoom(9999, 0, 0, INT_MAX);
 
         const auto result = idx.roomsInViewportWithCollisions(0, 0, 0, INT_MAX - 200, INT_MAX);

--- a/test/TAreaGridIndexTest.cpp
+++ b/test/TAreaGridIndexTest.cpp
@@ -21,6 +21,8 @@
 
 #include <QtTest/QtTest>
 
+#include <climits>
+
 /*
  * Unit tests for TAreaGridIndex.
  *
@@ -35,8 +37,8 @@
  * - rebuild (per-Z): populates, overwrites prior Z level, does not affect other Z levels
  * - rebuild (full): populates all Z levels, overwrites previous state, empty map -> isEmpty
  * - roomsAt: existing cell, non-existent cell (no crash), stable empty reference
- * - roomsInViewport: all in, some out, empty Z, multiple rooms per cell, inclusive edges, narrow range over a wide index
- * - roomsInViewportWithCollisions: solo rooms, colliding rooms, out-of-viewport exclusion, empty Z, narrow range over a wide index
+ * - roomsInViewport: all in, some out, empty Z, multiple rooms per cell, inclusive edges, narrow range over a wide index, ranges reaching INT_MIN/INT_MAX
+ * - roomsInViewportWithCollisions: solo rooms, colliding rooms, out-of-viewport exclusion, empty Z, narrow range over a wide index, ranges reaching INT_MAX
  * - isEmpty / clear / size
  * - Integration: add + full rebuild + remove + move
  */
@@ -481,6 +483,115 @@ private slots:
         QVERIFY(!idToCollision[11]);
         QVERIFY(idToCollision[13]);
         QVERIFY(idToCollision[2000]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ranges that reach the limits of the coordinate space
+    //
+    // A viewport bound is a room coordinate clamped into int, so a map holding
+    // a room out at the edge of that space - or a zoom so far out that the map
+    // collapses to a point - asks for a range that ends at INT_MAX. Probing
+    // such a range one column at a time is the arithmetic that never gets past
+    // its last step, so each of these cases hangs rather than answers wrongly
+    // when it regresses: run the binary under a timeout.
+    // -------------------------------------------------------------------------
+
+    void roomsInViewport_rangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
+    {
+        TAreaGridIndex idx;
+        for (int i = 0; i < 600; ++i) {
+            idx.addRoom(i + 1, 0, i, 0);
+        }
+        idx.addRoom(9999, 0, INT_MAX, 0);
+
+        // 201 of the 601 occupied columns are wanted, so probing them is the
+        // cheaper of the two ways through the range and the one taken.
+        const QList<int> result = idx.roomsInViewport(0, INT_MAX - 200, INT_MAX, -10, 10);
+
+        QCOMPARE(result, QList<int>({9999}));
+    }
+
+    void roomsInViewport_oneColumnWideAtTheCoordinateLimit_returnsTheRoomsInIt()
+    {
+        TAreaGridIndex idx;
+        for (int i = 0; i < 600; ++i) {
+            idx.addRoom(i + 1, 0, i, 0);
+        }
+        idx.addRoom(9999, 0, INT_MAX, 0);
+
+        const QList<int> result = idx.roomsInViewport(0, INT_MAX, INT_MAX, -10, 10);
+
+        QCOMPARE(result, QList<int>({9999}));
+    }
+
+    void roomsInViewport_rangeStartingAtTheCoordinateLimit_returnsTheRoomsInIt()
+    {
+        TAreaGridIndex idx;
+        for (int i = 0; i < 600; ++i) {
+            idx.addRoom(i + 1, 0, i, 0);
+        }
+        idx.addRoom(9999, 0, INT_MIN, 0);
+
+        const QList<int> result = idx.roomsInViewport(0, INT_MIN, INT_MIN + 200, -10, 10);
+
+        QCOMPARE(result, QList<int>({9999}));
+    }
+
+    void roomsInViewport_theWholeCoordinateRange_returnsEveryRoom()
+    {
+        TAreaGridIndex idx;
+        idx.addRoom(1, 0, INT_MIN, INT_MIN);
+        idx.addRoom(2, 0, 0, 0);
+        idx.addRoom(3, 0, INT_MAX, INT_MAX);
+
+        const QList<int> result = idx.roomsInViewport(0, INT_MIN, INT_MAX, INT_MIN, INT_MAX);
+        const QSet<int> visited(result.constBegin(), result.constEnd());
+
+        QCOMPARE(visited, QSet<int>({1, 2, 3}));
+    }
+
+    void roomsInViewport_yRangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
+    {
+        TAreaGridIndex idx;
+        for (int i = 0; i < 600; ++i) {
+            idx.addRoom(i + 1, 0, 0, i);
+        }
+        idx.addRoom(9999, 0, 0, INT_MAX);
+
+        const QList<int> result = idx.roomsInViewport(0, 0, 0, INT_MAX - 200, INT_MAX);
+
+        QCOMPARE(result, QList<int>({9999}));
+    }
+
+    void roomsInViewportWithCollisions_rangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
+    {
+        TAreaGridIndex idx;
+        for (int i = 0; i < 600; ++i) {
+            idx.addRoom(i + 1, 0, i, 0);
+        }
+        idx.addRoom(9998, 0, INT_MAX, 0);
+        idx.addRoom(9999, 0, INT_MAX, 0);
+
+        const auto result = idx.roomsInViewportWithCollisions(0, INT_MAX - 200, INT_MAX, -10, 10);
+
+        QCOMPARE(result.size(), 2);
+        for (const auto& [id, collision] : result) {
+            QVERIFY(collision);
+        }
+    }
+
+    void roomsInViewportWithCollisions_yRangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
+    {
+        TAreaGridIndex idx;
+        for (int i = 0; i < 600; ++i) {
+            idx.addRoom(i + 1, 0, 0, i);
+        }
+        idx.addRoom(9999, 0, 0, INT_MAX);
+
+        const auto result = idx.roomsInViewportWithCollisions(0, 0, 0, INT_MAX - 200, INT_MAX);
+
+        QCOMPARE(result.size(), 1);
+        QCOMPARE(result.first().first, 9999);
     }
 
     // -------------------------------------------------------------------------

--- a/test/TAreaGridIndexTest.cpp
+++ b/test/TAreaGridIndexTest.cpp
@@ -44,8 +44,7 @@
  */
 namespace {
 // More occupied columns (rows) than any range below asks for, so the scan probes
-// the cells it wants instead of walking the ones the index has - probing is the
-// loop that stopped terminating at the coordinate limit.
+// the cells it wants instead of walking the ones the index has.
 constexpr int cOccupiedCells = 600;
 
 void addRoomsAlongX(TAreaGridIndex& idx)
@@ -509,13 +508,8 @@ private slots:
     // -------------------------------------------------------------------------
     // Ranges that reach the limits of the coordinate space
     //
-    // A viewport bound is a room coordinate clamped into int, so a map holding a
-    // room out at the edge of that space asks for a range that ends at INT_MAX,
-    // and a zoom so far out that the map collapses to a point asks for the whole
-    // range. Probing a range that ends at INT_MAX one column at a time is the
-    // arithmetic that never gets past its last step, so each of these cases
-    // hangs rather than answers wrongly when it regresses: run the binary under
-    // a timeout.
+    // These cases hang rather than answer wrongly when they regress, so the
+    // binary needs a timeout to report them.
     // -------------------------------------------------------------------------
 
     void roomsInViewport_rangeEndingAtTheCoordinateLimit_returnsTheRoomsInIt()
@@ -553,10 +547,8 @@ private slots:
         QCOMPARE(result, QList<int>({9999}));
     }
 
-    // Three rooms is fewer than the 2^32 columns the range covers, so this is
-    // the key-walking branch rather than the probing one: what it pins is that
-    // the widest range there is still answers, which is what an absurd zoom now
-    // asks for.
+    // Three rooms is fewer than the 2^32 columns the range covers, so this takes
+    // the key-walking branch rather than the probing one.
     void roomsInViewport_theWholeCoordinateRange_returnsEveryRoom()
     {
         TAreaGridIndex idx;

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -150,6 +150,7 @@ set(MAP_GROUP_TEST_SOURCES
     MapAreaReassignmentTest.cpp
     MapAreaSelectionTest.cpp
     MapCloseDuringImportTest.cpp
+    MapCoordinateLimitTest.cpp
     MapDownloadTest.cpp
     RoomExitsDialogTest.cpp
     MapLevelOfDetailTest.cpp

--- a/test/functional_tests/MapCoordinateLimitTest.cpp
+++ b/test/functional_tests/MapCoordinateLimitTest.cpp
@@ -1,0 +1,289 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Makers                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * The two ends of the mapper's viewport query that a room out at the edge of
+ * the coordinate space reaches, and that a Lua spec cannot:
+ *
+ *   - viewportRoomBounds() for the zoom that leaves a room zero pixels across.
+ *     Every bound is then a division by that zero, and which non-number comes
+ *     back differs by processor, so the only way to pin the answer is to ask
+ *     the function directly with each of the pan offsets a machine can produce.
+ *     Nothing the mapper draws differs between the right answer and the wrong
+ *     one that a spec could see: at that zoom the whole map is one pixel.
+ *
+ *   - the paint that follows loading a map file which holds such a room. That
+ *     route needs no script in the session that freezes, and a spec cannot
+ *     take it: loading a map replaces the map of the profile the specs share.
+ *
+ * Both of these hang rather than fail when they regress, so what reports them
+ * is the 60 second cap every functional test carries rather than an assertion.
+ *
+ * Run with: ctest -R MapCoordinateLimitTest -V
+ */
+
+#include <QPixmap>
+#include <QSaveFile>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <climits>
+
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "T2DMap.h"
+#include "TArea.h"
+#include "TMap.h"
+#include "TRoom.h"
+#include "TRoomDB.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "dlgMapper.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class MapCoordinateLimitTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mProfileName = qsl("MapCoordinateLimit-Test");
+    const QString mLocalhost = qsl("localhost");
+    QString mPort;
+
+    static constexpr int kWidgetWidth = 600;
+    static constexpr int kWidgetHeight = 400;
+    // One pixel per room on a widget this tall, which is where the viewport's
+    // right-hand bound lands on the coordinate limit. The scroll wheel reaches
+    // it.
+    static constexpr double kOnePixelPerRoomZoom = 400.0;
+    // More occupied columns than the viewport at that zoom asks for, so the
+    // scan probes the columns it wants instead of walking the ones the area
+    // has - probing is the route that stopped terminating. The margin is wide
+    // because how many columns the viewport wants is half the widget's width in
+    // rooms, which platform chrome moves.
+    static constexpr int kOccupiedColumns = 2000;
+    static constexpr int kFarRoomId = 99999;
+
+    TMap* map() const { return mpHost->mpMap.data(); }
+
+    void deleteProfileDirectory() const
+    {
+        QDir dir(mudlet::getMudletPath(enums::profileHomePath, mProfileName));
+        if (dir.exists()) {
+            dir.removeRecursively();
+        }
+    }
+
+    bool addRoomAt(const int id, const int areaId, const int x, const int y) const { return map()->addRoom(id) && map()->setRoomArea(id, areaId) && map()->setRoomCoordinates(id, x, y, 0); }
+
+    // An area a few thousand columns wide with one room out at the coordinate
+    // limit, the player standing in that room, and the zoom that draws it a
+    // pixel per room already stored on the area - which is the state a saved
+    // map file carries.
+    int buildAreaWithARoomAtTheCoordinateLimit() const
+    {
+        TMap* pMap = map();
+        pMap->mapClear();
+        const int areaId = pMap->mpRoomDB->addArea(qsl("Coordinate Limit Area"));
+        if (areaId <= 0) {
+            return 0;
+        }
+        for (int i = 0; i < kOccupiedColumns; ++i) {
+            if (!addRoomAt(i + 1, areaId, i, 0)) {
+                return 0;
+            }
+        }
+        if (!addRoomAt(kFarRoomId, areaId, INT_MAX, 0)) {
+            return 0;
+        }
+        pMap->mRoomIdHash[pMap->mProfileName] = kFarRoomId;
+        TArea* pArea = pMap->mpRoomDB->getArea(areaId);
+        if (!pArea) {
+            return 0;
+        }
+        pArea->set2DMapZoom(kOnePixelPerRoomZoom);
+        return areaId;
+    }
+
+    // The widget the profile's own mapper holds, sized and left to centre
+    // itself on the player room the way a repaint after a map load does.
+    T2DMap* preparedWidget() const
+    {
+        TMap* pMap = map();
+        if (!pMap->mpMapper) {
+            mpHost->showHideOrCreateMapper(false);
+        }
+        if (!pMap->mpMapper || !pMap->mpMapper->mp2dMap) {
+            return nullptr;
+        }
+        T2DMap* p2dMap = pMap->mpMapper->mp2dMap;
+        p2dMap->init();
+        p2dMap->resize(kWidgetWidth, kWidgetHeight);
+        // Both false is what makes paintEvent() centre on the player room and
+        // pick up the area and zoom the map file brought with it.
+        p2dMap->mShiftMode = false;
+        p2dMap->mPick = false;
+        p2dMap->mMultiSelectionSet.clear();
+        return p2dMap;
+    }
+
+    static void renderFrame(T2DMap* p2dMap)
+    {
+        QPixmap target(kWidgetWidth, kWidgetHeight);
+        target.fill(Qt::black);
+        p2dMap->render(&target, QPoint(), QRegion(), QWidget::DrawWindowBackground);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        QVERIFY2(mpServer->serverPort() != 0, "the telnet stub did not start listening");
+        mPort = QString::number(mpServer->serverPort());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        mudlet::self()->mSkipDefaultPackageInstall = true;
+        deleteProfileDirectory();
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, mPort);
+        QVERIFY(mpHost);
+        QSignalSpy connected(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        QVERIFY2(connected.wait(3000), "could not connect to the telnet stub");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        if (mudlet::self()) {
+            deleteProfileDirectory();
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void test_theViewportCoversEveryCoordinateWhenARoomIsZeroPixelsAcross_data()
+    {
+        QTest::addColumn<float>("panOffset");
+
+        // mRX and mRY are qRound()ed from zero times the overflowed span, which
+        // is a NaN, and int(NaN) is not the same everywhere: x86-64 lands on
+        // INT_MIN and ARM64 on 0. The third row is the same zoom with the map
+        // panned so that both ends of the division are on the same side.
+        QTest::newRow("the pan offset an x86-64 build produces") << static_cast<float>(INT_MIN);
+        QTest::newRow("the pan offset an ARM64 build produces") << 0.0f;
+        QTest::newRow("panned past the widget") << 1000.0f;
+    }
+
+    void test_theViewportCoversEveryCoordinateWhenARoomIsZeroPixelsAcross()
+    {
+        QFETCH(float, panOffset);
+
+        const QRect bounds = T2DMap::viewportRoomBounds(panOffset, panOffset, 0.0f, 0.0f, kWidgetWidth, kWidgetHeight);
+
+        // left/right/top/bottom rather than width() and height(), which the
+        // whole range overflows
+        QCOMPARE(bounds.left(), INT_MIN);
+        QCOMPARE(bounds.right(), INT_MAX);
+        QCOMPARE(bounds.top(), INT_MIN);
+        QCOMPARE(bounds.bottom(), INT_MAX);
+    }
+
+    // The control for the case above: widening the range is only the right
+    // answer where there is no range to work out, so an ordinary zoom has to
+    // come back with the handful of coordinates that really can be on screen.
+    void test_theViewportStaysNarrowAtAnOrdinaryZoom()
+    {
+        const QRect bounds = T2DMap::viewportRoomBounds(kWidgetWidth / 2.0f, kWidgetHeight / 2.0f, 20.0f, 20.0f, kWidgetWidth, kWidgetHeight);
+
+        QCOMPARE(bounds.left(), -16);
+        QCOMPARE(bounds.right(), 16);
+        QCOMPARE(bounds.top(), -11);
+        QCOMPARE(bounds.bottom(), 11);
+    }
+
+    // The route that needs no script in the session that freezes: the room out
+    // at the limit, the area's zoom and the player's position all travel in the
+    // map file, so the first paint after the file is read back is the one that
+    // asks the index for a range ending at INT_MAX.
+    void test_aMapFileHoldingARoomAtTheCoordinateLimitIsPaintedWhenItIsLoadedBack()
+    {
+        const int areaId = buildAreaWithARoomAtTheCoordinateLimit();
+        QVERIFY2(areaId > 0, "the area under test could not be built");
+
+        const QString fileName = qsl("%1/coordinate-limit-map.dat").arg(mConfigDir.path());
+        QSaveFile file(fileName);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        QDataStream out(&file);
+        out.setVersion(QDataStream::Qt_5_12);
+        QVERIFY2(map()->serialize(out, map()->mDefaultVersion), "the map under test could not be saved");
+        QVERIFY(file.commit());
+
+        map()->mapClear();
+        QVERIFY2(map()->restore(fileName), "the map under test could not be read back");
+
+        // What the file has to have carried for the paint below to be the one
+        // this covers, checked before the paint rather than after it - a paint
+        // that never returns reports nothing at all.
+        const TRoom* pFarRoom = map()->mpRoomDB->getRoom(kFarRoomId);
+        QVERIFY2(pFarRoom, "the room at the coordinate limit did not survive the save and load");
+        QCOMPARE(pFarRoom->x(), INT_MAX);
+        QCOMPARE(map()->mRoomIdHash.value(map()->mProfileName), kFarRoomId);
+        const TArea* pArea = map()->mpRoomDB->getArea(pFarRoom->getArea());
+        QVERIFY(pArea);
+        QCOMPARE(pArea->get2DMapZoom(), kOnePixelPerRoomZoom);
+
+        T2DMap* p2dMap = preparedWidget();
+        QVERIFY2(p2dMap, "the profile's mapper could not be created");
+        renderFrame(p2dMap);
+
+        // Reached at all, which is the whole point: the scan this paint runs
+        // used to count in an int and so never got past a range ending at
+        // INT_MAX.
+        QCOMPARE(p2dMap->mAreaID, pFarRoom->getArea());
+    }
+};
+
+#include "MapCoordinateLimitTest.moc"
+MUDLET_GROUPED_TEST_MAIN(MapCoordinateLimitTest)

--- a/test/functional_tests/MapCoordinateLimitTest.cpp
+++ b/test/functional_tests/MapCoordinateLimitTest.cpp
@@ -18,22 +18,13 @@
  ***************************************************************************/
 
 /*
- * The two ends of the mapper's viewport query that a room out at the edge of
- * the coordinate space reaches, and that a Lua spec cannot:
+ * Why not a spec: viewportRoomBounds() has to be asked directly, because at the
+ * zoom these cases cover the whole map is one pixel and nothing drawn differs
+ * between the right answer and the wrong one; and loading a map file replaces
+ * the map of the profile the specs share.
  *
- *   - viewportRoomBounds() for the zoom that leaves a room zero pixels across.
- *     Every bound is then a division by that zero, and which non-number comes
- *     back differs by processor, so the only way to pin the answer is to ask
- *     the function directly with each of the pan offsets a machine can produce.
- *     Nothing the mapper draws differs between the right answer and the wrong
- *     one that a spec could see: at that zoom the whole map is one pixel.
- *
- *   - the paint that follows loading a map file which holds such a room. That
- *     route needs no script in the session that freezes, and a spec cannot
- *     take it: loading a map replaces the map of the profile the specs share.
- *
- * Both of these hang rather than fail when they regress, so what reports them
- * is the 60 second cap every functional test carries rather than an assertion.
+ * Both cases hang rather than fail when they regress, so what reports them is
+ * the 60 second cap every functional test carries rather than an assertion.
  *
  * Run with: ctest -R MapCoordinateLimitTest -V
  */
@@ -77,15 +68,12 @@ private:
 
     static constexpr int kWidgetWidth = 600;
     static constexpr int kWidgetHeight = 400;
-    // One pixel per room on a widget this tall, which is where the viewport's
-    // right-hand bound lands on the coordinate limit. The scroll wheel reaches
-    // it.
+    // One pixel per room on a widget this tall, which puts the viewport's
+    // right-hand bound on the coordinate limit.
     static constexpr double kOnePixelPerRoomZoom = 400.0;
-    // More occupied columns than the viewport at that zoom asks for, so the
-    // scan probes the columns it wants instead of walking the ones the area
-    // has - probing is the route that stopped terminating. The margin is wide
-    // because how many columns the viewport wants is half the widget's width in
-    // rooms, which platform chrome moves.
+    // More occupied columns than the viewport at that zoom asks for, so the scan
+    // probes the columns it wants instead of walking the ones the area has. The
+    // margin is wide because how many it wants tracks the widget's width.
     static constexpr int kOccupiedColumns = 2000;
     static constexpr int kFarRoomId = 99999;
 
@@ -101,10 +89,8 @@ private:
 
     bool addRoomAt(const int id, const int areaId, const int x, const int y) const { return map()->addRoom(id) && map()->setRoomArea(id, areaId) && map()->setRoomCoordinates(id, x, y, 0); }
 
-    // An area a few thousand columns wide with one room out at the coordinate
-    // limit, the player standing in that room, and the zoom that draws it a
-    // pixel per room already stored on the area - which is the state a saved
-    // map file carries.
+    // The player is left standing in the far room and the zoom is stored on the
+    // area, which is the state a saved map file carries.
     int buildAreaWithARoomAtTheCoordinateLimit() const
     {
         TMap* pMap = map();
@@ -130,8 +116,6 @@ private:
         return areaId;
     }
 
-    // The widget the profile's own mapper holds, sized and left to centre
-    // itself on the player room the way a repaint after a map load does.
     T2DMap* preparedWidget() const
     {
         TMap* pMap = map();
@@ -207,10 +191,8 @@ private slots:
     {
         QTest::addColumn<float>("panOffset");
 
-        // mRX and mRY are qRound()ed from zero times the overflowed span, which
-        // is a NaN, and int(NaN) is not the same everywhere: x86-64 lands on
-        // INT_MIN and ARM64 on 0. The third row is the same zoom with the map
-        // panned so that both ends of the division are on the same side.
+        // mRX and mRY are qRound()ed from a NaN, and int(NaN) is not the same
+        // everywhere: x86-64 lands on INT_MIN and ARM64 on 0.
         QTest::newRow("the pan offset an x86-64 build produces") << static_cast<float>(INT_MIN);
         QTest::newRow("the pan offset an ARM64 build produces") << 0.0f;
         QTest::newRow("panned past the widget") << 1000.0f;
@@ -230,9 +212,6 @@ private slots:
         QCOMPARE(bounds.bottom(), INT_MAX);
     }
 
-    // The control for the case above: widening the range is only the right
-    // answer where there is no range to work out, so an ordinary zoom has to
-    // come back with the handful of coordinates that really can be on screen.
     void test_theViewportStaysNarrowAtAnOrdinaryZoom()
     {
         const QRect bounds = T2DMap::viewportRoomBounds(kWidgetWidth / 2.0f, kWidgetHeight / 2.0f, 20.0f, 20.0f, kWidgetWidth, kWidgetHeight);
@@ -243,10 +222,6 @@ private slots:
         QCOMPARE(bounds.bottom(), 11);
     }
 
-    // The route that needs no script in the session that freezes: the room out
-    // at the limit, the area's zoom and the player's position all travel in the
-    // map file, so the first paint after the file is read back is the one that
-    // asks the index for a range ending at INT_MAX.
     void test_aMapFileHoldingARoomAtTheCoordinateLimitIsPaintedWhenItIsLoadedBack()
     {
         const int areaId = buildAreaWithARoomAtTheCoordinateLimit();
@@ -263,9 +238,8 @@ private slots:
         map()->mapClear();
         QVERIFY2(map()->restore(fileName), "the map under test could not be read back");
 
-        // What the file has to have carried for the paint below to be the one
-        // this covers, checked before the paint rather than after it - a paint
-        // that never returns reports nothing at all.
+        // Checked before the paint rather than after it: a paint that never
+        // returns reports nothing at all.
         const TRoom* pFarRoom = map()->mpRoomDB->getRoom(kFarRoomId);
         QVERIFY2(pFarRoom, "the room at the coordinate limit did not survive the save and load");
         QCOMPARE(pFarRoom->x(), INT_MAX);
@@ -278,9 +252,8 @@ private slots:
         QVERIFY2(p2dMap, "the profile's mapper could not be created");
         renderFrame(p2dMap);
 
-        // Reached at all, which is the whole point: the scan this paint runs
-        // used to count in an int and so never got past a range ending at
-        // INT_MAX.
+        // Reached at all is the point: a paint whose scan never returns never
+        // gets here.
         QCOMPARE(p2dMap->mAreaID, pFarRoom->getArea());
     }
 };


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- The 2D mapper froze at 100% CPU, permanently, on a map holding one room near the coordinate limit (x = 2147483647) once it was centred at zoom 400 - a value the scroll wheel reaches - and on `loadMap()` of a map saved in that state. An extreme `setMapZoom(1e40)` froze it the same way.
- `TAreaGridIndex`'s probing loops counted in `int`, so a range ending at `INT_MAX` never got past its last step (signed overflow, then forever). They count in `qint64` now, on both axes and in the collision variant.
- `T2DMap::viewportRoomBounds()` treats a room that is zero pixels across (the overflowed-zoom case, which yields NaN or infinities depending on the platform) as asking for the whole coordinate range, as 5.0.1 drew it, instead of collapsing onto one limit; and `paintRoomExits()` no longer asks `QRect::contains()` about a rectangle whose left is `INT_MIN`, where its `left - 1` wraps and inverts the test.
- Tests: seven `TAreaGridIndexTest` cases at the limits (the test is capped at 60 s in ctest because a regression hangs rather than fails), `MapCoordinateLimitTest` in the MAP group covering the degenerate viewport arithmetic and the saved-map route, and `MapViewportLimits_spec.lua` driving both user routes through the real widget.

#### Motivation for adding to Mudlet

Regression since 5.0.1 introduced by #10175 (QA finding F-17-1, alias F-R9-1), ranked first by impact in the QA campaign: a shared map file is enough to make the client unusable, and the only recovery was replacing the file.

#### Other info (issues closed, discussion etc)

`setMapZoom()` still has no upper bound, deliberately: 5.0.1 accepted `1e40` and drew the map, so rejecting it would depart from the behaviour being restored. At that degenerate zoom every room on the level is collected per paint (one pass over the level's keys), which is what 5.0.1 did.

**Test case:** in an area 600 columns wide add a room at x = 2147483647, `centerview` it and `setMapZoom(400)` - the call returns and the mapper keeps painting; `setMapZoom(1e40)` likewise.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_