### PR TITLE
Infra: screenshot the console scroll bar on Linux and macOS

### DIFF
--- a/.github/workflows/scrollbar-screenshots.yml
+++ b/.github/workflows/scrollbar-screenshots.yml
@@ -1,0 +1,278 @@
+# Diagnostic workflow for PR #10574: renders the console's scroll bar with and
+# without the handle that pull request paints, on Linux and on macOS, and uploads
+# the result. #9341 is a Windows problem, but the fix draws the handle on every
+# platform - this is how the other two get looked at.
+#
+# Deliberately close to build-mudlet.yml in how it configures the build: the same
+# runner images, Qt, compilers and options, so this restores that workflow's
+# ccache from development instead of building cold. It never saves a cache back.
+name: 📸 Console scroll bar screenshots
+
+on:
+  push:
+    branches:
+      - 'claude/pr-10574-screenshots-**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  screenshots:
+    name: ${{matrix.buildname}}
+    runs-on: ${{matrix.os}}
+    # The ccache this restores lives in the base repository, so a fork run would
+    # build cold for nothing
+    if: ${{ github.repository_owner == 'Mudlet' }}
+    timeout-minutes: 90
+    concurrency:
+      group: ${{github.workflow}}-${{matrix.buildname}}-${{github.ref}}
+      cancel-in-progress: true
+    env:
+      LUA_VERSION: '5.1.5'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            buildname: 'linux'
+            compiler: gcc_64
+            gcc_compiler_version: 12
+            qt: '6.11.1'
+            preset: 'ci-linux'
+            # The key build-mudlet.yml's 'ubuntu (x86_64)' job saves on development
+            ccache_key: 'ccache-ubuntu-22.04-X64-gcc_64v12-6.11.1-plain-development'
+          - os: macos-15
+            buildname: 'macos'
+            compiler: clang_64
+            qt: '6.11.1'
+            preset: 'ci-macos'
+            # The key build-mudlet.yml's 'macos (arm64)' job saves on development
+            ccache_key: 'ccache-macos-15-ARM64-clang_64-6.11.1-plain-development'
+
+    steps:
+    - name: Checkout Mudlet source code
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: ${{matrix.qt}}
+        dir: ${{runner.workspace}}
+        cache: false
+        modules: qt5compat qtmultimedia qtspeech
+
+    - name: Cache Lua build
+      uses: actions/cache@v6
+      with:
+        path: .lua
+        key: lua-${{ env.LUA_VERSION }}-${{ matrix.os }}-${{ runner.arch }}
+
+    - name: Install Lua via GitHub Actions
+      uses: leafo/gh-actions-lua@v13
+      with:
+        luaVersion: ${{ env.LUA_VERSION }}
+        buildCache: false
+
+    - name: Install Luarocks via GitHub Actions
+      uses: leafo/gh-actions-luarocks@v6
+
+    - name: (macOS) Install dependencies
+      if: runner.os == 'macOS'
+      env:
+        HOMEBREW_NO_ANALYTICS: "ON"
+        HOMEBREW_NO_AUTO_UPDATE: "ON"
+        HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
+        HOMEBREW_NO_INSTALL_CLEANUP: "ON"
+      timeout-minutes: 15
+      run: |
+        brew uninstall --ignore-dependencies llvm@15 2>/dev/null || true
+        brew install libzzip libzip ccache assimp hunspell oniguruma pcre2 pugixml sqlite yajl boost
+
+        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
+        echo "DEVELOPER_DIR=$(xcode-select --print-path)" >> $GITHUB_ENV
+        echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+
+        HOMEBREW_PREFIX=/opt/homebrew
+        echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >> $GITHUB_ENV
+        echo "CMAKE_PREFIX_PATH=${QT_ROOT_DIR}:${HOMEBREW_PREFIX}" >> $GITHUB_ENV
+        echo "LUA_DIR=$HOME/.lua" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=${HOMEBREW_PREFIX}/opt/pcre2/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+
+        luarocks --lua-version 5.1 install --local lua-yajl YAJL_DIR=${HOMEBREW_PREFIX}/opt/yajl
+        eval "$(luarocks path --local --lua-version "5.1")"
+        echo "LUA_PATH=$LUA_PATH" >> $GITHUB_ENV
+        echo "LUA_CPATH=$LUA_CPATH" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
+        echo "CC=clang" >> $GITHUB_ENV
+
+    - name: (Linux) Install dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install \
+          ccache \
+          g++-${{matrix.gcc_compiler_version}} \
+          libassimp-dev \
+          libboost-dev \
+          libcurl4-openssl-dev \
+          libglu1-mesa-dev \
+          libhunspell-dev \
+          liblua5.1-0-dev \
+          libonig-dev \
+          libpcre2-dev \
+          libpulse-dev \
+          libpugixml-dev \
+          libsecret-1-dev \
+          libspeechd-dev \
+          libsqlite3-dev \
+          libssl-dev \
+          libxkbcommon-x11-0 \
+          libxcb-render-util0-dev \
+          libxcb-image0-dev \
+          libyajl-dev \
+          libzip-dev \
+          qtkeychain-qt6-dev \
+          pcre2-utils \
+          pkg-config \
+          openssl \
+          ca-certificates \
+          libgstreamer-plugins-base1.0-0 \
+          libxcb-icccm4 \
+          libxcb-image0 \
+          libxcb-keysyms1 \
+          libxcb-render-util0 \
+          libxcb-xinerama0 \
+          xvfb \
+          -y
+
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-${{matrix.gcc_compiler_version}}
+
+        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
+
+        luarocks --lua-version 5.1 install --local lua-yajl
+        eval "$(luarocks path --local --lua-version "5.1")"
+        echo "LUA_PATH=$LUA_PATH" >> $GITHUB_ENV
+        echo "LUA_CPATH=$LUA_CPATH" >> $GITHUB_ENV
+
+    - name: (Linux) Install mold linker
+      if: runner.os == 'Linux'
+      timeout-minutes: 5
+      env:
+        MOLD_VERSION: '2.41.0'
+        MOLD_SHA256: 'a3696680d99e692970590a178bc3a33d78d60d1c6dc9db7a11b557b02b751f5d'
+      run: |
+        # the ci-linux preset links with mold, and matching it is what keeps the
+        # restored ccache useful
+        curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 120 -o mold.tar.gz \
+          "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"
+        echo "${MOLD_SHA256}  mold.tar.gz" | sha256sum -c
+        sudo tar xf mold.tar.gz -C /usr/local --strip-components=1
+        rm mold.tar.gz
+
+    - name: Restore ccache
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{runner.workspace}}/ccache
+        # Nothing is ever saved back from here, so this only ever reads what the
+        # build workflow left on development
+        key: ${{matrix.ccache_key}}
+        restore-keys: ${{matrix.ccache_key}}
+
+    - name: Get sentry-native commit hash
+      id: sentry-hash
+      run: echo "SENTRY_HASH=$(git -C 3rdparty/sentry-native rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore sentry-native
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          3rdparty/sentry-native/install_without_transport
+          3rdparty/sentry-native/install_with_transport
+        key: sentry-${{ runner.os }}-${{ runner.arch }}-${{ steps.sentry-hash.outputs.SENTRY_HASH }}
+
+    - name: check ccache stats prior to build
+      run: ccache --zero-stats --show-stats
+
+    - name: Build the test binary
+      timeout-minutes: 60
+      env:
+        NINJA_STATUS: '[%f/%t %o/sec] '
+        CMAKE_BUILD_TYPE: ''
+        USE_SANITIZER: ''
+        # ON because that is what the cached objects were compiled with - it adds
+        # -g and compile definitions to mudlet_core, so OFF would miss every one
+        WITH_SENTRY: 'ON'
+        SENTRY_SEND_DEBUG: '0'
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      run: |
+        cmake --preset ${{matrix.preset}}
+        cmake --build ${{runner.workspace}}/b/ninja --target functional_window_tests
+
+    - name: check ccache stats post build
+      run: ccache --show-stats
+
+    - name: install the Lua rocks the functional tests load
+      run: |
+        LUAROCKS="luarocks --lua-version 5.1 install --local"
+        $LUAROCKS LuaFileSystem
+        $LUAROCKS luautf8
+        $LUAROCKS lpeg
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          $LUAROCKS lua-zip ZIP_DIR=${HOMEBREW_PREFIX}/opt/libzip
+          $LUAROCKS LuaSQL-SQLite3 2.6.1 SQLITE_DIR=${HOMEBREW_PREFIX}/opt/sqlite
+          $LUAROCKS lrexlib-pcre2 PCRE2_DIR=${HOMEBREW_PREFIX}/opt/pcre2
+        else
+          $LUAROCKS lua-zip
+          $LUAROCKS LuaSQL-SQLite3 2.6.1
+          $LUAROCKS lrexlib-pcre2
+        fi
+      env:
+        RUNNER_OS: ${{runner.os}}
+
+    - name: (Linux) Take the screenshots
+      if: runner.os == 'Linux'
+      timeout-minutes: 15
+      working-directory: '${{runner.workspace}}/b/ninja/test/functional_tests'
+      env:
+        MUDLET_TEST_MODE: 1
+      run: |
+        set -x
+        # Twice over: offscreen is what ctest uses, X11 is what a player's desktop
+        # is. Both land on Fusion, so a difference between them is the platform
+        # plugin rather than the style.
+        mkdir -p "${{github.workspace}}/screenshots/linux-offscreen" "${{github.workspace}}/screenshots/linux-x11"
+        QT_QPA_PLATFORM=offscreen MUDLET_SCREENSHOT_DIR="${{github.workspace}}/screenshots/linux-offscreen" \
+          ./functional_window_tests ScrollBarScreenshotTest
+        xvfb-run --auto-servernum env QT_QPA_PLATFORM=xcb MUDLET_TEST_MODE=1 \
+          MUDLET_SCREENSHOT_DIR="${{github.workspace}}/screenshots/linux-x11" \
+          ./functional_window_tests ScrollBarScreenshotTest
+
+    - name: (macOS) Take the screenshots
+      if: runner.os == 'macOS'
+      timeout-minutes: 15
+      working-directory: '${{runner.workspace}}/b/ninja/test/functional_tests'
+      env:
+        MUDLET_TEST_MODE: 1
+      run: |
+        set -x
+        # Cocoa rather than the offscreen platform the ctest suite uses: the macOS
+        # style comes from the platform theme, so offscreen would quietly measure
+        # Fusion and say nothing about what a Mac user sees. Each run prints the
+        # style it actually got, and the images carry it in their caption.
+        mkdir -p "${{github.workspace}}/screenshots/macos-cocoa"
+        QT_QPA_PLATFORM=cocoa MUDLET_SCREENSHOT_DIR="${{github.workspace}}/screenshots/macos-cocoa" \
+          ./functional_window_tests ScrollBarScreenshotTest
+
+    - name: Upload the screenshots
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: scrollbar-screenshots-${{matrix.buildname}}
+        path: ${{github.workspace}}/screenshots
+        if-no-files-found: error

--- a/.github/workflows/scrollbar-screenshots.yml
+++ b/.github/workflows/scrollbar-screenshots.yml
@@ -12,6 +12,11 @@ on:
   push:
     branches:
       - 'claude/pr-10574-screenshots-**'
+  # So the run happens in the base repository, whose ccache this restores, even
+  # when the branch itself lives in a fork
+  pull_request:
+    branches:
+      - 'fix-invisible-console-scrollbar'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/scrollbar-screenshots.yml
+++ b/.github/workflows/scrollbar-screenshots.yml
@@ -266,13 +266,25 @@ jobs:
         MUDLET_TEST_MODE: 1
       run: |
         set -x
+        # Whether the runner is on overlay scroll bars decides which of two quite
+        # different things the macOS style draws, so it goes in the log
+        defaults read -g AppleShowScrollBars 2>/dev/null || echo "AppleShowScrollBars unset (Automatic)"
+
         # Cocoa rather than the offscreen platform the ctest suite uses: the macOS
         # style comes from the platform theme, so offscreen would quietly measure
         # Fusion and say nothing about what a Mac user sees. Each run prints the
         # style it actually got, and the images carry it in their caption.
         mkdir -p "${{github.workspace}}/screenshots/macos-cocoa"
-        QT_QPA_PLATFORM=cocoa MUDLET_SCREENSHOT_DIR="${{github.workspace}}/screenshots/macos-cocoa" \
-          ./functional_window_tests ScrollBarScreenshotTest
+        if ! QT_QPA_PLATFORM=cocoa MUDLET_SCREENSHOT_DIR="${{github.workspace}}/screenshots/macos-cocoa" \
+            ./functional_window_tests ScrollBarScreenshotTest; then
+          # A runner with no window session cannot run cocoa at all. Offscreen still
+          # says what Mudlet's own painting does, just against Fusion rather than the
+          # macOS style - worth having, as long as nobody mistakes it for the latter.
+          echo "::warning::the cocoa run failed - falling back to the offscreen platform, which does NOT use the macOS style"
+          mkdir -p "${{github.workspace}}/screenshots/macos-offscreen-fallback"
+          QT_QPA_PLATFORM=offscreen MUDLET_SCREENSHOT_DIR="${{github.workspace}}/screenshots/macos-offscreen-fallback" \
+            ./functional_window_tests ScrollBarScreenshotTest
+        fi
 
     - name: Upload the screenshots
       if: always()

--- a/test/functional_tests/CMakeLists.txt
+++ b/test/functional_tests/CMakeLists.txt
@@ -72,6 +72,7 @@ set(WINDOW_GROUP_TEST_SOURCES
     WrapLineRewrapTest.cpp
     ScrollLostOnPartialRepaintTest.cpp
     ScrollBarContrastTest.cpp
+    ScrollBarScreenshotTest.cpp
 )
 
 # Profiles: their config dir, their folders, and loading, saving and deleting them

--- a/test/functional_tests/ScrollBarScreenshotTest.cpp
+++ b/test/functional_tests/ScrollBarScreenshotTest.cpp
@@ -21,6 +21,7 @@
 #include <QDir>
 #include <QImage>
 #include <QPainter>
+#include <QProxyStyle>
 #include <QScrollBar>
 #include <QSignalSpy>
 #include <QStyleOptionSlider>
@@ -65,10 +66,10 @@ private:
     QString mPort;
     const QString mLocalhost = "localhost";
     QString mOutputDir;
-    // The style the fix installs on the scroll bar, kept so a capture can take it
-    // off and put it back: it lives in an anonymous namespace, so this pointer is
-    // the only handle a test has on it.
-    QStyle* mpFixStyle = nullptr;
+
+    // Kept in step with ConsoleScrollBarStyle in TConsole.cpp by hand: the style
+    // lives in an anonymous namespace, so the name cannot be shared.
+    static constexpr const char* csHandleColorProperty = "mudletScrollBarHandleColor";
 
     void runLua(const QString& script) { QVERIFY2(mpHost->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(script)); }
 
@@ -101,21 +102,33 @@ private:
     QScrollBar* scrollBar() const { return mpHost->mpConsole->mpScrollBar; }
     QWidget* display() const { return mpHost->mpConsole->mpMainDisplay; }
 
-    // The platform's own style, which is what the "before" render has to use: the
-    // scroll bar carries the fix's style, so QWidget::style() is not it.
-    static QString baseStyleName() { return QApplication::style()->objectName(); }
-
-    void useFix(const bool enabled)
+    // What the platform actually draws with. Mudlet's application style is a proxy
+    // with no object name of its own, so the name has to come from the style it
+    // wraps - "fusion", "macOS", "windows11".
+    static QString baseStyleName()
     {
-        scrollBar()->setStyle(enabled ? mpFixStyle : nullptr);
+        const QStyle* pStyle = QApplication::style();
+        const auto* pProxy = qobject_cast<const QProxyStyle*>(pStyle);
+        const QString name = pStyle->objectName().isEmpty() && pProxy ? pProxy->baseStyle()->objectName() : pStyle->objectName();
+        return name.isEmpty() ? QString::fromLatin1(pStyle->metaObject()->className()) : name;
+    }
+
+    // Clearing the handle colour is how the "before" render is taken: the style the
+    // fix installs falls straight through to the platform's own drawing when the
+    // property is not a valid colour, so the bar paints exactly as it did before
+    // the fix. Taking the style off the widget instead would not survive an
+    // application style sheet, which wraps a widget's own style in a QStyleSheetStyle
+    // that setStyle(nullptr) then destroys.
+    void useFix(const bool enabled, const QVariant& handleColor)
+    {
+        scrollBar()->setProperty(csHandleColorProperty, enabled ? handleColor : QVariant());
         scrollBar()->update();
         QTest::qWait(50ms);
     }
 
-    QRect handleRect() const
+    void initOption(QStyleOptionSlider& option) const
     {
         QScrollBar* pScrollBar = scrollBar();
-        QStyleOptionSlider option;
         option.initFrom(pScrollBar);
         option.orientation = pScrollBar->orientation();
         option.minimum = pScrollBar->minimum();
@@ -124,16 +137,40 @@ private:
         option.singleStep = pScrollBar->singleStep();
         option.sliderPosition = pScrollBar->sliderPosition();
         option.sliderValue = pScrollBar->value();
-        return pScrollBar->style()->subControlRect(QStyle::CC_ScrollBar, &option, QStyle::SC_ScrollBarSlider, pScrollBar);
+    }
+
+    QRect handleRect() const
+    {
+        QStyleOptionSlider option;
+        initOption(option);
+        return scrollBar()->style()->subControlRect(QStyle::CC_ScrollBar, &option, QStyle::SC_ScrollBarSlider, scrollBar());
     }
 
     // Magenta, so anything the widget tree leaves unpainted is obvious in the image
     // rather than passing for a colour a console could have.
-    QImage renderDisplay() const
+    //
+    // A widget render can only show the state the bar is really in, and no pointer
+    // is going anywhere near it in a headless run - so the hovered render is drawn
+    // through the style over the top of the bar instead. That matters because the
+    // hover feedback belongs to the handle the fix masks out.
+    QImage renderDisplay(const bool hovered) const
     {
         QImage shot(display()->size(), QImage::Format_RGB32);
         shot.fill(Qt::magenta);
         display()->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
+        if (!hovered) {
+            return shot;
+        }
+
+        QPainter painter(&shot);
+        painter.translate(scrollBar()->mapTo(display(), QPoint()));
+        QStyleOptionSlider option;
+        initOption(option);
+        option.rect = QRect(QPoint(), scrollBar()->size());
+        option.state |= QStyle::State_MouseOver;
+        option.activeSubControls = QStyle::SC_ScrollBarSlider;
+        option.subControls = QStyle::SC_All;
+        scrollBar()->style()->drawComplexControl(QStyle::CC_ScrollBar, &option, &painter, scrollBar());
         return shot;
     }
 
@@ -150,17 +187,22 @@ private:
     static constexpr int csContextWidth = 300;
     static constexpr int csContextHeight = 340;
     static constexpr int csZoomFactor = 5;
+    // csContextHeight / csZoomFactor, so the enlargement ends up as tall as the crop
+    // it sits beside
+    static constexpr int csZoomHeight = csContextHeight / csZoomFactor;
 
-    Capture capture(const QColor& background)
+    Capture capture(const QColor& background, const bool hovered = false)
     {
-        const QImage shot = renderDisplay();
+        const QImage shot = renderDisplay(hovered);
         const QRect bar(scrollBar()->mapTo(display(), QPoint()), scrollBar()->size());
         const QRect handle = handleRect().translated(bar.topLeft());
 
         // Centred on the handle so the crop shows it wherever the console put it.
         const int top = qBound(0, handle.center().y() - csContextHeight / 2, qMax(0, shot.height() - csContextHeight));
         const QRect context(qMax(0, bar.right() + 1 - csContextWidth), top, qMin(csContextWidth, bar.right() + 1), qMin(csContextHeight, shot.height() - top));
-        const QRect strip(bar.left() - 1, top, bar.width() + 2, context.height());
+        // A window around the handle rather than the whole crop: the point of the
+        // enlargement is the handle's shape and edges.
+        const QRect strip(bar.left() - 1, qBound(0, handle.center().y() - csZoomHeight / 2, qMax(0, shot.height() - csZoomHeight)), bar.width() + 2, csZoomHeight);
 
         Capture result;
         result.context = shot.copy(context);
@@ -233,18 +275,23 @@ private:
                                      .arg(after.handleOnBackground, 0, 'f', 2);
     }
 
-    void captureScenario(const QString& tag, const QString& what, const QColor& background)
+    void captureScenario(const QString& tag, const QString& what, const QColor& background, const bool hovered = false)
     {
-        useFix(false);
-        const Capture before = capture(background);
-        useFix(true);
-        const Capture after = capture(background);
+        const QVariant handleColor = scrollBar()->property(csHandleColorProperty);
+        QVERIFY2(handleColor.value<QColor>().isValid(), "the console never gave its scroll bar a handle colour - is this build missing the fix?");
+
+        useFix(false, handleColor);
+        const Capture before = capture(background, hovered);
+        useFix(true, handleColor);
+        const Capture after = capture(background, hovered);
         writeComparison(tag, qsl("%1 - %2 style - %3").arg(platformName(), baseStyleName(), what), before, after);
     }
 
     void fillConsoleSoTheHandleHasSomewhereToSit()
     {
-        runLua(qsl("for i = 1, 500 do echo('the quick brown fox jumps over the lazy dog - line ' .. i .. '\\n') end"));
+        // Long enough to reach the right-hand edge of the console, so the crop beside
+        // the scroll bar shows text rather than empty background.
+        runLua(qsl("for i = 1, 500 do echo(('the quick brown fox jumps over the lazy dog '):rep(3) .. 'line ' .. i .. '\\n') end"));
         QTRY_VERIFY(scrollBar()->maximum() > scrollBar()->minimum());
         // Half way up the scrollback, so the handle sits in the middle of the crop
         // rather than parked against an end stop.
@@ -296,7 +343,6 @@ private slots:
         // Which is also the assertion that this build carries the fix at all - an
         // unpatched console leaves the scroll bar on the application's style.
         QVERIFY2(scrollBar()->testAttribute(Qt::WA_SetStyle), "the console's scroll bar has no style of its own - is this build missing the fix?");
-        mpFixStyle = scrollBar()->style();
 
         fillConsoleSoTheHandleHasSomewhereToSit();
         qInfo().noquote() << qsl("%1: application style %2, writing to %3").arg(platformName(), baseStyleName(), mOutputDir);
@@ -331,6 +377,15 @@ private slots:
         runLua(qsl("setBackgroundColor(255, 255, 255)"));
         QTest::qWait(50ms);
         captureScenario(qsl("white-console"), qsl("white console, light appearance"), QColor(255, 255, 255));
+    }
+
+    // The platform draws its hover feedback on the handle, and the fix masks that
+    // handle out - so this is where any feedback lost to the fix shows up.
+    void test_captureHoveredHandle()
+    {
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        QTest::qWait(50ms);
+        captureScenario(qsl("black-console-hovered"), qsl("black console, pointer over the handle"), QColor(0, 0, 0), true);
     }
 
     // Dark appearance repaints the groove around the handle, so the pairing the

--- a/test/functional_tests/ScrollBarScreenshotTest.cpp
+++ b/test/functional_tests/ScrollBarScreenshotTest.cpp
@@ -1,0 +1,350 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include <QApplication>
+#include <QDir>
+#include <QImage>
+#include <QPainter>
+#include <QScrollBar>
+#include <QSignalSpy>
+#include <QStyleOptionSlider>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+#include <chrono>
+#include <cmath>
+
+#include "PortableModeTestHelper.h"
+#include "ProfileTestHelper.h"
+#include "Host.h"
+#include "MudletInstanceCoordinator.h"
+#include "TLuaInterpreter.h"
+#include "TMainConsole.h"
+#include "TelnetServerStub.h"
+#include "ctelnet.h"
+#include "mudlet.h"
+
+#include "GroupedTest.h"
+
+using namespace std::chrono_literals;
+
+// Reports what the console's scroll bar looks like with and without the handle
+// this platform's own style would have drawn, by writing the two renders out as
+// images for a human to compare. #9341 is a Windows problem, but the fix paints
+// the handle on every platform, so what Linux and macOS look like afterwards is
+// a question only a picture answers.
+//
+// Writes to $MUDLET_SCREENSHOT_DIR (the working directory if unset) and asserts
+// nothing about which of the two looks better - the measurements it prints and
+// the images it leaves behind are the output.
+class ScrollBarScreenshotTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QTemporaryDir mConfigDir;
+    QByteArray mSavedXdg;
+    TelnetServerStub* mpServer = nullptr;
+    Host* mpHost = nullptr;
+    const QString mHostname = "ScrollBarScreenshot-Test-Host";
+    QString mPort;
+    const QString mLocalhost = "localhost";
+    QString mOutputDir;
+    // The style the fix installs on the scroll bar, kept so a capture can take it
+    // off and put it back: it lives in an anonymous namespace, so this pointer is
+    // the only handle a test has on it.
+    QStyle* mpFixStyle = nullptr;
+
+    void runLua(const QString& script) { QVERIFY2(mpHost->getLuaInterpreter()->compileAndExecuteScript(script), qPrintable(script)); }
+
+    static qreal relativeLuminance(const QColor& colour)
+    {
+        auto channel = [](qreal value) {
+            return value <= 0.03928 ? value / 12.92 : std::pow((value + 0.055) / 1.055, 2.4);
+        };
+        return 0.2126 * channel(colour.redF()) + 0.7152 * channel(colour.greenF()) + 0.0722 * channel(colour.blueF());
+    }
+
+    static qreal contrastRatio(const QColor& first, const QColor& second)
+    {
+        const qreal a = relativeLuminance(first);
+        const qreal b = relativeLuminance(second);
+        return (std::max(a, b) + 0.05) / (std::min(a, b) + 0.05);
+    }
+
+    static QString platformName()
+    {
+#if defined(Q_OS_MACOS)
+        return qsl("macOS");
+#elif defined(Q_OS_LINUX)
+        return qsl("Linux");
+#else
+        return qsl("Windows");
+#endif
+    }
+
+    QScrollBar* scrollBar() const { return mpHost->mpConsole->mpScrollBar; }
+    QWidget* display() const { return mpHost->mpConsole->mpMainDisplay; }
+
+    // The platform's own style, which is what the "before" render has to use: the
+    // scroll bar carries the fix's style, so QWidget::style() is not it.
+    static QString baseStyleName() { return QApplication::style()->objectName(); }
+
+    void useFix(const bool enabled)
+    {
+        scrollBar()->setStyle(enabled ? mpFixStyle : nullptr);
+        scrollBar()->update();
+        QTest::qWait(50ms);
+    }
+
+    QRect handleRect() const
+    {
+        QScrollBar* pScrollBar = scrollBar();
+        QStyleOptionSlider option;
+        option.initFrom(pScrollBar);
+        option.orientation = pScrollBar->orientation();
+        option.minimum = pScrollBar->minimum();
+        option.maximum = pScrollBar->maximum();
+        option.pageStep = pScrollBar->pageStep();
+        option.singleStep = pScrollBar->singleStep();
+        option.sliderPosition = pScrollBar->sliderPosition();
+        option.sliderValue = pScrollBar->value();
+        return pScrollBar->style()->subControlRect(QStyle::CC_ScrollBar, &option, QStyle::SC_ScrollBarSlider, pScrollBar);
+    }
+
+    // Magenta, so anything the widget tree leaves unpainted is obvious in the image
+    // rather than passing for a colour a console could have.
+    QImage renderDisplay() const
+    {
+        QImage shot(display()->size(), QImage::Format_RGB32);
+        shot.fill(Qt::magenta);
+        display()->render(&shot, QPoint(), QRegion(), QWidget::DrawChildren);
+        return shot;
+    }
+
+    struct Capture
+    {
+        QImage context; // the right-hand edge of the console, scroll bar included
+        QImage zoom;    // the bar alone, enlarged
+        QColor handle;
+        QColor groove;
+        qreal handleOnGroove = 1.0;
+        qreal handleOnBackground = 1.0;
+    };
+
+    static constexpr int csContextWidth = 300;
+    static constexpr int csContextHeight = 340;
+    static constexpr int csZoomFactor = 5;
+
+    Capture capture(const QColor& background)
+    {
+        const QImage shot = renderDisplay();
+        const QRect bar(scrollBar()->mapTo(display(), QPoint()), scrollBar()->size());
+        const QRect handle = handleRect().translated(bar.topLeft());
+
+        // Centred on the handle so the crop shows it wherever the console put it.
+        const int top = qBound(0, handle.center().y() - csContextHeight / 2, qMax(0, shot.height() - csContextHeight));
+        const QRect context(qMax(0, bar.right() + 1 - csContextWidth), top, qMin(csContextWidth, bar.right() + 1), qMin(csContextHeight, shot.height() - top));
+        const QRect strip(bar.left() - 1, top, bar.width() + 2, context.height());
+
+        Capture result;
+        result.context = shot.copy(context);
+        result.zoom = shot.copy(strip).scaled(strip.width() * csZoomFactor, strip.height() * csZoomFactor, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+        result.handle = shot.pixelColor(handle.center());
+        // Half way between the top of the bar and the top of the handle is track on
+        // every style here - past the arrow button of the ones that have one.
+        result.groove = shot.pixelColor(bar.center().x(), (bar.top() + handle.top()) / 2);
+        result.handleOnGroove = contrastRatio(result.handle, result.groove);
+        result.handleOnBackground = contrastRatio(result.handle, background);
+        return result;
+    }
+
+    static void drawColumn(QPainter& painter, const QPoint& origin, const QString& title, const Capture& capture)
+    {
+        painter.setPen(Qt::black);
+        QFont heading = painter.font();
+        heading.setBold(true);
+        painter.setFont(heading);
+        painter.drawText(QRect(origin.x(), origin.y(), csContextWidth, 20), Qt::AlignLeft | Qt::AlignVCenter, title);
+        heading.setBold(false);
+        painter.setFont(heading);
+
+        const QPoint imageAt(origin.x(), origin.y() + 24);
+        painter.drawImage(imageAt, capture.context);
+        painter.drawImage(QPoint(imageAt.x() + capture.context.width() + 12, imageAt.y()), capture.zoom);
+        painter.setPen(QColor(60, 60, 60));
+        painter.drawRect(QRect(imageAt, capture.context.size()));
+        painter.drawRect(QRect(QPoint(imageAt.x() + capture.context.width() + 12, imageAt.y()), capture.zoom.size()));
+
+        painter.setPen(Qt::black);
+        const int textTop = imageAt.y() + capture.context.height() + 8;
+        painter.drawText(QRect(origin.x(), textTop, csContextWidth + capture.zoom.width() + 12, 18), Qt::AlignLeft, qsl("handle %1, groove %2").arg(capture.handle.name(), capture.groove.name()));
+        painter.drawText(QRect(origin.x(), textTop + 18, csContextWidth + capture.zoom.width() + 12, 18),
+                         Qt::AlignLeft,
+                         qsl("contrast vs groove %1:1, vs console %2:1").arg(capture.handleOnGroove, 0, 'f', 2).arg(capture.handleOnBackground, 0, 'f', 2));
+    }
+
+    void writeComparison(const QString& tag, const QString& caption, const Capture& before, const Capture& after)
+    {
+        const int columnWidth = csContextWidth + 12 + before.zoom.width();
+        const int width = 24 + columnWidth + 40 + columnWidth + 24;
+        const int height = 30 + 24 + qMax(before.context.height(), after.context.height()) + 56;
+
+        QImage comparison(width, height, QImage::Format_RGB32);
+        comparison.fill(QColor(245, 245, 245));
+        QPainter painter(&comparison);
+        QFont title = painter.font();
+        title.setBold(true);
+        painter.setFont(title);
+        painter.setPen(Qt::black);
+        painter.drawText(QRect(24, 6, width - 48, 20), Qt::AlignLeft | Qt::AlignVCenter, caption);
+        title.setBold(false);
+        painter.setFont(title);
+
+        drawColumn(painter, QPoint(24, 30), qsl("before - the platform's own handle"), before);
+        drawColumn(painter, QPoint(24 + columnWidth + 40, 30), qsl("after - the handle this PR paints"), after);
+        painter.end();
+
+        const QString path = qsl("%1/%2-%3.png").arg(mOutputDir, platformName().toLower(), tag);
+        QVERIFY2(comparison.save(path), qPrintable(qsl("could not write %1").arg(path)));
+        QVERIFY2(before.context.save(qsl("%1/%2-%3-before.png").arg(mOutputDir, platformName().toLower(), tag)), "could not write the before crop");
+        QVERIFY2(after.context.save(qsl("%1/%2-%3-after.png").arg(mOutputDir, platformName().toLower(), tag)), "could not write the after crop");
+        qInfo().noquote() << qsl("%1 | %2 | before: handle %3 on groove %4 (%5:1), on console (%6:1) | after: handle %7 on groove %8 (%9:1), on console (%10:1)")
+                                     .arg(platformName(), caption, before.handle.name(), before.groove.name())
+                                     .arg(before.handleOnGroove, 0, 'f', 2)
+                                     .arg(before.handleOnBackground, 0, 'f', 2)
+                                     .arg(after.handle.name(), after.groove.name())
+                                     .arg(after.handleOnGroove, 0, 'f', 2)
+                                     .arg(after.handleOnBackground, 0, 'f', 2);
+    }
+
+    void captureScenario(const QString& tag, const QString& what, const QColor& background)
+    {
+        useFix(false);
+        const Capture before = capture(background);
+        useFix(true);
+        const Capture after = capture(background);
+        writeComparison(tag, qsl("%1 - %2 style - %3").arg(platformName(), baseStyleName(), what), before, after);
+    }
+
+    void fillConsoleSoTheHandleHasSomewhereToSit()
+    {
+        runLua(qsl("for i = 1, 500 do echo('the quick brown fox jumps over the lazy dog - line ' .. i .. '\\n') end"));
+        QTRY_VERIFY(scrollBar()->maximum() > scrollBar()->minimum());
+        // Half way up the scrollback, so the handle sits in the middle of the crop
+        // rather than parked against an end stop.
+        scrollBar()->setValue(scrollBar()->maximum() / 2);
+        QTest::qWait(100ms);
+    }
+
+private slots:
+    void initTestCase()
+    {
+        if (portableMarkerPresent()) {
+            QSKIP("portable.txt present - it takes precedence over XDG_CONFIG_HOME, so the config dir cannot be redirected");
+        }
+
+        QVERIFY(mConfigDir.isValid());
+        QVERIFY(QDir().mkpath(qsl("%1/mudlet/profiles").arg(mConfigDir.path())));
+        mSavedXdg = qgetenv("XDG_CONFIG_HOME");
+        qputenv("XDG_CONFIG_HOME", mConfigDir.path().toUtf8());
+
+        mOutputDir = qEnvironmentVariable("MUDLET_SCREENSHOT_DIR", QDir::currentPath());
+        QVERIFY2(QDir().mkpath(mOutputDir), qPrintable(qsl("could not create %1").arg(mOutputDir)));
+
+        mpServer = new TelnetServerStub(qApp);
+        mpServer->start(mLocalhost, 0);
+        mPort = QString::number(mpServer->serverPort());
+        mudlet::start();
+        mudlet::self()->setupConfig();
+        mudlet::self()->takeOwnershipOfInstanceCoordinator(std::make_unique<MudletInstanceCoordinator>("MudletInstanceCoordinator"));
+        mudlet::self()->init();
+        mudlet::self()->setStorePasswordsSecurely(false);
+
+        QDir(mudlet::getMudletPath(enums::profileHomePath, mHostname)).removeRecursively();
+
+        mpHost = TestProfile::create(mHostname, mLocalhost, mPort);
+        if (!mpHost) {
+            QFAIL("No active host available for the test.");
+        }
+
+        QSignalSpy connected(&(mpHost->mTelnet), &cTelnet::signal_connected);
+        if (!connected.wait(2000)) {
+            QFAIL("Could not connect with the host.");
+        }
+
+        mudlet::self()->resize(1200, 800);
+        QTest::qWait(100ms);
+        QVERIFY(mpHost->mpConsole);
+        QVERIFY(!scrollBar()->size().isEmpty());
+
+        // Which is also the assertion that this build carries the fix at all - an
+        // unpatched console leaves the scroll bar on the application's style.
+        QVERIFY2(scrollBar()->testAttribute(Qt::WA_SetStyle), "the console's scroll bar has no style of its own - is this build missing the fix?");
+        mpFixStyle = scrollBar()->style();
+
+        fillConsoleSoTheHandleHasSomewhereToSit();
+        qInfo().noquote() << qsl("%1: application style %2, writing to %3").arg(platformName(), baseStyleName(), mOutputDir);
+    }
+
+    void cleanupTestCase()
+    {
+        delete mudlet::smpDebugArea;
+        delete mpServer;
+        mpServer = nullptr;
+        mpHost = nullptr;
+        if (mudlet::self()) {
+            const QString path = mudlet::getMudletPath(enums::profileHomePath, mHostname);
+            delete mudlet::self();
+            QDir(path).removeRecursively();
+        }
+        mSavedXdg.isNull() ? qunsetenv("XDG_CONFIG_HOME") : qputenv("XDG_CONFIG_HOME", mSavedXdg);
+    }
+
+    // What all but a handful of profiles look like: Mudlet's own black console.
+    void test_captureBlackConsole()
+    {
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        QTest::qWait(50ms);
+        captureScenario(qsl("black-console"), qsl("black console, light appearance"), QColor(0, 0, 0));
+    }
+
+    // The other end of the range a profile can set, where the fix picks a black
+    // handle instead of a white one.
+    void test_captureWhiteConsole()
+    {
+        runLua(qsl("setBackgroundColor(255, 255, 255)"));
+        QTest::qWait(50ms);
+        captureScenario(qsl("white-console"), qsl("white console, light appearance"), QColor(255, 255, 255));
+    }
+
+    // Dark appearance repaints the groove around the handle, so the pairing the
+    // fix makes is a different one here.
+    void test_captureBlackConsoleInDarkAppearance()
+    {
+        mudlet::self()->setAppearance(enums::Appearance::dark);
+        runLua(qsl("setBackgroundColor(0, 0, 0)"));
+        QTest::qWait(100ms);
+        captureScenario(qsl("black-console-dark-appearance"), qsl("black console, dark appearance"), QColor(0, 0, 0));
+        mudlet::self()->setAppearance(enums::Appearance::light);
+        QTest::qWait(50ms);
+    }
+};
+
+#include "ScrollBarScreenshotTest.moc"
+MUDLET_GROUPED_TEST_MAIN(ScrollBarScreenshotTest)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- `test/functional_tests/ScrollBarScreenshotTest.cpp` renders the real main console's scroll bar twice - once with the style #10574 installs on it, once with that style taken off so the platform draws the handle itself - and writes the pair out as a labelled comparison image, with the handle and groove colours sampled and their contrast measured.
- Three scenarios: the default black console, a white console, and a black console in dark appearance.
- `.github/workflows/scrollbar-screenshots.yml` builds the `functional_window_tests` binary on `ubuntu-22.04` and `macos-15` and runs that one case, uploading the images as artifacts. Linux is captured twice, under the offscreen platform and under X11; macOS is captured under cocoa rather than offscreen, because the macOS style comes from the platform theme and an offscreen run would quietly measure Fusion instead.
- The workflow configures the build exactly as `build-mudlet.yml` does, so it restores that workflow's ccache from `development` rather than building cold. It never saves a cache back.

#### Motivation for adding to Mudlet

#9341 is a Windows problem, but #10574 paints the console's scroll bar handle on every platform, taking the handle away from the platform's own style as it goes. Whether that helps or hurts on Linux and macOS is a question a picture answers and a contrast assertion does not, so this takes the picture on CI hardware for both.

The test asserts nothing about which of the two looks better - the measurements it prints and the images it leaves behind are the output. It does assert that the scroll bar carries a style of its own, so a build without the fix fails loudly rather than capturing two identical images.

#### Other info (issues closed, discussion etc)

Targets `fix-invisible-console-scrollbar` rather than `development` so the diff is only the harness. Diagnostic support for #10574 - not something that needs to land on its own.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJHdDkXFqv5c8U9RTYje91

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJHdDkXFqv5c8U9RTYje91)_