### PR TITLE
Fix: An older Mudlet still finds the saved password of a long profile name

### DIFF
--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -23,6 +23,7 @@
 #include "utils.h"
 
 #include <QCoreApplication>
+#include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -79,6 +80,62 @@ QString legacyPathComponent(const QString& input)
     QString sanitized = input;
     sanitized.replace(unsafeChars, qsl("_"));
     return sanitized.left(scmLegacyMaxPathComponentLength);
+}
+
+// Whether the first file exists and was written after the second. This is what decides
+// between the two copies a long profile name can have: a Mudlet that predates the
+// digest-bearing name writes only the legacy one, so whichever copy was written last holds
+// the password the user set last.
+bool fileWrittenAfter(const QString& path, const QString& otherPath)
+{
+    const QFileInfo info(path);
+
+    if (!info.exists()) {
+        return false;
+    }
+
+    const QFileInfo otherInfo(otherPath);
+    return !otherInfo.exists() || info.lastModified() > otherInfo.lastModified();
+}
+
+// Encrypts a credential with the profile's own key and writes it to one path, creating the
+// directory structure if it is not there. Shared by the two files a long profile name can
+// have: the one under the current naming, and the one the earlier naming scheme left.
+bool writeCredentialFile(const QString& filePath, const QString& profileName, const QString& credential)
+{
+    const QFileInfo fileInfo(filePath);
+    QDir dir = fileInfo.absoluteDir();
+
+    if (!dir.mkpath(dir.absolutePath())) {
+        qWarning() << "CredentialManager: Failed to create directory structure for" << filePath;
+        return false;
+    }
+
+    // Encrypt credential using profile-specific key (empty credentials are allowed)
+    const QString encrypted = SecureStringUtils::encryptStringForProfile(credential, profileName);
+
+    if (encrypted.isEmpty() && !credential.isEmpty()) {
+        qWarning() << "CredentialManager: Failed to encrypt credential for profile" << profileName;
+        return false;
+    }
+
+    QFile file(filePath);
+
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "CredentialManager: Failed to open file for writing:" << filePath << "Error:" << file.errorString();
+        return false;
+    }
+
+    const qint64 bytesWritten = file.write(encrypted.toUtf8());
+    file.close();
+
+    // Verify write operation succeeded
+    if (bytesWritten == -1) {
+        qWarning() << "CredentialManager: Failed to write encrypted credential to file:" << filePath;
+        return false;
+    }
+
+    return true;
 }
 } // namespace
 
@@ -1255,41 +1312,11 @@ bool CredentialManager::storeCredentialToFile(const QString& profileName, const 
         return false;
     }
 
-    // Create directory structure if it doesn't exist
-    QFileInfo fileInfo(filePath);
-    QDir dir = fileInfo.absoluteDir();
+    // Refreshed before the file under the current naming rather than after it, so that the
+    // current one stays the more recently written of the two and a later read keeps taking it
+    refreshLegacyFileCredential(profileName, key, credential);
 
-    if (!dir.mkpath(dir.absolutePath())) {
-        qWarning() << "CredentialManager: Failed to create directory structure for" << filePath;
-        return false;
-    }
-
-    // Encrypt credential using profile-specific key (empty credentials are allowed)
-    QString encrypted = SecureStringUtils::encryptStringForProfile(credential, profileName);
-
-    if (encrypted.isEmpty() && !credential.isEmpty()) {
-        qWarning() << "CredentialManager: Failed to encrypt credential for profile" << profileName;
-        return false;
-    }
-
-    // Write to file
-    QFile file(filePath);
-
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "CredentialManager: Failed to open file for writing:" << filePath << "Error:" << file.errorString();
-        return false;
-    }
-
-    qint64 bytesWritten = file.write(encrypted.toUtf8());
-    file.close();
-
-    // Verify write operation succeeded
-    if (bytesWritten == -1) {
-        qWarning() << "CredentialManager: Failed to write encrypted credential to file:" << filePath;
-        return false;
-    }
-
-    return true;
+    return writeCredentialFile(filePath, profileName, credential);
 }
 
 QString CredentialManager::retrieveCredentialFromFile(const QString& profileName, const QString& key)
@@ -1302,24 +1329,32 @@ QString CredentialManager::retrieveCredentialFromFile(const QString& profileName
         return QString();
     }
 
+    // A Mudlet that predates the digest-bearing name reads and writes only the truncated
+    // path, so a copy there that is newer than this one's - or a credential this naming
+    // scheme has never been given at all - is the password that was saved last
+    const QString legacyPath = generateLegacyFilePath(profileName, key);
+
+    if (!legacyPath.isEmpty() && fileWrittenAfter(legacyPath, filePath)) {
+        const QString migrated = readLegacyFileCredential(profileName, key);
+
+        if (!migrated.isEmpty()) {
+            // Copied across, not moved: the file the earlier naming scheme left is where an
+            // older Mudlet sharing this configuration directory looks, and it is the only
+            // place it looks, so taking it away would lose that Mudlet the password
+            writeCredentialFile(filePath, profileName, migrated);
+            return migrated;
+        }
+    }
+
     QFile file(filePath);
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         // Only log warning if file should exist (not for first-time access)
         if (file.exists()) {
             qWarning() << "CredentialManager: Failed to open existing file for reading:" << filePath << "Error:" << file.errorString();
-            return QString();
         }
 
-        // Nothing under the current naming, so a credential written while long names
-        // were truncated is moved across on the first read that misses it
-        const QString migrated = readLegacyFileCredential(profileName, key);
-
-        if (!migrated.isEmpty() && storeCredentialToFile(profileName, key, migrated)) {
-            removeLegacyFileCredential(profileName, key);
-        }
-
-        return migrated;
+        return QString();
     }
 
     QString encrypted = QString::fromUtf8(file.readAll());
@@ -1517,6 +1552,24 @@ void CredentialManager::removeLegacyFileCredential(const QString& profileName, c
     if (!QFile::remove(legacyPath)) {
         qWarning() << "CredentialManager: Failed to remove credential file left by the earlier naming scheme:" << legacyPath;
     }
+}
+
+// Keeps a credential file left by the earlier naming scheme in step with the one under the
+// current naming, so a Mudlet old enough to read only that one does not hand the user back a
+// password they have since changed. Only a file that already holds this profile's own
+// credential is refreshed - creating one would put two profiles whose names share their first
+// 50 characters back on a single file, which is what the digest-bearing name exists to prevent.
+void CredentialManager::refreshLegacyFileCredential(const QString& profileName, const QString& key, const QString& credential)
+{
+    QString existing = readLegacyFileCredential(profileName, key);
+    const bool ours = !existing.isEmpty();
+    SecureStringUtils::secureStringClear(existing);
+
+    if (!ours) {
+        return;
+    }
+
+    writeCredentialFile(generateLegacyFilePath(profileName, key), profileName, credential);
 }
 
 bool CredentialManager::isValidKeyName(const QString& key)

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -82,13 +82,11 @@ QString legacyPathComponent(const QString& input)
     return sanitized.left(scmLegacyMaxPathComponentLength);
 }
 
-// Whether the first file exists and was written after the second - or the second is not
-// there at all, which is how a credential that has only ever been filed under the truncated
-// path is picked up. This is what decides between the two copies a long profile name can
-// have: a Mudlet that predates the digest-bearing name writes only the legacy one, so
-// whichever copy was written last holds the password the user set last. Two writes a
-// filesystem cannot tell apart - one that records whole seconds, as FAT and some network
-// mounts do - count as "not after", leaving the copy under the current naming in charge.
+// Decides between the two copies a long profile name can have: a Mudlet that predates the
+// digest-bearing name writes only the legacy one, so whichever copy was written last holds
+// the password the user set last. Timestamps a filesystem cannot tell apart - one that
+// records whole seconds, as FAT and some network mounts do - count as "not after", leaving
+// the copy under the current naming in charge.
 bool fileWrittenAfter(const QString& path, const QString& otherPath)
 {
     const QFileInfo info(path);
@@ -97,8 +95,6 @@ bool fileWrittenAfter(const QString& path, const QString& otherPath)
     return info.exists() && (!otherInfo.exists() || info.lastModified() > otherInfo.lastModified());
 }
 
-// Shared by the two files a long profile name can have: the one under the current naming,
-// and the one the earlier naming scheme left.
 bool writeCredentialFile(const QString& filePath, const QString& profileName, const QString& credential)
 {
     if (!QDir().mkpath(QFileInfo(filePath).absolutePath())) {
@@ -116,11 +112,9 @@ bool writeCredentialFile(const QString& filePath, const QString& profileName, co
 
     const QByteArray payload = encrypted.toUtf8();
     // QSaveFile rather than QFile: opening a QFile for writing empties the file that is
-    // already there before a byte of the new credential is written, and a payload this
-    // small only leaves QFile's write buffer inside close(), which returns void - so a
-    // disk that fills up in between leaves an empty file where the password was, and the
-    // write is reported as having succeeded. Neither is survivable for the legacy copy,
-    // which is the only one an older Mudlet can read.
+    // already there before a byte of the new credential is written, and a payload this small
+    // only leaves QFile's write buffer inside close(), which returns void - so a disk that
+    // fills up in between leaves an empty file where the password was and reports success.
     QSaveFile file(filePath);
 
     if (!file.open(QIODevice::WriteOnly)) {
@@ -1329,17 +1323,15 @@ QString CredentialManager::retrieveCredentialFromFile(const QString& profileName
     }
 
     // A Mudlet that predates the digest-bearing name reads and writes only the truncated
-    // path, so a copy there that is newer than this one's - or a credential this naming
-    // scheme has never been given at all - is the password that was saved last
+    // path, so a copy there that is newer than this one's is the password saved last
     const QString legacyPath = generateLegacyFilePath(profileName, key);
 
     if (!legacyPath.isEmpty() && fileWrittenAfter(legacyPath, filePath)) {
         const QString migrated = readLegacyFileCredential(profileName, key);
 
         if (!migrated.isEmpty()) {
-            // Copied across, not moved: the file the earlier naming scheme left is where an
-            // older Mudlet sharing this configuration directory looks, and it is the only
-            // place it looks, so taking it away would lose that Mudlet the password
+            // Copied across, not moved: that file is the only place an older Mudlet sharing
+            // this configuration directory looks, so taking it away would lose it the password
             if (!writeCredentialFile(filePath, profileName, migrated)) {
                 qWarning() << "CredentialManager: could not copy the newer credential at" << legacyPath << "across to" << filePath << "- it will be read from the older path again next time";
             }
@@ -1347,10 +1339,8 @@ QString CredentialManager::retrieveCredentialFromFile(const QString& profileName
             return migrated;
         }
 
-        // The newer of the two files holds nothing for this profile - a colliding
-        // profile's credential, or a damaged one. Where this profile has a copy of its
-        // own, that copy is the older one, and handing an older password back without a
-        // word is the very thing this ordering exists to stop.
+        // Nothing this profile can decrypt: a colliding profile's credential, or a damaged
+        // one. Its own copy, where it has one, is then the older of the two
         if (QFile::exists(filePath)) {
             qWarning() << "CredentialManager: the credential file" << legacyPath << "is newer than" << filePath << "but holds nothing profile" << profileName
                        << "can decrypt - the older copy is being used instead";
@@ -1545,8 +1535,7 @@ QString CredentialManager::readLegacyFileCredential(const QString& profileName, 
     return SecureStringUtils::decryptStringForProfile(encrypted, profileName);
 }
 
-// The legacy path when the file there holds this profile's own credential, and an empty
-// string otherwise. Whose credential it is is the only thing that tells this profile's file
+// Whose credential the legacy file holds is the only thing that tells this profile's file
 // apart from one a profile it used to collide with left, so refreshing that file and
 // removing it both have to ask first.
 QString CredentialManager::ourLegacyFilePath(const QString& profileName, const QString& key)
@@ -1573,8 +1562,8 @@ void CredentialManager::removeLegacyFileCredential(const QString& profileName, c
 // Keeps a credential file left by the earlier naming scheme in step with the one under the
 // current naming, so a Mudlet old enough to read only that one does not hand the user back a
 // password they have since changed. Only a file that already holds this profile's own
-// credential is refreshed - creating one would put two profiles whose names share their first
-// 50 characters back on a single file, which is what the digest-bearing name exists to prevent.
+// credential is refreshed: creating one would put two profiles whose names share their first
+// 50 characters on a single file.
 void CredentialManager::refreshLegacyFileCredential(const QString& profileName, const QString& key, const QString& credential)
 {
     const QString legacyPath = ourLegacyFilePath(profileName, key);
@@ -1583,10 +1572,8 @@ void CredentialManager::refreshLegacyFileCredential(const QString& profileName, 
         return;
     }
 
-    // An empty credential stands for "no password", not for a password that happens to be
-    // empty: writing one would leave a file this profile can no longer prove is its own, and
-    // so could never refresh or remove again - and an older Mudlet reading it would find
-    // nothing but a complaint in its log.
+    // An empty credential stands for "no password": writing one would leave a file this
+    // profile can no longer prove is its own, and so could never refresh or remove again
     if (credential.isEmpty()) {
         if (!QFile::remove(legacyPath)) {
             qWarning() << "CredentialManager: Failed to remove credential file left by the earlier naming scheme:" << legacyPath;

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -1305,11 +1305,18 @@ bool CredentialManager::storeCredentialToFile(const QString& profileName, const 
         return false;
     }
 
-    // Refreshed before the file under the current naming rather than after it, so that the
-    // current one stays the more recently written of the two and a later read keeps taking it
+    if (!writeCredentialFile(filePath, profileName, credential)) {
+        return false;
+    }
+
+    // Only once the file under the current naming is committed: the two sit in directories
+    // of their own, so this one can be written where that one cannot, and a store that
+    // reports failure must not leave the two Mudlets holding different passwords. Writing it
+    // last can leave it the newer of the two, which the next read settles by taking it and
+    // copying it across once.
     refreshLegacyFileCredential(profileName, key, credential);
 
-    return writeCredentialFile(filePath, profileName, credential);
+    return true;
 }
 
 QString CredentialManager::retrieveCredentialFromFile(const QString& profileName, const QString& key)

--- a/src/CredentialManager.cpp
+++ b/src/CredentialManager.cpp
@@ -82,36 +82,31 @@ QString legacyPathComponent(const QString& input)
     return sanitized.left(scmLegacyMaxPathComponentLength);
 }
 
-// Whether the first file exists and was written after the second. This is what decides
-// between the two copies a long profile name can have: a Mudlet that predates the
-// digest-bearing name writes only the legacy one, so whichever copy was written last holds
-// the password the user set last.
+// Whether the first file exists and was written after the second - or the second is not
+// there at all, which is how a credential that has only ever been filed under the truncated
+// path is picked up. This is what decides between the two copies a long profile name can
+// have: a Mudlet that predates the digest-bearing name writes only the legacy one, so
+// whichever copy was written last holds the password the user set last. Two writes a
+// filesystem cannot tell apart - one that records whole seconds, as FAT and some network
+// mounts do - count as "not after", leaving the copy under the current naming in charge.
 bool fileWrittenAfter(const QString& path, const QString& otherPath)
 {
     const QFileInfo info(path);
-
-    if (!info.exists()) {
-        return false;
-    }
-
     const QFileInfo otherInfo(otherPath);
-    return !otherInfo.exists() || info.lastModified() > otherInfo.lastModified();
+
+    return info.exists() && (!otherInfo.exists() || info.lastModified() > otherInfo.lastModified());
 }
 
-// Encrypts a credential with the profile's own key and writes it to one path, creating the
-// directory structure if it is not there. Shared by the two files a long profile name can
-// have: the one under the current naming, and the one the earlier naming scheme left.
+// Shared by the two files a long profile name can have: the one under the current naming,
+// and the one the earlier naming scheme left.
 bool writeCredentialFile(const QString& filePath, const QString& profileName, const QString& credential)
 {
-    const QFileInfo fileInfo(filePath);
-    QDir dir = fileInfo.absoluteDir();
-
-    if (!dir.mkpath(dir.absolutePath())) {
+    if (!QDir().mkpath(QFileInfo(filePath).absolutePath())) {
         qWarning() << "CredentialManager: Failed to create directory structure for" << filePath;
         return false;
     }
 
-    // Encrypt credential using profile-specific key (empty credentials are allowed)
+    // an empty credential is allowed - it stands for "no password"
     const QString encrypted = SecureStringUtils::encryptStringForProfile(credential, profileName);
 
     if (encrypted.isEmpty() && !credential.isEmpty()) {
@@ -119,19 +114,23 @@ bool writeCredentialFile(const QString& filePath, const QString& profileName, co
         return false;
     }
 
-    QFile file(filePath);
+    const QByteArray payload = encrypted.toUtf8();
+    // QSaveFile rather than QFile: opening a QFile for writing empties the file that is
+    // already there before a byte of the new credential is written, and a payload this
+    // small only leaves QFile's write buffer inside close(), which returns void - so a
+    // disk that fills up in between leaves an empty file where the password was, and the
+    // write is reported as having succeeded. Neither is survivable for the legacy copy,
+    // which is the only one an older Mudlet can read.
+    QSaveFile file(filePath);
 
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    if (!file.open(QIODevice::WriteOnly)) {
         qWarning() << "CredentialManager: Failed to open file for writing:" << filePath << "Error:" << file.errorString();
         return false;
     }
 
-    const qint64 bytesWritten = file.write(encrypted.toUtf8());
-    file.close();
-
-    // Verify write operation succeeded
-    if (bytesWritten == -1) {
-        qWarning() << "CredentialManager: Failed to write encrypted credential to file:" << filePath;
+    if (file.write(payload) != payload.size() || !file.commit()) {
+        // whatever was there before is still there: QSaveFile discards the partial write
+        qWarning() << "CredentialManager: Failed to write encrypted credential to file:" << filePath << "Error:" << file.errorString();
         return false;
     }
 
@@ -1341,8 +1340,20 @@ QString CredentialManager::retrieveCredentialFromFile(const QString& profileName
             // Copied across, not moved: the file the earlier naming scheme left is where an
             // older Mudlet sharing this configuration directory looks, and it is the only
             // place it looks, so taking it away would lose that Mudlet the password
-            writeCredentialFile(filePath, profileName, migrated);
+            if (!writeCredentialFile(filePath, profileName, migrated)) {
+                qWarning() << "CredentialManager: could not copy the newer credential at" << legacyPath << "across to" << filePath << "- it will be read from the older path again next time";
+            }
+
             return migrated;
+        }
+
+        // The newer of the two files holds nothing for this profile - a colliding
+        // profile's credential, or a damaged one. Where this profile has a copy of its
+        // own, that copy is the older one, and handing an older password back without a
+        // word is the very thing this ordering exists to stop.
+        if (QFile::exists(filePath)) {
+            qWarning() << "CredentialManager: the credential file" << legacyPath << "is newer than" << filePath << "but holds nothing profile" << profileName
+                       << "can decrypt - the older copy is being used instead";
         }
     }
 
@@ -1386,7 +1397,7 @@ bool CredentialManager::removeCredentialFromFile(const QString& profileName, con
     }
 
     // A credential still filed under the legacy truncated path has to go as well, or
-    // the next read would migrate it and resurrect the password just removed
+    // the next read would copy it back and resurrect the password just removed
     removeLegacyFileCredential(profileName, key);
 
     // Check if file exists before attempting removal
@@ -1534,22 +1545,27 @@ QString CredentialManager::readLegacyFileCredential(const QString& profileName, 
     return SecureStringUtils::decryptStringForProfile(encrypted, profileName);
 }
 
+// The legacy path when the file there holds this profile's own credential, and an empty
+// string otherwise. Whose credential it is is the only thing that tells this profile's file
+// apart from one a profile it used to collide with left, so refreshing that file and
+// removing it both have to ask first.
+QString CredentialManager::ourLegacyFilePath(const QString& profileName, const QString& key)
+{
+    QString existing = readLegacyFileCredential(profileName, key);
+    const bool ours = !existing.isEmpty();
+    SecureStringUtils::secureStringClear(existing);
+
+    return ours ? generateLegacyFilePath(profileName, key) : QString();
+}
+
 // Deletes the legacy file, but only once it has proved to hold this profile's own
 // credential, so a profile it used to collide with never has its password removed on
 // this one's behalf.
 void CredentialManager::removeLegacyFileCredential(const QString& profileName, const QString& key)
 {
-    QString credential = readLegacyFileCredential(profileName, key);
-    const bool ours = !credential.isEmpty();
-    SecureStringUtils::secureStringClear(credential);
+    const QString legacyPath = ourLegacyFilePath(profileName, key);
 
-    if (!ours) {
-        return;
-    }
-
-    const QString legacyPath = generateLegacyFilePath(profileName, key);
-
-    if (!QFile::remove(legacyPath)) {
+    if (!legacyPath.isEmpty() && !QFile::remove(legacyPath)) {
         qWarning() << "CredentialManager: Failed to remove credential file left by the earlier naming scheme:" << legacyPath;
     }
 }
@@ -1561,15 +1577,28 @@ void CredentialManager::removeLegacyFileCredential(const QString& profileName, c
 // 50 characters back on a single file, which is what the digest-bearing name exists to prevent.
 void CredentialManager::refreshLegacyFileCredential(const QString& profileName, const QString& key, const QString& credential)
 {
-    QString existing = readLegacyFileCredential(profileName, key);
-    const bool ours = !existing.isEmpty();
-    SecureStringUtils::secureStringClear(existing);
+    const QString legacyPath = ourLegacyFilePath(profileName, key);
 
-    if (!ours) {
+    if (legacyPath.isEmpty()) {
         return;
     }
 
-    writeCredentialFile(generateLegacyFilePath(profileName, key), profileName, credential);
+    // An empty credential stands for "no password", not for a password that happens to be
+    // empty: writing one would leave a file this profile can no longer prove is its own, and
+    // so could never refresh or remove again - and an older Mudlet reading it would find
+    // nothing but a complaint in its log.
+    if (credential.isEmpty()) {
+        if (!QFile::remove(legacyPath)) {
+            qWarning() << "CredentialManager: Failed to remove credential file left by the earlier naming scheme:" << legacyPath;
+        }
+
+        return;
+    }
+
+    if (!writeCredentialFile(legacyPath, profileName, credential)) {
+        qWarning() << "CredentialManager: the copy of this profile's credential that an older Mudlet reads," << legacyPath
+                   << "could not be brought up to date - that Mudlet will go on offering the previous password for profile" << profileName;
+    }
 }
 
 bool CredentialManager::isValidKeyName(const QString& key)

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -116,6 +116,7 @@ private:
     static QString generateFilePath(const QString& profileName, const QString& key);
     static QString generateLegacyFilePath(const QString& profileName, const QString& key);
     static QString readLegacyFileCredential(const QString& profileName, const QString& key);
+    static QString ourLegacyFilePath(const QString& profileName, const QString& key);
     static void refreshLegacyFileCredential(const QString& profileName, const QString& key, const QString& credential);
     static void removeLegacyFileCredential(const QString& profileName, const QString& key);
     static QString generateServiceName(const QString& profileName, const QString& key);

--- a/src/CredentialManager.h
+++ b/src/CredentialManager.h
@@ -116,6 +116,7 @@ private:
     static QString generateFilePath(const QString& profileName, const QString& key);
     static QString generateLegacyFilePath(const QString& profileName, const QString& key);
     static QString readLegacyFileCredential(const QString& profileName, const QString& key);
+    static void refreshLegacyFileCredential(const QString& profileName, const QString& key, const QString& credential);
     static void removeLegacyFileCredential(const QString& profileName, const QString& key);
     static QString generateServiceName(const QString& profileName, const QString& key);
     static QString generateLegacyServiceName(const QString& profileName, const QString& key);

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -80,6 +80,25 @@ QString plantedCredential(const QString& path, const QString& profileName)
     return SecureStringUtils::decryptStringForProfile(QString::fromUtf8(file.readAll()), profileName);
 }
 
+// The 50 characters two long names share is the path component a Mudlet that shortened
+// names by truncation alone filed its credential under, so each case below needs both
+// halves of its profile name - and cleanupTestCase() needs the whole name again. Named
+// once here so that the two cannot drift apart, and so that the shape of a colliding
+// pair is stated where the names are rather than in each case.
+const QString scmKeptPrefix(50, QChar('k'));
+const QString scmKeptProfile = scmKeptPrefix + qsl("KeptForAnOlderMudlet");
+const QString scmNewerCopyPrefix(50, QChar('n'));
+const QString scmNewerCopyProfile = scmNewerCopyPrefix + qsl("NewerCopyIsTheOneHandedBack");
+const QString scmWrittenThroughPrefix(50, QChar('w'));
+const QString scmWrittenThroughProfile = scmWrittenThroughPrefix + qsl("WrittenThroughToTheOlderPath");
+const QString scmEmptyCredentialPrefix(50, QChar('e'));
+const QString scmEmptyCredentialProfile = scmEmptyCredentialPrefix + qsl("EmptyCredentialSavedHere");
+const QString scmCollidingPrefix(50, QChar('c'));
+const QString scmFirstCollidingProfile = scmCollidingPrefix + qsl("FirstOfTwoCollidingNames");
+const QString scmSecondCollidingProfile = scmCollidingPrefix + qsl("SecondOfTwoCollidingNames");
+const QString scmNeverFiledPrefix(50, QChar('f'));
+const QString scmNeverFiledProfile = scmNeverFiledPrefix + qsl("NeverFiledUnderTheTruncatedPath");
+
 // Which of two copies of one credential was written last is what decides between them, so a
 // case that needs one to be the newer says so outright rather than leaving a filesystem's
 // timestamp resolution to separate two writes made a moment apart.
@@ -112,6 +131,7 @@ private slots:
     void testTheTruncatedPathKeepsItsCopyForAnOlderMudlet();
     void testTheNewerOfTheTwoCopiesIsTheOneHandedBack();
     void testAPasswordSavedHereReachesTheTruncatedPathToo();
+    void testAnEmptyCredentialTakesTheTruncatedPathAwayRatherThanEmptyingIt();
     void testTheTruncatedPathIsNeverCreatedNorTakenOver();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
@@ -470,10 +490,9 @@ void CredentialManagerTest::testLegacyKeyAtTheLengthCapClaimsNoLongerKeysCredent
 // an older one loses the password from it the moment a newer Mudlet has read it once.
 void CredentialManagerTest::testTheTruncatedPathKeepsItsCopyForAnOlderMudlet()
 {
-    const QString truncated(50, QChar('k'));
-    const QString profile = truncated + "KeptForAnOlderMudlet";
+    const QString profile = scmKeptProfile;
     const QString key = "character";
-    const QString legacyPath = credentialPath(truncated, key);
+    const QString legacyPath = credentialPath(scmKeptPrefix, key);
 
     QVERIFY(plantCredential(legacyPath, profile, "saved_by_the_older_mudlet"));
 
@@ -495,10 +514,9 @@ void CredentialManagerTest::testTheTruncatedPathKeepsItsCopyForAnOlderMudlet()
 // scheme already holds rather than the stale one being handed back for ever.
 void CredentialManagerTest::testTheNewerOfTheTwoCopiesIsTheOneHandedBack()
 {
-    const QString truncated(50, QChar('n'));
-    const QString profile = truncated + "NewerCopyIsTheOneHandedBack";
+    const QString profile = scmNewerCopyProfile;
     const QString key = "character";
-    const QString legacyPath = credentialPath(truncated, key);
+    const QString legacyPath = credentialPath(scmNewerCopyPrefix, key);
     const QString currentPath = credentialPath(utils::sanitizeForPath(profile), key);
 
     QVERIFY(CredentialManager::storeCredential(profile, key, "the_password_this_mudlet_knows"));
@@ -523,10 +541,10 @@ void CredentialManagerTest::testTheNewerOfTheTwoCopiesIsTheOneHandedBack()
 // changed from.
 void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
 {
-    const QString truncated(50, QChar('w'));
-    const QString profile = truncated + "WrittenThroughToTheOlderPath";
+    const QString profile = scmWrittenThroughProfile;
     const QString key = "character";
-    const QString legacyPath = credentialPath(truncated, key);
+    const QString legacyPath = credentialPath(scmWrittenThroughPrefix, key);
+    const QString currentPath = credentialPath(utils::sanitizeForPath(profile), key);
 
     QVERIFY(plantCredential(legacyPath, profile, "the_password_both_started_with"));
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_both_started_with"));
@@ -536,11 +554,48 @@ void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
     QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_changed_here"));
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_changed_here"));
 
+    // Both copies, not only the one the read happened to take. Which of the two a later read
+    // prefers is deliberately not pinned: a store writes both inside one millisecond, which
+    // is all the resolution QFileInfo::lastModified() has, so neither is "written after" the
+    // other in whichever order they go - and a tie leaves fileWrittenAfter() answering for
+    // the file under the current naming.
+    QCOMPARE(plantedCredential(currentPath, profile), QString("the_password_changed_here"));
+
     // and removing the password still takes both copies with it, so neither Mudlet is left
-    // holding one that was deleted
+    // holding one that was deleted. That is what file storage does, which is what these
+    // cases run on; a removal that goes to a system keychain instead leaves both files
+    // where they are.
     QVERIFY(CredentialManager::removeCredential(profile, key));
     QVERIFY2(!QFile::exists(legacyPath), "the copy an older Mudlet reads outlived the removal of the password");
     QVERIFY(CredentialManager::retrieveCredential(profile, key).isEmpty());
+}
+
+// An empty credential stands for "no password", and the file the earlier naming scheme left
+// cannot be made to hold that: an empty file decrypts to nothing, which is exactly how a
+// file belonging to a profile this one used to collide with reads. A profile that wrote one
+// could therefore never recognise that file as its own again - it could neither refresh nor
+// remove it - and the older Mudlet would be left with a file it can only complain about.
+void CredentialManagerTest::testAnEmptyCredentialTakesTheTruncatedPathAwayRatherThanEmptyingIt()
+{
+    const QString profile = scmEmptyCredentialProfile;
+    const QString key = "character";
+    const QString legacyPath = credentialPath(scmEmptyCredentialPrefix, key);
+
+    QVERIFY(plantCredential(legacyPath, profile, "the_password_both_started_with"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_both_started_with"));
+
+    // what clearing the password field stores
+    QVERIFY(CredentialManager::storeCredential(profile, key, QString("")));
+
+    QVERIFY2(!QFile::exists(legacyPath), "an empty credential left a file at the truncated path that no profile can claim, refresh or remove again");
+
+    // ...and the profile can still be given that path back, so a password set in the older
+    // Mudlet afterwards is still kept in step rather than the two being locked apart
+    QVERIFY(plantCredential(legacyPath, profile, "set_again_in_the_older_mudlet"));
+    QVERIFY(CredentialManager::storeCredential(profile, key, "set_again_here"));
+    QCOMPARE(plantedCredential(legacyPath, profile), QString("set_again_here"));
+
+    CredentialManager::removeCredential(profile, key);
 }
 
 // Keeping the older scheme's file in step is only safe where one is already there and
@@ -549,11 +604,10 @@ void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
 // collision the digest-bearing name exists to end.
 void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
 {
-    const QString truncated(50, QChar('c'));
-    const QString first = truncated + "FirstOfTwoCollidingNames";
-    const QString second = truncated + "SecondOfTwoCollidingNames";
+    const QString first = scmFirstCollidingProfile;
+    const QString second = scmSecondCollidingProfile;
     const QString key = "character";
-    const QString legacyPath = credentialPath(truncated, key);
+    const QString legacyPath = credentialPath(scmCollidingPrefix, key);
 
     QVERIFY(plantCredential(legacyPath, first, "the_first_profiles_password"));
     QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("the_first_profiles_password"));
@@ -567,12 +621,18 @@ void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
     QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("the_first_profiles_password"));
     QCOMPARE(CredentialManager::retrieveCredential(second, key), QString("the_second_profiles_password_changed"));
 
+    // ...and that holds when the shared file is the newer of the two as well, which is the
+    // one place the two rules have to agree: modification time decides which file a read
+    // prefers, but only decrypting it decides whose credential it holds
+    QVERIFY(setModificationTime(legacyPath, 30));
+    QCOMPARE(CredentialManager::retrieveCredential(second, key), QString("the_second_profiles_password_changed"));
+    QCOMPARE(plantedCredential(legacyPath, first), QString("the_first_profiles_password"));
+
     // and a profile that never had a file at the truncated path is not given one, so no
     // sharing is created where there was none
-    const QString neverTruncated(50, QChar('f'));
-    const QString neverFiledThere = neverTruncated + "NeverFiledUnderTheTruncatedPath";
+    const QString neverFiledThere = scmNeverFiledProfile;
     QVERIFY(CredentialManager::storeCredential(neverFiledThere, key, "a_password_saved_only_here"));
-    QVERIFY2(!QFile::exists(credentialPath(neverTruncated, key)), "a credential was created at the path two long names would share");
+    QVERIFY2(!QFile::exists(credentialPath(scmNeverFiledPrefix, key)), "a credential was created at the path two long names would share");
 
     CredentialManager::removeCredential(first, key);
     CredentialManager::removeCredential(second, key);
@@ -948,11 +1008,10 @@ void CredentialManagerTest::cleanupTestCase()
     CredentialManager::removeCredential(truncatedPrefix + "FiledBeforeTheRename", "character");
     CredentialManager::removeCredential(truncatedPrefix + "StoredAfterwards", "character");
 
-    CredentialManager::removeCredential(QString(50, QChar('k')) + "KeptForAnOlderMudlet", "character");
-    CredentialManager::removeCredential(QString(50, QChar('n')) + "NewerCopyIsTheOneHandedBack", "character");
-    CredentialManager::removeCredential(QString(50, QChar('c')) + "FirstOfTwoCollidingNames", "character");
-    CredentialManager::removeCredential(QString(50, QChar('c')) + "SecondOfTwoCollidingNames", "character");
-    CredentialManager::removeCredential(QString(50, QChar('f')) + "NeverFiledUnderTheTruncatedPath", "character");
+    for (const QString& profile :
+         {scmKeptProfile, scmNewerCopyProfile, scmWrittenThroughProfile, scmEmptyCredentialProfile, scmFirstCollidingProfile, scmSecondCollidingProfile, scmNeverFiledProfile}) {
+        CredentialManager::removeCredential(profile, "character");
+    }
 }
 
 #include "CredentialManagerTest.moc"

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -23,8 +23,10 @@
 
 #include <QtTest/QtTest>
 
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QStandardPaths>
 #include <QTemporaryDir>
 
@@ -38,6 +40,55 @@
 // async one is what dlgConnectionProfiles and dlgProfilePreferences actually call,
 // and MUDLET_TEST_MODE routes it down the same file storage, so its callbacks are
 // delivered synchronously and need no event loop.
+
+namespace {
+// Where a credential sits for a path component spelled out in full - which is how a Mudlet
+// that shortened a long name by truncation alone filed one, and where such a Mudlet still
+// looks today.
+QString credentialPath(const QString& profileComponent, const QString& key)
+{
+    return qsl("%1/profiles/%2/passwords/%3").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), profileComponent, key);
+}
+
+// Writes a credential straight to one path, encrypted for that profile: what an older
+// Mudlet's own store leaves behind.
+bool plantCredential(const QString& path, const QString& profileName, const QString& credential)
+{
+    if (!QDir().mkpath(QFileInfo(path).absolutePath())) {
+        return false;
+    }
+
+    const QString encrypted = SecureStringUtils::encryptStringForProfile(credential, profileName);
+    QFile file(path);
+
+    if (encrypted.isEmpty() || !file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        return false;
+    }
+
+    return file.write(encrypted.toUtf8()) != -1;
+}
+
+// What such a file holds, read the way the profile it was encrypted for reads it
+QString plantedCredential(const QString& path, const QString& profileName)
+{
+    QFile file(path);
+
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return QString();
+    }
+
+    return SecureStringUtils::decryptStringForProfile(QString::fromUtf8(file.readAll()), profileName);
+}
+
+// Which of two copies of one credential was written last is what decides between them, so a
+// case that needs one to be the newer says so outright rather than leaving a filesystem's
+// timestamp resolution to separate two writes made a moment apart.
+bool setModificationTime(const QString& path, const int secondsFromNow)
+{
+    QFile file(path);
+    return file.open(QIODevice::ReadWrite) && file.setFileTime(QDateTime::currentDateTime().addSecs(secondsFromNow), QFileDevice::FileModificationTime);
+}
+} // namespace
 
 class CredentialManagerTest : public QObject
 {
@@ -58,6 +109,10 @@ private slots:
     void testCredentialsFiledUnderTheTruncatedPathSurvive();
     void testLegacySharedKeyPathOwnershipIsUndecidable();
     void testLegacyKeyAtTheLengthCapClaimsNoLongerKeysCredential();
+    void testTheTruncatedPathKeepsItsCopyForAnOlderMudlet();
+    void testTheNewerOfTheTwoCopiesIsTheOneHandedBack();
+    void testAPasswordSavedHereReachesTheTruncatedPathToo();
+    void testTheTruncatedPathIsNeverCreatedNorTakenOver();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
     void testAsyncStoreAndRetrieve();
@@ -407,6 +462,121 @@ void CredentialManagerTest::testLegacyKeyAtTheLengthCapClaimsNoLongerKeysCredent
 
     QVERIFY(QFile::remove(legacyPath));
     CredentialManager::removeCredential(profile, longerKey);
+}
+
+// The file the earlier naming scheme left is the only place a Mudlet from before the rename
+// looks, so bringing a credential across has to copy it and not move it. Configuration
+// directories are shared between installed Mudlets, so moving it means a user who still has
+// an older one loses the password from it the moment a newer Mudlet has read it once.
+void CredentialManagerTest::testTheTruncatedPathKeepsItsCopyForAnOlderMudlet()
+{
+    const QString truncated(50, QChar('k'));
+    const QString profile = truncated + "KeptForAnOlderMudlet";
+    const QString key = "character";
+    const QString legacyPath = credentialPath(truncated, key);
+
+    QVERIFY(plantCredential(legacyPath, profile, "saved_by_the_older_mudlet"));
+
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("saved_by_the_older_mudlet"));
+
+    QVERIFY2(QFile::exists(legacyPath), "reading the credential once took away the only copy an older Mudlet can find");
+    QCOMPARE(plantedCredential(legacyPath, profile), QString("saved_by_the_older_mudlet"));
+
+    // and it is under the current naming as well, which is what makes that copy the one
+    // this Mudlet goes to from here on
+    QVERIFY(QFile::exists(credentialPath(utils::sanitizeForPath(profile), key)));
+
+    CredentialManager::removeCredential(profile, key);
+}
+
+// Two Mudlets, one credential, two files - and only the older one of the two writes the
+// truncated path. Whichever file was written last therefore holds the password the user set
+// last, so a password re-entered in that older Mudlet has to win over the copy this naming
+// scheme already holds rather than the stale one being handed back for ever.
+void CredentialManagerTest::testTheNewerOfTheTwoCopiesIsTheOneHandedBack()
+{
+    const QString truncated(50, QChar('n'));
+    const QString profile = truncated + "NewerCopyIsTheOneHandedBack";
+    const QString key = "character";
+    const QString legacyPath = credentialPath(truncated, key);
+    const QString currentPath = credentialPath(utils::sanitizeForPath(profile), key);
+
+    QVERIFY(CredentialManager::storeCredential(profile, key, "the_password_this_mudlet_knows"));
+    QVERIFY(QFile::exists(currentPath));
+
+    QVERIFY(plantCredential(legacyPath, profile, "re_entered_in_the_older_mudlet"));
+    QVERIFY(setModificationTime(legacyPath, 30));
+
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("re_entered_in_the_older_mudlet"));
+
+    // and it is taken over rather than only read, so this naming scheme has it too once the
+    // two are no longer in that order
+    QVERIFY(setModificationTime(legacyPath, -30));
+    QCOMPARE(plantedCredential(currentPath, profile), QString("re_entered_in_the_older_mudlet"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("re_entered_in_the_older_mudlet"));
+
+    CredentialManager::removeCredential(profile, key);
+}
+
+// The same interoperability from the other side: a password changed here has to reach the
+// file the older Mudlet reads as well, or that Mudlet goes on offering the one it was
+// changed from.
+void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
+{
+    const QString truncated(50, QChar('w'));
+    const QString profile = truncated + "WrittenThroughToTheOlderPath";
+    const QString key = "character";
+    const QString legacyPath = credentialPath(truncated, key);
+
+    QVERIFY(plantCredential(legacyPath, profile, "the_password_both_started_with"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_both_started_with"));
+
+    QVERIFY(CredentialManager::storeCredential(profile, key, "the_password_changed_here"));
+
+    QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_changed_here"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_changed_here"));
+
+    // and removing the password still takes both copies with it, so neither Mudlet is left
+    // holding one that was deleted
+    QVERIFY(CredentialManager::removeCredential(profile, key));
+    QVERIFY2(!QFile::exists(legacyPath), "the copy an older Mudlet reads outlived the removal of the password");
+    QVERIFY(CredentialManager::retrieveCredential(profile, key).isEmpty());
+}
+
+// Keeping the older scheme's file in step is only safe where one is already there and
+// already this profile's own: two profiles whose names share their first 50 characters share
+// that path, so writing it for the second would put them back on a single file - the very
+// collision the digest-bearing name exists to end.
+void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
+{
+    const QString truncated(50, QChar('c'));
+    const QString first = truncated + "FirstOfTwoCollidingNames";
+    const QString second = truncated + "SecondOfTwoCollidingNames";
+    const QString key = "character";
+    const QString legacyPath = credentialPath(truncated, key);
+
+    QVERIFY(plantCredential(legacyPath, first, "the_first_profiles_password"));
+    QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("the_first_profiles_password"));
+
+    // the second profile saving a password of its own, and then changing it, leaves the
+    // shared file exactly as the first profile left it
+    QVERIFY(CredentialManager::storeCredential(second, key, "the_second_profiles_password"));
+    QVERIFY(CredentialManager::storeCredential(second, key, "the_second_profiles_password_changed"));
+    QCOMPARE(plantedCredential(legacyPath, first), QString("the_first_profiles_password"));
+
+    QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("the_first_profiles_password"));
+    QCOMPARE(CredentialManager::retrieveCredential(second, key), QString("the_second_profiles_password_changed"));
+
+    // and a profile that never had a file at the truncated path is not given one, so no
+    // sharing is created where there was none
+    const QString neverTruncated(50, QChar('f'));
+    const QString neverFiledThere = neverTruncated + "NeverFiledUnderTheTruncatedPath";
+    QVERIFY(CredentialManager::storeCredential(neverFiledThere, key, "a_password_saved_only_here"));
+    QVERIFY2(!QFile::exists(credentialPath(neverTruncated, key)), "a credential was created at the path two long names would share");
+
+    CredentialManager::removeCredential(first, key);
+    CredentialManager::removeCredential(second, key);
+    CredentialManager::removeCredential(neverFiledThere, key);
 }
 
 void CredentialManagerTest::testPathTraversalPrevention()
@@ -777,6 +947,12 @@ void CredentialManagerTest::cleanupTestCase()
     const QString truncatedPrefix(50, QChar('t'));
     CredentialManager::removeCredential(truncatedPrefix + "FiledBeforeTheRename", "character");
     CredentialManager::removeCredential(truncatedPrefix + "StoredAfterwards", "character");
+
+    CredentialManager::removeCredential(QString(50, QChar('k')) + "KeptForAnOlderMudlet", "character");
+    CredentialManager::removeCredential(QString(50, QChar('n')) + "NewerCopyIsTheOneHandedBack", "character");
+    CredentialManager::removeCredential(QString(50, QChar('c')) + "FirstOfTwoCollidingNames", "character");
+    CredentialManager::removeCredential(QString(50, QChar('c')) + "SecondOfTwoCollidingNames", "character");
+    CredentialManager::removeCredential(QString(50, QChar('f')) + "NeverFiledUnderTheTruncatedPath", "character");
 }
 
 #include "CredentialManagerTest.moc"

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -93,6 +93,8 @@ const QString scmFirstCollidingProfile = scmCollidingPrefix + qsl("FirstOfTwoCol
 const QString scmSecondCollidingProfile = scmCollidingPrefix + qsl("SecondOfTwoCollidingNames");
 const QString scmNeverFiledPrefix(50, QChar('f'));
 const QString scmNeverFiledProfile = scmNeverFiledPrefix + qsl("NeverFiledUnderTheTruncatedPath");
+const QString scmFailedStorePrefix(50, QChar('x'));
+const QString scmFailedStoreProfile = scmFailedStorePrefix + qsl("StoreThatCannotReachItsOwnFile");
 
 // Modification time decides between two copies of one credential, and a filesystem's
 // timestamp resolution cannot be trusted to separate two writes made a moment apart
@@ -127,6 +129,7 @@ private slots:
     void testAPasswordSavedHereReachesTheTruncatedPathToo();
     void testAnEmptyCredentialTakesTheTruncatedPathAwayRatherThanEmptyingIt();
     void testTheTruncatedPathIsNeverCreatedNorTakenOver();
+    void testAStoreThatFailsLeavesTheTruncatedPathAlone();
     void testPathTraversalPrevention();
     void testConcurrentAccess();
     void testAsyncStoreAndRetrieve();
@@ -541,10 +544,20 @@ void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
     QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_changed_here"));
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_changed_here"));
 
-    // Which of the two a later read prefers is deliberately not pinned: a store writes both
-    // inside one millisecond, all the resolution QFileInfo::lastModified() has, so neither is
-    // "written after" the other and a tie answers for the file under the current naming.
+    // Which of the two a later read prefers is deliberately not pinned: the copy for the
+    // older Mudlet is written last, so it is either the newer of the two or - within the one
+    // millisecond QFileInfo::lastModified() can tell apart - a tie, which answers for the
+    // file under the current naming.
     QCOMPARE(plantedCredential(currentPath, profile), QString("the_password_changed_here"));
+
+    // Either way a read settles it: where the copy for the older Mudlet is the newer, that
+    // read takes it and copies it across once, leaving the file under the current naming the
+    // newer again rather than every read going back to the older path
+    QVERIFY(setModificationTime(currentPath, -30));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_changed_here"));
+    QVERIFY2(QFileInfo(currentPath).lastModified() >= QFileInfo(legacyPath).lastModified(), "the copy under the current naming was not brought up to date by the read that took the older path");
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_changed_here"));
+    QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_changed_here"));
 
     // Removing the password takes both copies with it in file storage, which is what these
     // cases run on; a removal that goes to a system keychain leaves both files where they are
@@ -611,6 +624,40 @@ void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
     CredentialManager::removeCredential(first, key);
     CredentialManager::removeCredential(second, key);
     CredentialManager::removeCredential(neverFiledThere, key);
+}
+
+// The two files sit in directories of their own, so the copy an older Mudlet reads can be
+// written even where the file under the current naming cannot be. A store that reports
+// failure has to leave that copy as it found it, or the two Mudlets are left holding
+// different passwords for the same profile.
+void CredentialManagerTest::testAStoreThatFailsLeavesTheTruncatedPathAlone()
+{
+    const QString profile = scmFailedStoreProfile;
+    const QString key = "character";
+    const QString legacyPath = credentialPath(scmFailedStorePrefix, key);
+    const QString currentPath = credentialPath(utils::sanitizeForPath(profile), key);
+
+    QVERIFY(plantCredential(legacyPath, profile, "the_password_both_started_with"));
+    QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_both_started_with"));
+    QVERIFY(QFile::exists(currentPath));
+
+    // A directory where the credential file belongs: QSaveFile writes beside it and renames,
+    // and a rename onto a directory is refused whoever is running - a read-only directory
+    // would not be, since these cases can run as root
+    QVERIFY(QFile::remove(currentPath));
+    QVERIFY(QDir().mkpath(currentPath));
+
+    QVERIFY2(!CredentialManager::storeCredential(profile, key, "the_password_that_never_landed"), "a store that could not write its own file reported success");
+    QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_both_started_with"));
+
+    // and the same for the empty credential that clearing the password field stores, which
+    // takes the older Mudlet's copy away rather than emptying it
+    QVERIFY2(!CredentialManager::storeCredential(profile, key, QString("")), "a store that could not write its own file reported success");
+    QVERIFY2(QFile::exists(legacyPath), "a store that failed still took away the copy an older Mudlet reads");
+    QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_both_started_with"));
+
+    QVERIFY(QDir().rmdir(currentPath));
+    CredentialManager::removeCredential(profile, key);
 }
 
 void CredentialManagerTest::testPathTraversalPrevention()
@@ -983,7 +1030,7 @@ void CredentialManagerTest::cleanupTestCase()
     CredentialManager::removeCredential(truncatedPrefix + "StoredAfterwards", "character");
 
     for (const QString& profile :
-         {scmKeptProfile, scmNewerCopyProfile, scmWrittenThroughProfile, scmEmptyCredentialProfile, scmFirstCollidingProfile, scmSecondCollidingProfile, scmNeverFiledProfile}) {
+         {scmKeptProfile, scmNewerCopyProfile, scmWrittenThroughProfile, scmEmptyCredentialProfile, scmFirstCollidingProfile, scmSecondCollidingProfile, scmNeverFiledProfile, scmFailedStoreProfile}) {
         CredentialManager::removeCredential(profile, "character");
     }
 }

--- a/test/CredentialManagerTest.cpp
+++ b/test/CredentialManagerTest.cpp
@@ -42,16 +42,14 @@
 // delivered synchronously and need no event loop.
 
 namespace {
-// Where a credential sits for a path component spelled out in full - which is how a Mudlet
-// that shortened a long name by truncation alone filed one, and where such a Mudlet still
-// looks today.
+// Where a credential sits for a given path component - for a truncated long name, where a
+// Mudlet from before the rename still looks
 QString credentialPath(const QString& profileComponent, const QString& key)
 {
     return qsl("%1/profiles/%2/passwords/%3").arg(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation), profileComponent, key);
 }
 
-// Writes a credential straight to one path, encrypted for that profile: what an older
-// Mudlet's own store leaves behind.
+// Writes a credential the way an older Mudlet's own store leaves it behind
 bool plantCredential(const QString& path, const QString& profileName, const QString& credential)
 {
     if (!QDir().mkpath(QFileInfo(path).absolutePath())) {
@@ -68,7 +66,6 @@ bool plantCredential(const QString& path, const QString& profileName, const QStr
     return file.write(encrypted.toUtf8()) != -1;
 }
 
-// What such a file holds, read the way the profile it was encrypted for reads it
 QString plantedCredential(const QString& path, const QString& profileName)
 {
     QFile file(path);
@@ -80,11 +77,9 @@ QString plantedCredential(const QString& path, const QString& profileName)
     return SecureStringUtils::decryptStringForProfile(QString::fromUtf8(file.readAll()), profileName);
 }
 
-// The 50 characters two long names share is the path component a Mudlet that shortened
-// names by truncation alone filed its credential under, so each case below needs both
-// halves of its profile name - and cleanupTestCase() needs the whole name again. Named
-// once here so that the two cannot drift apart, and so that the shape of a colliding
-// pair is stated where the names are rather than in each case.
+// The first 50 characters of a long name are the path component a Mudlet that shortened
+// names by truncation alone filed its credential under, so each case needs both halves of
+// its profile name - and two names sharing that prefix are a colliding pair.
 const QString scmKeptPrefix(50, QChar('k'));
 const QString scmKeptProfile = scmKeptPrefix + qsl("KeptForAnOlderMudlet");
 const QString scmNewerCopyPrefix(50, QChar('n'));
@@ -99,9 +94,8 @@ const QString scmSecondCollidingProfile = scmCollidingPrefix + qsl("SecondOfTwoC
 const QString scmNeverFiledPrefix(50, QChar('f'));
 const QString scmNeverFiledProfile = scmNeverFiledPrefix + qsl("NeverFiledUnderTheTruncatedPath");
 
-// Which of two copies of one credential was written last is what decides between them, so a
-// case that needs one to be the newer says so outright rather than leaving a filesystem's
-// timestamp resolution to separate two writes made a moment apart.
+// Modification time decides between two copies of one credential, and a filesystem's
+// timestamp resolution cannot be trusted to separate two writes made a moment apart
 bool setModificationTime(const QString& path, const int secondsFromNow)
 {
     QFile file(path);
@@ -484,10 +478,8 @@ void CredentialManagerTest::testLegacyKeyAtTheLengthCapClaimsNoLongerKeysCredent
     CredentialManager::removeCredential(profile, longerKey);
 }
 
-// The file the earlier naming scheme left is the only place a Mudlet from before the rename
-// looks, so bringing a credential across has to copy it and not move it. Configuration
-// directories are shared between installed Mudlets, so moving it means a user who still has
-// an older one loses the password from it the moment a newer Mudlet has read it once.
+// Configuration directories are shared between installed Mudlets, so the file the earlier
+// naming scheme left has to be copied across rather than moved.
 void CredentialManagerTest::testTheTruncatedPathKeepsItsCopyForAnOlderMudlet()
 {
     const QString profile = scmKeptProfile;
@@ -501,17 +493,13 @@ void CredentialManagerTest::testTheTruncatedPathKeepsItsCopyForAnOlderMudlet()
     QVERIFY2(QFile::exists(legacyPath), "reading the credential once took away the only copy an older Mudlet can find");
     QCOMPARE(plantedCredential(legacyPath, profile), QString("saved_by_the_older_mudlet"));
 
-    // and it is under the current naming as well, which is what makes that copy the one
-    // this Mudlet goes to from here on
     QVERIFY(QFile::exists(credentialPath(utils::sanitizeForPath(profile), key)));
 
     CredentialManager::removeCredential(profile, key);
 }
 
-// Two Mudlets, one credential, two files - and only the older one of the two writes the
-// truncated path. Whichever file was written last therefore holds the password the user set
-// last, so a password re-entered in that older Mudlet has to win over the copy this naming
-// scheme already holds rather than the stale one being handed back for ever.
+// Only the older of the two Mudlets writes the truncated path, so whichever file was written
+// last holds the password the user set last.
 void CredentialManagerTest::testTheNewerOfTheTwoCopiesIsTheOneHandedBack()
 {
     const QString profile = scmNewerCopyProfile;
@@ -527,8 +515,8 @@ void CredentialManagerTest::testTheNewerOfTheTwoCopiesIsTheOneHandedBack()
 
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("re_entered_in_the_older_mudlet"));
 
-    // and it is taken over rather than only read, so this naming scheme has it too once the
-    // two are no longer in that order
+    // Taken over rather than only read: with the legacy copy no longer the newer of the two,
+    // the answer has to come from the file under the current naming
     QVERIFY(setModificationTime(legacyPath, -30));
     QCOMPARE(plantedCredential(currentPath, profile), QString("re_entered_in_the_older_mudlet"));
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("re_entered_in_the_older_mudlet"));
@@ -536,9 +524,8 @@ void CredentialManagerTest::testTheNewerOfTheTwoCopiesIsTheOneHandedBack()
     CredentialManager::removeCredential(profile, key);
 }
 
-// The same interoperability from the other side: a password changed here has to reach the
-// file the older Mudlet reads as well, or that Mudlet goes on offering the one it was
-// changed from.
+// A password changed here has to reach the file the older Mudlet reads as well, or that
+// Mudlet goes on offering the one it was changed from.
 void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
 {
     const QString profile = scmWrittenThroughProfile;
@@ -554,27 +541,21 @@ void CredentialManagerTest::testAPasswordSavedHereReachesTheTruncatedPathToo()
     QCOMPARE(plantedCredential(legacyPath, profile), QString("the_password_changed_here"));
     QCOMPARE(CredentialManager::retrieveCredential(profile, key), QString("the_password_changed_here"));
 
-    // Both copies, not only the one the read happened to take. Which of the two a later read
-    // prefers is deliberately not pinned: a store writes both inside one millisecond, which
-    // is all the resolution QFileInfo::lastModified() has, so neither is "written after" the
-    // other in whichever order they go - and a tie leaves fileWrittenAfter() answering for
-    // the file under the current naming.
+    // Which of the two a later read prefers is deliberately not pinned: a store writes both
+    // inside one millisecond, all the resolution QFileInfo::lastModified() has, so neither is
+    // "written after" the other and a tie answers for the file under the current naming.
     QCOMPARE(plantedCredential(currentPath, profile), QString("the_password_changed_here"));
 
-    // and removing the password still takes both copies with it, so neither Mudlet is left
-    // holding one that was deleted. That is what file storage does, which is what these
-    // cases run on; a removal that goes to a system keychain instead leaves both files
-    // where they are.
+    // Removing the password takes both copies with it in file storage, which is what these
+    // cases run on; a removal that goes to a system keychain leaves both files where they are
     QVERIFY(CredentialManager::removeCredential(profile, key));
     QVERIFY2(!QFile::exists(legacyPath), "the copy an older Mudlet reads outlived the removal of the password");
     QVERIFY(CredentialManager::retrieveCredential(profile, key).isEmpty());
 }
 
-// An empty credential stands for "no password", and the file the earlier naming scheme left
-// cannot be made to hold that: an empty file decrypts to nothing, which is exactly how a
-// file belonging to a profile this one used to collide with reads. A profile that wrote one
-// could therefore never recognise that file as its own again - it could neither refresh nor
-// remove it - and the older Mudlet would be left with a file it can only complain about.
+// An empty credential stands for "no password", and an empty file decrypts to nothing -
+// exactly how a file belonging to a profile this one used to collide with reads - so a
+// profile that wrote one could never recognise that file as its own again.
 void CredentialManagerTest::testAnEmptyCredentialTakesTheTruncatedPathAwayRatherThanEmptyingIt()
 {
     const QString profile = scmEmptyCredentialProfile;
@@ -589,8 +570,8 @@ void CredentialManagerTest::testAnEmptyCredentialTakesTheTruncatedPathAwayRather
 
     QVERIFY2(!QFile::exists(legacyPath), "an empty credential left a file at the truncated path that no profile can claim, refresh or remove again");
 
-    // ...and the profile can still be given that path back, so a password set in the older
-    // Mudlet afterwards is still kept in step rather than the two being locked apart
+    // The profile can still be given that path back, so a password set in the older Mudlet
+    // afterwards is kept in step again rather than the two being locked apart
     QVERIFY(plantCredential(legacyPath, profile, "set_again_in_the_older_mudlet"));
     QVERIFY(CredentialManager::storeCredential(profile, key, "set_again_here"));
     QCOMPARE(plantedCredential(legacyPath, profile), QString("set_again_here"));
@@ -598,10 +579,8 @@ void CredentialManagerTest::testAnEmptyCredentialTakesTheTruncatedPathAwayRather
     CredentialManager::removeCredential(profile, key);
 }
 
-// Keeping the older scheme's file in step is only safe where one is already there and
-// already this profile's own: two profiles whose names share their first 50 characters share
-// that path, so writing it for the second would put them back on a single file - the very
-// collision the digest-bearing name exists to end.
+// Two profiles whose names share their first 50 characters share the truncated path, so
+// keeping that file in step is only safe where it is already this profile's own.
 void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
 {
     const QString first = scmFirstCollidingProfile;
@@ -612,8 +591,6 @@ void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
     QVERIFY(plantCredential(legacyPath, first, "the_first_profiles_password"));
     QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("the_first_profiles_password"));
 
-    // the second profile saving a password of its own, and then changing it, leaves the
-    // shared file exactly as the first profile left it
     QVERIFY(CredentialManager::storeCredential(second, key, "the_second_profiles_password"));
     QVERIFY(CredentialManager::storeCredential(second, key, "the_second_profiles_password_changed"));
     QCOMPARE(plantedCredential(legacyPath, first), QString("the_first_profiles_password"));
@@ -621,15 +598,12 @@ void CredentialManagerTest::testTheTruncatedPathIsNeverCreatedNorTakenOver()
     QCOMPARE(CredentialManager::retrieveCredential(first, key), QString("the_first_profiles_password"));
     QCOMPARE(CredentialManager::retrieveCredential(second, key), QString("the_second_profiles_password_changed"));
 
-    // ...and that holds when the shared file is the newer of the two as well, which is the
-    // one place the two rules have to agree: modification time decides which file a read
-    // prefers, but only decrypting it decides whose credential it holds
+    // Modification time decides which file a read prefers, but only decrypting it decides
+    // whose credential it holds
     QVERIFY(setModificationTime(legacyPath, 30));
     QCOMPARE(CredentialManager::retrieveCredential(second, key), QString("the_second_profiles_password_changed"));
     QCOMPARE(plantedCredential(legacyPath, first), QString("the_first_profiles_password"));
 
-    // and a profile that never had a file at the truncated path is not given one, so no
-    // sharing is created where there was none
     const QString neverFiledThere = scmNeverFiledProfile;
     QVERIFY(CredentialManager::storeCredential(neverFiledThere, key, "a_password_saved_only_here"));
     QVERIFY2(!QFile::exists(credentialPath(scmNeverFiledPrefix, key)), "a credential was created at the path two long names would share");


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Since #10147 a profile whose name is over 50 characters files its password under `<33 chars>-<16-hex sha256>`, and the first read *moved* a credential filed under the old truncated path there. A 5.0.1 sharing the same config directory then reported "No password stored in encrypted file storage", and a password re-entered in that older Mudlet was never seen: the new Mudlet kept handing back the stale copy, reporting success.
- Both files are now kept and the one written last counts: a read takes the truncated-path copy when it is newer and copies it across rather than moving it; a store refreshes the truncated path only when a file is already there *and* decrypts with this profile's own key, so no new sharing is created and a colliding profile's file is never overwritten; removal still takes both.
- Credential files are written through `QSaveFile` (as `SecureStringUtils::storePassword()` already does): a full disk or interrupted write no longer truncates the only copy an older Mudlet can read, and a failed write is reported instead of returning true. An empty credential removes the legacy file rather than leaving an unreadable 0-byte one. Failed refreshes and undecryptable newer copies are logged.
- `CredentialManagerTest` gains six cases (kept copy, newer copy wins, write-through, collision never taken over, the newer-but-not-ours arrangement, empty credential); all fail without the fix.

#### Motivation for adding to Mudlet

Regression since 5.0.1 introduced by #10147 (QA finding F-43-2): a one-way, destructive migration in a directory that several installed Mudlets share.

#### Other info (issues closed, discussion etc)

Trade-off kept from #10147: where two long names share their first 50 characters, the truncated file stays with whichever profile already owned it, so an older Mudlet opening the other profile still sees the first one's password - exactly as before #10147, which nothing here can repair without putting both profiles back on one file.

**Test case:** with a profile name over 50 characters and file-based storage, save a password, read it, and check both `.../<truncated name>/passwords/character` and `.../<33 chars>-<hash>/passwords/character` exist; overwrite the truncated one with a newer file and read again - the newer value wins.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dfsx1R4np7VjdMngQ5iwUa)_