### PR TITLE
Fix: Dismissing the settings no longer turns MMCP auto-accept calls off

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -6813,9 +6813,12 @@ void dlgProfilePreferences::applyAll()
             pHost->mMMCPChatPort = ok ? port : csDefaultMMCPHostPort;
         }
 
-        /* Possible inclusion in 4.21 - these three have no controls on the form
-           yet, so an apply has nothing to write them from and must leave the
-           values the profile was loaded with alone (#10165's residue)
+        // The three MMCP options below have no controls on the form - their check boxes
+        // are commented out of profile_preferences.ui - so an apply has nothing to read
+        // them from and has to leave the values the profile was loaded with alone.
+        // Writing them back regardless is what turned auto-accept calls off for anyone
+        // who merely opened the settings.
+        /* restore these along with the check boxes:
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAutoAcceptCalls = checkBox_mmcpAutoAcceptCalls->isChecked();
         pHost->mMMCPAllowPeekRequests = checkBox_mmcpAllowPeekReq->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -6815,9 +6815,7 @@ void dlgProfilePreferences::applyAll()
 
         // The three MMCP options below have no controls on the form - their check boxes
         // are commented out of profile_preferences.ui - so an apply has nothing to read
-        // them from and has to leave the values the profile was loaded with alone.
-        // Writing them back regardless is what turned auto-accept calls off for anyone
-        // who merely opened the settings.
+        // them from.
         /* restore these along with the check boxes:
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAutoAcceptCalls = checkBox_mmcpAutoAcceptCalls->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -6813,15 +6813,13 @@ void dlgProfilePreferences::applyAll()
             pHost->mMMCPChatPort = ok ? port : csDefaultMMCPHostPort;
         }
 
-        /* Possible inclusion in 4.21
+        /* Possible inclusion in 4.21 - these three have no controls on the form
+           yet, so an apply has nothing to write them from and must leave the
+           values the profile was loaded with alone (#10165's residue)
         pHost->mMMCPAutostartServer = checkBox_mmcpAutostartServer->isChecked();
         pHost->mMMCPAutoAcceptCalls = checkBox_mmcpAutoAcceptCalls->isChecked();
         pHost->mMMCPAllowPeekRequests = checkBox_mmcpAllowPeekReq->isChecked();
         */
-        // remove these when the above is restored
-        pHost->mMMCPAutostartServer = false;
-        pHost->mMMCPAutoAcceptCalls = false;
-        pHost->mMMCPAllowPeekRequests = false;
 
         if (mSnapshot.dirty(checkBox_mmcpPrefixEmotes)) {
             pHost->mMMCPPrefixEmotes = checkBox_mmcpPrefixEmotes->isChecked();

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -205,6 +205,7 @@ set(SETTINGS_GROUP_TEST_SOURCES
     SettingsHostLifecycleTest.cpp
     SettingsInstantApplyTest.cpp
     SettingsLiveSyncTest.cpp
+    SettingsMmcpFlagsTest.cpp
     SettingsRoundTripTest.cpp
     SettingsSearchTest.cpp
     SettingsShellNavigationTest.cpp

--- a/test/functional_tests/SettingsMmcpFlagsTest.cpp
+++ b/test/functional_tests/SettingsMmcpFlagsTest.cpp
@@ -31,6 +31,7 @@
  */
 
 #include <QDir>
+#include <QFile>
 #include <QTemporaryDir>
 #include <QtTest/QtTest>
 
@@ -41,6 +42,7 @@
 #include "ProfileTestHelper.h"
 #include "SettingsTestHelper.h"
 #include "Host.h"
+#include "HostManager.h"
 #include "MudletInstanceCoordinator.h"
 #include "TelnetServerStub.h"
 #include "dlgProfilePreferences.h"
@@ -73,14 +75,15 @@ private:
     }
 
     // Auto-accept calls is on unless a profile XML says otherwise, which is what
-    // makes it the one of the three an apply can be seen to lose. The other two
-    // are off by default and are checked in the same breath, since the same
-    // three lines wrote all of them.
-    void verifyTheProfilesOptionsSurvived(const char* what)
+    // makes it the one of the three an apply can be seen to lose on a new profile.
+    // The other two are off by default, and the lines this fix removed wrote false,
+    // so only a profile that has turned them on can show them being lost - which is
+    // what test_theMmcpOptionsAProfileTurnedOnSurviveAnApply is for.
+    void verifyTheOptionsSurvived(Host* pHost, const bool autostartServer, const bool allowPeekRequests, const char* what)
     {
-        QVERIFY2(mpHost->getMMCPAutoAcceptCalls(), what);
-        QVERIFY2(!mpHost->getMMCPAutoStartServer(), "an apply turned the chat server's auto-start on, which no control on the form asked for");
-        QVERIFY2(!mpHost->getMMCPAllowPeekRequests(), "an apply turned peek requests on, which no control on the form asked for");
+        QVERIFY2(pHost->getMMCPAutoAcceptCalls(), what);
+        QVERIFY2(pHost->getMMCPAutoStartServer() == autostartServer, "an apply changed the chat server's auto-start, which no control on the form asked it to");
+        QVERIFY2(pHost->getMMCPAllowPeekRequests() == allowPeekRequests, "an apply changed peek requests, which no control on the form asked it to");
     }
 
     void verifyTheFixtureIsUsable()
@@ -88,6 +91,31 @@ private:
         QVERIFY2(mpHost->getMMCPAutoAcceptCalls(),
                  "auto-accept calls was already off before the settings were opened, so this case cannot show an apply turning it off - the profile default has changed");
         QVERIFY2(!mpHost->getMMCPAutoStartServer() && !mpHost->getMMCPAllowPeekRequests(), "the other two MMCP options are not at their defaults");
+    }
+
+    // The three MMCP options can only be set by the profile's own XML, since the
+    // form has no controls for them, so a save that turns all three on is the only
+    // way to stage the two that are off by default.
+    bool writeProfileSaveWithEveryMmcpOptionOn(const QString& profileName)
+    {
+        const QString folder = mudlet::getMudletPath(enums::profileXmlFilesPath, profileName);
+        if (!QDir().mkpath(folder)) {
+            return false;
+        }
+        // The shape XMLexport::writeHost() gives the MMCP child of <Host>
+        const QByteArray xml =
+                QByteArrayLiteral("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                  "<!DOCTYPE MudletPackage>\n"
+                                  "<MudletPackage version=\"1.001\">\n"
+                                  "<HostPackage>\n"
+                                  "<Host>\n"
+                                  "<MMCP chatName=\"tester\" chatPort=\"4050\" chatPrefix=\"\" autostartServer=\"yes\" allowPeekRequests=\"yes\" prefixEmotes=\"no\" chatMessageNewline=\"yes\" "
+                                  "autoAcceptCalls=\"yes\" snoopInMain=\"yes\"/>\n"
+                                  "</Host>\n"
+                                  "</HostPackage>\n"
+                                  "</MudletPackage>\n");
+        QFile file(qsl("%1/2020-01-01#00-00-00.xml").arg(folder));
+        return file.open(QIODevice::WriteOnly | QIODevice::Text) && file.write(xml) == xml.size();
     }
 
 private slots:
@@ -147,10 +175,15 @@ private slots:
         verifyTheFixtureIsUsable();
         openPreferences();
 
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
         QTest::keyClick(mpPreferences, Qt::Key_Escape);
         QVERIFY2(!mpPreferences->isVisible(), "Escape did not close the settings, so the apply it triggers never ran");
+        // Escape closing rather than discarding (#10237) is what made this finding a
+        // regression, so a case that only watched the dialog close would go on passing
+        // while covering nothing at all
+        QVERIFY2(TestSettings::waitForApply(applySpy), "Escape closed the settings without applying them, so this case no longer covers the finding");
 
-        verifyTheProfilesOptionsSurvived("dismissing the settings with Escape turned auto-accept calls off, and no control on the form can turn it back on");
+        verifyTheOptionsSurvived(mpHost, false, false, "dismissing the settings with Escape turned auto-accept calls off, and no control on the form can turn it back on");
     }
 
     // ...and the same for an apply the user really did ask for, by editing
@@ -166,7 +199,7 @@ private slots:
         QVERIFY2(TestSettings::waitForApply(applySpy), "the debounce never wrote the settings back");
         QCOMPARE(mpHost->mAnnounceIncomingText, !announceBefore);
 
-        verifyTheProfilesOptionsSurvived("applying the settings turned auto-accept calls off, and no control on the form can turn it back on");
+        verifyTheOptionsSurvived(mpHost, false, false, "applying the settings turned auto-accept calls off, and no control on the form can turn it back on");
         mpHost->mAnnounceIncomingText = announceBefore;
     }
 
@@ -183,6 +216,43 @@ private slots:
         QVERIFY2(TestSettings::waitForApply(applySpy), "ticking an MMCP option never wrote the settings back");
 
         QVERIFY2(mpHost->getMMCPPrefixEmotes() == !before, "an MMCP option the user really did tick was not applied");
+    }
+
+    // Two of the three options are off on a new profile and the removed lines wrote
+    // false, so a case against a new profile can only ever show auto-accept calls
+    // being lost. This one opens a profile whose save has all three on - the state a
+    // user who edited their XML is in, which is the only way to set them - so that
+    // every one of the three has somewhere to fall from. Last in the file because it
+    // opens a second profile, which the cases above should not have to allow for.
+    void test_theMmcpOptionsAProfileTurnedOnSurviveAnApply()
+    {
+        const QString profileName = qsl("SettingsMmcpFlags-Staged-Test");
+        deleteProfileDirectory(profileName);
+        QVERIFY2(writeProfileSaveWithEveryMmcpOptionOn(profileName), "could not write the staged profile save");
+
+        Host* pStagedHost = mudlet::self()->loadProfile(profileName, false);
+        QVERIFY(pStagedHost);
+        QVERIFY2(pStagedHost->mLoadedOk, "the staged profile save could not be loaded");
+        mudlet::self()->slot_connectionDialogueFinished(profileName, false);
+        QVERIFY2(pStagedHost->getMMCPAutoStartServer() && pStagedHost->getMMCPAllowPeekRequests() && pStagedHost->getMMCPAutoAcceptCalls(),
+                 "the profile save did not turn all three MMCP options on, so this case cannot show an apply turning them off");
+
+        auto* pStagedPreferences = new dlgProfilePreferences(mudlet::self(), pStagedHost);
+        pStagedPreferences->resize(1060, 760);
+        pStagedPreferences->show();
+        QVERIFY(QTest::qWaitForWindowExposed(pStagedPreferences));
+
+        QSignalSpy applySpy(pStagedPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        QTest::keyClick(pStagedPreferences, Qt::Key_Escape);
+        QVERIFY2(!pStagedPreferences->isVisible(), "Escape did not close the settings, so the apply it triggers never ran");
+        QVERIFY2(TestSettings::waitForApply(applySpy), "Escape closed the settings without applying them, so this case no longer covers the finding");
+
+        verifyTheOptionsSurvived(pStagedHost, true, true, "dismissing the settings with Escape turned this profile's auto-accept calls off");
+
+        delete pStagedPreferences;
+        pStagedHost->waitForProfileSave();
+        mudlet::self()->getHostManager().deleteHost(profileName);
+        deleteProfileDirectory(profileName);
     }
 };
 

--- a/test/functional_tests/SettingsMmcpFlagsTest.cpp
+++ b/test/functional_tests/SettingsMmcpFlagsTest.cpp
@@ -1,0 +1,190 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers - mudlet@mudlet.org           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * Three MMCP settings - auto-start the chat server, auto-accept incoming calls
+ * and allow peek requests - have no controls on the settings form: the check
+ * boxes are commented out of profile_preferences.ui pending a future release.
+ * applyAll() nonetheless wrote all three back as false, outside the dirty
+ * guards, so every apply reset them. Once Esc became a close rather than a
+ * discard (#10237), merely looking at the settings turned off a setting the
+ * profile XML is the only way to set - and, with no control to turn it back on,
+ * unrecoverably from the UI.
+ *
+ * Run with: ctest -R SettingsMmcpFlagsTest -V
+ */
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+#include <QCheckBox>
+#include <QSignalSpy>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "SettingsTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TelnetServerStub.h"
+#include "dlgProfilePreferences.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+class SettingsMmcpFlagsTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    dlgProfilePreferences* mpPreferences = nullptr;
+    const QString mProfileName = qsl("SettingsMmcpFlags-Test");
+    QString mPort; // assigned the stub's actual ephemeral port in initTestCase()
+    const QString mLocalhost = qsl("localhost");
+
+    static void deleteProfileDirectory(const QString& profileName) { TestSettings::deleteProfileDirectory(profileName); }
+
+    void openPreferences()
+    {
+        mpPreferences = new dlgProfilePreferences(mudlet::self(), mpHost);
+        mpPreferences->resize(1060, 760);
+        mpPreferences->show();
+        QVERIFY(QTest::qWaitForWindowExposed(mpPreferences));
+    }
+
+    // Auto-accept calls is on unless a profile XML says otherwise, which is what
+    // makes it the one of the three an apply can be seen to lose. The other two
+    // are off by default and are checked in the same breath, since the same
+    // three lines wrote all of them.
+    void verifyTheProfilesOptionsSurvived(const char* what)
+    {
+        QVERIFY2(mpHost->getMMCPAutoAcceptCalls(), what);
+        QVERIFY2(!mpHost->getMMCPAutoStartServer(), "an apply turned the chat server's auto-start on, which no control on the form asked for");
+        QVERIFY2(!mpHost->getMMCPAllowPeekRequests(), "an apply turned peek requests on, which no control on the form asked for");
+    }
+
+    void verifyTheFixtureIsUsable()
+    {
+        QVERIFY2(mpHost->getMMCPAutoAcceptCalls(),
+                 "auto-accept calls was already off before the settings were opened, so this case cannot show an apply turning it off - the profile default has changed");
+        QVERIFY2(!mpHost->getMMCPAutoStartServer() && !mpHost->getMMCPAllowPeekRequests(), "the other two MMCP options are not at their defaults");
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // A config root of this process's own - see the same block in
+        // DialogTeardownTest for why sharing the developer's one does not work
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0); // ephemeral OS-assigned port avoids collisions across concurrent test runs
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+        deleteProfileDirectory(mProfileName);
+
+        mpHost = TestProfile::create(mProfileName, mLocalhost, mPort);
+        QVERIFY2(mpHost, "No active host after profile creation");
+    }
+
+    void cleanupTestCase()
+    {
+        mpHost = nullptr;
+        delete mpServer;
+        mpServer = nullptr;
+        // Null when initTestCase skipped or failed ahead of mudlet::start(), and
+        // getMudletPath() dereferences the instance rather than checking it
+        if (mudlet::self()) {
+            deleteProfileDirectory(mProfileName);
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    void cleanup()
+    {
+        delete mpPreferences;
+        mpPreferences = nullptr;
+        mpHost->waitForProfileSave();
+    }
+
+    // The finding: open the settings, press Esc, and the profile's MMCP options
+    // are gone.
+    void test_dismissingWithEscapeKeepsTheMmcpOptions()
+    {
+        verifyTheFixtureIsUsable();
+        openPreferences();
+
+        QTest::keyClick(mpPreferences, Qt::Key_Escape);
+        QVERIFY2(!mpPreferences->isVisible(), "Escape did not close the settings, so the apply it triggers never ran");
+
+        verifyTheProfilesOptionsSurvived("dismissing the settings with Escape turned auto-accept calls off, and no control on the form can turn it back on");
+    }
+
+    // ...and the same for an apply the user really did ask for, by editing
+    // something else entirely.
+    void test_anUnrelatedEditKeepsTheMmcpOptions()
+    {
+        verifyTheFixtureIsUsable();
+        openPreferences();
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        const bool announceBefore = mpHost->mAnnounceIncomingText;
+        mpPreferences->checkBox_announceIncomingText->click();
+        QVERIFY2(TestSettings::waitForApply(applySpy), "the debounce never wrote the settings back");
+        QCOMPARE(mpHost->mAnnounceIncomingText, !announceBefore);
+
+        verifyTheProfilesOptionsSurvived("applying the settings turned auto-accept calls off, and no control on the form can turn it back on");
+        mpHost->mAnnounceIncomingText = announceBefore;
+    }
+
+    // The MMCP settings that do have controls still have to be written, or this
+    // would be a fix that simply stopped applying the page.
+    void test_theMmcpSettingsWithControlsAreStillApplied()
+    {
+        openPreferences();
+        const bool before = mpHost->getMMCPPrefixEmotes();
+        QCOMPARE(mpPreferences->checkBox_mmcpPrefixEmotes->isChecked(), before);
+
+        QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
+        mpPreferences->checkBox_mmcpPrefixEmotes->click();
+        QVERIFY2(TestSettings::waitForApply(applySpy), "ticking an MMCP option never wrote the settings back");
+
+        QVERIFY2(mpHost->getMMCPPrefixEmotes() == !before, "an MMCP option the user really did tick was not applied");
+    }
+};
+
+#include "SettingsMmcpFlagsTest.moc"
+MUDLET_GROUPED_TEST_MAIN(SettingsMmcpFlagsTest)

--- a/test/functional_tests/SettingsMmcpFlagsTest.cpp
+++ b/test/functional_tests/SettingsMmcpFlagsTest.cpp
@@ -18,14 +18,10 @@
  ***************************************************************************/
 
 /*
- * Three MMCP settings - auto-start the chat server, auto-accept incoming calls
- * and allow peek requests - have no controls on the settings form: the check
- * boxes are commented out of profile_preferences.ui pending a future release.
- * applyAll() nonetheless wrote all three back as false, outside the dirty
- * guards, so every apply reset them. Once Esc became a close rather than a
- * discard (#10237), merely looking at the settings turned off a setting the
- * profile XML is the only way to set - and, with no control to turn it back on,
- * unrecoverably from the UI.
+ * Three MMCP settings - auto-start the chat server, auto-accept incoming calls and
+ * allow peek requests - have no controls on the settings form: their check boxes are
+ * commented out of profile_preferences.ui. The profile's own XML is the only thing
+ * that sets them, so an apply has to leave them as it found them.
  *
  * Run with: ctest -R SettingsMmcpFlagsTest -V
  */
@@ -74,11 +70,6 @@ private:
         QVERIFY(QTest::qWaitForWindowExposed(mpPreferences));
     }
 
-    // Auto-accept calls is on unless a profile XML says otherwise, which is what
-    // makes it the one of the three an apply can be seen to lose on a new profile.
-    // The other two are off by default, and the lines this fix removed wrote false,
-    // so only a profile that has turned them on can show them being lost - which is
-    // what test_theMmcpOptionsAProfileTurnedOnSurviveAnApply is for.
     void verifyTheOptionsSurvived(Host* pHost, const bool autostartServer, const bool allowPeekRequests, const char* what)
     {
         QVERIFY2(pHost->getMMCPAutoAcceptCalls(), what);
@@ -93,9 +84,6 @@ private:
         QVERIFY2(!mpHost->getMMCPAutoStartServer() && !mpHost->getMMCPAllowPeekRequests(), "the other two MMCP options are not at their defaults");
     }
 
-    // The three MMCP options can only be set by the profile's own XML, since the
-    // form has no controls for them, so a save that turns all three on is the only
-    // way to stage the two that are off by default.
     bool writeProfileSaveWithEveryMmcpOptionOn(const QString& profileName)
     {
         const QString folder = mudlet::getMudletPath(enums::profileXmlFilesPath, profileName);
@@ -168,8 +156,6 @@ private slots:
         mpHost->waitForProfileSave();
     }
 
-    // The finding: open the settings, press Esc, and the profile's MMCP options
-    // are gone.
     void test_dismissingWithEscapeKeepsTheMmcpOptions()
     {
         verifyTheFixtureIsUsable();
@@ -178,16 +164,11 @@ private slots:
         QSignalSpy applySpy(mpPreferences, &dlgProfilePreferences::signal_preferencesSaved);
         QTest::keyClick(mpPreferences, Qt::Key_Escape);
         QVERIFY2(!mpPreferences->isVisible(), "Escape did not close the settings, so the apply it triggers never ran");
-        // Escape closing rather than discarding (#10237) is what made this finding a
-        // regression, so a case that only watched the dialog close would go on passing
-        // while covering nothing at all
         QVERIFY2(TestSettings::waitForApply(applySpy), "Escape closed the settings without applying them, so this case no longer covers the finding");
 
         verifyTheOptionsSurvived(mpHost, false, false, "dismissing the settings with Escape turned auto-accept calls off, and no control on the form can turn it back on");
     }
 
-    // ...and the same for an apply the user really did ask for, by editing
-    // something else entirely.
     void test_anUnrelatedEditKeepsTheMmcpOptions()
     {
         verifyTheFixtureIsUsable();
@@ -203,8 +184,6 @@ private slots:
         mpHost->mAnnounceIncomingText = announceBefore;
     }
 
-    // The MMCP settings that do have controls still have to be written, or this
-    // would be a fix that simply stopped applying the page.
     void test_theMmcpSettingsWithControlsAreStillApplied()
     {
         openPreferences();
@@ -218,12 +197,8 @@ private slots:
         QVERIFY2(mpHost->getMMCPPrefixEmotes() == !before, "an MMCP option the user really did tick was not applied");
     }
 
-    // Two of the three options are off on a new profile and the removed lines wrote
-    // false, so a case against a new profile can only ever show auto-accept calls
-    // being lost. This one opens a profile whose save has all three on - the state a
-    // user who edited their XML is in, which is the only way to set them - so that
-    // every one of the three has somewhere to fall from. Last in the file because it
-    // opens a second profile, which the cases above should not have to allow for.
+    // Last in the file because it opens a second profile, which the cases above
+    // should not have to allow for.
     void test_theMmcpOptionsAProfileTurnedOnSurviveAnApply()
     {
         const QString profileName = qsl("SettingsMmcpFlags-Staged-Test");


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Opening Preferences and dismissing it with Esc silently turned MMCP "auto-accept calls" off, permanently, with no control in the UI to turn it back on (only editing the profile XML).
- `applyAll()` wrote `mMMCPAutostartServer`, `mMMCPAutoAcceptCalls` and `mMMCPAllowPeekRequests` to `false` unconditionally, outside the `mSnapshot.dirty()` guards, for three check boxes that are commented out of `profile_preferences.ui`. Those writes are removed: with no controls to read them from, the values XMLimport loaded are the only ones there are.
- `SettingsMmcpFlagsTest` (SETTINGS group) covers Esc and a debounced apply on a fresh profile and on a profile whose XML turns all three options on, watches `signal_preferencesSaved` so the Esc case proves an apply ran, and checks the MMCP options that do have controls are still written.

#### Motivation for adding to Mudlet

Regression since 5.0.1 (QA finding F-22-1): the writes predate the settings redesign, but #10237 made Esc apply-and-close rather than discard, which put them one keypress away from anyone who merely looks at the settings. Residue of #10165.

#### Other info (issues closed, discussion etc)

**Test case:** with `autoAcceptCalls="yes"` in the profile, open Preferences (Alt+P), press Esc, save the profile - the XML still says `autoAcceptCalls="yes"`.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_