### PR TITLE
Fix: A profile font the system resolves, like Helvetica, is used again

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1521,36 +1521,63 @@ static bool platformResolvesFontFamily(const QString& requested)
 
     // Seeded from a UUID rather than a fixed name so that no machine can have a
     // font by that name, which would make every unknown family look resolved.
+    // Measured once for the process: the answer must not drift between one font's
+    // resolution and the next's.
     static const QString unrecognisedName = QUuid::createUuid().toString();
     static const QString unrecognisedFamily = QFontInfo(QFont(unrecognisedName)).family();
 
     // Should a platform ever hand an unrecognised name back rather than name the
     // family it drew instead, it tells the two apart for nobody - so take nothing
     // on it that the font database does not list, and leave the fallback alone.
-    if (unrecognisedFamily.compare(unrecognisedName, Qt::CaseInsensitive) == 0) {
+    // Said once, because it silently turns this whole test off: without it, a
+    // report of "Mudlet keeps replacing my font" cannot be told from one where the
+    // font really is missing.
+    static const bool nameResolutionIsReadable = []() {
+        if (unrecognisedFamily.compare(unrecognisedName, Qt::CaseInsensitive) == 0) {
+            qWarning().nospace().noquote() << "Host: this platform hands an unrecognised font family name back unchanged instead of naming the family it drew "
+                                              "in its place, so a name it resolves for itself cannot be told from a font nobody has - every name the font "
+                                              "database does not list will be reported as missing.";
+            return false;
+        }
+
+        return true;
+    }();
+
+    if (!nameResolutionIsReadable) {
         return false;
     }
 
     return QFontInfo(QFont(requested)).family() != unrecognisedFamily;
 }
 
-Host::FontFamilyResolution Host::resolveFontFamily(const QString& requested) const
+// The family as the font database spells it, not as it was typed: that spelling is what
+// getFont() reports back and what the Geyser wrappers remember. Empty when the database
+// lists nothing by that name.
+static QString installedFamily(const QStringList& availableFonts, const QString& name)
 {
-    const QStringList availableFonts = mudlet::self()->getAvailableFonts();
-    // The family as the font database spells it, not as it was typed: it is what
-    // ends up reported back by getFont() and remembered by the Geyser wrappers.
     for (const QString& family : availableFonts) {
-        if (family.compare(requested, Qt::CaseInsensitive) == 0) {
-            return {family, QFont::Normal, true};
+        if (family.compare(name, Qt::CaseInsensitive) == 0) {
+            return family;
         }
     }
 
-    auto [baseName, weight] = parseFontNameAndStyle(requested);
-    if (baseName != requested) {
-        for (const QString& family : availableFonts) {
-            if (family.compare(baseName, Qt::CaseInsensitive) == 0) {
-                return {family, weight, true};
-            }
+    return QString();
+}
+
+Host::FontFamilyResolution Host::resolveFontFamily(const QString& requested) const
+{
+    const QStringList availableFonts = mudlet::self()->getAvailableFonts();
+
+    if (const QString installed = installedFamily(availableFonts, requested); !installed.isEmpty()) {
+        return {installed, QFont::Normal, true};
+    }
+
+    const auto [baseName, weight] = parseFontNameAndStyle(requested);
+    const bool carriesAStyleSuffix = baseName != requested;
+
+    if (carriesAStyleSuffix) {
+        if (const QString installed = installedFamily(availableFonts, baseName); !installed.isEmpty()) {
+            return {installed, weight, true};
         }
     }
 
@@ -1563,7 +1590,7 @@ Host::FontFamilyResolution Host::resolveFontFamily(const QString& requested) con
         return {requested, QFont::Normal, true};
     }
 
-    if (baseName != requested && platformResolvesFontFamily(baseName)) {
+    if (carriesAStyleSuffix && platformResolvesFontFamily(baseName)) {
         return {baseName, weight, true};
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -68,6 +68,7 @@
 #include <QDirIterator>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QFontInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -81,6 +82,7 @@
 #include <QTemporaryFile>
 #include <QTextStream>
 #include <QThread>
+#include <QUuid>
 #include <zip.h>
 #include <memory>
 
@@ -1501,6 +1503,37 @@ std::pair<QString, QFont::Weight> Host::parseFontNameAndStyle(const QString& fon
     return {fontName, QFont::Normal};
 }
 
+// Whether the platform makes a font of the name itself. The font database lists
+// the families that are installed, not the names a platform resolves on top of
+// them: fontconfig turns "Helvetica", "Times" or "monospace" into a real family
+// without any of those being an installed family, and Windows has a substitution
+// table of its own. Qt answers with one fixed stand-in for a name that means
+// nothing anywhere - the arbitrary substitution issue #4159 is about - so a name
+// that lands anywhere else is one the platform recognised. An alias that resolves
+// to that very stand-in ("sans-serif" on most GNU/Linux systems, which is also
+// what an unknown name falls to) cannot be told from an unknown name and is
+// treated as missing.
+static bool platformResolvesFontFamily(const QString& requested)
+{
+    if (requested.isEmpty()) {
+        return false;
+    }
+
+    // Seeded from a UUID rather than a fixed name so that no machine can have a
+    // font by that name, which would make every unknown family look resolved.
+    static const QString unrecognisedName = QUuid::createUuid().toString();
+    static const QString unrecognisedFamily = QFontInfo(QFont(unrecognisedName)).family();
+
+    // Should a platform ever hand an unrecognised name back rather than name the
+    // family it drew instead, it tells the two apart for nobody - so take nothing
+    // on it that the font database does not list, and leave the fallback alone.
+    if (unrecognisedFamily.compare(unrecognisedName, Qt::CaseInsensitive) == 0) {
+        return false;
+    }
+
+    return QFontInfo(QFont(requested)).family() != unrecognisedFamily;
+}
+
 Host::FontFamilyResolution Host::resolveFontFamily(const QString& requested) const
 {
     const QStringList availableFonts = mudlet::self()->getAvailableFonts();
@@ -1519,6 +1552,19 @@ Host::FontFamilyResolution Host::resolveFontFamily(const QString& requested) con
                 return {family, weight, true};
             }
         }
+    }
+
+    // An alias the platform resolves is not a missing font, and the name to go on
+    // using is the one that was asked for: it is the profile's own choice, it is
+    // what gets saved, and the platform makes a real family of it every time it is
+    // drawn - swapping in the family it currently resolves to would quietly turn
+    // this machine's idea of "Helvetica" into what the profile asks for everywhere.
+    if (platformResolvesFontFamily(requested)) {
+        return {requested, QFont::Normal, true};
+    }
+
+    if (baseName != requested && platformResolvesFontFamily(baseName)) {
+        return {baseName, weight, true};
     }
 
     return {requested, QFont::Normal, false};

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1508,30 +1508,24 @@ std::pair<QString, QFont::Weight> Host::parseFontNameAndStyle(const QString& fon
 // them: fontconfig turns "Helvetica", "Times" or "monospace" into a real family
 // without any of those being an installed family, and Windows has a substitution
 // table of its own. Qt answers with one fixed stand-in for a name that means
-// nothing anywhere - the arbitrary substitution issue #4159 is about - so a name
-// that lands anywhere else is one the platform recognised. An alias that resolves
-// to that very stand-in ("sans-serif" on most GNU/Linux systems, which is also
-// what an unknown name falls to) cannot be told from an unknown name and is
-// treated as missing.
+// nothing anywhere, so a name that lands anywhere else is one the platform
+// recognised - and an alias that resolves to that very stand-in ("sans-serif" on
+// most GNU/Linux systems) cannot be told from an unknown name, so it counts as
+// missing.
 static bool platformResolvesFontFamily(const QString& requested)
 {
     if (requested.isEmpty()) {
         return false;
     }
 
-    // Seeded from a UUID rather than a fixed name so that no machine can have a
-    // font by that name, which would make every unknown family look resolved.
-    // Measured once for the process: the answer must not drift between one font's
-    // resolution and the next's.
+    // A UUID rather than a fixed name, so that no machine can have a font by that
+    // name and make every unknown family look resolved
     static const QString unrecognisedName = QUuid::createUuid().toString();
     static const QString unrecognisedFamily = QFontInfo(QFont(unrecognisedName)).family();
 
-    // Should a platform ever hand an unrecognised name back rather than name the
-    // family it drew instead, it tells the two apart for nobody - so take nothing
-    // on it that the font database does not list, and leave the fallback alone.
-    // Said once, because it silently turns this whole test off: without it, a
-    // report of "Mudlet keeps replacing my font" cannot be told from one where the
-    // font really is missing.
+    // A platform that hands an unrecognised name back unchanged tells an alias and an
+    // unknown name apart for nobody, so nothing the font database does not list can be
+    // taken on it - said once, because it silently turns this whole check off
     static const bool nameResolutionIsReadable = []() {
         if (unrecognisedFamily.compare(unrecognisedName, Qt::CaseInsensitive) == 0) {
             qWarning().nospace().noquote() << "Host: this platform hands an unrecognised font family name back unchanged instead of naming the family it drew "
@@ -1551,8 +1545,7 @@ static bool platformResolvesFontFamily(const QString& requested)
 }
 
 // The family as the font database spells it, not as it was typed: that spelling is what
-// getFont() reports back and what the Geyser wrappers remember. Empty when the database
-// lists nothing by that name.
+// getFont() reports back and what the Geyser wrappers remember
 static QString installedFamily(const QStringList& availableFonts, const QString& name)
 {
     for (const QString& family : availableFonts) {
@@ -1581,11 +1574,9 @@ Host::FontFamilyResolution Host::resolveFontFamily(const QString& requested) con
         }
     }
 
-    // An alias the platform resolves is not a missing font, and the name to go on
-    // using is the one that was asked for: it is the profile's own choice, it is
-    // what gets saved, and the platform makes a real family of it every time it is
-    // drawn - swapping in the family it currently resolves to would quietly turn
-    // this machine's idea of "Helvetica" into what the profile asks for everywhere.
+    // Go on using the name that was asked for rather than the family it resolves to:
+    // the name is what gets saved, so pinning this machine's idea of "Helvetica" into
+    // the profile would carry it to every other machine the profile is opened on
     if (platformResolvesFontFamily(requested)) {
         return {requested, QFont::Normal, true};
     }

--- a/src/Host.h
+++ b/src/Host.h
@@ -430,16 +430,14 @@ public:
         QString family;       // family to actually use
         QFont::Weight weight; // the weight parsed off a "Family Style" name, but only where the
                               // base family is the one being used; QFont::Normal otherwise
-        bool available;       // false when neither the font database nor the platform's own name
-                              // resolution recognises the name - a name that resolves to the same
-                              // stand-in as an unknown one counts as missing
+        bool available;       // false when neither the font database nor the platform's own
+                              // name resolution recognises the name
     };
     // Maps a requested font name onto a font this machine can make of it: the name itself
     // when it is an installed family, else the base family when the name is a "Family Style"
-    // one such as "EB Garamond SemiBold" (with the style as the weight), else the name as
-    // given when the platform resolves it for itself the way fontconfig resolves "Helvetica",
-    // else the base family when the platform resolves that (again with the style as the
-    // weight), else {requested, Normal, false}.
+    // one such as "EB Garamond SemiBold" (with the style as the weight), else either of
+    // those when the platform resolves it for itself the way fontconfig resolves
+    // "Helvetica", else {requested, Normal, false}.
     FontFamilyResolution resolveFontFamily(const QString& requested) const;
     // A profile can name a font that is not installed on this machine; Qt would then
     // silently draw the console in an arbitrary substitute, so switch to the bundled

--- a/src/Host.h
+++ b/src/Host.h
@@ -429,11 +429,13 @@ public:
     {
         QString family;       // family to actually use
         QFont::Weight weight; // weight parsed from a "Family Style" name, QFont::Normal otherwise
-        bool available;       // false when neither the name nor a style-stripped base family is installed
+        bool available;       // false when nothing on this machine makes a font of the name
     };
-    // Maps a requested font name onto an installed family: the name itself when it is
-    // installed, else the base family when the name is a "Family Style" one such as
-    // "EB Garamond SemiBold" (with the style as the weight), else {requested, Normal, false}.
+    // Maps a requested font name onto a font this machine can make of it: the name
+    // itself when it is an installed family, else the base family when the name is a
+    // "Family Style" one such as "EB Garamond SemiBold" (with the style as the weight),
+    // else the name as given when the platform resolves it for itself the way fontconfig
+    // resolves "Helvetica", else {requested, Normal, false}.
     FontFamilyResolution resolveFontFamily(const QString& requested) const;
     // A profile can name a font that is not installed on this machine; Qt would then
     // silently draw the console in an arbitrary substitute, so switch to the bundled

--- a/src/Host.h
+++ b/src/Host.h
@@ -428,14 +428,18 @@ public:
     struct FontFamilyResolution
     {
         QString family;       // family to actually use
-        QFont::Weight weight; // weight parsed from a "Family Style" name, QFont::Normal otherwise
-        bool available;       // false when nothing on this machine makes a font of the name
+        QFont::Weight weight; // the weight parsed off a "Family Style" name, but only where the
+                              // base family is the one being used; QFont::Normal otherwise
+        bool available;       // false when neither the font database nor the platform's own name
+                              // resolution recognises the name - a name that resolves to the same
+                              // stand-in as an unknown one counts as missing
     };
-    // Maps a requested font name onto a font this machine can make of it: the name
-    // itself when it is an installed family, else the base family when the name is a
-    // "Family Style" one such as "EB Garamond SemiBold" (with the style as the weight),
-    // else the name as given when the platform resolves it for itself the way fontconfig
-    // resolves "Helvetica", else {requested, Normal, false}.
+    // Maps a requested font name onto a font this machine can make of it: the name itself
+    // when it is an installed family, else the base family when the name is a "Family Style"
+    // one such as "EB Garamond SemiBold" (with the style as the weight), else the name as
+    // given when the platform resolves it for itself the way fontconfig resolves "Helvetica",
+    // else the base family when the platform resolves that (again with the style as the
+    // weight), else {requested, Normal, false}.
     FontFamilyResolution resolveFontFamily(const QString& requested) const;
     // A profile can name a font that is not installed on this machine; Qt would then
     // silently draw the console in an arbitrary substitute, so switch to the bundled

--- a/test/functional_tests/MissingDisplayFontTest.cpp
+++ b/test/functional_tests/MissingDisplayFontTest.cpp
@@ -83,10 +83,10 @@ private:
     // comes from: unlike a family Mudlet bundles, taking the package away really
     // does take this one off the machine.
     const QString mPackageSuppliedFamily = qsl("Zqxwvu Package Font Mono");
-    // Stands for a name no font database lists but the platform resolves anyway -
-    // a fontconfig alias such as "Helvetica" on GNU/Linux or FreeBSD. Which names
-    // those are is up to the machine, so the cases make one of their own out of
-    // Qt's substitution table instead, which every platform consults.
+    // Stands for a name no font database lists but the platform resolves anyway, like
+    // the fontconfig alias "Helvetica". Which names those are is up to the machine, so
+    // the cases make one of their own out of Qt's substitution table, which every
+    // platform consults.
     const QString mAliasFamily = qsl("Zqxwvu Alias Font Mono");
     QTemporaryDir mConfigDir;
     QTemporaryDir mSaveDir;
@@ -293,17 +293,12 @@ private:
         return contents.mid(from, end - from).section(QChar::fromLatin1(','), 0, 0);
     }
 
-    // Makes mAliasFamily into a name this machine resolves for itself, standing in for
-    // a fontconfig alias, and hands back the family it was pointed at - or an empty
-    // string on a platform that cannot show the difference at all.
-    //
-    // The family it is pointed at is one of the two this test registers itself, and
-    // never the one this machine falls back to for a name nothing knows: those two
-    // would be indistinguishable, which is the one thing the cases below have to be
-    // able to tell apart. On a minimal machine the stand-in can perfectly well be the
-    // bundled default, so which of the two is used has to be decided here rather than
-    // fixed - otherwise both cases skip on exactly the installations where the font
-    // they cover matters most.
+    // Makes mAliasFamily into a name this machine resolves for itself, and hands back the
+    // family it was pointed at - empty on a platform that cannot show the difference at all.
+    // That family is never this machine's own stand-in for a name nothing knows, which the
+    // cases below have to be able to tell a resolved alias apart from; since the stand-in
+    // can itself be the bundled default, which of the two families this test registers is
+    // used has to be decided here rather than fixed.
     QString stageAliasFamily()
     {
         // Asked afresh of a name nothing can have, so that what comes back is this
@@ -401,10 +396,9 @@ private slots:
         QCOMPARE(resolved.weight, QFont::Bold);
     }
 
-    // The font database lists installed families, not the names a platform
-    // resolves on top of them - fontconfig turns "Helvetica" and "monospace" into
-    // real families without either being a listed family - so deciding "missing"
-    // by that list alone calls a font the machine perfectly well draws missing.
+    // The font database lists installed families, not the names a platform resolves on
+    // top of them, so deciding "missing" by that list alone calls a font the machine
+    // draws perfectly well missing.
     void test_resolveAcceptsANameThePlatformResolvesForItself()
     {
         QVERIFY2(!mpHost->resolveFontFamily(mAliasFamily).available, "the alias name is resolvable before anything resolves it, so this case proves nothing");
@@ -412,20 +406,16 @@ private slots:
         if (standingInFor.isEmpty()) {
             QSKIP("this platform hands an unrecognised font name back unchanged instead of naming the family it drew in its place, so no name it resolves can be told from one nothing knows");
         }
-        // A failure of the case's own tool rather than of the machine it runs on, so
-        // it is reported as one: Qt consults the substitution table on every platform.
+        // Qt consults the substitution table on every platform, so a failure here is the
+        // case's own tool rather than the machine it runs on
         QCOMPARE(QFontInfo(QFont(mAliasFamily)).family(), standingInFor);
 
         const auto resolved = mpHost->resolveFontFamily(mAliasFamily);
         QVERIFY2(resolved.available, "a name the platform resolves was reported as an uninstalled font");
-        // the name the profile asked for, not the family it happens to resolve to
-        // here: that is what gets saved, and it resolves afresh on every machine
         QCOMPARE(resolved.family, mAliasFamily);
         QCOMPARE(resolved.weight, QFont::Normal);
     }
 
-    // ...and the display font is then left alone, rather than being stood in for
-    // and reported to the player as a font they do not have.
     void test_aDisplayFontThePlatformResolvesIsNotStoodInFor()
     {
         const QString standingInFor = stageAliasFamily();

--- a/test/functional_tests/MissingDisplayFontTest.cpp
+++ b/test/functional_tests/MissingDisplayFontTest.cpp
@@ -47,6 +47,7 @@
 
 #include <QFont>
 #include <QFontDatabase>
+#include <QFontInfo>
 #include <QTemporaryDir>
 #include <zip.h>
 
@@ -81,6 +82,11 @@ private:
     // comes from: unlike a family Mudlet bundles, taking the package away really
     // does take this one off the machine.
     const QString mPackageSuppliedFamily = qsl("Zqxwvu Package Font Mono");
+    // Stands for a name no font database lists but the platform resolves anyway -
+    // a fontconfig alias such as "Helvetica" on GNU/Linux or FreeBSD. Which names
+    // those are is up to the machine, so the cases make one of their own out of
+    // Qt's substitution table instead, which every platform consults.
+    const QString mAliasFamily = qsl("Zqxwvu Alias Font Mono");
     QTemporaryDir mConfigDir;
     QTemporaryDir mSaveDir;
     QTemporaryDir mArchiveDir;
@@ -286,6 +292,22 @@ private:
         return contents.mid(from, end - from).section(QChar::fromLatin1(','), 0, 0);
     }
 
+    // Makes mAliasFamily into a name this machine resolves for itself, standing in
+    // for a fontconfig alias, and hands back whether that is something the case can
+    // still tell from a name nothing knows - it is not on a machine whose stand-in
+    // for an unknown family is the very family the alias is pointed at.
+    bool stageAliasFamily()
+    {
+        const QString beforeStaging = QFontInfo(QFont(mAliasFamily)).family();
+        // ...nor on one that hands an unrecognised name straight back instead of
+        // naming the family it drew in its place
+        if (beforeStaging == mAliasFamily || beforeStaging == Host::scmDefaultFontFamily) {
+            return false;
+        }
+        QFont::insertSubstitution(mAliasFamily, Host::scmDefaultFontFamily);
+        return QFontInfo(QFont(mAliasFamily)).family() == Host::scmDefaultFontFamily;
+    }
+
 private slots:
     void initTestCase()
     {
@@ -332,6 +354,7 @@ private slots:
         // Cases share one Host: a stand-in left behind by one case must not
         // leak into the next, and only a user-choice change retires it now
         mpHost->setDisplayFont(mpHost->getDisplayFont(), Host::DisplayFontChange::UserChoice);
+        QFont::removeSubstitutions(mAliasFamily);
         unregisterBundledFonts();
     }
 
@@ -364,6 +387,41 @@ private slots:
         QVERIFY(resolved.available);
         QCOMPARE(resolved.family, Host::scmDefaultFontFamily);
         QCOMPARE(resolved.weight, QFont::Bold);
+    }
+
+    // The font database lists installed families, not the names a platform
+    // resolves on top of them - fontconfig turns "Helvetica" and "monospace" into
+    // real families without either being a listed family - so deciding "missing"
+    // by that list alone calls a font the machine perfectly well draws missing.
+    void test_resolveAcceptsANameThePlatformResolvesForItself()
+    {
+        QVERIFY2(!mpHost->resolveFontFamily(mAliasFamily).available, "the alias name is resolvable before anything resolves it, so this case proves nothing");
+        if (!stageAliasFamily()) {
+            QSKIP("this machine hands back the same family for an unknown name as for the staged alias, so the two cannot be told apart");
+        }
+
+        const auto resolved = mpHost->resolveFontFamily(mAliasFamily);
+        QVERIFY2(resolved.available, "a name the platform resolves was reported as an uninstalled font");
+        // the name the profile asked for, not the family it happens to resolve to
+        // here: that is what gets saved, and it resolves afresh on every machine
+        QCOMPARE(resolved.family, mAliasFamily);
+        QCOMPARE(resolved.weight, QFont::Normal);
+    }
+
+    // ...and the display font is then left alone, rather than being stood in for
+    // and reported to the player as a font they do not have.
+    void test_aDisplayFontThePlatformResolvesIsNotStoodInFor()
+    {
+        if (!stageAliasFamily()) {
+            QSKIP("this machine hands back the same family for an unknown name as for the staged alias, so the two cannot be told apart");
+        }
+
+        QVERIFY(mpHost->setDisplayFont(QFont(mAliasFamily, 13, QFont::Normal)).first);
+
+        QVERIFY2(!mpHost->substituteMissingDisplayFont(), "a name the platform resolves was stood in for");
+        QCOMPARE(mpHost->getDisplayFont().family(), mAliasFamily);
+        QCOMPARE(mpHost->getDisplayFont().pointSize(), 13);
+        QCOMPARE(mpHost->getDisplayFontForSaving().family(), mAliasFamily);
     }
 
     void test_installedDisplayFontIsLeftAlone()

--- a/test/functional_tests/MissingDisplayFontTest.cpp
+++ b/test/functional_tests/MissingDisplayFontTest.cpp
@@ -49,6 +49,7 @@
 #include <QFontDatabase>
 #include <QFontInfo>
 #include <QTemporaryDir>
+#include <QUuid>
 #include <zip.h>
 
 #include "Host.h"
@@ -292,20 +293,31 @@ private:
         return contents.mid(from, end - from).section(QChar::fromLatin1(','), 0, 0);
     }
 
-    // Makes mAliasFamily into a name this machine resolves for itself, standing in
-    // for a fontconfig alias, and hands back whether that is something the case can
-    // still tell from a name nothing knows - it is not on a machine whose stand-in
-    // for an unknown family is the very family the alias is pointed at.
-    bool stageAliasFamily()
+    // Makes mAliasFamily into a name this machine resolves for itself, standing in for
+    // a fontconfig alias, and hands back the family it was pointed at - or an empty
+    // string on a platform that cannot show the difference at all.
+    //
+    // The family it is pointed at is one of the two this test registers itself, and
+    // never the one this machine falls back to for a name nothing knows: those two
+    // would be indistinguishable, which is the one thing the cases below have to be
+    // able to tell apart. On a minimal machine the stand-in can perfectly well be the
+    // bundled default, so which of the two is used has to be decided here rather than
+    // fixed - otherwise both cases skip on exactly the installations where the font
+    // they cover matters most.
+    QString stageAliasFamily()
     {
-        const QString beforeStaging = QFontInfo(QFont(mAliasFamily)).family();
-        // ...nor on one that hands an unrecognised name straight back instead of
-        // naming the family it drew in its place
-        if (beforeStaging == mAliasFamily || beforeStaging == Host::scmDefaultFontFamily) {
-            return false;
+        // Asked afresh of a name nothing can have, so that what comes back is this
+        // machine's stand-in for an unknown family rather than a font it really has
+        const QString unknownName = QUuid::createUuid().toString();
+        const QString standIn = QFontInfo(QFont(unknownName)).family();
+
+        if (standIn == unknownName) {
+            return QString();
         }
-        QFont::insertSubstitution(mAliasFamily, Host::scmDefaultFontFamily);
-        return QFontInfo(QFont(mAliasFamily)).family() == Host::scmDefaultFontFamily;
+
+        const QString target = (standIn == Host::scmDefaultFontFamily) ? mOtherBundledFamily : Host::scmDefaultFontFamily;
+        QFont::insertSubstitution(mAliasFamily, target);
+        return target;
     }
 
 private slots:
@@ -396,9 +408,13 @@ private slots:
     void test_resolveAcceptsANameThePlatformResolvesForItself()
     {
         QVERIFY2(!mpHost->resolveFontFamily(mAliasFamily).available, "the alias name is resolvable before anything resolves it, so this case proves nothing");
-        if (!stageAliasFamily()) {
-            QSKIP("this machine hands back the same family for an unknown name as for the staged alias, so the two cannot be told apart");
+        const QString standingInFor = stageAliasFamily();
+        if (standingInFor.isEmpty()) {
+            QSKIP("this platform hands an unrecognised font name back unchanged instead of naming the family it drew in its place, so no name it resolves can be told from one nothing knows");
         }
+        // A failure of the case's own tool rather than of the machine it runs on, so
+        // it is reported as one: Qt consults the substitution table on every platform.
+        QCOMPARE(QFontInfo(QFont(mAliasFamily)).family(), standingInFor);
 
         const auto resolved = mpHost->resolveFontFamily(mAliasFamily);
         QVERIFY2(resolved.available, "a name the platform resolves was reported as an uninstalled font");
@@ -412,9 +428,11 @@ private slots:
     // and reported to the player as a font they do not have.
     void test_aDisplayFontThePlatformResolvesIsNotStoodInFor()
     {
-        if (!stageAliasFamily()) {
-            QSKIP("this machine hands back the same family for an unknown name as for the staged alias, so the two cannot be told apart");
+        const QString standingInFor = stageAliasFamily();
+        if (standingInFor.isEmpty()) {
+            QSKIP("this platform hands an unrecognised font name back unchanged instead of naming the family it drew in its place, so no name it resolves can be told from one nothing knows");
         }
+        QCOMPARE(QFontInfo(QFont(mAliasFamily)).family(), standingInFor);
 
         QVERIFY(mpHost->setDisplayFont(QFont(mAliasFamily, 13, QFont::Normal)).first);
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- A profile whose display font is a fontconfig alias (Helvetica, Nimbus Sans, Times, Courier) opened in Bitstream Vera Sans Mono with a "The font ... is not installed on this computer" warning, and `setFont()` refused the same names; 5.0.1 drew what the platform resolves them to.
- `Host::resolveFontFamily()` decided "installed" purely by membership in `QFontDatabase::families()`, which lists installed families, not the names fontconfig resolves on top of them. It now also asks the platform: a name is accepted when `QFontInfo` resolves it to something other than the family Qt hands back for a name nothing could have installed, so genuinely missing fonts still fall back to the default with the warning (#10134's purpose, issue #4159). The requested name is what goes on being used and saved.
- Every caller of the shared resolver benefits (display font, `setFont`, `setTextEditFont`, Geyser wrappers), which is also what #10206 asks for. `MissingDisplayFontTest` gains two cases staged through Qt's own substitution table, which run rather than skip on a minimal installation, plus a one-time diagnostic when a platform cannot show the difference at all.

#### Motivation for adding to Mudlet

Regression since 5.0.1 introduced by #10134 on Linux and FreeBSD (QA finding F-16-1); the user could not silence the warning (#10204).

#### Other info (issues closed, discussion etc)

A generic alias that resolves to the very family an unknown name falls to ("sans-serif" on most systems) still cannot be told apart and is treated as missing. Windows' font mapper was not testable here; the mechanism is cross-platform and self-checks.

**Test case:** on Linux with fontconfig, a profile with `<mDisplayFont>Helvetica,13,...` opens with `getFont("main")` reporting the resolved family (e.g. Nimbus Sans) and no warning; `setFont("main", "Total Nonsense Family")` still fails.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_