### PR TITLE
Fix: Report a profile.ini that cannot be parsed again

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3385,14 +3385,11 @@ QSettings& Host::profileIni()
 {
     if (!mpProfileIni) {
         mpProfileIni = new QSettings(mudlet::getMudletPath(enums::profileDataItemPath, getName(), qsl("profile.ini")), QSettings::IniFormat, this);
-        // Constructing it only splits the file into sections, and each section
-        // is parsed by the first lookup that needs it, so damage inside one is
-        // not visible in status() yet. allKeys() parses them all, and the keys
-        // it hands back are of no interest here:
+        // Constructing it only splits the file into sections, and each section is
+        // parsed by the first lookup that needs it, so status() cannot see damage
+        // inside one until allKeys() has parsed them all
         static_cast<void>(mpProfileIni->allKeys());
         if (mpProfileIni->status() == QSettings::FormatError) {
-            // Named, because with several profiles open there is otherwise no
-            // telling which one lost its command line history and notepad state
             qWarning().nospace().noquote() << "Host::profileIni() ERROR - the \"profile.ini\" file of profile \"" << getName() << "\" (" << mpProfileIni->fileName()
                                            << ") could not be parsed, the settings it held will be replaced.";
         }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3387,10 +3387,14 @@ QSettings& Host::profileIni()
         mpProfileIni = new QSettings(mudlet::getMudletPath(enums::profileDataItemPath, getName(), qsl("profile.ini")), QSettings::IniFormat, this);
         // Constructing it only splits the file into sections, and each section
         // is parsed by the first lookup that needs it, so damage inside one is
-        // not visible in status() yet. allKeys() parses them all:
-        mpProfileIni->allKeys();
+        // not visible in status() yet. allKeys() parses them all, and the keys
+        // it hands back are of no interest here:
+        static_cast<void>(mpProfileIni->allKeys());
         if (mpProfileIni->status() == QSettings::FormatError) {
-            qWarning().nospace().noquote() << "Host::profileIni() ERROR - the profile's \"profile.ini\" file could not be parsed, the settings it held will be replaced.";
+            // Named, because with several profiles open there is otherwise no
+            // telling which one lost its command line history and notepad state
+            qWarning().nospace().noquote() << "Host::profileIni() ERROR - the \"profile.ini\" file of profile \"" << getName() << "\" (" << mpProfileIni->fileName()
+                                           << ") could not be parsed, the settings it held will be replaced.";
         }
     }
     return *mpProfileIni;

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3385,6 +3385,10 @@ QSettings& Host::profileIni()
 {
     if (!mpProfileIni) {
         mpProfileIni = new QSettings(mudlet::getMudletPath(enums::profileDataItemPath, getName(), qsl("profile.ini")), QSettings::IniFormat, this);
+        // Constructing it only splits the file into sections, and each section
+        // is parsed by the first lookup that needs it, so damage inside one is
+        // not visible in status() yet. allKeys() parses them all:
+        mpProfileIni->allKeys();
         if (mpProfileIni->status() == QSettings::FormatError) {
             qWarning().nospace().noquote() << "Host::profileIni() ERROR - the profile's \"profile.ini\" file could not be parsed, the settings it held will be replaced.";
         }

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -83,10 +83,10 @@ set(PROFILE_GROUP_TEST_SOURCES
     MissingDisplayFontTest.cpp
     ProfileDeletionSafetyTest.cpp
     ProfileFolderNameTest.cpp
+    ProfileIniParseErrorTest.cpp
     ProfileLifecycleTest.cpp
     ProfileLoadTempFileTest.cpp
     ProfileRoundTripTest.cpp
-    ProfileIniParseErrorTest.cpp
     ProfileSaveShutdownRaceTest.cpp
     ResetProfileTest.cpp
     SavedVariableFenceTest.cpp

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -86,6 +86,7 @@ set(PROFILE_GROUP_TEST_SOURCES
     ProfileLifecycleTest.cpp
     ProfileLoadTempFileTest.cpp
     ProfileRoundTripTest.cpp
+    ProfileIniParseErrorTest.cpp
     ProfileSaveShutdownRaceTest.cpp
     ResetProfileTest.cpp
     SavedVariableFenceTest.cpp

--- a/test/functional_tests/ProfileIniParseErrorTest.cpp
+++ b/test/functional_tests/ProfileIniParseErrorTest.cpp
@@ -37,6 +37,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QRegularExpression>
+#include <QSettings>
 #include <QTemporaryDir>
 
 #include "PortableModeTestHelper.h"
@@ -49,12 +50,14 @@
 
 // Counts the parse diagnostic so that the case for a well-formed file can say it
 // was not printed - QTest::ignoreMessage only ever asserts the other direction.
+// Matched on the function that emits it rather than on the words "could not be
+// parsed", which any other subsystem is free to say about anything.
 static QtMessageHandler previousMessageHandler = nullptr;
 static int parseWarnings = 0;
 
 static void countParseWarnings(QtMsgType type, const QMessageLogContext& context, const QString& message)
 {
-    if (message.contains(QLatin1String("could not be parsed"))) {
+    if (message.contains(QLatin1String("Host::profileIni() ERROR"))) {
         ++parseWarnings;
     }
     if (previousMessageHandler) {
@@ -75,20 +78,39 @@ private:
     // sections as it is constructed and so catches a broken section header there
     static QByteArray unparseableIni() { return QByteArrayLiteral("[CommandLines]\nUsedIndexes=1\nthis line was truncated mid-write\n"); }
 
+    static QString iniPathFor(const QString& profileName) { return mudlet::getMudletPath(enums::profileDataItemPath, profileName, qsl("profile.ini")); }
+
+    // Whether QSettings really does refuse the fixture, which is what the whole case
+    // rests on. Asked of a copy at a path of its own, never of the fixture itself:
+    // QSettings keeps the sections it has parsed per file path and shares them between
+    // instances - and beyond the life of the one that parsed them - so probing the
+    // fixture would answer the question by consuming the parse the Host has to make.
+    static bool refusedByQSettings(const QString& path, const QString& copyPath)
+    {
+        if (!QFile::exists(copyPath) && !QFile::copy(path, copyPath)) {
+            return false;
+        }
+        QSettings probe(copyPath, QSettings::IniFormat);
+        probe.allKeys();
+        return probe.status() == QSettings::FormatError;
+    }
+
     // The Host has to meet the file on its first use of it: profile.ini is
     // opened once and kept, so anything written here afterwards would not be
-    // read again.
+    // read again. A null 'contents' is a profile that has never written one.
     Host* hostWithProfileIni(const QString& profileName, const QByteArray& contents)
     {
-        const QString iniPath = mudlet::getMudletPath(enums::profileDataItemPath, profileName, qsl("profile.ini"));
+        const QString iniPath = iniPathFor(profileName);
         if (!QDir().mkpath(QFileInfo(iniPath).absolutePath())) {
             return nullptr;
         }
-        QFile ini(iniPath);
-        if (!ini.open(QIODevice::WriteOnly | QIODevice::Truncate) || ini.write(contents) != contents.size()) {
-            return nullptr;
+        if (!contents.isNull()) {
+            QFile ini(iniPath);
+            if (!ini.open(QIODevice::WriteOnly | QIODevice::Truncate) || ini.write(contents) != contents.size()) {
+                return nullptr;
+            }
+            ini.close();
         }
-        ini.close();
 
         auto& hostManager = mudlet::self()->getHostManager();
         if (!hostManager.addHost(profileName, QString(), QString(), QString())) {
@@ -135,19 +157,26 @@ private slots:
     void test_anUnparseableProfileIniIsReported()
     {
         const QString profileName = qsl("ProfileIniParseError-Bad");
+        const QString iniPath = iniPathFor(profileName);
         parseWarnings = 0;
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl(R"(^Host::profileIni\(\) ERROR - the profile's "profile\.ini" file could not be parsed)")));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl(R"(^Host::profileIni\(\) ERROR - the "profile\.ini" file of profile "%1" \(.*\) could not be parsed)").arg(profileName)));
 
         Host* pHost = hostWithProfileIni(profileName, unparseableIni());
         QVERIFY2(pHost, "the profile with an unparseable profile.ini was not created");
+        QVERIFY2(refusedByQSettings(iniPath, qsl("%1.probe").arg(iniPath)), "QSettings no longer refuses the damaged fixture, so there is nothing here for the profile to report");
         pHost->writeProfileIniData(qsl("CommandLines/UsedIndexes"), qsl("1"));
 
-        QVERIFY2(parseWarnings == 1, "an unparseable profile.ini was accepted without a word");
-        // ...and what the warning promises: the settings it held are replaced
-        // rather than the write being dropped
-        QCOMPARE(pHost->readProfileIniData(qsl("CommandLines/UsedIndexes")), qsl("1"));
-
-        mudlet::self()->getHostManager().deleteHost(profileName);
+        QCOMPARE(parseWarnings, 1);
+        // ...and what the warning promises: the settings the file held are replaced
+        // rather than the write being dropped. Through the file rather than through
+        // readProfileIniData(), which answers from the very QSettings that has just
+        // cached the write and so would say "1" whatever became of the file.
+        mudlet::self()->getHostManager().deleteHost(profileName); // the Host's QSettings writes itself out as it goes
+        QFile written(iniPath);
+        QVERIFY(written.open(QIODevice::ReadOnly | QIODevice::Text));
+        const QString contents = QString::fromUtf8(written.readAll());
+        QVERIFY2(contents.contains(qsl("UsedIndexes=1")), qPrintable(qsl("the setting written to a damaged profile.ini did not reach the file, which holds: %1").arg(contents)));
+        QVERIFY2(!contents.contains(qsl("truncated mid-write")), qPrintable(qsl("the damage was left in place rather than the file being replaced, which holds: %1").arg(contents)));
     }
 
     // ...and a file that parses is not slandered, which is the state every
@@ -161,7 +190,7 @@ private slots:
         QVERIFY2(pHost, "the profile with a well-formed profile.ini was not created");
 
         QCOMPARE(pHost->readProfileIniData(qsl("CommandLines/UsedIndexes")), qsl("3"));
-        QVERIFY2(parseWarnings == 0, "a well-formed profile.ini was reported as unparseable");
+        QCOMPARE(parseWarnings, 0);
 
         mudlet::self()->getHostManager().deleteHost(profileName);
     }
@@ -173,16 +202,14 @@ private slots:
         const QString profileName = qsl("ProfileIniParseError-Absent");
         parseWarnings = 0;
 
-        QVERIFY(QDir().mkpath(mudlet::getMudletPath(enums::profileHomePath, profileName)));
-        auto& hostManager = mudlet::self()->getHostManager();
-        QVERIFY(hostManager.addHost(profileName, QString(), QString(), QString()));
-        Host* pHost = hostManager.getHost(profileName);
-        QVERIFY(pHost);
+        Host* pHost = hostWithProfileIni(profileName, QByteArray());
+        QVERIFY2(pHost, "the profile with no profile.ini was not created");
+        QVERIFY2(!QFile::exists(iniPathFor(profileName)), "the fixture wrote a profile.ini for a profile that is supposed to have none");
 
         QCOMPARE(pHost->readProfileIniData(qsl("CommandLines/UsedIndexes")), QString());
-        QVERIFY2(parseWarnings == 0, "a profile that has no profile.ini yet was reported as having an unparseable one");
+        QCOMPARE(parseWarnings, 0);
 
-        hostManager.deleteHost(profileName);
+        mudlet::self()->getHostManager().deleteHost(profileName);
     }
 };
 

--- a/test/functional_tests/ProfileIniParseErrorTest.cpp
+++ b/test/functional_tests/ProfileIniParseErrorTest.cpp
@@ -1,0 +1,190 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Mudlet Developers - mudlet@mudlet.org           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+/*
+ * A profile.ini that cannot be parsed has to be reported: the file holds the
+ * command lines' history settings and the notepad's window state, and all of it
+ * is silently replaced when the parse fails.
+ *
+ * Host now keeps one QSettings open for the profile's lifetime instead of making
+ * one per write, and the status check moved with it - but the constructor only
+ * splits the file into sections, and each section is parsed on the first lookup
+ * that needs it, so damage inside one still reads as NoError there and the
+ * diagnostic could never fire for it.
+ *
+ * Run with: ctest -R ProfileIniParseErrorTest -V
+ */
+
+#include <QtTest/QtTest>
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QTemporaryDir>
+
+#include "PortableModeTestHelper.h"
+#include "Host.h"
+#include "HostManager.h"
+#include "MudletInstanceCoordinator.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+// Counts the parse diagnostic so that the case for a well-formed file can say it
+// was not printed - QTest::ignoreMessage only ever asserts the other direction.
+static QtMessageHandler previousMessageHandler = nullptr;
+static int parseWarnings = 0;
+
+static void countParseWarnings(QtMsgType type, const QMessageLogContext& context, const QString& message)
+{
+    if (message.contains(QLatin1String("could not be parsed"))) {
+        ++parseWarnings;
+    }
+    if (previousMessageHandler) {
+        previousMessageHandler(type, context, message);
+    }
+}
+
+class ProfileIniParseErrorTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+
+    // Damage inside a section, which is where a crash or a full disk leaves it -
+    // and the only kind that gets this far, since QSettings splits the file into
+    // sections as it is constructed and so catches a broken section header there
+    static QByteArray unparseableIni() { return QByteArrayLiteral("[CommandLines]\nUsedIndexes=1\nthis line was truncated mid-write\n"); }
+
+    // The Host has to meet the file on its first use of it: profile.ini is
+    // opened once and kept, so anything written here afterwards would not be
+    // read again.
+    Host* hostWithProfileIni(const QString& profileName, const QByteArray& contents)
+    {
+        const QString iniPath = mudlet::getMudletPath(enums::profileDataItemPath, profileName, qsl("profile.ini"));
+        if (!QDir().mkpath(QFileInfo(iniPath).absolutePath())) {
+            return nullptr;
+        }
+        QFile ini(iniPath);
+        if (!ini.open(QIODevice::WriteOnly | QIODevice::Truncate) || ini.write(contents) != contents.size()) {
+            return nullptr;
+        }
+        ini.close();
+
+        auto& hostManager = mudlet::self()->getHostManager();
+        if (!hostManager.addHost(profileName, QString(), QString(), QString())) {
+            return nullptr;
+        }
+        return hostManager.getHost(profileName);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        // Keep the test hermetic: point the config dir resolution at a
+        // temporary directory instead of the user's real profiles.
+        QVERIFY(mConfigDir.isValid());
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        QCOMPARE(mudlet::getMudletPath(enums::mainPath), qsl("%1/mudlet").arg(mConfigDir.path()));
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>(qsl("MudletInstanceCoordinator")));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        previousMessageHandler = qInstallMessageHandler(countParseWarnings);
+    }
+
+    void cleanupTestCase()
+    {
+        qInstallMessageHandler(previousMessageHandler);
+        previousMessageHandler = nullptr;
+        if (mudlet::self()) {
+            delete mudlet::self();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // The finding itself: garbage in profile.ini, and the user is told about it.
+    void test_anUnparseableProfileIniIsReported()
+    {
+        const QString profileName = qsl("ProfileIniParseError-Bad");
+        parseWarnings = 0;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(qsl(R"(^Host::profileIni\(\) ERROR - the profile's "profile\.ini" file could not be parsed)")));
+
+        Host* pHost = hostWithProfileIni(profileName, unparseableIni());
+        QVERIFY2(pHost, "the profile with an unparseable profile.ini was not created");
+        pHost->writeProfileIniData(qsl("CommandLines/UsedIndexes"), qsl("1"));
+
+        QVERIFY2(parseWarnings == 1, "an unparseable profile.ini was accepted without a word");
+        // ...and what the warning promises: the settings it held are replaced
+        // rather than the write being dropped
+        QCOMPARE(pHost->readProfileIniData(qsl("CommandLines/UsedIndexes")), qsl("1"));
+
+        mudlet::self()->getHostManager().deleteHost(profileName);
+    }
+
+    // ...and a file that parses is not slandered, which is the state every
+    // profile that has never crashed is in.
+    void test_aWellFormedProfileIniIsNotReported()
+    {
+        const QString profileName = qsl("ProfileIniParseError-Good");
+        parseWarnings = 0;
+
+        Host* pHost = hostWithProfileIni(profileName, QByteArray("[CommandLines]\nUsedIndexes=3\n"));
+        QVERIFY2(pHost, "the profile with a well-formed profile.ini was not created");
+
+        QCOMPARE(pHost->readProfileIniData(qsl("CommandLines/UsedIndexes")), qsl("3"));
+        QVERIFY2(parseWarnings == 0, "a well-formed profile.ini was reported as unparseable");
+
+        mudlet::self()->getHostManager().deleteHost(profileName);
+    }
+
+    // A profile that has never stored anything has no profile.ini at all, and an
+    // absent file is not a broken one.
+    void test_anAbsentProfileIniIsNotReported()
+    {
+        const QString profileName = qsl("ProfileIniParseError-Absent");
+        parseWarnings = 0;
+
+        QVERIFY(QDir().mkpath(mudlet::getMudletPath(enums::profileHomePath, profileName)));
+        auto& hostManager = mudlet::self()->getHostManager();
+        QVERIFY(hostManager.addHost(profileName, QString(), QString(), QString()));
+        Host* pHost = hostManager.getHost(profileName);
+        QVERIFY(pHost);
+
+        QCOMPARE(pHost->readProfileIniData(qsl("CommandLines/UsedIndexes")), QString());
+        QVERIFY2(parseWarnings == 0, "a profile that has no profile.ini yet was reported as having an unparseable one");
+
+        hostManager.deleteHost(profileName);
+    }
+};
+
+#include "ProfileIniParseErrorTest.moc"
+MUDLET_GROUPED_TEST_MAIN(ProfileIniParseErrorTest)

--- a/test/functional_tests/ProfileIniParseErrorTest.cpp
+++ b/test/functional_tests/ProfileIniParseErrorTest.cpp
@@ -22,12 +22,6 @@
  * command lines' history settings and the notepad's window state, and all of it
  * is silently replaced when the parse fails.
  *
- * Host now keeps one QSettings open for the profile's lifetime instead of making
- * one per write, and the status check moved with it - but the constructor only
- * splits the file into sections, and each section is parsed on the first lookup
- * that needs it, so damage inside one still reads as NoError there and the
- * diagnostic could never fire for it.
- *
  * Run with: ctest -R ProfileIniParseErrorTest -V
  */
 
@@ -48,10 +42,8 @@
 
 #include "GroupedTest.h"
 
-// Counts the parse diagnostic so that the case for a well-formed file can say it
-// was not printed - QTest::ignoreMessage only ever asserts the other direction.
-// Matched on the function that emits it rather than on the words "could not be
-// parsed", which any other subsystem is free to say about anything.
+// QTest::ignoreMessage can only assert that a message was printed, so counting the
+// diagnostic is the only way to say it was not.
 static QtMessageHandler previousMessageHandler = nullptr;
 static int parseWarnings = 0;
 
@@ -73,18 +65,15 @@ private:
     QTemporaryDir mConfigDir;
     QByteArray mSavedXdg;
 
-    // Damage inside a section, which is where a crash or a full disk leaves it -
-    // and the only kind that gets this far, since QSettings splits the file into
-    // sections as it is constructed and so catches a broken section header there
+    // Damage inside a section: QSettings splits the file into sections as it is
+    // constructed, so a broken section header is caught there instead
     static QByteArray unparseableIni() { return QByteArrayLiteral("[CommandLines]\nUsedIndexes=1\nthis line was truncated mid-write\n"); }
 
     static QString iniPathFor(const QString& profileName) { return mudlet::getMudletPath(enums::profileDataItemPath, profileName, qsl("profile.ini")); }
 
-    // Whether QSettings really does refuse the fixture, which is what the whole case
-    // rests on. Asked of a copy at a path of its own, never of the fixture itself:
-    // QSettings keeps the sections it has parsed per file path and shares them between
-    // instances - and beyond the life of the one that parsed them - so probing the
-    // fixture would answer the question by consuming the parse the Host has to make.
+    // Probes a copy at a path of its own: QSettings keeps the sections it has parsed
+    // per file path and shares them between instances - and beyond the life of the one
+    // that parsed them - so probing the fixture would consume the parse the Host needs.
     static bool refusedByQSettings(const QString& path, const QString& copyPath)
     {
         if (!QFile::exists(copyPath) && !QFile::copy(path, copyPath)) {
@@ -95,9 +84,8 @@ private:
         return probe.status() == QSettings::FormatError;
     }
 
-    // The Host has to meet the file on its first use of it: profile.ini is
-    // opened once and kept, so anything written here afterwards would not be
-    // read again. A null 'contents' is a profile that has never written one.
+    // The file has to be in place before the Host first uses it: profile.ini is
+    // opened once and kept, so a later write here would not be read again
     Host* hostWithProfileIni(const QString& profileName, const QByteArray& contents)
     {
         const QString iniPath = iniPathFor(profileName);
@@ -153,7 +141,6 @@ private slots:
         mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
     }
 
-    // The finding itself: garbage in profile.ini, and the user is told about it.
     void test_anUnparseableProfileIniIsReported()
     {
         const QString profileName = qsl("ProfileIniParseError-Bad");
@@ -167,10 +154,9 @@ private slots:
         pHost->writeProfileIniData(qsl("CommandLines/UsedIndexes"), qsl("1"));
 
         QCOMPARE(parseWarnings, 1);
-        // ...and what the warning promises: the settings the file held are replaced
-        // rather than the write being dropped. Through the file rather than through
-        // readProfileIniData(), which answers from the very QSettings that has just
-        // cached the write and so would say "1" whatever became of the file.
+        // Read through the file rather than readProfileIniData(), which answers from
+        // the very QSettings that has just cached the write and so would say "1"
+        // whatever became of the file
         mudlet::self()->getHostManager().deleteHost(profileName); // the Host's QSettings writes itself out as it goes
         QFile written(iniPath);
         QVERIFY(written.open(QIODevice::ReadOnly | QIODevice::Text));
@@ -179,8 +165,6 @@ private slots:
         QVERIFY2(!contents.contains(qsl("truncated mid-write")), qPrintable(qsl("the damage was left in place rather than the file being replaced, which holds: %1").arg(contents)));
     }
 
-    // ...and a file that parses is not slandered, which is the state every
-    // profile that has never crashed is in.
     void test_aWellFormedProfileIniIsNotReported()
     {
         const QString profileName = qsl("ProfileIniParseError-Good");
@@ -195,8 +179,6 @@ private slots:
         mudlet::self()->getHostManager().deleteHost(profileName);
     }
 
-    // A profile that has never stored anything has no profile.ini at all, and an
-    // absent file is not a broken one.
     void test_anAbsentProfileIniIsNotReported()
     {
         const QString profileName = qsl("ProfileIniParseError-Absent");


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- An unparseable `profile.ini` (a crash or full disk can leave one) was no longer reported: `Host::profileIni()` checked `QSettings::status()` right after construction, but the constructor only splits the file into sections and each section is parsed on first lookup, so the `FormatError` branch was dead code. 5.0.1 reported it after every write.
- The whole file is now parsed with `allKeys()` before the check, so the warning fires once when the file is opened, naming the profile and the file; #10329's one-QSettings-per-Host, flushed-by-the-event-loop design is unchanged.
- `ProfileIniParseErrorTest` (PROFILE group) asserts the warning for a damaged file (validating the fixture on a copy, since QSettings caches parsed sections per path), that the damaged line is replaced on disk, and that a well-formed or absent profile.ini stays quiet.

#### Motivation for adding to Mudlet

Regression since 5.0.1 introduced by #10329 (QA finding F-43-3); related to #9826.

#### Other info (issues closed, discussion etc)

**Test case:** put a line without `=` inside a section of a profile's `profile.ini`, open the profile - stderr shows `Host::profileIni() ERROR - the "profile.ini" file of profile "..." (...) could not be parsed, the settings it held will be replaced.`

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_